### PR TITLE
refactor(link_stage): remove unsafe in determine_module_exports_kind

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -1,7 +1,6 @@
-use std::ptr::addr_of;
-
 use rolldown_common::{
-  EcmaModuleAstUsage, ExportsKind, ImportKind, ImportRecordMeta, Module, OutputFormat, WrapKind,
+  EcmaModuleAstUsage, ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta, Module,
+  OutputFormat, WrapKind,
 };
 
 use crate::utils::external_import_interop::import_record_needs_interop;
@@ -11,82 +10,91 @@ use super::LinkStage;
 impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_module_exports_kind(&mut self) {
-    self.module_table.modules.iter().filter_map(Module::as_normal).for_each(|importer| {
-      importer
-        .import_records
-        .iter()
-        .filter_map(|rec| rec.resolved_module.map(|module_idx| (rec, module_idx)))
-        .for_each(|(rec, module_idx)| {
-          let Module::Normal(importee) = &self.module_table[module_idx] else {
-            return;
-          };
-          match rec.kind {
-            ImportKind::Import => {
-              if matches!(importee.exports_kind, ExportsKind::None)
-                && !importee.meta.has_lazy_export()
-              {
-                // `import`ing a module with `ExportsKind::None` promotes it to `ExportsKind::Esm`.
-                // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
-                // If they are the same (self-import), writing `exports_kind` is still correct.
-                unsafe {
-                  let importee_mut = addr_of!(*importee).cast_mut();
-                  (&mut (*importee_mut)).exports_kind = ExportsKind::Esm;
-                }
-              }
-            }
-            ImportKind::Require => match importee.exports_kind {
-              ExportsKind::Esm => {
-                self.metas[importee.idx].sync_wrap_kind(WrapKind::Esm);
-              }
-              ExportsKind::CommonJs => {
-                self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-              }
-              ExportsKind::None => {
-                self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-                // A `require`'d module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`.
-                // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
-                // If they are the same (self-require), writing `exports_kind` is still correct.
-                unsafe {
-                  let importee_mut = addr_of!(*importee).cast_mut();
-                  (&mut (*importee_mut)).exports_kind = ExportsKind::CommonJs;
-                }
-              }
-            },
-            ImportKind::DynamicImport => {
-              if self.options.code_splitting.is_disabled() {
-                // When code splitting is disabled (e.g. iife/umd/cjs output), `import()` behaves
-                // like a `require()` that returns a promise, so the imported module must be wrapped.
-                match importee.exports_kind {
-                  ExportsKind::Esm => {
-                    self.metas[importee.idx].sync_wrap_kind(WrapKind::Esm);
-                  }
-                  ExportsKind::CommonJs => {
-                    self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-                  }
-                  ExportsKind::None => {
-                    self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
-                    // A dynamically-imported module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`
-                    // since we wrap it as CJS.
-                    // SAFETY: If `importee` and `importer` are different modules, no aliasing occurs.
-                    // If they are the same (self dynamic-import), writing `exports_kind` is still correct.
-                    unsafe {
-                      let importee_mut = addr_of!(*importee).cast_mut();
-                      (&mut (*importee_mut)).exports_kind = ExportsKind::CommonJs;
-                    }
-                  }
-                }
-              }
-            }
-            ImportKind::AtImport => {
-              unreachable!("A Js module would never import a CSS module via `@import`");
-            }
-            ImportKind::UrlImport => {
-              unreachable!("A Js module would never import a CSS module via `url()`");
-            }
-            ImportKind::NewUrl | ImportKind::HotAccept => {}
-          }
-        });
+    // Iterate by index so that we can release the iterator borrow on `module_table`
+    // before mutating an importee's `exports_kind` via `as_normal_mut`. Reads and
+    // writes interleave in the same order as the original closure walk, preserving
+    // the "earlier importer's promotion is observed by later importers" semantics.
+    let importer_indices: Vec<_> = self
+      .module_table
+      .modules
+      .iter_enumerated()
+      .filter_map(|(idx, m)| matches!(m, Module::Normal(_)).then_some(idx))
+      .collect();
 
+    for importer_idx in importer_indices {
+      let n_records = match &self.module_table[importer_idx] {
+        Module::Normal(m) => m.import_records.len(),
+        Module::External(_) => continue,
+      };
+
+      for rec_pos in 0..n_records {
+        let (kind, importee_idx) = {
+          let Module::Normal(m) = &self.module_table[importer_idx] else { continue };
+          let rec = &m.import_records[ImportRecordIdx::from_usize(rec_pos)];
+          let Some(importee_idx) = rec.resolved_module else { continue };
+          (rec.kind, importee_idx)
+        };
+        let (importee_kind, has_lazy) = match &self.module_table[importee_idx] {
+          Module::Normal(m) => (m.exports_kind, m.meta.has_lazy_export()),
+          Module::External(_) => continue,
+        };
+        match kind {
+          ImportKind::Import => {
+            if matches!(importee_kind, ExportsKind::None) && !has_lazy {
+              // `import`ing a module with `ExportsKind::None` promotes it to `ExportsKind::Esm`.
+              if let Some(m) = self.module_table[importee_idx].as_normal_mut() {
+                m.exports_kind = ExportsKind::Esm;
+              }
+            }
+          }
+          ImportKind::Require => match importee_kind {
+            ExportsKind::Esm => {
+              self.metas[importee_idx].sync_wrap_kind(WrapKind::Esm);
+            }
+            ExportsKind::CommonJs => {
+              self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+            }
+            ExportsKind::None => {
+              self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+              // A `require`'d module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`.
+              if let Some(m) = self.module_table[importee_idx].as_normal_mut() {
+                m.exports_kind = ExportsKind::CommonJs;
+              }
+            }
+          },
+          ImportKind::DynamicImport => {
+            if self.options.code_splitting.is_disabled() {
+              // When code splitting is disabled (e.g. iife/umd/cjs output), `import()` behaves
+              // like a `require()` that returns a promise, so the imported module must be wrapped.
+              match importee_kind {
+                ExportsKind::Esm => {
+                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Esm);
+                }
+                ExportsKind::CommonJs => {
+                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+                }
+                ExportsKind::None => {
+                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+                  // A dynamically-imported module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`
+                  // since we wrap it as CJS.
+                  if let Some(m) = self.module_table[importee_idx].as_normal_mut() {
+                    m.exports_kind = ExportsKind::CommonJs;
+                  }
+                }
+              }
+            }
+          }
+          ImportKind::AtImport => {
+            unreachable!("A Js module would never import a CSS module via `@import`");
+          }
+          ImportKind::UrlImport => {
+            unreachable!("A Js module would never import a CSS module via `url()`");
+          }
+          ImportKind::NewUrl | ImportKind::HotAccept => {}
+        }
+      }
+
+      let Module::Normal(importer) = &self.module_table[importer_idx] else { continue };
       let is_entry = self.entries.contains_key(&importer.idx);
       if matches!(importer.exports_kind, ExportsKind::CommonJs)
         && (!is_entry
@@ -96,7 +104,7 @@ impl LinkStage<'_> {
       {
         self.metas[importer.idx].sync_wrap_kind(WrapKind::Cjs);
       }
-    });
+    }
   }
 
   /// Builds the `safely_merge_cjs_ns_map` which groups ESM imports of the same CommonJS module.


### PR DESCRIPTION
Replaces the three `unsafe { addr_of!(*importee).cast_mut() }` blocks in `determine_module_exports_kind` with index-based iteration that releases the `module_table` borrow before each `as_normal_mut()` mutation. Reads and writes still interleave in the same order as the original closure walk, so behavior is preserved bit-for-bit — no fixture snapshots are touched.
