### PR TITLE
ci: run Windows CI on PRs labeled with `ci: windows`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       node-changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}
       pluginutils-changes: ${{ (steps.filter.outputs.pluginutils-changes == 'true') || (github.ref_name == 'main') }}
       docs-changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}
+      # Run Windows CI on `main` pushes, or on PRs labeled with `ci: windows`.
+      # Allows opting into Windows coverage per-PR without running it for every PR.
+      run-windows: ${{ (github.ref_name == 'main') || contains(github.event.pull_request.labels.*.name, 'ci: windows') }}
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -98,7 +101,10 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        target: ${{ github.ref_name == 'main' && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        target: >-
+          ${{ (github.ref_name == 'main') && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]')
+              || (needs.changes.outputs.run-windows == 'true') && fromJSON('["ubuntu-latest","windows-latest"]')
+              || fromJSON('["ubuntu-latest"]') }}
     uses: ./.github/workflows/reusable-cargo-test.yml
     with:
       os: ${{ matrix.target }}
@@ -108,7 +114,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-test.yml
     if: |
-      github.ref_name == 'main' &&
+      needs.changes.outputs.run-windows == 'true' &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -151,7 +157,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-dev-server-test.yml
     if: |
-      github.ref_name == 'main' &&
+      needs.changes.outputs.run-windows == 'true' &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -225,7 +231,7 @@ jobs:
     name: Vite Test Windows
     needs: [changes, build-rolldown-windows]
     if: |
-      github.ref_name == 'main' &&
+      needs.changes.outputs.run-windows == 'true' &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     runs-on: windows-latest
@@ -261,7 +267,7 @@ jobs:
 
   build-rolldown-windows:
     needs: changes
-    if: github.ref_name == 'main'
+    if: needs.changes.outputs.run-windows == 'true'
     uses: ./.github/workflows/reusable-native-build.yml
     with:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       docs-changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}
       # Run Windows CI on `main` pushes, or on PRs labeled with `ci: windows`.
       # Allows opting into Windows coverage per-PR without running it for every PR.
-      run-windows: ${{ (github.ref_name == 'main') || contains(github.event.pull_request.labels.*.name, 'ci: windows') }}
+      run-windows: "${{ (github.ref_name == 'main') || contains(github.event.pull_request.labels.*.name, 'ci: windows') }}"
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,8 @@ jobs:
       node-changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}
       pluginutils-changes: ${{ (steps.filter.outputs.pluginutils-changes == 'true') || (github.ref_name == 'main') }}
       docs-changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}
-      # Run Windows CI on `main` pushes, or on PRs labeled with `ci: windows`.
-      # Allows opting into Windows coverage per-PR without running it for every PR.
-      run-windows: "${{ (github.ref_name == 'main') || ((github.event_name == 'pull_request') && contains(github.event.pull_request.labels.*.name, 'ci: windows')) }}"
+      # Allows opting into Windows CI per-PR by adding the `ci: windows` label.
+      run-windows: "${{ (github.event_name == 'pull_request') && contains(github.event.pull_request.labels.*.name, 'ci: windows') }}"
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -114,7 +113,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-test.yml
     if: |
-      needs.changes.outputs.run-windows == 'true' &&
+      (github.ref_name == 'main' || needs.changes.outputs.run-windows == 'true') &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -157,7 +156,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-dev-server-test.yml
     if: |
-      needs.changes.outputs.run-windows == 'true' &&
+      (github.ref_name == 'main' || needs.changes.outputs.run-windows == 'true') &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -231,7 +230,7 @@ jobs:
     name: Vite Test Windows
     needs: [changes, build-rolldown-windows]
     if: |
-      needs.changes.outputs.run-windows == 'true' &&
+      (github.ref_name == 'main' || needs.changes.outputs.run-windows == 'true') &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     runs-on: windows-latest
@@ -267,7 +266,7 @@ jobs:
 
   build-rolldown-windows:
     needs: changes
-    if: needs.changes.outputs.run-windows == 'true'
+    if: github.ref_name == 'main' || needs.changes.outputs.run-windows == 'true'
     uses: ./.github/workflows/reusable-native-build.yml
     with:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       docs-changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}
       # Run Windows CI on `main` pushes, or on PRs labeled with `ci: windows`.
       # Allows opting into Windows coverage per-PR without running it for every PR.
-      run-windows: "${{ (github.ref_name == 'main') || contains(github.event.pull_request.labels.*.name, 'ci: windows') }}"
+      run-windows: "${{ (github.ref_name == 'main') || ((github.event_name == 'pull_request') && contains(github.event.pull_request.labels.*.name, 'ci: windows')) }}"
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 


### PR DESCRIPTION
## Summary
- Adds a `run-windows` output to the `changes` job that is `true` on `main` or when the PR has the `ci: windows` label
- Gates `build-rolldown-windows`, `node-test-windows`, `node-dev-server-test-windows`, `vite-test-windows`, and the `cargo-test` Windows matrix entry on this output
- macOS CI remains gated on `main` only (unchanged)

## How to use
1. Add the `ci: windows` label to your PR
2. Push a commit — Windows jobs will run
3. Remove the label when no longer needed

For making testing on Windows easier. Ref https://github.com/rolldown/rolldown/pull/7974

🤖 Generated with [Claude Code](https://claude.com/claude-code)