### PR TITLE
fix(dev/lazy): avoid module reinitialization in lazy compilation patches

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -32,6 +32,19 @@ pub struct HmrAstFinalizer<'me, 'ast> {
   pub affected_module_idx_to_init_fn_name: &'me FxHashMap<ModuleIdx, String>,
   pub use_pife_for_module_wrappers: bool,
 
+  /// Whether the runtime should short-circuit re-execution of the wrapped module body
+  /// when its stable id is already registered.
+  ///
+  /// `true` for lazy-compilation chunks: when a module appears in two lazy bundles served
+  /// concurrently, we want only the first one to actually execute the body.
+  ///
+  /// `false` for HMR patches: the patch's whole point is to re-execute the body and
+  /// replace the registered exports, so deduping would silently drop the update.
+  ///
+  /// Note: This works only as a **workaround**. In the future, HMR runtime should
+  /// provide a runtime API to trigger module disposal and re-execution. @hana
+  pub dedup_module_initializer: bool,
+
   // Each module has a unique index, which is used to generate something that needs to be unique.
   pub unique_index: usize,
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -467,6 +467,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
             exports: oxc::allocator::Vec::new_in(fields.allocator),
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
+            // Lazy chunk: opt the runtime into deduping the module body so two
+            // concurrent lazy bundles for the same module don't double-execute it.
+            dedup_module_initializer: true,
             dependencies: FxIndexSet::default(),
             imports: FxHashSet::default(),
             generated_static_import_infos: FxHashMap::default(),
@@ -704,6 +707,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
             exports: oxc::allocator::Vec::new_in(fields.allocator),
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
+            dedup_module_initializer: false,
             dependencies: FxIndexSet::default(),
             imports: FxHashSet::default(),
             generated_static_import_infos: FxHashMap::default(),
@@ -895,6 +899,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
             exports: oxc::allocator::Vec::new_in(fields.allocator),
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
+            dedup_module_initializer: false,
             dependencies: FxIndexSet::default(),
             imports: FxHashSet::default(),
             generated_static_import_infos: FxHashMap::default(),

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -9,7 +9,10 @@ use rolldown_ecmascript::{
   CJS_ROLLDOWN_EXPORTS_REF_IDENT, CJS_ROLLDOWN_MODULE_REF_IDENT,
 };
 
-use crate::hmr::{hmr_ast_finalizer::HmrAstFinalizer, utils::HmrAstBuilder};
+use crate::hmr::{
+  hmr_ast_finalizer::HmrAstFinalizer,
+  utils::{HmrAstBuilder, MODULE_ID_PARAM_FOR_HMR},
+};
 
 impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
   fn enter_program(
@@ -63,46 +66,63 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
 
     let init_fn_name = &self.affected_module_idx_to_init_fn_name[&self.module.idx];
 
-    let mut params = self.snippet.builder.formal_parameters(
+    // The runtime wrappers (createEsmInitializer / createCjsInitializer) call the body
+    // with the module's stable id as an extra argument, so it's available inside the body
+    // as `__rolldown_module_id__`. This lets registerModule / createModuleHotContext reference
+    // the id by identifier instead of duplicating the string literal.
+    let module_id_param = self.snippet.builder.formal_parameter(
+      SPAN,
+      self.builder.vec(),
+      self.snippet.builder.binding_pattern_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR),
+      NONE,
+      NONE,
+      false,
+      None,
+      false,
+      false,
+    );
+    let params = self.snippet.builder.formal_parameters(
       SPAN,
       ast::FormalParameterKind::Signature,
-      self.snippet.builder.vec_with_capacity(2),
+      {
+        if self.module.exports_kind.is_commonjs() {
+          self.snippet.builder.vec_from_array([
+            self.snippet.builder.formal_parameter(
+              SPAN,
+              self.builder.vec(),
+              self
+                .snippet
+                .builder
+                .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_EXPORTS_REF_IDENT),
+              NONE,
+              NONE,
+              false,
+              None,
+              false,
+              false,
+            ),
+            self.snippet.builder.formal_parameter(
+              SPAN,
+              self.builder.vec(),
+              self
+                .snippet
+                .builder
+                .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_MODULE_REF_IDENT),
+              NONE,
+              NONE,
+              false,
+              None,
+              false,
+              false,
+            ),
+            module_id_param,
+          ])
+        } else {
+          self.snippet.builder.vec1(module_id_param)
+        }
+      },
       NONE,
     );
-    if self.module.exports_kind.is_commonjs() {
-      params.items.push(
-        self.snippet.builder.formal_parameter(
-          SPAN,
-          self.builder.vec(),
-          self
-            .snippet
-            .builder
-            .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_EXPORTS_REF_IDENT),
-          NONE,
-          NONE,
-          false,
-          None,
-          false,
-          false,
-        ),
-      );
-      params.items.push(
-        self.snippet.builder.formal_parameter(
-          SPAN,
-          self.builder.vec(),
-          self
-            .snippet
-            .builder
-            .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_MODULE_REF_IDENT),
-          NONE,
-          NONE,
-          false,
-          None,
-          false,
-          false,
-        ),
-      );
-    }
     // function () { [user code] }
     let mut user_code_wrapper = self.snippet.builder.alloc_function(
       SPAN,
@@ -124,31 +144,41 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
     user_code_wrapper.pife = self.use_pife_for_module_wrappers;
 
-    let initializer_call = if self.module.exports_kind.is_commonjs() {
-      // __rolldown__runtime.createCjsInitializer((function (exports, module) { [user code] }))
-      self.snippet.builder.alloc_call_expression(
+    // Initializer call arguments: always (stable_id, factory). For lazy-compilation
+    // chunks we append a truthy dedup flag so the runtime short-circuits re-execution
+    // when another lazy blob has already registered this module. HMR patches omit the
+    // flag so the runtime always re-executes the body to publish new exports.
+    let mut initializer_args = self.snippet.builder.vec_with_capacity(3);
+    initializer_args.push(ast::Argument::StringLiteral(self.snippet.builder.alloc_string_literal(
+      SPAN,
+      self.snippet.builder.str(&self.module.stable_id),
+      None,
+    )));
+    initializer_args
+      .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
+    if self.dedup_module_initializer {
+      initializer_args.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
         SPAN,
-        self.snippet.id_ref_expr("__rolldown_runtime__.createCjsInitializer", SPAN),
-        NONE,
-        self
-          .snippet
-          .builder
-          .vec1(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper))),
-        false,
-      )
+        1.0,
+        None,
+        ast::NumberBase::Decimal,
+      )));
+    }
+
+    let initializer_callee = if self.module.exports_kind.is_commonjs() {
+      // __rolldown__runtime.createCjsInitializer(stable_id, (function (exports, module) { [user code] })[, 1])
+      "__rolldown_runtime__.createCjsInitializer"
     } else {
-      // __rolldown__runtime.createEsmInitializer((function () { [user code] }))
-      self.snippet.builder.alloc_call_expression(
-        SPAN,
-        self.snippet.id_ref_expr("__rolldown_runtime__.createEsmInitializer", SPAN),
-        NONE,
-        self
-          .snippet
-          .builder
-          .vec1(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper))),
-        false,
-      )
+      // __rolldown__runtime.createEsmInitializer(stable_id, (function () { [user code] })[, 1])
+      "__rolldown_runtime__.createEsmInitializer"
     };
+    let initializer_call = self.snippet.builder.alloc_call_expression(
+      SPAN,
+      self.snippet.id_ref_expr(initializer_callee, SPAN),
+      NONE,
+      initializer_args,
+      false,
+    );
 
     // var init_foo = __rolldown__runtime.createEsmInitializer((function () { [user code] }))
     let var_decl = self.snippet.builder.alloc_variable_declaration(

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -8,6 +8,7 @@ use rolldown_ecmascript::{CJS_MODULE_REF, CJS_ROLLDOWN_MODULE_REF};
 use crate::{hmr::hmr_ast_finalizer::HmrAstFinalizer, module_finalizers::ScopeHoistingFinalizer};
 
 pub static MODULE_EXPORTS_NAME_FOR_ESM: &str = "__rolldown_exports__";
+pub static MODULE_ID_PARAM_FOR_HMR: &str = "__rolldown_module_id__";
 
 pub trait HmrAstBuilder<'any, 'ast> {
   fn builder(&self) -> &oxc::ast::AstBuilder<'ast>;
@@ -21,6 +22,20 @@ pub trait HmrAstBuilder<'any, 'ast> {
   fn alias_name_for_import_meta_hot(&self) -> ast::Str<'ast>;
 
   fn cjs_module_name() -> &'static str;
+
+  /// How to refer to the current module id at the emission site.
+  ///
+  /// The HMR/lazy path wraps each module body in `createEsmInitializer(id, function () { … })`,
+  /// so inside the body the id is available as an identifier (`__rolldown_module_id__`) passed in
+  /// by the runtime. The main-bundle path has no such wrapper, so it still needs to emit the
+  /// stable id as a string literal.
+  fn module_id_argument(&self) -> ast::Argument<'ast> {
+    ast::Argument::StringLiteral(self.builder().alloc_string_literal(
+      SPAN,
+      self.builder().str(&self.module().stable_id),
+      None,
+    ))
+  }
 
   /// `__rolldown_runtime__.registerModule(moduleId, module)`
   fn create_register_module_stmt(&self) -> ast::Statement<'ast> {
@@ -63,15 +78,9 @@ pub trait HmrAstBuilder<'any, 'ast> {
     };
 
     // ...(moduleId, module)
-    // Use stable module ID for consistent lookup in runtime
-    let arguments = self.builder().vec_from_array([
-      ast::Argument::StringLiteral(self.builder().alloc_string_literal(
-        SPAN,
-        self.builder().str(&self.module().stable_id),
-        None,
-      )),
-      module_exports,
-    ]);
+    // moduleId is either `__rolldown_module_id__` (HMR/lazy path) or the stable-id
+    // string literal (main-bundle path).
+    let arguments = self.builder().vec_from_array([self.module_id_argument(), module_exports]);
 
     // __rolldown_runtime__.registerModule(moduleId, module)
     let register_call = self.builder().alloc_call_expression(
@@ -119,13 +128,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
                   ),
                 ),
                 NONE,
-                self.builder().vec1(ast::Argument::StringLiteral(
-                  self.builder().alloc_string_literal(
-                    SPAN,
-                    self.builder().str(&self.module().stable_id),
-                    None,
-                  ),
-                )),
+                self.builder().vec1(self.module_id_argument()),
                 false,
               ),
             )),
@@ -157,6 +160,16 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
 
   fn cjs_module_name() -> &'static str {
     CJS_ROLLDOWN_MODULE_REF
+  }
+
+  /// HMR/lazy path: each module body is wrapped in
+  /// `createEsmInitializer(id, function (__rolldown_module_id__) { … })`
+  /// (or `createCjsInitializer(id, function (exports, module, __rolldown_module_id__) { … })`),
+  /// so the id is in lexical scope as a parameter.
+  fn module_id_argument(&self) -> ast::Argument<'ast> {
+    ast::Argument::Identifier(
+      self.builder().alloc_identifier_reference(SPAN, MODULE_ID_PARAM_FOR_HMR),
+    )
   }
 }
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -57,11 +57,11 @@ main_hot.accept("parent.js", () => {});
 ```js
 //#region parent.js
 import * as import_node_assert_00 from "node:assert";
-var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_child_01 = __rolldown_runtime__.loadExports("child.js");
 		hot_parent.accept("child.js", () => {
 			globalThis.newAcceptWasCalled = true;
@@ -92,11 +92,11 @@ __rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 
 ```js
 //#region child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const foo = 1;
 	} finally {}
 }));

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
@@ -34,10 +34,10 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region a.js
-var require_a_0 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_a_0 = __rolldown_runtime__.createCjsInitializer("a.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("a.js", __rolldown_module__);
-		const hot_a = __rolldown_runtime__.createModuleHotContext("a.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
+		const hot_a = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		__rolldown_exports__ = __rolldown_module__.exports = {};
 		__rolldown_exports__.value = "v2";
 		__rolldown_module__.exports.other = "o2";

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -43,14 +43,14 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region parent.js
-var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const childValue = "not-child";
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
@@ -86,25 +86,25 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ```js
 //#region child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const value = "child";
 	} finally {}
 }));
 
 //#endregion
 //#region parent.js
-var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_1 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const childValue = "not-child";
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
@@ -134,14 +134,14 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ```js
 //#region parent.js
-var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_child_00 = __rolldown_runtime__.loadExports("child.js");
 		const parentValue = "parent";
 		assert.strictEqual(parentValue, "parent");

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
@@ -41,14 +41,14 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region parent.js
-var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_child_00 = __rolldown_runtime__.loadExports("child.js");
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
@@ -78,26 +78,26 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ```js
 //#region child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const value = "child";
 	} finally {}
 }));
 
 //#endregion
 //#region parent.js
-var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_parent_1 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_10.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_child_0();
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_child_10 = __rolldown_runtime__.loadExports("child.js");
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
@@ -39,7 +39,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region hmr.js
-var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			aliasA: () => aliasA,
@@ -47,8 +47,8 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			aliasC: () => aliasC,
 			plain: () => plain
 		});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const feature = {
 			selectA: "a",
 			selectB: "b",

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -63,14 +63,14 @@ export { __exportAll as n, __commonJSMin as t };
 
 ```js
 //#region hmr.js
-var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			foo: () => foo,
 			bar: () => bar
 		});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		async function foo() {
 			await Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("exist-dep-cjs.js"))).then(console.log);
 			await Promise.resolve().then(() => __rolldown_runtime__.loadExports("exist-dep-esm.js")).then(console.log);
@@ -89,21 +89,21 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region new-dep-cjs.js
-var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer("new-dep-cjs.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("new-dep-cjs.js", __rolldown_module__);
-		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("new-dep-cjs.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
+		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		__rolldown_exports__.value = "new-cjs";
 	} finally {}
 }));
 
 //#endregion
 //#region new-dep-esm.js
-var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer("new-dep-esm.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("new-dep-esm.js", { exports: __rolldown_exports__ });
-		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("new-dep-esm.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const value = "new-esm";
 	} finally {}
 }));

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -64,11 +64,11 @@ function text(el, text) {
 ```js
 //#region hmr.js
 import * as import_node_assert_00 from "node:assert";
-var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_sub_01 = __rolldown_runtime__.loadExports("sub/index.js");
 		import_node_assert_00.default.strictEqual(import_sub_01.foo, "foo");
 		import_node_assert_00.default.strictEqual(import_sub_01.bar, "bar");

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -60,11 +60,11 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region hmr.js
-var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const foo = "hello";
 		text(".hmr", foo);
 		function text(el, text) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -103,11 +103,11 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 ```js
 //#region self_accept.js
 import * as import_node_assert_00 from "node:assert";
-var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer("self_accept.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
-		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_self_accept = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const foo = "foo2";
 		hot_self_accept.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo2");
@@ -135,11 +135,11 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 ```js
 //#region self_accept.js
 import * as import_node_assert_00 from "node:assert";
-var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer("self_accept.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
-		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_self_accept = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const foo = "foo3";
 		hot_self_accept.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo3");
@@ -166,11 +166,11 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 
 ```js
 //#region single_accept/child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("single_accept/child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const count = 1;
 	} finally {}
 }));
@@ -194,11 +194,11 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 
 ```js
 //#region single_accept/child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("single_accept/child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const count = 2;
 	} finally {}
 }));
@@ -222,11 +222,11 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 
 ```js
 //#region array_accept/child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("array_accept/child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const count = 1;
 	} finally {}
 }));
@@ -250,11 +250,11 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 
 ```js
 //#region array_accept/child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_child_0 = __rolldown_runtime__.createEsmInitializer("array_accept/child.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const count = 2;
 	} finally {}
 }));
@@ -279,11 +279,11 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 ```js
 //#region optional_chaining.js
 import * as import_node_assert_00 from "node:assert";
-var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer("optional_chaining.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("optional_chaining.js", { exports: __rolldown_exports__ });
-		const hot_optional_chaining = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_optional_chaining = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const foo = "foo2";
 		hot_optional_chaining?.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo2");

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -62,11 +62,11 @@ sayMessage();
 
 ```js
 //#region foo.js
-var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_foo_0 = __rolldown_runtime__.createEsmInitializer("foo.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_foo = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_common_00 = __rolldown_runtime__.loadExports("common.js");
 		const foo = import_common_00.prefix + "foo-new";
 	} finally {}
@@ -74,15 +74,15 @@ var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region messenger.js
-var init_messenger_1 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_messenger_1 = __rolldown_runtime__.createEsmInitializer("messenger.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});
-		__rolldown_runtime__.registerModule("messenger.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_foo_0();
-		const hot_messenger = __rolldown_runtime__.createModuleHotContext("messenger.js");
+		const hot_messenger = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_foo_10 = __rolldown_runtime__.loadExports("foo.js");
 		var import_bar_11 = __rolldown_runtime__.loadExports("bar.js");
 		var import_common_12 = __rolldown_runtime__.loadExports("common.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -62,12 +62,12 @@ setInterval(sayMessage, 1e3);
 
 ```js
 //#region bar.js
-var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_bar_0 = __rolldown_runtime__.createEsmInitializer("bar.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ bar: () => bar });
-		__rolldown_runtime__.registerModule("bar.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_common_1();
-		const hot_bar = __rolldown_runtime__.createModuleHotContext("bar.js");
+		const hot_bar = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_common_00 = __rolldown_runtime__.loadExports("common.js");
 		const bar = import_common_00.prefix + "bar";
 	} finally {}
@@ -75,23 +75,23 @@ var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region common.js
-var init_common_1 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_common_1 = __rolldown_runtime__.createEsmInitializer("common.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ prefix: () => prefix });
-		__rolldown_runtime__.registerModule("common.js", { exports: __rolldown_exports__ });
-		const hot_common = __rolldown_runtime__.createModuleHotContext("common.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_common = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const prefix = "prefix-new:";
 	} finally {}
 }));
 
 //#endregion
 //#region foo.js
-var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_foo_2 = __rolldown_runtime__.createEsmInitializer("foo.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_common_1();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_common_20 = __rolldown_runtime__.loadExports("common.js");
 		const foo = import_common_20.prefix + "foo";
 	} finally {}
@@ -99,17 +99,17 @@ var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region messenger.js
-var init_messenger_3 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_messenger_3 = __rolldown_runtime__.createEsmInitializer("messenger.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});
-		__rolldown_runtime__.registerModule("messenger.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_foo_2();
 		init_bar_0();
 		init_common_1();
-		const hot_messenger = __rolldown_runtime__.createModuleHotContext("messenger.js");
+		const hot_messenger = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_foo_30 = __rolldown_runtime__.loadExports("foo.js");
 		var import_bar_31 = __rolldown_runtime__.loadExports("bar.js");
 		var import_common_32 = __rolldown_runtime__.loadExports("common.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -149,12 +149,12 @@ if (main_hot) main_hot.accept();
 
 ```js
 //#region cases/deconflict_import_bindings/foo.mjs
-var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_foo_0 = __rolldown_runtime__.createEsmInitializer("cases/deconflict_import_bindings/foo.mjs", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_00 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		const foo = "foo";
 	} finally {}
@@ -162,12 +162,12 @@ var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var init_foo_1 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_foo_1 = __rolldown_runtime__.createEsmInitializer("cases/deconflict_import_bindings/foo/index.mjs", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_10 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		const foo = "foo-index";
 	} finally {}
@@ -176,14 +176,14 @@ var init_foo_1 = __rolldown_runtime__.createEsmInitializer((function() {
 //#endregion
 //#region cases/deconflict_import_bindings/index.js
 import * as import_node_assert_20 from "node:assert";
-var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitializer("cases/deconflict_import_bindings/index.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_foo_0();
 		init_foo_1();
 		init_trigger_dep_11();
-		const hot_deconflict_import_bindings = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/index.js");
+		const hot_deconflict_import_bindings = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_foo_21 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/foo.mjs");
 		var import_foo_22 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/foo/index.mjs");
 		var import_trigger_dep_23 = __rolldown_runtime__.loadExports("trigger-dep.js");
@@ -194,16 +194,16 @@ var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitialize
 
 //#endregion
 //#region cases/manual_reexport/barrel.js
-var init_barrel_3 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_barrel_3 = __rolldown_runtime__.createEsmInitializer("cases/manual_reexport/barrel.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			Globals: () => import_lib_30.Globals,
 			value: () => import_lib_30.value
 		});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/barrel.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_lib_5();
 		init_trigger_dep_11();
-		const hot_barrel = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/barrel.js");
+		const hot_barrel = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_lib_30 = __rolldown_runtime__.loadExports("cases/manual_reexport/lib.js");
 		var import_trigger_dep_31 = __rolldown_runtime__.loadExports("trigger-dep.js");
 	} finally {}
@@ -212,13 +212,13 @@ var init_barrel_3 = __rolldown_runtime__.createEsmInitializer((function() {
 //#endregion
 //#region cases/manual_reexport/index.js
 import * as import_node_assert_40 from "node:assert";
-var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer("cases/manual_reexport/index.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_barrel_3();
 		init_trigger_dep_11();
-		const hot_manual_reexport = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/index.js");
+		const hot_manual_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_barrel_41 = __rolldown_runtime__.loadExports("cases/manual_reexport/barrel.js");
 		var import_trigger_dep_42 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		import_node_assert_40.default.strictEqual(import_barrel_41.value, "lib");
@@ -228,15 +228,15 @@ var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer((function
 
 //#endregion
 //#region cases/manual_reexport/lib.js
-var init_lib_5 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_lib_5 = __rolldown_runtime__.createEsmInitializer("cases/manual_reexport/lib.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			Globals: () => Globals,
 			value: () => value
 		});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/lib.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_lib = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/lib.js");
+		const hot_lib = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_50 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		const Globals = Object;
 		const value = "lib";
@@ -245,11 +245,11 @@ var init_lib_5 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region cases/require/cjs-lib-reassign-module-exports.js
-var require_cjs_lib_reassign_module_exports_6 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_cjs_lib_reassign_module_exports_6 = __rolldown_runtime__.createCjsInitializer("cases/require/cjs-lib-reassign-module-exports.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/cjs-lib-reassign-module-exports.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_cjs_lib_reassign_module_exports = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib-reassign-module-exports.js");
+		const hot_cjs_lib_reassign_module_exports = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_60 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		__rolldown_module__.exports = function() {
 			return "exports";
@@ -260,11 +260,11 @@ var require_cjs_lib_reassign_module_exports_6 = __rolldown_runtime__.createCjsIn
 
 //#endregion
 //#region cases/require/cjs-lib.js
-var require_cjs_lib_7 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_cjs_lib_7 = __rolldown_runtime__.createCjsInitializer("cases/require/cjs-lib.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
+		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_70 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		__rolldown_exports__.foo = "foo";
 		__rolldown_exports__.bar = "bar";
@@ -285,12 +285,12 @@ var require_cjs_lib_7 = __rolldown_runtime__.createCjsInitializer((function(__ro
 //#endregion
 //#region cases/require/index.js
 import * as import_node_assert_80 from "node:assert";
-var init_require_8 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_require_8 = __rolldown_runtime__.createEsmInitializer("cases/require/index.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/require/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_require = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
+		const hot_require = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_81 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		const requiredCjsLibReassignModuleExports = (require_cjs_lib_reassign_module_exports_6(), __rolldown_runtime__.loadExports("cases/require/cjs-lib-reassign-module-exports.js"));
 		import_node_assert_80.default.strictEqual(requiredCjsLibReassignModuleExports(), "exports");
@@ -313,11 +313,11 @@ var init_require_8 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region cases/require/umd-lib.js
-var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer("cases/require/umd-lib.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/umd-lib.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_umd_lib = __rolldown_runtime__.createModuleHotContext("cases/require/umd-lib.js");
+		const hot_umd_lib = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_trigger_dep_90 = __rolldown_runtime__.loadExports("trigger-dep.js");
 		(function(root, umdLib) {
 			if (typeof __rolldown_runtime__.loadExports === "function" && typeof __rolldown_exports__ === "object" && typeof __rolldown_module__ === "object") {
@@ -341,14 +341,14 @@ var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer((function(__ro
 
 //#endregion
 //#region main.js
-var init_main_10 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_main_10 = __rolldown_runtime__.createEsmInitializer("main.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("main.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		init_require_8();
 		init_manual_reexport_4();
 		init_deconflict_import_bindings_2();
-		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
+		const hot_main = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_require_100 = __rolldown_runtime__.loadExports("cases/require/index.js");
 		var import_manual_reexport_101 = __rolldown_runtime__.loadExports("cases/manual_reexport/index.js");
 		var import_deconflict_import_bindings_102 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/index.js");
@@ -360,10 +360,10 @@ var init_main_10 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region trigger-dep.js
-var init_trigger_dep_11 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_trigger_dep_11 = __rolldown_runtime__.createEsmInitializer("trigger-dep.js", (function(__rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("trigger-dep.js", {});
-		const hot_trigger_dep = __rolldown_runtime__.createModuleHotContext("trigger-dep.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		const hot_trigger_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		console.log();
 	} finally {}
 }));

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -45,11 +45,11 @@ assert.strictEqual(a.b.c, "c");
 ```js
 //#region c.js
 import * as import_node_assert_00 from "node:assert";
-var init_c_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_c_0 = __rolldown_runtime__.createEsmInitializer("c.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ c: () => c });
-		__rolldown_runtime__.registerModule("c.js", { exports: __rolldown_exports__ });
-		const hot_c = __rolldown_runtime__.createModuleHotContext("c.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_c = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_b_01 = __rolldown_runtime__.loadExports("b.js");
 		const c = "cc";
 		import_node_assert_00.default.strictEqual(c, "cc");

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -76,13 +76,13 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 ```js
 //#region hmr.js
 import * as import_node_assert_00 from "node:assert";
-var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		require_new_dep_cjs_1();
 		init_new_dep_esm_2();
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_dep_cjs_01 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs.js"));
 		var import_dep_esm_02 = __rolldown_runtime__.loadExports("modules/dep-esm.js");
 		var import_dep_cjs_default_03 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs-default.js"));
@@ -115,21 +115,21 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 //#region modules/new-dep-cjs.js
-var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer("modules/new-dep-cjs.js", (function(__rolldown_exports__, __rolldown_module__, __rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule("modules/new-dep-cjs.js", __rolldown_module__);
-		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("modules/new-dep-cjs.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, __rolldown_module__);
+		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		__rolldown_exports__.value = "new-cjs";
 	} finally {}
 }));
 
 //#endregion
 //#region modules/new-dep-esm.js
-var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer("modules/new-dep-esm.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("modules/new-dep-esm.js", { exports: __rolldown_exports__ });
-		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("modules/new-dep-esm.js");
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const value = "new-esm";
 	} finally {}
 }));

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -85,18 +85,35 @@ export class DevRuntime {
   /**
    * __esmMin
    *
-   * @type {<T>(fn: any, res: T) => () => T}
+   * When `dedup` is truthy and `id` is already registered on the runtime,
+   * skip the factory: another lazy blob got there first. HMR patches pass
+   * no `dedup` so they always re-run the factory and replace the registered
+   * exports.
+   *
+   * @type {<T>(id: string, fn: any, dedup: any, res: T) => () => T}
    * @internal
    */
-  createEsmInitializer = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
+  createEsmInitializer = (id, fn, dedup, res) => () => (
+    fn && (dedup && this.modules[id] ? (fn = 0) : (res = fn((fn = 0, id)))),
+    res
+  );
   /**
    * __commonJSMin
    *
-   * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
+   * Same dedup gate as createEsmInitializer. With `dedup` truthy and `id`
+   * registered, reuse the registered exports object; otherwise run the
+   * factory.
+   *
+   * @type {<T extends { exports: any }>(id: string, cb: any, dedup: any, mod: { exports: any }, registered: any) => () => T}
    * @internal
    */
-  createCjsInitializer = (cb, mod) => () => (
-    mod || cb((mod = { exports: {} }).exports, mod), mod.exports
+  createCjsInitializer = (id, cb, dedup, mod, registered) => () => (
+    mod || (
+      dedup && (registered = this.modules[id])
+        ? (mod = { exports: registered.exports })
+        : cb((mod = { exports: {} }).exports, mod, id)
+    ),
+    mod.exports
   );
   /** @internal */
   // @ts-expect-error The variable will be injected at build time.

--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -152,7 +152,10 @@ impl Plugin for LazyCompilationPlugin {
         // The proxy module ID includes the ?rolldown-lazy=1 suffix
         let proxy_id = args.id;
 
-        let code = render_proxy_template(template, proxy_id, stable_id.as_str(), original_id)?;
+        let stable_proxy_id = format!("{stable_id}?rolldown-lazy=1");
+
+        let code =
+          render_proxy_template(template, proxy_id, &stable_id, &stable_proxy_id, original_id)?;
         return Ok(Some(rolldown_plugin::HookLoadOutput {
           code: ArcStr::from(code),
           ..Default::default()
@@ -204,12 +207,14 @@ fn render_proxy_template(
   template: &str,
   proxy_id: &str,
   stable_id: &str,
+  stable_proxy_id: &str,
   original_id: &str,
 ) -> serde_json::Result<String> {
   Ok(
     template
       .replace("$PROXY_MODULE_ID", &serde_json::to_string(proxy_id)?)
       .replace("$STABLE_MODULE_ID", &serde_json::to_string(stable_id)?)
+      .replace("$STABLE_PROXY_MODULE_ID", &serde_json::to_string(stable_proxy_id)?)
       .replace("$MODULE_ID", &serde_json::to_string(original_id)?),
   )
 }
@@ -222,10 +227,12 @@ mod tests {
   fn windows_path() {
     let proxy_id = r"D:\Users\foo\bar\baz.js?rolldown-lazy=1";
     let stable_id = r"src\bar\baz.js";
+    let stable_proxy_id = r"src\bar\baz.js?rolldown-lazy=1";
     let original_id = r"D:\Users\foo\bar\baz.js";
 
     let template = "P=$PROXY_MODULE_ID;S=$STABLE_MODULE_ID;M=$MODULE_ID;";
-    let rendered = render_proxy_template(template, proxy_id, stable_id, original_id).unwrap();
+    let rendered =
+      render_proxy_template(template, proxy_id, stable_id, stable_proxy_id, original_id).unwrap();
 
     assert_eq!(
       rendered,
@@ -236,8 +243,14 @@ mod tests {
   #[test]
   fn unix_path() {
     let id = "/Users/foo/bar.js?rolldown-lazy=1";
-    let rendered =
-      render_proxy_template("$PROXY_MODULE_ID", id, "src/bar.js", "/Users/foo/bar.js").unwrap();
+    let rendered = render_proxy_template(
+      "$PROXY_MODULE_ID",
+      id,
+      "src/bar.js",
+      "src/bar.js?rolldown-lazy=1",
+      "/Users/foo/bar.js",
+    )
+    .unwrap();
     assert_eq!(rendered, "\"/Users/foo/bar.js?rolldown-lazy=1\"");
   }
 }

--- a/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
+++ b/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
@@ -1,4 +1,7 @@
 const lazyExports = (async () => {
+  // Remove the cache of the current module from the runtime's module map.
+  // This module with key $STABLE_PROXY_MODULE_ID is swapped in the lazy loaded chunk again with the real module.
+  delete __rolldown_runtime__.modules[$STABLE_PROXY_MODULE_ID];
   // Dev server will intercept this import and serve the actual module code.
   // We send the proxy module ID (with ?rolldown-lazy=1) so the server can mark it as fetched.
   await import(


### PR DESCRIPTION
## Summary

When a module appears in two lazy-compilation chunks served concurrently
  (e.g. two `compileLazyEntry` requests racing for `shared.js`), the browser
  runs the module body twice. Non-idempotent module code blows up — concretely,
  `Object.defineProperty(this, "key", { configurable: false })` on the second
  run throws `Cannot redefine property`.

  This PR makes module initializers opt into runtime-side deduping:

  - `createEsmInitializer` / `createCjsInitializer` take a new `dedup` flag.
    When truthy and the stable id is already in `runtime.modules`, the factory
    is skipped (or, for CJS, the registered exports are reused).
  - The Rust emitter (`HmrAstFinalizer`) gains a `dedup_module_initializer`
    field. `compile_lazy_entry` sets it to `true`; the two HMR-patch render
    paths set it to `false` so HMR keeps re-running the factory and replacing
    exports — that's the whole point of a patch.
  - The stable module id is now passed into the factory as
    `__rolldown_module_id__`, so `registerModule` and `createModuleHotContext`
    reference it by identifier instead of duplicating the string literal.
  - The lazy proxy template deletes its own `runtime.modules` entry before
    triggering the real chunk, so the dedup gate on the real module's id
    starts from a clean slate.

  The dedup gate is a workaround. The proper fix is a runtime API for module
  disposal that HMR can call before re-execution; see the TODO on
  `HmrAstFinalizer::dedup_module_initializer`.

  ## Test plan

  - [x] `cargo test -p rolldown --test integration` (1690 passed, 70 ignored)
  - [x] `cargo clippy -p rolldown --tests --no-deps` clean