### PR TITLE
fix: use try_init() to avoid SetGlobalDefaultError panic

### DIFF
--- a/crates/rolldown_devtools/src/init_tracing.rs
+++ b/crates/rolldown_devtools/src/init_tracing.rs
@@ -38,7 +38,8 @@ impl DebugTracer {
     tracing_subscriber::registry()
       .with(DevtoolsLayer.with_filter(devtools_event_filter))
       .with(fmt::layer().event_format(DevtoolsFormatter))
-      .init();
+      .try_init()
+      .ok();
 
     tracer
   }

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -51,7 +51,8 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
       tracing_subscriber::registry()
         .with(Targets::from_str(&env_var).unwrap())
         .with(chrome_layer.with_filter(filter_for_removing_devtools_event))
-        .init();
+        .try_init()
+        .ok();
       Some(Box::new(guard))
     }
     "json" => {
@@ -66,7 +67,8 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         .with(
           fmt::layer().pretty().with_span_events(FmtSpan::NONE).with_level(true).with_target(false),
         )
-        .init();
+        .try_init()
+        .ok();
       tracing::debug!("Tracing initialized");
       None
     }
@@ -75,7 +77,8 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         .with(filter_for_removing_devtools_event)
         .with(Targets::from_str(&env_var).unwrap())
         .with(fmt::layer().pretty().with_span_events(FmtSpan::CLOSE | FmtSpan::ENTER))
-        .init();
+        .try_init()
+        .ok();
       tracing::debug!("Tracing initialized");
       None
     }


### PR DESCRIPTION
## Summary

- Replace `.init()` with `.try_init().ok()` in `rolldown_devtools::DebugTracer::init()` and all 3 call sites in `rolldown_tracing::try_init_tracing()`
- Prevents `SetGlobalDefaultError` panic when rolldown is embedded in a host binary that has already installed a global tracing subscriber

## Context

When rolldown is bundled into a host binary (e.g., vite-plus bundles `rolldown_binding` via `pub extern crate`), the host may install a global tracing subscriber during NAPI module init. Later, when `DebugTracer::init()` runs (triggered by `build.rolldownOptions.devtools: {}`), it calls `.init()` which panics:

```
thread '<unnamed>' panicked at tracing-subscriber-0.3.23/src/util.rs:94:14:
failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")
```

`.try_init()` returns `Result` instead of panicking, so a previously-installed subscriber is silently accepted.

Ref: voidzero-dev/vite-plus#1356

## Test plan

- [x] `cargo check -p rolldown_devtools -p rolldown_tracing` passes
- [ ] CI passes