### PR TITLE
fix: await async init in transitive strict-order reexports

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -164,7 +164,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           self.snippet.builder.vec(),
           false,
         );
-        body.push(self.snippet.builder.statement_expression(SPAN, init_call));
+        let init_stmt = if importee_linking_info.is_tla_or_contains_tla_dependency {
+          self.snippet.builder.statement_expression(
+            SPAN,
+            ast::Expression::AwaitExpression(
+              self.snippet.builder.alloc_await_expression(SPAN, init_call),
+            ),
+          )
+        } else {
+          self.snippet.builder.statement_expression(SPAN, init_call)
+        };
+        body.push(init_stmt);
       } else {
         // Importee is not included (barrel module) — traverse its import records
         // to find included importees transitively.

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/_config.json
@@ -1,0 +1,7 @@
+{
+  "configVariants": [
+    {
+      "strictExecutionOrder": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/_test.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { ready, value } from './dist/main.js';
+
+assert.strictEqual(value, 42);
+assert.strictEqual(ready, true);

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/artifacts.snap
@@ -1,0 +1,68 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region lib.js
+const value = 42;
+//#endregion
+//#region deep.js
+const value$1 = "hello";
+await Promise.resolve();
+//#endregion
+//#region middle.js
+globalThis.__bug2_ready = value$1 === "hello";
+//#endregion
+//#region main.js
+const ready = globalThis.__bug2_ready === true;
+//#endregion
+export { ready, value };
+
+```
+
+# Variant: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var value;
+var init_lib = __esmMin((() => {
+	value = 42;
+}));
+//#endregion
+//#region deep.js
+var value$1;
+var init_deep = __esmMin((async () => {
+	value$1 = "hello";
+	await Promise.resolve();
+}));
+//#endregion
+//#region middle.js
+var init_middle = __esmMin((async () => {
+	await init_deep();
+	globalThis.__bug2_ready = value$1 === "hello";
+}));
+//#endregion
+//#region barrel.js
+var init_barrel = __esmMin((async () => {
+	init_lib();
+	await init_middle();
+}));
+//#endregion
+//#region main.js
+var ready;
+//#endregion
+await __esmMin((async () => {
+	await init_barrel();
+	ready = globalThis.__bug2_ready === true;
+}))();
+export { ready, value };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/barrel.js
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/barrel.js
@@ -1,0 +1,2 @@
+export { value } from './lib.js';
+export { unused } from './middle.js';

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/deep.js
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/deep.js
@@ -1,0 +1,3 @@
+export const value = 'hello';
+
+await Promise.resolve();

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/lib.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/main.js
@@ -1,0 +1,5 @@
+import { value } from './barrel.js';
+
+const ready = globalThis.__bug2_ready === true;
+
+export { ready, value };

--- a/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/middle.js
+++ b/crates/rolldown/tests/rolldown/issues/9083_gen_transitive/middle.js
@@ -1,0 +1,5 @@
+import { value } from './deep.js';
+
+globalThis.__bug2_ready = value === 'hello';
+
+export const unused = value;


### PR DESCRIPTION
## Summary
- partially fixes #9083 (bug 2) in `generate_transitive_esm_init`
- await async ESM init wrappers when strict execution order emits fallback init calls for excluded re-export statements
- keep Bug1 out of scope here; the direct included `export *` path is handled separately in #9101

## Tests
- add `crates/rolldown/tests/rolldown/issues/9083_gen_transitive`
- `cargo test -p rolldown 9083_gen_transitive --test integration`
- `cargo run -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/issues/9083_gen_transitive/_config.json`