### PR TITLE
fix(plugin/copy-module): honor external resolutions from other plugins

### DIFF
--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -74,6 +74,16 @@ impl Plugin for CopyModulePlugin {
       Err(_) => return Ok(None),
     };
 
+    // Honor external resolutions from other plugins. `rolldown-plugin-dts`,
+    // for instance, marks TypeScript ambient-module glob specifiers like
+    // `typeof import("*.jpg")` as `{ id, external: true }` so they pass
+    // through untouched. Without this check the copy plugin would ignore the
+    // `external` flag and try to read `*.jpg` from disk, emitting a
+    // confusing `Failed to read copy module *.jpg` error.
+    if resolved_id.external.is_external() {
+      return Ok(None);
+    }
+
     // Strip query/fragment (e.g. `file.txt?url`) before extension check and file read
     let clean_id = clean_url(resolved_id.id.as_str());
     let resolved_path = Path::new(clean_id);

--- a/packages/rolldown/tests/builtin-plugin/copy-module.test.ts
+++ b/packages/rolldown/tests/builtin-plugin/copy-module.test.ts
@@ -1,0 +1,50 @@
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+// Regression test for the case where another plugin marks a specifier with
+// a copy-configured extension as `external` during `resolveId`. The copy
+// plugin must honor the external flag and not attempt to read the path from
+// disk.
+//
+// The motivating real-world scenario is `rolldown-plugin-dts`, which treats
+// TypeScript ambient-module glob specifiers like `typeof import("*.jpg")`
+// as external. Before the fix the copy plugin would try to read `*.jpg`
+// and fail with `Failed to read copy module *.jpg: No such file or
+// directory`.
+test('copy moduleType honors `external: true` from other plugins', async () => {
+  const ENTRY = 'virtual:entry';
+  const GLOB_SPECIFIER = '*.txt';
+
+  const bundle = await rolldown({
+    input: ENTRY,
+    cwd: process.cwd(),
+    moduleTypes: {
+      '.txt': 'copy',
+    },
+    plugins: [
+      {
+        name: 'virtual',
+        resolveId(source) {
+          if (source === ENTRY) return { id: ENTRY };
+          if (source === GLOB_SPECIFIER) {
+            return { id: GLOB_SPECIFIER, external: true };
+          }
+          return null;
+        },
+        load(id) {
+          if (id === ENTRY) {
+            return `import '${GLOB_SPECIFIER}';\nexport {};`;
+          }
+          return null;
+        },
+      },
+    ],
+  });
+
+  const { output } = await bundle.generate({ format: 'esm' });
+  await bundle.close();
+
+  const chunk = output.find((o) => o.type === 'chunk');
+  expect(chunk).toBeDefined();
+  expect(chunk!.code).toContain(GLOB_SPECIFIER);
+});


### PR DESCRIPTION
When another plugin resolves a specifier and marks it `external: true`, `CopyModulePlugin::resolve_id` was ignoring the flag and attempting to red the id, producing `Failed to read copy module <id>`.

This surfaces with `rolldown-plugin-dts`, which returns ambient-module glob specifiers such as `typeof import("*.jpg")` as external. If `.jpg` is also configured as `moduleTypes: copy`, the copy plugin  invokes `ctx.resolve`, which runs the dts resolver, gets back `{ id: "*.jpg", external: true }`, and then crashes trying to read `*.jpg` off disk.

Real world example: https://github.com/alveusgg/data/pull/265