### PR TITLE
fix(runtime): prevent `__toESM` double-wrapping for native ESM packages in CJS output

### DIFF
--- a/crates/rolldown/src/runtime/index.js
+++ b/crates/rolldown/src/runtime/index.js
@@ -90,9 +90,9 @@ export var __toESM = (mod, isNodeMode, target) => (
       // file that has been converted to a CommonJS file using a Babel-
       // compatible transform (i.e. "__esModule" has not been set), then set
       // "default" to the CommonJS "module.exports" for node compatibility.
-      isNodeMode || !mod || !mod.__esModule
-        ? __defProp(target, 'default', { value: mod, enumerable: true })
-        : target,
+      (isNodeMode ? mod && mod[Symbol.toStringTag] === 'Module' : mod && mod.__esModule)
+        ? target
+        : __defProp(target, 'default', { value: mod, enumerable: true }),
       mod,
     )
 );

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -49,9 +49,9 @@ export var __reExport = (target, mod, secondTarget) => (
 export var __toESM = (mod, isNodeMode, target) => (
   (target = mod != null ? __create(__getProtoOf(mod)) : {}),
   __copyProps(
-    isNodeMode || !mod || !mod.__esModule
-      ? __defProp(target, 'default', { value: mod, enumerable: true })
-      : target,
+    (isNodeMode ? mod && mod[Symbol.toStringTag] === 'Module' : mod && mod.__esModule)
+      ? target
+      : __defProp(target, 'default', { value: mod, enumerable: true }),
     mod,
   )
 );

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "format": "cjs",
+    "external": ["esm-pkg"],
+    "input": [
+      {
+        "name": "main",
+        "import": "main.mjs"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/_test.mjs
@@ -1,0 +1,2 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
+require('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let esm_pkg = require("esm-pkg");
+esm_pkg = __toESM(esm_pkg, 1);
+let assert = require("assert");
+assert = __toESM(assert, 1);
+//#region main.mjs
+const instance = new esm_pkg.default();
+assert.default.strictEqual(instance.ok, true);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/main.mjs
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/main.mjs
@@ -1,0 +1,4 @@
+import Foo from 'esm-pkg';
+import assert from 'assert';
+const instance = new Foo();
+assert.strictEqual(instance.ok, true);

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/node_modules/esm-pkg/index.js
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/node_modules/esm-pkg/index.js
@@ -1,0 +1,5 @@
+export default class Foo {
+  constructor() {
+    this.ok = true;
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/node_modules/esm-pkg/package.json
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/esm_default_import_external_no_double_wrap/node_modules/esm-pkg/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "esm-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "default": "./index.js"
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/common_js_min/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/common_js_min/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var e=Object.create,t=Object.defineProperty,n=Object.getOwnPropertyDescriptor,r=Object.getOwnPropertyNames,i=Object.getPrototypeOf,a=Object.prototype.hasOwnProperty,o=(e,t)=>()=>(t||e((t={exports:{}}).exports,t),t.exports),s=(e,i,o,s)=>{if(i&&typeof i==`object`||typeof i==`function`)for(var c=r(i),l=0,u=c.length,d;l<u;l++)d=c[l],!a.call(e,d)&&d!==o&&t(e,d,{get:(e=>i[e]).bind(null,d),enumerable:!(s=n(i,d))||s.enumerable});return e},c=((n,r,a)=>(a=n==null?{}:e(i(n)),s(r||!n||!n.__esModule?t(a,`default`,{value:n,enumerable:!0}):a,n)))(o(((e,t)=>{t.exports=123}))());assert.equal(c.foo,123);
+var e=Object.create,t=Object.defineProperty,n=Object.getOwnPropertyDescriptor,r=Object.getOwnPropertyNames,i=Object.getPrototypeOf,a=Object.prototype.hasOwnProperty,o=(e,t)=>()=>(t||e((t={exports:{}}).exports,t),t.exports),s=(e,i,o,s)=>{if(i&&typeof i==`object`||typeof i==`function`)for(var c=r(i),l=0,u=c.length,d;l<u;l++)d=c[l],!a.call(e,d)&&d!==o&&t(e,d,{get:(e=>i[e]).bind(null,d),enumerable:!(s=n(i,d))||s.enumerable});return e},c=((n,r,a)=>(a=n==null?{}:e(i(n)),s((r?n&&n[Symbol.toStringTag]===`Module`:n&&n.__esModule)?a:t(a,`default`,{value:n,enumerable:!0}),n)))(o(((e,t)=>{t.exports=123}))());assert.equal(c.foo,123);
 ```


### PR DESCRIPTION
When outputting CJS format and the source is ESM (`"type": "module"` or `.mjs`):

(Generated code by rolldown)

```js
let mod = require("esm-package");
mod = __toESM(mod, 1);
new mod.default(...); // TypeError: mod.default is not a constructor (caused by double-wrapping)
```

ref #8842