### PR TITLE
perf(rolldown_plugin_vite_import_glob): skip self-import earlier using raw path comparison

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -476,11 +476,14 @@ impl GlobImportVisit<'_> {
       .filter_map(Result::ok)
       .filter(|e| !e.file_type().is_dir());
 
-    let self_path = self.relative_path(Path::new(self.id), Some(dir));
-
     for entry in entries {
       let file = entry.path();
       let path = file.to_slash_lossy();
+
+      // Skip the file itself if it matches the glob pattern, to avoid self-importing.
+      if self.id == path {
+        continue;
+      }
 
       let matches_rule = |v: &PathWithGlob| -> bool {
         path.strip_prefix(&v.path).map(|path| fast_glob::glob_match(v.glob, path)).unwrap_or(false)
@@ -501,10 +504,6 @@ impl GlobImportVisit<'_> {
       }
 
       let mut import_path = self.relative_path(file, Some(dir));
-      if self_path == import_path {
-        continue;
-      }
-
       let file_path = if let Some(base) = &options.base {
         if base.starts_with('/') {
           import_path = self.relative_path(file, None);


### PR DESCRIPTION
## Summary

- Skip self-import earlier in `GlobImportVisit` by comparing the raw entry path against `self.id` at the top of the loop, before computing the relative `import_path`.
- Remove the pre-loop `self_path` computation and the later `self_path == import_path` check, since the new early exit makes them redundant.

## Motivation

Previously, every matched entry required building a relative `import_path` before we could detect and skip the self-import case. By comparing against `self.id` directly against the slash-normalized entry path, we short-circuit sooner and avoid unnecessary relative-path work for the skipped entry.