### PR TITLE
refactor: replace tokio::sync::Mutex with std::sync::Mutex for non-IO data

### DIFF
--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -1,9 +1,10 @@
 use std::{
   collections::VecDeque,
   path::PathBuf,
-  sync::{Arc, atomic::AtomicU32},
+  sync::{Arc, Mutex as StdMutex, atomic::AtomicU32},
 };
 
+use anyhow::Context;
 use arcstr::ArcStr;
 use futures::FutureExt;
 use notify::EventKind;
@@ -35,7 +36,7 @@ pub struct BundleCoordinator {
   ctx: SharedDevContext,
   next_hmr_patch_id: Arc<AtomicU32>,
   rx: CoordinatorReceiver,
-  watcher: Mutex<DynFsWatcher>,
+  watcher: StdMutex<DynFsWatcher>,
   watched_files: FxDashSet<ArcStr>,
   /// Tracks the state of the initial build
   state: CoordinatorState,
@@ -59,7 +60,7 @@ impl BundleCoordinator {
       ctx,
       next_hmr_patch_id: Arc::new(AtomicU32::new(0)),
       rx,
-      watcher: Mutex::new(watcher),
+      watcher: StdMutex::new(watcher),
       watched_files: FxDashSet::default(),
       state: CoordinatorState::Initialized,
       queued_file_changes_waited_for_full_build: FxIndexMap::default(),
@@ -439,7 +440,7 @@ impl BundleCoordinator {
     let bundler = self.bundler.lock().await;
     let watch_files = bundler.watch_files();
 
-    let mut watcher = self.watcher.lock().await;
+    let mut watcher = self.watcher.lock().ok().context("Failed to acquire watcher lock")?;
     let mut paths_mut = watcher.paths_mut();
     for watch_file in watch_files.iter() {
       let watch_file = &**watch_file;


### PR DESCRIPTION
## Summary

- Replace `tokio::sync::Mutex` with `std::sync::Mutex` for two places that only guard plain data and never hold the lock across an `.await` point:
  - `PluginDriver.tx` / `NativePluginContextImpl.tx` — `Arc<Mutex<Option<UnboundedSender<ModuleLoaderMsg>>>>`
  - `BundleCoordinator.watcher` — `Mutex<DynFsWatcher>`
- De-async `PluginDriver::set_context_load_modules_tx` as a consequence, and drop the redundant `.await` at its two call sites in `ScanStage`.

## Why

Per tokio's own guidance, the async mutex should be reserved for protecting IO resources where the lock genuinely needs to be held across `.await`. For plain data the blocking `std::sync::Mutex` is both cheaper and less prone to latent deadlocks when used through sync NAPI bindings. This continues the migration started in #9031 (which collapsed the `FileEmitter.tx` path to sync for the `emit_chunk` deadlock fix).

Scope of this change:

- `PluginDriver.tx` is only ever acquired to **clone an `Option<UnboundedSender>`** and to swap a new sender in at scan boundaries. The existing code in `NativePluginContextImpl::load` already drops the guard before awaiting `sender.send(...)`; the only reason it used `tokio::sync::Mutex` was incidental. Switching to `std::sync::Mutex` makes that invariant syntactically enforced (no `.await` possible while the guard is live) and lets `set_context_load_modules_tx` shed its unnecessary `async` marker.
- `BundleCoordinator.watcher` is used exclusively inside `update_watch_paths`, where the guard is held only over synchronous `paths_mut.add(...)` / `paths_mut.commit()` calls. No `.await` exists in that critical section, so async mutex is pure overhead here.

No behavioral change for plugin authors or bundler consumers, the JS APIs and message flows are unchanged.

## Refs

- Closes part of #9114 (tokio → std mutex migration)
- Related: #9031 (sync-NAPI deadlock fix for `emit_chunk`; established the `std::sync::Mutex` pattern for the tx slot on `FileEmitter`)