### PR TITLE
fix: await async export-star init wrappers

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1394,7 +1394,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 {
                   let wrapper_ref_name =
                     self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());
-                  program.body.push(self.snippet.call_expr_stmt(wrapper_ref_name));
+                  let init_call = self.snippet.call_expr_expr(wrapper_ref_name);
+                  let init_stmt = if importee_linking_info.is_tla_or_contains_tla_dependency {
+                    self.snippet.builder.statement_expression(
+                      SPAN,
+                      ast::Expression::AwaitExpression(
+                        self.snippet.builder.alloc_await_expression(SPAN, init_call),
+                      ),
+                    )
+                  } else {
+                    self.snippet.builder.statement_expression(SPAN, init_call)
+                  };
+                  program.body.push(init_stmt);
                 }
 
                 match importee.exports_kind {

--- a/crates/rolldown/tests/rolldown/issues/9083/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9083/_config.json
@@ -1,0 +1,7 @@
+{
+  "configVariants": [
+    {
+      "strictExecutionOrder": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/9083/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9083/_test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import { manager, setup } from './dist/main.js';
+
+setup();
+
+assert.strictEqual(manager.value, 'hello');
+assert.strictEqual(manager.ready, true);

--- a/crates/rolldown/tests/rolldown/issues/9083/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9083/_test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
-import { manager, setup } from './dist/main.js';
+import { manager } from './dist/main.js';
 
-setup();
-
+// Without the fix, barrel init calls init_middle() without awaiting it, so the
+// entry evaluates before `manager` is initialized and this import fails.
 assert.strictEqual(manager.value, 'hello');
 assert.strictEqual(manager.ready, true);

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region deep.js
+const value = "hello";
+await Promise.resolve();
+//#endregion
+//#region middle.js
+const manager = {
+	value,
+	ready: false
+};
+function setup() {
+	manager.ready = true;
+}
+//#endregion
+export { manager, setup };
+
+```
+
+# Variant: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region deep.js
+var value;
+var init_deep = __esmMin((async () => {
+	value = "hello";
+	await Promise.resolve();
+}));
+//#endregion
+//#region middle.js
+function setup() {
+	manager.ready = true;
+}
+var manager;
+var init_middle = __esmMin((async () => {
+	await init_deep();
+	manager = {
+		value,
+		ready: false
+	};
+}));
+//#endregion
+await __esmMin((async () => {
+	await init_middle();
+}))();
+export { manager, setup };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -7,8 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region deep.js
-await Promise.resolve();
-await Promise.resolve();
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+await sleep(100);
 //#endregion
 //#region middle.js
 const manager = {
@@ -35,10 +37,12 @@ export { manager };
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region deep.js
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 var value;
 var init_deep = __esmMin((async () => {
-	await Promise.resolve();
-	await Promise.resolve();
+	await sleep(100);
 	value = "hello";
 }));
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -7,19 +7,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region deep.js
-const value = "hello";
+await Promise.resolve();
 await Promise.resolve();
 //#endregion
 //#region middle.js
 const manager = {
-	value,
+	value: "hello",
 	ready: false
 };
 function setup() {
 	manager.ready = true;
 }
 //#endregion
-export { manager, setup };
+//#region main.js
+setup();
+//#endregion
+export { manager };
 
 ```
 
@@ -34,8 +37,9 @@ export { manager, setup };
 //#region deep.js
 var value;
 var init_deep = __esmMin((async () => {
-	value = "hello";
 	await Promise.resolve();
+	await Promise.resolve();
+	value = "hello";
 }));
 //#endregion
 //#region middle.js
@@ -51,9 +55,15 @@ var init_middle = __esmMin((async () => {
 	};
 }));
 //#endregion
-await __esmMin((async () => {
+//#region barrel.js
+var init_barrel = __esmMin((async () => {
 	await init_middle();
+}));
+//#endregion
+await __esmMin((async () => {
+	await init_barrel();
+	setup();
 }))();
-export { manager, setup };
+export { manager };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9083/barrel.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/barrel.js
@@ -1,0 +1,2 @@
+// Pure barrel re-export
+export * from './middle.js';

--- a/crates/rolldown/tests/rolldown/issues/9083/deep.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/deep.js
@@ -1,0 +1,3 @@
+export const value = 'hello';
+
+await Promise.resolve();

--- a/crates/rolldown/tests/rolldown/issues/9083/deep.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/deep.js
@@ -1,3 +1,6 @@
-export const value = 'hello';
-
+// Has top-level await — value is assigned after two awaits so a missing
+// await through the export-star barrel leaves downstream init incomplete.
 await Promise.resolve();
+await Promise.resolve();
+
+export const value = 'hello';

--- a/crates/rolldown/tests/rolldown/issues/9083/deep.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/deep.js
@@ -1,6 +1,7 @@
-// Has top-level await — value is assigned after two awaits so a missing
-// await through the export-star barrel leaves downstream init incomplete.
-await Promise.resolve();
-await Promise.resolve();
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+await sleep(100);
 
 export const value = 'hello';

--- a/crates/rolldown/tests/rolldown/issues/9083/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/main.js
@@ -1,0 +1,1 @@
+export * from './middle.js';

--- a/crates/rolldown/tests/rolldown/issues/9083/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/main.js
@@ -1,1 +1,6 @@
-export * from './middle.js';
+// Imports from barrel which re-exports from middle which transitively depends on deep (TLA)
+import { manager, setup } from './barrel.js';
+
+setup();
+
+export { manager };

--- a/crates/rolldown/tests/rolldown/issues/9083/middle.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/middle.js
@@ -1,9 +1,6 @@
 import { value } from './deep.js';
 
-const manager = { value, ready: false };
-
-function setup() {
+export const manager = { value, ready: false };
+export function setup() {
   manager.ready = true;
 }
-
-export { manager, setup };

--- a/crates/rolldown/tests/rolldown/issues/9083/middle.js
+++ b/crates/rolldown/tests/rolldown/issues/9083/middle.js
@@ -1,0 +1,9 @@
+import { value } from './deep.js';
+
+const manager = { value, ready: false };
+
+function setup() {
+  manager.ready = true;
+}
+
+export { manager, setup };


### PR DESCRIPTION
## Summary
- await async init wrappers when lowering `export * from` for ESM-wrapped modules with transitive TLA dependencies
- add a regression fixture for issue 9083 covering the transitive barrel case under `strictExecutionOrder`

## Testing
- `INSTA_UPDATE=always cargo run -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/issues/9083/_config.json`
- `INSTA_UPDATE=always cargo run -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/issues/9028/_config.json`
- `cargo fmt --all --check`

Partially fixes #9083 (Bug1 only).