### PR TITLE
refactor: calculate side-effect-free function symbols on demand

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -37,7 +37,6 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub options: &'me SharedOptions,
   pub file_emitter: &'me SharedFileEmitter,
   pub constant_value_map: &'me FxHashMap<SymbolRef, ConstExportMeta>,
-  pub side_effect_free_function_symbols: &'me FxHashSet<SymbolRef>,
   pub safely_merge_cjs_ns_map: &'me FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub used_symbol_refs: &'me FxHashSet<SymbolRef>,
   /// Pre-resolved paths for external modules (always a `FxHashMap` variant).

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -426,7 +426,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             .and_then(|ref_id| self.scope.scoping().get_reference(ref_id).symbol_id())
             .map(|id| {
               let symbol_ref = self.ctx.symbol_db.canonical_ref_for((self.ctx.idx, id).into());
-              self.ctx.side_effect_free_function_symbols.contains(&symbol_ref)
+              symbol_ref.is_side_effect_free_function(self.ctx.symbol_db, self.ctx.modules)
                 && symbol_ref.is_not_reassigned(self.ctx.symbol_db) == Some(true)
             })
             .unwrap_or(false);

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
 
-use rolldown_common::{
-  ConcatenateWrappedModuleKind, EcmaViewMeta, PrependRenderedImport, SymbolRef, SymbolRefFlags,
-};
+use rolldown_common::{ConcatenateWrappedModuleKind, PrependRenderedImport};
 use rolldown_utils::{index_vec_ext::IndexVecExt as _, rayon::ParallelIterator as _};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tracing::debug_span;
 
 use crate::{chunk_graph::ChunkGraph, module_finalizers::ScopeHoistingFinalizerContext};
@@ -14,30 +12,6 @@ use super::GenerateStage;
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn finalize_modules(&mut self, chunk_graph: &mut ChunkGraph) {
-    let side_effect_free_function_symbols = self
-      .link_output
-      .module_table
-      .iter()
-      .zip(self.link_output.symbol_db.inner().iter())
-      .filter_map(|(m, symbol_for_module)| {
-        let normal_module = m.as_normal()?;
-        let idx = normal_module.idx;
-        normal_module
-          .meta
-          .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
-          .then(move || {
-            let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
-              flag
-                .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
-            }))
-          })
-          .flatten()
-      })
-      .flatten()
-      .collect::<FxHashSet<SymbolRef>>();
-
     let transfer_parts_rendered_maps = debug_span!("finalize_modules").in_scope(|| {
       self
         .link_output
@@ -69,7 +43,6 @@ impl GenerateStage<'_> {
             options: self.options,
             file_emitter: &self.plugin_driver.file_emitter,
             constant_value_map: &self.link_output.global_constant_symbol_map,
-            side_effect_free_function_symbols: &side_effect_free_function_symbols,
             safely_merge_cjs_ns_map: &self.link_output.safely_merge_cjs_ns_map,
             used_symbol_refs: &self.link_output.used_symbol_refs,
             resolved_paths: self.resolved_paths.as_ref(),

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -10,7 +10,7 @@ use oxc::{
   ast_visit::{Visit, walk},
 };
 use rolldown_common::{
-  AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, ModuleIdx,
+  AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, IndexModules, ModuleIdx,
   SharedNormalizedBundlerOptions, SideEffectDetail, StmtInfoIdx, SymbolRef, SymbolRefDb,
   SymbolRefFlags,
 };
@@ -53,34 +53,14 @@ type ModuleIdxAndStmtIdxToDynamicImportExprAddrMap =
   FxHashMap<ModuleIdx, FxHashMap<StmtInfoIdx, FxHashSet<Address>>>;
 
 impl LinkStage<'_> {
-  fn prepare_cross_module_optimization(&mut self) -> CrossModuleOptimizationConfig {
-    let side_effect_free_function_symbols = self
-      .module_table
-      .iter()
-      .zip(self.symbols.inner().iter())
-      .filter_map(|(m, symbol_for_module)| {
-        let normal_module = m.as_normal()?;
-        let idx = normal_module.idx;
-        normal_module
-          .meta
-          .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
-          .then(move || {
-            let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
-              flag
-                .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
-            }))
-          })
-          .flatten()
-      })
-      .flatten()
-      .collect::<FxHashSet<SymbolRef>>();
-    self.side_effects_free_function_symbol_ref = side_effect_free_function_symbols;
+  fn prepare_cross_module_optimization(&self) -> CrossModuleOptimizationConfig {
+    let has_side_effect_free_functions = self.module_table.iter().any(|m| {
+      m.as_normal()
+        .is_some_and(|n| n.meta.contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction))
+    });
 
     #[expect(clippy::bool_to_int_with_if)]
-    let other_optimization_pass =
-      if self.side_effects_free_function_symbol_ref.is_empty() { 0 } else { 1 };
+    let other_optimization_pass = if has_side_effect_free_functions { 1 } else { 0 };
     let cross_module_inline_const_pass = self.options.optimization.inline_const_pass() - 1;
     CrossModuleOptimizationConfig {
       pass: cross_module_inline_const_pass.max(other_optimization_pass),
@@ -222,7 +202,7 @@ impl LinkStage<'_> {
               export_default_symbol: module.default_export_ref,
               module_idx,
               config: &cross_module_inline_const_ctx.config,
-              global_side_effect_free_function_symbols: &self.side_effects_free_function_symbol_ref,
+              modules: &self.module_table.modules,
               symbols: &self.symbols,
               flat_options: self.flat_options,
               options: self.options,
@@ -285,7 +265,7 @@ struct CrossModuleOptimizationImmutableCtx<'a, 'ast: 'a> {
   export_default_symbol: SymbolRef,
   module_idx: ModuleIdx,
   config: &'a CrossModuleOptimizationConfig,
-  global_side_effect_free_function_symbols: &'a FxHashSet<SymbolRef>,
+  modules: &'a IndexModules,
   symbols: &'a SymbolRefDb,
   flat_options: FlatOptions,
   options: &'a SharedNormalizedBundlerOptions,
@@ -378,8 +358,8 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
           .immutable_ctx
           .symbols
           .canonical_ref_for((self.immutable_ctx.module_idx, symbol_id).into());
-        let is_free =
-          self.immutable_ctx.global_side_effect_free_function_symbols.contains(&symbol_ref);
+        let is_free = symbol_ref
+          .is_side_effect_free_function(self.immutable_ctx.symbols, self.immutable_ctx.modules);
         let is_annotation_only = is_free
           && self
             .immutable_ctx

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -100,7 +100,6 @@ pub struct LinkStage<'a> {
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
   pub flat_options: FlatOptions,
-  pub side_effects_free_function_symbol_ref: FxHashSet<SymbolRef>,
   pub user_defined_entry_modules: FxHashSet<ModuleIdx>,
   pub tla_module_count: usize,
   /// Centralized map of modules that use top-level `await` → span of the
@@ -191,7 +190,6 @@ impl<'a> LinkStage<'a> {
         .overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids: scan_stage_output.entry_point_to_reference_ids,
       flat_options: scan_stage_output.flat_options,
-      side_effects_free_function_symbol_ref: FxHashSet::default(),
       user_defined_entry_modules: scan_stage_output.user_defined_entry_modules,
       tla_module_count: scan_stage_output.tla_module_count,
       tla_keyword_span_map: scan_stage_output.tla_keyword_span_map,

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -1,7 +1,7 @@
 use oxc::semantic::SymbolId;
 use rolldown_std_utils::OptionExt;
 
-use crate::{IndexModules, Module, ModuleIdx, SymbolRefDb, SymbolRefFlags};
+use crate::{EcmaViewMeta, IndexModules, Module, ModuleIdx, SymbolRefDb, SymbolRefFlags};
 
 use super::symbol_ref_db::{GetLocalDb, GetLocalDbMut};
 
@@ -46,6 +46,16 @@ impl SymbolRef {
     let flags = self.flags(db)?;
     // Not having this flag means we don't know
     flags.contains(SymbolRefFlags::IsNotReassigned).then_some(true)
+  }
+
+  pub fn is_side_effect_free_function(&self, db: &SymbolRefDb, modules: &IndexModules) -> bool {
+    let Some(normal_module) = modules[self.owner].as_normal() else {
+      return false;
+    };
+    if !normal_module.meta.contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction) {
+      return false;
+    }
+    self.flags(db).is_some_and(|flag| flag.contains(SymbolRefFlags::SideEffectsFreeFunction))
   }
 
   pub fn is_declared_in_root_scope(&self, db: &SymbolRefDb) -> bool {


### PR DESCRIPTION
## Summary

- Replaces pre-computed FxHashSet<SymbolRef> with on-demand O(1) lookups via a new SymbolRef::is_side_effect_free_function() method.
- Eliminates the upfront sequential scan of all modules/symbols and the HashSet allocation in both the link and generate stages.
- Since the checks now happen inside par_iter loops rather than in a sequential pre-computation step, the work is distributed across worker threads - each thread only checks the symbols it actually encounters.