### PR TITLE
fix(dev/lazy): fix exports of lazy requests in lazy chunks

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -608,8 +608,25 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       return;
     };
 
-    // Handle lazy proxy modules - rewrite to lazy entry import pattern
-    // For dynamic imports to lazy proxies, we need to trigger lazy loading via /@vite/lazy endpoint
+    // Handle lazy proxy modules - rewrite to mirror the proxy module's runtime contract.
+    //
+    // In a regular full build, scope finalizer rewrites `import('./foo')` to point at the
+    // proxy module's chunk URL. That chunk's content is `proxy-module-template.js`, which
+    // exposes `'rolldown:exports'` at the top level so consumers can do
+    // `.then(__unwrap_lazy_compilation_entry).then(m => m.X)`.
+    //
+    // In HMR partial bundles there's no separately bundled proxy chunk - the proxy module's
+    // body gets wrapped inside a `createEsmInitializer` and its top-level `export` is lost.
+    // To keep the same surface as the full build, we rewrite the dynamic import to:
+    //
+    //   import(`/@vite/lazy?id=...&clientId=...`)
+    //     .then(() => __rolldown_runtime__.loadExports("<stable_proxy_id>"))
+    //
+    // After the partial bundle evaluates, the proxy module is registered under
+    // `<stable_proxy_id>` with a `'rolldown:exports'` getter (set up by `__exportAll` inside
+    // the init wrapper). Reading it back via `loadExports` yields the namespace object that
+    // the existing `__unwrap_lazy_compilation_entry` chain expects.
+    //
     // TODO: hyf0 should switch to a more robust way to identify lazy proxy modules
     if importee.id.contains("?rolldown-lazy=1") {
       // Build: encodeURIComponent(importee.id)
@@ -654,7 +671,60 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         self.builder.expression_template_literal(SPAN, quasis, expressions)
       };
 
-      *it = self.builder.expression_import(SPAN, url_expr, None, None);
+      // Build: import(`/@vite/lazy?id=...&clientId=...`)
+      let import_expr = self.builder.expression_import(SPAN, url_expr, None, None);
+
+      // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
+      let load_exports_call = ast::Expression::CallExpression(self.builder.alloc_call_expression(
+        SPAN,
+        self.snippet.id_ref_expr("__rolldown_runtime__.loadExports", SPAN),
+        NONE,
+        self.builder.vec1(ast::Argument::StringLiteral(self.builder.alloc_string_literal(
+          SPAN,
+          self.builder.str(&importee.stable_id),
+          None,
+        ))),
+        false,
+      ));
+
+      // Build: () => __rolldown_runtime__.loadExports("<stable_proxy_id>")
+      let arrow_fn = self.builder.expression_arrow_function(
+        SPAN,
+        /* expression */ true,
+        /* async */ false,
+        NONE,
+        self.builder.formal_parameters(
+          SPAN,
+          ast::FormalParameterKind::ArrowFormalParameters,
+          self.builder.vec(),
+          NONE,
+        ),
+        NONE,
+        self.builder.function_body(
+          SPAN,
+          self.builder.vec(),
+          self.builder.vec1(ast::Statement::ExpressionStatement(
+            self.builder.alloc_expression_statement(SPAN, load_exports_call),
+          )),
+        ),
+      );
+
+      // Build: import(...).then(() => __rolldown_runtime__.loadExports("..."))
+      let then_callee =
+        Expression::StaticMemberExpression(self.builder.alloc_static_member_expression(
+          SPAN,
+          import_expr,
+          self.builder.identifier_name(SPAN, "then"),
+          false,
+        ));
+
+      *it = self.builder.expression_call(
+        SPAN,
+        then_callee,
+        NONE,
+        self.builder.vec1(ast::Argument::from(arrow_fn)),
+        false,
+      );
       return;
     }
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -94,5 +94,8 @@
     "packages/test-dev-server/tests/playground/lazy-issue-9312": {
       "entry": ["dev.config.mjs", "app.js", "page-a.js", "page-b.js", "selectors.js"], // Playwright test with dev config and source files
     },
+    "packages/test-dev-server/tests/playground/lazy-nested-dynamic-import": {
+      "entry": ["dev.config.mjs", "app.js", "outer.js", "inner.js"], // Playwright test with dev config and source files
+    },
   },
 }

--- a/packages/test-dev-server/tests/browser.spec.ts
+++ b/packages/test-dev-server/tests/browser.spec.ts
@@ -1,10 +1,18 @@
 import { setTimeout } from 'node:timers/promises';
 import { describe, expect, test } from 'vitest';
 import { CONFIG } from './src/config';
-import { editFile, getIssue9312Page, getLazyPage, getPage, waitForBuildStable } from './test-utils';
+import {
+  editFile,
+  getIssue9312Page,
+  getLazyPage,
+  getNestedLazyPage,
+  getPage,
+  waitForBuildStable,
+} from './test-utils';
 
 const LAZY_URL = `http://localhost:${CONFIG.ports.lazyCompilation}`;
 const ISSUE_9312_URL = `http://localhost:${CONFIG.ports.lazyIssue9312}`;
+const NESTED_LAZY_URL = `http://localhost:${CONFIG.ports.lazyNestedDynamicImport}`;
 
 describe('hmr-full-bundle-mode', () => {
   test.sequential('should render initial content', async () => {
@@ -146,4 +154,42 @@ describe('lazy-issue-9312', () => {
     expect(log).toContain('sel.bar = bar_value');
     expect(log).not.toContain('UNDEFINED');
   });
+});
+
+// Regression test for the fix in
+// `crates/rolldown/src/hmr/hmr_ast_finalizer.rs::try_rewrite_dynamic_import`
+// (the `?rolldown-lazy=1` branch). `outer.js` is itself loaded as a lazy chunk,
+// and its body contains `await import('./inner.js')`, which also resolves to a
+// lazy proxy. Before the fix the HMR AST finalizer rewrote that inner dynamic
+// import to a plain `import('/@vite/lazy?id=...')`, returning the partial
+// bundle's raw namespace — which has no `'rolldown:exports'` key, so
+// `__unwrap_lazy_compilation_entry` fell through and `inner.foo` came back
+// `undefined`. The fix chains `.then(() => loadExports("<stable_proxy_id>"))`
+// so the namespace read by the unwrap helper is the proxy module's registered
+// exports (which carry the `'rolldown:exports'` getter).
+describe('lazy-nested-dynamic-import', () => {
+  // `retry: 0` is critical: the bug only manifests on the first click of a fresh
+  // page. The first click triggers `mark_as_fetched`, which rebuilds main.js so
+  // it references the *fetched* proxy chunk — and the fetched proxy chunk imports
+  // the full-build outer.js (compiled by scope_finalizer), bypassing the buggy
+  // HMR-finalizer rewrite entirely. With retries enabled, the reload between
+  // attempts would always land on the post-rebuild fetched-proxy path and mask
+  // the regression.
+  test.sequential(
+    'lazy chunk can dynamically import another lazy chunk',
+    { retry: 0 },
+    async () => {
+      const page = getNestedLazyPage();
+
+      await page.goto(NESTED_LAZY_URL, { waitUntil: 'domcontentloaded' });
+      await page.click('#btn');
+      await expect.poll(() => page.textContent('#status')).toBe('done');
+
+      const log = (await page.textContent('#log')) ?? '';
+      expect(log).toContain('outer.outerName = outer');
+      expect(log).toContain('inner.foo = inner_foo');
+      expect(log).toContain('inner.bar = inner_bar');
+      expect(log).not.toContain('UNDEFINED');
+    },
+  );
 });

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/app.js
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/app.js
@@ -1,0 +1,18 @@
+const log = (msg) => {
+  document.getElementById('log').textContent += msg + '\n';
+};
+
+log('app loaded.');
+
+document.getElementById('btn').addEventListener('click', async () => {
+  log('--- loading outer (lazy chunk) ---');
+  const outer = await import('./outer.js');
+  log(`outer.outerName = ${outer.outerName}`);
+
+  log('--- triggering nested dynamic import (lazy -> lazy) ---');
+  const inner = await outer.loadInner();
+  log(`inner.foo = ${inner.foo === undefined ? 'UNDEFINED' : inner.foo}`);
+  log(`inner.bar = ${inner.bar === undefined ? 'UNDEFINED' : inner.bar}`);
+
+  document.getElementById('status').textContent = 'done';
+});

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/dev.config.mjs
@@ -1,0 +1,32 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+// Regression test for the lazy-chunk-nested-dynamic-import bug fixed in
+// `crates/rolldown/src/hmr/hmr_ast_finalizer.rs::try_rewrite_dynamic_import`
+// (the `?rolldown-lazy=1` branch).
+//
+// Scenario: `outer.js` is itself loaded as a lazy chunk, and its body contains
+// `await import('./inner.js')` which also resolves to a lazy proxy. The dynamic
+// import inside the lazy chunk's HMR partial bundle must be rewritten to:
+//
+//   import('/@vite/lazy?id=...').then(() => __rolldown_runtime__.loadExports("<stable_proxy_id>"))
+//
+// so that `__unwrap_lazy_compilation_entry` finds `'rolldown:exports'` on the
+// registered proxy module instead of the raw partial-bundle namespace.
+export default defineDevConfig({
+  platform: 'browser',
+  dev: {
+    port: 3639,
+  },
+  build: {
+    input: { main: 'app.js' },
+    output: {
+      strictExecutionOrder: true,
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: { lazy: true },
+      incrementalBuild: true,
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>lazy-nested-dynamic-import</title>
+  </head>
+  <body>
+    <h1>lazy-nested-dynamic-import</h1>
+    <button id="btn">load</button>
+    <div id="status">pending</div>
+    <pre id="log"></pre>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/inner.js
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/inner.js
@@ -1,0 +1,2 @@
+export const foo = 'inner_foo';
+export const bar = 'inner_bar';

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/outer.js
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/outer.js
@@ -1,0 +1,10 @@
+export const outerName = 'outer';
+
+// Nested dynamic import: this `import('./inner.js')` runs inside outer.js's body,
+// which is itself a lazy chunk. After the lazy-compilation plugin resolves the
+// dynamic import to `inner.js?rolldown-lazy=1`, the HMR AST finalizer rewrites
+// this call so the result mirrors the full-build proxy contract (a namespace
+// with the `'rolldown:exports'` key for `__unwrap_lazy_compilation_entry`).
+export async function loadInner() {
+  return await import('./inner.js');
+}

--- a/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/package.json
+++ b/packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-lazy-nested-dynamic-import",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/src/config.ts
+++ b/packages/test-dev-server/tests/src/config.ts
@@ -17,10 +17,16 @@ export const CONFIG = {
     tmpLazyCompilationDir: nodePath.join(testsDir, 'tmp-playground/lazy-compilation'),
     lazyIssue9312Dir: nodePath.join(testsDir, 'playground/lazy-issue-9312'),
     tmpLazyIssue9312Dir: nodePath.join(testsDir, 'tmp-playground/lazy-issue-9312'),
+    lazyNestedDynamicImportDir: nodePath.join(testsDir, 'playground/lazy-nested-dynamic-import'),
+    tmpLazyNestedDynamicImportDir: nodePath.join(
+      testsDir,
+      'tmp-playground/lazy-nested-dynamic-import',
+    ),
   },
   ports: {
     hmrFullBundleMode: 3636,
     lazyCompilation: 3637,
     lazyIssue9312: 3638,
+    lazyNestedDynamicImport: 3639,
   },
 };

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -70,6 +70,19 @@ export function getIssue9312Page() {
   return page;
 }
 
+/**
+ * Get the Playwright page for the lazy-nested-dynamic-import regression test.
+ */
+export function getNestedLazyPage() {
+  const page = (global as any).__nestedLazyPage;
+  if (!page) {
+    throw new Error(
+      'lazy-nested-dynamic-import page not initialized. Check vitest-setup-browser.ts',
+    );
+  }
+  return page;
+}
+
 interface DevStatus {
   hasStaleOutput: boolean;
   lastFullBuildFailed: boolean;

--- a/packages/test-dev-server/tests/vitest-setup-browser.ts
+++ b/packages/test-dev-server/tests/vitest-setup-browser.ts
@@ -16,6 +16,7 @@ let browser: Browser | null = null;
 let hmrPage: Page | null = null;
 let lazyPage: Page | null = null;
 let issue9312Page: Page | null = null;
+let nestedLazyPage: Page | null = null;
 
 async function killPort(port: number): Promise<void> {
   try {
@@ -73,6 +74,7 @@ beforeAll(async () => {
     killPort(CONFIG.ports.hmrFullBundleMode),
     killPort(CONFIG.ports.lazyCompilation),
     killPort(CONFIG.ports.lazyIssue9312),
+    killPort(CONFIG.ports.lazyNestedDynamicImport),
   ]);
 
   // Always recreate tmp playground from source to pick up any fixture changes.
@@ -91,12 +93,14 @@ beforeAll(async () => {
   startDevServer(CONFIG.paths.tmpFullBundleModeDir);
   startDevServer(CONFIG.paths.tmpLazyCompilationDir);
   startDevServer(CONFIG.paths.tmpLazyIssue9312Dir);
+  startDevServer(CONFIG.paths.tmpLazyNestedDynamicImportDir);
 
   // Wait for servers to be ready
   await Promise.all([
     waitForDevServerReady(CONFIG.ports.hmrFullBundleMode),
     waitForDevServerReady(CONFIG.ports.lazyCompilation),
     waitForDevServerReady(CONFIG.ports.lazyIssue9312),
+    waitForDevServerReady(CONFIG.ports.lazyNestedDynamicImport),
   ]);
 
   // Launch browser and create pages
@@ -105,6 +109,7 @@ beforeAll(async () => {
   hmrPage = await browser.newPage();
   lazyPage = await browser.newPage();
   issue9312Page = await browser.newPage();
+  nestedLazyPage = await browser.newPage();
 
   // Only navigate the HMR page here. The lazy page is NOT navigated in setup
   // to avoid warming the lazy-compilation server (main.js triggers a dynamic
@@ -119,6 +124,7 @@ beforeAll(async () => {
   (global as any).__page = hmrPage;
   (global as any).__lazyPage = lazyPage;
   (global as any).__issue9312Page = issue9312Page;
+  (global as any).__nestedLazyPage = nestedLazyPage;
 });
 
 beforeEach(async (ctx) => {
@@ -147,6 +153,10 @@ afterAll(async () => {
     await issue9312Page.close().catch(() => {});
     issue9312Page = null;
   }
+  if (nestedLazyPage) {
+    await nestedLazyPage.close().catch(() => {});
+    nestedLazyPage = null;
+  }
   if (browser) {
     await browser.close().catch(() => {});
     browser = null;
@@ -158,5 +168,6 @@ afterAll(async () => {
     killPort(CONFIG.ports.hmrFullBundleMode),
     killPort(CONFIG.ports.lazyCompilation),
     killPort(CONFIG.ports.lazyIssue9312),
+    killPort(CONFIG.ports.lazyNestedDynamicImport),
   ]).catch(() => {});
 });


### PR DESCRIPTION
## Summary

This PR fixes a case where dynamic imported chunks in lazy chunks are not able to fetch the correct exports. 

Before:

```js
import(`/@vite/lazy?id=…&clientId=…`)
```

After:

```js
import(`/@vite/lazy?id=…&clientId=…`)
    .then(() => __rolldown_runtime__.loadExports("<stable_proxy_id>"))
```

When a lazy chunk's body contains `import('./another-lazy.js')`, the HMR partial
bundle returned the raw chunk namespace (raw lazy chunk) instead of the registered proxy exports, 
so `inner.foo` came back `undefined`. 

In this PR, we intentionally skip loading the raw lazy chunk, instead,
we use `__rolldown_runtime__.loadExports(...)` to load real module exports.


## Test plan

- [x] `pnpm test:browser` — all 7 tests pass with the fix in place
- [x] New playground: `packages/test-dev-server/tests/playground/lazy-nested-dynamic-import/` 
- [x] Reverted the fix locally → `pnpm test:browser -t 'lazy-nested-dynamic-import'` fails with
`inner.foo = UNDEFINED` / `inner.bar = UNDEFINED`
- [x] Restored the fix → test passes on first try (~135 ms, no retry)
- [x] `pnpm run lint-knip` clean for the new playground