### PR TITLE
fix: improve error message for invalid return values in function options

### DIFF
--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -1,12 +1,46 @@
-use std::sync::Arc;
+use std::{ptr, sync::Arc};
 
 use futures::Future;
 use napi::{
-  Either, Status,
-  bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise},
-  threadsafe_function::{ThreadsafeFunction, UnknownReturnValue},
+  Either, Status, ValueType,
+  bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue},
+  sys,
+  threadsafe_function::ThreadsafeFunction,
 };
-use rolldown_utils::debug::pretty_type_name;
+
+/// Used as the fallback branch in `Either<Ret, InvalidReturnValue>` to catch
+/// type mismatches from JS function options. Always passes NAPI validation so
+/// that when `Ret` validation fails, the error is handled in Rust with a clear
+/// message instead of becoming an uncatchable `napi_fatal_exception`.
+pub struct InvalidReturnValue {
+  pub value_type: ValueType,
+}
+
+impl TypeName for InvalidReturnValue {
+  fn type_name() -> &'static str {
+    "InvalidReturnValue"
+  }
+
+  fn value_type() -> ValueType {
+    ValueType::Unknown
+  }
+}
+
+impl ValidateNapiValue for InvalidReturnValue {
+  unsafe fn validate(
+    _env: sys::napi_env,
+    _napi_val: sys::napi_value,
+  ) -> napi::Result<sys::napi_value> {
+    Ok(ptr::null_mut())
+  }
+}
+
+impl FromNapiValue for InvalidReturnValue {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let value_type = napi::type_of!(env, napi_val)?;
+    Ok(InvalidReturnValue { value_type })
+  }
+}
 
 /// `JsCallback`  is a type alias for `ThreadsafeFunction`. It represents a JavaScript function that passed to Rust side.
 /// Related concepts are complex, so we use `JsCallback` to simplify the mental model. For details, please refer to:
@@ -68,7 +102,7 @@ use rolldown_utils::debug::pretty_type_name;
 /// - Js: `(a: string | null | undefined, b: number) => Promise<number | null | undefined | void> | number | null | undefined | void`
 /// - Js(Simplified): `(a: Nullable<string>, b: number) => MaybePromise<VoidNullable<number>>`
 pub type JsCallback<Args = (), Ret = ()> =
-  Arc<ThreadsafeFunction<Args, Either<Ret, UnknownReturnValue>, Args, Status, false, true>>;
+  Arc<ThreadsafeFunction<Args, Either<Ret, InvalidReturnValue>, Args, Status, false, true>>;
 
 /// Shortcut for `JsCallback<FnArgs<..., Either<Promise<Ret>, Ret>>`, which could be simplified to `MaybeAsyncJsCallback<...>, Ret>`.
 pub type MaybeAsyncJsCallback<Args = (), Ret = ()> = JsCallback<Args, Either<Promise<Ret>, Ret>>;
@@ -80,29 +114,49 @@ pub trait JsCallbackExt<Args, Ret> {
 impl<Args, Ret> JsCallbackExt<Args, Ret> for JsCallback<Args, Ret>
 where
   Args: 'static + Send + JsValuesTupleIntoVec,
-  Ret: 'static + Send + FromNapiValue,
-  napi::Either<Ret, UnknownReturnValue>: FromNapiValue,
+  Ret: 'static + Send + FromNapiValue + TypeName,
+  napi::Either<Ret, InvalidReturnValue>: FromNapiValue,
 {
   async fn invoke_async(&self, args: Args) -> Result<Ret, napi::Error> {
     match self.call_async(args).await? {
       Either::A(ret) => Ok(ret),
-      Either::B(_unknown) => create_unknown_return_error::<Ret, Self>(),
+      Either::B(invalid) => Err(create_invalid_return_error(
+        invalid.value_type,
+        Ret::value_type(),
+        rolldown_utils::debug::pretty_type_name::<Self>(),
+      )),
     }
   }
 }
 
-fn create_unknown_return_error<Ret, T>() -> Result<Ret, napi::Error> {
-  // TODO: should provide more information about the unknown return value
-  let js_type = "unknown";
-  let expected_rust_type = pretty_type_name::<Ret>();
+fn js_type_name(value_type: ValueType) -> &'static str {
+  match value_type {
+    ValueType::Undefined => "undefined",
+    ValueType::Null => "null",
+    ValueType::Boolean => "boolean",
+    ValueType::Number => "number",
+    ValueType::String => "string",
+    ValueType::Symbol => "symbol",
+    ValueType::Object => "object",
+    ValueType::Function => "function",
+    ValueType::External => "external",
+    ValueType::Unknown => "unknown",
+  }
+}
 
-  Err(napi::Error::new(
-    napi::Status::InvalidArg,
+fn create_invalid_return_error(
+  received: ValueType,
+  expected: ValueType,
+  fn_type: std::borrow::Cow<'_, str>,
+) -> napi::Error {
+  napi::Error::new(
+    Status::InvalidArg,
     format!(
-      "UNKNOWN_RETURN_VALUE. Cannot convert {js_type} to `{expected_rust_type}` in {}.",
-      pretty_type_name::<T>(),
+      "The function returned `{}`, but expected `{}` in `{fn_type}`.",
+      js_type_name(received),
+      js_type_name(expected),
     ),
-  ))
+  )
 }
 
 pub trait MaybeAsyncJsCallbackExt<Args, Ret> {
@@ -113,29 +167,18 @@ pub trait MaybeAsyncJsCallbackExt<Args, Ret> {
 impl<Args, Ret> MaybeAsyncJsCallbackExt<Args, Ret> for JsCallback<Args, Either<Promise<Ret>, Ret>>
 where
   Args: 'static + Send + JsValuesTupleIntoVec,
-  Ret: 'static + Send + FromNapiValue,
-  napi::Either<napi::Either<Promise<Ret>, Ret>, UnknownReturnValue>: FromNapiValue,
+  Ret: 'static + Send + FromNapiValue + TypeName,
+  napi::Either<napi::Either<Promise<Ret>, Ret>, InvalidReturnValue>: FromNapiValue,
 {
-  #[expect(clippy::manual_async_fn)]
-  fn await_call(&self, args: Args) -> impl Future<Output = Result<Ret, napi::Error>> + Send {
-    async move {
-      match self.call_async(args).await? {
-        Either::A(Either::A(promise)) => promise.await,
-        Either::A(Either::B(ret)) => Ok(ret),
-        Either::B(_unknown) => {
-          // TODO: should provide more information about the unknown return value
-          let js_type = "unknown";
-          let expected_rust_type = pretty_type_name::<Ret>();
-
-          Err(napi::Error::new(
-            napi::Status::InvalidArg,
-            format!(
-              "UNKNOWN_RETURN_VALUE. Cannot convert {js_type} to `{expected_rust_type}` in {}.",
-              pretty_type_name::<Self>(),
-            ),
-          ))
-        }
-      }
+  async fn await_call(&self, args: Args) -> Result<Ret, napi::Error> {
+    match self.call_async(args).await? {
+      Either::A(Either::A(promise)) => promise.await,
+      Either::A(Either::B(ret)) => Ok(ret),
+      Either::B(invalid) => Err(create_invalid_return_error(
+        invalid.value_type,
+        Ret::value_type(),
+        rolldown_utils::debug::pretty_type_name::<Self>(),
+      )),
     }
   }
 }


### PR DESCRIPTION
Related to #9005

## Problem

When a user's JS function option (plugin hook, `external`, `treeshake.moduleSideEffects`, etc.) returned a value whose type did not match what Rust expected, the error was unhelpful in two ways:

1. **The message was vague.** Errors read like:
   ```
   UNKNOWN_RETURN_VALUE. Cannot convert unknown to `Option<String>` in ThreadsafeFunction<..., Either<..., UnknownReturnValue>, ...>.
   ```
   The "received" side was always the literal string `"unknown"` — we never inspected the actual JS value — and the "expected" side was a Rust type name (`Option<String>`) that plugin authors writing JavaScript do not recognise.

2. **In some paths the mismatch bypassed our error channel entirely** and surfaced as an uncatchable `napi_fatal_exception`, because NAPI's built-in `UnknownReturnValue` fallback validates as `Unknown` and lets the underlying type check fail further up the stack.

## Fix

Replace NAPI's `UnknownReturnValue` with a custom `InvalidReturnValue` type in `crates/rolldown_binding/src/types/js_callback.rs`:

- `InvalidReturnValue` captures the **actual `ValueType`** of whatever JS returned (`string`, `number`, `object`, `function`, …) by inspecting the napi value in its `FromNapiValue` impl.
- Its `ValidateNapiValue` impl always succeeds, so type mismatches are consistently caught on the Rust side as a clean `napi::Error` instead of becoming a fatal exception.
- `JsCallback<Args, Ret>` is retyped from `Either<Ret, UnknownReturnValue>` to `Either<Ret, InvalidReturnValue>`. When the `Ret` branch fails to validate, we now hit the `Either::B(invalid)` arm with real information.
- The new error message is:
  ```
  The function returned `string`, but expected `number` in `ThreadsafeFunction<(String, bool), ..., ...>`.
  ```
  - Both `received` and `expected` are printed as **JS type names** (via a `js_type_name(ValueType)` helper) so the text reads naturally to JS plugin authors.
  - `fn_type` keeps `pretty_type_name::<Self>()` from the previous implementation so the callback's `Args`/`Ret` signature is still visible for debugging — this is what tells you *which* hook threw.
- `invoke_async` / `await_call` are simplified into plain `async fn`s; the `#[expect(clippy::manual_async_fn)]` workaround is no longer needed.