### PR TITLE
ci: use app token for release PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,9 +59,16 @@ jobs:
           config: cliff.toml
           args: --unreleased --prepend CHANGELOG.md --tag ${{ env.VERSION }}
 
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         if: ${{ steps.changelog.outputs.content }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: |
             CHANGELOG.md
             packages/**/package.json


### PR DESCRIPTION
## Summary

- generate a GitHub App installation token in the Prepare Release workflow
- pass that token to `peter-evans/create-pull-request` so release PR creation does not use `GITHUB_TOKEN`

## Validation

- `git diff --check -- .github/workflows/prepare-release.yml`
- YAML parse check with Ruby
- `just lint-repo` partially ran: `typos` and `cargo ls-lint` passed, then `vp fmt` failed because local `vite-plus` is not installed/resolvable
