### PR TITLE
refactor(runtime_helper): wrap DependedRuntimeHelperMap in a struct

### DIFF
--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -50,11 +50,11 @@ impl LinkStage<'_> {
         let mut symbols_to_be_declared = vec![];
         stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
           if stmt_info.meta.contains(StmtInfoMeta::HasDummyRecord) {
-            depended_runtime_helper_map[RuntimeHelper::Require.bit_index()].push(stmt_info_idx);
+            depended_runtime_helper_map.push(RuntimeHelper::Require, stmt_info_idx);
           }
           // Handle non-static dynamic imports like `import(foo)` or `import('a' + 'b')`
           if stmt_info.meta.intersects(StmtInfoMeta::NonStaticDynamicImport) {
-            depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()].push(stmt_info_idx);
+            depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
           }
           stmt_info.import_records.iter().for_each(|rec_id| {
             let rec = &importer.import_records[*rec_id];
@@ -80,8 +80,7 @@ impl LinkStage<'_> {
                         stmt_info.side_effect = true.into();
                         // Only reference __toESM if this import needs interop (namespace or default import)
                         if import_record_needs_interop(importer, *rec_id) {
-                          depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                            .push(stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
                         }
                       }
                     }
@@ -101,8 +100,7 @@ impl LinkStage<'_> {
                   {
                     // When format is CJS and dynamicImportInCjs is false, we need __toESM
                     // to wrap the require call: `Promise.resolve().then(() => __toESM(require("external")))`
-                    depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                      .push(stmt_info_idx);
+                    depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
                   }
                   _ => {}
                 }
@@ -132,8 +130,8 @@ impl LinkStage<'_> {
                           if meta.has_dynamic_exports {
                             stmt_info.side_effect = true.into();
                             stmt_info.meta.insert(StmtInfoMeta::ReExportDynamicExports);
-                            depended_runtime_helper_map[RuntimeHelper::ReExport.bit_index()]
-                              .push(stmt_info_idx);
+                            depended_runtime_helper_map
+                              .push(RuntimeHelper::ReExport, stmt_info_idx);
                             stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
                             stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
                           }
@@ -147,10 +145,8 @@ impl LinkStage<'_> {
                           stmt_info
                             .referenced_symbols
                             .push(importee_linking_info.wrapper_ref.unwrap().into());
-                          depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                            .push(stmt_info_idx);
-                          depended_runtime_helper_map[RuntimeHelper::ReExport.bit_index()]
-                            .push(stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ReExport, stmt_info_idx);
                           if !commonjs_treeshake {
                             stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
                           }
@@ -172,8 +168,7 @@ impl LinkStage<'_> {
                               import_record_needs_interop(importer, *rec_id)
                             };
                           if needs_toesm {
-                            depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                              .push(stmt_info_idx);
+                            depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
                           }
                           symbols_to_be_declared.push((rec.namespace_ref, stmt_info_idx));
                           symbol_db.ast_scopes.set_symbol_name(
@@ -194,8 +189,7 @@ impl LinkStage<'_> {
                         if is_reexport_all && importee_linking_info.has_dynamic_exports {
                           // Turn `export * from 'bar_esm'` into `init_bar_esm();__reExport(foo_exports, bar_esm_exports);`
                           // something like `__reExport(foo_exports, other_exports)`
-                          depended_runtime_helper_map[RuntimeHelper::ReExport.bit_index()]
-                            .push(stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ReExport, stmt_info_idx);
                           stmt_info.meta.insert(StmtInfoMeta::ReExportDynamicExports);
                           stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
                           stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
@@ -221,8 +215,7 @@ impl LinkStage<'_> {
                       stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
 
                       if !rec.meta.contains(ImportRecordMeta::IsRequireUnused) {
-                        depended_runtime_helper_map[RuntimeHelper::ToCommonJs.bit_index()]
-                          .push(stmt_info_idx);
+                        depended_runtime_helper_map.push(RuntimeHelper::ToCommonJs, stmt_info_idx);
                       }
                     }
                   },
@@ -235,8 +228,7 @@ impl LinkStage<'_> {
                           stmt_info
                             .referenced_symbols
                             .push(importee_linking_info.wrapper_ref.unwrap().into());
-                          depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                            .push(stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
                         }
                         WrapKind::Esm => {
                           // `(init_foo(), foo_exports)`
@@ -251,8 +243,7 @@ impl LinkStage<'_> {
                         ExportsKind::CommonJs => {
                           // `import('./some-cjs-module.js')` would be converted to
                           // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
-                          depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
-                            .push(stmt_info_idx);
+                          depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
                         }
                         ExportsKind::Esm | ExportsKind::None => {}
                       }
@@ -270,7 +261,7 @@ impl LinkStage<'_> {
             }
           });
           if keep_names && stmt_info.meta.intersects(StmtInfoMeta::KeepNamesType) {
-            depended_runtime_helper_map[RuntimeHelper::Name.bit_index()].push(stmt_info_idx);
+            depended_runtime_helper_map.push(RuntimeHelper::Name, stmt_info_idx);
           }
         });
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -343,22 +343,20 @@ impl LinkStage<'_> {
       .for_each(|(module, meta)| {
         let idx = module.idx;
         let mut normalized_runtime_helper = RuntimeHelper::default();
-        for (index, stmt_info_idxs) in module.depended_runtime_helper.iter().enumerate() {
+        for (helper, stmt_info_idxs) in module.depended_runtime_helper.iter() {
           if stmt_info_idxs.is_empty() {
             continue;
           }
           let any_included = stmt_info_idxs
             .iter()
             .any(|stmt_info_idx| is_stmt_info_included_vec[module.idx].has_bit(*stmt_info_idx));
-          #[expect(clippy::cast_possible_truncation)]
-          // Note: `RuntimeHelper` is a bitmask with at most 32 bits, so the index is guaranteed to fit in u32.
+          // We also need to process the runtime helper of an eliminated module so that we
+          // can propagate it to its importers later.
           normalized_runtime_helper.set(
-            RuntimeHelper::from_bits(1 << index as u32).unwrap(),
+            helper,
             any_included
               || (module.id != RUNTIME_MODULE_ID && !is_module_included_vec.has_bit(idx)),
           );
-          // We also need to process the runtime helper of the eliminate module so that we
-          // could propagate them to its importers later
         }
         meta.depended_runtime_helper = normalized_runtime_helper;
         meta.module_namespace_included_reason = module_namespace_included_reason[module.idx];

--- a/crates/rolldown_common/src/generated/runtime_helper.rs
+++ b/crates/rolldown_common/src/generated/runtime_helper.rs
@@ -37,15 +37,30 @@ impl RuntimeHelper {
   }
 }
 use crate::StmtInfoIdx;
-pub type DependedRuntimeHelperMap = [Vec<StmtInfoIdx>; RUNTIME_HELPER_NAMES.len()];
-pub trait DependedRuntimeHelperMapExt {
+
+/// Maps each single-bit `RuntimeHelper` to the `StmtInfoIdx`s that depend on it.
+#[derive(Debug, Default, Clone)]
+pub struct DependedRuntimeHelperMap([Vec<StmtInfoIdx>; RUNTIME_HELPER_NAMES.len()]);
+
+impl DependedRuntimeHelperMap {
+  /// Record that `stmt_info_idx` depends on `helper`. `helper` must have exactly one bit set.
+  #[inline]
+  pub fn push(&mut self, helper: RuntimeHelper, stmt_info_idx: StmtInfoIdx) {
+    self.0[helper.bit_index()].push(stmt_info_idx);
+  }
+
+  /// Iterate over `(single-bit helper, &statements)` pairs for each defined `RuntimeHelper` bit.
+  pub fn iter(&self) -> impl Iterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
+    self.0.iter().enumerate().map(|(i, v)| {
+      // `i` is always within `0..RUNTIME_HELPER_NAMES.len()`, matching a defined single-bit flag.
+      (RuntimeHelper::from_bits_truncate(1 << i), v)
+    })
+  }
+
   /// Debug function to print runtime names and their associated statement indices
-  fn debug_print(&self);
-}
-impl DependedRuntimeHelperMapExt for DependedRuntimeHelperMap {
-  fn debug_print(&self) {
+  pub fn debug_print(&self) {
     eprintln!("DependedRuntimeHelperMap debug:");
-    for (idx, stmt_infos) in self.iter().enumerate() {
+    for (idx, stmt_infos) in self.0.iter().enumerate() {
       if let Some(runtime_name) = RUNTIME_HELPER_NAMES.get(idx) {
         eprintln!("  {runtime_name} (idx: {idx}): {stmt_infos:?}");
       } else {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -17,9 +17,7 @@ mod utils;
 pub mod bundler_options {
   pub use crate::generated::{
     checks_options::ChecksOptions,
-    runtime_helper::{
-      DependedRuntimeHelperMap, DependedRuntimeHelperMapExt, RUNTIME_HELPER_NAMES, RuntimeHelper,
-    },
+    runtime_helper::{DependedRuntimeHelperMap, RUNTIME_HELPER_NAMES, RuntimeHelper},
   };
 
   #[cfg(feature = "deserialize_bundler_options")]

--- a/tasks/generator/src/generators/runtime_helper.rs
+++ b/tasks/generator/src/generators/runtime_helper.rs
@@ -83,15 +83,30 @@ impl RuntimeHelper {
   }
 }
 use crate::StmtInfoIdx;
-pub type DependedRuntimeHelperMap = [Vec<StmtInfoIdx>; RUNTIME_HELPER_NAMES.len()];
-pub trait DependedRuntimeHelperMapExt {
+
+/// Maps each single-bit `RuntimeHelper` to the `StmtInfoIdx`s that depend on it.
+#[derive(Debug, Default, Clone)]
+pub struct DependedRuntimeHelperMap([Vec<StmtInfoIdx>; RUNTIME_HELPER_NAMES.len()]);
+
+impl DependedRuntimeHelperMap {
+  /// Record that `stmt_info_idx` depends on `helper`. `helper` must have exactly one bit set.
+  #[inline]
+  pub fn push(&mut self, helper: RuntimeHelper, stmt_info_idx: StmtInfoIdx) {
+    self.0[helper.bit_index()].push(stmt_info_idx);
+  }
+
+  /// Iterate over `(single-bit helper, &statements)` pairs for each defined `RuntimeHelper` bit.
+  pub fn iter(&self) -> impl Iterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
+    self.0.iter().enumerate().map(|(i, v)| {
+      // `i` is always within `0..RUNTIME_HELPER_NAMES.len()`, matching a defined single-bit flag.
+      (RuntimeHelper::from_bits_truncate(1 << i), v)
+    })
+  }
+
   /// Debug function to print runtime names and their associated statement indices
-  fn debug_print(&self);
-}
-impl DependedRuntimeHelperMapExt for DependedRuntimeHelperMap {
-  fn debug_print(&self) {
+  pub fn debug_print(&self) {
     eprintln!("DependedRuntimeHelperMap debug:");
-    for (idx, stmt_infos) in self.iter().enumerate() {
+    for (idx, stmt_infos) in self.0.iter().enumerate() {
       if let Some(runtime_name) = RUNTIME_HELPER_NAMES.get(idx) {
         eprintln!("  {runtime_name} (idx: {idx}): {stmt_infos:?}");
       } else {


### PR DESCRIPTION
Replaces the `DependedRuntimeHelperMap` type alias (`[Vec<StmtInfoIdx>; N]`) with a newtype struct that encapsulates the bit-indexing logic, so callsites no longer need to translate a `RuntimeHelper` into a bit index.

## Before

```rust
depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()].push(stmt_info_idx);
```

## After

```rust
depended_runtime_helper_map.push(RuntimeHelper::ToEsm, stmt_info_idx);
```

## Changes

- **`tasks/generator/src/generators/runtime_helper.rs`** — generator emits a newtype `pub struct DependedRuntimeHelperMap([Vec<StmtInfoIdx>; N])` with inherent methods:
  - `push(helper: RuntimeHelper, stmt_info_idx: StmtInfoIdx)` — wraps the old index lookup.
  - `iter()` yields `(RuntimeHelper, &Vec<StmtInfoIdx>)` pairs, so callers no longer need the `RuntimeHelper::from_bits(1 << index as u32).unwrap()` round-trip.
  - `debug_print()` moved from the old `DependedRuntimeHelperMapExt` trait onto the struct directly.
  - Derives `Debug + Default + Clone` to match the prior type alias's auto-implementations.
- **`crates/rolldown_common/src/lib.rs`** — drops the `DependedRuntimeHelperMapExt` re-export.
- **`crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs`** — all 10 `map[Helper.bit_index()].push(idx)` sites now use `map.push(Helper, idx)`.
- **`crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs`** — the `enumerate()` + `from_bits(1 << index as u32)` pattern is replaced with `for (helper, stmt_info_idxs) in module.depended_runtime_helper.iter()`, and the `#[expect(clippy::cast_possible_truncation)]` is no longer needed.

## Verification

- `cargo check -p rolldown -p rolldown_common --tests` — clean.
- `cargo clippy -p rolldown -p rolldown_common --all-targets -- -D warnings` — clean.
- Rolldown lib unit tests: 53 pass.
- Integration fixtures `issues/5930`, `issues/7115`, `issues/7233` — no snapshot drift, confirming the refactor is behaviourally equivalent.
