### PR TITLE
refactor: drop redundant clear() in determine_safely_merge_cjs_ns

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -105,8 +105,6 @@ impl LinkStage<'_> {
   /// a single namespace binding, reducing code size.
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_safely_merge_cjs_ns(&mut self) {
-    self.safely_merge_cjs_ns_map.clear();
-
     for importer in self.module_table.modules.iter().filter_map(Module::as_normal) {
       for (rec_idx, rec) in importer.import_records.iter_enumerated() {
         if !matches!(rec.kind, ImportKind::Import)


### PR DESCRIPTION
`determine_safely_merge_cjs_ns` is called exactly once per `LinkStage`, and the map is initialized empty in the constructor, so the leading `clear()` is dead code. Removes it to reduce noise.
