### PR TITLE
refactor(link_stage): detach depended_runtime_helper from EcmaView to remove unsafe

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -148,7 +148,6 @@ pub async fn create_ecma_view(
     dummy_record_set,
     constant_export_map,
     enum_member_value_map,
-    depended_runtime_helper: Box::default(),
     import_attribute_map,
     json_module_none_self_reference_included_symbol: None,
     cjs_reexport_import_record_ids,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -194,7 +194,6 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
         dummy_record_set,
         constant_export_map: FxHashMap::default(),
         enum_member_value_map: FxHashMap::default(),
-        depended_runtime_helper: Box::default(),
         import_attribute_map: FxHashMap::default(),
         json_module_none_self_reference_included_symbol: None,
         cjs_reexport_import_record_ids: Vec::new(),

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -5,9 +5,9 @@ use oxc_index::IndexVec;
 #[cfg(debug_assertions)]
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
-  ConstExportMeta, EntryPoint, EntryPointKind, FlatOptions, ImportKind, ModuleIdx, ModuleTable,
-  PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb, UsedSymbolRefs,
-  dynamic_import_usage::DynamicImportExportsUsage,
+  ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
+  ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
+  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
 #[cfg(target_family = "wasm")]
@@ -87,6 +87,10 @@ pub struct LinkStage<'a> {
   pub module_table: ModuleTable,
   pub entries: FxIndexMap<ModuleIdx, Vec<EntryPoint>>,
   pub symbols: SymbolRefDb,
+  /// Per-module runtime-helper-dependency map. Detached from `EcmaView` so the
+  /// parallel walk in `reference_needed_symbols` can mutate it through `&mut`
+  /// from a zipped iterator without aliasing tricks.
+  pub depended_runtime_helper: IndexVec<ModuleIdx, Box<DependedRuntimeHelperMap>>,
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
@@ -148,6 +152,12 @@ impl<'a> LinkStage<'a> {
     Self {
       sorted_modules: Vec::new(),
       global_constant_symbol_map: constant_symbol_map,
+      depended_runtime_helper: scan_stage_output
+        .module_table
+        .modules
+        .iter()
+        .map(|_| Box::default())
+        .collect::<IndexVec<ModuleIdx, _>>(),
       metas: scan_stage_output
         .module_table
         .modules

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -34,8 +34,11 @@ impl LinkStage<'_> {
       .modules
       .par_iter()
       .zip(symbols_inner.par_iter_mut())
-      .filter_map(|(module, symbol_db)| module.as_normal().map(|importer| (importer, symbol_db)))
-      .map(|(importer, symbol_ref_for_module)| {
+      .zip(self.depended_runtime_helper.par_iter_mut())
+      .filter_map(|((module, symbol_db), depended_helper)| {
+        module.as_normal().map(|importer| (importer, symbol_db, depended_helper))
+      })
+      .map(|(importer, symbol_ref_for_module, depended_runtime_helper_map)| {
         let symbol_db =
           symbol_ref_for_module.as_mut().expect("normal module should have symbol db");
         let mut record_meta_pairs: Vec<(ImportRecordIdx, ImportRecordMeta)> = vec![];
@@ -45,8 +48,6 @@ impl LinkStage<'_> {
         // - Mutating on `stmt_infos` doesn't rely on other mutating operations of other modules
         // - Mutating and parallel reading is in different memory locations
         let stmt_infos = unsafe { &mut *(addr_of!(importer.stmt_infos).cast_mut()) };
-        let depended_runtime_helper_map =
-          unsafe { &mut *(addr_of!(importer.depended_runtime_helper).cast_mut()) };
         let mut symbols_to_be_declared = vec![];
         stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
           if stmt_info.meta.contains(StmtInfoMeta::HasDummyRecord) {

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -339,11 +339,14 @@ impl LinkStage<'_> {
       .modules
       .par_iter_mut()
       .zip_eq(self.metas.par_iter_mut())
-      .filter_map(|(m, meta)| m.as_normal_mut().map(|m| (m, meta)))
-      .for_each(|(module, meta)| {
+      .zip_eq(self.depended_runtime_helper.par_iter())
+      .filter_map(|((m, meta), depended_helper)| {
+        m.as_normal_mut().map(|m| (m, meta, depended_helper))
+      })
+      .for_each(|(module, meta, depended_helper)| {
         let idx = module.idx;
         let mut normalized_runtime_helper = RuntimeHelper::default();
-        for (helper, stmt_info_idxs) in module.depended_runtime_helper.iter() {
+        for (helper, stmt_info_idxs) in depended_helper.iter() {
           if stmt_info_idxs.is_empty() {
             continue;
           }

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -1,4 +1,4 @@
-use crate::{ConstExportMeta, DependedRuntimeHelperMap, ImportAttribute, SourcemapChainElement};
+use crate::{ConstExportMeta, ImportAttribute, SourcemapChainElement};
 use arcstr::ArcStr;
 use bitflags::bitflags;
 use oxc::{semantic::SymbolId, span::Span};
@@ -97,7 +97,6 @@ pub struct EcmaView {
   /// `Span` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
   pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
-  pub depended_runtime_helper: Box<DependedRuntimeHelperMap>,
 
   pub hmr_hot_ref: Option<SymbolRef>,
   pub hmr_info: HmrInfo,


### PR DESCRIPTION
## Summary

Lift the per-module `depended_runtime_helper` map out of `EcmaView` into a parallel `IndexVec<ModuleIdx, Box<DependedRuntimeHelperMap>>` on `LinkStage`. This lets `reference_needed_symbols` mutate the map through a safe `par_iter_mut().zip(...)` pipeline instead of casting away `&` via `addr_of!`, eliminating the second remaining `unsafe` block in that pass.

related to https://github.com/rolldown/rolldown/issues/9242, which removed the analogous unsafe for `stmt_infos`.

## Changes

- Add `depended_runtime_helper` field on `LinkStage` and initialize it alongside the module table.
- Remove `depended_runtime_helper` from `EcmaView` and its two construction sites (`ecma_module_view_factory`, `runtime_module_task`).
- `reference_needed_symbols`: zip the new field into the parallel walk; drop the `unsafe { &mut *addr_of!(importer.depended_runtime_helper).cast_mut() }` block.
- `include_statements`: read the map from its new home via a parallel zip.
