### PR TITLE
ci: use vp instead of pnpm in check-wasi-binding-deps

### DIFF
--- a/scripts/misc/check-wasi-binding-deps.mjs
+++ b/scripts/misc/check-wasi-binding-deps.mjs
@@ -14,7 +14,6 @@ import semver from 'semver';
 const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
 const TRACKED = ['@napi-rs/wasm-runtime', '@emnapi/core', '@emnapi/runtime'];
 const BINDING_PKG = path.join(REPO_ROOT, 'packages/rolldown/npm/wasm32-wasi/package.json');
-const BROWSER_DIR = path.join(REPO_ROOT, 'packages/browser');
 
 function readBindingSpecifiers() {
   const pkg = JSON.parse(fs.readFileSync(BINDING_PKG, 'utf8'));
@@ -31,16 +30,18 @@ function readBindingSpecifiers() {
 }
 
 function readBrowserResolved() {
-  const stdout = execFileSync('pnpm', ['--dir', BROWSER_DIR, 'ls', ...TRACKED, '--json'], {
-    encoding: 'utf8',
-  });
+  const stdout = execFileSync(
+    'vp',
+    ['pm', 'list', '--filter', '@rolldown/browser', '--json', '--', ...TRACKED],
+    { encoding: 'utf8', cwd: REPO_ROOT },
+  );
   const parsed = JSON.parse(stdout);
   const deps = parsed[0]?.dependencies ?? {};
   const out = {};
   for (const name of TRACKED) {
     const entry = deps[name];
     if (!entry?.version) {
-      console.error(`${name} is not installed under @rolldown/browser — did \`pnpm install\` run?`);
+      console.error(`${name} is not installed under @rolldown/browser — did \`vp install\` run?`);
       process.exit(1);
     }
     out[name] = entry.version;


### PR DESCRIPTION
See https://github.com/rolldown/rolldown/actions/runs/24709484698/job/72274455296

## Summary

- Replace `pnpm --dir <browser> ls ... --json` in `scripts/misc/check-wasi-binding-deps.mjs` with `vp pm list --filter @rolldown/browser --json -- ...`.
- Update the "did the install step run?" hint to reference `vp install`.

## Why

The publish workflows (`publish-to-npm.yml` / `publish-to-pkg.pr.new.yml`) set up the runner with `voidzero-dev/setup-vp`, which only puts `vp` on `PATH` — `pnpm` is not available. The check script added in #9162 shelled out to `pnpm`, so the step failed as soon as it ran:

```
Error: spawnSync pnpm ENOENT
    ...
    spawnargs: [
      '--dir',
      '/home/runner/work/rolldown/rolldown/packages/browser',
      'ls',
      '@napi-rs/wasm-runtime',
      '@emnapi/core',
      '@emnapi/runtime',
      '--json'
    ],
```

`vp pm list` is `pnpm ls`-compatible here: with `--filter @rolldown/browser --json -- <pkgs...>` it returns the same JSON shape (`[{ dependencies: { <pkg>: { version, ... } } }]`), so no parsing changes are needed.