### PR TITLE
fix: collect destructured bindings in HMR module exports

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -189,11 +189,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                 ast::Declaration::VariableDeclaration(var_decl) => {
                   // export var foo = 1
                   // export var { foo, bar } = { foo: 1, bar: 2 }
-                  self.exports.extend(var_decl.declarations.iter().filter_map(|decl| {
-                    decl.id.get_identifier_name().map(|ident| {
+                  self.exports.extend(var_decl.declarations.iter().flat_map(|decl| {
+                    decl.id.get_binding_identifiers().into_iter().map(|ident| {
                       self.snippet.object_property_kind_object_property(
-                        ident.as_str(),
-                        self.snippet.id_ref_expr(ident.as_str(), SPAN),
+                        ident.name.as_str(),
+                        self.snippet.id_ref_expr(ident.name.as_str(), SPAN),
                         false,
                       )
                     })

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
@@ -1,0 +1,75 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region hmr.js
+var hmr_exports = /* @__PURE__ */ __exportAll({
+	aliasA: () => aliasA,
+	aliasB: () => aliasB,
+	aliasC: () => aliasC,
+	plain: () => plain
+});
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const { selectA: aliasA, selectB: aliasB, selectC: aliasC } = {
+	selectA: "a",
+	selectB: "b",
+	selectC: "c"
+};
+const plain = "plain";
+console.log(aliasA, aliasB, aliasC, plain);
+hmr_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region hmr.js
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			aliasA: () => aliasA,
+			aliasB: () => aliasB,
+			aliasC: () => aliasC,
+			plain: () => plain
+		});
+		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		const feature = {
+			selectA: "a",
+			selectB: "b",
+			selectC: "c"
+		};
+		const { selectA: aliasA, selectB: aliasB, selectC: aliasC } = feature;
+		const plain = "plain-updated";
+		console.log(aliasA, aliasB, aliasC, plain);
+		hot_hmr.accept();
+	} finally {}
+}));
+
+//#endregion
+init_hmr_0()
+__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/hmr.hmr-0.js
@@ -1,0 +1,13 @@
+const feature = {
+  selectA: 'a',
+  selectB: 'b',
+  selectC: 'c',
+};
+
+export const { selectA: aliasA, selectB: aliasB, selectC: aliasC } = feature;
+
+export const plain = 'plain-updated';
+
+console.log(aliasA, aliasB, aliasC, plain);
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/hmr.js
@@ -1,0 +1,15 @@
+const feature = {
+  selectA: 'a',
+  selectB: 'b',
+  selectC: 'c',
+};
+
+// Destructured re-export — these aliases must survive into __exportAll
+// in both the regular-finalizer Assets output and the HMR-stage patch.
+export const { selectA: aliasA, selectB: aliasB, selectC: aliasC } = feature;
+
+export const plain = 'plain';
+
+console.log(aliasA, aliasB, aliasC, plain);
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/main.js
@@ -1,0 +1,1 @@
+import './hmr.js';


### PR DESCRIPTION
## Summary

Fix the HMR AST finalizer to support destructured exports.

Previously `export const { a: aliasA, b: aliasB } = obj` had all aliases silently dropped from the module's `__exportAll` table, so `loadExports(id).aliasA` returned undefined at runtime.

 ## Test

 Added crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/.