### PR TITLE
fix(binding): treat empty inlineConst object as omitted

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
@@ -22,6 +22,8 @@ impl TryFrom<BindingOptimization> for rolldown_common::OptimizationOption {
   fn try_from(value: BindingOptimization) -> std::result::Result<Self, Self::Error> {
     let inline_const = match value.inline_const {
       Some(Either::A(bool_val)) => Some(InlineConstOption::Bool(bool_val)),
+      // An empty object is treated as `undefined` so its defaults match the omitted case.
+      Some(Either::B(config_val)) if config_val.mode.is_none() && config_val.pass.is_none() => None,
       Some(Either::B(config_val)) => {
         let mode = if let Some(mode_str) = config_val.mode.as_ref() {
           match mode_str.as_str() {

--- a/packages/rolldown/tests/optimization-inline-const.test.ts
+++ b/packages/rolldown/tests/optimization-inline-const.test.ts
@@ -1,0 +1,37 @@
+import { rolldown } from 'rolldown';
+import type { InputOptions, Plugin } from 'rolldown';
+import { describe, expect, test } from 'vitest';
+
+const fixturePlugin: Plugin = {
+  name: 'inline-const-fixture',
+  resolveId(id) {
+    if (id === 'virtual:main' || id === 'virtual:foo') return '\0' + id;
+  },
+  load(id) {
+    if (id === '\0virtual:main') {
+      return `import { X } from 'virtual:foo';\nconsole.log(X);\nconsole.log(X);\nconsole.log(X);`;
+    }
+    if (id === '\0virtual:foo') {
+      return `export const X = 'shared-constant';`;
+    }
+  },
+};
+
+async function bundle(optimization?: InputOptions['optimization']) {
+  const b = await rolldown({
+    input: 'virtual:main',
+    optimization,
+    plugins: [fixturePlugin],
+  });
+  const result = await b.generate({ format: 'esm' });
+  await b.close();
+  return result.output[0].code;
+}
+
+describe('optimization.inlineConst', () => {
+  test('empty object is treated the same as omitting the option', async () => {
+    const omitted = await bundle({ inlineConst: undefined });
+    const empty = await bundle({ inlineConst: {} });
+    expect(empty).toBe(omitted);
+  });
+});


### PR DESCRIPTION
Fixes #9244.

In the napi binding, an empty `inlineConst: {}` was parsed as a `Config` with both fields undefined and normalized to `(mode: 'all', pass: 1)`, instead of falling back to the omitted default `(mode: 'smart', pass: 1)`. This guards the empty-object case to return `None` so it matches the omitted form.
