### PR TITLE
fix(dev): visit identifier references for runtime rewrites in HMR finalizer

### DIFF
--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -8,7 +8,6 @@ use rolldown_ecmascript::{
   CJS_EXPORTS_REF_STR, CJS_MODULE_REF_STR, CJS_ROLLDOWN_EXPORTS_REF,
   CJS_ROLLDOWN_EXPORTS_REF_IDENT, CJS_ROLLDOWN_MODULE_REF_IDENT,
 };
-use rolldown_ecmascript_utils::ExpressionExt;
 
 use crate::hmr::{hmr_ast_finalizer::HmrAstFinalizer, utils::HmrAstBuilder};
 
@@ -198,26 +197,41 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       }
     }
 
-    if let Some(ident) = node.as_identifier_mut() {
-      if let Some(reference_id) = ident.reference_id.get() {
-        let reference = ctx.scoping().get_reference(reference_id);
-        if let Some(symbol_id) = reference.symbol_id() {
-          if let Some(binding_name) = self.import_bindings.get(&symbol_id) {
-            *node = self.snippet.id_ref_expr(binding_name.as_str(), ident.span);
-            return;
-          }
-        } else if ident.name == CJS_EXPORTS_REF_STR {
-          // Rewrite `exports` to `__rolldown_exports__`
-          ident.name = CJS_ROLLDOWN_EXPORTS_REF_IDENT;
-        } else if ident.name == CJS_MODULE_REF_STR {
-          // Rewrite `module` to `__rolldown_module__`
-          ident.name = CJS_ROLLDOWN_MODULE_REF_IDENT;
-        }
-      }
-    }
-
     self.try_rewrite_dynamic_import(node);
     self.try_rewrite_require(node, ctx);
     self.rewrite_import_meta_hot(node);
+  }
+
+  fn exit_identifier_reference(
+    &mut self,
+    node: &mut ast::IdentifierReference<'ast>,
+    ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
+  ) {
+    self.rewrite_identifier_reference(node, ctx);
+  }
+}
+
+impl<'ast> HmrAstFinalizer<'_, 'ast> {
+  /// Rewrite a bare `exports` / `module` identifier to the wrapper-parameter
+  /// name (`__rolldown_exports__` / `__rolldown_module__`), or an import-binding
+  /// identifier to its generated binding name.
+  fn rewrite_identifier_reference(
+    &self,
+    ident: &mut ast::IdentifierReference<'ast>,
+    ctx: &oxc_traverse::TraverseCtx<'ast, ()>,
+  ) {
+    let Some(reference_id) = ident.reference_id.get() else {
+      return;
+    };
+    let reference = ctx.scoping().get_reference(reference_id);
+    if let Some(symbol_id) = reference.symbol_id() {
+      if let Some(binding_name) = self.import_bindings.get(&symbol_id) {
+        ident.name = self.snippet.atom(binding_name.as_str()).into();
+      }
+    } else if ident.name == CJS_EXPORTS_REF_STR {
+      ident.name = CJS_ROLLDOWN_EXPORTS_REF_IDENT;
+    } else if ident.name == CJS_MODULE_REF_STR {
+      ident.name = CJS_ROLLDOWN_MODULE_REF_IDENT;
+    }
   }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/a.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/a.hmr-0.js
@@ -1,0 +1,7 @@
+exports = module.exports = {};
+exports.value = 'v2';
+module.exports.other = 'o2';
+
+console.log(exports.value, exports.other);
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/a.js
@@ -1,0 +1,13 @@
+// Covers the CJS idiom `exports = module.exports = {}` — both `exports` and
+// `module` appear as bare identifiers on an AssignmentTarget LHS. Under the
+// HMR wrapper `function(__rolldown_exports__, __rolldown_module__, …)` those
+// bare identifiers have no enclosing binding, so they must be rewritten to the
+// wrapper-parameter names. Without the rewrite the HMR patch throws
+// `ReferenceError: exports is not defined` at runtime.
+exports = module.exports = {};
+exports.value = 'v1';
+module.exports.other = 'o1';
+
+console.log(exports.value, exports.other);
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+	__rolldown_runtime__.registerModule("a.js", module);
+	exports = module.exports = {};
+	exports.value = "v1";
+	module.exports.other = "o1";
+	console.log(exports.value, exports.other);
+	a_hot.accept();
+}));
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+require_a();
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region a.js
+var require_a_0 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
+	try {
+		__rolldown_runtime__.registerModule("a.js", __rolldown_module__);
+		const hot_a = __rolldown_runtime__.createModuleHotContext("a.js");
+		__rolldown_exports__ = __rolldown_module__.exports = {};
+		__rolldown_exports__.value = "v2";
+		__rolldown_module__.exports.other = "o2";
+		console.log(__rolldown_exports__.value, __rolldown_exports__.other);
+		hot_a.accept();
+	} finally {}
+}));
+
+//#endregion
+require_a_0()
+__rolldown_runtime__.applyUpdates([['a.js', 'a.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: a.js, accepted_via: a.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/main.js
@@ -1,0 +1,2 @@
+import assert from 'node:assert';
+import './a.js';


### PR DESCRIPTION
## Summary

Resolved a case where identifier references are not visited.

```js
exports = module.exports = {};
```

In this case, `exports` should be rewritten to `__rolldown_exports__`.