### PR TITLE
fix: keep browser:false imports ignored when plugins return this.resolve()

### DIFF
--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -14,6 +14,28 @@ fn is_http_url(s: &str) -> bool {
   s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
 }
 
+fn should_preserve_ignored<Fs: FileSystem>(
+  resolver: &Resolver<Fs>,
+  specifier: &str,
+  importer: Option<&str>,
+  import_kind: ImportKind,
+  is_user_defined_entry: bool,
+  resolved_id: &str,
+) -> bool {
+  // `this.resolve()` may surface browser:false mappings as the ignored path itself.
+  // If a plugin returns that object from `resolveId`, recover the ignored bit so
+  // module loading still produces an empty module instead of trying to read the path.
+  match resolver.resolve(
+    importer.map(Path::new),
+    specifier,
+    import_kind,
+    is_user_defined_entry,
+  ) {
+    Err(ResolveError::Ignored(path)) => path == Path::new(resolved_id),
+    _ => false,
+  }
+}
+
 /// Infers ModuleDefFormat from file path and optional package.json.
 /// This matches the logic used in the internal resolver's `infer_module_def_format`.
 pub fn infer_module_def_format(
@@ -78,10 +100,22 @@ pub async fn resolve_id_with_plugins<Fs: FileSystem>(
         .as_ref()
         .map(|p| resolver.try_get_package_json_or_create(p.as_path()))
         .transpose()?;
+      let external = r.external.unwrap_or_default();
+      let ignored = package_json.is_none()
+        && !external.is_external()
+        && should_preserve_ignored(
+          resolver,
+          specifier,
+          importer,
+          import_kind,
+          is_user_defined_entry,
+          r.id.as_str(),
+        );
       return Ok(Ok(ResolvedId {
         module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
         id: ModuleId::new(r.id),
-        external: r.external.unwrap_or_default(),
+        ignored,
+        external,
         normalize_external_id: r.normalize_external_id,
         side_effects: r.side_effects,
         package_json,
@@ -108,10 +142,22 @@ pub async fn resolve_id_with_plugins<Fs: FileSystem>(
       .as_ref()
       .map(|p| resolver.try_get_package_json_or_create(p.as_path()))
       .transpose()?;
+    let external = r.external.unwrap_or_default();
+    let ignored = package_json.is_none()
+      && !external.is_external()
+      && should_preserve_ignored(
+        resolver,
+        specifier,
+        importer,
+        import_kind,
+        is_user_defined_entry,
+        r.id.as_str(),
+      );
     return Ok(Ok(ResolvedId {
       module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
       id: ModuleId::new(r.id),
-      external: r.external.unwrap_or_default(),
+      ignored,
+      external,
       normalize_external_id: r.normalize_external_id,
       side_effects: r.side_effects,
       package_json,

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -25,12 +25,7 @@ fn should_preserve_ignored<Fs: FileSystem>(
   // `this.resolve()` may surface browser:false mappings as the ignored path itself.
   // If a plugin returns that object from `resolveId`, recover the ignored bit so
   // module loading still produces an empty module instead of trying to read the path.
-  match resolver.resolve(
-    importer.map(Path::new),
-    specifier,
-    import_kind,
-    is_user_defined_entry,
-  ) {
+  match resolver.resolve(importer.map(Path::new), specifier, import_kind, is_user_defined_entry) {
     Err(ResolveError::Ignored(path)) => path == Path::new(resolved_id),
     _ => false,
   }

--- a/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/_config.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const entry = path.join(__dirname, './main.js');
+
+export default defineTest({
+  config: {
+    input: entry,
+    platform: 'browser',
+    plugins: [
+      {
+        name: 'return-this-resolve',
+        async resolveId(source, importer, options) {
+          if (!importer) {
+            return;
+          }
+          const resolved = await this.resolve(source, importer, {
+            ...options,
+            skipSelf: true,
+          });
+
+          return resolved;
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    expect(output.output[0].code).toBe('');
+  },
+});

--- a/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/demo/index.js
+++ b/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/demo/index.js
@@ -1,0 +1,1 @@
+import 'buffer';

--- a/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/demo/package.json
+++ b/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/demo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo",
+  "type": "module",
+  "browser": {
+    "buffer": false
+  }
+}

--- a/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/main.js
+++ b/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/main.js
@@ -1,0 +1,1 @@
+import 'demo-pkg';

--- a/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/main.js
+++ b/packages/rolldown/tests/fixtures/resolve/issue-browser-false-return-resolved/main.js
@@ -1,1 +1,1 @@
-import 'demo-pkg';
+import './demo/index.js';


### PR DESCRIPTION
Closes #9107

This fixes a case where `browser: false` handling was lost if a plugin returned the result of `this.resolve(..., { skipSelf: true })` from `resolveId`.

In normal browser resolution, Rolldown correctly treats those imports as ignored. But in the plugin-return path, the returned `ResolvedId` could lose that ignored state. In the repro, that caused `buffer` to resolve to the package directory and later fail during loading with `Is a directory`.

## Fix

When a plugin returns a resolved id, Rolldown now checks whether the same request would be treated as ignored by the internal resolver. If so, the returned `ResolvedId` is marked as ignored as well.

This keeps the plugin-return path consistent with normal browser resolution.

## Test

- adds a regression fixture for a `browser: false` import resolved through a plugin that returns `this.resolve()`
