### PR TITLE
fix: avoid extra shared chunks for statically owned lazy-entry modules

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -353,7 +353,12 @@ impl GenerateStage<'_> {
           continue;
         };
 
-        for dep_idx in module.import_records.iter().filter_map(|r| r.resolved_module) {
+        for dep_idx in module
+          .import_records
+          .iter()
+          .filter(|rec| rec.kind.is_static())
+          .filter_map(|r| r.resolved_module)
+        {
           // Can't put it at the beginning of the loop,
           if let Some(chunk_idx) = dynamic_entry_modules.get(&dep_idx) {
             ret.entry(entry_chunk_idx).or_default().insert(*chunk_idx);
@@ -620,9 +625,6 @@ impl GenerateStage<'_> {
       // the dynamic entries would not be able to access the shared modules.
       let all_dynamic_entries_reachable =
         dynamic_entry.iter().all(|idx| reached_dynamic_chunk.is_some_and(|set| set.contains(idx)));
-      if !all_dynamic_entries_reachable {
-        return None;
-      }
       // If any dynamic entry chunk depends on the pending common chunk,
       // merging into the user-defined entry would make the dynamic entry
       // import the entry chunk. This is only safe if the entry chunk
@@ -649,6 +651,39 @@ impl GenerateStage<'_> {
           return None;
         }
       }
+      let candidate_modules =
+        chunk.modules.iter().copied().chain(info.modules.iter().copied()).collect::<FxHashSet<_>>();
+      let mut statically_owned_modules = chunk.modules.iter().copied().collect::<FxHashSet<_>>();
+      let mut changed = true;
+      while changed {
+        changed = false;
+        for &module_idx in &info.modules {
+          if statically_owned_modules.contains(&module_idx) {
+            continue;
+          }
+          let Some(module) = module_table[module_idx].as_normal() else {
+            continue;
+          };
+
+          let is_statically_owned = module.importers_idx.iter().any(|importer_idx| {
+            candidate_modules.contains(importer_idx)
+              && statically_owned_modules.contains(importer_idx)
+              && module_table[*importer_idx].as_normal().is_some_and(|importer| {
+                importer
+                  .import_records
+                  .iter()
+                  .any(|rec| rec.kind.is_static() && rec.resolved_module == Some(module_idx))
+              })
+          });
+
+          if is_statically_owned {
+            statically_owned_modules.insert(module_idx);
+            changed = true;
+          }
+        }
+      }
+      let modules_are_statically_used_by_target_chunk =
+        info.modules.iter().all(|module_idx| statically_owned_modules.contains(module_idx));
       let modules_set = chunk
         .modules
         .iter()
@@ -673,7 +708,23 @@ impl GenerateStage<'_> {
         // all importer are in current chunk (includes those modules will be merged)
         importers.iter().all(|importer| modules_set.contains(importer))
       });
-      all_dynamic_entry_importers_valid.then_some(chunk_idx)
+      let all_dynamic_entries_importers_valid = dynamic_entry.iter().all(|dynamic_chunk_idx| {
+        let dynamic_chunk = &chunk_graph.chunk_table[*dynamic_chunk_idx];
+        let Some(dynamic_entry_module_idx) = dynamic_chunk.entry_module_idx() else {
+          return false;
+        };
+        let Some(importers) = dynamic_entry_to_dynamic_importers.get(&dynamic_entry_module_idx)
+        else {
+          return false;
+        };
+
+        importers.iter().all(|importer| modules_set.contains(importer))
+      });
+
+      ((all_dynamic_entries_reachable
+        || (modules_are_statically_used_by_target_chunk && all_dynamic_entries_importers_valid))
+        && all_dynamic_entry_importers_valid)
+        .then_some(chunk_idx)
     }
   }
 

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
@@ -3,21 +3,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## entry.js
+## chunk.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
+
+```
+
+## entry.js
+
+```js
+import { n as __toESM } from "./chunk.js";
 //#region entry.js
 import("./foo.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(({ default: { bar } }) => console.log(bar));
 //#endregion
-export { __commonJSMin as t };
 
 ```
 
 ## foo.js
 
 ```js
-import { t as __commonJSMin } from "./entry.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.bar = 123;

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
@@ -3,11 +3,30 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ## internal-cjs.js
 
 ```js
 //#region internal-cjs.js
-var require_internal_cjs = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
+var require_internal_cjs = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -38,12 +57,11 @@ exports.value = value;
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("external"))).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("external"))).then(console.log);
 Promise.resolve().then(() => require("./internal.js")).then(console.log);
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./internal-cjs.js").default)).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./internal-cjs.js").default)).then(console.log);
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
@@ -39,7 +39,7 @@ export { foo as t };
 ### lazy-chunk.js
 
 ```js
-import { n as init_user_lib, r as __esmMin, t as foo } from "./main.js";
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#endregion
 __esmMin((() => {
 	init_user_lib();
@@ -51,12 +51,24 @@ __esmMin((() => {
 ### main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#region polyfill.js
 var init_polyfill = __esmMin((() => {
 	Object.somePolyfilledFunction = () => {};
 }));
 //#endregion
+__esmMin((() => {
+	init_polyfill();
+	init_user_lib();
+	foo();
+}))();
+
+```
+
+### user-lib.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region user-lib.js
 async function foo() {
 	return import("./lazy-chunk.js");
@@ -65,11 +77,6 @@ var init_user_lib = __esmMin((() => {
 	Object.somePolyfilledFunction();
 }));
 //#endregion
-__esmMin((() => {
-	init_polyfill();
-	init_user_lib();
-	foo();
-}))();
 export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as read, r as __esmMin, t as init_read } from "./main.js";
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 //#endregion
 __esmMin((() => {
 	init_read();
@@ -18,8 +18,8 @@ __esmMin((() => {
 ## main.js
 
 ```js
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var setup;
 var init_setup = __esmMin((() => {
@@ -27,15 +27,6 @@ var init_setup = __esmMin((() => {
 		globalThis.foo = "foo";
 	};
 	setup();
-}));
-//#endregion
-//#region read.js
-var foo, read;
-var init_read = __esmMin((() => {
-	foo = globalThis.foo;
-	read = () => {
-		console.log("read", foo);
-	};
 }));
 //#endregion
 __esmMin((() => {
@@ -46,6 +37,22 @@ __esmMin((() => {
 	import("./dynamic.js");
 	nodeAssert.strictEqual(globalThis.foo, "foo");
 }))();
+
+```
+
+## read.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region read.js
+var foo, read;
+var init_read = __esmMin((() => {
+	foo = globalThis.foo;
+	read = () => {
+		console.log("read", foo);
+	};
+}));
+//#endregion
 export { read as n, __esmMin as r, init_read as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -3,10 +3,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+import { createRequire } from "node:module";
+// HIDDEN [\0rolldown/runtime.js]
+export { __require as n, __toESM as r, __commonJSMin as t };
+
+```
+
 ## lib.js
 
 ```js
-import { t as __commonJSMin } from "./main.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
@@ -21,9 +30,8 @@ export {};
 ## main.js
 
 ```js
-import { createRequire } from "node:module";
+import { n as __require, r as __toESM, t as __commonJSMin } from "./chunk.js";
 import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
 //#region non-node-mode.js
 async function main$1() {
 	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
@@ -53,7 +61,7 @@ main();
 	module.exports = {};
 })))();
 //#endregion
-export { __commonJSMin as t };
+export {};
 
 ```
 
@@ -61,11 +69,30 @@ export { __commonJSMin as t };
 
 ## Assets
 
+### chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ### lib.js
 
 ```js
 //#region lib.js
-var require_lib = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports) => {
+var require_lib = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.parse = "parse";
 }));
@@ -82,14 +109,13 @@ Object.defineProperty(exports, "default", {
 ### main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 let node_assert = require("node:assert");
-let node_assert$1 = __toESM(node_assert, 1);
-node_assert = __toESM(node_assert);
+let node_assert$1 = require_chunk.__toESM(node_assert, 1);
+node_assert = require_chunk.__toESM(node_assert);
 //#region non-node-mode.js
 async function main$1() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default));
 	node_assert.default.deepEqual(Object.keys(exports).sort(), ["parse"]);
 	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -98,16 +124,16 @@ main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
 	node_assert$1.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 	node_assert$1.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert$1.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
-(/* @__PURE__ */ __commonJSMin(((exports, module) => {
+(/* @__PURE__ */ require_chunk.__commonJSMin(((exports, module) => {
 	const nodeAssert = require("node:assert");
 	async function main() {
-		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
+		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
 		nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 		nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 		nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -116,7 +142,6 @@ main();
 	module.exports = {};
 })))();
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -3,14 +3,39 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ## dynamic.js
 
 ```js
-const require_main = require("./main.js");
+const require_chunk = require("./chunk.js");
 //#region dynamic.js
 var ddd;
 //#endregion
-require_main.__esmMin((() => {
+require_chunk.__esmMin((() => {
 	ddd = 100;
 }))();
 exports.ddd = ddd;
@@ -20,13 +45,12 @@ exports.ddd = ddd;
 ## main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_chunk.__toESM(node_assert);
 //#endregion
 //#region entry.js
-var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {
+var import_lib = (/* @__PURE__ */ require_chunk.__commonJSMin(((exports) => {
 	const remoteProvider = async function() {
 		return await Promise.resolve().then(() => require("./dynamic.js"));
 	};
@@ -36,6 +60,5 @@ var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	(0, node_assert.default)((await (0, import_lib.defaultProvider)()).ddd === 100);
 })();
 //#endregion
-exports.__esmMin = __esmMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
-import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./index.js";
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./chunk.js";
 //#region d.js
 var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability });
 async function loadEventStreamCapability() {
@@ -28,10 +28,18 @@ export default require_c();
 
 ```
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
 ## e.js
 
 ```js
-import { n as __esmMin } from "./index.js";
+import { n as __esmMin } from "./chunk.js";
 //#endregion
 __esmMin((() => {
 	console.log("event");
@@ -42,7 +50,8 @@ __esmMin((() => {
 ## index.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { a as __toESM, t as __commonJSMin } from "./chunk.js";
+//#endregion
 //#region a.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.defaultProvider = async function test() {
@@ -51,6 +60,5 @@ __esmMin((() => {
 	};
 })))();
 //#endregion
-export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
@@ -6,13 +6,24 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as utilityClass, t as helper } from "./main.js";
+import { n as utilityClass, t as helper } from "./shared.js";
 new utilityClass(helper());
 //#endregion
 
 ```
 
 ## main.js
+
+```js
+import { t as helper } from "./shared.js";
+//#region main.js
+console.log(helper());
+import("./dynamic.js");
+//#endregion
+
+```
+
+## shared.js
 
 ```js
 //#region shared.js
@@ -24,10 +35,6 @@ var utilityClass = class {
 		this.value = value;
 	}
 };
-//#endregion
-//#region main.js
-console.log(helper());
-import("./dynamic.js");
 //#endregion
 export { utilityClass as n, helper as t };
 

--- a/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region a.js
-var require_a = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
+var require_a = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -23,13 +23,31 @@ Object.defineProperty(exports, "default", {
 
 ```
 
-## main.js
+## chunk.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
+## main.js
+
+```js
+const require_chunk = require("./chunk.js");
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./a.js").default)).then((m) => console.log(m.default));
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./a.js").default)).then((m) => console.log(m.default));
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-a.js
 
 ```js
-import { t as import_lodash } from "./main.js";
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
 //#region lazy-a.js
 assert(typeof import_lodash.debounce === "function");
@@ -18,18 +18,25 @@ assert(typeof import_lodash.noop === "function");
 ## main.js
 
 ```js
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
+//#region main.js
+assert(typeof import_lodash.debounce === "function");
+assert(typeof import_lodash.noop === "function");
+import("./lazy-a.js");
+//#endregion
+
+```
+
+## utils.js
+
+```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
-//#endregion
-//#region main.js
-assert(typeof import_lodash.debounce === "function");
-assert(typeof import_lodash.noop === "function");
-import("./lazy-a.js");
 //#endregion
 export { import_lodash as n, import_lodash as t };
 
@@ -42,12 +49,12 @@ export { import_lodash as n, import_lodash as t };
 ### lazy-a.js
 
 ```js
-const require_main = require("./main.js");
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = require_main.__toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
 //#region lazy-a.js
-(0, node_assert.default)(typeof require_main.import_lodash.debounce === "function");
-(0, node_assert.default)(typeof require_main.import_lodash$1.noop === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
 //#endregion
 
 ```
@@ -55,23 +62,33 @@ node_assert = require_main.__toESM(node_assert);
 ### main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
+//#region main.js
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
+Promise.resolve().then(() => require("./lazy-a.js"));
 //#endregion
+
+```
+
+### utils.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
 //#endregion
-//#region main.js
-(0, node_assert.default)(typeof import_lodash.debounce === "function");
-(0, node_assert.default)(typeof import_lodash.noop === "function");
-Promise.resolve().then(() => require("./lazy-a.js"));
-//#endregion
-exports.__toESM = __toESM;
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 Object.defineProperty(exports, "import_lodash", {
 	enumerable: true,
 	get: function() {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/mod.rs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/mod.rs
@@ -1,2 +1,3 @@
 mod allow_extension_exports;
 mod allow_extension_merge_same_exports;
+mod startup_entry_shared_module_not_eager_chunked;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": true,
+  "expectWarning": false,
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+//#region route-shared.js
+const shared = "shared";
+//#endregion
+//#region route-graph.js
+const eagerValue = `${shared}-eager`;
+const loadRouteComponent = () => import("./route-component.js");
+//#endregion
+//#region main.js
+assert.strictEqual(eagerValue, "shared-eager");
+loadRouteComponent().then((mod) => {
+	assert.strictEqual(mod.componentValue, "shared-lazy");
+});
+//#endregion
+export { shared as t };
+
+```
+
+## route-component.js
+
+```js
+import { t as shared } from "./main.js";
+//#region route-component.js
+const componentValue = `${shared}-lazy`;
+//#endregion
+export { componentValue };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/main.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { eagerValue, loadRouteComponent } from './route-graph.js';
+
+assert.strictEqual(eagerValue, 'shared-eager');
+
+loadRouteComponent().then((mod) => {
+  assert.strictEqual(mod.componentValue, 'shared-lazy');
+});

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/mod.rs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/mod.rs
@@ -1,0 +1,12 @@
+use rolldown::BundlerOptions;
+use rolldown_testing::{manual_integration_test, test_config::TestMeta};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn startup_entry_shared_module_not_eager_chunked() {
+  Box::pin(
+    manual_integration_test!()
+      .build(TestMeta { expect_executed: true, expect_warning: Some(false), ..Default::default() })
+      .run(BundlerOptions::default()),
+  )
+  .await;
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-component.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-component.js
@@ -1,0 +1,5 @@
+import { shared } from './route-shared.js';
+
+const componentValue = `${shared}-lazy`;
+
+export { componentValue };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-graph.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-graph.js
@@ -1,0 +1,6 @@
+import { shared } from './route-shared.js';
+
+const eagerValue = `${shared}-eager`;
+const loadRouteComponent = () => import('./route-component.js');
+
+export { eagerValue, loadRouteComponent };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-shared.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/route-shared.js
@@ -1,0 +1,3 @@
+const shared = 'shared';
+
+export { shared };

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -3,10 +3,18 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __toESM as r, __commonJSMin as t };
+
+```
+
 ## exist-dep-cjs.js
 
 ```js
-import { t as __commonJSMin } from "./main.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region exist-dep-cjs.js
 var require_exist_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
@@ -21,7 +29,7 @@ export default require_exist_dep_cjs();
 ## exist-dep-esm.js
 
 ```js
-import { n as __exportAll } from "./main.js";
+import { n as __exportAll } from "./chunk.js";
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
@@ -35,7 +43,7 @@ export { value };
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { n as __exportAll, r as __toESM } from "./chunk.js";
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
@@ -53,7 +61,6 @@ var main_exports = /* @__PURE__ */ __exportAll({});
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#endregion
-export { __exportAll as n, __commonJSMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 import { t as trim } from "./string.js";
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
@@ -20,10 +20,18 @@ export { bar_default as default };
 
 ```
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
+
+```
+
 ## foo.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 import { n as unused, t as trim } from "./string.js";
 //#region utils/index.js
 var utils_exports = /* @__PURE__ */ __exportAll({
@@ -48,15 +56,18 @@ export { foo_default as default };
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as t };
+import "./chunk.js";
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", {});
+import("./foo.js"), import("./bar.js");
+//#endregion
 
 ```
 
 ## string.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 //#region utils/string.js
 var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,


### PR DESCRIPTION
## Summary
Fix two chunk-merging false negatives in shared entry/lazy-entry graphs:
- compute static-entry reachability using only static imports
- avoid splitting out an extra shared chunk when the target entry already statically owns those modules

Related issue:
- https://github.com/TanStack/router/issues/7197

## Background
While investigating [TanStack Router issue `#7197`](https://github.com/TanStack/router/issues/7197), I found a more general Rolldown chunk-merging problem.


The relevant graph shape is:
- a startup entry statically imports an intermediate module
- that intermediate module statically imports some shared module
- that same intermediate module also exposes a lazy import to another chunk
- the lazy chunk imports that same shared module


In this topology, the shared module is already statically owned by the startup-entry side of the graph, but Rolldown can still bail out and emit it as a separate common chunk. That output shape is suboptimal for this case: the shared module still needs to be loaded eagerly, but it should stay merged into the startup entry chunk instead of being split out as its own extra shared chunk.

## Cause
#7194 added `all_dynamic_entries_reachable` as a safety check before merging shared modules into a user-defined entry chunk.
That guard is still correct in general, but it has two false negatives for this class of graphs:
- static-entry reachability was traversing dynamic imports, which over-approximated what a static entry actually reaches
- the merge bailout was too strict for shared modules that are already transitively statically owned by the target entry chunk

At the same time, the fallback cannot be too broad, or it causes real regressions by making dynamic chunks import side-effectful entry chunks.

## Fix
This PR makes two functional changes in the chunk optimizer:
- only traverse static imports when computing static-entry reachability
- allow merging into a user-defined entry when the pending shared modules are already transitively statically owned by that target chunk

The second part is intentionally narrower than a simple "used by target chunk" check. During validation, that broader form caused regressions in cases like:
- #8849
- #9049
- `optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry`

So the final rule keeps the safety guarantees from #7194:
- dynamic-entry importer checks still have to pass
- side-effect leaks through unrelated dynamic-entry paths are still blocked
- the fallback only applies when the target chunk already statically owns the pending modules through its own static dependency chain


## Test
Added a regression test here:
`crates/rolldown/tests/rolldown/optimization/chunk_merging/startup_entry_shared_module_not_eager_chunked/`
The test is intentionally modeled after the TanStack Router failure:

- `main.js` statically imports `route-graph.js`
- `route-graph.js` statically imports `route-shared.js`
- `route-graph.js` lazily imports `route-component.js`
- `route-component.js` also imports `route-shared.js`

Expected behavior with the fix:
- `route-shared` is merged into `main.js`
- `route-component.js` imports from `main.js`
- no separate `route-shared.js` common chunk is emitted

This regression was validated by temporarily removing the second fix:
- without the fix, Rolldown emits a separate `route-shared.js` chunk imported by both `main.js` and `route-component.js`
- with the fix restored, that extra shared chunk disappears
