### PR TITLE
fix(chunk-optimizer): pick dominator for runtime placement to avoid cycles

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -5,8 +5,9 @@ use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkDebugInfo, ChunkIdx, ChunkKind, ChunkMeta, ChunkReasonType,
-  FacadeChunkEliminationReason, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTable,
-  PostChunkOptimizationOperation, PreserveEntrySignatures, RuntimeHelper, StmtInfos, WrapKind,
+  FacadeChunkEliminationReason, ImportKind, Module, ModuleIdx, ModuleNamespaceIncludedReason,
+  ModuleTable, PostChunkOptimizationOperation, PreserveEntrySignatures, RuntimeHelper, StmtInfos,
+  WrapKind,
 };
 use rolldown_utils::{BitSet, IndexBitSet, indexmap::FxIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1091,17 +1092,16 @@ impl GenerateStage<'_> {
     );
   }
 
-  /// Assign the runtime module to a chunk once facade elimination has run.
+  /// Re-home the runtime module to avoid closing a static import cycle when
+  /// facade elimination introduces new helper consumers.
   ///
-  /// Facade elimination can introduce new runtime-helper consumers
-  /// (`runtime_dependent_chunks`). The runtime module may also already be
-  /// co-located with other modules in some host chunk from the merge phase.
-  /// When the host has other modules AND a facade-elim consumer that is not
-  /// the host exists, ≥2 distinct consumers need helpers from the host; if
-  /// the host also has a forward path back to the other consumer, the
-  /// dependency graph closes a cycle. Peel the runtime out in that case and
-  /// let the placement step below re-home it into the single consumer chunk
-  /// (when there is exactly one) or a dedicated `rolldown-runtime.js` chunk.
+  /// If the runtime's current host has a static forward path to any new
+  /// consumer, that consumer's helper-import back-edge would close a cycle.
+  /// Peel the runtime out and re-home it in the *dominator* of the consumer
+  /// set — a chunk every other consumer already reaches via static forward
+  /// edges. With no dominator, fall back to a dedicated leaf
+  /// `rolldown-runtime.js` chunk. Absent any cycle risk, leave the runtime
+  /// where the merge phase placed it (most compact layout).
   fn rehome_runtime_module(
     &self,
     chunk_graph: &mut ChunkGraph,
@@ -1111,12 +1111,18 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
     module_is_assigned: &mut IndexBitSet<ModuleIdx>,
   ) {
-    if let Some(host_idx) = chunk_graph.module_to_chunk[runtime_module_idx] {
+    let original_host = chunk_graph.module_to_chunk[runtime_module_idx];
+    let module_table = &self.link_output.module_table;
+
+    let cycle_risk = original_host.is_some_and(|host| {
+      runtime_dependent_chunks.iter().any(|&c| {
+        c != host && Self::chunk_reaches_via_static_import(host, c, chunk_graph, module_table)
+      })
+    });
+
+    if cycle_risk && let Some(host_idx) = original_host {
       let host_chunk = &chunk_graph.chunk_table[host_idx];
-      let host_has_other_modules = host_chunk.modules.len() > 1;
-      let has_external_consumer = runtime_dependent_chunks.iter().any(|&c| c != host_idx);
-      if host_has_other_modules
-        && has_external_consumer
+      if host_chunk.modules.len() > 1
         && let Some(pos) = host_chunk.modules.iter().position(|m| *m == runtime_module_idx)
       {
         let host_chunk = &mut chunk_graph.chunk_table[host_idx];
@@ -1129,10 +1135,6 @@ impl GenerateStage<'_> {
       return;
     }
 
-    // Pick a placement based on the full set of consumer chunks: every
-    // non-removed chunk with a non-empty `depended_runtime_helper`,
-    // unioned with `runtime_dependent_chunks`. Single consumer → reuse it;
-    // multiple consumers → dedicated leaf `rolldown-runtime` chunk.
     let removed_chunks = &chunk_graph.post_chunk_optimization_operations;
     let mut consumer_chunks: FxHashSet<ChunkIdx> = chunk_graph
       .chunk_table
@@ -1143,11 +1145,17 @@ impl GenerateStage<'_> {
       })
       .collect();
     consumer_chunks.extend(runtime_dependent_chunks.iter().copied());
+    // The original host was an implicit consumer: the merge phase put the
+    // runtime there because the chunk's bitset required it.
+    if let Some(host) = original_host
+      && !removed_chunks.contains_key(&host)
+    {
+      consumer_chunks.insert(host);
+    }
 
-    let runtime_chunk_idx = if consumer_chunks.len() == 1 {
-      consumer_chunks.into_iter().next().unwrap()
-    } else {
-      let runtime_chunk = Chunk::new(
+    let dominator = Self::find_consumer_dominator(&consumer_chunks, chunk_graph, module_table);
+    let runtime_chunk_idx = dominator.unwrap_or_else(|| {
+      chunk_graph.add_chunk(Chunk::new(
         Some("rolldown-runtime".into()),
         None,
         index_splitting_info[runtime_module_idx].bits.clone(),
@@ -1155,15 +1163,83 @@ impl GenerateStage<'_> {
         ChunkKind::Common,
         input_base.clone(),
         None,
-      );
-      chunk_graph.add_chunk(runtime_chunk)
-    };
+      ))
+    });
     chunk_graph.add_module_to_chunk(
       runtime_module_idx,
       runtime_chunk_idx,
       self.link_output.metas[runtime_module_idx].depended_runtime_helper,
     );
     module_is_assigned.set_bit(runtime_module_idx);
+  }
+
+  /// Return the unique `consumers` member that every other member reaches
+  /// through static forward chunk edges (an ES `import`, not dynamic). Such a
+  /// chunk is a "downstream sink" of the consumer set — placing the runtime
+  /// there adds no new back-edges, so no cycle can form. Returns `None` when
+  /// the set has no dominator (e.g. consumers sit in parallel sub-graphs).
+  fn find_consumer_dominator(
+    consumers: &FxHashSet<ChunkIdx>,
+    chunk_graph: &ChunkGraph,
+    module_table: &ModuleTable,
+  ) -> Option<ChunkIdx> {
+    if consumers.len() <= 1 {
+      return consumers.iter().copied().next();
+    }
+    consumers.iter().copied().find(|&candidate| {
+      consumers.iter().all(|&other| {
+        other == candidate
+          || Self::chunk_reaches_via_static_import(other, candidate, chunk_graph, module_table)
+      })
+    })
+  }
+
+  /// BFS from `from` across chunks, following only static ES `import` edges
+  /// through still-live target chunks. Returns whether `to` is reachable.
+  ///
+  /// Edge filtering rationale:
+  /// - Only `ImportKind::Import` is followed. Dynamic imports and `require`
+  ///   don't force load-time ordering between chunks, so they can't close the
+  ///   helper-import cycle this check is guarding against.
+  /// - Targets present in `post_chunk_optimization_operations` are skipped.
+  ///   Those chunks are already slated for removal/redirection by the
+  ///   surrounding facade-elimination pass, so their edges aren't part of the
+  ///   post-optimization graph.
+  /// - Self-edges (`target_chunk == current`) are skipped — an intra-chunk
+  ///   import can't form an inter-chunk cycle.
+  fn chunk_reaches_via_static_import(
+    from: ChunkIdx,
+    to: ChunkIdx,
+    chunk_graph: &ChunkGraph,
+    module_table: &ModuleTable,
+  ) -> bool {
+    let mut visited = FxHashSet::default();
+    let mut queue = VecDeque::from([from]);
+    while let Some(current) = queue.pop_front() {
+      if !visited.insert(current) {
+        continue;
+      }
+      if current == to {
+        return true;
+      }
+      for &module_idx in &chunk_graph.chunk_table[current].modules {
+        let Some(module) = module_table[module_idx].as_normal() else {
+          continue;
+        };
+        queue.extend(
+          module
+            .import_records
+            .iter()
+            .filter(|rec| matches!(rec.kind, ImportKind::Import))
+            .filter_map(|rec| chunk_graph.module_to_chunk[rec.resolved_module?])
+            .filter(|&target_chunk| {
+              target_chunk != current
+                && !chunk_graph.post_chunk_optimization_operations.contains_key(&target_chunk)
+            }),
+        );
+      }
+    }
+    false
   }
 
   /// Move modules from common chunks into facade entry chunks, then retarget

--- a/crates/rolldown/tests/rolldown/issues/8920_2/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "input": [
+      { "name": "entry-0", "import": "./node0.js" },
+      { "name": "entry-2", "import": "./node2.js" }
+    ],
+    "external": ["external-0"],
+    "treeshake": false,
+    "preserveEntrySignatures": "allow-extension",
+    "strictExecutionOrder": false,
+    "minifyInternalExports": false,
+    "experimental": {
+      "chunkOptimization": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/8920_2/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/_test.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+// Regression for the fuzz-discovered chunk cycle that followed the fix for
+// #8989 (PR #9057). The peel-and-place logic for the runtime module placed
+// `__exportAll` into a single `consumer_chunks` element whenever that set
+// had exactly one member. When that chunk already had an outbound static
+// import to another chunk that also needed helpers, the new helper
+// back-edge closed a cycle (entry-2 ↔ node1 here).
+//
+// After the fix, the runtime is placed in the *dominator* of the consumer
+// set — a chunk every other consumer already reaches via forward static
+// edges — so helper imports follow the existing DAG. For this fixture the
+// dominator is `entry-2.js`, giving a 3-chunk output with no cycle.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const read = (name) => fs.readFileSync(path.join(distDir, name), 'utf8');
+
+const entry0 = read('entry-0.js');
+const entry2 = read('entry-2.js');
+const node1 = read('node1.js');
+
+// Runtime helpers live in entry-2.js (the dominator); no dedicated
+// rolldown-runtime.js chunk is emitted.
+assert(entry2.includes('rolldown/runtime.js'), 'entry-2.js should host the runtime module');
+assert(
+  !fs.existsSync(path.join(distDir, 'rolldown-runtime.js')),
+  'no dedicated rolldown-runtime.js chunk should be emitted',
+);
+
+// No static cycle between entry-2 and node1: node1 may forward-import from
+// entry-2, but entry-2 must not statically import from node1.
+assert(
+  /import \{[^}]*\} from "\.\/entry-2\.js"/.test(node1),
+  'node1.js should statically import from entry-2.js (forward edge)',
+);
+assert(
+  !/^import .* from "\.\/node1\.js"/m.test(entry2),
+  'entry-2.js must not statically import from node1.js (would close a cycle)',
+);
+
+// entry-0 reaches the runtime through node1 → entry-2.
+assert(/from "\.\/node1\.js"/.test(entry0), 'entry-0.js should import from node1.js');

--- a/crates/rolldown/tests/rolldown/issues/8920_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/artifacts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-0.js
+
+```js
+import { node1_exports } from "./node1.js";
+//#region node0.js
+globalThis.__acyclic_output_fuzz_0 = 0;
+var use_0_1 = node1_exports;
+use_0_1.ref = 0;
+var node_0 = {};
+node_0.value = 0;
+//#endregion
+export { node_0, use_0_1 };
+
+```
+
+## entry-2.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region node2.js
+var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
+globalThis.__acyclic_output_fuzz_2 = 2;
+import("./node1.js").then((n) => n.node1_exports);
+var node_2 = {};
+node_2.value = 2;
+//#endregion
+export { __exportAll, node2_exports, node_2 };
+
+```
+
+## node1.js
+
+```js
+import { __exportAll, node2_exports } from "./entry-2.js";
+//#region node1.js
+var node1_exports = /* @__PURE__ */ __exportAll({
+	node_1: () => node_1,
+	use_1_2: () => use_1_2
+});
+globalThis.__acyclic_output_fuzz_1 = 1;
+var use_1_2 = node2_exports;
+use_1_2.ref = 1;
+var node_1 = {};
+node_1.value = 1;
+//#endregion
+export { node1_exports };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8920_2/node0.js
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/node0.js
@@ -1,0 +1,8 @@
+globalThis.__acyclic_output_fuzz_0 = 0;
+import * as imported_0_1 from './node1.js';
+var use_0_1 = imported_0_1;
+use_0_1.ref = 0;
+export { use_0_1 };
+var node_0 = {};
+node_0.value = 0;
+export { node_0 };

--- a/crates/rolldown/tests/rolldown/issues/8920_2/node1.js
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/node1.js
@@ -1,0 +1,8 @@
+globalThis.__acyclic_output_fuzz_1 = 1;
+import * as imported_1_2 from './node2.js';
+var use_1_2 = imported_1_2;
+use_1_2.ref = 1;
+export { use_1_2 };
+var node_1 = {};
+node_1.value = 1;
+export { node_1 };

--- a/crates/rolldown/tests/rolldown/issues/8920_2/node2.js
+++ b/crates/rolldown/tests/rolldown/issues/8920_2/node2.js
@@ -1,0 +1,5 @@
+globalThis.__acyclic_output_fuzz_2 = 2;
+void import('./node1.js');
+var node_2 = {};
+node_2.value = 2;
+export { node_2 };

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -142,7 +142,12 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 
 ### Runtime Module Placement
 
-Facade elimination can introduce **new runtime-helper consumers** after the merge phase has already placed the runtime module. When eliminating a dynamic-import facade with `WrapKind::Esm | WrapKind::None`, the elimination calls `include_symbol(module.namespace_object_ref)` to materialize the simulated namespace and explicitly inserts `RuntimeHelper::ExportAll` into the target chunk's `depended_runtime_helper` (the emitted JS symbol is `__exportAll`). The target chunk is added to `runtime_dependent_chunks`. For `WrapKind::Cjs | WrapKind::Esm` the elimination calls `include_symbol(wrapper_ref)` instead — the `require_xxx` symbol transitively pulls in whatever helpers the wrapper depends on (`RuntimeHelper::ToEsm`, `RuntimeHelper::CommonJsMin`, etc., emitted as `__toESM`, `__commonJSMin`, …) via the existing inclusion-propagation machinery, and the target chunk is again added to `runtime_dependent_chunks`.
+Facade elimination can introduce **new runtime-helper consumers** after the merge phase has already placed the runtime module. Eliminating a dynamic-import facade runs two independent `wrap_kind`-gated branches on the target chunk, and either branch adds the chunk to `runtime_dependent_chunks`:
+
+- `WrapKind::Esm | WrapKind::None` — `include_symbol(module.namespace_object_ref)` materializes the simulated namespace and explicitly inserts `RuntimeHelper::ExportAll` into the target chunk's `depended_runtime_helper` (emitted JS symbol: `__exportAll`).
+- `WrapKind::Cjs | WrapKind::Esm` — `include_symbol(wrapper_ref)` pulls in the `require_xxx` symbol, which transitively drags whatever helpers the wrapper depends on (`RuntimeHelper::ToEsm`, `RuntimeHelper::CommonJsMin`, etc., emitted as `__toESM`, `__commonJSMin`, …) via the existing inclusion-propagation machinery.
+
+`WrapKind::Esm` hits both branches, so ESM facades can add `ExportAll` _and_ wrapper-driven helpers to the same chunk.
 
 The danger is that the runtime module may already be **co-located** with other modules in some host chunk from the merge phase (the chunker placed it there because the host's bitset matched the runtime's bitset). If the new helper-import edge points from a facade-elim consumer back to that host, and the host has any forward path back to the consumer, the dependency graph closes a cycle. See [#8989](https://github.com/rolldown/rolldown/issues/8989) for the canonical reproduction:
 
@@ -152,47 +157,43 @@ chunk(node2) ──forward──> chunk(node3) ──forward──> chunk(node4)
      └──────── helper edge after facade elim ────────────┘
 ```
 
-The placement logic at the bottom of `optimize_facade_entry_chunks` runs whenever `runtime_dependent_chunks` is non-empty. It is a **two-step decision**:
+The placement logic lives in `rehome_runtime_module`, called from `optimize_facade_entry_chunks` whenever `runtime_dependent_chunks` is non-empty. It is a **two-step decision** driven by static-import reachability between chunks:
 
-**Step 1 — Peel decision (cycle prevention)**
+**Step 1 — Peel decision (cycle risk only)**
 
-Peel the runtime out of its current host chunk if both predicates hold:
+Peel the runtime out of its current host chunk only when the host has a **static forward path** to some facade-elim consumer that is not the host. That is the precondition for a back-edge cycle: without such a path, the new helper import cannot close a cycle no matter where we place the runtime, so the most compact layout is to leave it where the merge phase already put it. Reachability is computed by `chunk_reaches_via_static_import`, a BFS that follows only `ImportKind::Import` edges through still-live target chunks.
 
-- `host_has_other_modules` — the host contains modules besides the runtime. If runtime is alone in its chunk, that chunk is already a leaf and cannot participate in a cycle. (Skipping this case also avoids leaving an empty chunk that would crash downstream code expecting `chunk.modules[0]` to exist.)
-- `has_external_consumer` — `runtime_dependent_chunks` contains a chunk that is _not_ the host. If every facade-elim consumer IS the host itself, helpers don't have to cross any chunk boundary and no new edges are introduced.
+When cycle risk is present and the host has other modules, the implementation removes `runtime_module_idx` from the host's `modules` vec via `swap_remove` (ordering doesn't matter — `sort_chunk_modules` re-establishes it later) and sets `module_to_chunk[runtime_module_idx] = None`. If runtime is alone in its host chunk, it stays there — that chunk is already a leaf and cannot participate in a cycle, and peeling would leave an empty chunk that downstream code expecting `chunk.modules[0]` would choke on.
 
-When both are true, the implementation removes `runtime_module_idx` from the host's `modules` vec via `swap_remove` (ordering doesn't matter — `sort_chunk_modules` re-establishes it later) and sets `module_to_chunk[runtime_module_idx] = None`.
+**Step 2 — Placement decision (dominator search)**
 
-**Step 2 — Placement decision (consumer-set count)**
-
-When the runtime is unplaced (either because Step 1 just peeled it, or because the merge phase never placed it), compute the full consumer set:
+When the runtime is unplaced (either because Step 1 peeled it, or because the merge phase never placed it), compute the full consumer set:
 
 ```
-consumer_chunks = (non-removed chunks with non-empty depended_runtime_helper) ∪ runtime_dependent_chunks
+consumer_chunks = (non-removed chunks with non-empty depended_runtime_helper)
+                ∪ runtime_dependent_chunks
+                ∪ ({original_host} if original_host is not marked Removed)
 ```
 
-The first term picks up chunks that already required helpers from the linking stage; the second term picks up chunks that facade elimination just announced. Deduplication is automatic via `FxHashSet`. Then:
+The first term picks up chunks that already required helpers from the linking stage; the second term picks up chunks that facade elimination just announced; the third term re-adds the original host — the merge phase placed the runtime there because its bitset required it, making it an implicit consumer. The "not Removed" gate is defensive: `apply_common_chunk_merges` already retargets `module_to_chunk` when a host is merged into another chunk, so in practice `original_host` resolves to a still-live chunk. Deduplication is automatic via `FxHashSet`.
 
-- `consumer_chunks.len() == 1` → runtime moves into that single consumer chunk. No extra chunk is created; the lone consumer hosts both its own modules and the runtime.
-- `consumer_chunks.len() > 1` → runtime is placed in a fresh `rolldown-runtime.js` chunk created with the runtime's bitset. Every consumer imports from it. This chunk is structurally a leaf — not because being freshly created prevents outgoing edges, but because the runtime module itself contains no `import` statements, so the only module assigned to the chunk has no dependencies for the cross-chunk linker to translate into outgoing imports. Cycles are therefore impossible.
+Then find a **dominator** — a member C such that every other consumer statically reaches C via forward edges. `find_consumer_dominator` checks each candidate with `chunk_reaches_via_static_import`. A dominator, if any, is a downstream sink of the consumer set: placing the runtime there means every other consumer's helper import rides an existing forward edge, so no back-edge is added and no cycle can form.
 
-**Why both steps are needed**
+- **Dominator found** → runtime moves into that chunk. No extra chunk is created.
+- **No dominator** (consumers sit in parallel sub-graphs or form a more complex shape) → runtime is placed in a fresh `rolldown-runtime.js` chunk created with the runtime's bitset. Every consumer imports from it. This chunk is structurally a leaf — not because being freshly created prevents outgoing edges, but because the runtime module itself contains no `import` statements, so the only module assigned to the chunk has no dependencies for the cross-chunk linker to translate into outgoing imports. Cycles are therefore impossible.
 
-The peel gate exists because relying on the consumer-count alone over-triggers — many fixtures have multiple consumers that don't actually form cycles (e.g., `import_missing_neither_es6_nor_common_js`, where runtime lives in `foo.js` and `require.js` imports `__toCommonJS` from it without any back-edge). The peel gate keeps these untouched.
+**Why this shape**
 
-The consumer-set count exists because relying on `runtime_dependent_chunks.len()` alone (the original code's optimization) undercounts: it ignores chunks that already required helpers from the linking stage. After peeling, the unioned set correctly identifies whether runtime can piggyback on a single consumer or needs its own home.
+Relying on `runtime_dependent_chunks.len()` alone undercounts — it ignores chunks that already required helpers from the linking stage and the original host. Relying on consumer count alone (splitting the "single consumer" case from the "many consumers" case) over-triggers and under-triggers both: a sole consumer can still sit in the middle of the graph and create a cycle via back-edges from other implicit consumers (fuzz-discovered case in [#8920](https://github.com/rolldown/rolldown/issues/8920)), and a set of multiple consumers may have a natural downstream sink that hosts the runtime at zero extra cost ([#8989](https://github.com/rolldown/rolldown/issues/8989)).
+
+The dominator search unifies both by asking the right question directly: "is there a chunk every consumer already reaches forward?". If yes, reuse it; if no, add a leaf.
 
 **Regression coverage**
 
-`crates/rolldown/tests/rolldown/issues/8989/` contains the cycle reproduction with explicit `_test.mjs` assertions covering the full set of structural invariants:
+- `crates/rolldown/tests/rolldown/issues/8989/` — original cycle. Four entries with `node3` dynamically importing `node4` and `node1` namespace-importing `node2`. The merge phase drops the runtime into `entry2` (which already forward-reaches `node4` via `entry3`). Cycle risk → peel. Dominator search picks `node4` (leaf, all consumers reach it). Assertions cover the leaf invariant, the `entry2 → node4` direction, and that `node4` hosts the runtime.
+- `crates/rolldown/tests/rolldown/issues/8920_2/` — fuzz-discovered shape where the previous single-consumer rule silently produced a cycle. Two entries with only a dynamic edge between them; `node1` is the shared common chunk. The merge phase places the runtime in `entry-2`, but `entry-2` has no static outbound edges — no cycle risk. Runtime stays in `entry-2`, the dominator of `{entry-2, node1}` by virtue of `node1 → entry-2` already being a forward static edge. Three chunks, no `rolldown-runtime.js` emitted.
 
-- `node4.js` is a leaf — no static imports from any sibling `entry*.js` / `node*.js` chunk
-- `node4.js` hosts the runtime module (`HIDDEN [\0rolldown/runtime.js]`) and re-exports `__exportAll`
-- `entry2.js` imports `__exportAll` _from_ `node4.js`, never the reverse, and never self-imports
-- `entry3.js` statically imports from `node4.js` (the original forward edge that the bug used to close into a cycle)
-- `entry1.js` imports from both `entry2.js` and `entry3.js`
-
-If a future regression caused runtime to land back in `entry2.js`, the leaf-invariant assertion on `node4.js` (or the direction-check on `entry2 → node4`) would fire.
+Both fixtures assert structural invariants in `_test.mjs`, so any regression (e.g. reverting to the single-consumer-picks-itself rule, or over-peeling when no cycle risk exists) fails immediately rather than only showing up as a snapshot diff.
 
 ## Lazy Module Initialization Order
 


### PR DESCRIPTION
Fixes a chunk-splitting issue where the runtime module could be placed in a chunk that introduced a cyclic dependency between chunks. The optimizer now selects the dominator of all runtime consumers for placement, ensuring runtime-containing chunks load before their dependents. Includes a regression test for issue #8920 and updates to the code-splitting design doc.

closes #9161
closes https://github.com/rolldown/rolldown/issues/9224