### PR TITLE
refactor(link_stage): detach stmt_infos from EcmaView

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
   ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts, RuntimeModuleBrief,
-  SharedFileEmitter, SymbolRef, SymbolRefDb, UsedSymbolRefs,
+  SharedFileEmitter, StmtInfos, SymbolRef, SymbolRefDb, UsedSymbolRefs,
 };
 
 pub type FinalizerMutableFields = (
@@ -28,6 +28,9 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub chunk: &'me Chunk,
   pub chunk_idx: ChunkIdx,
   pub module: &'me NormalModule,
+  /// Statement-info table for the current module, threaded in from the
+  /// link-stage side `IndexVec<ModuleIdx, StmtInfos>` (see `LinkStage.stmt_infos`).
+  pub stmt_infos: &'me StmtInfos,
   pub modules: &'me IndexModules,
   pub linking_info: &'me LinkingMetadata,
   pub linking_infos: &'me LinkingMetadataVec,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -128,10 +128,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       self.ctx.linking_info.shimmed_missing_exports.iter().collect::<Vec<_>>();
     shimmed_exports.sort_unstable_by_key(|(name, _)| name.as_str());
     shimmed_exports.into_iter().for_each(|(_name, symbol_ref)| {
-      debug_assert!(!self.ctx.module.stmt_infos.declared_stmts_by_symbol(symbol_ref).is_empty());
+      debug_assert!(!self.ctx.stmt_infos.declared_stmts_by_symbol(symbol_ref).is_empty());
       let is_included: bool = self
         .ctx
-        .module
         .stmt_infos
         .declared_stmts_by_symbol(symbol_ref)
         .iter()

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1423,11 +1423,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let old_body = program.body.take_in(self.alloc);
     // the first statement info is the namespace variable declaration
     // skip first statement info to make sure `program.body` has same index as `stmt_infos`
-    old_body
-      .into_iter()
-      .enumerate()
-      .zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1))
-      .for_each(|((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
+    old_body.into_iter().enumerate().zip(self.ctx.stmt_infos.iter_enumerated().skip(1)).for_each(
+      |((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
         let is_stmt_included = self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx);
 
         if !is_stmt_included {
@@ -1754,7 +1751,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if is_module_decl {
           last_import_stmt_idx = Some(program.body.len());
         }
-      });
+      },
+    );
     last_import_stmt_idx.unwrap_or(0)
   }
 

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -929,24 +929,24 @@ impl GenerateStage<'_> {
     for elimination in &facade_eliminations {
       let entry_module_idx = elimination.entry_module_idx;
       let wrap_kind = self.link_output.metas[entry_module_idx].wrap_kind();
-      let Some(module) = self.link_output.module_table[entry_module_idx].as_normal_mut() else {
+      if self.link_output.module_table[entry_module_idx].as_normal().is_none() {
         continue;
-      };
+      }
       // For CJS modules, we don't need to include `__exportAll` and the namespace symbols.
       // Instead, we should include the wrapper_ref (`require_xxx`), which will be handled
       // in the include_symbol call below.
       if !matches!(wrap_kind, WrapKind::Cjs) {
         // Filter in place to avoid cloning
-        module.stmt_infos[StmtInfos::NAMESPACE_STMT_IDX].referenced_symbols.retain(
-          |item| match item {
+        self.link_output.stmt_infos[entry_module_idx][StmtInfos::NAMESPACE_STMT_IDX]
+          .referenced_symbols
+          .retain(|item| match item {
             rolldown_common::SymbolOrMemberExprRef::Symbol(symbol_ref) => {
               // module namespace symbol requires `__exportAll` runtime helper
               self.link_output.used_symbol_refs.contains(symbol_ref)
                 || symbol_ref.owner == runtime_module_idx
             }
             rolldown_common::SymbolOrMemberExprRef::MemberExpr(_member_expr_ref) => true,
-          },
-        );
+          });
       }
     }
 
@@ -956,6 +956,7 @@ impl GenerateStage<'_> {
     let runtime = &self.link_output.runtime;
     let context = &mut IncludeContext {
       modules: &self.link_output.module_table.modules,
+      stmt_infos: &self.link_output.stmt_infos,
       symbols: &self.link_output.symbol_db,
       is_included_vec: &mut stmt_info_included_vec,
       is_module_included_vec: &mut module_included_vec,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -473,8 +473,7 @@ impl GenerateStage<'_> {
           // At that point, we don't yet know which statements will be tree-shaken.
           // related context: https://github.com/rolldown/rolldown/blob/dbd0f6de5d44be2327e7532bb6f0a38bc04a1047/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs#L187-L194
           let importer = self.link_output.module_table[ns.owner].as_normal()?;
-          let is_stmt_included = importer
-            .stmt_infos
+          let is_stmt_included = self.link_output.stmt_infos[importer.idx]
             .declared_stmts_by_symbol(ns)
             .iter()
             .all(|item| self.link_output.metas[importer.idx].stmt_info_included.has_bit(*item));

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -223,35 +223,37 @@ impl GenerateStage<'_> {
                   .push((module.idx, import.clone()));
               }
             });
-          module.stmt_infos.iter_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
-            if !self.link_output.metas[module.idx].stmt_info_included.has_bit(stmt_info_idx) {
-              return;
-            }
-            stmt_info.declared_symbols.iter().for_each(|declared| {
-              symbol_needs_to_assign.push(*declared);
-            });
+          self.link_output.stmt_infos[module.idx].iter_enumerated().for_each(
+            |(stmt_info_idx, stmt_info)| {
+              if !self.link_output.metas[module.idx].stmt_info_included.has_bit(stmt_info_idx) {
+                return;
+              }
+              stmt_info.declared_symbols.iter().for_each(|declared| {
+                symbol_needs_to_assign.push(*declared);
+              });
 
-            stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
-              match reference_ref {
-                rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
-                  depended_symbols.insert(symbols.canonical_ref_resolving_namespace(*referenced));
-                }
-                rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
-                  match member_expr.represent_symbol_ref(
-                    &self.link_output.metas[module.idx].resolved_member_expr_refs,
-                  ) {
-                    Some(sym_ref) => {
-                      depended_symbols.insert(symbols.canonical_ref_resolving_namespace(sym_ref));
-                    }
-                    _ => {
-                      // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
-                      // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
+              stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
+                match reference_ref {
+                  rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
+                    depended_symbols.insert(symbols.canonical_ref_resolving_namespace(*referenced));
+                  }
+                  rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
+                    match member_expr.represent_symbol_ref(
+                      &self.link_output.metas[module.idx].resolved_member_expr_refs,
+                    ) {
+                      Some(sym_ref) => {
+                        depended_symbols.insert(symbols.canonical_ref_resolving_namespace(sym_ref));
+                      }
+                      _ => {
+                        // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
+                        // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
+                      }
                     }
                   }
                 }
-              }
-            });
-          });
+              });
+            },
+          );
         });
 
         if let Some(entry_id) = &chunk.entry_module_idx() {

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -39,6 +39,7 @@ impl GenerateStage<'_> {
             symbol_db: &self.link_output.symbol_db,
             linking_info,
             module,
+            stmt_infos: &self.link_output.stmt_infos[idx],
             modules: &self.link_output.module_table.modules,
             linking_infos: &self.link_output.metas,
             runtime: &self.link_output.runtime,

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -12,6 +12,8 @@ use rolldown_common::{
   SymbolRefFlags,
 };
 use rolldown_error::{AmbiguousExternalNamespaceModule, BuildDiagnostic};
+#[cfg(not(target_family = "wasm"))]
+use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
   ecmascript::{is_validate_identifier_name, legitimize_identifier_name},
   index_vec_ext::{IndexVecExt, IndexVecRefExt},
@@ -403,12 +405,13 @@ impl LinkStage<'_> {
       .module_table
       .modules
       .par_iter()
-      .map(|module| match module {
+      .zip(self.stmt_infos.par_iter())
+      .map(|(module, stmt_infos)| match module {
         Module::Normal(module) => {
           let mut resolved_map = FxHashMap::default();
           let mut side_effects_dependency = vec![];
           let mut written_cjs_exports: Vec<SymbolRef> = vec![];
-          module.stmt_infos.iter().for_each(|stmt_info| {
+          stmt_infos.iter().for_each(|stmt_info| {
             stmt_info.referenced_symbols.iter().for_each(|symbol_ref| {
               // `depended_refs` is used to store necessary symbols that must be included once the resolved symbol gets included
               let mut depended_refs: Vec<SymbolRef> = vec![];

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -53,87 +53,86 @@ fn init_entry_point_stmt_info(
 impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn create_exports_for_ecma_modules(&mut self) {
-    self.module_table.modules.iter_mut().filter_map(|m| m.as_normal_mut()).for_each(
-      |ecma_module| {
-        let linking_info = &mut self.metas[ecma_module.idx];
+    for m in &mut self.module_table.modules {
+      let Some(ecma_module) = m.as_normal_mut() else { continue };
+      let idx = ecma_module.idx;
+      let linking_info = &mut self.metas[idx];
+      let stmt_infos = &mut self.stmt_infos[idx];
 
-        if let Some(entry) = self.entries.get(&ecma_module.idx).and_then(|entries| entries.first())
-        {
-          init_entry_point_stmt_info(
-            linking_info,
-            entry,
-            &self.dynamic_import_exports_usage_map,
-            self.options,
-            &self.overrode_preserve_entry_signature_map,
-            !ecma_module.dynamic_importers.is_empty(),
-          );
+      if let Some(entry) = self.entries.get(&idx).and_then(|entries| entries.first()) {
+        init_entry_point_stmt_info(
+          linking_info,
+          entry,
+          &self.dynamic_import_exports_usage_map,
+          self.options,
+          &self.overrode_preserve_entry_signature_map,
+          !ecma_module.dynamic_importers.is_empty(),
+        );
+      }
+
+      // Create facade StmtInfo that declares variables based on the missing exports, so they can participate in the symbol de-conflict and
+      // tree-shaking process.
+      linking_info.shimmed_missing_exports.iter().for_each(|(_name, symbol_ref)| {
+        let stmt_info = StmtInfo {
+          declared_symbols: vec![TaggedSymbolRef::Normal(*symbol_ref)],
+          referenced_symbols: vec![],
+          side_effect: false.into(),
+          import_records: Vec::new(),
+          #[cfg(debug_assertions)]
+          debug_label: None,
+          meta: StmtInfoMeta::default(),
+          ..Default::default()
+        };
+        stmt_infos.add_stmt_info(stmt_info);
+      });
+
+      // Generate export of Module Namespace Object for Namespace Import
+      // - Namespace import: https://tc39.es/ecma262/#prod-NameSpaceImport
+      // - Module Namespace Object: https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
+      // Though Module Namespace Object is created in runtime, as a bundler, we have stimulus the behavior in compile-time and generate a
+      // real statement to construct the Module Namespace Object and assign it to a variable.
+      // This is only a concept of esm, so no need to care about this in commonjs.
+      if matches!(ecma_module.exports_kind, ExportsKind::Esm) {
+        let meta = &mut self.metas[ecma_module.idx];
+        let mut referenced_symbols = vec![];
+        let mut declared_symbols = vec![];
+        if !meta.is_canonical_exports_empty() || self.options.generated_code.symbols {
+          referenced_symbols.push(self.runtime.resolve_symbol("__exportAll").into());
+          referenced_symbols
+            .extend(meta.canonical_exports(false).map(|(_, export)| export.symbol_ref.into()));
         }
-
-        // Create facade StmtInfo that declares variables based on the missing exports, so they can participate in the symbol de-conflict and
-        // tree-shaking process.
-        linking_info.shimmed_missing_exports.iter().for_each(|(_name, symbol_ref)| {
-          let stmt_info = StmtInfo {
-            declared_symbols: vec![TaggedSymbolRef::Normal(*symbol_ref)],
-            referenced_symbols: vec![],
-            side_effect: false.into(),
-            import_records: Vec::new(),
-            #[cfg(debug_assertions)]
-            debug_label: None,
-            meta: StmtInfoMeta::default(),
-            ..Default::default()
-          };
-          ecma_module.stmt_infos.add_stmt_info(stmt_info);
-        });
-
-        // Generate export of Module Namespace Object for Namespace Import
-        // - Namespace import: https://tc39.es/ecma262/#prod-NameSpaceImport
-        // - Module Namespace Object: https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
-        // Though Module Namespace Object is created in runtime, as a bundler, we have stimulus the behavior in compile-time and generate a
-        // real statement to construct the Module Namespace Object and assign it to a variable.
-        // This is only a concept of esm, so no need to care about this in commonjs.
-        if matches!(ecma_module.exports_kind, ExportsKind::Esm) {
-          let meta = &mut self.metas[ecma_module.idx];
-          let mut referenced_symbols = vec![];
-          let mut declared_symbols = vec![];
-          if !meta.is_canonical_exports_empty() || self.options.generated_code.symbols {
-            referenced_symbols.push(self.runtime.resolve_symbol("__exportAll").into());
-            referenced_symbols
-              .extend(meta.canonical_exports(false).map(|(_, export)| export.symbol_ref.into()));
-          }
-          if !meta.star_exports_from_external_modules.is_empty() {
-            referenced_symbols.push(self.runtime.resolve_symbol("__reExport").into());
-            match self.options.format {
-              OutputFormat::Esm => {
-                meta.star_exports_from_external_modules.iter().copied().for_each(|rec_idx| {
-                  let rec = &ecma_module.import_records[rec_idx];
-                  if rec.meta.contains(ImportRecordMeta::EntryLevelExternal) {
-                    return;
-                  }
-                  referenced_symbols.push(rec.namespace_ref.into());
-                  declared_symbols.push(TaggedSymbolRef::Normal(
-                    ecma_module.import_records[rec_idx].namespace_ref,
-                  ));
-                });
-              }
-              OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {}
+        if !meta.star_exports_from_external_modules.is_empty() {
+          referenced_symbols.push(self.runtime.resolve_symbol("__reExport").into());
+          match self.options.format {
+            OutputFormat::Esm => {
+              meta.star_exports_from_external_modules.iter().copied().for_each(|rec_idx| {
+                let rec = &ecma_module.import_records[rec_idx];
+                if rec.meta.contains(ImportRecordMeta::EntryLevelExternal) {
+                  return;
+                }
+                referenced_symbols.push(rec.namespace_ref.into());
+                declared_symbols
+                  .push(TaggedSymbolRef::Normal(ecma_module.import_records[rec_idx].namespace_ref));
+              });
             }
+            OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {}
           }
-          // Create a StmtInfo to represent the statement that declares and constructs the Module Namespace Object.
-          // Corresponding AST for this statement will be created by the finalizer.
-          declared_symbols.push(TaggedSymbolRef::Normal(ecma_module.namespace_object_ref));
-          let namespace_stmt_info = StmtInfo {
-            declared_symbols,
-            referenced_symbols,
-            side_effect: false.into(),
-            import_records: Vec::new(),
-            #[cfg(debug_assertions)]
-            debug_label: None,
-            meta: StmtInfoMeta::default(),
-            ..Default::default()
-          };
-          ecma_module.stmt_infos.replace_namespace_stmt_info(namespace_stmt_info);
         }
-      },
-    );
+        // Create a StmtInfo to represent the statement that declares and constructs the Module Namespace Object.
+        // Corresponding AST for this statement will be created by the finalizer.
+        declared_symbols.push(TaggedSymbolRef::Normal(ecma_module.namespace_object_ref));
+        let namespace_stmt_info = StmtInfo {
+          declared_symbols,
+          referenced_symbols,
+          side_effect: false.into(),
+          import_records: Vec::new(),
+          #[cfg(debug_assertions)]
+          debug_label: None,
+          meta: StmtInfoMeta::default(),
+          ..Default::default()
+        };
+        stmt_infos.replace_namespace_stmt_info(namespace_stmt_info);
+      }
+    }
   }
 }

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -239,11 +239,11 @@ impl LinkStage<'_> {
 
     let mut new_constant_refs = FxHashSet::default();
     for (side_effect_mutations, local_constants, unreachable_addresses) in mutation_result {
-      if let Some((module_idx, mutations)) = side_effect_mutations {
-        if let Some(module) = self.module_table[module_idx].as_normal_mut() {
-          for (stmt_info_idx, side_effect_detail) in mutations {
-            module.stmt_infos[stmt_info_idx].side_effect = side_effect_detail;
-          }
+      if let Some((module_idx, mutations)) = side_effect_mutations
+        && self.module_table[module_idx].as_normal().is_some()
+      {
+        for (stmt_info_idx, side_effect_detail) in mutations {
+          self.stmt_infos[module_idx][stmt_info_idx].side_effect = side_effect_detail;
         }
       }
 

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -8,12 +8,14 @@ use oxc::{
 use oxc_str::CompactStr;
 use rolldown_common::{
   EcmaModuleAstUsage, ExportsKind, GetLocalDbMut, LocalExport, Module, ModuleIdx, ModuleType,
-  NormalModule, StmtInfo, StmtInfoIdx, SymbolOrMemberExprRef, SymbolRef, SymbolRefDbForModule,
-  TaggedSymbolRef, WrapKind,
+  NormalModule, StmtInfo, StmtInfoIdx, StmtInfos, SymbolOrMemberExprRef, SymbolRef,
+  SymbolRefDbForModule, TaggedSymbolRef, WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_utils::ecmascript::legitimize_json_local_binding_name;
+#[cfg(not(target_family = "wasm"))]
+use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
   indexmap::FxIndexMap,
   rayon::{IntoParallelRefMutIterator, ParallelIterator},
@@ -38,13 +40,14 @@ impl LinkStage<'_> {
       .module_table
       .modules
       .par_iter_mut()
-      .filter_map(Module::as_normal_mut)
-      .filter(|module| module.meta.has_lazy_export())
-      .for_each(|module| {
+      .zip(self.stmt_infos.par_iter_mut())
+      .filter_map(|(m, stmt_infos)| m.as_normal_mut().map(|m| (m, stmt_infos)))
+      .filter(|(module, _)| module.meta.has_lazy_export())
+      .for_each(|(module, stmt_infos)| {
         let default_symbol_ref = module.default_export_ref;
         let is_json = matches!(module.module_type, ModuleType::Json);
         if !is_json || module.exports_kind == ExportsKind::CommonJs {
-          update_module_default_export_info(module, default_symbol_ref);
+          update_module_default_export_info(module, stmt_infos, default_symbol_ref);
         }
         lazy_modules.push(LazyModuleInfo {
           idx: module.idx,
@@ -55,7 +58,7 @@ impl LinkStage<'_> {
         // generate `module.exports = expr`
         if module.exports_kind == ExportsKind::CommonJs {
           // since the wrap arguments are generate on demand, we need to insert the module ref usage here.
-          module.stmt_infos.infos[FIRST_TOP_LEVEL_STMT_IDX].side_effect = true.into();
+          stmt_infos.infos[FIRST_TOP_LEVEL_STMT_IDX].side_effect = true.into();
           module.ecma_view.ast_usage.insert(EcmaModuleAstUsage::ModuleRef);
         }
       });
@@ -72,9 +75,11 @@ impl LinkStage<'_> {
           continue;
         }
         // if json is not a ObjectExpression, we will fallback to normal esm lazy export transform
+        let stmt_infos = &mut self.stmt_infos[module_idx];
         let module = &mut self.module_table[module_idx];
         let module = module.as_normal_mut().unwrap();
-        update_module_default_export_info(module, module.default_export_ref);
+        let default_export_ref = module.default_export_ref;
+        update_module_default_export_info(module, stmt_infos, default_export_ref);
       }
 
       // shadowing the previous mutable ref, to avoid reference mutable ref twice at the same time.
@@ -113,13 +118,16 @@ fn replace_first_expr_stmt(ecma_ast: &mut EcmaAst, kind: LazyExportWrap) {
   });
 }
 
-fn update_module_default_export_info(module: &mut NormalModule, default_symbol_ref: SymbolRef) {
+fn update_module_default_export_info(
+  module: &mut NormalModule,
+  stmt_infos: &mut StmtInfos,
+  default_symbol_ref: SymbolRef,
+) {
   module.named_exports.insert(
     "default".into(),
     LocalExport { span: SPAN, referenced: default_symbol_ref, came_from_commonjs: false },
   );
-  module
-    .stmt_infos
+  stmt_infos
     .declare_symbol_for_stmt(FIRST_TOP_LEVEL_STMT_IDX, TaggedSymbolRef::Normal(default_symbol_ref));
 }
 
@@ -256,7 +264,8 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   // update module stmts info
   // clear stmt info, since we need to split `ObjectExpression` into multiple decl, the original stmt info is invalid.
   // preserve the first one, which is `NamespaceRef`
-  let stmt_info = module.stmt_infos.drain(FIRST_TOP_LEVEL_STMT_IDX..);
+  let stmt_infos = &mut link_staged.stmt_infos[module_idx];
+  let stmt_info = stmt_infos.drain(FIRST_TOP_LEVEL_STMT_IDX..);
   let mut all_declared_symbols =
     stmt_info.flat_map(|info| info.referenced_symbols).collect::<Vec<_>>();
   for (local, (exported, _)) in &declaration_binding_names {
@@ -266,7 +275,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     all_declared_symbols.push(SymbolOrMemberExprRef::from(symbol_ref));
     let stmt_info =
       StmtInfo::default().with_declared_symbols(vec![TaggedSymbolRef::Normal(symbol_ref)]);
-    module.stmt_infos.add_stmt_info(stmt_info);
+    stmt_infos.add_stmt_info(stmt_info);
     module.named_exports.insert(
       exported.clone(),
       LocalExport { span: SPAN, referenced: symbol_ref, came_from_commonjs: false },
@@ -277,7 +286,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     .with_declared_symbols(vec![TaggedSymbolRef::Normal(default_export_ref)])
     .with_referenced_symbols(all_declared_symbols.clone());
 
-  module.stmt_infos.add_stmt_info(stmt_info);
+  stmt_infos.add_stmt_info(stmt_info);
   module.named_exports.insert(
     "default".into(),
     LocalExport { span: SPAN, referenced: default_export_ref, came_from_commonjs: false },
@@ -285,7 +294,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
 
   // declare namespace object statement
   module.exports_kind = ExportsKind::Esm;
-  module.stmt_infos.replace_namespace_stmt_info(
+  stmt_infos.replace_namespace_stmt_info(
     StmtInfo::default()
       .with_declared_symbols(vec![TaggedSymbolRef::Normal(namespace_object_ref)])
       .with_referenced_symbols(all_declared_symbols),

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,8 +6,8 @@ use oxc_index::IndexVec;
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
-  ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
-  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  Module, ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, StmtInfos,
+  SymbolRef, SymbolRefDb, UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
 #[cfg(target_family = "wasm")]
@@ -63,6 +63,8 @@ pub struct LinkStageOutput {
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
   pub symbol_db: SymbolRefDb,
+  /// Per-module statement-info table; see `LinkStage.stmt_infos`.
+  pub stmt_infos: IndexVec<ModuleIdx, StmtInfos>,
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
@@ -91,6 +93,13 @@ pub struct LinkStage<'a> {
   /// parallel walk in `reference_needed_symbols` can mutate it through `&mut`
   /// from a zipped iterator without aliasing tricks.
   pub depended_runtime_helper: IndexVec<ModuleIdx, Box<DependedRuntimeHelperMap>>,
+  /// Per-module statement-info table. Detached from `EcmaView` at `LinkStage::new`
+  /// (the field on `EcmaView` is left as an empty placeholder) so the parallel
+  /// walk in `reference_needed_symbols` can mutate it through `&mut` from a
+  /// zipped iterator without aliasing tricks. Threaded through `LinkStageOutput`
+  /// to the generate stage and module finalizers, which used to read
+  /// `module.stmt_infos` directly.
+  pub stmt_infos: IndexVec<ModuleIdx, StmtInfos>,
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
@@ -157,6 +166,21 @@ impl<'a> LinkStage<'a> {
         .modules
         .iter()
         .map(|_| Box::default())
+        .collect::<IndexVec<ModuleIdx, _>>(),
+      // Detach `stmt_infos` from each `EcmaView`. The vestigial field is left
+      // as an empty placeholder; every link/generate/finalize reader now goes
+      // through `link_stage.stmt_infos[idx]` (or `link_output.stmt_infos[idx]`)
+      // instead of `module.stmt_infos`. Removing the placeholder field from
+      // `EcmaView` is a follow-up cleanup that requires re-routing the scan
+      // stage to produce it on the side rather than via the factory.
+      stmt_infos: scan_stage_output
+        .module_table
+        .modules
+        .iter_mut()
+        .map(|m| match m {
+          Module::Normal(n) => std::mem::replace(&mut n.stmt_infos, StmtInfos::new()),
+          Module::External(_) => StmtInfos::new(),
+        })
         .collect::<IndexVec<ModuleIdx, _>>(),
       metas: scan_stage_output
         .module_table
@@ -236,6 +260,7 @@ impl<'a> LinkStage<'a> {
       sorted_modules: self.sorted_modules,
       metas: self.metas,
       symbol_db: self.symbols,
+      stmt_infos: self.stmt_infos,
       runtime: self.runtime,
       warnings: self.warnings,
       errors: self.errors,

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -23,12 +23,11 @@ impl LinkStage<'_> {
           },
         );
 
-        let Module::Normal(module) = &self.module_table[module_idx] else {
+        let Module::Normal(_) = &self.module_table[module_idx] else {
           return (module_idx, extended_dependencies, RuntimeHelper::default());
         };
 
-        module
-          .stmt_infos
+        self.stmt_infos[module_idx]
           .iter_enumerated()
           .filter(|(idx, _)| meta.stmt_info_included.has_bit(*idx))
           .for_each(|(_, stmt_info)| {

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -1,5 +1,3 @@
-use std::ptr::addr_of;
-
 use rolldown_common::{
   ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta, Module, OutputFormat, RuntimeHelper,
   StmtInfoMeta, SymbolRefDb, TaggedSymbolRef, WrapKind,
@@ -35,19 +33,15 @@ impl LinkStage<'_> {
       .par_iter()
       .zip(symbols_inner.par_iter_mut())
       .zip(self.depended_runtime_helper.par_iter_mut())
-      .filter_map(|((module, symbol_db), depended_helper)| {
-        module.as_normal().map(|importer| (importer, symbol_db, depended_helper))
+      .zip(self.stmt_infos.par_iter_mut())
+      .filter_map(|(((module, symbol_db), depended_helper), stmt_infos)| {
+        module.as_normal().map(|importer| (importer, symbol_db, depended_helper, stmt_infos))
       })
-      .map(|(importer, symbol_ref_for_module, depended_runtime_helper_map)| {
+      .map(|(importer, symbol_ref_for_module, depended_runtime_helper_map, stmt_infos)| {
         let symbol_db =
           symbol_ref_for_module.as_mut().expect("normal module should have symbol db");
         let mut record_meta_pairs: Vec<(ImportRecordIdx, ImportRecordMeta)> = vec![];
         let importer_idx = importer.idx;
-        // safety: No race conditions here:
-        // - Mutating on `stmt_infos` is isolated in threads for each module
-        // - Mutating on `stmt_infos` doesn't rely on other mutating operations of other modules
-        // - Mutating and parallel reading is in different memory locations
-        let stmt_infos = unsafe { &mut *(addr_of!(importer.stmt_infos).cast_mut()) };
         let mut symbols_to_be_declared = vec![];
         stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
           if stmt_info.meta.contains(StmtInfoMeta::HasDummyRecord) {

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -53,6 +53,9 @@ bitflags::bitflags! {
 
 pub struct IncludeContext<'a> {
   pub modules: &'a IndexModules,
+  /// Per-module statement-info table, detached from `EcmaView` and held on
+  /// `LinkStage` for the duration of the link/generate stages.
+  pub stmt_infos: &'a IndexVec<ModuleIdx, StmtInfos>,
   pub symbols: &'a SymbolRefDb,
   pub is_included_vec: &'a mut StmtInclusionVec,
   pub is_module_included_vec: &'a mut ModuleInclusionVec,
@@ -78,6 +81,7 @@ impl<'a> IncludeContext<'a> {
   #[expect(clippy::too_many_arguments)]
   pub fn new(
     modules: &'a IndexModules,
+    stmt_infos: &'a IndexVec<ModuleIdx, StmtInfos>,
     symbols: &'a SymbolRefDb,
     is_included_vec: &'a mut StmtInclusionVec,
     is_module_included_vec: &'a mut ModuleInclusionVec,
@@ -91,6 +95,7 @@ impl<'a> IncludeContext<'a> {
   ) -> Self {
     Self {
       modules,
+      stmt_infos,
       symbols,
       is_included_vec,
       is_module_included_vec,
@@ -207,8 +212,9 @@ impl LinkStage<'_> {
       .module_table
       .modules
       .iter()
-      .map(|m| {
-        m.as_normal().map_or(IndexBitSet::default(), |m| IndexBitSet::new(m.stmt_infos.len()))
+      .zip(self.stmt_infos.iter())
+      .map(|(m, stmt_infos)| {
+        m.as_normal().map_or(IndexBitSet::default(), |_| IndexBitSet::new(stmt_infos.len()))
       })
       .collect::<IndexVec<ModuleIdx, _>>();
     let mut used_symbol_refs = UsedSymbolRefs::default();
@@ -223,6 +229,7 @@ impl LinkStage<'_> {
       .any(|m| m.as_normal().is_some_and(|n| !n.ecma_view.enum_member_value_map.is_empty()));
     let context = &mut IncludeContext::new(
       &self.module_table.modules,
+      &self.stmt_infos,
       &self.symbols,
       &mut is_stmt_info_included_vec,
       &mut is_module_included_vec,
@@ -253,11 +260,13 @@ impl LinkStage<'_> {
       meta.referenced_symbols_by_entry_point_chunk.iter().for_each(
         |(symbol_ref, _came_from_cjs)| {
           if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
-            module.stmt_infos.declared_stmts_by_symbol(symbol_ref).iter().copied().for_each(
-              |stmt_info_id| {
+            context.stmt_infos[symbol_ref.owner]
+              .declared_stmts_by_symbol(symbol_ref)
+              .iter()
+              .copied()
+              .for_each(|stmt_info_id| {
                 include_statement(context, module, stmt_info_id);
-              },
-            );
+              });
             include_symbol_and_check_cjs_bailout(
               context,
               *symbol_ref,
@@ -372,6 +381,7 @@ impl LinkStage<'_> {
     );
     let context = &mut IncludeContext::new(
       &self.module_table.modules,
+      &self.stmt_infos,
       &self.symbols,
       &mut is_stmt_info_included_vec,
       &mut is_module_included_vec,
@@ -403,6 +413,7 @@ impl LinkStage<'_> {
         .iter()
         .filter_map(Module::as_normal)
         .map(|m| m.to_debug_normal_module_for_tree_shaking(
+          &self.stmt_infos[m.idx],
           self.metas[m.idx].is_included,
           &self.metas[m.idx].stmt_info_included
         ))
@@ -440,11 +451,13 @@ impl LinkStage<'_> {
     let meta = &self.metas[entry.idx];
     meta.referenced_symbols_by_entry_point_chunk.iter().for_each(|(symbol_ref, _came_from_cjs)| {
       if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
-        module.stmt_infos.declared_stmts_by_symbol(symbol_ref).iter().copied().for_each(
-          |stmt_info_id| {
+        context.stmt_infos[symbol_ref.owner]
+          .declared_stmts_by_symbol(symbol_ref)
+          .iter()
+          .copied()
+          .for_each(|stmt_info_id| {
             include_statement(context, module, stmt_info_id);
-          },
-        );
+          });
         include_symbol_and_check_cjs_bailout(
           context,
           *symbol_ref,
@@ -648,7 +661,7 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
 
   let forced_no_treeshake = matches!(module.side_effects, DeterminedSideEffects::NoTreeshake);
   if ctx.tree_shaking && !forced_no_treeshake {
-    module.stmt_infos.iter_enumerated_without_namespace_stmt().for_each(
+    ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
       |(stmt_info_id, stmt_info)| {
         // No need to handle the namespace statement specially, because it doesn't have side effects and will only be included if it is used.
         let bail_eval = module.meta.has_eval()
@@ -668,7 +681,7 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
     );
   } else {
     // Skip the namespace statement. It should be included only if it is used no matter tree shaking is enabled or not.
-    module.stmt_infos.iter_enumerated_without_namespace_stmt().for_each(
+    ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
       |(stmt_info_id, stmt_info)| {
         if stmt_info.force_tree_shaking {
           if stmt_info.side_effect.has_side_effect() {
@@ -797,11 +810,13 @@ pub fn include_symbol(
         .or_default()
         .insert(canonical_ref);
     }
-    module.stmt_infos.declared_stmts_by_symbol(&canonical_ref).iter().copied().for_each(
-      |stmt_info_id| {
+    ctx.stmt_infos[canonical_ref.owner]
+      .declared_stmts_by_symbol(&canonical_ref)
+      .iter()
+      .copied()
+      .for_each(|stmt_info_id| {
         include_statement(ctx, module, stmt_info_id);
-      },
-    );
+      });
     if !is_simulated_facade_chunk {
       include_module(ctx, module);
     }
@@ -811,8 +826,7 @@ pub fn include_symbol(
     rolldown_common::PropertyWriteSideEffects::False
   ) {
     ctx.modules[symbol_ref.owner].as_normal().inspect(|module| {
-      module
-        .stmt_infos
+      ctx.stmt_infos[symbol_ref.owner]
         .symbol_ref_to_referenced_stmt_idx()
         .get(&symbol_ref)
         .as_ref()
@@ -837,7 +851,7 @@ pub fn include_statement(
     return;
   }
 
-  let stmt_info = module.stmt_infos.get(stmt_info_idx);
+  let stmt_info = ctx.stmt_infos[module.idx].get(stmt_info_idx);
 
   // FIXME: bailout for require() import for now
   // it is fine for now, since webpack did not support it either
@@ -907,11 +921,13 @@ pub fn include_statement(
       if let Some(resolved_ref) = member_expr_resolution.resolved {
         member_expr_resolution.depended_refs.iter().for_each(|sym_ref| {
           if let Module::Normal(module) = &ctx.modules[sym_ref.owner] {
-            module.stmt_infos.declared_stmts_by_symbol(sym_ref).iter().copied().for_each(
-              |stmt_info_id| {
+            ctx.stmt_infos[sym_ref.owner]
+              .declared_stmts_by_symbol(sym_ref)
+              .iter()
+              .copied()
+              .for_each(|stmt_info_id| {
                 include_statement(ctx, module, stmt_info_id);
-              },
-            );
+              });
           }
         });
         include_symbol(ctx, resolved_ref, include_kind);
@@ -962,11 +978,13 @@ pub fn include_statement(
         )
         .for_each(|sym_ref| {
           if let Module::Normal(module) = &ctx.modules[sym_ref.owner] {
-            module.stmt_infos.declared_stmts_by_symbol(sym_ref).iter().copied().for_each(
-              |stmt_info_id| {
+            ctx.stmt_infos[sym_ref.owner]
+              .declared_stmts_by_symbol(sym_ref)
+              .iter()
+              .copied()
+              .for_each(|stmt_info_id| {
                 include_statement(ctx, module, stmt_info_id);
-              },
-            );
+              });
           }
         });
       include_symbol_and_check_cjs_bailout(ctx, *original_ref, include_kind);

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -1,6 +1,6 @@
 use rolldown_common::{
   EcmaViewMeta, ExportsKind, ImportKind, IndexModules, Module, ModuleIdx, NormalModule,
-  NormalizedBundlerOptions, RuntimeModuleBrief, StmtInfo, StmtInfoMeta, SymbolRefDb,
+  NormalizedBundlerOptions, RuntimeModuleBrief, StmtInfo, StmtInfoMeta, StmtInfos, SymbolRefDb,
   TaggedSymbolRef, WrapKind,
 };
 use rolldown_utils::IndexBitSet;
@@ -187,17 +187,26 @@ impl LinkStage<'_> {
       }
     }
 
-    self.module_table.modules.iter_mut().filter_map(|m| m.as_normal_mut()).for_each(
-      |ecma_module| {
-        let linking_info = &mut self.metas[ecma_module.idx];
-        create_wrapper(ecma_module, linking_info, &mut self.symbols, &self.runtime, self.options);
-      },
-    );
+    for m in &self.module_table.modules {
+      let Some(ecma_module) = m.as_normal() else { continue };
+      let idx = ecma_module.idx;
+      let linking_info = &mut self.metas[idx];
+      let stmt_infos = &mut self.stmt_infos[idx];
+      create_wrapper(
+        ecma_module,
+        stmt_infos,
+        linking_info,
+        &mut self.symbols,
+        &self.runtime,
+        self.options,
+      );
+    }
   }
 }
 
 pub fn create_wrapper(
-  module: &mut NormalModule,
+  module: &NormalModule,
+  stmt_infos: &mut StmtInfos,
   linking_info: &mut LinkingMetadata,
   symbols: &mut SymbolRefDb,
   runtime: &RuntimeModuleBrief,
@@ -231,7 +240,7 @@ pub fn create_wrapper(
         force_tree_shaking: true,
       };
 
-      linking_info.wrapper_stmt_info = Some(module.stmt_infos.add_stmt_info(stmt_info));
+      linking_info.wrapper_stmt_info = Some(stmt_infos.add_stmt_info(stmt_info));
       linking_info.wrapper_ref = Some(wrapper_ref);
     }
     // If this is a lazily-initialized ESM file, we're going to need to
@@ -261,7 +270,7 @@ pub fn create_wrapper(
         force_tree_shaking: true,
       };
 
-      linking_info.wrapper_stmt_info = Some(module.stmt_infos.add_stmt_info(stmt_info));
+      linking_info.wrapper_stmt_info = Some(stmt_infos.add_stmt_info(stmt_info));
       linking_info.wrapper_ref = Some(wrapper_ref);
     }
     WrapKind::None => {}

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -106,8 +106,7 @@ pub fn deconflict_chunk_symbols(
       let meta = &link_output.metas[module.idx];
       let is_cjs_wrapped_module = matches!(meta.wrap_kind(), WrapKind::Cjs);
 
-      module
-        .stmt_infos
+      link_output.stmt_infos[module.idx]
         .iter_enumerated()
         .filter(|(idx, _)| meta.stmt_info_included.has_bit(*idx))
         .for_each(|(_, stmt_info)| {

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -53,15 +53,14 @@ impl NormalModule {
 
   pub fn to_debug_normal_module_for_tree_shaking(
     &self,
+    stmt_infos: &crate::StmtInfos,
     is_included: bool,
     stmt_info_included: &IndexBitSet<StmtInfoIdx>,
   ) -> DebugNormalModuleForTreeShaking {
     DebugNormalModuleForTreeShaking {
       id: self.repr_name.clone(),
       is_included,
-      stmt_infos: self
-        .ecma_view
-        .stmt_infos
+      stmt_infos: stmt_infos
         .iter_enumerated()
         .map(|(idx, stmt)| {
           stmt.to_debug_stmt_info_for_tree_shaking(stmt_info_included.has_bit(idx))


### PR DESCRIPTION
Move `stmt_infos` out of `EcmaView` into a side `IndexVec<ModuleIdx, StmtInfos>` held by `LinkStage` (and threaded through `LinkStageOutput` to the generate stage). This lets `reference_needed_symbols` mutate per-module `stmt_infos` in parallel via a normal `par_iter_mut` zip, replacing the previous `unsafe { addr_of!(...).cast_mut() }` aliasing trick. Readers across link/generate/finalize stages now go through the side table or the threaded `IncludeContext.stmt_infos` field.

related to #9242