### PR TITLE
fix: add optional chaining for getOrder method call in plugin normalization

### DIFF
--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -52,7 +52,7 @@ export function makeBuiltinPluginCallable(
       }
     };
 
-    const order = callablePlugin.getOrder(key);
+    const order = callablePlugin.getOrder?.(key);
     if (order == undefined) {
       // @ts-expect-error
       wrappedPlugin[key] = wrappedHook;


### PR DESCRIPTION
## Summary

Fix TypeError in `makeBuiltinPluginCallable` when a plugin object doesn't have a `getOrder` method.

## Problem

When normalizing builtin plugins, the code attempted to call `getOrder()` without checking if the method exists. This causes a TypeError when a plugin lacks this method:

```
TypeError: callablePlugin.getOrder is not a function
```

This issue occurs in monorepo environments where multiple plugins with varying interfaces are used.

## Solution

Use optional chaining (?.) to safely attempt the method call, returning `undefined` if the method doesn't exist:

```typescript
const order = callablePlugin.getOrder?.(key);
```

This maintains backward compatibility while handling plugins with optional `getOrder` methods.

## Changed Files

- `packages/rolldown/src/builtin-plugin/utils.ts` - Added optional chaining to line 55