### PR TITLE
fix: include array rest pattern in binding_identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,6 @@ dependencies = [
  "oxc",
  "rolldown_common",
  "rolldown_utils",
- "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
 simdutf8 = "0.1.5"
-smallvec = "1.15.0"
 string_cache = "0.9.0"
 sugar_path = { version = "2.0.1", features = ["cached_current_dir"] }
 terminal_size = "0.4.2"

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -38,7 +38,7 @@ use rolldown_common::{
   StmtInfo, StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags,
   TaggedSymbolRef, ThisExprReplaceKind, generate_replace_this_expr_map,
 };
-use rolldown_ecmascript_utils::{BindingPatternExt, FunctionExt};
+use rolldown_ecmascript_utils::FunctionExt;
 use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
 use rolldown_std_utils::PathExt;
 use rolldown_utils::concat_string;
@@ -769,7 +769,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         match decl {
           ast::Declaration::VariableDeclaration(var_decl) => {
             var_decl.declarations.iter().for_each(|decl| {
-              decl.id.binding_identifiers().into_iter().for_each(|id| {
+              decl.id.get_binding_identifiers().into_iter().for_each(|id| {
                 self.add_local_export(&id.name, id.symbol_id(), id.span);
               });
               if let BindingPattern::BindingIdentifier(ref binding) = decl.id {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -546,7 +546,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     let mut ret = vec![];
     let exprs = decl.declarations.iter_mut().filter_map(|var_decl| {
-      ret.extend(var_decl.id.binding_identifiers().iter().map(|item| item.name));
+      ret.extend(var_decl.id.get_binding_identifiers().iter().map(|item| item.name));
       // Turn `var ... = ...` to `... = ...`
       if let Some(ref mut init_expr) = var_decl.init {
         let left = var_decl.id.take_in(self.alloc).into_assignment_target(self.alloc);

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "strictExecutionOrder": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var stages;
+var init_lib = __esmMin((() => {
+	stages = {
+		a: "1",
+		b: "2",
+		c: "3"
+	};
+}));
+//#endregion
+//#region main.js
+var first, rest, all;
+//#endregion
+__esmMin((() => {
+	init_lib();
+	[first, ...rest] = Object.values(stages);
+	if (!first) throw new Error("empty");
+	all = [first, ...rest];
+	assert.deepStrictEqual(all, [
+		"1",
+		"2",
+		"3"
+	]);
+}))();
+export { all };
+
+```

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/lib.js
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/lib.js
@@ -1,0 +1,1 @@
+export const stages = { a: '1', b: '2', c: '3' };

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/main.js
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/main.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import { stages } from './lib';
+const values = Object.values(stages);
+const [first, ...rest] = values;
+if (!first) throw new Error('empty');
+export const all = [first, ...rest];
+assert.deepStrictEqual(all, ['1', '2', '3']);

--- a/crates/rolldown_ecmascript_utils/Cargo.toml
+++ b/crates/rolldown_ecmascript_utils/Cargo.toml
@@ -19,4 +19,3 @@ memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_utils = { workspace = true }
-smallvec = { workspace = true }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -2,52 +2,23 @@ use oxc::{
   allocator::{Allocator, Box, Dummy as _, IntoIn as _, TakeIn as _},
   ast::ast::{
     ArrayAssignmentTarget, ArrayExpressionElement, AssignmentTarget, AssignmentTargetMaybeDefault,
-    AssignmentTargetRest, AssignmentTargetWithDefault, BindingIdentifier, BindingPattern,
-    Expression, ObjectAssignmentTarget, ObjectPropertyKind, PropertyKind,
+    AssignmentTargetRest, AssignmentTargetWithDefault, BindingPattern, Expression,
+    ObjectAssignmentTarget, ObjectPropertyKind, PropertyKind,
   },
   span::SPAN,
 };
-use smallvec::SmallVec;
 
 use crate::AstSnippet;
 
 use super::binding_property_ext::BindingPropertyExt as _;
 
 pub trait BindingPatternExt<'ast> {
-  fn binding_identifiers(&self) -> smallvec::SmallVec<[&Box<'_, BindingIdentifier<'ast>>; 1]>;
-
   fn into_assignment_target(self, alloc: &'ast Allocator) -> AssignmentTarget<'ast>;
 
   fn into_expression(self, snippet: &AstSnippet<'ast>) -> Expression<'ast>;
 }
 
 impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
-  fn binding_identifiers(&self) -> smallvec::SmallVec<[&Box<'_, BindingIdentifier<'ast>>; 1]> {
-    let mut stack = vec![self];
-    let mut ret = SmallVec::default();
-    while let Some(binding) = stack.pop() {
-      match binding {
-        BindingPattern::BindingIdentifier(id) => {
-          ret.push(id);
-        }
-        BindingPattern::ArrayPattern(arr_pat) => {
-          stack.extend(arr_pat.elements.iter().flatten().rev());
-        }
-        BindingPattern::ObjectPattern(obj_pat) => {
-          if let Some(obj_pat) = &obj_pat.rest {
-            stack.push(&obj_pat.argument);
-          }
-          stack.extend(obj_pat.properties.iter().map(|prop| &prop.value).rev());
-        }
-        //
-        BindingPattern::AssignmentPattern(assign_pat) => {
-          stack.push(&assign_pat.left);
-        }
-      }
-    }
-    ret
-  }
-
   fn into_assignment_target(self, alloc: &'ast Allocator) -> AssignmentTarget<'ast> {
     match self {
       // Turn `var a = 1` into `a = 1`


### PR DESCRIPTION
## Summary
- Array destructuring rest patterns (`const [first, ...rest] = values`) were missing from binding identifier collection, causing `ReferenceError` in scope-hoisted output
- Replaced the buggy custom `BindingPatternExt::binding_identifiers()` with oxc's built-in `get_binding_identifiers()` which handles all pattern variants correctly
- Removed the now-unused `smallvec` dependency from `rolldown_ecmascript_utils`

Closes #9105

## Test plan
- [x] Added integration test `es_module/array_destructuring_rest_binding` reproducing the reported scenario
- [x] `cargo check` passes
- [x] Existing `top_level_var` tests still pass