### PR TITLE
Allow undefined in sourcesContent type

### DIFF
--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -7,7 +7,7 @@ export interface ExistingRawSourceMap {
   mappings: string;
   names?: string[];
   sources?: (string | null)[];
-  sourcesContent?: (string | null | undefined)[];
+  sourcesContent?: (string | null | undefined)[];
   sourceRoot?: string;
   version?: number; // make it optional to compat { mappings: '' }
   x_google_ignoreList?: number[];

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -7,7 +7,7 @@ export interface ExistingRawSourceMap {
   mappings: string;
   names?: string[];
   sources?: (string | null)[];
-  sourcesContent?: (string | null)[];
+  sourcesContent?: (string | null | undefined)[];
   sourceRoot?: string;
   version?: number; // make it optional to compat { mappings: '' }
   x_google_ignoreList?: number[];

--- a/packages/rolldown/src/utils/transform-sourcemap.ts
+++ b/packages/rolldown/src/utils/transform-sourcemap.ts
@@ -1,6 +1,6 @@
 import type { ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap';
 
-export function isEmptySourcemapFiled(array: undefined | (string | null)[]): boolean {
+export function isEmptySourcemapFiled(array: undefined | (string | null | undefined)[]): boolean {
   if (!array) {
     return true;
   }


### PR DESCRIPTION
Updated sourcesContent type to allow undefined values.

This makes it compatible to BindingSourceMap

Fixes: #9135