### PR TITLE
ci: remove pull_request_target workflows

### DIFF
--- a/.github/workflows/automation-labeled.yml
+++ b/.github/workflows/automation-labeled.yml
@@ -3,7 +3,7 @@ name: 'Automation Labeled'
 permissions: {}
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request:
     types: [labeled]
   issues:
     types: [labeled]
@@ -13,23 +13,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  convert_stale_PR_to_draft:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.event.label.name == 'stale'
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
-      - name: Convert Stale PR to Draft
-        run: |
-          gh pr ready ${{ github.event.pull_request.number }} --undo
-
   needs-reproduction:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'needs-reproduction'
+    if: github.event_name == 'issues' && github.event.label.name == 'needs-reproduction'
     permissions:
       issues: write
     steps:
@@ -67,7 +53,7 @@ jobs:
           edit-mode: replace
 
   create_issue_if_doc_labeled_on_pr:
-    if: github.event_name == 'pull_request_target' && github.event.label.name == 'documentation'
+    if: github.event_name == 'pull_request' && github.event.label.name == 'documentation' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -3,7 +3,7 @@ name: Lint Pr Title
 permissions: {}
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Summary
- Remove the stale PR draft conversion automation.
- Switch PR label/title workflows from `pull_request_target` to `pull_request`.
- Scope issue and PR label jobs to their intended events.

## Why
`pull_request_target` runs in the context of the base repository and can receive write-capable tokens even for PR-related events. That makes it worth avoiding unless a workflow genuinely needs privileged access for fork PRs.

After reviewing the jobs that used it:
- PR title linting only validates metadata, so it can run on `pull_request`.
- `needs-reproduction` is issue-label automation and does not need any PR trigger.
- documentation issue creation only needs to run for same-repo PRs, so it can run on `pull_request` with a same-repo guard.
- stale PR draft conversion was the only job that still required privileged PR mutation for fork PRs, and we are removing that automation instead of keeping `pull_request_target`.