### PR TITLE
chore(deps): bump rolldown-ariadne to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "rolldown-ariadne"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dff57c9de498bb1eb5b1ce682c2e3a0ae956b266fa0933c3e151b87b078967"
+checksum = "ee296fe9ac0007f2c0eff04d55c980de537aa3d736e873d70c9c47d4c737ea44"
 dependencies = [
  "unicode-width",
  "yansi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ string_wizard = { version = "0.0.27", path = "crates/string_wizard", features = 
 anyhow = "1.0.98"
 append-only-vec = "0.1.7"
 arcstr = { version = "1.2.0", default-features = false }
-ariadne = { package = "rolldown-ariadne", version = "0.5.3" }
+ariadne = { package = "rolldown-ariadne", version = "0.6.0" }
 async-channel = "2.3.1"
 async-scoped = "0.9.0"
 async-trait = "0.1.88"


### PR DESCRIPTION
Bumps the workspace `ariadne` (`rolldown-ariadne`) dependency from `0.5.3` to `0.6.0`. Workspace builds clean with the new version — no usage-site changes needed.
