### PR TITLE
fix(vite-import-glob): error on unsupported extglob patterns instead of silently producing {}

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -12,7 +12,6 @@ description = "Rolldown plugin for glob imports"
 
 [lib]
 doctest = false
-test = false
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -12,6 +12,7 @@ description = "Rolldown plugin for glob imports"
 
 [lib]
 doctest = false
+test = false
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -63,8 +63,12 @@ impl Plugin for ViteImportGlobPlugin {
         magic_string: None,
         import_decls: Vec::new(),
         restore_query_extension: self.restore_query_extension,
+        errors: Vec::new(),
       };
       visitor.visit_program(&parser_ret.program);
+      if !visitor.errors.is_empty() {
+        return Err(anyhow::anyhow!(visitor.errors.join("\n\n")));
+      }
       if let Some(magic_string) = visitor.magic_string {
         return Ok(Some(HookTransformOutput {
           code: Some(magic_string.to_string()),

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -1,4 +1,4 @@
-mod utils;
+pub mod utils;
 
 use std::{borrow::Cow, path::PathBuf};
 

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -22,7 +22,7 @@ pub struct GlobImportVisit<'a> {
   pub code: &'a str,
   pub magic_string: Option<MagicString<'a>>,
   pub import_decls: Vec<String>,
-  pub errors: Vec<String>,
+  pub(crate) errors: Vec<String>,
 }
 
 impl<'ast> Visit<'ast> for GlobImportVisit<'_> {
@@ -76,7 +76,7 @@ impl<'a> PathWithGlob<'a> {
     for (i, b) in path.as_bytes().iter().enumerate() {
       if *b == b'/' {
         last_slash = i;
-      } else if [b'\\', b'*', b'?', b'[', b']', b'{', b'}', b'!', b'('].contains(b) {
+      } else if [b'\\', b'*', b'?', b'[', b']', b'{', b'}'].contains(b) {
         return path.len() - last_slash;
       }
     }
@@ -386,7 +386,7 @@ impl GlobImportVisit<'_> {
   /// Returns `true` if the pattern contains extglob syntax: `!(`, `?(`, `*(`, `+(`, or `@(`.
   /// Extglob is not supported by the underlying `fast-glob` matcher and silently matches
   /// nothing. We detect it early to emit a build error instead.
-  fn has_extglob(pattern: &str) -> bool {
+  pub fn has_extglob(pattern: &str) -> bool {
     let bytes = pattern.as_bytes();
     let mut i = 0;
     while i + 1 < bytes.len() {
@@ -650,53 +650,5 @@ impl GlobImportVisit<'_> {
         _ => {}
       }
     }
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::GlobImportVisit;
-
-  #[test]
-  fn has_extglob_negation() {
-    assert!(GlobImportVisit::has_extglob("!(*.d.ts)"));
-    assert!(GlobImportVisit::has_extglob("**/!(*.d.ts)"));
-    assert!(GlobImportVisit::has_extglob("./routes/**/!(*.d.ts)"));
-  }
-
-  #[test]
-  fn has_extglob_other_forms() {
-    // Proper extglob: operator immediately before '('
-    assert!(GlobImportVisit::has_extglob("?(x)"));
-    assert!(GlobImportVisit::has_extglob("*(x)"));
-    assert!(GlobImportVisit::has_extglob("+(.js|.ts)"));
-    assert!(GlobImportVisit::has_extglob("@(foo|bar)"));
-    assert!(GlobImportVisit::has_extglob("[jt]s?(x)")); // correct extglob form
-    // Note: (x)? is NOT standard extglob — it was an accidental tinyglobby quirk
-  }
-
-  #[test]
-  fn has_extglob_standard_patterns_not_flagged() {
-    assert!(!GlobImportVisit::has_extglob("**/*.ts"));
-    assert!(!GlobImportVisit::has_extglob("./**/*.{ts,tsx}"));
-    assert!(!GlobImportVisit::has_extglob("./dir/*.js"));
-    assert!(!GlobImportVisit::has_extglob("[abc]"));
-    assert!(!GlobImportVisit::has_extglob("!**/*.d.ts")); // array-negation prefix, not extglob
-  }
-
-  #[test]
-  fn has_extglob_escaped_chars_not_flagged() {
-    assert!(!GlobImportVisit::has_extglob("\\!(*.d.ts)")); // escaped !
-    assert!(!GlobImportVisit::has_extglob("\\*(foo)")); // escaped *
-  }
-
-  #[test]
-  fn find_glob_syntax_detects_extglob_start() {
-    use super::PathWithGlob;
-    // !(*.d.ts) must be recognized as a glob-syntax start (! and ( are special)
-    let path = String::from("/root/routes/!(*.d.ts)");
-    let glob = "!(*.d.ts)";
-    let result = PathWithGlob::new(path, glob);
-    assert_eq!(result.glob, "!(*.d.ts)");
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -22,6 +22,7 @@ pub struct GlobImportVisit<'a> {
   pub code: &'a str,
   pub magic_string: Option<MagicString<'a>>,
   pub import_decls: Vec<String>,
+  pub errors: Vec<String>,
 }
 
 impl<'ast> Visit<'ast> for GlobImportVisit<'_> {
@@ -75,7 +76,7 @@ impl<'a> PathWithGlob<'a> {
     for (i, b) in path.as_bytes().iter().enumerate() {
       if *b == b'/' {
         last_slash = i;
-      } else if [b'\\', b'*', b'?', b'[', b']', b'{', b'}'].contains(b) {
+      } else if [b'\\', b'*', b'?', b'[', b']', b'{', b'}', b'!', b'('].contains(b) {
         return path.len() - last_slash;
       }
     }
@@ -382,8 +383,27 @@ impl GlobImportVisit<'_> {
     if end == 0 { self.root.to_slash_lossy() } else { Cow::Owned(head.path[..end].to_string()) }
   }
 
+  /// Returns `true` if the pattern contains extglob syntax: `!(`, `?(`, `*(`, `+(`, or `@(`.
+  /// Extglob is not supported by the underlying `fast-glob` matcher and silently matches
+  /// nothing. We detect it early to emit a build error instead.
+  fn has_extglob(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+      if bytes[i] == b'\\' {
+        i += 2; // skip escaped character
+        continue;
+      }
+      if matches!(bytes[i], b'!' | b'?' | b'*' | b'+' | b'@') && bytes[i + 1] == b'(' {
+        return true;
+      }
+      i += 1;
+    }
+    false
+  }
+
   fn eval_glob_expr(
-    &self,
+    &mut self,
     arg: &Argument,
     files: &mut Vec<ImportGlobFileData>,
     options: &ImportGlobOptions,
@@ -427,6 +447,19 @@ impl GlobImportVisit<'_> {
         }
       }
       _ => {}
+    }
+
+    for value in &values {
+      let raw = value.strip_prefix('!').unwrap_or(value);
+      if Self::has_extglob(raw) {
+        self.errors.push(format!(
+          "import.meta.glob does not support extglob patterns: \"{value}\"\n\
+           Extglob syntax (e.g. `!(*.d.ts)`, `?(x)`, `*(x)`) is not supported by the glob matcher.\n\
+           Use an array with '!' prefix for negation instead:\n\
+           `['**/*.{{ts,tsx}}', '!**/*.d.ts']`  instead of  `'**/!(*.d.ts)'`"
+        ));
+        return None;
+      }
     }
 
     for value in values {
@@ -617,5 +650,53 @@ impl GlobImportVisit<'_> {
         _ => {}
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::GlobImportVisit;
+
+  #[test]
+  fn has_extglob_negation() {
+    assert!(GlobImportVisit::has_extglob("!(*.d.ts)"));
+    assert!(GlobImportVisit::has_extglob("**/!(*.d.ts)"));
+    assert!(GlobImportVisit::has_extglob("./routes/**/!(*.d.ts)"));
+  }
+
+  #[test]
+  fn has_extglob_other_forms() {
+    // Proper extglob: operator immediately before '('
+    assert!(GlobImportVisit::has_extglob("?(x)"));
+    assert!(GlobImportVisit::has_extglob("*(x)"));
+    assert!(GlobImportVisit::has_extglob("+(.js|.ts)"));
+    assert!(GlobImportVisit::has_extglob("@(foo|bar)"));
+    assert!(GlobImportVisit::has_extglob("[jt]s?(x)")); // correct extglob form
+    // Note: (x)? is NOT standard extglob — it was an accidental tinyglobby quirk
+  }
+
+  #[test]
+  fn has_extglob_standard_patterns_not_flagged() {
+    assert!(!GlobImportVisit::has_extglob("**/*.ts"));
+    assert!(!GlobImportVisit::has_extglob("./**/*.{ts,tsx}"));
+    assert!(!GlobImportVisit::has_extglob("./dir/*.js"));
+    assert!(!GlobImportVisit::has_extglob("[abc]"));
+    assert!(!GlobImportVisit::has_extglob("!**/*.d.ts")); // array-negation prefix, not extglob
+  }
+
+  #[test]
+  fn has_extglob_escaped_chars_not_flagged() {
+    assert!(!GlobImportVisit::has_extglob("\\!(*.d.ts)")); // escaped !
+    assert!(!GlobImportVisit::has_extglob("\\*(foo)")); // escaped *
+  }
+
+  #[test]
+  fn find_glob_syntax_detects_extglob_start() {
+    use super::PathWithGlob;
+    // !(*.d.ts) must be recognized as a glob-syntax start (! and ( are special)
+    let path = String::from("/root/routes/!(*.d.ts)");
+    let glob = "!(*.d.ts)";
+    let result = PathWithGlob::new(path, glob);
+    assert_eq!(result.glob, "!(*.d.ts)");
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/tests/has_extglob.rs
+++ b/crates/rolldown_plugin_vite_import_glob/tests/has_extglob.rs
@@ -1,0 +1,36 @@
+use rolldown_plugin_vite_import_glob::utils::GlobImportVisit;
+
+#[test]
+fn detects_negation_form() {
+  assert!(GlobImportVisit::has_extglob("!(*.d.ts)"));
+  assert!(GlobImportVisit::has_extglob("**/!(*.d.ts)"));
+  assert!(GlobImportVisit::has_extglob("./routes/**/!(*.d.ts)"));
+}
+
+#[test]
+fn detects_other_extglob_operators() {
+  assert!(GlobImportVisit::has_extglob("?(x)"));
+  assert!(GlobImportVisit::has_extglob("*(x)"));
+  assert!(GlobImportVisit::has_extglob("+(.js|.ts)"));
+  assert!(GlobImportVisit::has_extglob("@(foo|bar)"));
+  assert!(GlobImportVisit::has_extglob("[jt]s?(x)"));
+  // Note: (x)? is NOT standard extglob — accidental tinyglobby quirk, not detected here
+}
+
+#[test]
+fn does_not_flag_standard_patterns() {
+  assert!(!GlobImportVisit::has_extglob("**/*.ts"));
+  assert!(!GlobImportVisit::has_extglob("./**/*.{ts,tsx}"));
+  assert!(!GlobImportVisit::has_extglob("./dir/*.js"));
+  assert!(!GlobImportVisit::has_extglob("[abc]"));
+  // Leading '!' in array negation form — not extglob
+  assert!(!GlobImportVisit::has_extglob("!**/*.d.ts"));
+  // Directories with '(' in their name must not be flagged
+  assert!(!GlobImportVisit::has_extglob("./foo(bar)/*.ts"));
+}
+
+#[test]
+fn does_not_flag_escaped_chars() {
+  assert!(!GlobImportVisit::has_extglob("\\!(*.d.ts)"));
+  assert!(!GlobImportVisit::has_extglob("\\*(foo)"));
+}

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/_config.ts
@@ -1,0 +1,14 @@
+import { defineTest } from 'rolldown-tests';
+import { viteImportGlobPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    plugins: [viteImportGlobPlugin()],
+  },
+  catchError(err: unknown) {
+    const message = String(err);
+    expect(message).toContain('extglob');
+    expect(message).toContain('!(*.d.ts)');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/dir/foo.d.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/dir/foo.d.ts
@@ -1,0 +1,1 @@
+export declare const foo: string;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/dir/foo.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/dir/foo.ts
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/extglob-error/main.js
@@ -1,0 +1,3 @@
+// Extglob patterns like !(*.d.ts) are not supported — should produce a build error.
+const modules = import.meta.glob('./dir/**/!(*.d.ts)');
+export { modules };


### PR DESCRIPTION
## Problem

Closes #9090

`import.meta.glob` patterns using extglob syntax (`!(*.d.ts)`, `?(x)`, `*(x)`, `+(x)`, `@(x)`) are **not supported** by the `fast-glob` matcher used in `builtin:vite-import-glob`. Previously, such patterns would silently compile to `Object.assign({})`, matching no files at all and causing hard-to-debug runtime failures.

Real-world impact: after the Vite 8 upgrade, a pattern like `import.meta.glob('../routes/**/!(*.d.ts)')` compiles to `Object.assign({})` — matching nothing — which causes the consuming module to fail at runtime with no build-time warning.

## Root cause

**`fast_glob::glob_match`** interprets `!` at the start of a pattern as whole-pattern negation (not extglob), and `(` as a literal character, so `!(*.d.ts)` matches nothing instead of excluding `.d.ts` files.

## Changes

| File | Change |
|---|---|
| `src/utils.rs` | Add `has_extglob()` to detect `[!?*+@](` operators |
| `src/utils.rs` | Add `pub(crate) errors: Vec<String>` to `GlobImportVisit` |
| `src/utils.rs` | Check for extglob in `eval_glob_expr`, push descriptive error |
| `src/lib.rs` | After `visit_program`, return `Err` if any errors were collected |
| `tests/has_extglob.rs` | Integration tests for `has_extglob` (4 test cases) |
| `tests/fixtures/.../extglob-error/` | Fixture asserting a build error is raised |

## Error message

```
import.meta.glob does not support extglob patterns: "./dir/**/!(*.d.ts)"
Extglob syntax (e.g. `!(*.d.ts)`, `?(x)`, `*(x)`) is not supported by the glob matcher.
Use an array with '!' prefix for negation instead:
`['**/*.{ts,tsx}', '!**/*.d.ts']`  instead of  `'**/!(*.d.ts)'`
```

## Note on `(x)?` form

The pattern `[jt]s(x)?` from the original issue report is **not** standard extglob — it was an accidental side-effect of tinyglobby's parser. Proper extglob would be `[jt]s?(x)`. This PR does not detect the `(x)?` form; it is a separate, lower-priority quirk.

## Testing

```
cargo test -p rolldown_plugin_vite_import_glob
# running 4 tests
# test detects_negation_form ... ok
# test detects_other_extglob_operators ... ok
# test does_not_flag_escaped_chars ... ok
# test does_not_flag_standard_patterns ... ok
# test result: ok. 4 passed; 0 failed
```