### PR TITLE
chore(sort_modules): fix stale async-entry sort key comment

### DIFF
--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -16,7 +16,7 @@ enum Status {
 impl LinkStage<'_> {
   /// Some notes about the module execution order:
   /// - We assume user-defined entries are always executed orderly.
-  /// - Async entries is sorted by `Module#debug_id` of entry module to ensure deterministic output.
+  /// - Non-user-defined entries (dynamic-import and emitted entries) are canonicalized in `LinkStage::new` by sorting on `(entry.kind, module.id().as_str())` to ensure deterministic output.
   /// - `require(...)` is treated as implicit static `import`, which required modules are executed before the module that requires them.
   /// - Since import statements are hoisted, `require(...)` is always placed after static `import` statements.
   /// - Order of `require(...)` is determined by who shows up first while scanning ast. For such code


### PR DESCRIPTION
Fixes a stale doc comment on `LinkStage::sort_modules` that claimed async entries are sorted by `Module#debug_id`. The actual canonicalization happens in `LinkStage::new` and sorts on `(entry.kind, module.id().as_str())` — the comment now points readers at the real source of determinism.
