### PR TITLE
fix: use sentinel id for `browser: false` ignored modules

### DIFF
--- a/crates/rolldown/src/utils/load_source.rs
+++ b/crates/rolldown/src/utils/load_source.rs
@@ -21,25 +21,20 @@ pub async fn load_source<Fs: FileSystem + 'static>(
   is_read_from_disk: &mut bool,
   module_idx: ModuleIdx,
 ) -> anyhow::Result<(StrOrBytes, ModuleType)> {
-  let (maybe_source, mut maybe_module_type) = match plugin_driver
-    .load(&HookLoadArgs { id: &resolved_id.id, module_idx, asserted_module_type })
-    .await?
-  {
-    Some(load_hook_output) => {
-      sourcemap_chain.extend(load_hook_output.map.map(SourcemapChainElement::Load));
-      if let Some(v) = load_hook_output.side_effects {
-        *side_effects = Some(v);
-      }
-
-      (Some(load_hook_output.code.to_string()), load_hook_output.module_type)
-    }
-    _ => {
-      if resolved_id.ignored {
-        (Some(String::new()), Some(ModuleType::Empty))
-      } else {
-        (None, None)
-      }
-    }
+  let (maybe_source, mut maybe_module_type) = if resolved_id.id.is_empty_module() {
+    (Some(String::new()), Some(ModuleType::Empty))
+  } else {
+    plugin_driver
+      .load(&HookLoadArgs { id: &resolved_id.id, module_idx, asserted_module_type })
+      .await?
+      .map(|load_hook_output| {
+        sourcemap_chain.extend(load_hook_output.map.map(SourcemapChainElement::Load));
+        if let Some(v) = load_hook_output.side_effects {
+          *side_effects = Some(v);
+        }
+        (Some(load_hook_output.code.to_string()), load_hook_output.module_type)
+      })
+      .unwrap_or_default()
   };
 
   // If we're given a specific module type to use and the load hook did not provide a

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -8,6 +8,8 @@ use sugar_path::SugarPath;
 
 use super::stable_module_id::StableModuleId;
 
+const EMPTY_MODULE_PREFIX: &str = "\0rolldown/empty.js?";
+
 /// `ModuleId` is the unique string identifier for each module.
 /// - It will be used to identify the module in the whole bundle.
 /// - Users could stored the `ModuleId` to track the module in different stages/hooks.
@@ -26,6 +28,22 @@ impl ModuleId {
   #[inline]
   pub const fn new_arc_str(inner: ArcStr) -> Self {
     Self { inner }
+  }
+
+  /// Construct the sentinel id used for `browser: false` ignored modules,
+  /// concatenated with the original resolved path so each ignored module
+  /// stays distinguishable while sharing the empty-module load behavior.
+  pub fn new_empty(original: &str) -> Self {
+    Self::new(format!("{EMPTY_MODULE_PREFIX}{original}"))
+  }
+
+  pub fn is_empty_module(&self) -> bool {
+    self.inner.starts_with(EMPTY_MODULE_PREFIX)
+  }
+
+  /// For an id created via `new_empty`, returns the original id portion.
+  pub fn strip_empty_prefix(&self) -> Option<&str> {
+    self.inner.strip_prefix(EMPTY_MODULE_PREFIX)
   }
 
   pub fn as_str(&self) -> &str {

--- a/crates/rolldown_common/src/types/resolved_id.rs
+++ b/crates/rolldown_common/src/types/resolved_id.rs
@@ -37,8 +37,6 @@ impl From<bool> for ResolvedExternal {
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedId {
   pub id: ModuleId,
-  // https://github.com/defunctzombie/package-browser-field-spec/blob/8c4869f6a5cb0de26d208de804ad0a62473f5a03/README.md?plain=1#L62-L77
-  pub ignored: bool,
   pub module_def_format: ModuleDefFormat,
   pub external: ResolvedExternal,
   // If the js side is return object, the relative id is finally id, else it will be converted to an absolute id
@@ -54,7 +52,6 @@ impl ResolvedId {
   pub fn make_dummy() -> Self {
     Self {
       id: ModuleId::default(),
-      ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: false.into(),
       normalize_external_id: None,
@@ -72,14 +69,16 @@ impl ResolvedId {
       return format!("<{}>", self.id.as_str());
     }
 
-    let stable = stabilize_id(&self.id, cwd.as_ref());
-    if self.ignored { format!("(ignored) {stable}") } else { stable }
+    if let Some(original) = self.id.strip_empty_prefix() {
+      return format!("(ignored) {}", stabilize_id(original, cwd.as_ref()));
+    }
+
+    stabilize_id(&self.id, cwd.as_ref())
   }
 
   pub fn new_external_without_side_effects(id: ArcStr) -> Self {
     Self {
       id: ModuleId::new(id),
-      ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: true.into(),
       normalize_external_id: None,

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -161,9 +161,7 @@ fn resolve_id<Fs: FileSystem>(
         ..Default::default()
       }),
       ResolveError::Ignored(p) => Ok(ResolvedId {
-        //(hyf0) TODO: This `p` doesn't seem to contains `query` or `fragment` of the input. We need to make sure this is ok
-        id: ModuleId::new(p.to_str().expect("Should be valid utf8")),
-        ignored: true,
+        id: ModuleId::new_empty(p.to_str().expect("Should be valid utf8")),
         ..Default::default()
       }),
       _ => Err(err),

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/_config.ts
@@ -1,0 +1,33 @@
+import { defineTest } from 'rolldown-tests';
+import { expect, vi } from 'vitest';
+
+const onResolved = vi.fn();
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    platform: 'browser',
+    plugins: [
+      {
+        name: 'probe',
+        async resolveId(source, importer, options) {
+          if (source !== 'buffer') {
+            return;
+          }
+          const resolved = await this.resolve(source, importer, {
+            ...options,
+            skipSelf: true,
+          });
+          onResolved(resolved);
+          return resolved;
+        },
+      },
+    ],
+  },
+  afterTest() {
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringContaining('\0rolldown/empty.js?') }),
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/index.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/index.js
@@ -1,0 +1,1 @@
+import 'buffer';

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/package.json
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/demo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo",
+  "type": "module",
+  "browser": {
+    "buffer": false
+  }
+}

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-browser-false/main.js
@@ -1,0 +1,1 @@
+import './demo/index.js';


### PR DESCRIPTION
closes #9107