### PR TITLE
refactor(link_stage): simplify exports-kind filter and clarify safety comments

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -15,18 +15,19 @@ impl LinkStage<'_> {
       importer
         .import_records
         .iter()
-        .filter_map(|rec| rec.resolved_module.map(|module_idx| (rec, module_idx)))
-        .for_each(|(rec, module_idx)| {
-          let Module::Normal(importee) = &self.module_table[module_idx] else {
-            return;
-          };
+        .filter_map(|rec| {
+          let importee = rec.resolved_module.and_then(|idx| self.module_table[idx].as_normal())?;
+          Some((rec, importee))
+        })
+        .for_each(|(rec, importee)| {
           match rec.kind {
             ImportKind::Import => {
               if matches!(importee.exports_kind, ExportsKind::None)
                 && !importee.meta.has_lazy_export()
               {
-                // `import` a module that has `ExportsKind::None`, which will be turned into `ExportsKind::Esm`
-                // SAFETY: If `importee` and `importer` are different, so this is safe. If they are the same, then behaviors are still expected.
+                // `import`ing a module with `ExportsKind::None` promotes it to `ExportsKind::Esm`.
+                // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
+                // If they are the same (self-import), writing `exports_kind` is still correct.
                 unsafe {
                   let importee_mut = addr_of!(*importee).cast_mut();
                   (&mut (*importee_mut)).exports_kind = ExportsKind::Esm;
@@ -42,8 +43,9 @@ impl LinkStage<'_> {
               }
               ExportsKind::None => {
                 self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-                // SAFETY: If `importee` and `importer` are different, so this is safe. If they are the same, then behaviors are still expected.
-                // A module with `ExportsKind::None` that `require` self should be turned into `ExportsKind::CommonJs`.
+                // A `require`'d module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`.
+                // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
+                // If they are the same (self-require), writing `exports_kind` is still correct.
                 unsafe {
                   let importee_mut = addr_of!(*importee).cast_mut();
                   (&mut (*importee_mut)).exports_kind = ExportsKind::CommonJs;
@@ -52,8 +54,8 @@ impl LinkStage<'_> {
             },
             ImportKind::DynamicImport => {
               if self.options.code_splitting.is_disabled() {
-                // For iife, then import() is just a require() that
-                // returns a promise, so the imported file must also be wrapped
+                // When code splitting is disabled (e.g. iife/umd/cjs output), `import()` behaves
+                // like a `require()` that returns a promise, so the imported module must be wrapped.
                 match importee.exports_kind {
                   ExportsKind::Esm => {
                     self.metas[importee.idx].sync_wrap_kind(WrapKind::Esm);
@@ -63,8 +65,10 @@ impl LinkStage<'_> {
                   }
                   ExportsKind::None => {
                     self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-                    // SAFETY: If `importee` and `importer` are different, so this is safe. If they are the same, then behaviors are still expected.
-                    // A module with `ExportsKind::None` that `require` self should be turned into `ExportsKind::CommonJs`.
+                    // A dynamically-imported module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`
+                    // since we wrap it as CJS.
+                    // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
+                    // If they are the same (self dynamic-import), writing `exports_kind` is still correct.
                     unsafe {
                       let importee_mut = addr_of!(*importee).cast_mut();
                       (&mut (*importee_mut)).exports_kind = ExportsKind::CommonJs;


### PR DESCRIPTION
Collapse the two-step `filter_map` + `for_each` in `determine_module_exports_kind` so the iterator yields `(rec, &NormalModule)` directly via `Module::as_normal`, removing the inline `let-else` inside the closure. Also rewrites the `SAFETY:` and promotion comments to be clearer about what each branch does and why self-import aliasing is safe.

Note: replaces #9178 which was auto-closed as merged after a stack reorder (GitHub detected all its commits were in its former base branch). Same content, now targeting main directly.
