### PR TITLE
refactor: extract duplicated top-level await handling into shared helper

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -185,46 +185,15 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_for_of_statement(&mut self, it: &ast::ForOfStatement<'ast>) {
-    let is_top_level_await = it.r#await && self.is_valid_tla_scope();
-    if is_top_level_await && !self.immutable_ctx.flat_options.keep_esm_import_export_syntax() {
-      self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.immutable_ctx.id.as_arc_str().clone(),
-        self.immutable_ctx.source.clone(),
-        it.span(),
-        format!(
-          "Top-level await is currently not supported with the '{format}' output format",
-          format = self.immutable_ctx.options.format
-        ),
-      ));
+    if it.r#await && self.is_valid_tla_scope() {
+      self.handle_top_level_await(it.span());
     }
-    if is_top_level_await {
-      self.result.ast_usage.insert(EcmaModuleAstUsage::TopLevelAwait);
-      if self.result.tla_keyword_span.is_none() {
-        self.result.tla_keyword_span = Some(it.span());
-      }
-    }
-
     walk::walk_for_of_statement(self, it);
   }
 
   fn visit_await_expression(&mut self, it: &ast::AwaitExpression<'ast>) {
-    let is_top_level_await = self.is_valid_tla_scope();
-    if !self.immutable_ctx.flat_options.keep_esm_import_export_syntax() && is_top_level_await {
-      self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.immutable_ctx.id.as_arc_str().clone(),
-        self.immutable_ctx.source.clone(),
-        it.span(),
-        format!(
-          "Top-level await is currently not supported with the '{format}' output format",
-          format = self.immutable_ctx.options.format
-        ),
-      ));
-    }
-    if is_top_level_await {
-      self.result.ast_usage.insert(EcmaModuleAstUsage::TopLevelAwait);
-      if self.result.tla_keyword_span.is_none() {
-        self.result.tla_keyword_span = Some(it.span());
-      }
+    if self.is_valid_tla_scope() {
+      self.handle_top_level_await(it.span());
     }
     walk::walk_await_expression(self, it);
   }
@@ -569,6 +538,24 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
+  fn handle_top_level_await(&mut self, span: Span) {
+    if !self.immutable_ctx.flat_options.keep_esm_import_export_syntax() {
+      self.result.errors.push(BuildDiagnostic::unsupported_feature(
+        self.immutable_ctx.id.as_arc_str().clone(),
+        self.immutable_ctx.source.clone(),
+        span,
+        format!(
+          "Top-level await is currently not supported with the '{format}' output format",
+          format = self.immutable_ctx.options.format
+        ),
+      ));
+    }
+    self.result.ast_usage.insert(EcmaModuleAstUsage::TopLevelAwait);
+    if self.result.tla_keyword_span.is_none() {
+      self.result.tla_keyword_span = Some(span);
+    }
+  }
+
   /// visit `Class` of declaration
   #[expect(clippy::unused_self)]
   pub fn get_class_id(&self, class: &ast::Class<'ast>) -> Option<SymbolId> {


### PR DESCRIPTION
## Summary
- Extract the duplicated top-level await error reporting and AST usage tracking from `visit_for_of_statement` and `visit_await_expression` into a single `handle_top_level_await` method, reducing code duplication.