### PR TITLE
feat: add support for loongarch64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -70,6 +70,14 @@ jobs:
             build: vp run ci:build-release-binding --target powerpc64le-unknown-linux-gnu --use-napi-cross
 
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            use-cross: true
+            # Setting `CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER` for napi-rs selecting the correct linker in the cross-rs container
+            build: |
+              export CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-unknown-linux-gnu-gcc
+              vp run ci:build-release-binding --target loongarch64-unknown-linux-gnu --use-cross
+
+          - os: ubuntu-latest
             target: wasm32-wasip1-threads
             build: |
               vp run --filter rolldown build-binding:wasi:release
@@ -109,6 +117,14 @@ jobs:
       - name: Setup python
         run: pip install setuptools
         if: ${{ matrix.os == 'macos-latest' }}
+
+      - name: Setup cross
+        # TODO: Update cross-rs to v0.2.6 or higher when available
+        # We are pinning to this specific commit because it was the latest working
+        # version with loongarch64 support when added. The support for loongarch64
+        # is unavailable in the current stable release of cross-rs (v0.2.5).
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev f86fd03bb70b4c6802847c18087e21391498b0b4
+        if: ${{ matrix.use-cross }}
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -70,6 +70,14 @@ jobs:
             build: vp run ci:build-release-binding --target powerpc64le-unknown-linux-gnu --use-napi-cross
 
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            use-cross: true
+            # Setting `CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER` for napi-rs selecting the correct linker in the cross-rs container
+            build: |
+              export CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-unknown-linux-gnu-gcc
+              vp run ci:build-release-binding --target loongarch64-unknown-linux-gnu --use-cross
+
+          - os: ubuntu-latest
             target: wasm32-wasip1-threads
             build: |
               vp run --filter rolldown build-binding:wasi:release
@@ -104,6 +112,19 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-zigbuild
+
+      # https://github.com/nodejs/node-gyp/issues/2869
+      - name: Setup python
+        run: pip install setuptools
+        if: ${{ matrix.os == 'macos-latest' }}
+
+      - name: Setup cross
+        # TODO: Update cross-rs to v0.2.6 or higher when available
+        # We are pinning to this specific commit because it was the latest working
+        # version with loongarch64 support when added. The support for loongarch64
+        # is unavailable in the current stable release of cross-rs (v0.2.5).
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev f86fd03bb70b4c6802847c18087e21391498b0b4
+        if: ${{ matrix.use-cross }}
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
         with:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -49,6 +49,7 @@ Prebuilt binaries are distributed for the following platforms (grouped by [Node.
 - Experimental
   - Linux x64 musl (`x86_64-unknown-linux-musl`)
   - Linux armv7 (`armv7-unknown-linux-gnueabihf`)
+  - Linux loong64 glibc (`loongarch64-unknown-linux-gnu`)
   - FreeBSD x64 (`x86_64-unknown-freebsd`)
   - OpenHarmony arm64 (`aarch64-unknown-linux-ohos`)
 - Other

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -162,7 +162,8 @@
       "aarch64-linux-android",
       "wasm32-wasip1-threads",
       "s390x-unknown-linux-gnu",
-      "powerpc64le-unknown-linux-gnu"
+      "powerpc64le-unknown-linux-gnu",
+      "loongarch64-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,


### PR DESCRIPTION
This pull request adds support for `loongarch64-unknown-linux-gnu` in CI and includes an update to the documentation.

Note that there is currently no LoongArch support for `--use-napi-cross`, so we are using `--use-cross`, which uses `cross-rs` for cross-compiling. However, since support for LoongArch is unavailable in the current stable release of `cross-rs` (v0.2.5), we are using a pinned commit.

Support for `loongarch64-unknown-linux-musl` is blocked by `rustix` merging bytecodealliance/rustix#1591 and `oxc-resolver` releasing a version using `rustix` with that PR included. This implementation can be verified with [this commit](https://github.com/SkyBird233/rolldown/commit/ed98952ac3ed34bcf4bb01d9f6ba61f437fcaf1d) and [the corresponding workflow run](https://github.com/SkyBird233/rolldown/actions/runs/24341704276).

The `loongarch64` outputs in [this workflow](https://github.com/SkyBird233/rolldown/actions/runs/24341704276) have been smoke-tested on LoongArch64.