### PR TITLE
fix: parse CjsPackageJson files as unambiguous to allow sloppy mode syntax

### DIFF
--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -28,8 +28,9 @@ fn pure_esm_js_oxc_source_type(module_def_format: ModuleDefFormat) -> OxcSourceT
     ModuleDefFormat::EsmMjs | ModuleDefFormat::EsmMts | ModuleDefFormat::EsmPackageJson => {
       default_source_type.with_module(true)
     }
-    ModuleDefFormat::CjsPackageJson | ModuleDefFormat::Unknown => {
-      // treat unknown format as ESM for now: https://github.com/rolldown/rolldown/issues/7009
+    ModuleDefFormat::CjsPackageJson => default_source_type.with_unambiguous(true),
+    ModuleDefFormat::Unknown => {
+      // Rolldown defaults to ESM for files of unknown format
       default_source_type.with_module(true)
     }
   }

--- a/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./index.js"
+      }
+    ],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region index.js
+exports.foo = function a() {
+	return "foo";
+};
+arguments = 1;
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/index.js
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/index.js
@@ -1,0 +1,5 @@
+exports.foo = function a() {
+  return 'foo';
+};
+
+arguments = 1;

--- a/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/package.json
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_type_commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./index.js"
+      }
+    ],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region index.js
+var obj = {
+	a: 1,
+	b: 2
+};
+with(obj) exports.result = a + b;
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/index.js
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/index.js
@@ -1,0 +1,4 @@
+var obj = { a: 1, b: 2 };
+with (obj) {
+  exports.result = a + b;
+}

--- a/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/package.json
+++ b/crates/rolldown/tests/rolldown/issues/7009/js_with_statement/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- `.js` files in `type: commonjs` packages were incorrectly parsed as ESM (strict mode), rejecting valid sloppy-mode syntax like `arguments = 1` and `with` statements.
- Changes the oxc source type for `CjsPackageJson` from `with_module(true)` to `with_unambiguous(true)`, letting the parser infer the module kind from file content.

Closes #7009