### PR TITLE
fix: implement dynamic dominator merge logic

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -597,6 +597,7 @@ impl GenerateStage<'_> {
             module_table,
             dynamic_entry_to_dynamic_importers,
             entry_chunk_reference,
+            &info.modules,
           )
         },
       )
@@ -749,18 +750,38 @@ impl GenerateStage<'_> {
   /// gain `D`'s chunk as a static dependency, no load can reach them without
   /// `D` already being loaded.
   ///
-  /// The leak guard rejects `D` when any user-defined entry reaches one of the
-  /// covered dynamic entries without also reaching `D` — after the merge that
-  /// other path would pull `D`'s chunk in as a static dep and run `D`'s side
-  /// effects on a load that previously did not touch `D`.
+  /// Two extra guards:
+  /// - **Export-pollution guard:** rejects the merge when any pending module
+  ///   has named exports. Those exports would still be needed cross-chunk by
+  ///   the other dynamic entries, forcing `D`'s chunk file to expose them at
+  ///   the file level — which is what `import('./D.js')` resolves to at
+  ///   runtime, polluting the dynamic-entry namespace observed by callers.
+  /// - **Side-effect leak guard:** rejects `D` when any user-defined entry
+  ///   reaches one of the covered dynamic entries without also reaching `D` —
+  ///   after the merge that other path would pull `D`'s chunk in as a static
+  ///   dep and run `D`'s side effects on a load that previously did not
+  ///   touch `D`.
   fn find_dynamic_dominator(
     dynamic_entry: &[ChunkIdx],
     dynamic_entry_modules: &[ModuleIdx],
     module_table: &ModuleTable,
     dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
     entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
+    pending_modules: &[ModuleIdx],
   ) -> Option<ChunkIdx> {
     if dynamic_entry.len() < 2 {
+      return None;
+    }
+    // Refuse the merge whenever any pending module exposes named exports. The
+    // other dynamic-entry chunks in `chunk_idxs` still need those exports
+    // cross-chunk, so after the merge the dominator's chunk would have to add
+    // them to its file-level export list — and that list is what
+    // `import('./dominator.js')` resolves to at runtime, polluting the
+    // dynamic-entry namespace observed by callers.
+    let exposes_exports = pending_modules
+      .iter()
+      .any(|m| module_table[*m].as_normal().is_some_and(|n| !n.named_exports.is_empty()));
+    if exposes_exports {
       return None;
     }
     dynamic_entry.iter().zip(dynamic_entry_modules.iter()).find_map(

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -763,62 +763,67 @@ impl GenerateStage<'_> {
     if dynamic_entry.len() < 2 {
       return None;
     }
-    let dynamic_entry_set: FxHashSet<ChunkIdx> = dynamic_entry.iter().copied().collect();
-    for (candidate_pos, (chunk_idx, entry_module_idx)) in
-      dynamic_entry.iter().zip(dynamic_entry_modules.iter()).enumerate()
-    {
-      let mut reachable: FxHashSet<ModuleIdx> = FxHashSet::default();
-      let mut queue: VecDeque<ModuleIdx> = VecDeque::from([*entry_module_idx]);
-      while let Some(cur) = queue.pop_front() {
-        if !reachable.insert(cur) {
-          continue;
-        }
-        let Some(module) = module_table[cur].as_normal() else {
-          continue;
-        };
-        for rec in &module.import_records {
-          if let Some(dep_idx) = rec.resolved_module
-            && !reachable.contains(&dep_idx)
-          {
-            queue.push_back(dep_idx);
-          }
-        }
-      }
+    dynamic_entry.iter().zip(dynamic_entry_modules.iter()).find_map(
+      |(candidate_chunk_idx, candidate_module_idx)| {
+        let reach = Self::collect_module_graph_reach(*candidate_module_idx, module_table);
 
-      let dominates_others =
-        dynamic_entry_modules.iter().enumerate().all(|(idx, other_entry_module_idx)| {
-          if idx == candidate_pos {
-            return true;
-          }
-          if !reachable.contains(other_entry_module_idx) {
+        let dominates = dynamic_entry.iter().zip(dynamic_entry_modules.iter()).all(
+          |(other_chunk_idx, other_module_idx)| {
+            if other_chunk_idx == candidate_chunk_idx {
+              return true;
+            }
+            if !reach.contains(other_module_idx) {
+              return false;
+            }
+            let Some(other_module) = module_table[*other_module_idx].as_normal() else {
+              return false;
+            };
+            let static_importers_in_reach =
+              other_module.importers_idx.iter().all(|i| reach.contains(i));
+            let dynamic_importers_in_reach = dynamic_entry_to_dynamic_importers
+              .get(other_module_idx)
+              .is_none_or(|imps| imps.iter().all(|i| reach.contains(i)));
+            static_importers_in_reach && dynamic_importers_in_reach
+          },
+        );
+        if !dominates {
+          return None;
+        }
+
+        let leak = entry_chunk_reference.values().any(|reached_dynamic_chunks| {
+          if reached_dynamic_chunks.contains(candidate_chunk_idx) {
+            // The user-defined entry already loads the candidate before the
+            // other dynamic entries — no extra side effects can leak.
             return false;
           }
-          let Some(other_module) = module_table[*other_entry_module_idx].as_normal() else {
-            return false;
-          };
-          let static_importers_ok =
-            other_module.importers_idx.iter().all(|importer| reachable.contains(importer));
-          let dynamic_importers_ok = dynamic_entry_to_dynamic_importers
-            .get(other_entry_module_idx)
-            .is_none_or(|importers| importers.iter().all(|i| reachable.contains(i)));
-          static_importers_ok && dynamic_importers_ok
+          dynamic_entry
+            .iter()
+            .any(|other| other != candidate_chunk_idx && reached_dynamic_chunks.contains(other))
         });
-      if !dominates_others {
+        (!leak).then_some(*candidate_chunk_idx)
+      },
+    )
+  }
+
+  /// BFS the module graph from `start`, following every resolved import-record
+  /// edge regardless of import kind. Returns the set of modules transitively
+  /// reachable from `start`, including `start` itself.
+  fn collect_module_graph_reach(
+    start: ModuleIdx,
+    module_table: &ModuleTable,
+  ) -> FxHashSet<ModuleIdx> {
+    let mut reached = FxHashSet::default();
+    let mut queue = VecDeque::from([start]);
+    while let Some(cur) = queue.pop_front() {
+      if !reached.insert(cur) {
         continue;
       }
-
-      let leak = entry_chunk_reference.values().any(|reached| {
-        let reaches_some_other = dynamic_entry_set.iter().any(|d| reached.contains(d));
-        let reaches_dominator = reached.contains(chunk_idx);
-        reaches_some_other && !reaches_dominator
-      });
-      if leak {
+      let Some(module) = module_table[cur].as_normal() else {
         continue;
-      }
-
-      return Some(*chunk_idx);
+      };
+      queue.extend(module.import_records.iter().filter_map(|rec| rec.resolved_module));
     }
-    None
+    reached
   }
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -589,7 +589,17 @@ impl GenerateStage<'_> {
       Self::find_merge_target(&user_defined_entry, &user_defined_entry_modules, module_table);
     if user_defined_entry.is_empty() {
       let dynamic_chunk_entry_modules = Self::collect_entry_modules(&dynamic_entry, chunk_graph)?;
-      Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table)
+      Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table).or_else(
+        || {
+          Self::find_dynamic_dominator(
+            &dynamic_entry,
+            &dynamic_chunk_entry_modules,
+            module_table,
+            dynamic_entry_to_dynamic_importers,
+            entry_chunk_reference,
+          )
+        },
+      )
     } else {
       let chunk_idx = merged_user_defined_chunk?;
       let chunk = &chunk_graph.chunk_table[chunk_idx];
@@ -725,6 +735,90 @@ impl GenerateStage<'_> {
       });
       can_merge.then_some(*chunk_idx)
     })
+  }
+
+  /// Fallback merge-target search for the case where every chunk in `chunk_idxs`
+  /// is a dynamic entry (`find_merge_target` only inspects static
+  /// `importers_idx`, so it always fails here).
+  ///
+  /// Picks `D` from `dynamic_entry` such that the module-graph reachability
+  /// from `D`'s entry (following all import kinds) covers every other dynamic
+  /// entry in the set together with that entry's static and dynamic importers.
+  /// That guarantees every load path to those other entries goes through `D`,
+  /// so when shared modules are merged into `D`'s chunk and the other chunks
+  /// gain `D`'s chunk as a static dependency, no load can reach them without
+  /// `D` already being loaded.
+  ///
+  /// The leak guard rejects `D` when any user-defined entry reaches one of the
+  /// covered dynamic entries without also reaching `D` — after the merge that
+  /// other path would pull `D`'s chunk in as a static dep and run `D`'s side
+  /// effects on a load that previously did not touch `D`.
+  fn find_dynamic_dominator(
+    dynamic_entry: &[ChunkIdx],
+    dynamic_entry_modules: &[ModuleIdx],
+    module_table: &ModuleTable,
+    dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
+    entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
+  ) -> Option<ChunkIdx> {
+    if dynamic_entry.len() < 2 {
+      return None;
+    }
+    let dynamic_entry_set: FxHashSet<ChunkIdx> = dynamic_entry.iter().copied().collect();
+    for (candidate_pos, (chunk_idx, entry_module_idx)) in
+      dynamic_entry.iter().zip(dynamic_entry_modules.iter()).enumerate()
+    {
+      let mut reachable: FxHashSet<ModuleIdx> = FxHashSet::default();
+      let mut queue: VecDeque<ModuleIdx> = VecDeque::from([*entry_module_idx]);
+      while let Some(cur) = queue.pop_front() {
+        if !reachable.insert(cur) {
+          continue;
+        }
+        let Some(module) = module_table[cur].as_normal() else {
+          continue;
+        };
+        for rec in &module.import_records {
+          if let Some(dep_idx) = rec.resolved_module
+            && !reachable.contains(&dep_idx)
+          {
+            queue.push_back(dep_idx);
+          }
+        }
+      }
+
+      let dominates_others =
+        dynamic_entry_modules.iter().enumerate().all(|(idx, other_entry_module_idx)| {
+          if idx == candidate_pos {
+            return true;
+          }
+          if !reachable.contains(other_entry_module_idx) {
+            return false;
+          }
+          let Some(other_module) = module_table[*other_entry_module_idx].as_normal() else {
+            return false;
+          };
+          let static_importers_ok =
+            other_module.importers_idx.iter().all(|importer| reachable.contains(importer));
+          let dynamic_importers_ok = dynamic_entry_to_dynamic_importers
+            .get(other_entry_module_idx)
+            .is_none_or(|importers| importers.iter().all(|i| reachable.contains(i)));
+          static_importers_ok && dynamic_importers_ok
+        });
+      if !dominates_others {
+        continue;
+      }
+
+      let leak = entry_chunk_reference.values().any(|reached| {
+        let reaches_some_other = dynamic_entry_set.iter().any(|d| reached.contains(d));
+        let reaches_dominator = reached.contains(chunk_idx);
+        reaches_some_other && !reaches_dominator
+      });
+      if leak {
+        continue;
+      }
+
+      return Some(*chunk_idx);
+    }
+    None
   }
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.

--- a/crates/rolldown/tests/rolldown/issues/5871/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5871/artifacts.snap
@@ -6,13 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## 1.js
 
 ```js
-import "./2.js";
-
-```
-
-## 2.js
-
-```js
 //#region 2.js
 import("./3.js");
 //#endregion
@@ -22,7 +15,7 @@ import("./3.js");
 ## 3.js
 
 ```js
-import "./2.js";
+import "./1.js";
 //#region 4.js
 import("./1.js");
 //#endregion

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/app.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/app.js
@@ -1,0 +1,3 @@
+import './shared.js';
+console.log('app');
+import('./sidebar.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## app.js
+
+```js
+//#region shared.js
+console.log("shared");
+//#endregion
+//#region app.js
+console.log("app");
+import("./sidebar.js");
+//#endregion
+
+```
+
+## entry.js
+
+```js
+//#region entry.js
+console.log("entry");
+import("./app.js");
+//#endregion
+
+```
+
+## sidebar.js
+
+```js
+import "./app.js";
+//#region sidebar.js
+console.log("sidebar");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/entry.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/entry.js
@@ -1,0 +1,2 @@
+console.log('entry');
+import('./app.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/shared.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/shared.js
@@ -1,0 +1,1 @@
+console.log('shared');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/sidebar.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/sidebar.js
@@ -1,0 +1,2 @@
+import './shared.js';
+console.log('sidebar');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/a.js
@@ -1,0 +1,2 @@
+import './shared.js';
+console.log('a');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import "./shared.js";
+//#region a.js
+console.log("a");
+//#endregion
+
+```
+
+## b.js
+
+```js
+import "./shared.js";
+//#region b.js
+console.log("b");
+//#endregion
+
+```
+
+## entry.js
+
+```js
+//#region entry.js
+console.log("entry");
+import("./a.js");
+import("./b.js");
+//#endregion
+
+```
+
+## shared.js
+
+```js
+//#region shared.js
+console.log("shared");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/b.js
@@ -1,0 +1,2 @@
+import './shared.js';
+console.log('b');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/entry.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/entry.js
@@ -1,0 +1,3 @@
+console.log('entry');
+import('./a.js');
+import('./b.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/shared.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/shared.js
@@ -1,0 +1,1 @@
+console.log('shared');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dynamic1.js
+
+```js
+import "./sharedDynamic.js";
+//#region dynamic1.js
+console.log(true);
+const promise = import("./dynamic2.js");
+//#endregion
+export { promise };
+
+```
+
+## dynamic2.js
+
+```js
+import { t as sharedDynamic } from "./sharedDynamic.js";
+export { sharedDynamic };
+
+```
+
+## main.js
+
+```js
+//#region main.js
+import("./dynamic1.js").then(({ promise, ...ns }) => ns);
+//#endregion
+
+```
+
+## sharedDynamic.js
+
+```js
+//#region sharedDynamic.js
+const sharedDynamic = true;
+//#endregion
+export { sharedDynamic as t };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/dynamic1.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/dynamic1.js
@@ -1,0 +1,4 @@
+import { sharedDynamic } from './sharedDynamic.js';
+
+console.log(sharedDynamic);
+export const promise = import('./dynamic2.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/dynamic2.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/dynamic2.js
@@ -1,0 +1,1 @@
+export { sharedDynamic } from './sharedDynamic.js';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/main.js
@@ -1,0 +1,1 @@
+import('./dynamic1.js').then(({ promise, ...ns }) => ns);

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/sharedDynamic.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/sharedDynamic.js
@@ -1,0 +1,1 @@
+export const sharedDynamic = true;


### PR DESCRIPTION
A bit of context:

## How chunk splitting works 

(To anyone swinging by here, skip this if you already know how the internal workflow is)

1. Each user entry and each dynamic-import target gets an entry index. A module's bits bitset records which entries reach it via static imports (dynamic imports don't propagate bits as they're separate roots).
2. Modules with a unique bitset would normally each form their own chunk. The `chunk_optimization` pass then tries to merge common modules into an existing entry chunk via `try_insert_into_existing_chunk` — picking a "merge target" that's guaranteed to be loaded before any of the entries needing the shared module.

## What is broken right now

When a module is shared between a user entry and one of its descendant dynamic chunks, things work as expected. The optimizer picks the user entry as the merge target.

But it does not handle the case when there is a shared module between **two dynamic chunks** where one imports the other one dynamically.

In the broken example of https://github.com/rolldown/rolldown/issues/9269, `app_chunk` imports `sidebar_chunk` via a dynamic import, so `app_chunk` would be the expected merge target (it always loaded before sidebar runs), but `find_merge_target` only inspects static importer sets and so finds nothing.

## How this PR fixes it

The PR adds a dominator check to `find_merge_target` to allow dynamic importers to be considered as merge targets, as long as they "dominate" the entry chunks that need the shared module, meaning they are guaranteed to be loaded before those chunks. This allows the optimizer to correctly merge shared modules into the appropriate dynamic chunk, even when there are dynamic import relationships between chunks. If no dominator merge target is found, it falls back to the existing logic and emit a separate common chunk.

---

Resolves #9269 