### PR TITLE
fix: preserve `ignored` flag through plugin `this.resolve()` round-trip

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -70,6 +70,7 @@ impl BindingPluginContext {
       // TODO: should use `&str` instead. (claude code) Attempt failed due to PathBuf conversion requires to_string_lossy()
       package_json_path:
         info.package_json.map(|item| item.realpath().to_string_lossy().to_string()),
+      ignored: info.ignored,
     }))
   }
 
@@ -150,4 +151,5 @@ pub struct BindingPluginContextResolvedId {
   pub external: BindingResolvedExternal,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
   pub module_side_effects: Option<BindingHookSideEffects>,
+  pub ignored: bool,
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
@@ -18,6 +18,8 @@ pub struct BindingHookResolveIdOutput {
   /// we could get the related package json object via the path string.
   #[napi(ts_type = "string | null")]
   pub package_json_path: Option<String>,
+  /// @internal When true, the module should be treated as ignored (browser: false mapping).
+  pub ignored: Option<bool>,
 }
 
 impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutput {
@@ -30,6 +32,7 @@ impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutpu
       normalize_external_id: value.normalize_external_id,
       side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
       package_json_path: value.package_json_path,
+      ignored: value.ignored.unwrap_or(false),
     })
   }
 }

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
@@ -8,6 +8,7 @@ pub struct HookResolveIdOutput {
   pub normalize_external_id: Option<bool>,
   pub side_effects: Option<HookSideEffects>,
   pub package_json_path: Option<String>,
+  pub ignored: bool,
 }
 
 impl HookResolveIdOutput {
@@ -24,6 +25,7 @@ impl HookResolveIdOutput {
       package_json_path: resolved_id
         .package_json
         .map(|p| p.realpath().to_string_lossy().to_string()),
+      ignored: resolved_id.ignored,
     }
   }
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -85,6 +85,7 @@ pub async fn resolve_id_with_plugins<Fs: FileSystem>(
         normalize_external_id: r.normalize_external_id,
         side_effects: r.side_effects,
         package_json,
+        ignored: r.ignored,
         ..Default::default()
       }));
     }
@@ -115,6 +116,7 @@ pub async fn resolve_id_with_plugins<Fs: FileSystem>(
       normalize_external_id: r.normalize_external_id,
       side_effects: r.side_effects,
       package_json,
+      ignored: r.ignored,
       ..Default::default()
     }));
   }

--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -116,6 +116,7 @@ impl Plugin for LazyCompilationPlugin {
         normalize_external_id: None,
         side_effects: None,
         package_json_path: None,
+        ignored: false,
       }));
     }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2218,6 +2218,8 @@ export interface BindingHookResolveIdOutput {
    * we could get the related package json object via the path string.
    */
   packageJsonPath?: string | null
+  /** @internal When true, the module should be treated as ignored (browser: false mapping). */
+  ignored?: boolean
 }
 
 export type BindingHookSideEffects =
@@ -2453,6 +2455,7 @@ export interface BindingPluginContextResolvedId {
   packageJsonPath?: string
   external: boolean | 'absolute' | 'relative'
   moduleSideEffects?: boolean | 'no-treeshake'
+  ignored: boolean
 }
 
 export interface BindingPluginContextResolveOptions {

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -137,6 +137,7 @@ export function bindingifyResolveId(
         normalizeExternalId: false,
         moduleSideEffects: exist.moduleSideEffects ?? undefined,
         packageJsonPath: ret.packageJsonPath,
+        ignored: ret.ignored,
       };
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -179,6 +180,7 @@ export function bindingifyResolveDynamicImport(
         id: ret.id,
         external: ret.external,
         packageJsonPath: ret.packageJsonPath,
+        ignored: ret.ignored,
       };
 
       if (ret.moduleSideEffects !== null) {

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -71,6 +71,8 @@ export interface ModuleOptions {
 export interface ResolvedId extends ModuleOptions {
   external: boolean | 'absolute';
   id: string;
+  /** @internal When true, the module is ignored (e.g. browser: false mapping). */
+  ignored?: boolean;
 }
 
 // Separate interface to dedupe the JSDoc comment
@@ -111,6 +113,8 @@ export interface PartialResolvedId
    */
   external?: boolean | 'absolute' | 'relative';
   id: string;
+  /** @internal When true, the module is ignored (e.g. browser: false mapping). */
+  ignored?: boolean;
 }
 
 /** @category Plugin APIs */

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -365,6 +365,7 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
       ...info,
       moduleSideEffects: info.moduleSideEffects ?? res.moduleSideEffects ?? null,
       packageJsonPath: res.packageJsonPath,
+      ignored: res.ignored,
     };
   }
 

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
@@ -1,0 +1,31 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// Regression test: Returning the result of `this.resolve()` from `resolveId` should
+// preserve `browser: false` handling (the module should be ignored/empty).
+export default defineTest({
+  config: {
+    input: './main.js',
+    platform: 'browser',
+    plugins: [
+      {
+        name: 'probe',
+        async resolveId(source, importer, options) {
+          if (options?.isEntry || !importer) {
+            return;
+          }
+          const resolved = await this.resolve(source, importer, {
+            ...options,
+            skipSelf: true,
+          });
+          return resolved;
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    expect(output.output).toHaveLength(1);
+    expect(output.output[0].type).toBe('chunk');
+    expect(output.output[0].code).toBe('');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
@@ -1,8 +1,8 @@
 import { defineTest } from 'rolldown-tests';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 
-// Regression test: Returning the result of `this.resolve()` from `resolveId` should
-// preserve `browser: false` handling (the module should be ignored/empty).
+const onResolved = vi.fn();
+
 export default defineTest({
   config: {
     input: './main.js',
@@ -18,14 +18,14 @@ export default defineTest({
             ...options,
             skipSelf: true,
           });
+          onResolved(resolved);
           return resolved;
         },
       },
     ],
   },
-  afterTest(output) {
-    expect(output.output).toHaveLength(1);
-    expect(output.output[0].type).toBe('chunk');
-    expect(output.output[0].code).toBe('');
+  afterTest() {
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith(expect.objectContaining({ ignored: true }));
   },
 });

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/index.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/index.js
@@ -1,0 +1,1 @@
+import 'buffer';

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/package.json
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo",
+  "type": "module",
+  "browser": {
+    "buffer": false
+  }
+}

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/main.js
@@ -1,0 +1,1 @@
+import './demo/index.js';


### PR DESCRIPTION
## Summary

When a plugin's `resolveId` hook calls `this.resolve(..., { skipSelf: true })` and returns the result directly, the `ignored` flag (set when `browser: false` maps a module to nothing) was silently dropped. The bundler then tried to load the raw directory path returned by the resolver, failing with `Is a directory`.

**Root cause**: `HookResolveIdOutput` had no `ignored` field, so `ResolvedId.ignored = true` was lost when passing through the plugin/NAPI boundary and back.

Closes #9107

## Changes

- **`HookResolveIdOutput`** — added `ignored: bool`; `from_resolved_id()` now copies it
- **`resolve_id_with_plugins.rs`** — propagates `ignored` from plugin output into the final `ResolvedId` (both regular and dynamic import paths)
- **NAPI bindings** — `BindingPluginContextResolvedId` (return of `this.resolve()`) and `BindingHookResolveIdOutput` (return of `resolveId` hook) both carry `ignored`
- **TypeScript** — `ResolvedId`, `PartialResolvedId`, `bindingify-build-hooks.ts`, and `plugin-context.ts` all thread `ignored` through; `binding.d.cts` regenerated

## Test

Added regression fixture under `plugin/context/resolve-browser-false`: reproduces the exact scenario — `browser: { "buffer": false }` in a local `package.json`, a plugin that forwards the `this.resolve()` result, and `platform: "browser"`.

The test fixture (plugin shape and the `code === ''` empty-output assertion) is adapted from @AlexanderKolberg's #9108, which proposed an alternative fix for the same issue. This PR takes a different fix approach — threading `ignored` through the plugin/NAPI boundary instead of re-querying the internal resolver to recover the bit — but reuses the clean regression case from #9108, so credit for the test case goes to them.

---

Co-authored-by: Alexander Kolberg <74478295+AlexanderKolberg@users.noreply.github.com>
