### PR TITLE
fix(optimization)!: default unspecified inlineConst.mode to smart

### DIFF
--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/_config.json
@@ -7,6 +7,7 @@
   "configVariants": [
     {
       "inlineConst": {
+        "mode": "all",
         "pass": 2
       }
     }

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/artifacts.snap
@@ -27,7 +27,7 @@ assert.strictEqual(mutable_let, "mutable_let1");
 
 ```
 
-# Variant: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
+# Variant: [inline_const: Config(InlineConstConfig { mode: Some(All), pass: 2 })]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/_config.json
@@ -13,6 +13,7 @@
     "minify": "dceOnly",
     "optimization": {
       "inlineConst": {
+        "mode": "all",
         "pass": 1
       }
     }
@@ -21,6 +22,7 @@
     {
       "_configName": "inlineConstPass2",
       "inlineConst": {
+        "mode": "all",
         "pass": 2
       }
     }

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
@@ -39,7 +39,7 @@ demo();
 
 ```
 
-# Variant: inlineConstPass2: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
+# Variant: inlineConstPass2: [inline_const: Config(InlineConstConfig { mode: Some(All), pass: 2 })]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/_config.json
@@ -3,6 +3,7 @@
     "minify": "dceOnly",
     "optimization": {
       "inlineConst": {
+        "mode": "all",
         "pass": 3
       }
     }

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
@@ -36,7 +36,7 @@ impl TryFrom<BindingOptimization> for rolldown_common::OptimizationOption {
             }
           }
         } else {
-          None
+          Some(InlineConstMode::Smart)
         };
 
         Some(InlineConstOption::Config(InlineConstConfig {

--- a/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
@@ -20,7 +20,7 @@ pub struct InlineConstConfig {
 
 impl Default for InlineConstConfig {
   fn default() -> Self {
-    Self { mode: Some(InlineConstMode::All), pass: 1 }
+    Self { mode: Some(InlineConstMode::Smart), pass: 1 }
   }
 }
 
@@ -110,7 +110,9 @@ pub fn normalize_optimization_option(
     }
     Some(InlineConstOption::Bool(false)) => None,
     Some(InlineConstOption::Config(config)) => {
-      let mode = config.mode.unwrap_or(InlineConstMode::All);
+      // When `mode` is unspecified, default to `Smart` to match the omitted-option
+      // default. See https://github.com/rolldown/rolldown/issues/9244.
+      let mode = config.mode.unwrap_or(InlineConstMode::Smart);
       let pass = config.pass;
       Some(NormalizedInlineConstConfig { mode, pass })
     }

--- a/packages/rolldown/tests/optimization-inline-const.test.ts
+++ b/packages/rolldown/tests/optimization-inline-const.test.ts
@@ -34,4 +34,12 @@ describe('optimization.inlineConst', () => {
     const empty = await bundle({ inlineConst: {} });
     expect(empty).toBe(omitted);
   });
+
+  test('partial config without `mode` defaults to smart, not all', async () => {
+    // Per https://github.com/rolldown/rolldown/issues/9244, supplying only
+    // `pass` should not silently flip the mode to `all`.
+    const partial = await bundle({ inlineConst: { pass: 1 } });
+    const explicitSmart = await bundle({ inlineConst: { mode: 'smart', pass: 1 } });
+    expect(partial).toBe(explicitSmart);
+  });
 });


### PR DESCRIPTION
 when `optimization.inlineConst` is a partial config object with no `mode` field (e.g., `{ pass: 1 }`), it now defaults to `'smart'` to match the documented default for the omitted-option case, instead of silently falling back to `'all'`. Both the napi binding and the Rust normalizer are aligned, and the three existing fixture tests that relied on the old implicit `mode: 'all'` default were made explicit so their semantics are preserved.

**BREAKING CHANGE:** users who pass `optimization.inlineConst` as a partial config object without a `mode` field (e.g., `{ pass: 2 }`) will see different bundle output. Previously such configs silently used `mode: 'all'`; they now use `mode: 'smart'` (the documented default). To preserve the previous behavior, set `mode: 'all'` explicitly.