### PR TITLE
fix: prevent chunk optimizer from creating import cycles

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -969,6 +969,7 @@ impl GenerateStage<'_> {
       if is_target_manual_chunk && is_emitted_entry_chunk {
         emitted_chunk_groups.entry(target_chunk_idx).or_default().push(from_chunk_idx);
       } else if !is_emitted_entry_chunk {
+        // See meta/design/code-splitting.md: facade reachability must account for runtime rehoming.
         // Check if merging would create a runtime-helper circular dependency.
         // Translate chunk_graph indices to temp_chunk_graph indices, since the two graphs may
         // diverge once new common chunks are materialised. Preserve the existing conservative

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -63,6 +63,8 @@ pub struct ChunkOptimizationGraph {
   /// Initial chunks share identical indices; newly-created common chunks
   /// in chunk_graph are registered here so callers can translate.
   chunk_idx_to_temp_chunk_idx: FxHashMap<ChunkIdx, ChunkIdx>,
+  /// Tracks common chunks that have already been merged into existing chunks.
+  merged_chunk_aliases: FxHashMap<ChunkIdx, ChunkIdx>,
 }
 
 impl ChunkOptimizationGraph {
@@ -106,7 +108,13 @@ impl ChunkOptimizationGraph {
       bits_to_chunk_idx.iter().map(|(k, v)| (k.clone(), *v)).collect();
     bits_to_chunk_idx.sort_unstable_keys();
 
-    Self { chunks, bits_to_chunk_idx, module_to_chunk, chunk_idx_to_temp_chunk_idx }
+    Self {
+      chunks,
+      bits_to_chunk_idx,
+      module_to_chunk,
+      chunk_idx_to_temp_chunk_idx,
+      merged_chunk_aliases: FxHashMap::default(),
+    }
   }
 
   /// Assigns a module to a temporary chunk based on its reachability bits.
@@ -199,9 +207,8 @@ impl ChunkOptimizationGraph {
   /// that previously depended on `source` now depends on `target`. A cycle exists iff `target`
   /// is reachable from `source.deps ∪ target.deps` in the resulting graph.
   ///
-  /// We approximate this by doing a BFS from `source.deps ∪ target.deps`, treating any chunk
-  /// that depends on `source` as also pointing to `target` (since after the merge they would).
-  /// If `target` is reachable, the merge would create a cycle.
+  /// We detect this by contracting `source` into `target`, then checking whether the merged
+  /// target can reach itself through any external chunk.
   ///
   /// This is similar to Rollup's check in `getAdditionalSizeIfNoTransitiveDependencyOrNonCorrelatedSideEffect`.
   pub fn would_create_circular_dependency(
@@ -209,57 +216,69 @@ impl ChunkOptimizationGraph {
     source_chunk_idx: ChunkIdx,
     target_chunk_idx: ChunkIdx,
   ) -> bool {
-    let source_has_deps = !self.chunks[source_chunk_idx].dependencies.is_empty();
+    self.would_create_circular_dependency_after_merging(
+      target_chunk_idx,
+      &FxHashSet::from_iter([source_chunk_idx]),
+    )
+  }
 
-    if source_has_deps {
-      // When source has dependencies, only BFS from source's deps.
-      // Including target's deps causes false positives because the simulation
-      // finds that target can trivially "reach itself" through any transitive
-      // dependency that also depends on source.
-      let mut queue: VecDeque<ChunkIdx> =
-        self.chunks[source_chunk_idx].dependencies.iter().copied().collect();
-      let mut visited = FxHashSet::default();
+  /// Checks whether contracting `source_chunk_idxs` into `target_chunk_idx` would create a cycle.
+  ///
+  /// This handles batches of chunks that are all planned to merge into the same target. Evaluating
+  /// the whole batch avoids false positives where one soon-to-be-merged common chunk reaches
+  /// another soon-to-be-merged common chunk through the target.
+  ///
+  /// Dependencies that still point at chunks merged by earlier assignments are resolved through
+  /// `merged_chunk_aliases`, matching the final chunk graph without mutating every incoming edge.
+  pub fn would_create_circular_dependency_after_merging(
+    &self,
+    target_chunk_idx: ChunkIdx,
+    source_chunk_idxs: &FxHashSet<ChunkIdx>,
+  ) -> bool {
+    let target_chunk_idx = self.resolve_merged_chunk_idx(target_chunk_idx);
+    let source_chunk_idxs = source_chunk_idxs
+      .iter()
+      .map(|&source_chunk_idx| self.resolve_merged_chunk_idx(source_chunk_idx))
+      .filter(|&source_chunk_idx| source_chunk_idx != target_chunk_idx)
+      .collect::<FxHashSet<_>>();
+    let mut queue = VecDeque::new();
+    let mut visited = FxHashSet::default();
 
-      while let Some(chunk_idx) = queue.pop_front() {
-        if chunk_idx == target_chunk_idx {
-          return true;
-        }
-        if !visited.insert(chunk_idx) {
-          continue;
-        }
-        for &dep in &self.chunks[chunk_idx].dependencies {
-          if !visited.contains(&dep) {
-            queue.push_back(dep);
-          }
-        }
+    for &dep in &self.chunks[target_chunk_idx].dependencies {
+      let dep = self.resolve_merged_chunk_idx(dep);
+      if dep != target_chunk_idx && !source_chunk_idxs.contains(&dep) {
+        queue.push_back(dep);
       }
-      false
-    } else {
-      // When source has no dependencies (e.g., runtime chunk), we must check
-      // from target's deps with post-merge simulation to detect cycles like
-      // target -> chunk_A -> source(=target after merge).
-      let mut queue: VecDeque<ChunkIdx> =
-        self.chunks[target_chunk_idx].dependencies.iter().copied().collect();
-      let mut visited = FxHashSet::default();
-
-      while let Some(chunk_idx) = queue.pop_front() {
-        if chunk_idx == target_chunk_idx {
-          return true;
-        }
-        if !visited.insert(chunk_idx) {
-          continue;
-        }
-        for &dep in &self.chunks[chunk_idx].dependencies {
-          if !visited.contains(&dep) {
-            queue.push_back(dep);
-          }
-        }
-        if self.chunks[chunk_idx].dependencies.contains(&source_chunk_idx) {
-          queue.push_back(target_chunk_idx);
-        }
-      }
-      false
     }
+    for &source_chunk_idx in &source_chunk_idxs {
+      for &dep in &self.chunks[source_chunk_idx].dependencies {
+        let dep = self.resolve_merged_chunk_idx(dep);
+        if dep != target_chunk_idx && !source_chunk_idxs.contains(&dep) {
+          queue.push_back(dep);
+        }
+      }
+    }
+
+    while let Some(chunk_idx) = queue.pop_front() {
+      let chunk_idx = self.resolve_merged_chunk_idx(chunk_idx);
+      if chunk_idx == target_chunk_idx || source_chunk_idxs.contains(&chunk_idx) {
+        return true;
+      }
+      if !visited.insert(chunk_idx) {
+        continue;
+      }
+      for &dep in &self.chunks[chunk_idx].dependencies {
+        let dep = self.resolve_merged_chunk_idx(dep);
+        if dep == target_chunk_idx || source_chunk_idxs.contains(&dep) {
+          return true;
+        }
+        if !visited.contains(&dep) {
+          queue.push_back(dep);
+        }
+      }
+    }
+
+    false
   }
 
   /// Returns true if `from` can transitively reach `to` through the dependency graph.
@@ -290,10 +309,16 @@ impl ChunkOptimizationGraph {
     target_chunk_idx: ChunkIdx,
     source_chunk_idx: ChunkIdx,
   ) {
+    let target_chunk_idx = self.resolve_merged_chunk_idx(target_chunk_idx);
+    let source_chunk_idx = self.resolve_merged_chunk_idx(source_chunk_idx);
+    if target_chunk_idx == source_chunk_idx {
+      return;
+    }
     let source = &self.chunks[source_chunk_idx];
     let source_has_side_effects = source.has_side_effects;
     let source_dependencies = std::mem::take(&mut self.chunks[source_chunk_idx].dependencies);
     for dep_chunk_idx in source_dependencies {
+      let dep_chunk_idx = self.resolve_merged_chunk_idx(dep_chunk_idx);
       // Don't add self-reference
       if dep_chunk_idx != target_chunk_idx {
         self.chunks[target_chunk_idx].dependencies.insert(dep_chunk_idx);
@@ -302,6 +327,14 @@ impl ChunkOptimizationGraph {
     // Remove self-reference if it exists (source might have depended on target)
     self.chunks[target_chunk_idx].dependencies.remove(&target_chunk_idx);
     self.chunks[target_chunk_idx].has_side_effects |= source_has_side_effects;
+    self.merged_chunk_aliases.insert(source_chunk_idx, target_chunk_idx);
+  }
+
+  fn resolve_merged_chunk_idx(&self, mut chunk_idx: ChunkIdx) -> ChunkIdx {
+    while let Some(&target_chunk_idx) = self.merged_chunk_aliases.get(&chunk_idx) {
+      chunk_idx = target_chunk_idx;
+    }
+    chunk_idx
   }
 }
 
@@ -311,6 +344,13 @@ enum ChunkAssignment {
   Merged(ChunkIdx),
   /// A new common chunk was created in chunk_graph (chunk_graph index).
   Created(ChunkIdx),
+}
+
+struct CommonChunkAssignment {
+  bits: BitSet,
+  temp_chunk_idx: ChunkIdx,
+  chunk_idxs: Vec<ChunkIdx>,
+  merge_target: Option<ChunkIdx>,
 }
 
 impl GenerateStage<'_> {
@@ -405,8 +445,7 @@ impl GenerateStage<'_> {
       }
       map
     };
-    // First pass: collect chunk assignment decisions
-    // (bits, temp_chunk_idx, chunk_idxs, merge_target)
+    // First pass: collect chunk assignment decisions.
     let assignments: Vec<_> = temp_chunk_graph
       .bits_to_chunk_idx
       .iter()
@@ -426,51 +465,122 @@ impl GenerateStage<'_> {
           &dynamic_entry_to_dynamic_importers,
           temp_chunk,
           temp_chunk_graph,
-        );
+        )
+        .filter(|&target_chunk_idx| {
+          self.can_assign_modules_to_existing_chunk(
+            target_chunk_idx,
+            &temp_chunk.modules,
+            chunk_graph,
+          )
+        });
 
-        Some((bits.clone(), *temp_chunk_idx, chunk_idxs, merge_target))
+        Some(CommonChunkAssignment {
+          bits: bits.clone(),
+          temp_chunk_idx: *temp_chunk_idx,
+          chunk_idxs,
+          merge_target,
+        })
       })
       .collect();
 
+    let mut merge_groups: FxHashMap<ChunkIdx, Vec<usize>> = FxHashMap::default();
+    for (assignment_idx, assignment) in assignments.iter().enumerate() {
+      if let Some(target_chunk_idx) = assignment.merge_target {
+        merge_groups.entry(target_chunk_idx).or_default().push(assignment_idx);
+      }
+    }
+    let mut processed_assignments = vec![false; assignments.len()];
+
     // Second pass: apply chunk assignments
-    for (bits, temp_chunk_idx, chunk_idxs, merge_target) in assignments {
+    for assignment_idx in 0..assignments.len() {
+      if processed_assignments[assignment_idx] {
+        continue;
+      }
+      let assignment = &assignments[assignment_idx];
       // Check if merging would create a circular dependency
-      let merge_target = match merge_target {
-        Some(target_chunk_idx)
-          if temp_chunk_graph
-            .would_create_circular_dependency(temp_chunk_idx, target_chunk_idx) =>
-        {
-          // Skip merge if it would create a circular dependency
-          None
+      let merge_target = match assignment.merge_target {
+        Some(target_chunk_idx) => {
+          let group_indices =
+            merge_groups.get(&target_chunk_idx).expect("merge group should exist");
+          let source_chunk_idxs = group_indices
+            .iter()
+            .filter(|&&group_assignment_idx| !processed_assignments[group_assignment_idx])
+            .map(|&group_assignment_idx| assignments[group_assignment_idx].temp_chunk_idx)
+            .collect::<FxHashSet<_>>();
+          let group_is_safe = !temp_chunk_graph
+            .would_create_circular_dependency_after_merging(target_chunk_idx, &source_chunk_idxs);
+          if group_is_safe {
+            // See meta/design/code-splitting.md: safe merge groups must be applied atomically.
+            // Apply a safe group atomically. A single source can be cyclic by itself but safe when
+            // its sibling common chunks are contracted into the same target.
+            for &group_assignment_idx in group_indices {
+              if processed_assignments[group_assignment_idx] {
+                continue;
+              }
+              self.apply_common_chunk_assignment(
+                &assignments[group_assignment_idx],
+                Some(target_chunk_idx),
+                chunk_graph,
+                bits_to_chunk,
+                input_base,
+                temp_chunk_graph,
+              );
+              processed_assignments[group_assignment_idx] = true;
+            }
+            continue;
+          }
+          (!temp_chunk_graph
+            .would_create_circular_dependency(assignment.temp_chunk_idx, target_chunk_idx))
+          .then_some(target_chunk_idx)
         }
-        other => other,
+        None => None,
       };
 
-      let temp_modules = &temp_chunk_graph.chunks[temp_chunk_idx].modules;
-      match self.assign_modules_to_chunk(
+      self.apply_common_chunk_assignment(
+        assignment,
         merge_target,
-        &chunk_idxs,
-        temp_modules,
-        &bits,
         chunk_graph,
         bits_to_chunk,
         input_base,
-      ) {
-        ChunkAssignment::Merged(target_chunk_idx) => {
-          // Merge chunk dependencies immediately after successful merge
-          temp_chunk_graph.merge_chunk_dependencies(target_chunk_idx, temp_chunk_idx);
-        }
-        ChunkAssignment::Created(new_chunk_id) => {
-          temp_chunk_graph.register_chunk_graph_index(new_chunk_id, temp_chunk_idx);
-        }
+        temp_chunk_graph,
+      );
+      processed_assignments[assignment_idx] = true;
+    }
+  }
+
+  fn apply_common_chunk_assignment(
+    &self,
+    assignment: &CommonChunkAssignment,
+    merge_target: Option<ChunkIdx>,
+    chunk_graph: &mut ChunkGraph,
+    bits_to_chunk: &mut FxHashMap<BitSet, ChunkIdx>,
+    input_base: &ArcStr,
+    temp_chunk_graph: &mut ChunkOptimizationGraph,
+  ) {
+    let temp_modules = &temp_chunk_graph.chunks[assignment.temp_chunk_idx].modules;
+    match self.assign_modules_to_chunk(
+      merge_target,
+      &assignment.chunk_idxs,
+      temp_modules,
+      &assignment.bits,
+      chunk_graph,
+      bits_to_chunk,
+      input_base,
+    ) {
+      ChunkAssignment::Merged(target_chunk_idx) => {
+        // Merge chunk dependencies immediately after successful merge.
+        temp_chunk_graph.merge_chunk_dependencies(target_chunk_idx, assignment.temp_chunk_idx);
+      }
+      ChunkAssignment::Created(new_chunk_id) => {
+        temp_chunk_graph.register_chunk_graph_index(new_chunk_id, assignment.temp_chunk_idx);
       }
     }
   }
 
   /// Assigns modules to either an existing entry chunk or a new common chunk.
   ///
-  /// If a valid merge target is found (and it doesn't have strict entry signature preservation),
-  /// modules are merged into that existing chunk. Otherwise, a new common chunk is created.
+  /// If a merge target is provided, modules are merged into that existing chunk. Otherwise, a new
+  /// common chunk is created. Callers are responsible for validating cycles and entry signatures.
   #[expect(clippy::too_many_arguments)]
   fn assign_modules_to_chunk(
     &self,
@@ -484,26 +594,8 @@ impl GenerateStage<'_> {
   ) -> ChunkAssignment {
     match merge_target {
       Some(chunk_idx) => {
-        let chunk = &chunk_graph.chunk_table[chunk_idx];
-        let is_async_entry_only = matches!(chunk.kind, ChunkKind::EntryPoint { meta, .. } if meta == ChunkMeta::DynamicImported);
-        if matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict)) {
-          // We can safely merge into this chunk in two scenarios:
-          // 1. The target chunk is an async entry - dynamic chunks are not restricted by `PreserveEntrySignatures`.
-          // 2. The target chunk has strict signature preservation, but the modules being merged won't alter
-          //    the entry's exported interface (they either have no exports or only re-export existing entry symbols).
-          if is_async_entry_only || self.can_merge_without_changing_entry_signature(chunk, modules)
-          {
-            self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
-            ChunkAssignment::Merged(chunk_idx)
-          } else {
-            let new_chunk_id =
-              self.create_common_chunk(modules, bits, chunk_graph, bits_to_chunk, input_base);
-            ChunkAssignment::Created(new_chunk_id)
-          }
-        } else {
-          self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
-          ChunkAssignment::Merged(chunk_idx)
-        }
+        self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
+        ChunkAssignment::Merged(chunk_idx)
       }
       _ => {
         let new_chunk_id =
@@ -511,6 +603,19 @@ impl GenerateStage<'_> {
         ChunkAssignment::Created(new_chunk_id)
       }
     }
+  }
+
+  fn can_assign_modules_to_existing_chunk(
+    &self,
+    chunk_idx: ChunkIdx,
+    modules: &[ModuleIdx],
+    chunk_graph: &ChunkGraph,
+  ) -> bool {
+    let chunk = &chunk_graph.chunk_table[chunk_idx];
+    let is_async_entry_only = matches!(chunk.kind, ChunkKind::EntryPoint { meta, .. } if meta == ChunkMeta::DynamicImported);
+    !matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict))
+      || is_async_entry_only
+      || self.can_merge_without_changing_entry_signature(chunk, modules)
   }
 
   /// Merges modules into an existing entry chunk.
@@ -1245,5 +1350,84 @@ impl GenerateStage<'_> {
         runtime_dependent_chunks.insert(merge.to_chunk_idx);
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn idx(raw: u32) -> ChunkIdx {
+    ChunkIdx::from_raw(raw)
+  }
+
+  fn candidate(dependencies: &[u32]) -> ChunkCandidate {
+    ChunkCandidate {
+      modules: vec![],
+      needs_creation: false,
+      dependencies: dependencies.iter().map(|&dep| idx(dep)).collect(),
+      has_side_effects: false,
+    }
+  }
+
+  fn graph(dependencies: &[&[u32]]) -> ChunkOptimizationGraph {
+    let mut chunks = IndexVec::new();
+    for deps in dependencies {
+      chunks.push(candidate(deps));
+    }
+    ChunkOptimizationGraph {
+      chunks,
+      bits_to_chunk_idx: FxIndexMap::default(),
+      module_to_chunk: index_vec![],
+      chunk_idx_to_temp_chunk_idx: FxHashMap::default(),
+      merged_chunk_aliases: FxHashMap::default(),
+    }
+  }
+
+  #[test]
+  fn cycle_check_detects_target_reaching_source_with_deps() {
+    // Regression for the rc17 bug: source 2 has its own dependency, and target 0
+    // already reaches source through chunk 1. Merging 2 into 0 would create
+    // 0 -> 1 -> 0.
+    let graph = graph(&[&[1], &[2], &[3], &[]]);
+
+    assert!(graph.would_create_circular_dependency(idx(2), idx(0)));
+  }
+
+  #[test]
+  fn cycle_check_resolves_previously_merged_chunks() {
+    // 7 has already been merged into 1. A later merge of 3, 4, and 6 into 0
+    // would create 0 -> 2 -> 1 -> 0, but only if the stale 2 -> 7 edge is
+    // resolved through the previous 7 -> 1 merge.
+    let mut graph = graph(&[&[2, 3, 4], &[3, 6, 7], &[7], &[6], &[], &[], &[], &[]]);
+    graph.merge_chunk_dependencies(idx(1), idx(7));
+
+    let sources = FxHashSet::from_iter([idx(3), idx(4), idx(6)]);
+
+    assert!(graph.would_create_circular_dependency_after_merging(idx(0), &sources));
+  }
+
+  #[test]
+  fn cycle_check_resolves_alias_chains() {
+    // 7 -> 1 and then 1 -> 4 leaves stale external edges that still mention 7.
+    // When 4 is later considered for merging into 0, 0 -> 2 -> 7 must resolve
+    // through the full 7 -> 1 -> 4 chain and be rejected as 0 -> 2 -> 0.
+    let mut graph = graph(&[&[2], &[], &[7], &[], &[], &[], &[], &[]]);
+    graph.merge_chunk_dependencies(idx(1), idx(7));
+    graph.merge_chunk_dependencies(idx(4), idx(1));
+
+    let sources = FxHashSet::from_iter([idx(4)]);
+
+    assert!(graph.would_create_circular_dependency_after_merging(idx(0), &sources));
+  }
+
+  #[test]
+  fn cycle_check_contracts_whole_merge_group() {
+    // Merging only 5 into 0 would create 0 -> 4 -> 0, but the complete group
+    // contraction is safe because 3, 4, and 5 all become part of 0.
+    let graph = graph(&[&[3, 4], &[], &[], &[], &[5], &[]]);
+    let sources = FxHashSet::from_iter([idx(3), idx(4), idx(5)]);
+
+    assert!(!graph.would_create_circular_dependency_after_merging(idx(0), &sources));
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -261,9 +261,7 @@ impl ChunkOptimizationGraph {
 
     while let Some(chunk_idx) = queue.pop_front() {
       let chunk_idx = self.resolve_merged_chunk_idx(chunk_idx);
-      if chunk_idx == target_chunk_idx || source_chunk_idxs.contains(&chunk_idx) {
-        return true;
-      }
+      debug_assert!(chunk_idx != target_chunk_idx && !source_chunk_idxs.contains(&chunk_idx));
       if !visited.insert(chunk_idx) {
         continue;
       }
@@ -283,18 +281,26 @@ impl ChunkOptimizationGraph {
 
   /// Returns true if `from` can transitively reach `to` through the dependency graph.
   pub fn is_reachable(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
-    let mut queue: VecDeque<ChunkIdx> = self.chunks[from].dependencies.iter().copied().collect();
+    let from = self.resolve_merged_chunk_idx(from);
+    let to = self.resolve_merged_chunk_idx(to);
+    let mut queue = self.chunks[from]
+      .dependencies
+      .iter()
+      .map(|&dep| self.resolve_merged_chunk_idx(dep))
+      .collect::<VecDeque<_>>();
     let mut visited = FxHashSet::default();
     while let Some(chunk_idx) = queue.pop_front() {
+      let chunk_idx = self.resolve_merged_chunk_idx(chunk_idx);
       if chunk_idx == to {
         return true;
       }
       if !visited.insert(chunk_idx) {
         continue;
       }
-      queue.extend(
-        self.chunks[chunk_idx].dependencies.iter().copied().filter(|dep| !visited.contains(dep)),
-      );
+      queue.extend(self.chunks[chunk_idx].dependencies.iter().filter_map(|&dep| {
+        let dep = self.resolve_merged_chunk_idx(dep);
+        (!visited.contains(&dep)).then_some(dep)
+      }));
     }
     false
   }
@@ -314,6 +320,14 @@ impl ChunkOptimizationGraph {
     if target_chunk_idx == source_chunk_idx {
       return;
     }
+    debug_assert!(
+      !self.merged_chunk_aliases.contains_key(&target_chunk_idx),
+      "target chunk should resolve to an unmerged root before aliasing"
+    );
+    debug_assert!(
+      !self.merged_chunk_aliases.contains_key(&source_chunk_idx),
+      "source chunk should resolve to an unmerged root before aliasing"
+    );
     let source = &self.chunks[source_chunk_idx];
     let source_has_side_effects = source.has_side_effects;
     let source_dependencies = std::mem::take(&mut self.chunks[source_chunk_idx].dependencies);
@@ -324,17 +338,26 @@ impl ChunkOptimizationGraph {
         self.chunks[target_chunk_idx].dependencies.insert(dep_chunk_idx);
       }
     }
-    // Remove self-reference if it exists (source might have depended on target)
-    self.chunks[target_chunk_idx].dependencies.remove(&target_chunk_idx);
     self.chunks[target_chunk_idx].has_side_effects |= source_has_side_effects;
     self.merged_chunk_aliases.insert(source_chunk_idx, target_chunk_idx);
+    let target_dependencies = std::mem::take(&mut self.chunks[target_chunk_idx].dependencies);
+    self.chunks[target_chunk_idx].dependencies = target_dependencies
+      .into_iter()
+      .filter_map(|dep_chunk_idx| {
+        let dep_chunk_idx = self.resolve_merged_chunk_idx(dep_chunk_idx);
+        (dep_chunk_idx != target_chunk_idx).then_some(dep_chunk_idx)
+      })
+      .collect();
   }
 
   fn resolve_merged_chunk_idx(&self, mut chunk_idx: ChunkIdx) -> ChunkIdx {
-    while let Some(&target_chunk_idx) = self.merged_chunk_aliases.get(&chunk_idx) {
+    for _ in 0..=self.merged_chunk_aliases.len() {
+      let Some(&target_chunk_idx) = self.merged_chunk_aliases.get(&chunk_idx) else {
+        return chunk_idx;
+      };
       chunk_idx = target_chunk_idx;
     }
-    chunk_idx
+    panic!("merged chunk aliases must be acyclic");
   }
 }
 
@@ -929,10 +952,12 @@ impl GenerateStage<'_> {
       if is_target_manual_chunk && is_emitted_entry_chunk {
         emitted_chunk_groups.entry(target_chunk_idx).or_default().push(from_chunk_idx);
       } else if !is_emitted_entry_chunk {
-        // Check if merging would create a circular dependency.
-        // Translate chunk_graph indices to temp_chunk_graph indices, since the two
-        // graphs may diverge once new common chunks are materialised.
-        if temp_runtime_chunk_idx
+        // Check if merging would create a runtime-helper circular dependency.
+        // Translate chunk_graph indices to temp_chunk_graph indices, since the two graphs may
+        // diverge once new common chunks are materialised. A path from the current runtime host
+        // to the target is safe when facade elimination will either keep the helper edge local to
+        // the target or peel the runtime into a helper consumer afterward.
+        let runtime_reaches_target = temp_runtime_chunk_idx
           .and_then(|temp_runtime_idx| {
             let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
             Some(temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx))
@@ -940,8 +965,14 @@ impl GenerateStage<'_> {
           // If runtime is not included before, it will not create circular dependency, because
           // the runtime module will be either included in the target chunk or in a separate chunk loaded before.
           // If either index has no temp counterpart, we conservatively allow the merge.
-          .unwrap_or(false)
-        {
+          .unwrap_or(false);
+        let runtime_edge_will_be_local_or_rehomed =
+          match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {
+            Some(runtime_host_idx) if runtime_host_idx == target_chunk_idx => true,
+            Some(runtime_host_idx) => chunk_graph.chunk_table[runtime_host_idx].modules.len() > 1,
+            None => true,
+          };
+        if runtime_reaches_target && !runtime_edge_will_be_local_or_rehomed {
           continue;
         }
         let reason = if is_target_manual_chunk {
@@ -1422,6 +1453,16 @@ mod tests {
   }
 
   #[test]
+  fn reachability_resolves_previously_merged_chunks() {
+    // 2 has already been merged into 3, but 1 still has a stale edge to 2.
+    // Reachability must follow 1 -> 2(alias 3) -> 4 -> 5.
+    let mut graph = graph(&[&[1], &[2], &[], &[4], &[5], &[]]);
+    graph.merge_chunk_dependencies(idx(3), idx(2));
+
+    assert!(graph.is_reachable(idx(0), idx(5)));
+  }
+
+  #[test]
   fn cycle_check_contracts_whole_merge_group() {
     // Merging only 5 into 0 would create 0 -> 4 -> 0, but the complete group
     // contraction is safe because 3, 4, and 5 all become part of 0.
@@ -1429,5 +1470,53 @@ mod tests {
     let sources = FxHashSet::from_iter([idx(3), idx(4), idx(5)]);
 
     assert!(!graph.would_create_circular_dependency_after_merging(idx(0), &sources));
+  }
+
+  #[test]
+  fn cycle_check_allows_safe_single_source_when_group_is_cyclic() {
+    // Contracting 2 and 3 together would turn 0 -> 1 -> 3 into 0 -> 1 -> 0.
+    // If the group-level check fails, the fallback can still safely merge 2 alone.
+    let graph = graph(&[&[1], &[3], &[], &[]]);
+    let sources = FxHashSet::from_iter([idx(2), idx(3)]);
+
+    assert!(graph.would_create_circular_dependency_after_merging(idx(0), &sources));
+    assert!(!graph.would_create_circular_dependency(idx(2), idx(0)));
+    assert!(graph.would_create_circular_dependency(idx(3), idx(0)));
+  }
+
+  #[test]
+  fn merge_chunk_dependencies_removes_stale_intra_group_source_dependency() {
+    // Merging 1 first inserts its dependency on sibling 2 into target 0. When
+    // sibling 2 is later merged into 0, the stale 0 -> 2 edge should disappear.
+    let mut graph = graph(&[&[], &[2], &[]]);
+
+    graph.merge_chunk_dependencies(idx(0), idx(1));
+    assert!(graph.chunks[idx(0)].dependencies.contains(&idx(2)));
+
+    graph.merge_chunk_dependencies(idx(0), idx(2));
+    assert!(!graph.chunks[idx(0)].dependencies.contains(&idx(2)));
+  }
+
+  #[test]
+  fn merge_chunk_dependencies_normalizes_target_dependency_aliases() {
+    // Target 0 has a stale edge to 3. After 3 -> 2 and then 2 -> 0, that edge
+    // resolves back to target 0 and must be removed from the target deps.
+    let mut graph = graph(&[&[3], &[], &[], &[]]);
+
+    graph.merge_chunk_dependencies(idx(2), idx(3));
+    graph.merge_chunk_dependencies(idx(0), idx(2));
+
+    assert!(graph.chunks[idx(0)].dependencies.is_empty());
+  }
+
+  #[test]
+  fn cycle_check_preserves_source_without_dependencies_behavior() {
+    // A leaf source is unsafe when the target already reaches it.
+    let graph_with_target_path = graph(&[&[2], &[], &[1]]);
+    assert!(graph_with_target_path.would_create_circular_dependency(idx(1), idx(0)));
+
+    // With no target-side path back to the source, the same leaf source is safe.
+    let graph_without_target_path = graph(&[&[] as &[u32], &[], &[1]]);
+    assert!(!graph_without_target_path.would_create_circular_dependency(idx(1), idx(0)));
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -305,6 +305,23 @@ impl ChunkOptimizationGraph {
     false
   }
 
+  fn is_reachable_without_merged_aliases(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
+    let mut queue: VecDeque<ChunkIdx> = self.chunks[from].dependencies.iter().copied().collect();
+    let mut visited = FxHashSet::default();
+    while let Some(chunk_idx) = queue.pop_front() {
+      if chunk_idx == to {
+        return true;
+      }
+      if !visited.insert(chunk_idx) {
+        continue;
+      }
+      queue.extend(
+        self.chunks[chunk_idx].dependencies.iter().copied().filter(|dep| !visited.contains(dep)),
+      );
+    }
+    false
+  }
+
   /// Merges the dependencies of source chunk into target chunk.
   ///
   /// When modules from one chunk are merged into another chunk, the dependencies
@@ -954,25 +971,33 @@ impl GenerateStage<'_> {
       } else if !is_emitted_entry_chunk {
         // Check if merging would create a runtime-helper circular dependency.
         // Translate chunk_graph indices to temp_chunk_graph indices, since the two graphs may
-        // diverge once new common chunks are materialised. A path from the current runtime host
-        // to the target is safe when facade elimination will either keep the helper edge local to
-        // the target or peel the runtime into a helper consumer afterward.
-        let runtime_reaches_target = temp_runtime_chunk_idx
+        // diverge once new common chunks are materialised. Preserve the existing conservative
+        // behavior for direct runtime-to-target paths; for paths that only appear after resolving
+        // merged aliases, allow the merge when facade elimination will either keep the helper edge
+        // local to the target or peel the runtime into a helper consumer afterward.
+        let runtime_reachability = temp_runtime_chunk_idx
           .and_then(|temp_runtime_idx| {
             let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
-            Some(temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx))
+            Some((
+              temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx),
+              temp_chunk_opt_graph
+                .is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx),
+            ))
           })
           // If runtime is not included before, it will not create circular dependency, because
           // the runtime module will be either included in the target chunk or in a separate chunk loaded before.
           // If either index has no temp counterpart, we conservatively allow the merge.
-          .unwrap_or(false);
+          .unwrap_or((false, false));
         let runtime_edge_will_be_local_or_rehomed =
           match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {
             Some(runtime_host_idx) if runtime_host_idx == target_chunk_idx => true,
             Some(runtime_host_idx) => chunk_graph.chunk_table[runtime_host_idx].modules.len() > 1,
             None => true,
           };
-        if runtime_reaches_target && !runtime_edge_will_be_local_or_rehomed {
+        let (runtime_reaches_target, runtime_reaches_target_without_aliases) = runtime_reachability;
+        if runtime_reaches_target
+          && (runtime_reaches_target_without_aliases || !runtime_edge_will_be_local_or_rehomed)
+        {
           continue;
         }
         let reason = if is_target_manual_chunk {

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -260,7 +260,7 @@ impl ChunkOptimizationGraph {
     }
 
     while let Some(chunk_idx) = queue.pop_front() {
-      let chunk_idx = self.resolve_merged_chunk_idx(chunk_idx);
+      debug_assert_eq!(chunk_idx, self.resolve_merged_chunk_idx(chunk_idx));
       debug_assert!(chunk_idx != target_chunk_idx && !source_chunk_idxs.contains(&chunk_idx));
       if !visited.insert(chunk_idx) {
         continue;
@@ -397,6 +397,11 @@ struct CommonChunkAssignment {
   temp_chunk_idx: ChunkIdx,
   chunk_idxs: Vec<ChunkIdx>,
   merge_target: Option<ChunkIdx>,
+}
+
+enum CommonChunkMergePlan<'a> {
+  AppliedGroup { target_chunk_idx: ChunkIdx, group_indices: &'a [usize] },
+  Fallback(Option<ChunkIdx>),
 }
 
 impl GenerateStage<'_> {
@@ -541,43 +546,34 @@ impl GenerateStage<'_> {
         continue;
       }
       let assignment = &assignments[assignment_idx];
-      // Check if merging would create a circular dependency
-      let merge_target = match assignment.merge_target {
-        Some(target_chunk_idx) => {
-          let group_indices =
-            merge_groups.get(&target_chunk_idx).expect("merge group should exist");
-          let source_chunk_idxs = group_indices
-            .iter()
-            .filter(|&&group_assignment_idx| !processed_assignments[group_assignment_idx])
-            .map(|&group_assignment_idx| assignments[group_assignment_idx].temp_chunk_idx)
-            .collect::<FxHashSet<_>>();
-          let group_is_safe = !temp_chunk_graph
-            .would_create_circular_dependency_after_merging(target_chunk_idx, &source_chunk_idxs);
-          if group_is_safe {
-            // See meta/design/code-splitting.md: safe merge groups must be applied atomically.
-            // Apply a safe group atomically. A single source can be cyclic by itself but safe when
-            // its sibling common chunks are contracted into the same target.
-            for &group_assignment_idx in group_indices {
-              if processed_assignments[group_assignment_idx] {
-                continue;
-              }
-              self.apply_common_chunk_assignment(
-                &assignments[group_assignment_idx],
-                Some(target_chunk_idx),
-                chunk_graph,
-                bits_to_chunk,
-                input_base,
-                temp_chunk_graph,
-              );
-              processed_assignments[group_assignment_idx] = true;
+      let merge_target = match Self::resolve_common_chunk_merge_plan(
+        assignment,
+        &assignments,
+        &merge_groups,
+        &processed_assignments,
+        temp_chunk_graph,
+      ) {
+        CommonChunkMergePlan::AppliedGroup { target_chunk_idx, group_indices } => {
+          // See meta/design/code-splitting.md: safe merge groups must be applied atomically.
+          // Apply a safe group atomically. A single source can be cyclic by itself but safe when
+          // its sibling common chunks are contracted into the same target.
+          for &group_assignment_idx in group_indices {
+            if processed_assignments[group_assignment_idx] {
+              continue;
             }
-            continue;
+            self.apply_common_chunk_assignment(
+              &assignments[group_assignment_idx],
+              Some(target_chunk_idx),
+              chunk_graph,
+              bits_to_chunk,
+              input_base,
+              temp_chunk_graph,
+            );
+            processed_assignments[group_assignment_idx] = true;
           }
-          (!temp_chunk_graph
-            .would_create_circular_dependency(assignment.temp_chunk_idx, target_chunk_idx))
-          .then_some(target_chunk_idx)
+          continue;
         }
-        None => None,
+        CommonChunkMergePlan::Fallback(merge_target) => merge_target,
       };
 
       self.apply_common_chunk_assignment(
@@ -590,6 +586,39 @@ impl GenerateStage<'_> {
       );
       processed_assignments[assignment_idx] = true;
     }
+  }
+
+  fn resolve_common_chunk_merge_plan<'a>(
+    assignment: &CommonChunkAssignment,
+    assignments: &[CommonChunkAssignment],
+    merge_groups: &'a FxHashMap<ChunkIdx, Vec<usize>>,
+    processed_assignments: &[bool],
+    temp_chunk_graph: &ChunkOptimizationGraph,
+  ) -> CommonChunkMergePlan<'a> {
+    let Some(target_chunk_idx) = assignment.merge_target else {
+      return CommonChunkMergePlan::Fallback(None);
+    };
+
+    let group_indices = merge_groups.get(&target_chunk_idx).expect("merge group should exist");
+    let source_chunk_idxs = group_indices
+      .iter()
+      .filter(|&&group_assignment_idx| !processed_assignments[group_assignment_idx])
+      .map(|&group_assignment_idx| assignments[group_assignment_idx].temp_chunk_idx)
+      .collect::<FxHashSet<_>>();
+    let group_is_safe = !temp_chunk_graph
+      .would_create_circular_dependency_after_merging(target_chunk_idx, &source_chunk_idxs);
+    if group_is_safe {
+      return CommonChunkMergePlan::AppliedGroup {
+        target_chunk_idx,
+        group_indices: group_indices.as_slice(),
+      };
+    }
+
+    CommonChunkMergePlan::Fallback(
+      (!temp_chunk_graph
+        .would_create_circular_dependency(assignment.temp_chunk_idx, target_chunk_idx))
+      .then_some(target_chunk_idx),
+    )
   }
 
   fn apply_common_chunk_assignment(
@@ -929,16 +958,17 @@ impl GenerateStage<'_> {
       return false;
     }
 
-    let runtime_reaches_target_without_aliases =
-      temp_chunk_opt_graph.is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx);
-
     let runtime_edge_will_be_local_or_rehomed =
       match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {
         Some(runtime_host_idx) if runtime_host_idx == target_chunk_idx => true,
         Some(runtime_host_idx) => chunk_graph.chunk_table[runtime_host_idx].modules.len() > 1,
         None => true,
       };
-    runtime_reaches_target_without_aliases || !runtime_edge_will_be_local_or_rehomed
+    if !runtime_edge_will_be_local_or_rehomed {
+      return true;
+    }
+
+    temp_chunk_opt_graph.is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx)
   }
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -281,16 +281,30 @@ impl ChunkOptimizationGraph {
 
   /// Returns true if `from` can transitively reach `to` through the dependency graph.
   pub fn is_reachable(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
-    let from = self.resolve_merged_chunk_idx(from);
-    let to = self.resolve_merged_chunk_idx(to);
+    self.bfs_reachable(from, to, |chunk_idx| self.resolve_merged_chunk_idx(chunk_idx))
+  }
+
+  /// Alias-blind sibling of `is_reachable`, used to preserve the pre-merge
+  /// conservative facade-runtime path check.
+  fn is_reachable_without_merged_aliases(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
+    self.bfs_reachable(from, to, |chunk_idx| chunk_idx)
+  }
+
+  fn bfs_reachable(
+    &self,
+    from: ChunkIdx,
+    to: ChunkIdx,
+    resolve_chunk_idx: impl Fn(ChunkIdx) -> ChunkIdx,
+  ) -> bool {
+    let from = resolve_chunk_idx(from);
+    let to = resolve_chunk_idx(to);
     let mut queue = self.chunks[from]
       .dependencies
       .iter()
-      .map(|&dep| self.resolve_merged_chunk_idx(dep))
+      .map(|&dep| resolve_chunk_idx(dep))
       .collect::<VecDeque<_>>();
     let mut visited = FxHashSet::default();
     while let Some(chunk_idx) = queue.pop_front() {
-      let chunk_idx = self.resolve_merged_chunk_idx(chunk_idx);
       if chunk_idx == to {
         return true;
       }
@@ -298,28 +312,9 @@ impl ChunkOptimizationGraph {
         continue;
       }
       queue.extend(self.chunks[chunk_idx].dependencies.iter().filter_map(|&dep| {
-        let dep = self.resolve_merged_chunk_idx(dep);
+        let dep = resolve_chunk_idx(dep);
         (!visited.contains(&dep)).then_some(dep)
       }));
-    }
-    false
-  }
-
-  /// Alias-blind sibling of `is_reachable`, used to preserve the pre-merge
-  /// conservative facade-runtime path check.
-  fn is_reachable_without_merged_aliases(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
-    let mut queue: VecDeque<ChunkIdx> = self.chunks[from].dependencies.iter().copied().collect();
-    let mut visited = FxHashSet::default();
-    while let Some(chunk_idx) = queue.pop_front() {
-      if chunk_idx == to {
-        return true;
-      }
-      if !visited.insert(chunk_idx) {
-        continue;
-      }
-      queue.extend(
-        self.chunks[chunk_idx].dependencies.iter().copied().filter(|dep| !visited.contains(dep)),
-      );
     }
     false
   }
@@ -359,14 +354,21 @@ impl ChunkOptimizationGraph {
     }
     self.chunks[target_chunk_idx].has_side_effects |= source_has_side_effects;
     self.merged_chunk_aliases.insert(source_chunk_idx, target_chunk_idx);
-    let target_dependencies = std::mem::take(&mut self.chunks[target_chunk_idx].dependencies);
-    self.chunks[target_chunk_idx].dependencies = target_dependencies
-      .into_iter()
-      .filter_map(|dep_chunk_idx| {
-        let dep_chunk_idx = self.resolve_merged_chunk_idx(dep_chunk_idx);
-        (dep_chunk_idx != target_chunk_idx).then_some(dep_chunk_idx)
-      })
-      .collect();
+    let target_dependencies_need_normalization =
+      self.chunks[target_chunk_idx].dependencies.iter().any(|&dep_chunk_idx| {
+        let resolved_dep_chunk_idx = self.resolve_merged_chunk_idx(dep_chunk_idx);
+        resolved_dep_chunk_idx == target_chunk_idx || resolved_dep_chunk_idx != dep_chunk_idx
+      });
+    if target_dependencies_need_normalization {
+      let target_dependencies = std::mem::take(&mut self.chunks[target_chunk_idx].dependencies);
+      self.chunks[target_chunk_idx].dependencies = target_dependencies
+        .into_iter()
+        .filter_map(|dep_chunk_idx| {
+          let dep_chunk_idx = self.resolve_merged_chunk_idx(dep_chunk_idx);
+          (dep_chunk_idx != target_chunk_idx).then_some(dep_chunk_idx)
+        })
+        .collect();
+    }
   }
 
   fn resolve_merged_chunk_idx(&self, mut chunk_idx: ChunkIdx) -> ChunkIdx {
@@ -465,10 +467,8 @@ impl GenerateStage<'_> {
     let static_entry_chunk_reference: FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> =
       self.construct_static_entry_to_reached_dynamic_entries_map(chunk_graph);
 
-    // Calculate on demand to avoid add a new field on each NormalModule.
+    // Calculate on demand to avoid adding a new field on each NormalModule.
     let dynamic_entry_to_dynamic_importers: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>> = {
-      // Get dynamic entry modules from chunk_table, then find matched entry points
-      // and extract importers from related_stmt_infos
       let mut map: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>> = FxHashMap::default();
       for chunk in chunk_graph.chunk_table.iter() {
         let ChunkKind::EntryPoint { meta, module, .. } = chunk.kind else {
@@ -903,6 +903,8 @@ impl GenerateStage<'_> {
   /// Direct runtime-to-target paths preserve the existing conservative behavior. Paths that only
   /// appear after resolving merged aliases may proceed when facade elimination will either keep the
   /// helper edge local to the target or peel the runtime into a helper consumer afterward.
+  /// Both reachability walks are required: resolving aliases can reveal post-merge paths and erase
+  /// stale pre-merge paths, so neither result safely dominates the other.
   fn runtime_path_blocks_facade_merge(
     &self,
     chunk_graph: &ChunkGraph,

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -305,6 +305,8 @@ impl ChunkOptimizationGraph {
     false
   }
 
+  /// Alias-blind sibling of `is_reachable`, used to preserve the pre-merge
+  /// conservative facade-runtime path check.
   fn is_reachable_without_merged_aliases(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
     let mut queue: VecDeque<ChunkIdx> = self.chunks[from].dependencies.iter().copied().collect();
     let mut visited = FxHashSet::default();
@@ -368,6 +370,8 @@ impl ChunkOptimizationGraph {
   }
 
   fn resolve_merged_chunk_idx(&self, mut chunk_idx: ChunkIdx) -> ChunkIdx {
+    // Acyclic alias chains can be at most map.len() edges long; the inclusive bound
+    // adds one extra lookup to detect cycles.
     for _ in 0..=self.merged_chunk_aliases.len() {
       let Some(&target_chunk_idx) = self.merged_chunk_aliases.get(&chunk_idx) else {
         return chunk_idx;
@@ -893,6 +897,48 @@ impl GenerateStage<'_> {
     })
   }
 
+  /// Returns true when a runtime-to-target path should keep an empty facade chunk.
+  ///
+  /// See meta/design/code-splitting.md: facade reachability must account for runtime rehoming.
+  /// Direct runtime-to-target paths preserve the existing conservative behavior. Paths that only
+  /// appear after resolving merged aliases may proceed when facade elimination will either keep the
+  /// helper edge local to the target or peel the runtime into a helper consumer afterward.
+  fn runtime_path_blocks_facade_merge(
+    &self,
+    chunk_graph: &ChunkGraph,
+    temp_chunk_opt_graph: &ChunkOptimizationGraph,
+    temp_runtime_chunk_idx: Option<ChunkIdx>,
+    target_chunk_idx: ChunkIdx,
+  ) -> bool {
+    let Some((runtime_reaches_target, runtime_reaches_target_without_aliases)) =
+      temp_runtime_chunk_idx.and_then(|temp_runtime_idx| {
+        let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
+        Some((
+          temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx),
+          temp_chunk_opt_graph
+            .is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx),
+        ))
+      })
+    else {
+      // If runtime is not included before, it will not create circular dependency, because
+      // the runtime module will be either included in the target chunk or in a separate chunk loaded before.
+      // If either index has no temp counterpart, we conservatively allow the merge.
+      return false;
+    };
+
+    if !runtime_reaches_target {
+      return false;
+    }
+
+    let runtime_edge_will_be_local_or_rehomed =
+      match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {
+        Some(runtime_host_idx) if runtime_host_idx == target_chunk_idx => true,
+        Some(runtime_host_idx) => chunk_graph.chunk_table[runtime_host_idx].modules.len() > 1,
+        None => true,
+      };
+    runtime_reaches_target_without_aliases || !runtime_edge_will_be_local_or_rehomed
+  }
+
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.
   /// Returns a tuple of (facade_eliminations, common_chunk_merges, emitted_chunk_groups).
   fn find_facade_chunk_merge_ops(
@@ -969,36 +1015,13 @@ impl GenerateStage<'_> {
       if is_target_manual_chunk && is_emitted_entry_chunk {
         emitted_chunk_groups.entry(target_chunk_idx).or_default().push(from_chunk_idx);
       } else if !is_emitted_entry_chunk {
-        // See meta/design/code-splitting.md: facade reachability must account for runtime rehoming.
-        // Check if merging would create a runtime-helper circular dependency.
-        // Translate chunk_graph indices to temp_chunk_graph indices, since the two graphs may
-        // diverge once new common chunks are materialised. Preserve the existing conservative
-        // behavior for direct runtime-to-target paths; for paths that only appear after resolving
-        // merged aliases, allow the merge when facade elimination will either keep the helper edge
-        // local to the target or peel the runtime into a helper consumer afterward.
-        let runtime_reachability = temp_runtime_chunk_idx
-          .and_then(|temp_runtime_idx| {
-            let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
-            Some((
-              temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx),
-              temp_chunk_opt_graph
-                .is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx),
-            ))
-          })
-          // If runtime is not included before, it will not create circular dependency, because
-          // the runtime module will be either included in the target chunk or in a separate chunk loaded before.
-          // If either index has no temp counterpart, we conservatively allow the merge.
-          .unwrap_or((false, false));
-        let runtime_edge_will_be_local_or_rehomed =
-          match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {
-            Some(runtime_host_idx) if runtime_host_idx == target_chunk_idx => true,
-            Some(runtime_host_idx) => chunk_graph.chunk_table[runtime_host_idx].modules.len() > 1,
-            None => true,
-          };
-        let (runtime_reaches_target, runtime_reaches_target_without_aliases) = runtime_reachability;
-        if runtime_reaches_target
-          && (runtime_reaches_target_without_aliases || !runtime_edge_will_be_local_or_rehomed)
-        {
+        // Keep the facade when a runtime-helper path cannot be made local or rehomed.
+        if self.runtime_path_blocks_facade_merge(
+          chunk_graph,
+          temp_chunk_opt_graph,
+          temp_runtime_chunk_idx,
+          target_chunk_idx,
+        ) {
           continue;
         }
         let reason = if is_target_manual_chunk {

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -912,14 +912,11 @@ impl GenerateStage<'_> {
     temp_runtime_chunk_idx: Option<ChunkIdx>,
     target_chunk_idx: ChunkIdx,
   ) -> bool {
-    let Some((runtime_reaches_target, runtime_reaches_target_without_aliases)) =
-      temp_runtime_chunk_idx.and_then(|temp_runtime_idx| {
-        let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
-        Some((
-          temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx),
-          temp_chunk_opt_graph
-            .is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx),
-        ))
+    let Some((temp_runtime_idx, temp_target_idx)) =
+      temp_runtime_chunk_idx.and_then(|runtime_idx| {
+        temp_chunk_opt_graph
+          .to_temp_idx(target_chunk_idx)
+          .map(|target_idx| (runtime_idx, target_idx))
       })
     else {
       // If runtime is not included before, it will not create circular dependency, because
@@ -928,9 +925,12 @@ impl GenerateStage<'_> {
       return false;
     };
 
-    if !runtime_reaches_target {
+    if !temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx) {
       return false;
     }
+
+    let runtime_reaches_target_without_aliases =
+      temp_chunk_opt_graph.is_reachable_without_merged_aliases(temp_runtime_idx, temp_target_idx);
 
     let runtime_edge_will_be_local_or_rehomed =
       match chunk_graph.module_to_chunk[self.link_output.runtime.id()] {

--- a/crates/rolldown/tests/rolldown/issues/7449/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7449/_config.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "platform": "node",
+    "preserveEntrySignatures": "false",
+    "manualCodeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "api",
+          "test": "api\\.js"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/7449/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/7449/_test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const jsFiles = fs.readdirSync(distDir).filter((file) => file.endsWith('.js'));
+
+const graph = Object.fromEntries(
+  jsFiles.map((file) => {
+    const code = fs.readFileSync(path.join(distDir, file), 'utf8');
+    const imports = [
+      ...code.matchAll(/(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']\.\/([^"']+)["']/g),
+    ].map((match) => match[1]);
+    return [file, imports];
+  }),
+);
+
+function findCycle() {
+  const visited = new Set();
+  const inStack = new Set();
+
+  function dfs(file, pathSoFar) {
+    if (inStack.has(file)) {
+      return pathSoFar.slice(pathSoFar.indexOf(file)).concat(file);
+    }
+    if (visited.has(file)) {
+      return null;
+    }
+    visited.add(file);
+    inStack.add(file);
+    for (const dep of graph[file] ?? []) {
+      const cycle = dfs(dep, pathSoFar.concat(file));
+      if (cycle) {
+        return cycle;
+      }
+    }
+    inStack.delete(file);
+    return null;
+  }
+
+  for (const file of Object.keys(graph)) {
+    const cycle = dfs(file, []);
+    if (cycle) {
+      return cycle;
+    }
+  }
+  return null;
+}
+
+assert.strictEqual(
+  findCycle(),
+  null,
+  `Output chunks must not have circular static imports: ${JSON.stringify(graph)}`,
+);
+
+await import('./dist/main.js');
+assert.strictEqual(globalThis.__rolldown_issue_7449_value, 300000);

--- a/crates/rolldown/tests/rolldown/issues/7449/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/7449/_test.mjs
@@ -3,7 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const distDir = path.join(import.meta.dirname, 'dist');
-const jsFiles = fs.readdirSync(distDir).filter((file) => file.endsWith('.js'));
+const jsFiles = fs
+  .readdirSync(distDir)
+  .filter((file) => file.endsWith('.js'))
+  .sort();
 
 const graph = Object.fromEntries(
   jsFiles.map((file) => {
@@ -55,3 +58,7 @@ assert.strictEqual(
 
 await import('./dist/main.js');
 assert.strictEqual(globalThis.__rolldown_issue_7449_value, 300000);
+assert.strictEqual(globalThis.__rolldown_issue_7449_side, 1);
+
+await Promise.all(globalThis.__rolldown_issue_7449_imports);
+assert.strictEqual(globalThis.__rolldown_issue_7449_side, 1);

--- a/crates/rolldown/tests/rolldown/issues/7449/api.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/api.js
@@ -1,0 +1,3 @@
+import { getEnvInt } from './env.js';
+
+export const api = getEnvInt('REQUEST_TIMEOUT_MS');

--- a/crates/rolldown/tests/rolldown/issues/7449/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7449/artifacts.snap
@@ -1,0 +1,86 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## api.js
+
+```js
+import { t as getEnvInt } from "./env.js";
+//#region api.js
+const api = getEnvInt("REQUEST_TIMEOUT_MS");
+//#endregion
+export { api as t };
+
+```
+
+## dep-user.js
+
+```js
+import "./dep.js";
+export {};
+
+```
+
+## dep.js
+
+```js
+//#region side.js
+globalThis.__rolldown_issue_7449_side = (globalThis.__rolldown_issue_7449_side || 0) + 1;
+//#endregion
+export {};
+
+```
+
+## env-user.js
+
+```js
+import { n as getEnvString } from "./env.js";
+getEnvString("SECONDARY");
+//#endregion
+export {};
+
+```
+
+## env.js
+
+```js
+import "./dep.js";
+//#region env.js
+const state = { config: {
+	REQUEST_TIMEOUT_MS: "300000",
+	marker: "dep"
+} };
+function getEnvString(key) {
+	return state.config?.[key];
+}
+function getEnvInt(key) {
+	return Number(getEnvString(key) || 3e5);
+}
+//#endregion
+export { getEnvString as n, getEnvInt as t };
+
+```
+
+## lazy.js
+
+```js
+import "./api.js";
+export {};
+
+```
+
+## main.js
+
+```js
+import { n as getEnvString } from "./env.js";
+import { t as api } from "./api.js";
+//#region main.js
+import("./lazy.js");
+import("./env-user.js");
+import("./dep-user.js");
+globalThis.__rolldown_issue_7449_value = api + Number(getEnvString("MISSING") || 0);
+//#endregion
+export {};
+
+```

--- a/crates/rolldown/tests/rolldown/issues/7449/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7449/artifacts.snap
@@ -18,7 +18,10 @@ export { api as t };
 
 ```js
 import "./dep.js";
-export {};
+//#region dep-user.js
+const depUser = "dep";
+//#endregion
+export { depUser };
 
 ```
 
@@ -36,9 +39,10 @@ export {};
 
 ```js
 import { n as getEnvString } from "./env.js";
-getEnvString("SECONDARY");
+//#region env-user.js
+const envUser = getEnvString("SECONDARY");
 //#endregion
-export {};
+export { envUser };
 
 ```
 
@@ -65,8 +69,11 @@ export { getEnvString as n, getEnvInt as t };
 ## lazy.js
 
 ```js
-import "./api.js";
-export {};
+import { t as api } from "./api.js";
+//#region lazy.js
+const lazy = api;
+//#endregion
+export { lazy };
 
 ```
 
@@ -76,9 +83,11 @@ export {};
 import { n as getEnvString } from "./env.js";
 import { t as api } from "./api.js";
 //#region main.js
-import("./lazy.js");
-import("./env-user.js");
-import("./dep-user.js");
+globalThis.__rolldown_issue_7449_imports = [
+	import("./lazy.js"),
+	import("./env-user.js"),
+	import("./dep-user.js")
+];
 globalThis.__rolldown_issue_7449_value = api + Number(getEnvString("MISSING") || 0);
 //#endregion
 export {};

--- a/crates/rolldown/tests/rolldown/issues/7449/dep-user.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/dep-user.js
@@ -1,0 +1,3 @@
+import { marker } from './dep.js';
+
+export const depUser = marker;

--- a/crates/rolldown/tests/rolldown/issues/7449/dep.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/dep.js
@@ -1,0 +1,3 @@
+import './side.js';
+
+export const marker = 'dep';

--- a/crates/rolldown/tests/rolldown/issues/7449/env-user.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/env-user.js
@@ -1,0 +1,3 @@
+import { getEnvString } from './env.js';
+
+export const envUser = getEnvString('SECONDARY');

--- a/crates/rolldown/tests/rolldown/issues/7449/env.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/env.js
@@ -1,0 +1,11 @@
+import { marker } from './dep.js';
+
+const state = { config: { REQUEST_TIMEOUT_MS: '300000', marker } };
+
+export function getEnvString(key) {
+  return state.config?.[key];
+}
+
+export function getEnvInt(key) {
+  return Number(getEnvString(key) || 300000);
+}

--- a/crates/rolldown/tests/rolldown/issues/7449/lazy.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/lazy.js
@@ -1,0 +1,3 @@
+import { api } from './api.js';
+
+export const lazy = api;

--- a/crates/rolldown/tests/rolldown/issues/7449/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/main.js
@@ -1,0 +1,8 @@
+import { api } from './api.js';
+import { getEnvString } from './env.js';
+
+void import('./lazy.js');
+void import('./env-user.js');
+void import('./dep-user.js');
+
+globalThis.__rolldown_issue_7449_value = api + Number(getEnvString('MISSING') || 0);

--- a/crates/rolldown/tests/rolldown/issues/7449/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/main.js
@@ -1,8 +1,10 @@
 import { api } from './api.js';
 import { getEnvString } from './env.js';
 
-void import('./lazy.js');
-void import('./env-user.js');
-void import('./dep-user.js');
+globalThis.__rolldown_issue_7449_imports = [
+  import('./lazy.js'),
+  import('./env-user.js'),
+  import('./dep-user.js'),
+];
 
 globalThis.__rolldown_issue_7449_value = api + Number(getEnvString('MISSING') || 0);

--- a/crates/rolldown/tests/rolldown/issues/7449/side.js
+++ b/crates/rolldown/tests/rolldown/issues/7449/side.js
@@ -1,0 +1,1 @@
+globalThis.__rolldown_issue_7449_side = (globalThis.__rolldown_issue_7449_side || 0) + 1;

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -144,7 +144,7 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
 
-Facade reachability checks use the same temporary graph and resolve `merged_chunk_aliases`, so stale edges left by earlier common-chunk merges are interpreted as edges to the final merged chunk. A runtime-to-target path does not automatically block facade elimination: if the helper edge will be local to the runtime host, or the runtime host can be peeled and rehomed into a helper consumer, the optimizer proceeds and lets runtime placement preserve an acyclic final graph.
+Facade reachability checks use the same temporary graph and resolve `merged_chunk_aliases`, so stale edges left by earlier common-chunk merges are interpreted as edges to the final merged chunk. Direct runtime-to-target paths keep the existing conservative behavior and block facade elimination. If the path only appears after resolving merged aliases, the optimizer may still proceed when the helper edge will be local to the runtime host, or when the runtime host can be peeled and rehomed into a helper consumer.
 
 ### Runtime Module Placement
 

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -130,7 +130,7 @@ For each common chunk, translates its `bits` to chunk indices (bit positions dir
 
 Merging is skipped if it would:
 
-- **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency_after_merging()`. The check contracts the target plus the planned source chunks and resolves any source chunks already merged by earlier assignments through `merged_chunk_aliases`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
+- **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency_after_merging()`. The check contracts the target plus the planned source chunks and resolves any source chunks already merged by earlier assignments through `merged_chunk_aliases`. Merge application also normalizes the target dependency set through those aliases so the temporary graph stays minimal after atomically applied groups. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
 - **Change an entry's export signature** — when `preserveEntrySignatures: 'strict'`, adding modules to an entry chunk would expose symbols that the original entry didn't export.
 
 The group-level check matters because a single common chunk can appear cyclic if tested alone while the complete group is safe after all sibling common chunks are contracted into the same target. When a group is safe, the optimizer applies that group atomically; otherwise it falls back to checking each source chunk individually and creates a separate common chunk for unsafe sources.
@@ -143,6 +143,8 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
+
+Facade reachability checks use the same temporary graph and resolve `merged_chunk_aliases`, so stale edges left by earlier common-chunk merges are interpreted as edges to the final merged chunk. A runtime-to-target path does not automatically block facade elimination: if the helper edge will be local to the runtime host, or the runtime host can be peeled and rehomed into a helper consumer, the optimizer proceeds and lets runtime placement preserve an acyclic final graph.
 
 ### Runtime Module Placement
 

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -25,14 +25,14 @@ The trade-off is that this approach can produce many small chunks when there are
 
 ## How Other Bundlers Handle Key Problems
 
-| Problem                    | Rollup                                                  | esbuild                                                 | Rolldown                                                                         |
-| -------------------------- | ------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Shared module detection    | `Set<entryIndex>` per module                            | `BitSet` per file                                       | `BitSet` per module                                                              |
-| Separate chunk vs. inline? | Always separate; `experimentalMinChunkSize` for merging | Always separate; no merging                             | Separate by default; optimizer merges into entry chunks                          |
-| Circular chunk deps        | Warns; allows cyclic reexports                          | Enforces acyclic static chunk graph                     | Enforces acyclic via `would_create_circular_dependency` check before every merge |
-| Dynamic imports            | New entry points; computes "already loaded" atoms       | New entry points; rewrites to chunk unique keys         | New entry points; facade elimination for empty dynamic entries                   |
-| External modules           | Excluded from chunk graph                               | Excluded from bundling                                  | Filtered from entry list at source (never get bit positions)                     |
-| Granularity                | Module level                                            | File level (was statement-level, backed off due to TLA) | Module level                                                                     |
+| Problem                    | Rollup                                                  | esbuild                                                 | Rolldown                                                               |
+| -------------------------- | ------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Shared module detection    | `Set<entryIndex>` per module                            | `BitSet` per file                                       | `BitSet` per module                                                    |
+| Separate chunk vs. inline? | Always separate; `experimentalMinChunkSize` for merging | Always separate; no merging                             | Separate by default; optimizer merges into entry chunks                |
+| Circular chunk deps        | Warns; allows cyclic reexports                          | Enforces acyclic static chunk graph                     | Enforces acyclic via `ChunkOptimizationGraph` merge-contraction checks |
+| Dynamic imports            | New entry points; computes "already loaded" atoms       | New entry points; rewrites to chunk unique keys         | New entry points; facade elimination for empty dynamic entries         |
+| External modules           | Excluded from chunk graph                               | Excluded from bundling                                  | Filtered from entry list at source (never get bit positions)           |
+| Granularity                | Module level                                            | File level (was statement-level, backed off due to TLA) | Module level                                                           |
 
 ## Pipeline
 
@@ -126,10 +126,14 @@ The chunk optimizer reduces chunk count by merging common chunks back into entry
 
 ### Common Module Merging (`try_insert_common_module_to_exist_chunk`)
 
-For each common chunk, translates its `bits` to chunk indices (bit positions directly map to `ChunkIdx`), then tries to merge it into one of those entry chunks. Merging is skipped if it would:
+For each common chunk, translates its `bits` to chunk indices (bit positions directly map to `ChunkIdx`), then tries to merge it into one of those entry chunks. Before applying assignments, the optimizer groups all common chunks that target the same entry chunk and tests the group as a single contraction in the temporary `ChunkOptimizationGraph`.
 
-- **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency()`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
+Merging is skipped if it would:
+
+- **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency_after_merging()`. The check contracts the target plus the planned source chunks and resolves any source chunks already merged by earlier assignments through `merged_chunk_aliases`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
 - **Change an entry's export signature** — when `preserveEntrySignatures: 'strict'`, adding modules to an entry chunk would expose symbols that the original entry didn't export.
+
+The group-level check matters because a single common chunk can appear cyclic if tested alone while the complete group is safe after all sibling common chunks are contracted into the same target. When a group is safe, the optimizer applies that group atomically; otherwise it falls back to checking each source chunk individually and creates a separate common chunk for unsafe sources.
 
 The trade-off of merging: entry chunks may include modules that not all consumers of that entry need. This adds a small amount of unnecessary code loading but significantly reduces chunk count and HTTP requests.
 


### PR DESCRIPTION
## Summary

- Fix chunk-optimizer cycle detection by modeling merges as graph contractions instead of special-casing source/target dependency walks.
- Track aliases for common chunks already merged into existing chunks, so later cycle and reachability checks resolve stale dependency edges through the final merge target.
- Normalize target dependency sets after merges, preventing stale intra-group or alias-chain edges from lingering in the temporary graph.
- Apply safe same-target common-chunk merge groups atomically, with an individual fallback when the whole group would create a static import cycle.
- Keep alias-aware facade reachability compatible with runtime rehoming, so #8989-style safe facade elimination is not blocked by the more accurate graph walk.
- Add a regression fixture for the Promptfoo/tsdown circular-chunk failure and document the merge-contraction/runtime-rehome behavior in the code-splitting design note.

Related to rolldown/tsdown#760 and the Promptfoo/tsdown reproduction discussed in #7449. This does not close #7449's original CJS execution-order reproduction.

## Why

`tsdown@0.21.10` builds Promptfoo with `rolldown@1.0.0-rc.17` into a cyclic static chunk graph. At runtime the generated server imports `fetch-*.js`, which imports back into `server/index.js` before `state$2` is initialized:

```text
ReferenceError: Cannot access 'state$2' before initialization
    at getEnvString (.../dist/src/server/index.js:125:2)
    at .../dist/src/fetch-*.js:44:28
```

The previous cycle check only explored `source.deps` when the source chunk had dependencies. That misses cases where the target already reaches the source through another chunk, so merging the source into the target creates `target -> ... -> target`.

## Related Work

- Supersedes #8227 with a narrower graph-level fix. That PR explored a defensive TDZ mitigation in `manualCodeSplitting`; this PR keeps the generated static chunk graph acyclic instead.
- Related to #7449, but does not close it. The original issue body is an execution-order repro; this PR covers the later Promptfoo/tsdown circular-chunk case discussed there.
- Related to #9164. That draft fixes runtime placement cycles. This patch applies cleanly on top of #9164 and keeps the #8989 runtime-rehome path working with alias-aware reachability.
- Related to #8625 / #6677 in the broader `advancedChunks` area. That PR fixes empty chunk generation and also touches `chunk_optimizer.rs`, but the issue class is different.

## Validation

- `cargo test -p rolldown chunk_optimizer::tests -- --nocapture`
- `just t-run crates/rolldown/tests/rolldown/issues/tsdown_760/_config.json`
- `just t-run crates/rolldown/tests/rolldown/issues/8989/_config.json`
- `just t-run crates/rolldown/tests/rolldown/issues/9049/_config.json`
- `just t-run crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/_config.json`
- `just t-run crates/rolldown/tests/rolldown/code_splitting/issue_8184/_config.json`
- `just t-run crates/rolldown/tests/rolldown/code_splitting/issue_8809/_config.json`
- `just lint-rust && just lint-repo && git diff --check`
- `just build-rolldown`
- Earlier full-branch validation: `just test-rust`, `just test-node-rolldown`, `just test-node-rollup`, `vp check`, `vp run lint-publint`.
- Promptfoo PR #8878 proof:
  - unpatched `tsdown@0.21.10` / `rolldown@1.0.0-rc.17` reproduces the server startup TDZ crash.
  - local Promptfoo override to this patched Rolldown package clean-builds, starts `dist/src/server/index.js`, runs the CI `--share` eval, and `/api/results` returns exactly one uploaded result.
