### PR TITLE
refactor(bitset): return bool from set_bit to fuse guard-and-set

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -635,11 +635,9 @@ pub fn include_runtime_symbol(
 
 /// if no export is used, and the module has no side effects, the module should not be included
 pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
-  if ctx.is_module_included_vec.has_bit(module.idx) {
+  if !ctx.is_module_included_vec.set_bit(module.idx) {
     return;
   }
-
-  ctx.is_module_included_vec.set_bit(module.idx);
   ctx.module_inclusion_changed = true;
 
   if module.idx == ctx.runtime_idx && !module.side_effects.has_side_effects() {
@@ -833,14 +831,12 @@ pub fn include_statement(
   module: &NormalModule,
   stmt_info_idx: StmtInfoIdx,
 ) {
-  if ctx.is_included_vec[module.idx].has_bit(stmt_info_idx) {
+  // include the statement itself
+  if !ctx.is_included_vec[module.idx].set_bit(stmt_info_idx) {
     return;
   }
 
   let stmt_info = module.stmt_infos.get(stmt_info_idx);
-
-  // include the statement itself
-  ctx.is_included_vec[module.idx].set_bit(stmt_info_idx);
 
   // FIXME: bailout for require() import for now
   // it is fine for now, since webpack did not support it either

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -20,10 +20,9 @@ struct Context<'a> {
 
 fn wrap_module_recursively(ctx: &mut Context, target: ModuleIdx) {
   // Only consider `NormalModule`
-  if ctx.visited_modules.has_bit(target) {
+  if !ctx.visited_modules.set_bit(target) {
     return;
   }
-  ctx.visited_modules.set_bit(target);
 
   let Module::Normal(module) = &ctx.modules[target] else {
     return;
@@ -66,10 +65,9 @@ fn has_dynamic_exports_due_to_export_star(
   linking_infos: &mut LinkingMetadataVec,
   visited_modules: &mut IndexBitSet<ModuleIdx>,
 ) -> bool {
-  if visited_modules.has_bit(target) {
+  if !visited_modules.set_bit(target) {
     return linking_infos[target].has_dynamic_exports;
   }
-  visited_modules.set_bit(target);
 
   let has_dynamic_exports = match &modules[target] {
     Module::Normal(module) => {

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -18,8 +18,12 @@ impl BitSet {
     (self.entries[idx] & (1 << (bit & 7))) != 0
   }
 
-  pub fn set_bit(&mut self, bit: u32) {
-    self.entries[bit as usize / 8] |= 1 << (bit & 7);
+  pub fn set_bit(&mut self, bit: u32) -> bool {
+    let byte = &mut self.entries[bit as usize / 8];
+    let mask = 1 << (bit & 7);
+    let was_set = *byte & mask != 0;
+    *byte |= mask;
+    !was_set
   }
 
   pub fn clear_bit(&mut self, bit: u32) {

--- a/crates/rolldown_utils/src/index_bitset.rs
+++ b/crates/rolldown_utils/src/index_bitset.rs
@@ -34,8 +34,8 @@ impl<I: Idx> IndexBitSet<I> {
     self.inner.has_bit(Self::bit(idx))
   }
 
-  pub fn set_bit(&mut self, idx: I) {
-    self.inner.set_bit(Self::bit(idx));
+  pub fn set_bit(&mut self, idx: I) -> bool {
+    self.inner.set_bit(Self::bit(idx))
   }
 
   pub fn clear_bit(&mut self, idx: I) {


### PR DESCRIPTION
`BitSet::set_bit` and `IndexBitSet::set_bit` now return `true` when the bit was newly set, mirroring `HashSet::insert`. Fuses four `if has_bit(x) { return } set_bit(x)` patterns into a single `if !set_bit(x) { return }` in `wrap_module_recursively`, `has_dynamic_exports_due_to_export_star`, `include_module`, and `include_statement`.
