### PR TITLE
chore(ai): add rolldown REPL decode skill

### DIFF
--- a/.claude/skills/rolldown-repl-decode/SKILL.md
+++ b/.claude/skills/rolldown-repl-decode/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: rolldown-repl-decode
+description: Use whenever a rolldown REPL share URL appears in the conversation — `repl.rolldown.rs/#…`, `rolldown-repl.netlify.app/#…`, or any URL whose hash is a base64-encoded rolldown REPL payload. This commonly happens when investigating GitHub issues in rolldown/rolldown that include a "minimal reproduction" REPL link. Decodes the hash into the actual source files + rolldown version so the issue can be reproduced or understood. Trigger even if the user only pastes the URL without explicitly asking to decode it.
+---
+
+# Decode a rolldown REPL share URL
+
+The rolldown REPL stores all state (input files + selected rolldown version) in `location.hash` as `base64(zlib(JSON))`. Browsers never send the hash to the server, so naive HTTP fetches return an empty shell. This skill decodes the hash locally so you can read what the user actually had in their REPL.
+
+## When to use
+
+- An issue or message links to `https://repl.rolldown.rs/#…` (or any other host serving the rolldown REPL).
+- The user pastes such a URL and asks something like "what's wrong with this", "why does this fail", or "reproduce this bug".
+- You're investigating a rolldown bug and the reporter included a REPL link as the reproduction.
+
+If the URL has no `#…` payload, there's nothing to decode — tell the user and stop.
+
+## How
+
+Run the bundled decoder. It prints a JSON summary to stdout, and with `--write` it also drops each file onto disk:
+
+```bash
+node .claude/skills/rolldown-repl-decode/scripts/decode.mjs '<full-url>'
+node .claude/skills/rolldown-repl-decode/scripts/decode.mjs '<full-url>' --write /tmp/repl-repro
+```
+
+Quote the URL — the `#` would otherwise be eaten by the shell.
+
+## What you get
+
+The decoded JSON has shape:
+
+```json
+{
+  "v": "<rolldown version, e.g. 'latest' or '1.2.3'>",
+  "f": {
+    "src/index.js": { "n": "src/index.js", "c": "...source...", "e": true },
+    "...": { ... }
+  }
+}
+```
+
+Where `n` is the filename, `c` is the source content, and `e` (when present) marks the entry file. The script reshapes this into a summary (file list + sizes + version) for quick reading. Use `--write <dir>` when you actually need the source on disk to reproduce — e.g. to run `pnpm rolldown` against it.
+
+## Typical workflow for issue investigation
+
+1. Read the GitHub issue (e.g. `gh issue view 9211 -R rolldown/rolldown`).
+2. Spot the REPL URL in the body.
+3. Run the decoder with `--write /tmp/repl-<issue-number>/` to get the files.
+4. Note the `v` field — if the issue is version-specific, install that exact version before reproducing.
+5. Build/run rolldown against the decoded files and compare with the issue's described output.
+
+## Notes
+
+- The decoder handles both the modern zlib-compressed format (`\x78\xDA` header) and the legacy `decodeURIComponent(escape(...))` fallback that older share links used.
+- Plain Node `.mjs` (uses `node:zlib`, `node:buffer`, `node:fs`). No `npm install` needed.
+- If decoding fails with "Invalid base64", the URL was probably truncated when copied. Ask the user to repaste the full URL.

--- a/.claude/skills/rolldown-repl-decode/scripts/decode.mjs
+++ b/.claude/skills/rolldown-repl-decode/scripts/decode.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Decode a rolldown REPL share URL into its source files + version.
+//
+// The REPL encodes state as base64(zlib(JSON({f: files, v: version}))) in the
+// URL hash. Implementation matches rolldown/repl `app/utils/url.ts` (utoa/atou).
+//
+// Usage:
+//   node decode.mjs '<full-url-or-just-the-hash>'
+//   node decode.mjs '<url>' --write <out-dir>   # also write files to disk
+
+import { argv, exit } from 'node:process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { Buffer } from 'node:buffer';
+import zlib from 'node:zlib';
+
+function decodeHash(raw) {
+  if (raw.includes('#')) raw = raw.split('#').slice(1).join('#');
+  raw = decodeURIComponent(raw);
+  // Pad base64 if needed.
+  raw += '='.repeat(-raw.length & 3);
+  const bin = Buffer.from(raw, 'base64');
+  let text;
+  if (bin[0] === 0x78 && bin[1] === 0xda) {
+    // Modern format: zlib-compressed.
+    text = zlib.inflateSync(bin).toString('utf-8');
+  } else {
+    // Legacy format: decodeURIComponent(escape(binary))
+    text = decodeURIComponent(bin.toString('latin1'));
+  }
+  return JSON.parse(text);
+}
+
+function fileBytes(meta) {
+  // The actual REPL payload uses `c` for content and `n` for filename.
+  // Older payloads may use `code` — accept both.
+  return (meta?.c ?? meta?.code ?? '').length;
+}
+
+function fileContent(meta) {
+  return meta?.c ?? meta?.code ?? '';
+}
+
+function main() {
+  const args = argv.slice(2);
+  const writeIdx = args.indexOf('--write');
+  const writeDir = writeIdx >= 0 ? args[writeIdx + 1] : null;
+  const positional = args.filter((a, i) => a !== '--write' && (writeIdx < 0 || i !== writeIdx + 1));
+  const url = positional[0];
+  if (!url) {
+    console.error('usage: decode.mjs <url> [--write <dir>]');
+    exit(2);
+  }
+
+  const state = decodeHash(url);
+  const files = state.f || {};
+  const version = state.v || 'unknown';
+
+  const summary = {
+    version,
+    file_count: Object.keys(files).length,
+    files: Object.entries(files).map(([name, meta]) => ({
+      filename: name,
+      language: meta?.language ?? null,
+      bytes: fileBytes(meta),
+    })),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (writeDir) {
+    mkdirSync(writeDir, { recursive: true });
+    for (const [name, meta] of Object.entries(files)) {
+      const path = join(writeDir, name);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, fileContent(meta), 'utf-8');
+    }
+    console.error(`\nwrote ${Object.keys(files).length} files to ${writeDir}`);
+  }
+}
+
+main();

--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,8 @@ crates/rolldown/tests/rolldown/warnings/eval2/node_modules
 crates/rolldown_devtools_action/bindings/**
 
 # AI config
-.claude
+.claude/*
+!.claude/skills
 CLAUDE.local.md
 .sisyphus
 


### PR DESCRIPTION
## Summary

Adds the `rolldown-repl-decode` Claude Code skill into the repo so it ships with the project.

## Why

When users report a Rolldown bug, the most useful context is almost always the REPL share link — it captures the exact source files **and** the Rolldown version that reproduce the issue. But the REPL stores all of that state in `location.hash` as `base64(zlib(JSON))`, which the browser never sends to the server. A naive `fetch` of the URL returns an empty page, so Claude Code has no way to read what the user actually typed.

This skill bridges that gap. With it installed, Claude Code can:

- Detect a Rolldown REPL link (`repl.rolldown.rs/#…`, `rolldown-repl.netlify.app/#…`) anywhere in an issue body or chat.
- Decode the hash locally to recover the source files + Rolldown version.
- Optionally drop the files onto disk so the bug can be reproduced against the matching Rolldown version.

End result: Claude Code can analyze and fix REPL-linked issues with the actual reproduction in hand, instead of asking the reporter to repaste their code.

## What's in this PR

- `.claude/skills/rolldown-repl-decode/SKILL.md` — when-to-trigger metadata + usage.
- `.claude/skills/rolldown-repl-decode/scripts/decode.mjs` — plain Node script (no deps) that prints the decoded file list + version, and writes the sources to disk with `--write <dir>`.
- `.gitignore` — loosen `.claude` ignore so `.claude/skills/` is tracked, while keeping local user state (`settings.local.json`, history, worktrees) ignored.

## Test plan

- [x] `node .claude/skills/rolldown-repl-decode/scripts/decode.mjs` prints usage.
- [x] Decoded a real REPL share URL end-to-end (file list + version + `--write` output).