### PR TITLE
docs: remove minifier alpha status notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 > 🚧 **Release Candidate**
 >
-> Rolldown is currently in RC status. While it can already handle most production use cases, there may still be bugs and rough edges. Most notably, the built-in minification feature is still in alpha status.
+> Rolldown is currently in RC status. While it can already handle most production use cases, there may still be bugs and rough edges.
 
 # Rolldown
 

--- a/docs/guide/notable-features.md
+++ b/docs/guide/notable-features.md
@@ -87,38 +87,6 @@ This is conceptually similar to [esbuild's `loader` option](https://esbuild.gith
 
 ## Minification
 
-- ⚠️ Experimental
 - Configurable via the [`output.minify`](/reference/OutputOptions.minify) option.
 
-The minification is powered by [`oxc-minifier`](https://github.com/oxc-project/oxc/tree/main/crates/oxc_minifier), which is currently in alpha and can still have bugs. We recommend thoroughly testing your output in production environments.
-
-If you prefer an external minifier instead, Rolldown is compatible with Rollup minifier plugins, such as:
-
-[`rollup-plugin-esbuild`](https://github.com/egoist/rollup-plugin-esbuild):
-
-```js [rolldown.config.js]
-import { defineConfig } from 'rolldown';
-import { minify } from 'rollup-plugin-esbuild';
-
-export default defineConfig({
-  plugins: [minify()],
-});
-```
-
-[`rollup-plugin-swc3`](https://github.com/SukkaW/rollup-plugin-swc):
-
-```js [rolldown.config.js]
-import { defineConfig } from 'rolldown';
-import { minify } from 'rollup-plugin-swc3';
-
-export default defineConfig({
-  plugins: [
-    minify({
-      module: true,
-      // swc's minify option here
-      mangle: {},
-      compress: {},
-    }),
-  ],
-});
-```
+The minification is powered by [Oxc Minifier](https://oxc.rs/docs/guide/usage/minifier). See its documentation for more details.


### PR DESCRIPTION
Remove the alpha status notices as it's not alpha anymore.