### PR TITLE
fix: `@__NO_SIDE_EFFECTS__` wrapper should not remove dynamic imports

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -771,29 +771,31 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 if let Some(value) = self.extract_constant_value_from_expr(decl.init.as_ref()) {
                   self.add_constant_symbol(symbol_id, ConstExportMeta::new(value, false));
                 }
-                let is_side_effect_free_function = decl
+                let (is_side_effect_free_function, is_pure_annotation_only) = decl
                   .init
                   .as_ref()
                   .map(|expr| match expr {
-                    Expression::FunctionExpression(func) => func.is_side_effect_free() || func.pure,
-                    Expression::ArrowFunctionExpression(func) => {
-                      func.is_side_effect_free() || func.pure
+                    Expression::FunctionExpression(func) => {
+                      let empty = func.is_side_effect_free();
+                      (empty || func.pure, func.pure && !empty)
                     }
-                    _ => false,
+                    Expression::ArrowFunctionExpression(func) => {
+                      let empty = func.is_side_effect_free();
+                      (empty || func.pure, func.pure && !empty)
+                    }
+                    _ => (false, false),
                   })
-                  .unwrap_or(false);
+                  .unwrap_or((false, false));
                 if is_side_effect_free_function {
                   self
                     .result
                     .ecma_view_meta
                     .insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-                  self
-                    .result
-                    .symbol_ref_db
-                    .flags
-                    .entry(symbol_id)
-                    .or_default()
-                    .insert(SymbolRefFlags::SideEffectsFreeFunction);
+                  let flags = self.result.symbol_ref_db.flags.entry(symbol_id).or_default();
+                  flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
+                  if is_pure_annotation_only {
+                    flags.insert(SymbolRefFlags::PureAnnotationOnly);
+                  }
                 }
               }
             });
@@ -802,15 +804,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             let binding_id = fn_decl.id.as_ref().unwrap();
             let symbol_id = binding_id.symbol_id();
             self.add_local_export(binding_id.name.as_str(), symbol_id, binding_id.span);
-            if fn_decl.is_side_effect_free() || fn_decl.pure {
+            let empty = fn_decl.is_side_effect_free();
+            if empty || fn_decl.pure {
               self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-              self
-                .result
-                .symbol_ref_db
-                .flags
-                .entry(symbol_id)
-                .or_default()
-                .insert(SymbolRefFlags::SideEffectsFreeFunction);
+              let flags = self.result.symbol_ref_db.flags.entry(symbol_id).or_default();
+              flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
+              if fn_decl.pure && !empty {
+                flags.insert(SymbolRefFlags::PureAnnotationOnly);
+              }
             }
           }
           ast::Declaration::ClassDeclaration(cls_decl) => {
@@ -863,15 +864,19 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         None
       }
       ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => {
-        if fn_decl.is_side_effect_free() || fn_decl.pure {
+        let empty = fn_decl.is_side_effect_free();
+        if empty || fn_decl.pure {
           self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-          self
+          let flags = self
             .result
             .symbol_ref_db
             .flags
             .entry(self.result.default_export_ref.symbol)
-            .or_default()
-            .insert(SymbolRefFlags::SideEffectsFreeFunction);
+            .or_default();
+          flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
+          if fn_decl.pure && !empty {
+            flags.insert(SymbolRefFlags::PureAnnotationOnly);
+          }
         }
         fn_decl.id.as_ref().map(|id| {
           let symbol_id = id.symbol_id();

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -366,7 +366,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
 
   fn visit_call_expression(&mut self, it: &oxc::ast::ast::CallExpression<'ast>) {
     let mut pre_addr = None;
-    let is_side_effects_free_function = it
+    let (is_side_effects_free_function, is_pure_annotation_only) = it
       .callee
       .as_identifier()
       .and_then(|item| {
@@ -377,13 +377,29 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
           .immutable_ctx
           .symbols
           .canonical_ref_for((self.immutable_ctx.module_idx, symbol_id).into());
-        Some(self.immutable_ctx.global_side_effect_free_function_symbols.contains(&symbol_ref))
+        let is_free =
+          self.immutable_ctx.global_side_effect_free_function_symbols.contains(&symbol_ref);
+        let is_annotation_only = is_free
+          && self
+            .immutable_ctx
+            .symbols
+            .local_db(symbol_ref.owner)
+            .flags
+            .get(&symbol_ref.symbol)
+            .is_some_and(|f| f.contains(SymbolRefFlags::PureAnnotationOnly));
+        Some((is_free, is_annotation_only))
       })
-      .unwrap_or(false);
+      .unwrap_or((false, false));
 
     if is_side_effects_free_function {
       self.side_effect_free_call_expr_addr.insert(it.unstable_address());
-      pre_addr = self.latest_side_effect_free_call_expr_addr.replace(it.unstable_address());
+      // Only track as latest side-effect-free call for unreachable import detection
+      // when the function is truly empty (not just annotated with @__NO_SIDE_EFFECTS__).
+      // Annotated functions may still use their arguments, so dynamic imports in
+      // callback arguments should not be treated as unreachable.
+      if !is_pure_annotation_only {
+        pre_addr = self.latest_side_effect_free_call_expr_addr.replace(it.unstable_address());
+      }
     }
     walk::walk_call_expression(self, it);
     if let Some(addr) = pre_addr {

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "platform": "node",
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/_test.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { pages, wrapper } from './dist/entry.js';
+
+const result = await pages[0].load();
+assert.strictEqual(result.message, 'Hello from page.js');

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/artifacts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+//#region entry.js
+/* @__NO_SIDE_EFFECTS__ */
+function wrapper(load) {
+	return { load };
+}
+const pages = [/* @__PURE__ */ wrapper(() => import("./page.js"))];
+//#endregion
+export { pages, wrapper };
+
+```
+
+## page.js
+
+```js
+//#region page.js
+const message = "Hello from page.js";
+//#endregion
+export { message };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/entry.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/entry.js
@@ -1,0 +1,8 @@
+// @__NO_SIDE_EFFECTS__
+export function wrapper(load) {
+  return {
+    load,
+  };
+}
+
+export const pages = [wrapper(() => import('./page.js'))];

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/page.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_should_keep_dynamic_import/page.js
@@ -1,0 +1,1 @@
+export const message = 'Hello from page.js';

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -26,6 +26,10 @@ bitflags::bitflags! {
   #[derive(Debug, Default, Clone, Copy)]
   pub struct SymbolRefFlags: u8 {
     const IsNotReassigned = 1;
+    /// The function is side-effect-free solely because of a `@__NO_SIDE_EFFECTS__` annotation,
+    /// NOT because its body is empty. Such functions may still use their arguments, so
+    /// dynamic imports inside callback arguments should not be treated as unreachable.
+    const PureAnnotationOnly = 1 << 1;
     const MustStartWithCapitalLetterForJSX = 1 << 2;
     /// If the SymbolRef points to a side-effects-free function
     const SideEffectsFreeFunction = 1 << 3;


### PR DESCRIPTION
## Summary
- Adds a `PureAnnotationOnly` flag to `SymbolRefFlags` to distinguish functions that are side-effect-free solely due to `@__NO_SIDE_EFFECTS__` annotation vs functions with genuinely empty bodies
- In the cross-module optimization pass, annotated-only functions no longer mark their call expressions for unreachable import detection — preserving dynamic imports inside callback arguments
- Adds a regression test (`no_side_effects_should_keep_dynamic_import`) with runtime assertion that the dynamic import resolves correctly

## Test plan
- [x] New integration test: `tree_shaking::no_side_effects_should_keep_dynamic_import` passes
- [x] `_test.mjs` asserts `pages[0].load()` resolves to `{ message: 'Hello from page.js' }`

Closes #9074