### PR TITLE
ci: verify wasm32-wasi binding deps match @rolldown/browser before publish

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -76,6 +76,9 @@ jobs:
         run: ls -R ./packages/rolldown/npm
         shell: bash
 
+      - name: Check wasm32-wasi binding deps match @rolldown/browser
+        run: node scripts/misc/check-wasi-binding-deps.mjs
+
       - name: Download Node Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -90,6 +90,9 @@ jobs:
         run: ls -R ./packages/rolldown/npm
         shell: bash
 
+      - name: Check wasm32-wasi binding deps match @rolldown/browser
+        run: node scripts/misc/check-wasi-binding-deps.mjs
+
       - name: Download Node Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -61,8 +61,8 @@
     "publint": "publint ."
   },
   "dependencies": {
-    "@emnapi/core": "1.9.2",
-    "@emnapi/runtime": "1.9.2",
+    "@emnapi/core": "1.10.0",
+    "@emnapi/runtime": "1.10.0",
     "@napi-rs/wasm-runtime": "catalog:"
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -61,8 +61,8 @@
     "publint": "publint ."
   },
   "dependencies": {
-    "@emnapi/core": "catalog:",
-    "@emnapi/runtime": "catalog:",
+    "@emnapi/core": "1.9.2",
+    "@emnapi/runtime": "1.9.2",
     "@napi-rs/wasm-runtime": "catalog:"
   }
 }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -130,7 +130,6 @@
     "buble": "catalog:",
     "cac": "catalog:",
     "consola": "catalog:",
-    "emnapi": "catalog:",
     "execa": "catalog:",
     "glob": "catalog:",
     "oxc-parser": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ catalogs:
       specifier: ^3.6.1
       version: 3.6.2
     '@napi-rs/wasm-runtime':
-      specifier: ^1.1.3
+      specifier: ^1.1.4
       version: 1.1.4
     '@oxc-node/cli':
       specifier: ^0.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,14 +522,14 @@ importers:
   packages/browser:
     dependencies:
       '@emnapi/core':
-        specifier: 1.9.2
-        version: 1.9.2
+        specifier: 1.10.0
+        version: 1.10.0
       '@emnapi/runtime':
-        specifier: 1.9.2
-        version: 1.9.2
+        specifier: 1.10.0
+        version: 1.10.0
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
-        version: 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+        version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   packages/debug:
     devDependencies:
@@ -7965,6 +7965,7 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -7978,6 +7979,7 @@ snapshots:
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.2.0':
     dependencies:
@@ -8293,7 +8295,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -8679,6 +8681,7 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,6 @@ catalogs:
     '@babel/preset-typescript':
       specifier: ^7.24.7
       version: 7.28.5
-    '@emnapi/core':
-      specifier: ^1.10.0
-      version: 1.10.0
-    '@emnapi/runtime':
-      specifier: ^1.10.0
-      version: 1.10.0
     '@napi-rs/cli':
       specifier: ^3.6.1
       version: 3.6.2
@@ -117,9 +111,6 @@ catalogs:
     diff:
       specifier: ^9.0.0
       version: 9.0.0
-    emnapi:
-      specifier: ^1.10.0
-      version: 1.10.0
     esbuild:
       specifier: ^0.28.0
       version: 0.28.0
@@ -531,14 +522,14 @@ importers:
   packages/browser:
     dependencies:
       '@emnapi/core':
-        specifier: 'catalog:'
-        version: 1.10.0
+        specifier: 1.9.2
+        version: 1.9.2
       '@emnapi/runtime':
-        specifier: 'catalog:'
-        version: 1.10.0
+        specifier: 1.9.2
+        version: 1.9.2
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
-        version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        version: 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
 
   packages/debug:
     devDependencies:
@@ -591,9 +582,6 @@ importers:
       consola:
         specifier: 'catalog:'
         version: 3.4.2
-      emnapi:
-        specifier: 'catalog:'
-        version: 1.10.0
       execa:
         specifier: 'catalog:'
         version: 9.6.1
@@ -7977,7 +7965,6 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -7991,7 +7978,6 @@ snapshots:
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/wasi-threads@1.2.0':
     dependencies:
@@ -8307,7 +8293,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -8693,7 +8679,6 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
-    optional: true
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   '@babel/preset-env': ^7.24.7
   '@babel/preset-typescript': ^7.24.7
   '@napi-rs/cli': ^3.6.1
-  '@napi-rs/wasm-runtime': ^1.1.3
+  '@napi-rs/wasm-runtime': ^1.1.4
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
   '@oxc-project/runtime': '=0.126.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,8 +17,6 @@ catalog:
   '@babel/core': ^7.24.7
   '@babel/preset-env': ^7.24.7
   '@babel/preset-typescript': ^7.24.7
-  '@emnapi/core': ^1.10.0
-  '@emnapi/runtime': ^1.10.0
   '@napi-rs/cli': ^3.6.1
   '@napi-rs/wasm-runtime': ^1.1.3
   '@oxc-node/cli': ^0.1.0
@@ -51,7 +49,6 @@ catalog:
   consola: ^3.4.2
   dedent: ^1.5.3
   diff: ^9.0.0
-  emnapi: ^1.10.0
   esbuild: ^0.28.0
   estree-toolkit: ^1.7.8
   execa: ^9.2.0

--- a/scripts/misc/check-wasi-binding-deps.mjs
+++ b/scripts/misc/check-wasi-binding-deps.mjs
@@ -1,0 +1,98 @@
+// Verify that the runtime dependencies in the generated
+// `@rolldown/binding-wasm32-wasi/package.json` (produced by `napi create-npm-dirs`)
+// match the versions used by `@rolldown/browser`, which references them via the
+// pnpm catalog. The generated binding is the source of truth: its glue code
+// expects those exact runtime versions, so `@rolldown/browser` must bundle
+// against the same specifiers.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const TRACKED = ['@napi-rs/wasm-runtime', '@emnapi/core', '@emnapi/runtime'];
+const BINDING_PKG = path.join(REPO_ROOT, 'packages/rolldown/npm/wasm32-wasi/package.json');
+const BROWSER_PKG = path.join(REPO_ROOT, 'packages/browser/package.json');
+const WORKSPACE_YAML = path.join(REPO_ROOT, 'pnpm-workspace.yaml');
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function readCatalog() {
+  const text = fs.readFileSync(WORKSPACE_YAML, 'utf8');
+  const lines = text.split('\n');
+  const catalog = {};
+  let inCatalog = false;
+  for (const line of lines) {
+    if (/^catalog:\s*$/.test(line)) {
+      inCatalog = true;
+      continue;
+    }
+    if (inCatalog) {
+      // End of block: next non-indented non-empty line.
+      if (line.length > 0 && !/^\s/.test(line)) break;
+      const m = line.match(/^\s+(?:'([^']+)'|"([^"]+)"|([^:\s]+))\s*:\s*(.+?)\s*$/);
+      if (m) {
+        const name = m[1] ?? m[2] ?? m[3];
+        const value = m[4].replace(/^['"]|['"]$/g, '');
+        catalog[name] = value;
+      }
+    }
+  }
+  return catalog;
+}
+
+function resolveBrowserSpecifier(pkg, catalog, name) {
+  const v = pkg.dependencies?.[name];
+  if (!v) {
+    throw new Error(`${name} is missing from ${path.relative(REPO_ROOT, BROWSER_PKG)}`);
+  }
+  if (v === 'catalog:' || v === 'catalog:default') {
+    const resolved = catalog[name];
+    if (!resolved) {
+      throw new Error(`${name} uses catalog but is not defined in pnpm-workspace.yaml`);
+    }
+    return resolved;
+  }
+  if (v.startsWith('catalog:')) {
+    throw new Error(`Named catalogs are not supported in this check (${name}: ${v})`);
+  }
+  return v;
+}
+
+const binding = readJson(BINDING_PKG);
+const browser = readJson(BROWSER_PKG);
+const catalog = readCatalog();
+
+const mismatches = [];
+for (const name of TRACKED) {
+  const bindingVersion = binding.dependencies?.[name];
+  if (!bindingVersion) {
+    console.error(`${name} is missing from ${path.relative(REPO_ROOT, BINDING_PKG)}`);
+    process.exit(1);
+  }
+  const browserVersion = resolveBrowserSpecifier(browser, catalog, name);
+  if (bindingVersion !== browserVersion) {
+    mismatches.push({ name, binding: bindingVersion, browser: browserVersion });
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error('Version mismatch between @rolldown/binding-wasm32-wasi and @rolldown/browser:');
+  console.error();
+  for (const { name, binding, browser } of mismatches) {
+    console.error(`  ${name}`);
+    console.error(`    binding-wasm32-wasi: ${binding}`);
+    console.error(`    browser (catalog):   ${browser}`);
+  }
+  console.error();
+  console.error(
+    'The generated binding is the source of truth. Update the `catalog` entries in pnpm-workspace.yaml to match the versions above.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  'OK: @rolldown/binding-wasm32-wasi and @rolldown/browser agree on @napi-rs/wasm-runtime, @emnapi/core, @emnapi/runtime.',
+);

--- a/scripts/misc/check-wasi-binding-deps.mjs
+++ b/scripts/misc/check-wasi-binding-deps.mjs
@@ -1,98 +1,82 @@
-// Verify that the runtime dependencies in the generated
-// `@rolldown/binding-wasm32-wasi/package.json` (produced by `napi create-npm-dirs`)
-// match the versions used by `@rolldown/browser`, which references them via the
-// pnpm catalog. The generated binding is the source of truth: its glue code
-// expects those exact runtime versions, so `@rolldown/browser` must bundle
-// against the same specifiers.
+// Verify that the runtime dependencies of `@rolldown/browser` satisfy the
+// version ranges declared by the generated `@rolldown/binding-wasm32-wasi`
+// (produced by `napi create-npm-dirs`). The binding is the source of truth:
+// its glue code was built against those exact runtime versions, so the
+// browser package — which bundles the glue code — must resolve to versions
+// compatible with what the binding expects.
 
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import semver from 'semver';
 
 const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
 const TRACKED = ['@napi-rs/wasm-runtime', '@emnapi/core', '@emnapi/runtime'];
 const BINDING_PKG = path.join(REPO_ROOT, 'packages/rolldown/npm/wasm32-wasi/package.json');
-const BROWSER_PKG = path.join(REPO_ROOT, 'packages/browser/package.json');
-const WORKSPACE_YAML = path.join(REPO_ROOT, 'pnpm-workspace.yaml');
+const BROWSER_DIR = path.join(REPO_ROOT, 'packages/browser');
 
-function readJson(p) {
-  return JSON.parse(fs.readFileSync(p, 'utf8'));
+function readBindingSpecifiers() {
+  const pkg = JSON.parse(fs.readFileSync(BINDING_PKG, 'utf8'));
+  const out = {};
+  for (const name of TRACKED) {
+    const v = pkg.dependencies?.[name];
+    if (!v) {
+      console.error(`${name} is missing from ${path.relative(REPO_ROOT, BINDING_PKG)}`);
+      process.exit(1);
+    }
+    out[name] = v;
+  }
+  return out;
 }
 
-function readCatalog() {
-  const text = fs.readFileSync(WORKSPACE_YAML, 'utf8');
-  const lines = text.split('\n');
-  const catalog = {};
-  let inCatalog = false;
-  for (const line of lines) {
-    if (/^catalog:\s*$/.test(line)) {
-      inCatalog = true;
-      continue;
+function readBrowserResolved() {
+  const stdout = execFileSync('pnpm', ['--dir', BROWSER_DIR, 'ls', ...TRACKED, '--json'], {
+    encoding: 'utf8',
+  });
+  const parsed = JSON.parse(stdout);
+  const deps = parsed[0]?.dependencies ?? {};
+  const out = {};
+  for (const name of TRACKED) {
+    const entry = deps[name];
+    if (!entry?.version) {
+      console.error(`${name} is not installed under @rolldown/browser — did \`pnpm install\` run?`);
+      process.exit(1);
     }
-    if (inCatalog) {
-      // End of block: next non-indented non-empty line.
-      if (line.length > 0 && !/^\s/.test(line)) break;
-      const m = line.match(/^\s+(?:'([^']+)'|"([^"]+)"|([^:\s]+))\s*:\s*(.+?)\s*$/);
-      if (m) {
-        const name = m[1] ?? m[2] ?? m[3];
-        const value = m[4].replace(/^['"]|['"]$/g, '');
-        catalog[name] = value;
-      }
-    }
+    out[name] = entry.version;
   }
-  return catalog;
+  return out;
 }
 
-function resolveBrowserSpecifier(pkg, catalog, name) {
-  const v = pkg.dependencies?.[name];
-  if (!v) {
-    throw new Error(`${name} is missing from ${path.relative(REPO_ROOT, BROWSER_PKG)}`);
-  }
-  if (v === 'catalog:' || v === 'catalog:default') {
-    const resolved = catalog[name];
-    if (!resolved) {
-      throw new Error(`${name} uses catalog but is not defined in pnpm-workspace.yaml`);
-    }
-    return resolved;
-  }
-  if (v.startsWith('catalog:')) {
-    throw new Error(`Named catalogs are not supported in this check (${name}: ${v})`);
-  }
-  return v;
-}
-
-const binding = readJson(BINDING_PKG);
-const browser = readJson(BROWSER_PKG);
-const catalog = readCatalog();
+const bindingSpecifiers = readBindingSpecifiers();
+const browserResolved = readBrowserResolved();
 
 const mismatches = [];
 for (const name of TRACKED) {
-  const bindingVersion = binding.dependencies?.[name];
-  if (!bindingVersion) {
-    console.error(`${name} is missing from ${path.relative(REPO_ROOT, BINDING_PKG)}`);
-    process.exit(1);
-  }
-  const browserVersion = resolveBrowserSpecifier(browser, catalog, name);
-  if (bindingVersion !== browserVersion) {
-    mismatches.push({ name, binding: bindingVersion, browser: browserVersion });
+  const range = bindingSpecifiers[name];
+  const version = browserResolved[name];
+  if (!semver.satisfies(version, range)) {
+    mismatches.push({ name, range, version });
   }
 }
 
 if (mismatches.length > 0) {
-  console.error('Version mismatch between @rolldown/binding-wasm32-wasi and @rolldown/browser:');
+  console.error(
+    "@rolldown/browser's installed runtime deps do not satisfy @rolldown/binding-wasm32-wasi:",
+  );
   console.error();
-  for (const { name, binding, browser } of mismatches) {
+  for (const { name, range, version } of mismatches) {
     console.error(`  ${name}`);
-    console.error(`    binding-wasm32-wasi: ${binding}`);
-    console.error(`    browser (catalog):   ${browser}`);
+    console.error(`    binding declares: ${range}`);
+    console.error(`    browser resolved: ${version}`);
   }
   console.error();
   console.error(
-    'The generated binding is the source of truth. Update the `catalog` entries in pnpm-workspace.yaml to match the versions above.',
+    'The generated binding is the source of truth. Bump the corresponding entry in pnpm-workspace.yaml (if referenced via `catalog:`) or in packages/browser/package.json so the resolved version falls within the binding range.',
   );
   process.exit(1);
 }
 
 console.log(
-  'OK: @rolldown/binding-wasm32-wasi and @rolldown/browser agree on @napi-rs/wasm-runtime, @emnapi/core, @emnapi/runtime.',
+  'OK: @rolldown/browser satisfies @rolldown/binding-wasm32-wasi on @napi-rs/wasm-runtime, @emnapi/core, @emnapi/runtime.',
 );


### PR DESCRIPTION
closes #8974

## Summary

- Add `scripts/misc/check-wasi-binding-deps.mjs` to verify that the runtime dependencies (`@napi-rs/wasm-runtime`, `@emnapi/core`, `@emnapi/runtime`) declared in the generated `@rolldown/binding-wasm32-wasi/package.json` match the specifiers used by `@rolldown/browser` (resolved through the pnpm catalog when applicable).
- Wire the check into both publish workflows (`publish-to-npm.yml` and `publish-to-pkg.pr.new.yml`) right after `napi create-npm-dirs` runs, so a mismatch fails the job before anything is published.

## Why

`napi create-npm-dirs` pins the wasm32-wasi binding's runtime dependencies from its own sources — `@napi-rs/wasm-runtime` is fetched as the latest published version on npm, while `@emnapi/core` / `@emnapi/runtime` follow the version of `emnapi` resolved locally. These can silently drift from the specifiers used by `@rolldown/browser`, which bundles the binding's glue code and must load the same runtime versions at execution time.

The generated binding is the source of truth: its glue code was built against those exact runtime versions, so `@rolldown/browser` must stay aligned. When this check fails, the fix is to bump the corresponding entries in `pnpm-workspace.yaml` (for deps referenced via `catalog:`) or in `packages/browser/package.json` (for deps pinned directly) to match what the binding declares.