### PR TITLE
chore: disable Renovate auto-updates for oxc packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["oxc-node"],
       "schedule": ["at any time"]
+    },
+    {
+      "description": "Disable oxc auto-updates — upgraded manually via `upgrade-oxc` skill",
+      "matchPackageNames": ["/^oxc/", "/^@oxc-project/"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,7 @@
     {
       "description": "Disable oxc auto-updates — upgraded manually via `upgrade-oxc` skill",
       "matchPackageNames": ["/^oxc/", "/^@oxc-project/"],
+      "excludePackageNames": ["oxc-node"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Adds a Renovate package rule to disable automatic updates for all oxc* and @oxc-project/* packages. These are upgraded manually via the upgrade-oxc skill to avoid breaking changes from automated bumps.


related pr https://github.com/rolldown/rolldown/pull/9128#issuecomment-4257192291