### PR TITLE
docs: correct IncrementalFullBuild row in BundleMode table

### DIFF
--- a/meta/design/bundler-data-lifecycle.md
+++ b/meta/design/bundler-data-lifecycle.md
@@ -97,11 +97,11 @@ pub enum BundleMode {
 }
 ```
 
-| Mode                   | `ScanStageCache` in | `ScanStageCache` out | Shared state reset | Use case                                   |
-| ---------------------- | ------------------- | -------------------- | ------------------ | ------------------------------------------ |
-| `FullBuild`            | None                | Discarded            | Yes                | One-shot build, non-incremental watch      |
-| `IncrementalFullBuild` | None                | Saved                | Yes                | First build with `incremental: true`       |
-| `IncrementalBuild`     | Existing            | Updated              | No                 | Subsequent builds with `incremental: true` |
+| Mode                   | `ScanStageCache` in | `ScanStageCache` out | Shared state reset | Use case                                                                        |
+| ---------------------- | ------------------- | -------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| `FullBuild`            | None                | Discarded            | Yes                | One-shot build, non-incremental watch                                           |
+| `IncrementalFullBuild` | Fresh               | Saved                | Yes                | First build with `incremental: true`, or dev-mode recovery after a failed build |
+| `IncrementalBuild`     | Existing            | Updated              | No                 | Subsequent builds with `incremental: true`                                      |
 
 **Key distinction:** `IncrementalFullBuild` vs `FullBuild` — both do a full scan, but `IncrementalFullBuild` retains the resulting `ScanStageCache` for later incremental builds. Without this distinction, watch mode with `incremental: false` was silently paying the cost of materializing and retaining scan-stage state on every rebuild for no benefit.
 


### PR DESCRIPTION
The `IncrementalFullBuild` row in the `BundleMode` table previously listed `ScanStageCache in = None`, but `create_bundle` never receives a literal `None` for that mode — `with_cached_bundle` always passes `Some(_)` with a default-constructed cache. The use case column also omitted the dev-mode recovery path (see `bundle_coordinator.rs:83, 219, 413`) that re-queues a full build after a failed build.

## Changes

- **`ScanStageCache in`**: `None` → `Fresh`
- **Use case**: now also mentions *or dev-mode recovery after a failed build*
