### PR TITLE
fix: relax overly conservative side-effect leak check in chunk optimizer

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -404,7 +404,6 @@ impl GenerateStage<'_> {
           &dynamic_entry_to_dynamic_importers,
           temp_chunk,
           temp_chunk_graph,
-          *temp_chunk_idx,
         );
 
         Some((bits.clone(), *temp_chunk_idx, chunk_idxs, merge_target))
@@ -557,7 +556,6 @@ impl GenerateStage<'_> {
   /// entry chunk when possible, rather than creating a separate common chunk.
   ///
   /// Returns `Some(ChunkIdx)` if a suitable merge target is found, `None` otherwise.
-  #[expect(clippy::too_many_arguments)]
   fn try_insert_into_existing_chunk(
     chunk_idxs: &[ChunkIdx],
     entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
@@ -566,7 +564,6 @@ impl GenerateStage<'_> {
     dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
     info: &ChunkCandidate,
     temp_chunk_graph: &ChunkOptimizationGraph,
-    temp_chunk_idx: ChunkIdx,
   ) -> Option<ChunkIdx> {
     let mut user_defined_entry = vec![];
     let mut dynamic_entry = vec![];
@@ -609,11 +606,24 @@ impl GenerateStage<'_> {
       // import the entry chunk. This is only safe if the entry chunk
       // has no side effects; otherwise loading the dynamic chunk would
       // trigger the entry's side effects unexpectedly.
-      let would_make_dynamic_entry_depend_on_user_entry = dynamic_entry
-        .iter()
-        .any(|dynamic_chunk_idx| temp_chunk_graph.is_reachable(*dynamic_chunk_idx, temp_chunk_idx));
-      if would_make_dynamic_entry_depend_on_user_entry {
-        if temp_chunk_graph.chunks[chunk_idx].has_side_effects {
+      //
+      // However, the leak only happens if the dynamic entry can be reached
+      // via some *other* user-defined entry. If the dynamic entry is only
+      // reachable from `chunk_idx` (the merge target), then loading the
+      // dynamic entry always implies `chunk_idx` has already been loaded,
+      // so its side effects have already run — no leak.
+      // All dynamic entries in `dynamic_entry` already depend on `temp_chunk_idx`
+      // (that's how they ended up in `chunk_idxs`), so we check them all directly.
+      if temp_chunk_graph.chunks[chunk_idx].has_side_effects && !dynamic_entry.is_empty() {
+        // Check whether any *other* user-defined entry can reach these
+        // dynamic entries (directly or transitively via dynamic import).
+        // If yes, merging would leak `chunk_idx`'s side effects into that
+        // other entry's dynamic load.
+        let leak_possible = entry_chunk_reference.iter().any(|(other_entry_chunk_idx, reached)| {
+          *other_entry_chunk_idx != chunk_idx
+            && dynamic_entry.iter().any(|dyn_idx| reached.contains(dyn_idx))
+        });
+        if leak_possible {
           return None;
         }
       }

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
@@ -3,28 +3,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as n, __commonJSMin as t };
-
-```
-
 ## entry.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 import("./foo.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(({ default: { bar } }) => console.log(bar));
 //#endregion
+export { __commonJSMin as t };
 
 ```
 
 ## foo.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./entry.js";
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.bar = 123;

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
@@ -3,30 +3,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## internal-cjs.js
 
 ```js
 //#region internal-cjs.js
-var require_internal_cjs = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
+var require_internal_cjs = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -57,11 +38,12 @@ exports.value = value;
 ## main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("external"))).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("external"))).then(console.log);
 Promise.resolve().then(() => require("./internal.js")).then(console.log);
-Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./internal-cjs.js").default)).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./internal-cjs.js").default)).then(console.log);
 //#endregion
+exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { t as foo } from "./user-lib.js";
+import { t as foo } from "./main.js";
 //#region lazy-chunk.js
 foo();
 //#endregion
@@ -16,24 +16,17 @@ foo();
 ## main.js
 
 ```js
-import { t as foo } from "./user-lib.js";
 //#region polyfill.js
 Object.somePolyfilledFunction = () => {};
 //#endregion
-//#region main.js
-foo();
-//#endregion
-
-```
-
-## user-lib.js
-
-```js
 //#region user-lib.js
 Object.somePolyfilledFunction();
 async function foo() {
 	return import("./lazy-chunk.js");
 }
+//#endregion
+//#region main.js
+foo();
 //#endregion
 export { foo as t };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
+import { n as init_user_lib, r as __esmMin, t as foo } from "./main.js";
 //#endregion
 __esmMin((() => {
 	init_user_lib();
@@ -18,24 +18,12 @@ __esmMin((() => {
 ## main.js
 
 ```js
-import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region polyfill.js
 var init_polyfill = __esmMin((() => {
 	Object.somePolyfilledFunction = () => {};
 }));
 //#endregion
-__esmMin((() => {
-	init_polyfill();
-	init_user_lib();
-	foo();
-}))();
-
-```
-
-## user-lib.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
 //#region user-lib.js
 async function foo() {
 	return import("./lazy-chunk.js");
@@ -44,6 +32,11 @@ var init_user_lib = __esmMin((() => {
 	Object.somePolyfilledFunction();
 }));
 //#endregion
+__esmMin((() => {
+	init_polyfill();
+	init_user_lib();
+	foo();
+}))();
 export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as read, r as __esmMin, t as init_read } from "./read.js";
+import { n as read, r as __esmMin, t as init_read } from "./main.js";
 //#endregion
 __esmMin((() => {
 	init_read();
@@ -18,8 +18,8 @@ __esmMin((() => {
 ## main.js
 
 ```js
-import { n as read, r as __esmMin, t as init_read } from "./read.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var setup;
 var init_setup = __esmMin((() => {
@@ -27,6 +27,15 @@ var init_setup = __esmMin((() => {
 		globalThis.foo = "foo";
 	};
 	setup();
+}));
+//#endregion
+//#region read.js
+var foo, read;
+var init_read = __esmMin((() => {
+	foo = globalThis.foo;
+	read = () => {
+		console.log("read", foo);
+	};
 }));
 //#endregion
 __esmMin((() => {
@@ -37,22 +46,6 @@ __esmMin((() => {
 	import("./dynamic.js");
 	nodeAssert.strictEqual(globalThis.foo, "foo");
 }))();
-
-```
-
-## read.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region read.js
-var foo, read;
-var init_read = __esmMin((() => {
-	foo = globalThis.foo;
-	read = () => {
-		console.log("read", foo);
-	};
-}));
-//#endregion
 export { read as n, __esmMin as r, init_read as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -3,19 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-import { createRequire } from "node:module";
-// HIDDEN [\0rolldown/runtime.js]
-export { __require as n, __toESM as r, __commonJSMin as t };
-
-```
-
 ## lib.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./main.js";
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
@@ -30,8 +21,9 @@ export {};
 ## main.js
 
 ```js
-import { n as __require, r as __toESM, t as __commonJSMin } from "./chunk.js";
+import { createRequire } from "node:module";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region non-node-mode.js
 async function main$1() {
 	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
@@ -61,7 +53,7 @@ main();
 	module.exports = {};
 })))();
 //#endregion
-export {};
+export { __commonJSMin as t };
 
 ```
 
@@ -69,30 +61,11 @@ export {};
 
 ## Assets
 
-### chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ### lib.js
 
 ```js
 //#region lib.js
-var require_lib = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports) => {
+var require_lib = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.parse = "parse";
 }));
@@ -109,13 +82,14 @@ Object.defineProperty(exports, "default", {
 ### main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
-let node_assert$1 = require_chunk.__toESM(node_assert, 1);
-node_assert = require_chunk.__toESM(node_assert);
+let node_assert$1 = __toESM(node_assert, 1);
+node_assert = __toESM(node_assert);
 //#region non-node-mode.js
 async function main$1() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default));
 	node_assert.default.deepEqual(Object.keys(exports).sort(), ["parse"]);
 	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -124,16 +98,16 @@ main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
 	node_assert$1.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 	node_assert$1.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert$1.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
-(/* @__PURE__ */ require_chunk.__commonJSMin(((exports, module) => {
+(/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const nodeAssert = require("node:assert");
 	async function main() {
-		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
+		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
 		nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 		nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 		nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -142,6 +116,7 @@ main();
 	module.exports = {};
 })))();
 //#endregion
+exports.__commonJSMin = __commonJSMin;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
@@ -6,20 +6,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## allow-extension.js
 
 ```js
-import { t as shared } from "./lib.js";
+//#region allow-extension/lib.js
+const shared = "shared";
+//#endregion
 //#region allow-extension/main.js
 console.log(shared);
 import("./dynamic.js");
 const unused = 42;
 //#endregion
-export { unused };
+export { shared as t, unused };
 
 ```
 
 ## dynamic.js
 
 ```js
-import { t as shared } from "./lib.js";
+import { t as shared } from "./allow-extension.js";
 //#region allow-extension/dynamic.js
 console.log(shared);
 //#endregion
@@ -29,7 +31,7 @@ console.log(shared);
 ## dynamic2.js
 
 ```js
-import { t as shared } from "./lib2.js";
+import { t as shared } from "./false.js";
 //#region false/dynamic.js
 console.log(shared);
 //#endregion
@@ -39,7 +41,7 @@ console.log(shared);
 ## dynamic3.js
 
 ```js
-import { t as shared } from "./lib3.js";
+import { t as shared } from "./lib.js";
 //#region not-specified/dynamic.js
 console.log(shared);
 //#endregion
@@ -49,7 +51,7 @@ console.log(shared);
 ## dynamic4.js
 
 ```js
-import { t as shared } from "./lib4.js";
+import { t as shared } from "./lib2.js";
 //#region strict/dynamic.js
 console.log(shared);
 //#endregion
@@ -59,35 +61,18 @@ console.log(shared);
 ## false.js
 
 ```js
-import { t as shared } from "./lib2.js";
+//#region false/lib.js
+const shared = "shared";
+//#endregion
 //#region false/main.js
 console.log(shared);
 import("./dynamic2.js");
 //#endregion
+export { shared as t };
 
 ```
 
 ## lib.js
-
-```js
-//#region allow-extension/lib.js
-const shared = "shared";
-//#endregion
-export { shared as t };
-
-```
-
-## lib2.js
-
-```js
-//#region false/lib.js
-const shared = "shared";
-//#endregion
-export { shared as t };
-
-```
-
-## lib3.js
 
 ```js
 //#region not-specified/lib.js
@@ -97,7 +82,7 @@ export { shared as t };
 
 ```
 
-## lib4.js
+## lib2.js
 
 ```js
 //#region strict/lib.js
@@ -116,7 +101,7 @@ export { shared as t };
 ## not-specified.js
 
 ```js
-import { t as shared } from "./lib3.js";
+import { t as shared } from "./lib.js";
 //#region not-specified/main.js
 console.log(shared);
 import("./dynamic3.js");
@@ -129,7 +114,7 @@ export { unused };
 ## strict.js
 
 ```js
-import { t as shared } from "./lib4.js";
+import { t as shared } from "./lib2.js";
 //#region strict/main.js
 console.log(shared);
 import("./dynamic4.js");

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -3,39 +3,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-Object.defineProperty(exports, "__esmMin", {
-	enumerable: true,
-	get: function() {
-		return __esmMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## dynamic.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_main = require("./main.js");
 //#region dynamic.js
 var ddd;
 //#endregion
-require_chunk.__esmMin((() => {
+require_main.__esmMin((() => {
 	ddd = 100;
 }))();
 exports.ddd = ddd;
@@ -45,12 +20,13 @@ exports.ddd = ddd;
 ## main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = __toESM(node_assert);
 //#endregion
 //#region entry.js
-var import_lib = (/* @__PURE__ */ require_chunk.__commonJSMin(((exports) => {
+var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	const remoteProvider = async function() {
 		return await Promise.resolve().then(() => require("./dynamic.js"));
 	};
@@ -60,5 +36,6 @@ var import_lib = (/* @__PURE__ */ require_chunk.__commonJSMin(((exports) => {
 	(0, node_assert.default)((await (0, import_lib.defaultProvider)()).ddd === 100);
 })();
 //#endregion
+exports.__esmMin = __esmMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
-import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./chunk.js";
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./index.js";
 //#region d.js
 var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability });
 async function loadEventStreamCapability() {
@@ -28,18 +28,10 @@ export default require_c();
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as a, __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
-
-```
-
 ## e.js
 
 ```js
-import { n as __esmMin } from "./chunk.js";
+import { n as __esmMin } from "./index.js";
 //#endregion
 __esmMin((() => {
 	console.log("event");
@@ -50,8 +42,7 @@ __esmMin((() => {
 ## index.js
 
 ```js
-import { a as __toESM, t as __commonJSMin } from "./chunk.js";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region a.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.defaultProvider = async function test() {
@@ -60,5 +51,6 @@ import { a as __toESM, t as __commonJSMin } from "./chunk.js";
 	};
 })))();
 //#endregion
+export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
@@ -6,24 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as utilityClass, t as helper } from "./shared.js";
+import { n as utilityClass, t as helper } from "./main.js";
 new utilityClass(helper());
 //#endregion
 
 ```
 
 ## main.js
-
-```js
-import { t as helper } from "./shared.js";
-//#region main.js
-console.log(helper());
-import("./dynamic.js");
-//#endregion
-
-```
-
-## shared.js
 
 ```js
 //#region shared.js
@@ -35,6 +24,10 @@ var utilityClass = class {
 		this.value = value;
 	}
 };
+//#endregion
+//#region main.js
+console.log(helper());
+import("./dynamic.js");
 //#endregion
 export { utilityClass as n, helper as t };
 

--- a/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region a.js
-var require_a = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
+var require_a = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -23,31 +23,13 @@ Object.defineProperty(exports, "default", {
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./a.js").default)).then((m) => console.log(m.default));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./a.js").default)).then((m) => console.log(m.default));
 //#endregion
+exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-a.js
 
 ```js
-import { t as import_lodash } from "./utils.js";
+import { t as import_lodash } from "./main.js";
 import assert from "node:assert";
 //#region lazy-a.js
 assert(typeof import_lodash.debounce === "function");
@@ -18,25 +18,18 @@ assert(typeof import_lodash.noop === "function");
 ## main.js
 
 ```js
-import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
-//#region main.js
-assert(typeof import_lodash.debounce === "function");
-assert(typeof import_lodash.noop === "function");
-import("./lazy-a.js");
-//#endregion
-
-```
-
-## utils.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
+//#endregion
+//#region main.js
+assert(typeof import_lodash.debounce === "function");
+assert(typeof import_lodash.noop === "function");
+import("./lazy-a.js");
 //#endregion
 export { import_lodash as n, import_lodash as t };
 
@@ -49,12 +42,12 @@ export { import_lodash as n, import_lodash as t };
 ### lazy-a.js
 
 ```js
-const require_utils = require("./utils.js");
+const require_main = require("./main.js");
 let node_assert = require("node:assert");
-node_assert = require_utils.__toESM(node_assert);
+node_assert = require_main.__toESM(node_assert);
 //#region lazy-a.js
-(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
-(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
+(0, node_assert.default)(typeof require_main.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_main.import_lodash$1.noop === "function");
 //#endregion
 
 ```
@@ -62,33 +55,23 @@ node_assert = require_utils.__toESM(node_assert);
 ### main.js
 
 ```js
-const require_utils = require("./utils.js");
-let node_assert = require("node:assert");
-node_assert = require_utils.__toESM(node_assert);
-//#region main.js
-(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
-(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
-Promise.resolve().then(() => require("./lazy-a.js"));
-//#endregion
-
-```
-
-### utils.js
-
-```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
 //#endregion
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
+//#region main.js
+(0, node_assert.default)(typeof import_lodash.debounce === "function");
+(0, node_assert.default)(typeof import_lodash.noop === "function");
+Promise.resolve().then(() => require("./lazy-a.js"));
+//#endregion
+exports.__toESM = __toESM;
 Object.defineProperty(exports, "import_lodash", {
 	enumerable: true,
 	get: function() {

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __toESM as r, __commonJSMin as t };
-
-```
-
 ## exist-dep-cjs.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./main.js";
 //#region exist-dep-cjs.js
 var require_exist_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
@@ -29,7 +21,7 @@ export default require_exist_dep_cjs();
 ## exist-dep-esm.js
 
 ```js
-import { n as __exportAll } from "./chunk.js";
+import { n as __exportAll } from "./main.js";
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
@@ -43,7 +35,7 @@ export { value };
 ## main.js
 
 ```js
-import { n as __exportAll, r as __toESM } from "./chunk.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
@@ -61,6 +53,7 @@ var main_exports = /* @__PURE__ */ __exportAll({});
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#endregion
+export { __exportAll as n, __commonJSMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./main.js";
 import { t as trim } from "./string.js";
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
@@ -20,18 +20,10 @@ export { bar_default as default };
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as t };
-
-```
-
 ## foo.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./main.js";
 import { n as unused, t as trim } from "./string.js";
 //#region utils/index.js
 var utils_exports = /* @__PURE__ */ __exportAll({
@@ -56,18 +48,15 @@ export { foo_default as default };
 ## main.js
 
 ```js
-import "./chunk.js";
-__rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
-import("./foo.js"), import("./bar.js");
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
 
 ```
 
 ## string.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./main.js";
 //#region utils/string.js
 var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## async-entry.js
 
 ```js
-import { n as inc, r as reset, t as count } from "./shared.js";
+import { count, inc, reset } from "./main.js";
 import assert from "node:assert";
 //#region async-entry.js
 reset();
@@ -25,17 +25,6 @@ assert.strictEqual(count, count);
 ## main.js
 
 ```js
-import { n as inc, r as reset, t as count } from "./shared.js";
-//#region main.js
-import("./async-entry.js");
-//#endregion
-export { count, inc, reset };
-
-```
-
-## shared.js
-
-```js
 //#region shared.js
 let count = 0;
 function reset() {
@@ -45,6 +34,9 @@ function inc() {
 	count += 1;
 }
 //#endregion
-export { inc as n, reset as r, count as t };
+//#region main.js
+import("./async-entry.js");
+//#endregion
+export { count, inc, reset };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -7,19 +7,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-const require_shared = require("./shared.js");
+const require_main = require("./main.js");
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 //#region async-entry.js
-require_shared.reset();
-node_assert.default.strictEqual(require_shared.count, 0);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
-require_shared.inc();
-node_assert.default.strictEqual(require_shared.count, 1);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
-require_shared.inc();
-node_assert.default.strictEqual(require_shared.count, 2);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
+require_main.reset();
+node_assert.default.strictEqual(require_main.count, 0);
+node_assert.default.strictEqual(require_main.count, require_main.count);
+require_main.inc();
+node_assert.default.strictEqual(require_main.count, 1);
+node_assert.default.strictEqual(require_main.count, require_main.count);
+require_main.inc();
+node_assert.default.strictEqual(require_main.count, 2);
+node_assert.default.strictEqual(require_main.count, require_main.count);
 //#endregion
 
 ```
@@ -28,24 +28,6 @@ node_assert.default.strictEqual(require_shared.count, require_shared.count);
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_shared = require("./shared.js");
-//#region main.js
-Promise.resolve().then(() => require("./async-entry.js"));
-//#endregion
-Object.defineProperty(exports, "count", {
-	enumerable: true,
-	get: function() {
-		return require_shared.count;
-	}
-});
-exports.inc = require_shared.inc;
-exports.reset = require_shared.reset;
-
-```
-
-## shared.js
-
-```js
 //#region shared.js
 let count = 0;
 function reset() {
@@ -55,23 +37,16 @@ function inc() {
 	count += 1;
 }
 //#endregion
+//#region main.js
+Promise.resolve().then(() => require("./async-entry.js"));
+//#endregion
 Object.defineProperty(exports, "count", {
 	enumerable: true,
 	get: function() {
 		return count;
 	}
 });
-Object.defineProperty(exports, "inc", {
-	enumerable: true,
-	get: function() {
-		return inc;
-	}
-});
-Object.defineProperty(exports, "reset", {
-	enumerable: true,
-	get: function() {
-		return reset;
-	}
-});
+exports.inc = inc;
+exports.reset = reset;
 
 ```

--- a/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
@@ -33,9 +33,8 @@ export default defineTest({
       [
         "assets/sanitized-+emitted-C6bBH0W1.txt",
         "assets/sanitized-asset-BIR0xpQL",
-        "sanitized-dynamic-Bz1iwkVe.js",
+        "sanitized-dynamic-DVinTJUZ.js",
         "sanitized-main.js",
-        "sanitized-share-CSwYeRHk.js",
       ]
     `);
   },


### PR DESCRIPTION
## Summary
- Remove redundant `is_reachable` check in `try_insert_into_existing_chunk` — all dynamic entries in `chunk_idxs` already depend on the pending common chunk by construction, so filtering them via `is_reachable` was a no-op.
- Refine the side-effect leak guard: instead of unconditionally blocking the merge when any dynamic entry depends on the common chunk, only block it when a *different* user-defined entry can also reach those dynamic entries. This allows more merges that are actually safe (the dynamic entry is only reachable from the merge target, so its side effects have already run).
- Remove the now-unused `temp_chunk_idx` parameter from `try_insert_into_existing_chunk`.

## Test plan
- All 1677 integration tests pass.
- Clippy and fmt pass.