### PR TITLE
fix: never panic during diagnostic emission

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -134,7 +134,7 @@ impl Diagnostic {
           span.source(),
           span.start()..span.end()
         )
-        .expect("Failed to write report message");
+        .ok();
       } else {
         builder = builder.with_label(label);
       }
@@ -154,12 +154,14 @@ impl Diagnostic {
   pub fn convert_to_string(&self, color: bool) -> String {
     let builder = self.init_report_builder();
     let mut output = Vec::new();
-    builder
+    let result = builder
       .with_config(Config::default().with_color(color).with_index_type(ariadne::IndexType::Byte))
       .finish()
-      .write_for_stdout(sources(self.files.clone()), &mut output)
-      .unwrap();
-    String::from_utf8(output).expect("Diagnostic should be valid utf8")
+      .write_for_stdout(sources(self.files.clone()), &mut output);
+    match result {
+      Ok(()) => String::from_utf8_lossy(&output).into_owned(),
+      Err(_) => format!("[{}] {}", self.kind, self.title),
+    }
   }
 
   pub fn to_color_string(&self) -> String {

--- a/crates/rolldown_error/src/build_diagnostic/events/oxc_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/oxc_error.rs
@@ -38,10 +38,21 @@ impl BuildEvent for OxcError {
     let file_id = diagnostic.add_file(opts.stabilize_path(&self.id), self.source.clone());
 
     self.error_labels.iter().for_each(|label| {
-      let offset = u32::try_from(label.offset()).unwrap();
+      // Skip labels with spans that don't fit in u32 or would overflow,
+      // rather than panicking or attaching a bogus span.
+      let Ok(offset) = u32::try_from(label.offset()) else {
+        return;
+      };
+      let Ok(len) = u32::try_from(label.len()) else {
+        return;
+      };
+      let Some(end) = offset.checked_add(len) else {
+        return;
+      };
+
       diagnostic.add_label(
         &file_id,
-        offset..offset + u32::try_from(label.len()).unwrap(),
+        offset..end,
         label.label().unwrap_or(&String::default()).to_owned(),
       );
     });

--- a/crates/rolldown_error/src/utils/is_context_too_long.rs
+++ b/crates/rolldown_error/src/utils/is_context_too_long.rs
@@ -10,15 +10,17 @@ pub fn is_context_too_long(
 ) -> bool {
   let span = label.span();
   let source_id = span.source();
-  let source = files.get(source_id).expect("should have file");
+  let Some(source) = files.get(source_id) else {
+    return true;
+  };
   if source.len() < 600 {
     return false;
   }
   let rope = ropey::Rope::from_str(source);
 
   if span.start() > rope.len_bytes() || span.end() > rope.len_bytes() {
-    unreachable!(
-      "Internal error: Diagnostic span is out of range. This should never happen! \
+    eprintln!(
+      "Internal error: Diagnostic span is out of range. \
        Span: {}..{}, Rope length: {} bytes, Source ID: {:?}, Label message: {:?}. \
        Please report this bug with the source file that triggered this error.",
       span.start(),
@@ -27,6 +29,7 @@ pub fn is_context_too_long(
       source_id,
       label.display_info().msg()
     );
+    return true;
   }
 
   // 1. If start to beginning of the file is less than 300 characters, treated as it has line feed before.


### PR DESCRIPTION
## Summary

Rolldown should never panic while emitting diagnostics. From a user DX perspective, a bundler crash during warning/error reporting is far worse than a degraded diagnostic — users should always see a meaningful message, even when internal state is inconsistent (e.g. an out-of-range span).

- Replace `unreachable!()` in `is_context_too_long` with a fallback that renders the label as plain text when the span exceeds source bounds (direct fix for #9073)
- Make `Diagnostic::convert_to_string` panic-free by gracefully handling ariadne render failures and using `from_utf8_lossy`
- Skip OXC error labels whose spans are unrepresentable as `u32` rather than panicking or silently attaching bogus ranges

## Test plan
- [x] `cargo test -p rolldown_error` passes
- [x] `cargo clippy -p rolldown_error` clean

Closes #9073