### PR TITLE
fix: preserve transitive facades in preserveModules

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -356,11 +356,10 @@ impl GenerateStage<'_> {
               module_idx,
             );
             let needs_export_entry_signatures = if self.options.preserve_modules {
-              if is_user_defined {
-                !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
-              } else {
-                is_dynamic_imported
-              }
+              // Preserve the export boundary of every emitted module chunk.
+              // Tree-shaking still applies later via `used_symbol_refs`, so
+              // unused exports are not reintroduced for preserve-modules mode.
+              true
             } else {
               is_dynamic_imported
                 || !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -834,6 +834,12 @@ pub fn include_statement(
     return;
   }
 
+  // In preserve-modules mode, emitting a module file requires preserving the
+  // module boundary once any statement inside that module becomes reachable.
+  if ctx.options.preserve_modules {
+    include_module(ctx, module);
+  }
+
   let stmt_info = module.stmt_infos.get(stmt_info_idx);
 
   // FIXME: bailout for require() import for now

--- a/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
@@ -37,6 +37,13 @@ module.exports = plugin;
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 exports.__commonJSMin = __commonJSMin;
+exports.__copyProps = __copyProps;
+exports.__create = __create;
+exports.__defProp = __defProp;
+exports.__getOwnPropDesc = __getOwnPropDesc;
+exports.__getOwnPropNames = __getOwnPropNames;
+exports.__getProtoOf = __getProtoOf;
+exports.__hasOwnProp = __hasOwnProp;
 exports.__toESM = __toESM;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/5930_1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5930_1/artifacts.snap
@@ -8,6 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 exports.__commonJSMin = __commonJSMin;
+exports.__copyProps = __copyProps;
+exports.__create = __create;
+exports.__defProp = __defProp;
+exports.__getOwnPropDesc = __getOwnPropDesc;
+exports.__getOwnPropNames = __getOwnPropNames;
+exports.__getProtoOf = __getProtoOf;
+exports.__hasOwnProp = __hasOwnProp;
 exports.__toESM = __toESM;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-export { __exportAll, __reExport };
+export { __copyProps, __defProp, __exportAll, __getOwnPropDesc, __getOwnPropNames, __hasOwnProp, __reExport };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
@@ -7,7 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+exports.__copyProps = __copyProps;
+exports.__defProp = __defProp;
 exports.__exportAll = __exportAll;
+exports.__getOwnPropDesc = __getOwnPropDesc;
+exports.__getOwnPropNames = __getOwnPropNames;
+exports.__hasOwnProp = __hasOwnProp;
 exports.__reExport = __reExport;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -7,7 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+exports.__copyProps = __copyProps;
+exports.__defProp = __defProp;
 exports.__exportAll = __exportAll;
+exports.__getOwnPropDesc = __getOwnPropDesc;
+exports.__getOwnPropNames = __getOwnPropNames;
+exports.__hasOwnProp = __hasOwnProp;
 exports.__reExport = __reExport;
 
 ```
@@ -48,6 +53,18 @@ Object.keys(zod).forEach(function(k) {
 ```js
 require("./_virtual/_rolldown/runtime.js");
 let zod = require("zod");
+Object.defineProperty(exports, "object", {
+	enumerable: true,
+	get: function() {
+		return zod.object;
+	}
+});
+Object.defineProperty(exports, "string", {
+	enumerable: true,
+	get: function() {
+		return zod.string;
+	}
+});
 Object.keys(zod).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
 		enumerable: true,

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -7,7 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+exports.__copyProps = __copyProps;
+exports.__defProp = __defProp;
 exports.__exportAll = __exportAll;
+exports.__getOwnPropDesc = __getOwnPropDesc;
+exports.__getOwnPropNames = __getOwnPropNames;
+exports.__hasOwnProp = __hasOwnProp;
 exports.__reExport = __reExport;
 
 ```
@@ -49,6 +54,18 @@ Object.keys(zod).forEach(function(k) {
 require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
+Object.defineProperty(exports, "object", {
+	enumerable: true,
+	get: function() {
+		return zod.object;
+	}
+});
+Object.defineProperty(exports, "string", {
+	enumerable: true,
+	get: function() {
+		return zod.string;
+	}
+});
 Object.keys(zod).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
 		enumerable: true,
@@ -63,6 +80,18 @@ Object.keys(zod).forEach(function(k) {
 ## server.js
 
 ```js
-require("zod");
+let zod = require("zod");
+Object.defineProperty(exports, "object", {
+	enumerable: true,
+	get: function() {
+		return zod.object;
+	}
+});
+Object.defineProperty(exports, "string", {
+	enumerable: true,
+	get: function() {
+		return zod.string;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9209/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9209/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./packages/ui/index.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9209/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9209/artifacts.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## card/components/card.js
+
+```js
+//#region packages/card/components/card.js
+function Card() {
+	return "card";
+}
+//#endregion
+export { Card as default };
+
+```
+
+## card/components/content-card.js
+
+```js
+//#region packages/card/components/content-card.js
+function BigCard() {
+	return "big-card";
+}
+//#endregion
+export { BigCard };
+
+```
+
+## card/index.js
+
+```js
+import Card from "./components/card.js";
+import { BigCard } from "./components/content-card.js";
+export { BigCard, Card };
+
+```
+
+## ui/index.js
+
+```js
+import Card from "../card/components/card.js";
+import { BigCard } from "../card/components/content-card.js";
+export { BigCard, Card };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9209/packages/card/components/card.js
+++ b/crates/rolldown/tests/rolldown/issues/9209/packages/card/components/card.js
@@ -1,0 +1,3 @@
+export default function Card() {
+  return 'card';
+}

--- a/crates/rolldown/tests/rolldown/issues/9209/packages/card/components/content-card.js
+++ b/crates/rolldown/tests/rolldown/issues/9209/packages/card/components/content-card.js
@@ -1,0 +1,3 @@
+export function BigCard() {
+  return 'big-card';
+}

--- a/crates/rolldown/tests/rolldown/issues/9209/packages/card/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9209/packages/card/index.js
@@ -1,0 +1,2 @@
+export { default as Card } from './components/card.js';
+export { BigCard } from './components/content-card.js';

--- a/crates/rolldown/tests/rolldown/issues/9209/packages/ui/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9209/packages/ui/index.js
@@ -1,0 +1,1 @@
+export * from '../card';


### PR DESCRIPTION
Fix preserveModules output so reachable  transitive facade modules are still emitted and  keep their export boundary.

This fixes cases like issue #9209 where an  aggregate entry reaches a public subpath facade module, but the facade file was either skipped or emitted without its expected exports.