### PR TITLE
feat(experimental/lazy-barrel): advice on oversized barrel modules

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -10,7 +10,8 @@ use rolldown_common::{
   StrOrBytes, try_extract_lazy_barrel_info,
 };
 use rolldown_error::{
-  BuildDiagnostic, BuildResult, UnloadableDependencyContext, downcast_napi_error_diagnostics,
+  BuildDiagnostic, BuildResult, EventKindSwitcher, UnloadableDependencyContext,
+  downcast_napi_error_diagnostics,
 };
 use rolldown_std_utils::PathExt as _;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
@@ -181,6 +182,25 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     } else {
       None
     };
+
+    // Eagerly resolving every import in a giant barrel is a known bottleneck.
+    // The threshold targets only the real outliers (large icon packs); normal
+    // component and utility barrels stay well below it.
+    if barrel_info.is_some()
+      && self.ctx.options.checks.contains(EventKindSwitcher::LazyBarrelLargeReexports)
+    {
+      const LARGE_BARREL_IMPORT_THRESHOLD: usize = 5000;
+      let import_record_count = raw_import_records.len();
+      if import_record_count > LARGE_BARREL_IMPORT_THRESHOLD {
+        warnings.push(
+          BuildDiagnostic::lazy_barrel_large_reexports(
+            self.resolved_id.id.to_string(),
+            import_record_count,
+          )
+          .with_severity_warning(),
+        );
+      }
+    }
 
     let module = NormalModule {
       repr_name,

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -10,7 +10,7 @@ use rolldown_common::{
   StrOrBytes, try_extract_lazy_barrel_info,
 };
 use rolldown_error::{
-  BuildDiagnostic, BuildResult, EventKindSwitcher, UnloadableDependencyContext,
+  BuildDiagnostic, BuildResult, DiagnosticOptions, EventKindSwitcher, UnloadableDependencyContext,
   downcast_napi_error_diagnostics,
 };
 use rolldown_std_utils::PathExt as _;
@@ -187,18 +187,27 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     // The threshold targets only the real outliers (large icon packs); normal
     // component and utility barrels stay well below it.
     if barrel_info.is_some()
-      && self.ctx.options.checks.contains(EventKindSwitcher::LazyBarrelLargeReexports)
+      && self.ctx.options.checks.contains(EventKindSwitcher::LargeBarrelModules)
     {
       const LARGE_BARREL_IMPORT_THRESHOLD: usize = 5000;
       let import_record_count = raw_import_records.len();
       if import_record_count > LARGE_BARREL_IMPORT_THRESHOLD {
-        warnings.push(
-          BuildDiagnostic::lazy_barrel_large_reexports(
-            self.resolved_id.id.to_string(),
-            import_record_count,
-          )
-          .with_severity_warning(),
-        );
+        if let Some(on_log) = self.ctx.options.on_log.as_ref() {
+          let event = BuildDiagnostic::large_barrel_modules(id.to_string(), import_record_count)
+            .with_severity(rolldown_error::Severity::Info)
+            .to_diagnostic_with(&DiagnosticOptions { cwd: self.ctx.options.cwd.clone() });
+          on_log
+            .call(
+              rolldown_common::LogLevel::Info,
+              rolldown_common::Log {
+                message: event.to_color_string(),
+                id: Some(id.to_string()),
+                code: Some(event.kind()),
+                ..Default::default()
+              },
+            )
+            .await?;
+        }
       }
     }
 

--- a/crates/rolldown_binding/src/generated/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/generated/binding_checks_options.rs
@@ -24,7 +24,7 @@ pub struct BindingChecksOptions {
   pub duplicate_shebang: Option<bool>,
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
-  pub lazy_barrel_large_reexports: Option<bool>,
+  pub large_barrel_modules: Option<bool>,
 }
 impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
   fn from(value: BindingChecksOptions) -> Self {
@@ -49,7 +49,7 @@ impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
       duplicate_shebang: value.duplicate_shebang,
       unsupported_tsconfig_option: value.unsupported_tsconfig_option,
       ineffective_dynamic_import: value.ineffective_dynamic_import,
-      lazy_barrel_large_reexports: value.lazy_barrel_large_reexports,
+      large_barrel_modules: value.large_barrel_modules,
     }
   }
 }

--- a/crates/rolldown_binding/src/generated/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/generated/binding_checks_options.rs
@@ -24,6 +24,7 @@ pub struct BindingChecksOptions {
   pub duplicate_shebang: Option<bool>,
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
+  pub lazy_barrel_large_reexports: Option<bool>,
 }
 impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
   fn from(value: BindingChecksOptions) -> Self {
@@ -48,6 +49,7 @@ impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
       duplicate_shebang: value.duplicate_shebang,
       unsupported_tsconfig_option: value.unsupported_tsconfig_option,
       ineffective_dynamic_import: value.ineffective_dynamic_import,
+      lazy_barrel_large_reexports: value.lazy_barrel_large_reexports,
     }
   }
 }

--- a/crates/rolldown_common/src/generated/checks_options.rs
+++ b/crates/rolldown_common/src/generated/checks_options.rs
@@ -32,7 +32,7 @@ pub struct ChecksOptions {
   pub duplicate_shebang: Option<bool>,
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
-  pub lazy_barrel_large_reexports: Option<bool>,
+  pub large_barrel_modules: Option<bool>,
 }
 impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
   fn from(value: ChecksOptions) -> Self {
@@ -110,8 +110,8 @@ impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
       value.ineffective_dynamic_import.unwrap_or(true),
     );
     flag.set(
-      rolldown_error::EventKindSwitcher::LazyBarrelLargeReexports,
-      value.lazy_barrel_large_reexports.unwrap_or(true),
+      rolldown_error::EventKindSwitcher::LargeBarrelModules,
+      value.large_barrel_modules.unwrap_or(true),
     );
     flag
   }

--- a/crates/rolldown_common/src/generated/checks_options.rs
+++ b/crates/rolldown_common/src/generated/checks_options.rs
@@ -32,6 +32,7 @@ pub struct ChecksOptions {
   pub duplicate_shebang: Option<bool>,
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
+  pub lazy_barrel_large_reexports: Option<bool>,
 }
 impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
   fn from(value: ChecksOptions) -> Self {
@@ -107,6 +108,10 @@ impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
     flag.set(
       rolldown_error::EventKindSwitcher::IneffectiveDynamicImport,
       value.ineffective_dynamic_import.unwrap_or(true),
+    );
+    flag.set(
+      rolldown_error::EventKindSwitcher::LazyBarrelLargeReexports,
+      value.lazy_barrel_large_reexports.unwrap_or(true),
     );
     flag
   }

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -433,4 +433,11 @@ impl BuildDiagnostic {
       dynamic_importers,
     })
   }
+
+  pub fn lazy_barrel_large_reexports(module_id: String, reexport_count: usize) -> Self {
+    Self::new_inner(super::events::lazy_barrel_large_reexports::LazyBarrelLargeReexports {
+      module_id,
+      reexport_count,
+    })
+  }
 }

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -434,8 +434,8 @@ impl BuildDiagnostic {
     })
   }
 
-  pub fn lazy_barrel_large_reexports(module_id: String, reexport_count: usize) -> Self {
-    Self::new_inner(super::events::lazy_barrel_large_reexports::LazyBarrelLargeReexports {
+  pub fn large_barrel_modules(module_id: String, reexport_count: usize) -> Self {
+    Self::new_inner(super::events::large_barrel_modules::LargeBarrelModules {
       module_id,
       reexport_count,
     })

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -117,6 +117,7 @@ impl Diagnostic {
     let mut message = self.title.clone();
     let mut builder = AriadneReport::build(
       match self.severity {
+        Severity::Info => ReportKind::Advice,
         Severity::Error => ReportKind::Error,
         Severity::Warning => ReportKind::Warning,
       },
@@ -207,6 +208,10 @@ impl Diagnostic {
 
     let file = span.source().to_string();
     Some((file, line, column, utf16_pos))
+  }
+
+  pub fn kind(&self) -> String {
+    self.kind.clone()
   }
 }
 

--- a/crates/rolldown_error/src/build_diagnostic/events/large_barrel_modules.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/large_barrel_modules.rs
@@ -2,14 +2,14 @@ use super::BuildEvent;
 use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::EventKind};
 
 #[derive(Debug)]
-pub struct LazyBarrelLargeReexports {
+pub struct LargeBarrelModules {
   pub module_id: String,
   pub reexport_count: usize,
 }
 
-impl BuildEvent for LazyBarrelLargeReexports {
+impl BuildEvent for LargeBarrelModules {
   fn kind(&self) -> EventKind {
-    EventKind::LazyBarrelLargeReexports
+    EventKind::LargeBarrelModules
   }
 
   fn message(&self, opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/build_diagnostic/events/lazy_barrel_large_reexports.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/lazy_barrel_large_reexports.rs
@@ -1,0 +1,37 @@
+use super::BuildEvent;
+use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::EventKind};
+
+#[derive(Debug)]
+pub struct LazyBarrelLargeReexports {
+  pub module_id: String,
+  pub reexport_count: usize,
+}
+
+impl BuildEvent for LazyBarrelLargeReexports {
+  fn kind(&self) -> EventKind {
+    EventKind::LazyBarrelLargeReexports
+  }
+
+  fn message(&self, opts: &DiagnosticOptions) -> String {
+    format!(
+      "{} has {} re-exports. Eagerly resolving every entry can significantly slow down the build. Consider using `@rolldown/plugin-transform-imports` to rewrite imports at the source level so the barrel file is never loaded.",
+      opts.stabilize_path(&self.module_id),
+      self.reexport_count,
+    )
+  }
+
+  fn on_diagnostic(
+    &self,
+    diagnostic: &mut crate::build_diagnostic::diagnostic::Diagnostic,
+    _opts: &DiagnosticOptions,
+  ) {
+    diagnostic.helps.push(
+      "See https://github.com/rolldown/plugins/tree/main/packages/transform-imports for usage."
+        .to_string(),
+    );
+  }
+
+  fn id(&self) -> Option<String> {
+    Some(self.module_id.clone())
+  }
+}

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -35,6 +35,7 @@ pub mod invalid_define_config;
 pub mod invalid_export_option;
 pub mod invalid_option;
 pub mod json_parse;
+pub mod lazy_barrel_large_reexports;
 pub mod missing_export;
 pub mod missing_global_name;
 pub mod missing_name_option_for_iife_export;

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -35,7 +35,7 @@ pub mod invalid_define_config;
 pub mod invalid_export_option;
 pub mod invalid_option;
 pub mod json_parse;
-pub mod lazy_barrel_large_reexports;
+pub mod large_barrel_modules;
 pub mod missing_export;
 pub mod missing_global_name;
 pub mod missing_name_option_for_iife_export;

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -61,6 +61,7 @@ impl BuildDiagnostic {
     self.severity
   }
 
+  #[must_use]
   pub fn with_severity(mut self, severity: Severity) -> Self {
     self.severity = severity;
     self

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -17,6 +17,7 @@ use self::{diagnostic::Diagnostic, events::BuildEvent, events::tsconfig_error::T
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
+  Info,
   Error,
   Warning,
 }
@@ -58,6 +59,11 @@ impl BuildDiagnostic {
 
   pub fn severity(&self) -> Severity {
     self.severity
+  }
+
+  pub fn with_severity(mut self, severity: Severity) -> Self {
+    self.severity = severity;
+    self
   }
 
   #[must_use]

--- a/crates/rolldown_error/src/generated/event_kind_switcher.rs
+++ b/crates/rolldown_error/src/generated/event_kind_switcher.rs
@@ -49,6 +49,6 @@ bitflags! {
     const RuntimeModuleSymbolNotFoundError = 1 << 42;
     const IneffectiveDynamicImport = 1 << 44;
     const RequireTlaError = 1 << 45;
-    const LazyBarrelLargeReexports = 1 << 46;
+    const LargeBarrelModules = 1 << 46;
   }
 }

--- a/crates/rolldown_error/src/generated/event_kind_switcher.rs
+++ b/crates/rolldown_error/src/generated/event_kind_switcher.rs
@@ -49,5 +49,6 @@ bitflags! {
     const RuntimeModuleSymbolNotFoundError = 1 << 42;
     const IneffectiveDynamicImport = 1 << 44;
     const RequireTlaError = 1 << 45;
+    const LazyBarrelLargeReexports = 1 << 46;
   }
 }

--- a/crates/rolldown_error/src/types/event_kind.rs
+++ b/crates/rolldown_error/src/types/event_kind.rs
@@ -112,6 +112,12 @@ pub enum EventKind {
   /// Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
   IneffectiveDynamicImport = 44,
   RequireTlaError = 45,
+  /// Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  ///
+  /// Such modules can significantly slow down module resolution. Consider using
+  /// [`@rolldown/plugin-transform-imports`](https://github.com/rolldown/plugins/tree/main/packages/transform-imports)
+  /// to rewrite barrel imports at the source level so the barrel file is never loaded.
+  LazyBarrelLargeReexports = 46,
 }
 
 impl Display for EventKind {
@@ -171,6 +177,7 @@ impl Display for EventKind {
       }
       EventKind::IneffectiveDynamicImport => write!(f, "INEFFECTIVE_DYNAMIC_IMPORT"),
       EventKind::RequireTlaError => write!(f, "REQUIRE_TLA"),
+      EventKind::LazyBarrelLargeReexports => write!(f, "LAZY_BARREL_LARGE_REEXPORTS"),
     }
   }
 }

--- a/crates/rolldown_error/src/types/event_kind.rs
+++ b/crates/rolldown_error/src/types/event_kind.rs
@@ -112,12 +112,12 @@ pub enum EventKind {
   /// Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
   IneffectiveDynamicImport = 44,
   RequireTlaError = 45,
-  /// Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  /// Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
   ///
   /// Such modules can significantly slow down module resolution. Consider using
   /// [`@rolldown/plugin-transform-imports`](https://github.com/rolldown/plugins/tree/main/packages/transform-imports)
   /// to rewrite barrel imports at the source level so the barrel file is never loaded.
-  LazyBarrelLargeReexports = 46,
+  LargeBarrelModules = 46,
 }
 
 impl Display for EventKind {
@@ -177,7 +177,7 @@ impl Display for EventKind {
       }
       EventKind::IneffectiveDynamicImport => write!(f, "INEFFECTIVE_DYNAMIC_IMPORT"),
       EventKind::RequireTlaError => write!(f, "REQUIRE_TLA"),
-      EventKind::LazyBarrelLargeReexports => write!(f, "LAZY_BARREL_LARGE_REEXPORTS"),
+      EventKind::LargeBarrelModules => write!(f, "LARGE_BARREL_MODULES"),
     }
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1485,6 +1485,12 @@
             "boolean",
             "null"
           ]
+        },
+        "lazyBarrelLargeReexports": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1486,7 +1486,7 @@
             "null"
           ]
         },
-        "lazyBarrelLargeReexports": {
+        "largeBarrelModules": {
           "type": [
             "boolean",
             "null"

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1877,6 +1877,7 @@ export interface BindingChecksOptions {
   duplicateShebang?: boolean
   unsupportedTsconfigOption?: boolean
   ineffectiveDynamicImport?: boolean
+  lazyBarrelLargeReexports?: boolean
 }
 
 export interface BindingChunkImportMap {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1877,7 +1877,7 @@ export interface BindingChecksOptions {
   duplicateShebang?: boolean
   unsupportedTsconfigOption?: boolean
   ineffectiveDynamicImport?: boolean
-  lazyBarrelLargeReexports?: boolean
+  largeBarrelModules?: boolean
 }
 
 export interface BindingChunkImportMap {

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -159,4 +159,14 @@ export interface ChecksOptions {
    * @default true
    * */
   ineffectiveDynamicImport?: boolean;
+
+  /**
+   * Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+   *
+   * Such modules can significantly slow down module resolution. Consider using
+   * [`@rolldown/plugin-transform-imports`](https://github.com/rolldown/plugins/tree/main/packages/transform-imports)
+   * to rewrite barrel imports at the source level so the barrel file is never loaded.
+   * @default true
+   * */
+  lazyBarrelLargeReexports?: boolean;
 }

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -161,12 +161,12 @@ export interface ChecksOptions {
   ineffectiveDynamicImport?: boolean;
 
   /**
-   * Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+   * Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
    *
    * Such modules can significantly slow down module resolution. Consider using
    * [`@rolldown/plugin-transform-imports`](https://github.com/rolldown/plugins/tree/main/packages/transform-imports)
    * to rewrite barrel imports at the source level so the barrel file is never loaded.
    * @default true
    * */
-  lazyBarrelLargeReexports?: boolean;
+  largeBarrelModules?: boolean;
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -410,10 +410,10 @@ const ChecksOptionsSchema = v.strictObject({
       'Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting',
     ),
   ),
-  lazyBarrelLargeReexports: v.pipe(
+  largeBarrelModules: v.pipe(
     v.optional(v.boolean()),
     v.description(
-      'Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000)',
+      'Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000)',
     ),
   ),
 });

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -410,6 +410,12 @@ const ChecksOptionsSchema = v.strictObject({
       'Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting',
     ),
   ),
+  lazyBarrelLargeReexports: v.pipe(
+    v.optional(v.boolean()),
+    v.description(
+      'Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000)',
+    ),
+  ),
 });
 isTypeTrue<IsSchemaSubType<typeof ChecksOptionsSchema, ChecksOptions>>();
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -35,7 +35,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
-  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  --checks.large-barrel-modules Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -179,7 +179,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
-  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  --checks.large-barrel-modules Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -323,7 +323,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
-  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  --checks.large-barrel-modules Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -467,7 +467,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
-  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
+  --checks.large-barrel-modules Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -35,6 +35,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -178,6 +179,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -321,6 +323,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
@@ -464,6 +467,7 @@ OPTIONS
   --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
   --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
   --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.lazy-barrel-large-reexports Whether to emit warnings when a barrel module has a very large number of re-exports (more than 5000).
   --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
   --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.


### PR DESCRIPTION
## Summary

Adds a build-time advisory when the experimental `lazyBarrel` flag is enabled and a barrel module exceeds **5000 re-exports** (think large icon packs like `lucide-react` or `@mui/icons-material`). Eagerly resolving every re-export in such a barrel is a known bottleneck, so rolldown now points users at [`@rolldown/plugin-transform-imports`](https://github.com/rolldown/plugins/tree/main/packages/transform-imports), which rewrites imports at the source so the barrel file is never loaded.

Example output:

```
advice[LARGE_BARREL_MODULES]: node_modules/lucide-react/dist/esm/lucide-react.js has 1463 re-exports. Eagerly resolving every entry can significantly slow down the build. Consider using `@rolldown/plugin-transform-imports` to rewrite imports at the source level so the barrel file is never loaded.
  help: See https://github.com/rolldown/plugins/tree/main/packages/transform-imports for usage.
```

## What's in this PR

- **New diagnostic event `LargeBarrelModules`** (`EventKind = 46`) under `rolldown_error`, with a dedicated `BuildEvent` impl that formats the module id, re-export count, and a help link.
- **`Severity::Info` variant** on `BuildDiagnostic`, rendered as `ReportKind::Advice` via ariadne (distinct from the existing `error:` / `warning:` prefixes). A `with_severity()` builder is added so the same diagnostic can be downgraded to an info-level log.
- **Detection in `module_task.rs`**: after lazy-barrel info is computed, if the resolved barrel has more than 5000 import records, an `Info`-level `Log` is dispatched through `on_log` with `code = "LARGE_BARREL_MODULES"`. Gated on the new check flag so users can silence it.
- **New check flag** `checks.largeBarrelModules` (default `true`), propagated through the usual codegen: Rust `EventKindSwitcher`, NAPI binding, TS `ChecksOptions`, validator, JSON schema, and CLI `--checks.large-barrel-modules`.

## How to opt out

```js
export default {
  experimental: { lazyBarrel: true },
  checks: { largeBarrelModules: false },
}
```

Or from the CLI:

```sh
rolldown --no-checks.large-barrel-modules
```

## Notes on the threshold

5000 was chosen so that ordinary component or utility barrels (typically in the low hundreds) stay quiet, and only the real outliers (icon packs, mass re-export shims) trip it. The threshold is intentionally not user-configurable for now; once we have real-world feedback it can be promoted to an option.
<img width="710" height="119" alt="image" src="https://github.com/user-attachments/assets/45b73c26-0294-45dc-b2d0-f25627eaed5e" />
