### PR TITLE
chore(justfile): drop the `--` separator before forwarded args in `vp run`

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ test-node-hmr *args: build build-test-dev-server
   just test-node-hmr-only {{ args }}
 
 test-node-hmr-only *args:
-  vp run --filter @rolldown/test-dev-server-tests test -- {{ args }}
+  vp run --filter @rolldown/test-dev-server-tests test {{ args }}
 
 # Run Vite's test suite to check Rolldown's behaviors.
 test-vite: # We don't use `test-node-vite` because it's not expected to run in `just test-node`.
@@ -110,12 +110,12 @@ t-node: t-node-rolldown t-node-rollup
 
 # Run Rolldown's tests without building Rolldown.
 t-node-rolldown *args="":
-  vp run --filter rolldown-tests test:main -- {{ args }}
-  vp run --filter rolldown-tests test:watcher -- {{ args }}
+  vp run --filter rolldown-tests test:main {{ args }}
+  vp run --filter rolldown-tests test:watcher {{ args }}
 
 # Run Rollup's test suite without building Rolldown.
 t-node-rollup *args="":
-  vp run --filter rollup-tests test -- {{ args }}
+  vp run --filter rollup-tests test {{ args }}
 
 # Run specific rust test without enabling extended tests.
 [unix]


### PR DESCRIPTION
## Summary

- Remove the literal `--` between the task name and `{{ args }}` in the four `vp run` invocations under `t-node-rolldown`, `t-node-rollup`, and `test-node-hmr-only`.
- Lets `--update`, `--testNamePattern`, and similar vitest flags reach vitest as actual flags instead of being captured as positional file filters.

## Why

`vp run TASK -- ARGS` does not strip the `--` the way `npm run` / `pnpm run` do. It splices the separator literally into the final command, producing for example:

```
vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests -- --update --testNamePattern '...'
```

Vitest treats everything after `--` as positional file filters, so `--update` is silently ignored. Concretely, `just test-update` could not refresh snapshots: the cli help snapshot in `cli-e2e.test.ts.snap` reported four mismatches every time and never wrote the new content.

Dropping the `--` makes vp produce the expected command:

```
vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests --update --testNamePattern '...'
```

and snapshots update normally. Behavior without args is unchanged because `{{ args }}` expands to nothing in that case.

## Verification

1. Reset a snapshot to a stale state and confirm the failure is reproducible:
   ```
   just test-update
   # FAIL  cli/cli-e2e.test.ts > basic arguments > should show help when --help is used with other arguments (#8523)
   #   Snapshots  4 failed
   ```
2. Apply the patch and rerun the same scenario via `just t-node-rolldown --update --testNamePattern "should show help when --help is used with other arguments"`. The snapshot updates and the test passes.
3. Default `just test` / `just test-node` invocations (no extra args) continue to work because `{{ args }}` expands to an empty string in either form.

## Notes

- This works around what looks like a `vp run` quirk; the npm/pnpm convention is to strip the `--` separator. Worth filing upstream against vite+ as a follow-up.
