### PR TITLE
refactor: extract UsedSymbolRefs newtype wrapper

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
   ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts, RuntimeModuleBrief,
-  SharedFileEmitter, SymbolRef, SymbolRefDb,
+  SharedFileEmitter, SymbolRef, SymbolRefDb, UsedSymbolRefs,
 };
 
 pub type FinalizerMutableFields = (
@@ -38,7 +38,7 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub file_emitter: &'me SharedFileEmitter,
   pub constant_value_map: &'me FxHashMap<SymbolRef, ConstExportMeta>,
   pub safely_merge_cjs_ns_map: &'me FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
-  pub used_symbol_refs: &'me FxHashSet<SymbolRef>,
+  pub used_symbol_refs: &'me UsedSymbolRefs,
   /// Pre-resolved paths for external modules (always a `FxHashMap` variant).
   pub resolved_paths: Option<&'me PathsOutputOption>,
   /// True if any module in the bundle has enum member values to inline.

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,7 +6,7 @@ use oxc_index::IndexVec;
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, EntryPoint, EntryPointKind, FlatOptions, ImportKind, ModuleIdx, ModuleTable,
-  PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
+  PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb, UsedSymbolRefs,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
@@ -66,7 +66,7 @@ pub struct LinkStageOutput {
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
-  pub used_symbol_refs: FxHashSet<SymbolRef>,
+  pub used_symbol_refs: UsedSymbolRefs,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
@@ -94,7 +94,7 @@ pub struct LinkStage<'a> {
   pub errors: Vec<BuildDiagnostic>,
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
-  pub used_symbol_refs: FxHashSet<SymbolRef>,
+  pub used_symbol_refs: UsedSymbolRefs,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -187,7 +187,7 @@ impl<'a> LinkStage<'a> {
       ast_table: scan_stage_output.index_ecma_ast,
       dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
       options,
-      used_symbol_refs: FxHashSet::default(),
+      used_symbol_refs: UsedSymbolRefs::default(),
       safely_merge_cjs_ns_map: FxHashMap::default(),
       normal_symbol_exports_chain_map: FxHashMap::default(),
       external_import_namespace_merger: FxHashMap::default(),

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -10,7 +10,8 @@ use rolldown_common::{
   ModuleNamespaceIncludedReason, ModuleType, NormalModule, NormalizedBundlerOptions,
   RUNTIME_HELPER_NAMES, RUNTIME_MODULE_ID, RuntimeHelper, RuntimeModuleBrief, SideEffectDetail,
   StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
-  dynamic_import_usage::DynamicImportExportsUsage, side_effects::DeterminedSideEffects,
+  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  side_effects::DeterminedSideEffects,
 };
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
@@ -59,7 +60,7 @@ pub struct IncludeContext<'a> {
   pub inline_const_smart: bool,
   pub runtime_idx: ModuleIdx,
   pub metas: &'a LinkingMetadataVec,
-  pub used_symbol_refs: &'a mut FxHashSet<SymbolRef>,
+  pub used_symbol_refs: &'a mut UsedSymbolRefs,
   pub constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
   pub options: &'a NormalizedBundlerOptions,
   pub normal_symbol_exports_chain_map: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -82,7 +83,7 @@ impl<'a> IncludeContext<'a> {
     is_module_included_vec: &'a mut ModuleInclusionVec,
     runtime_idx: ModuleIdx,
     metas: &'a LinkingMetadataVec,
-    used_symbol_refs: &'a mut FxHashSet<SymbolRef>,
+    used_symbol_refs: &'a mut UsedSymbolRefs,
     constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
     options: &'a NormalizedBundlerOptions,
     normal_symbol_exports_chain_map: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -212,7 +213,7 @@ impl LinkStage<'_> {
         m.as_normal().map_or(IndexBitSet::default(), |m| IndexBitSet::new(m.stmt_infos.len()))
       })
       .collect::<IndexVec<ModuleIdx, _>>();
-    let mut used_symbol_refs = FxHashSet::default();
+    let mut used_symbol_refs = UsedSymbolRefs::default();
     let mut is_module_included_vec: ModuleInclusionVec =
       IndexBitSet::new(self.module_table.modules.len());
     let mut module_namespace_included_reason: ModuleNamespaceReasonVec =

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -216,6 +216,7 @@ pub use crate::{
   types::symbol_ref_db::{
     GetLocalDb, GetLocalDbMut, SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags,
   },
+  types::used_symbol_refs::UsedSymbolRefs,
   types::watch::WatcherChangeKind,
   types::wrap_kind::WrapKind,
 };

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -60,5 +60,6 @@ pub mod str_or_bytes;
 pub mod symbol_or_member_expr_ref;
 pub mod symbol_ref;
 pub mod symbol_ref_db;
+pub mod used_symbol_refs;
 pub mod watch;
 pub mod wrap_kind;

--- a/crates/rolldown_common/src/types/used_symbol_refs.rs
+++ b/crates/rolldown_common/src/types/used_symbol_refs.rs
@@ -1,0 +1,25 @@
+use rustc_hash::FxHashSet;
+
+use super::symbol_ref::SymbolRef;
+
+#[derive(Debug, Default)]
+pub struct UsedSymbolRefs {
+  inner: FxHashSet<SymbolRef>,
+}
+
+impl UsedSymbolRefs {
+  #[inline]
+  pub fn insert(&mut self, symbol_ref: SymbolRef) {
+    self.inner.insert(symbol_ref);
+  }
+
+  #[inline]
+  pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.contains(symbol_ref)
+  }
+
+  #[inline]
+  pub fn remove(&mut self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.remove(symbol_ref)
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces a `UsedSymbolRefs` newtype struct wrapping `FxHashSet<SymbolRef>` to encapsulate the used symbol refs collection
- Replaces all direct `FxHashSet<SymbolRef>` usages in the link stage, tree shaking, and finalizer context
- Provides a controlled API surface (`insert`, `contains`, `remove`) for future extensibility
