### PR TITLE
fix(rolldown_plugin_lazy_compilation): use loadExports for fetched proxy to preserve original export names

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template-fetched.js
+++ b/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template-fetched.js
@@ -1,6 +1,6 @@
 const lazyExports = (async () => {
-  const mod = await import($MODULE_ID);
-  return mod;
+  await import($MODULE_ID);
+  return __rolldown_runtime__.loadExports($STABLE_MODULE_ID);
 })();
 
 export { lazyExports as 'rolldown:exports' };

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -101,5 +101,8 @@
     "packages/test-dev-server/tests/playground/lazy-compilation": {
       "entry": ["dev.config.mjs", "main.js", "lazy-module.js"], // Playwright test with dev config and source files
     },
+    "packages/test-dev-server/tests/playground/lazy-issue-9312": {
+      "entry": ["dev.config.mjs", "app.js", "page-a.js", "page-b.js", "selectors.js"], // Playwright test with dev config and source files
+    },
   },
 }

--- a/packages/test-dev-server/tests/browser.spec.ts
+++ b/packages/test-dev-server/tests/browser.spec.ts
@@ -1,9 +1,10 @@
 import { setTimeout } from 'node:timers/promises';
 import { describe, expect, test } from 'vitest';
 import { CONFIG } from './src/config';
-import { editFile, getLazyPage, getPage, waitForBuildStable } from './test-utils';
+import { editFile, getIssue9312Page, getLazyPage, getPage, waitForBuildStable } from './test-utils';
 
 const LAZY_URL = `http://localhost:${CONFIG.ports.lazyCompilation}`;
+const ISSUE_9312_URL = `http://localhost:${CONFIG.ports.lazyIssue9312}`;
 
 describe('hmr-full-bundle-mode', () => {
   test.sequential('should render initial content', async () => {
@@ -105,5 +106,44 @@ describe('lazy-compilation', () => {
     // This would NOT happen with eager bundling where everything is in one bundle.
     const lazyModuleChunks = jsRequests.filter((url) => url.includes('lazy-module'));
     expect(lazyModuleChunks.length).toBe(2);
+  });
+});
+
+// Regression test for PR #9132: when a dynamically imported module is shared by
+// multiple lazy entries (so it lands in a `ChunkKind::Common` chunk with
+// minified export keys), the fetched proxy must read exports from the runtime
+// registry via `loadExports` rather than returning the raw chunk namespace.
+// Before the fix, `sel.foo` was `undefined` because the namespace key was an
+// alias like `$` instead of `foo`.
+describe('lazy-issue-9312', () => {
+  test.sequential('preserves original export names for shared lazy module', async () => {
+    const page = getIssue9312Page();
+
+    // First load: triggers initial lazy fetches through the NOT-fetched proxy
+    // template. The server marks each proxy fetched and rebuilds main.js to
+    // embed the *fetched* proxy chunks. We don't assert against this load — we
+    // need the rebuilt output to land first, because the bug only manifests
+    // through the fetched-template path.
+    await page.goto(ISSUE_9312_URL, { waitUntil: 'domcontentloaded' });
+    await page.click('#btn');
+    await expect.poll(() => page.textContent('#status')).toBe('done');
+
+    // Wait for the rebuild(s) triggered by mark_as_fetched to settle.
+    await waitForBuildStable(CONFIG.ports.lazyIssue9312);
+
+    // Second load: main.js now imports the fetched-proxy chunks for page-a,
+    // page-b, and selectors. This is the path PR #9132 fixes — before the fix,
+    // returning the raw chunk namespace meant `sel.foo === undefined` because
+    // chunk-level export aliasing renamed `foo`/`bar` to short identifiers.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.click('#btn');
+    await expect.poll(() => page.textContent('#status')).toBe('done');
+
+    const log = (await page.textContent('#log')) ?? '';
+    expect(log).toContain('page-a.a = foo_value');
+    expect(log).toContain('page-b.b = bar_value');
+    expect(log).toContain('sel.foo = foo_value');
+    expect(log).toContain('sel.bar = bar_value');
+    expect(log).not.toContain('UNDEFINED');
   });
 });

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/app.js
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/app.js
@@ -1,0 +1,22 @@
+const log = (msg) => {
+  document.getElementById('log').textContent += msg + '\n';
+};
+
+log('app loaded.');
+
+document.getElementById('btn').addEventListener('click', async () => {
+  log('--- loading page-a ---');
+  const a = await import('./page-a.js');
+  log(`page-a.a = ${a.a}`);
+
+  log('--- loading page-b ---');
+  const b = await import('./page-b.js');
+  log(`page-b.b = ${b.b}`);
+
+  log('--- loading selectors directly ---');
+  const sel = await import('./selectors.js');
+  log(`sel.foo = ${sel.foo === undefined ? 'UNDEFINED' : sel.foo}`);
+  log(`sel.bar = ${sel.bar === undefined ? 'UNDEFINED' : sel.bar}`);
+
+  document.getElementById('status').textContent = 'done';
+});

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/dev.config.mjs
@@ -1,0 +1,27 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+// Reproduction for the lazy-compilation export-name bug fixed in PR #9132.
+// Mirrors `src2` of /Users/shuyuan/Examples/lazy-trace: app.js dynamically imports
+// page-a, page-b, and selectors. page-a/page-b each statically import selectors,
+// so selectors lands in a `ChunkKind::Common` chunk where chunk-level export keys
+// get aliased. The fetched proxy must use `loadExports` (runtime registry) instead
+// of returning the raw chunk namespace, otherwise direct `import('./selectors')`
+// would yield `sel.foo === undefined`.
+export default defineDevConfig({
+  platform: 'browser',
+  dev: {
+    port: 3638,
+  },
+  build: {
+    input: { main: 'app.js' },
+    output: {
+      strictExecutionOrder: true,
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: { lazy: true },
+      incrementalBuild: true,
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>lazy-issue-9312</title>
+  </head>
+  <body>
+    <h1>lazy-issue-9312</h1>
+    <button id="btn">load</button>
+    <div id="status">pending</div>
+    <pre id="log"></pre>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/package.json
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-lazy-issue-9312",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/page-a.js
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/page-a.js
@@ -1,0 +1,2 @@
+import { foo } from './selectors.js';
+export const a = foo;

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/page-b.js
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/page-b.js
@@ -1,0 +1,2 @@
+import { bar } from './selectors.js';
+export const b = bar;

--- a/packages/test-dev-server/tests/playground/lazy-issue-9312/selectors.js
+++ b/packages/test-dev-server/tests/playground/lazy-issue-9312/selectors.js
@@ -1,0 +1,2 @@
+export const foo = 'foo_value';
+export const bar = 'bar_value';

--- a/packages/test-dev-server/tests/src/config.ts
+++ b/packages/test-dev-server/tests/src/config.ts
@@ -15,9 +15,12 @@ export const CONFIG = {
     tmpFullBundleModeDir: nodePath.join(testsDir, 'tmp-playground/hmr-full-bundle-mode'),
     lazyCompilationDir: nodePath.join(testsDir, 'playground/lazy-compilation'),
     tmpLazyCompilationDir: nodePath.join(testsDir, 'tmp-playground/lazy-compilation'),
+    lazyIssue9312Dir: nodePath.join(testsDir, 'playground/lazy-issue-9312'),
+    tmpLazyIssue9312Dir: nodePath.join(testsDir, 'tmp-playground/lazy-issue-9312'),
   },
   ports: {
     hmrFullBundleMode: 3636,
     lazyCompilation: 3637,
+    lazyIssue9312: 3638,
   },
 };

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -59,6 +59,17 @@ export function getLazyPage() {
   return page;
 }
 
+/**
+ * Get the Playwright page for the lazy-issue-9312 regression test.
+ */
+export function getIssue9312Page() {
+  const page = (global as any).__issue9312Page;
+  if (!page) {
+    throw new Error('issue-9312 page not initialized. Check vitest-setup-browser.ts');
+  }
+  return page;
+}
+
 interface DevStatus {
   hasStaleOutput: boolean;
   lastFullBuildFailed: boolean;

--- a/packages/test-dev-server/tests/vitest-setup-browser.ts
+++ b/packages/test-dev-server/tests/vitest-setup-browser.ts
@@ -15,6 +15,7 @@ import { CONFIG } from './src/config';
 let browser: Browser | null = null;
 let hmrPage: Page | null = null;
 let lazyPage: Page | null = null;
+let issue9312Page: Page | null = null;
 
 async function killPort(port: number): Promise<void> {
   try {
@@ -71,6 +72,7 @@ beforeAll(async () => {
   await Promise.all([
     killPort(CONFIG.ports.hmrFullBundleMode),
     killPort(CONFIG.ports.lazyCompilation),
+    killPort(CONFIG.ports.lazyIssue9312),
   ]);
 
   // Always recreate tmp playground from source to pick up any fixture changes.
@@ -83,14 +85,18 @@ beforeAll(async () => {
   // Reset HMR test files to original state
   await resetTestFiles();
 
-  // Start both dev servers (ports configured in each playground's dev.config.mjs)
+  // Start dev servers (ports configured in each playground's dev.config.mjs).
+  // lazy-issue-9312 is self-contained (not a pnpm workspace member), so it runs
+  // the CLI directly via `node <abs path>` instead of `pnpm serve`.
   startDevServer(CONFIG.paths.tmpFullBundleModeDir);
   startDevServer(CONFIG.paths.tmpLazyCompilationDir);
+  startDevServer(CONFIG.paths.tmpLazyIssue9312Dir);
 
   // Wait for servers to be ready
   await Promise.all([
     waitForDevServerReady(CONFIG.ports.hmrFullBundleMode),
     waitForDevServerReady(CONFIG.ports.lazyCompilation),
+    waitForDevServerReady(CONFIG.ports.lazyIssue9312),
   ]);
 
   // Launch browser and create pages
@@ -98,16 +104,21 @@ beforeAll(async () => {
 
   hmrPage = await browser.newPage();
   lazyPage = await browser.newPage();
+  issue9312Page = await browser.newPage();
 
   // Only navigate the HMR page here. The lazy page is NOT navigated in setup
   // to avoid warming the lazy-compilation server (main.js triggers a dynamic
   // import after 1s, which would pre-compile the lazy module before the test).
+  // The issue-9312 page is also navigated by the test itself; it relies on a
+  // user click to fire the dynamic imports, so pre-navigating is harmless,
+  // but keeping symmetry with the lazy page makes intent clearer.
   await hmrPage.goto(`http://localhost:${CONFIG.ports.hmrFullBundleMode}`, {
     waitUntil: 'networkidle',
   });
 
   (global as any).__page = hmrPage;
   (global as any).__lazyPage = lazyPage;
+  (global as any).__issue9312Page = issue9312Page;
 });
 
 beforeEach(async (ctx) => {
@@ -132,6 +143,10 @@ afterAll(async () => {
     await lazyPage.close().catch(() => {});
     lazyPage = null;
   }
+  if (issue9312Page) {
+    await issue9312Page.close().catch(() => {});
+    issue9312Page = null;
+  }
   if (browser) {
     await browser.close().catch(() => {});
     browser = null;
@@ -142,5 +157,6 @@ afterAll(async () => {
   await Promise.all([
     killPort(CONFIG.ports.hmrFullBundleMode),
     killPort(CONFIG.ports.lazyCompilation),
+    killPort(CONFIG.ports.lazyIssue9312),
   ]).catch(() => {});
 });


### PR DESCRIPTION
## Summary

When a dynamic import target ends up in a `ChunkKind::Common` chunk (shared across multiple entry boundaries), rolldown minifies all its export names. The lazy compilation fetched proxy previously did `const mod = await import(...); return mod`, passing the raw chunk namespace to user code — so `sel.foo` became `undefined` because the actual key was a short alias like `$`.

Fix: switch the fetched proxy template to use `__rolldown_runtime__.loadExports()` instead of returning the chunk namespace directly. The runtime registry stores exports with their original names, bypassing the mangled chunk-level exports.

## Test plan

Added `packages/test-dev-server/tests/playground/lazy-issue-9312`

We should probably come up with a lazy compilation test infra that makes writing multiple test cases easier.