### PR TITLE
fix(rolldown): set worker thread count with ROLLDOWN_WORKER_THREADS

### DIFF
--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -92,14 +92,19 @@ fn init() {
       // it's too high for us
       // we don't have that many `blocking` tasks to run at this moment
       .unwrap_or(4);
+    let worker_threads = std::env::var("ROLLDOWN_WORKER_THREADS")
+      .ok()
+      .and_then(|v| v.parse::<usize>().ok())
+      // unlike the web server scenario
+      // rolldown puts a lot of blocking tasks in the worker threads rather than blocking_threads
+      // so we need to increase the worker threads rather than the blocking_threads
+      .unwrap_or(num_cpus::get_physical() * 3 / 2);
     let mut builder = tokio::runtime::Builder::new_multi_thread();
 
     let rt = builder
       .max_blocking_threads(max_blocking_threads)
-      // unlike the web server scenario
-      // rolldown puts a lot of blocking tasks in the worker threads rather than blocking_threads
-      // so we need to increase the worker threads rather than the blocking_threads
-      .worker_threads(num_cpus::get_physical() * 3 / 2)
+      .worker_threads(worker_threads)
+      .thread_name("rolldown-worker")
       .enable_all()
       .build()
       .expect("Failed to create tokio runtime");


### PR DESCRIPTION
## Summary

In scenarios where you're running many concurrent instances of rolldown on the same machine (e.g., scheduled via Bazel), it's preferable to have each use a smaller number of worker threads.

As it was, each instance of rolldown would start a thread pool with count 1.5 times the number of physical CPUs.  Running many instances concurrently would lead to high system load averages, with lots of rolldown worker threads just waiting to get scheduled, and each build running slower than it otherwise would.

## Fix

Similar to the existing `ROLLDOWN_MAX_BLOCKING_THREADS` env var, we allow override of the worker thread count via `ROLLDOWN_WORKER_THREADS`.

We also set the thread name to "rolldown-worker" so it's easier to spot the change.

## Test Plan

We can observe the number of worker threads started with strace on Linux.

Note that, in each invocation, we'll see (2) more worker threads than the value we set in `.worker_threads(...)` for Tokio.  I believe these are the ephemeral threads creating for blocking calls.

#### Default stays the same

By default, expect the same 1.5X number of worker threads as before:

```sh
# My system has 8 cores
$ cat /proc/cpuinfo | grep 'cpu cores' | uniq
cpu cores	: 8

$ cd examples/basic-typescript
$ strace -f -e trace=prctl -o prctl.log -- pnpm build
$ cat prctl.log | grep -F 'prctl(PR_SET_NAME, "rolldown-worker"' | wc -l
14
# Expected: (8 * 1.5) + 2 = 14
```

#### Can set to 1

```sh
$ cd examples/basic-typescript
$ strace -f -e trace=prctl -o prctl.log -- env ROLLDOWN_WORKER_THREADS=1 pnpm build
$ cat prctl.log | grep -F 'prctl(PR_SET_NAME, "rolldown-worker"' | wc -l
3
# Expected: 1 + 2 = 3
```

#### Can set to 100

```sh
$ cd examples/basic-typescript
$ strace -f -e trace=prctl -o prctl.log -- env ROLLDOWN_WORKER_THREADS=100 pnpm build
$ cat prctl.log | grep -F 'prctl(PR_SET_NAME, "rolldown-worker"' | wc -l
102
# Expected: 100 + 2 = 102
```