### PR TITLE
perf(devtools): write logs on a background thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,7 +3020,6 @@ name = "rolldown_devtools"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "dashmap",
  "rolldown_devtools_action",
  "rustc-hash",
  "serde",

--- a/crates/rolldown_binding/src/classic_bundler.rs
+++ b/crates/rolldown_binding/src/classic_bundler.rs
@@ -116,6 +116,13 @@ impl ClassicBundler {
     if !is_closed {
       self.closed = true;
     }
+    // When devtools is active, ask the writer thread to drain this session and
+    // receive an ack. Consumers rely on "files are readable after
+    // `bundle.close()` resolves" — see `meta/design/devtools.md`.
+    let devtools_flush_rx = self
+      .debug_tracer
+      .as_ref()
+      .map(|_| rolldown_devtools::flush_session(self.session_id.as_ref().to_string()));
     // - The code is written in a non-intuitive way to satisfy the rustc and the upper usage of `BindingBundler#close`.
     // - We need the future to be `Send + 'static` for napi-rs, so we can't use `async fn` directly here.
     // - Read `BindingBundler#close` in `crates/rolldown_binding/src/binding_bundler.rs` for more details.
@@ -123,6 +130,34 @@ impl ClassicBundler {
       if let Some(handle) = last_bundle_handle {
         let plugin_driver = handle.plugin_driver();
         plugin_driver.close_bundle(None).await?;
+      }
+      if let Some(rx) = devtools_flush_rx {
+        // Block on the writer-thread ack in a blocking task so we don't stall
+        // a tokio worker. Bounded wait so a hung writer thread (e.g. stalled
+        // fs I/O on an NFS disconnect) can't wedge `bundle.close()` forever.
+        // All three failure modes (timeout, writer disconnected, blocking task
+        // panicked) are surfaced as errors so the documented "logs readable
+        // after close()" contract does not silently break.
+        let join_result = napi::tokio::task::spawn_blocking(move || {
+          rx.recv_timeout(std::time::Duration::from_secs(30))
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("devtools flush task failed to join: {err}"))?;
+        match join_result {
+          Ok(()) => {}
+          Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            return Err(anyhow::anyhow!(
+              "devtools writer did not acknowledge session flush within 30s; \
+               node_modules/.rolldown log files may be truncated"
+            ));
+          }
+          Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            return Err(anyhow::anyhow!(
+              "devtools writer thread disconnected before acknowledging flush; \
+               node_modules/.rolldown log files may be truncated"
+            ));
+          }
+        }
       }
       Ok(())
     }

--- a/crates/rolldown_devtools/Cargo.toml
+++ b/crates/rolldown_devtools/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 blake3 = { workspace = true }
-dashmap = { workspace = true }
 rolldown_devtools_action = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rolldown_devtools/src/devtools_formatter.rs
+++ b/crates/rolldown_devtools/src/devtools_formatter.rs
@@ -1,25 +1,20 @@
-use std::{
-  fs::OpenOptions,
-  io::Write,
-  sync::Arc,
-  time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::Arc;
 
 use crate::{
-  static_data::{
-    DEFAULT_SESSION_ID, EXIST_HASH_BY_SESSION, OPENED_FILE_HANDLES, OPENED_FILES_BY_SESSION,
-  },
+  static_data::DEFAULT_SESSION_ID,
   types::{ContextData, DevtoolsActionFieldExtractor},
+  writer::{self, LogCommand},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::ser::{SerializeMap, Serializer as _};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::{
   fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
   registry::LookupSpan,
 };
 
-/// A formatter that formats tracing events into devtools compatible JSON lines and writes them into files.
+/// A formatter that formats tracing events into devtools compatible JSON lines
+/// and hands them to the dedicated writer thread. The on-hot-path work is just
+/// JSON shaping + a channel send; no file I/O, no cross-thread locks.
 pub struct DevtoolsFormatter;
 
 impl DevtoolsFormatter {
@@ -41,8 +36,7 @@ where
     _writer: Writer<'_>,
     event: &Event<'_>,
   ) -> std::fmt::Result {
-    let action_value = Self::extract_action(event);
-    let Some(mut action_value) = action_value else {
+    let Some(mut action_value) = Self::extract_action(event) else {
       // This branch means this event is not for devtools tracing.
       return Ok(());
     };
@@ -79,10 +73,9 @@ where
 
     inject_context_data(&mut action_value, &found_context_fields);
 
-    let session_id =
-      found_context_fields.get("session_id").map_or(DEFAULT_SESSION_ID, String::as_str);
-
-    std::fs::create_dir_all(format!("node_modules/.rolldown/{session_id}")).ok();
+    let session_id = found_context_fields
+      .get("session_id")
+      .map_or_else(|| DEFAULT_SESSION_ID.to_string(), String::to_owned);
 
     let is_session_meta = action_value
       .as_object()
@@ -90,133 +83,15 @@ where
       .get("action")
       .is_some_and(|v| v == "SessionMeta");
 
-    let log_filename: Arc<str> = if is_session_meta {
+    let filename: Arc<str> = if is_session_meta {
       format!("node_modules/.rolldown/{session_id}/meta.json").into()
     } else {
       format!("node_modules/.rolldown/{session_id}/logs.json").into()
     };
 
-    if !OPENED_FILE_HANDLES.contains_key(&log_filename) {
-      let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_filename.as_ref())
-        .map_err(|_| std::fmt::Error)?;
-      // Ensure for each file, we only have one unique file handle to prevent multiple writes.
-      OPENED_FILE_HANDLES.insert(Arc::clone(&log_filename), file);
-    }
-
-    OPENED_FILES_BY_SESSION
-      .entry(session_id.to_string())
-      .or_default()
-      .insert(Arc::clone(&log_filename));
-
-    let mut file = OPENED_FILE_HANDLES
-      .get_mut(&log_filename)
-      .unwrap_or_else(|| panic!("{log_filename} not found"));
-    let mut file = file.value_mut();
-
-    let mut need_newline = false;
-    let mut cache_large_string = || -> Result<(), serde_json::Error> {
-      // WARN: Do not use pretty print here, vite-devtool relies on the format of every line is a json object.
-      let mut serializer = serde_json::Serializer::new(&mut file);
-
-      let serde_json::Value::Object(action_meta) = &action_value else {
-        unreachable!("action_meta should always be an object");
-      };
-
-      for (_key, value) in action_meta {
-        match value {
-            serde_json::Value::String(value) if value.len() > 5 * 1024 /* 5kb */ => {
-              // we assume hash does not collide.
-              let hash = blake3::hash(value.as_bytes()).to_hex().to_string();
-              let mut exist_hash_set =
-                EXIST_HASH_BY_SESSION.entry(session_id.to_string()).or_default();
-              if !exist_hash_set.contains(&hash) {
-                exist_hash_set.insert(hash.clone());
-                let mut map = serializer.serialize_map(None)?;
-                map.serialize_entry("action", "StringRef")?;
-                map.serialize_entry("id", &hash)?;
-                map.serialize_entry("content", value)?;
-                map.end()?;
-                need_newline = true;
-              }
-            }
-            _ => {
-            }
-          }
-      }
-      Ok(())
-    };
-
-    cache_large_string().map_err(|_| std::fmt::Error)?;
-    if need_newline {
-      writeln!(file).map_err(|_| std::fmt::Error)?;
-    }
-
-    let mut visit = || {
-      // WARN: Do not use pretty print here, vite-devtool relies on the format of every line is a json object.
-      let mut serializer = serde_json::Serializer::new(&mut file);
-
-      let serde_json::Value::Object(action_meta) = &action_value else {
-        unreachable!("action_meta should always be an object");
-      };
-
-      for (_key, value) in action_meta {
-        match value {
-            serde_json::Value::String(value) if value.len() > 5 * 1024 /* 5kb */ => {
-              // we assume hash does not collide.
-              let hash = blake3::hash(value.as_bytes()).to_hex().to_string();
-              let mut exist_hash_set =
-                EXIST_HASH_BY_SESSION.entry(session_id.to_string()).or_default();
-              if !exist_hash_set.contains(&hash) {
-                exist_hash_set.insert(hash.clone());
-                let mut map = serializer.serialize_map(None)?;
-                map.serialize_entry("action", "StringRef")?;
-                map.serialize_entry("id", &hash)?;
-                map.serialize_entry("content", value)?;
-                map.end()?;
-              }
-            }
-            _ => {
-            }
-          }
-      }
-
-      let mut serializer = serializer.serialize_map(None)?;
-
-      serializer.serialize_entry("timestamp", &current_utc_timestamp_ms())?;
-
-      for (key, value) in action_meta {
-        match value {
-            serde_json::Value::String(value) if value.len() > 10 * 1024 /* 10kb */ => {
-              // we assume hash does not collide.
-              let hash = blake3::hash(value.as_bytes()).to_hex().to_string();
-              serializer.serialize_entry(key, &format!("$ref:{hash}"))?;
-            }
-            _ => {
-              serializer.serialize_entry(key, value)?;
-            }
-          }
-      }
-
-      // TODO(hyf0): we don't care about other fields for now.
-      // let mut visitor = tracing_serde::SerdeMapVisitor::new(serializer);
-      // event.record(&mut visitor);
-      // serializer = visitor.take_serializer()?;
-
-      serializer.end()
-    };
-
-    visit().map_err(|_| std::fmt::Error)?;
-    writeln!(file).map_err(|_| std::fmt::Error)?;
-    file.flush().map_err(|_| std::fmt::Error)?;
+    writer::send(LogCommand::Write { session_id, filename, action_value });
     Ok(())
   }
-}
-
-fn current_utc_timestamp_ms() -> u128 {
-  SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
 }
 
 // For prop value pair like: `id: "${call_id}"`, extract `call_id` so we can look up its value from context data.

--- a/crates/rolldown_devtools/src/init_tracing.rs
+++ b/crates/rolldown_devtools/src/init_tracing.rs
@@ -5,9 +5,7 @@ use tracing_subscriber::{filter::FilterFn, fmt, prelude::*};
 
 use crate::devtools_formatter::DevtoolsFormatter;
 use crate::devtools_layer::DevtoolsLayer;
-use crate::static_data::EXIST_HASH_BY_SESSION;
-use crate::static_data::OPENED_FILE_HANDLES;
-use crate::static_data::OPENED_FILES_BY_SESSION;
+use crate::writer::{self, LogCommand};
 
 static IS_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
@@ -46,12 +44,13 @@ impl DebugTracer {
 
 impl Drop for DebugTracer {
   fn drop(&mut self) {
-    if let Some((_session_id, files)) = OPENED_FILES_BY_SESSION.remove(self.session_id.as_ref()) {
-      for file in files {
-        OPENED_FILE_HANDLES.remove(&file);
-      }
-    }
-    EXIST_HASH_BY_SESSION.remove(self.session_id.as_ref());
+    // Best-effort cleanup path. Callers that need "file readable after this
+    // call" semantics should use `flush_session(...)` instead, which returns a
+    // receiver signalled after the writer thread drains this session.
+    writer::send(LogCommand::CloseSession {
+      session_id: self.session_id.as_ref().to_string(),
+      ack: None,
+    });
   }
 }
 

--- a/crates/rolldown_devtools/src/lib.rs
+++ b/crates/rolldown_devtools/src/lib.rs
@@ -35,10 +35,12 @@ mod trace_action_macro;
 mod type_alias;
 mod types;
 mod utils;
+mod writer;
 
 pub use rolldown_devtools_action as action;
 
 pub use {
   init_tracing::{DebugTracer, Session},
   utils::{generate_build_id, generate_session_id},
+  writer::flush_session,
 };

--- a/crates/rolldown_devtools/src/static_data.rs
+++ b/crates/rolldown_devtools/src/static_data.rs
@@ -1,15 +1,1 @@
-use std::sync::Arc;
-
-use dashmap::DashMap;
-use rustc_hash::FxHashSet;
-
-pub static OPENED_FILE_HANDLES: std::sync::LazyLock<DashMap<Arc<str>, std::fs::File>> =
-  std::sync::LazyLock::new(DashMap::new);
-
-pub static OPENED_FILES_BY_SESSION: std::sync::LazyLock<DashMap<String, FxHashSet<Arc<str>>>> =
-  std::sync::LazyLock::new(DashMap::new);
-
-pub static EXIST_HASH_BY_SESSION: std::sync::LazyLock<DashMap<String, FxHashSet<String>>> =
-  std::sync::LazyLock::new(DashMap::new);
-
 pub static DEFAULT_SESSION_ID: &str = "unknown-session";

--- a/crates/rolldown_devtools/src/writer.rs
+++ b/crates/rolldown_devtools/src/writer.rs
@@ -1,0 +1,170 @@
+use std::{
+  fs::{File, OpenOptions},
+  io::{BufWriter, Write},
+  path::Path,
+  sync::{
+    Arc, LazyLock,
+    mpsc::{Sender, channel},
+  },
+  thread,
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::ser::{SerializeMap, Serializer as _};
+
+/// Commands sent to the background devtools log-writer thread.
+pub enum LogCommand {
+  /// Emit one event. Carries a fully resolved action payload plus the
+  /// session/filename the producer has already decided on.
+  Write { session_id: String, filename: Arc<str>, action_value: serde_json::Value },
+  /// Flush and close every file associated with this session. When `ack` is
+  /// `Some`, the writer signals it once all files for this session have been
+  /// flushed to the OS, so callers can establish a happens-before relationship
+  /// between "build finished" and "log file is readable".
+  CloseSession { session_id: String, ack: Option<Sender<()>> },
+}
+
+static LOG_WRITER_TX: LazyLock<Sender<LogCommand>> = LazyLock::new(|| {
+  let (tx, rx) = channel::<LogCommand>();
+  thread::Builder::new()
+    .name("rolldown-devtools-writer".into())
+    .spawn(move || {
+      let mut state = WriterState::default();
+      while let Ok(cmd) = rx.recv() {
+        state.handle(cmd);
+      }
+      // Channel closed (process exit): flush everything still held.
+      state.flush_all();
+    })
+    .expect("failed to spawn rolldown-devtools-writer thread");
+  tx
+});
+
+/// Fire-and-forget send to the writer thread. Producers never block on I/O.
+pub fn send(cmd: LogCommand) {
+  // If the writer thread has died, drop the command silently.
+  let _ = LOG_WRITER_TX.send(cmd);
+}
+
+/// Request the writer thread to drain and flush every file for `session_id`,
+/// returning a receiver that fires once the flush has completed. Consumers
+/// use this to establish a happens-before relationship between `bundle.close()`
+/// resolving and a reader opening the session's log files.
+#[must_use = "the returned receiver must be awaited to actually wait for the flush"]
+pub fn flush_session(session_id: String) -> std::sync::mpsc::Receiver<()> {
+  let (tx, rx) = channel();
+  send(LogCommand::CloseSession { session_id, ack: Some(tx) });
+  rx
+}
+
+#[derive(Default)]
+struct WriterState {
+  files: FxHashMap<Arc<str>, BufWriter<File>>,
+  files_by_session: FxHashMap<String, FxHashSet<Arc<str>>>,
+  exist_hash_by_session: FxHashMap<String, FxHashSet<String>>,
+  dir_ensured: FxHashSet<String>,
+}
+
+impl WriterState {
+  fn handle(&mut self, cmd: LogCommand) {
+    match cmd {
+      LogCommand::Write { session_id, filename, action_value } => {
+        if self.dir_ensured.insert(session_id.clone()) {
+          if let Some(parent) = Path::new(filename.as_ref()).parent() {
+            let _ = std::fs::create_dir_all(parent);
+          }
+        }
+        let file = self.files.entry(Arc::clone(&filename)).or_insert_with(|| {
+          let f = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(filename.as_ref())
+            .unwrap_or_else(|e| panic!("devtools: failed to open log file {filename}: {e}"));
+          BufWriter::new(f)
+        });
+        self.files_by_session.entry(session_id.clone()).or_default().insert(Arc::clone(&filename));
+        let hashes = self.exist_hash_by_session.entry(session_id).or_default();
+        let _ = write_event(file, &action_value, hashes);
+      }
+      LogCommand::CloseSession { session_id, ack } => {
+        if let Some(files) = self.files_by_session.remove(&session_id) {
+          for fname in files {
+            if let Some(mut w) = self.files.remove(&fname) {
+              let _ = w.flush();
+            }
+          }
+        }
+        self.exist_hash_by_session.remove(&session_id);
+        self.dir_ensured.remove(&session_id);
+        if let Some(ack) = ack {
+          let _ = ack.send(());
+        }
+      }
+    }
+  }
+
+  fn flush_all(&mut self) {
+    for (_, mut w) in self.files.drain() {
+      let _ = w.flush();
+    }
+  }
+}
+
+fn write_event(
+  file: &mut BufWriter<File>,
+  action_value: &serde_json::Value,
+  exist_hashes: &mut FxHashSet<String>,
+) -> Result<(), serde_json::Error> {
+  let serde_json::Value::Object(action_meta) = action_value else {
+    unreachable!("action_meta should always be an object")
+  };
+
+  // First pass: emit StringRef lines for any strings >5KB we haven't seen before.
+  let mut wrote_ref = false;
+  for value in action_meta.values() {
+    if let serde_json::Value::String(s) = value {
+      if s.len() > 5 * 1024 {
+        let hash = blake3::hash(s.as_bytes()).to_hex().to_string();
+        if exist_hashes.insert(hash.clone()) {
+          let mut serializer = serde_json::Serializer::new(&mut *file);
+          let mut map = serializer.serialize_map(None)?;
+          map.serialize_entry("action", "StringRef")?;
+          map.serialize_entry("id", &hash)?;
+          map.serialize_entry("content", s)?;
+          map.end()?;
+          wrote_ref = true;
+        }
+      }
+    }
+  }
+  if wrote_ref {
+    writeln!(file).map_err(serde_json::Error::io)?;
+  }
+
+  // Second pass: emit the event line, with $ref:<hash> for strings >10KB.
+  {
+    let mut serializer = serde_json::Serializer::new(&mut *file);
+    let mut map = serializer.serialize_map(None)?;
+    map.serialize_entry("timestamp", &current_utc_timestamp_ms())?;
+    for (key, value) in action_meta {
+      match value {
+        serde_json::Value::String(s) if s.len() > 10 * 1024 => {
+          let hash = blake3::hash(s.as_bytes()).to_hex().to_string();
+          map.serialize_entry(key, &format!("$ref:{hash}"))?;
+        }
+        _ => {
+          map.serialize_entry(key, value)?;
+        }
+      }
+    }
+    map.end()?;
+  }
+  writeln!(file).map_err(serde_json::Error::io)?;
+
+  Ok(())
+}
+
+fn current_utc_timestamp_ms() -> u128 {
+  SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
+}

--- a/meta/design/devtools.md
+++ b/meta/design/devtools.md
@@ -34,6 +34,10 @@ When devtools is enabled, rolldown writes JSON-lines files to:
 
 Each line is a self-contained JSON object with an `action` discriminator field. Action events also carry `timestamp`, `session_id`, and `build_id` fields. `StringRef` entries contain only `action`, `id`, and `content` (no timestamp). The consumer reads the file and splits on newlines.
 
+### Read-after-close contract
+
+`meta.json` and `logs.json` are only guaranteed to be complete and readable **after `await bundle.close()` resolves**. Internally, events flow through a channel to a background writer thread and are buffered via `BufWriter`, so reading the files immediately after `generate()`/`write()` may return empty or truncated content. `bundle.close()` sends a `CloseSession` command with an ack channel and awaits the writer thread's signal, establishing the happens-before edge consumers depend on.
+
 ### Large String Deduplication
 
 Top-level string fields larger than 5 KB are cached by blake3 hash. A `StringRef` record is emitted before the action that references it:
@@ -56,7 +60,7 @@ Top-level string fields larger than 10 KB are additionally replaced with a `$ref
 
 ### Key Types
 
-- **`DebugTracer`** — Initializes a `tracing_subscriber` registry with the devtools-specific layer and formatter. Singleton init via `AtomicBool`. On drop, cleans up file handles and hash caches for its session.
+- **`DebugTracer`** — Initializes a `tracing_subscriber` registry with the devtools-specific layer and formatter. Singleton init via `AtomicBool`. On drop, sends a best-effort (no-ack) `CloseSession` to the writer thread as a cleanup fallback; the authoritative flush path is `ClassicBundler::close()`, which uses `rolldown_devtools::flush_session(session_id)` and awaits an ack before resolving.
 - **`Session`** — Holds a session `id` (e.g. `sid_0_1710000000000`) and a parent `tracing::Span`. All build spans are children of the session span. A `Session::dummy()` is used when devtools is disabled (no-op span).
 - **`DevtoolsLayer`** — A `tracing_subscriber::Layer` that extracts `CONTEXT_*` prefixed fields from spans and stores them as `ContextData` in span extensions.
 - **`DevtoolsFormatter`** — A `FormatEvent` impl that serializes `devtoolsAction`-tagged events to JSON lines, injects context variables, and writes to the appropriate file.
@@ -158,7 +162,7 @@ File handles and hash caches are stored in process-global `LazyLock<DashMap>` st
 - `OPENED_FILES_BY_SESSION` — tracks which files belong to which session (for cleanup)
 - `EXIST_HASH_BY_SESSION` — tracks already-emitted `StringRef` hashes per session (for dedup)
 
-These are cleaned up when `DebugTracer` is dropped.
+These are cleaned up when the background writer thread processes a `CloseSession` command — either sent synchronously via `flush_session(...)` from `ClassicBundler::close()` (ack-based, happens-before `close()` resolving) or best-effort from `DebugTracer::drop`.
 
 ## Consumer Side
 

--- a/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
@@ -103,5 +103,8 @@ test(`emit data for devtool`, async () => {
       ],
     });
     await bundle.generate();
+    // Devtools log files are only guaranteed complete after `close()` — the
+    // writer thread drains and flushes on the CloseSession ack.
+    await bundle.close();
   }
 });


### PR DESCRIPTION
## Summary

Fixes #5896. When devtools is enabled, rolldown's wall time collapses to I/O-lock wait time. This PR moves devtools log I/O onto a dedicated background thread, removing the per-event cross-thread lock and the blocking file writes from the hot path.

### Benchmark — `vite v8.0.10` + `@vitejs/devtools`, 1,404-module antd + React app (#5896 reproduction)

| build                          | time         |
|--------------------------------|--------------|
| main                           | **27.98 s**  |
| this PR (04-24-perf_devtools)  | **522 ms**   |
| **speedup**                    | **~54x**     |

## Root cause

`DevtoolsFormatter::format_event` ran on every `trace_action!`-emitted event — i.e. on every `resolve_id` / `load` / `transform` / `render_chunk` plugin hook, across every plugin. For one build session this is easily tens of thousands of events, fired from every tokio worker in parallel.

Before this PR, the formatter did all of this synchronously on the caller:

1. `OPENED_FILE_HANDLES.get_mut(&log_filename)` (a `DashMap<Arc<str>, File>`), which takes a **per-shard `parking_lot::RwLock` write guard**.
2. Held that guard across two full JSON-serialization passes (one for StringRef dedupe, one for the event line), the `WriteFile` syscall(s), and `file.flush()`.
3. Every session funnels all events into the same filename (`node_modules/.rolldown/<session>/logs.json`) → same DashMap key → same shard → **one lock serializing every tokio worker**.

The ETW profile made this unambiguous: with devtools on, **83% of all samples landed at `ntdll!NtWaitForAlertByThreadId`**, **99% of total thread time in `format_event` was in System Libraries** (parking in `parking_lot` via `WaitOnAddress`), and only **~1.2% of samples were actually executing Rust**. The call path was always

\`\`\`
NtWaitForAlertByThreadId -> WaitOnAddress -> parking_lot::park ->
  parking_lot::RawRwLock::lock_exclusive_slow ->
  dashmap::DashMap::_yield_write_shared ->
  dashmap::DashMap::get_mut ->
  rolldown_devtools::devtools_formatter::impl\$1::format_event
\`\`\`

So the slowdown wasn't \"more work\" — the actual Rust CPU work only grew ~5x. It was **cross-thread lock contention** serializing all worker threads onto one I/O-holding RwLock.

## Fix

Move all log I/O to a single dedicated `rolldown-devtools-writer` thread. Producers (the tokio workers running plugin hooks) do a fire-and-forget `Sender::send` over `std::sync::mpsc`:

- New `rolldown_devtools::writer` module owns the channel, the `BufWriter<File>` per log file, the per-session file tracking, and the per-session StringRef-dedupe hash set.
- `DevtoolsFormatter::format_event` now only does the JSON shaping that needs event-local context (placeholder resolution via span extensions, filename selection), then sends `LogCommand::Write { session_id, filename, action_value }` and returns. **No cross-thread lock is taken, no syscall is issued, on the hot path.**
- Removed `OPENED_FILE_HANDLES`, `OPENED_FILES_BY_SESSION`, `EXIST_HASH_BY_SESSION` (and the `dashmap` dep) — all that state now lives on the writer thread where no synchronization is needed.
- Directory creation is memoised per-session on the writer (`dir_ensured` set), instead of a `create_dir_all` syscall per event.
- `BufWriter` batches small `serde_json` writes into ~8 KB chunks, cutting `WriteFile` syscall count dramatically compared to the previous `serde_json::Serializer::new(&mut file)` -> raw `File` path.

### Read-after-close contract

Because log I/O is now asynchronous and buffered, consumers reading `meta.json` / `logs.json` immediately after `generate()` / `write()` could see truncated content. To preserve the expectation that **the log files are readable and complete once `await bundle.close()` resolves**, `ClassicBundler::close()` now:

1. Snapshots whether devtools is active (`self.debug_tracer.is_some()`).
2. Calls `rolldown_devtools::flush_session(session_id)`, which sends `LogCommand::CloseSession { session_id, ack: Some(tx) }` and returns the corresponding `Receiver<()>`.
3. `spawn_blocking`s `rx.recv_timeout(30s)` so a stalled fs (e.g. NFS disconnect) can't wedge `close()` indefinitely, and surfaces timeout / disconnect as errors rather than silently truncating logs.

`DebugTracer::Drop` still sends a best-effort no-ack `CloseSession` for the abnormal-exit path; the authoritative flush path is `ClassicBundler::close()`. Documented in `meta/design/devtools.md`.

## Why this is faster

- **No lock contention on the hot path.** Previously N tokio workers serialized on one `parking_lot::RwLock` write guard held across I/O; now they only contend on `std::sync::mpsc`'s sender, which is lock-free-ish and never held across I/O.
- **Producer / writer pipelining.** On main, log I/O was on the critical path of every worker task. Now workers return to doing compile work the moment they hand off the event; the writer thread drains the queue in parallel with them. Total wall time becomes `max(compute, log_drain)` instead of `sum`.
- **Fewer syscalls.** `BufWriter` + per-session cached `create_dir_all` eliminate the per-event `mkdir` syscall and collapse each event's many `write()` calls into one.

This PR is strictly about unblocking the hot path. Other independent wins (lazy `content: Some(code.clone())` in `trace_action!` payloads, single-pass StringRef dedupe, skipping the JSON-string round-trip through `DevtoolsActionFieldExtractor`) are deliberately left for follow-ups — they reduce CPU work, but CPU was never the bottleneck.

## Test plan

- [ ] `cargo test --workspace` green
- [ ] Manual: run an antd build with `devtools: {}`, confirm `node_modules/.rolldown/<sid>/{meta,logs}.json` are well-formed JSON-lines and contain the expected action events
- [ ] Manual: confirm log files are complete after `await bundle.close()` (read file in a Node consumer immediately after close, assert last line parses)
- [ ] Re-record samply profile on the antd repro — verify `format_event` is no longer a hotspot and Rust-leaf sample share recovers