### PR TITLE
fix: treat namespace member access as side-effect-free

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -116,6 +116,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         self.immutable_ctx.flat_options,
         self.immutable_ctx.options,
         None,
+        Some(&self.namespace_object_symbol_ids),
       );
       self.current_stmt_info.side_effect = detector.detect_side_effect_of_stmt(stmt);
 

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -178,6 +178,9 @@ pub struct AstScanner<'me, 'ast> {
   traverse_state: TraverseState,
   current_comment_idx: usize,
   untranspiled_syntax: UntranspiledSyntax,
+  /// Symbol IDs of namespace imports (`import * as ns from '...'`).
+  /// Used to treat property reads on namespace objects as side-effect-free.
+  namespace_object_symbol_ids: FxHashSet<SymbolId>,
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
@@ -272,6 +275,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       traverse_state: TraverseState::empty(),
       current_comment_idx: 0,
       untranspiled_syntax: UntranspiledSyntax::empty(),
+      namespace_object_symbol_ids: FxHashSet::default(),
     }
   }
 
@@ -552,6 +556,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         span_imported,
       },
     );
+    self.namespace_object_symbol_ids.insert(local);
   }
 
   fn add_local_export(&mut self, export_name: &str, local: SymbolId, span: Span) {

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -3,12 +3,14 @@ use oxc::ast::ast::{
   IdentifierReference, UnaryOperator, VariableDeclarationKind,
 };
 use oxc::ast::match_member_expression;
+use oxc::semantic::SymbolId;
 use oxc_allocator::{Address, UnstableAddress};
 use oxc_ecmascript::GlobalContext;
 use oxc_ecmascript::side_effects::{
   MayHaveSideEffects, MayHaveSideEffectsContext, PropertyReadSideEffects,
 };
 use rolldown_common::{AstScopes, FlatOptions, SharedNormalizedBundlerOptions, SideEffectDetail};
+use rolldown_ecmascript_utils::ExpressionExt;
 use rustc_hash::FxHashSet;
 
 /// Detect if a statement "may" have side effect.
@@ -18,6 +20,10 @@ pub struct SideEffectDetector<'a> {
   flat_options: FlatOptions,
   /// Cross-module optimization: addresses of call expressions to known-pure functions.
   side_effect_free_call_expr_addr: Option<&'a FxHashSet<Address>>,
+  /// Symbol IDs of namespace imports (`import * as ns from '...'`).
+  /// Property reads on ES module namespace objects are guaranteed side-effect-free
+  /// because namespace objects are frozen/sealed by spec with no getters.
+  namespace_object_symbol_ids: Option<&'a FxHashSet<SymbolId>>,
 }
 
 impl<'a> SideEffectDetector<'a> {
@@ -26,8 +32,15 @@ impl<'a> SideEffectDetector<'a> {
     flat_options: FlatOptions,
     options: &'a SharedNormalizedBundlerOptions,
     side_effect_free_call_expr_addr: Option<&'a FxHashSet<Address>>,
+    namespace_object_symbol_ids: Option<&'a FxHashSet<SymbolId>>,
   ) -> Self {
-    Self { scope, options, flat_options, side_effect_free_call_expr_addr }
+    Self {
+      scope,
+      options,
+      flat_options,
+      side_effect_free_call_expr_addr,
+      namespace_object_symbol_ids,
+    }
   }
 
   /// Check if a call expression has been marked pure by cross-module optimization.
@@ -53,11 +66,27 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
+  /// Check if the member expression's direct object is an ES module namespace import.
+  /// ES module namespace objects are frozen/sealed by spec — property reads on them
+  /// can never have side effects (no getters possible).
+  fn is_namespace_member_access(&self, member_expr: &ast::MemberExpression) -> Option<bool> {
+    let namespace_ids = self.namespace_object_symbol_ids?;
+    let ident = member_expr.object().as_identifier()?;
+    let ref_id = ident.reference_id.get()?;
+    let symbol_id = self.scope.symbol_id_for(ref_id)?;
+    Some(namespace_ids.contains(&symbol_id))
+  }
+
   fn detect_side_effect_of_member_expr(
     &self,
     member_expr: &ast::MemberExpression,
   ) -> SideEffectDetail {
     if self.is_expr_manual_pure_functions(member_expr.object()) {
+      return false.into();
+    }
+    // ES module namespace objects are frozen/sealed by spec — property reads
+    // on them are guaranteed side-effect-free.
+    if self.is_namespace_member_access(member_expr) == Some(true) {
       return false.into();
     }
     // Only `import.meta.url` is a spec-defined side-effect-free property read.
@@ -558,7 +587,7 @@ mod test {
     let options = Arc::new(NormalizedBundlerOptions::default());
     let flags = FlatOptions::from_shared_options(&options);
     ast.program().body.iter().any(|stmt| {
-      SideEffectDetector::new(&ast_scopes, flags, &options, None)
+      SideEffectDetector::new(&ast_scopes, flags, &options, None, None)
         .detect_side_effect_of_stmt(stmt)
         .has_side_effect()
     })
@@ -578,7 +607,8 @@ mod test {
       .body
       .iter()
       .map(|stmt| {
-        SideEffectDetector::new(&ast_scopes, flags, &options, None).detect_side_effect_of_stmt(stmt)
+        SideEffectDetector::new(&ast_scopes, flags, &options, None, None)
+          .detect_side_effect_of_stmt(stmt)
       })
       .collect_vec()
   }

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -335,6 +335,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
           self.immutable_ctx.flat_options,
           self.immutable_ctx.options,
           Some(&self.side_effect_free_call_expr_addr),
+          None,
         )
         .detect_side_effect_of_stmt(stmt);
         self.side_effect_detail_mutations.insert(stmt_info_idx, side_effect_detail);

--- a/packages/rolldown/tests/fixtures/issues/9061/_config.ts
+++ b/packages/rolldown/tests/fixtures/issues/9061/_config.ts
@@ -1,0 +1,23 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    transform: {
+      define: {
+        'process.env.NODE_ENV': '"production"',
+      },
+    },
+  },
+  afterTest(output) {
+    // The lazy chunk should NOT be emitted because:
+    // 1. TanStackRouterDevtoolsInProd is unused (tree-shaken)
+    // 2. Devtools.TanStackRouterDevtools (namespace member access) should be side-effect-free
+    // 3. So the TanStackRouterDevtools class (which contains import('./lazy.js')) is not included
+    const lazyChunk = output.output.find(
+      (item) => item.type === 'chunk' && item.fileName.includes('lazy'),
+    );
+    expect(lazyChunk).toBeUndefined();
+  },
+});

--- a/packages/rolldown/tests/fixtures/issues/9061/lazy.js
+++ b/packages/rolldown/tests/fixtures/issues/9061/lazy.js
@@ -1,0 +1,1 @@
+export const lazy = 'lazy chunk content';

--- a/packages/rolldown/tests/fixtures/issues/9061/main.js
+++ b/packages/rolldown/tests/fixtures/issues/9061/main.js
@@ -1,0 +1,5 @@
+import { TanStackRouterDevtools } from './solid-router-devtools.js';
+
+export function foo() {
+  console.log(TanStackRouterDevtools);
+}

--- a/packages/rolldown/tests/fixtures/issues/9061/solid-router-devtools.js
+++ b/packages/rolldown/tests/fixtures/issues/9061/solid-router-devtools.js
@@ -1,0 +1,10 @@
+import * as Devtools from './tan-stack-router-devtools.js';
+
+export const TanStackRouterDevtools =
+  process.env.NODE_ENV !== 'development'
+    ? function () {
+        return null;
+      }
+    : Devtools.TanStackRouterDevtools;
+
+export const TanStackRouterDevtoolsInProd = Devtools.TanStackRouterDevtools;

--- a/packages/rolldown/tests/fixtures/issues/9061/tan-stack-router-devtools.js
+++ b/packages/rolldown/tests/fixtures/issues/9061/tan-stack-router-devtools.js
@@ -1,0 +1,5 @@
+export class TanStackRouterDevtools {
+  foo() {
+    import('./lazy.js');
+  }
+}


### PR DESCRIPTION
## Summary
- Treat property reads on ES module namespace objects (`import * as ns`) as side-effect-free, since namespace objects are frozen/sealed by spec with no getters
- Track namespace import symbols in the AST scanner and pass them to the `SideEffectDetector`
- This allows tree-shaking of unused exports whose initializers reference namespace member expressions (e.g. `ns.foo`), preventing unnecessary dynamic chunks from being emitted

## Limitation

This optimization only applies to **direct** (one-level) namespace member access — e.g. `ns.foo` — not deeper chains like `ns.foo.bar`.

For `ns.foo.bar`, the outer `.bar` access has `ns.foo` (a member expression) as its object, not the namespace identifier directly, so it won't be recognized as a namespace access. While `ns.foo` itself is side-effect-free, the value it returns could be any object with getters, so treating `ns.foo.bar` as side-effect-free would require knowing the type of the resolved export.

Supporting deeper chains would require re-analyzing side effects after the `bind_imports_and_exports` phase, where member expressions are resolved to their target symbols through the module graph. This would add a second side-effect analysis pass, which has performance implications. The current single-level approach covers the most common patterns (like the reported issue) without requiring this additional pass.

Closes #9061