### PR TITLE
fix(link): error on missing export between TS modules

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -855,7 +855,7 @@ impl BindImportsAndExportsContext<'_> {
               importee.as_normal().map(|m| &m.module_type),
               Some(ModuleType::Ts | ModuleType::Tsx)
             ) && matches!(module.module_type, ModuleType::Ts | ModuleType::Tsx);
-          let mut diagnostic = BuildDiagnostic::missing_export(
+          let diagnostic = BuildDiagnostic::missing_export(
             module.id.to_string(),
             module.stable_id.to_string(),
             importee.id().to_string(),
@@ -865,12 +865,7 @@ impl BindImportsAndExportsContext<'_> {
             named_import.span_imported,
             is_ts_like_importing_ts_like.then(|| format!("If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import {{ type Foo }} from '{}'`).", rec.module_request))
           );
-          if is_ts_like_importing_ts_like {
-            diagnostic = diagnostic.with_severity_warning();
-            self.warnings.push(diagnostic);
-          } else {
-            self.errors.push(diagnostic);
-          }
+          self.errors.push(diagnostic);
         }
       }
     }

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/_config.json
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/_config.json
@@ -7,5 +7,5 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
+# Errors
 
 ## MISSING_EXPORT
 
 ```text
-[MISSING_EXPORT] Warning: "default" is not exported by "keep/declare-class.ts".
+[MISSING_EXPORT] Error: "default" is not exported by "keep/declare-class.ts".
    ╭─[ entry.ts:1:8 ]
    │
  1 │ import dc_def, { bar as dc } from './keep/declare-class'
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## MISSING_EXPORT
 
 ```text
-[MISSING_EXPORT] Warning: "default" is not exported by "keep/declare-let.ts".
+[MISSING_EXPORT] Error: "default" is not exported by "keep/declare-let.ts".
    ╭─[ entry.ts:2:8 ]
    │
  2 │ import dl_def, { bar as dl } from './keep/declare-let'
@@ -30,91 +30,5 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ 
    │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './keep/declare-let'`).
 ───╯
-
-```
-
-## TOLERATED_TRANSFORM
-
-```text
-[TOLERATED_TRANSFORM] Warning: Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-   ╭─[ keep/value-namespace-merged.ts:5:13 ]
-   │
- 5 │     export let num = 0
-   │                ───┬───  
-   │                   ╰───── 
-───╯
-
-```
-
-## TOLERATED_TRANSFORM
-
-```text
-[TOLERATED_TRANSFORM] Warning: Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
-   ╭─[ keep/value-namespace.ts:2:13 ]
-   │
- 2 │     export let num = 0
-   │                ───┬───  
-   │                   ╰───── 
-───╯
-
-```
-
-# Assets
-
-## entry.js
-
-```js
-//#region keep/interface-merged.ts
-var foo$3 = class foo$3 {
-	static {
-		this.x = new foo$3();
-	}
-};
-//#endregion
-//#region keep/interface-nested.ts
-var interface_nested_default = foo;
-//#endregion
-//#region keep/type-nested.ts
-var type_nested_default = foo;
-//#endregion
-//#region keep/value-namespace.ts
-let foo$2;
-(function(_foo) {
-	_foo.num = 0;
-})(foo$2 || (foo$2 = {}));
-var value_namespace_default = foo$2;
-//#endregion
-//#region keep/value-namespace-merged.ts
-let foo$1;
-(function(_foo) {
-	_foo.num = 0;
-})(foo$1 || (foo$1 = {}));
-var value_namespace_merged_default = foo$1;
-//#endregion
-//#region entry.ts
-var entry_default = [
-	dc_def,
-	123,
-	dl_def,
-	123,
-	foo$3,
-	123,
-	interface_nested_default,
-	123,
-	type_nested_default,
-	123,
-	value_namespace_default,
-	123,
-	value_namespace_merged_default,
-	123,
-	123,
-	123,
-	123,
-	123,
-	123,
-	123
-];
-//#endregion
-export { entry_default as default };
 
 ```

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/diff.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/diff.md
@@ -93,84 +93,30 @@ export {
 ```
 ### rolldown
 ```js
-//#region keep/interface-merged.ts
-var foo$3 = class foo$3 {
-	static {
-		this.x = new foo$3();
-	}
-};
-//#endregion
-//#region keep/interface-nested.ts
-var interface_nested_default = foo;
-//#endregion
-//#region keep/type-nested.ts
-var type_nested_default = foo;
-//#endregion
-//#region keep/value-namespace.ts
-let foo$2;
-(function(_foo) {
-	_foo.num = 0;
-})(foo$2 || (foo$2 = {}));
-var value_namespace_default = foo$2;
-//#endregion
-//#region keep/value-namespace-merged.ts
-let foo$1;
-(function(_foo) {
-	_foo.num = 0;
-})(foo$1 || (foo$1 = {}));
-var value_namespace_merged_default = foo$1;
-//#endregion
-//#region entry.ts
-var entry_default = [
-	dc_def,
-	123,
-	dl_def,
-	123,
-	foo$3,
-	123,
-	interface_nested_default,
-	123,
-	type_nested_default,
-	123,
-	value_namespace_default,
-	123,
-	value_namespace_merged_default,
-	123,
-	123,
-	123,
-	123,
-	123,
-	123,
-	123
-];
-//#endregion
-export { entry_default as default };
 
 ```
 ### diff
 ```diff
 ===================================================================
 --- esbuild	/out.js
-+++ rolldown	entry.js
-@@ -1,37 +1,19 @@
++++ rolldown
+@@ -1,37 +0,0 @@
 -var declare_class_default = foo;
 -var bar = 123;
 -var declare_let_default = foo;
 -var bar2 = 123;
 -var foo2 = class _foo {
-+var foo$3 = class foo$3 {
-     static {
+-    static {
 -        this.x = new _foo();
-+        this.x = new foo$3();
-     }
- };
+-    }
+-};
 -var interface_merged_default = foo2;
 -var bar3 = 123;
 -if (true) {}
- var interface_nested_default = foo;
+-var interface_nested_default = foo;
 -var bar4 = 123;
 -if (true) {}
- var type_nested_default = foo;
+-var type_nested_default = foo;
 -var bar5 = 123;
 -var foo3;
 -(foo5 => {
@@ -191,17 +137,6 @@ export { entry_default as default };
 -var bar12 = 123;
 -var bar13 = 123;
 -var entry_default = [declare_class_default, bar, declare_let_default, bar2, interface_merged_default, bar3, interface_nested_default, bar4, type_nested_default, bar5, value_namespace_default, bar6, value_namespace_merged_default, bar7, bar8, bar9, bar10, bar11, bar12, bar13];
-+var foo$2;
-+(function (_foo) {
-+    _foo.num = 0;
-+})(foo$2 || (foo$2 = {}));
-+var value_namespace_default = foo$2;
-+var foo$1;
-+(function (_foo) {
-+    _foo.num = 0;
-+})(foo$1 || (foo$1 = {}));
-+var value_namespace_merged_default = foo$1;
-+var entry_default = [dc_def, 123, dl_def, 123, foo$3, 123, interface_nested_default, 123, type_nested_default, 123, value_namespace_default, 123, value_namespace_merged_default, 123, 123, 123, 123, 123, 123, 123];
- export {entry_default as default};
+-export {entry_default as default};
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/_config.json
@@ -1,3 +1,3 @@
 {
-  "expectExecuted": false
+  "expectError": true
 }

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/artifacts.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
+# Errors
 
 ## MISSING_EXPORT
 
 ```text
-[MISSING_EXPORT] Warning: "Bar" is not exported by "bar.ts".
+[MISSING_EXPORT] Error: "Bar" is not exported by "bar.ts".
    ╭─[ main.ts:3:10 ]
    │
  3 │ import { Bar } from './bar.ts'
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## MISSING_EXPORT
 
 ```text
-[MISSING_EXPORT] Warning: "Foo" is not exported by "foo.ts".
+[MISSING_EXPORT] Error: "Foo" is not exported by "foo.ts".
    ╭─[ main.ts:1:10 ]
    │
  1 │ export { Foo } from './foo.ts'
@@ -30,14 +30,5 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ 
    │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './foo.ts'`).
 ───╯
-
-```
-
-# Assets
-
-## main.js
-
-```js
-export { Bar, Foo };
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/_config.json
@@ -1,3 +1,3 @@
 {
-  "expectExecuted": false
+  "expectError": true
 }

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
+# Errors
 
 ## MISSING_EXPORT
 
 ```text
-[MISSING_EXPORT] Warning: "default" is not exported by "foo.ts".
+[MISSING_EXPORT] Error: "default" is not exported by "foo.ts".
    ╭─[ main.ts:1:8 ]
    │
  1 │ import dc_def, { bar as dc } from "./foo";
@@ -15,17 +15,5 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ 
    │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './foo'`).
 ───╯
-
-```
-
-# Assets
-
-## main.js
-
-```js
-//#region main.ts
-var main_default = [dc_def, 123];
-//#endregion
-export { main_default as default };
 
 ```


### PR DESCRIPTION
Rolldown previously downgraded `MISSING_EXPORT` to a warning when both importer and importee were TypeScript modules, while still emitting the dangling re-export in the output — producing syntactically valid but semantically broken JavaScript that crashed downstream bundlers like webpack.

This change removes the TS-to-TS severity downgrade so a missing export is always an error, matching Rollup's behavior. The existing `If you meant to import a type...` hint is preserved.

Fixes #9141.
