### PR TITLE
refactor(scan_stage): remove stmt_infos field from EcmaView

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -112,7 +112,6 @@ pub async fn create_ecma_view(
     source: ast.source().clone(),
     named_imports,
     named_exports,
-    stmt_infos,
     imports,
     default_export_ref,
     exports_kind,
@@ -153,7 +152,8 @@ pub async fn create_ecma_view(
     cjs_reexport_import_record_ids,
   };
 
-  let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage, preserve_jsx };
+  let ecma_related =
+    EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage, preserve_jsx, stmt_infos };
   Ok(CreateEcmaViewReturn { ecma_view, ecma_related, raw_import_records, tla_keyword_span })
 }
 

--- a/crates/rolldown/src/module_loader/deferred_scan_data.rs
+++ b/crates/rolldown/src/module_loader/deferred_scan_data.rs
@@ -39,7 +39,7 @@ pub async fn defer_sync_scan_data(
         normalize_side_effects(
           options,
           &normal.originative_resolved_id,
-          Some(&normal.stmt_infos),
+          Some(&scan_stage_output.stmt_infos[module_idx]),
           data.side_effects,
         )
         .await?

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -16,8 +16,8 @@ use rolldown_common::{
   ExternalModuleTaskResult, FlatOptions, HybridIndexVec, ImportKind, ImportRecordIdx,
   ImportRecordMeta, ImportedExports, ImporterRecord, Module, ModuleId, ModuleIdx, ModuleLoaderMsg,
   ModuleType, NormalModuleTaskResult, PreserveEntrySignatures, RUNTIME_MODULE_ID, ResolvedId,
-  RuntimeModuleBrief, RuntimeModuleTaskResult, ScanMode, SourceMapGenMsg, StmtInfoIdx, SymbolRefDb,
-  SymbolRefDbForModule,
+  RuntimeModuleBrief, RuntimeModuleTaskResult, ScanMode, SourceMapGenMsg, StmtInfoIdx, StmtInfos,
+  SymbolRefDb, SymbolRefDbForModule,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{
@@ -45,6 +45,10 @@ pub struct IntermediateNormalModules {
   pub modules: HybridIndexVec<ModuleIdx, Option<Module>>,
   pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
   pub index_ecma_ast: HybridIndexVec<ModuleIdx, Option<EcmaAst>>,
+  /// Per-module statement-info table collected as modules complete. Held here
+  /// instead of on `EcmaView` so the link stage can carry it as a side
+  /// `IndexVec<ModuleIdx, StmtInfos>` without a `mem::replace`.
+  pub stmt_infos: HybridIndexVec<ModuleIdx, Option<StmtInfos>>,
 }
 
 impl IntermediateNormalModules {
@@ -61,12 +65,18 @@ impl IntermediateNormalModules {
       } else {
         HybridIndexVec::Map(FxHashMap::default())
       },
+      stmt_infos: if is_full_scan {
+        HybridIndexVec::IndexVec(IndexVec::default())
+      } else {
+        HybridIndexVec::Map(FxHashMap::default())
+      },
     }
   }
 
   pub fn alloc_ecma_module_idx(&mut self) -> ModuleIdx {
     let id = self.modules.push(None);
     self.index_ecma_ast.push(None);
+    self.stmt_infos.push(None);
     self.importers.push(Vec::new());
     id
   }
@@ -74,6 +84,7 @@ impl IntermediateNormalModules {
   pub fn alloc_ecma_module_idx_sparse(&mut self, i: ModuleIdx) -> ModuleIdx {
     self.modules.insert(i, None);
     self.index_ecma_ast.insert(i, None);
+    self.stmt_infos.insert(i, None);
     if i >= self.importers.len() {
       self.importers.push(Vec::new());
     }
@@ -117,6 +128,11 @@ pub struct ModuleLoaderOutput {
   // Stored all modules
   pub module_table: HybridIndexVec<ModuleIdx, Module>,
   pub index_ecma_ast: HybridIndexVec<ModuleIdx, Option<EcmaAst>>,
+  /// Side table of per-module `StmtInfos` (one slot per module index, with
+  /// `StmtInfos::new()` placeholder for external modules). Threaded through
+  /// `ScanStageOutput`/`NormalizedScanStageOutput` to the link stage instead
+  /// of living on each `EcmaView`.
+  pub stmt_infos: HybridIndexVec<ModuleIdx, StmtInfos>,
   pub symbol_ref_db: SymbolRefDb,
   // Entries that user defined + dynamic import entries
   pub entry_points: Vec<EntryPoint>,
@@ -372,7 +388,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             mut module,
             mut barrel_info,
             ecma_related:
-              EcmaRelated { ast, symbols, mut dynamic_import_rec_exports_usage, preserve_jsx },
+              EcmaRelated {
+                ast,
+                symbols,
+                mut dynamic_import_rec_exports_usage,
+                preserve_jsx,
+                stmt_infos,
+              },
             resolved_deps,
             raw_import_records,
             warnings,
@@ -501,6 +523,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
 
           module.set_import_records(import_records);
           *self.intermediate_normal_modules.index_ecma_ast.get_mut(module_idx) = Some(ast);
+          *self.intermediate_normal_modules.stmt_infos.get_mut(module_idx) = Some(stmt_infos);
           *self.intermediate_normal_modules.modules.get_mut(module_idx) = Some(module);
 
           if let Some((imported_exports_per_record, _)) = initialized_barrel_tracking {
@@ -555,6 +578,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
           let RuntimeModuleTaskResult {
             local_symbol_ref_db,
             mut module,
+            stmt_infos,
             runtime,
             ast,
             raw_import_records,
@@ -581,6 +605,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
 
           *self.intermediate_normal_modules.modules.get_mut(runtime.id()) = Some(module.into());
           *self.intermediate_normal_modules.index_ecma_ast.get_mut(runtime.id()) = Some(ast);
+          *self.intermediate_normal_modules.stmt_infos.get_mut(runtime.id()) = Some(stmt_infos);
 
           self.symbol_ref_db.store_local_db(runtime.id(), local_symbol_ref_db);
           self.remaining -= 1;
@@ -710,6 +735,21 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       HybridIndexVec::Map(map)
     };
 
+    // Build the side `stmt_infos` table parallel to `module_table`. Slots that
+    // never received a `Some(stmt_infos)` (external modules, or normal modules
+    // not produced by tasks) get a fresh empty `StmtInfos` placeholder.
+    let stmt_infos_iter = std::mem::take(&mut self.intermediate_normal_modules.stmt_infos)
+      .into_iter_enumerated()
+      .into_iter()
+      .map(|(idx, stmt_infos)| (idx, stmt_infos.unwrap_or_else(StmtInfos::new)));
+    let stmt_infos = if is_dense_index_vec {
+      let vec = stmt_infos_iter.map(|(_, s)| s).collect();
+      HybridIndexVec::IndexVec(IndexVec::from_vec(vec))
+    } else {
+      let map = stmt_infos_iter.collect::<FxHashMap<_, _>>();
+      HybridIndexVec::Map(map)
+    };
+
     // Some module was not treated as an entry, but was emitted by `this.emitFile` during
     // processing, those module info also need to be updated
     // see https://github.com/rolldown/rolldown/issues/5030 as an example
@@ -768,6 +808,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       entry_point_to_reference_ids,
       symbol_ref_db: std::mem::take(&mut self.symbol_ref_db),
       index_ecma_ast: std::mem::take(&mut self.intermediate_normal_modules.index_ecma_ast),
+      stmt_infos,
       new_added_modules_from_partial_scan: std::mem::take(
         &mut self.new_added_modules_from_partial_scan,
       ),

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -175,7 +175,6 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
         side_effects: determined_side_effects,
         named_imports,
         named_exports,
-        stmt_infos,
         imports,
         default_export_ref,
         exports_kind: ExportsKind::Esm,
@@ -207,6 +206,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
     let result = ModuleLoaderMsg::RuntimeNormalModuleDone(Box::new(RuntimeModuleTaskResult {
       ast,
       module,
+      stmt_infos,
       runtime,
       resolved_deps,
       raw_import_records,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,8 +6,8 @@ use oxc_index::IndexVec;
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
-  Module, ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, StmtInfos,
-  SymbolRef, SymbolRefDb, UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
+  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
 #[cfg(target_family = "wasm")]
@@ -21,7 +21,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   SharedOptions,
-  type_alias::IndexEcmaAst,
+  type_alias::{IndexEcmaAst, IndexStmtInfos},
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
 };
 
@@ -64,7 +64,7 @@ pub struct LinkStageOutput {
   pub metas: LinkingMetadataVec,
   pub symbol_db: SymbolRefDb,
   /// Per-module statement-info table; see `LinkStage.stmt_infos`.
-  pub stmt_infos: IndexVec<ModuleIdx, StmtInfos>,
+  pub stmt_infos: IndexStmtInfos,
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
@@ -99,7 +99,7 @@ pub struct LinkStage<'a> {
   /// zipped iterator without aliasing tricks. Threaded through `LinkStageOutput`
   /// to the generate stage and module finalizers, which used to read
   /// `module.stmt_infos` directly.
-  pub stmt_infos: IndexVec<ModuleIdx, StmtInfos>,
+  pub stmt_infos: IndexStmtInfos,
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
@@ -167,21 +167,10 @@ impl<'a> LinkStage<'a> {
         .iter()
         .map(|_| Box::default())
         .collect::<IndexVec<ModuleIdx, _>>(),
-      // Detach `stmt_infos` from each `EcmaView`. The vestigial field is left
-      // as an empty placeholder; every link/generate/finalize reader now goes
-      // through `link_stage.stmt_infos[idx]` (or `link_output.stmt_infos[idx]`)
-      // instead of `module.stmt_infos`. Removing the placeholder field from
-      // `EcmaView` is a follow-up cleanup that requires re-routing the scan
-      // stage to produce it on the side rather than via the factory.
-      stmt_infos: scan_stage_output
-        .module_table
-        .modules
-        .iter_mut()
-        .map(|m| match m {
-          Module::Normal(n) => std::mem::replace(&mut n.stmt_infos, StmtInfos::new()),
-          Module::External(_) => StmtInfos::new(),
-        })
-        .collect::<IndexVec<ModuleIdx, _>>(),
+      // `stmt_infos` is produced by the scan stage on the side (in
+      // `NormalizedScanStageOutput.stmt_infos`) rather than living on each
+      // `EcmaView`, so we can move it directly here.
+      stmt_infos: std::mem::take(&mut scan_stage_output.stmt_infos),
       metas: scan_stage_output
         .module_table
         .modules

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -23,7 +23,10 @@ use rolldown_utils::IndexBitSet;
 use rolldown_utils::indexmap::FxIndexMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{stages::link_stage::LinkStage, types::linking_metadata::LinkingMetadataVec};
+use crate::{
+  stages::link_stage::LinkStage, type_alias::IndexStmtInfos,
+  types::linking_metadata::LinkingMetadataVec,
+};
 
 pub type StmtInclusionVec = IndexVec<ModuleIdx, IndexBitSet<StmtInfoIdx>>;
 pub type ModuleInclusionVec = IndexBitSet<ModuleIdx>;
@@ -55,7 +58,7 @@ pub struct IncludeContext<'a> {
   pub modules: &'a IndexModules,
   /// Per-module statement-info table, detached from `EcmaView` and held on
   /// `LinkStage` for the duration of the link/generate stages.
-  pub stmt_infos: &'a IndexVec<ModuleIdx, StmtInfos>,
+  pub stmt_infos: &'a IndexStmtInfos,
   pub symbols: &'a SymbolRefDb,
   pub is_included_vec: &'a mut StmtInclusionVec,
   pub is_module_included_vec: &'a mut ModuleInclusionVec,
@@ -81,7 +84,7 @@ impl<'a> IncludeContext<'a> {
   #[expect(clippy::too_many_arguments)]
   pub fn new(
     modules: &'a IndexModules,
-    stmt_infos: &'a IndexVec<ModuleIdx, StmtInfos>,
+    stmt_infos: &'a IndexStmtInfos,
     symbols: &'a SymbolRefDb,
     is_included_vec: &'a mut StmtInclusionVec,
     is_module_included_vec: &'a mut ModuleInclusionVec,

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -8,7 +8,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_common::SourceMapGenMsg;
 use rolldown_common::{
   EntryPoint, FlatOptions, HybridIndexVec, Module, ModuleIdx, ModuleTable, PreserveEntrySignatures,
-  ResolvedId, RuntimeModuleBrief, ScanMode, SourcemapChainElement, SymbolRefDb,
+  ResolvedId, RuntimeModuleBrief, ScanMode, SourcemapChainElement, StmtInfos, SymbolRefDb,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_ecmascript::EcmaAst;
@@ -20,7 +20,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
   SharedOptions, SharedResolver,
   module_loader::{ModuleLoader, module_loader::ModuleLoaderOutput},
-  type_alias::IndexEcmaAst,
+  type_alias::{IndexEcmaAst, IndexStmtInfos},
   types::scan_stage_cache::ScanStageCache,
   utils::load_entry_module::load_entry_module,
 };
@@ -41,6 +41,10 @@ pub struct ScanStage<Fs: FileSystem + Clone + 'static> {
 pub struct NormalizedScanStageOutput {
   pub module_table: ModuleTable,
   pub index_ecma_ast: IndexEcmaAst,
+  /// Per-module `StmtInfos` side table, parallel to `module_table.modules`.
+  /// External modules get an empty `StmtInfos::new()` placeholder. Routed
+  /// directly into `LinkStage.stmt_infos` instead of living on `EcmaView`.
+  pub stmt_infos: IndexStmtInfos,
   pub entry_points: Vec<EntryPoint>,
   pub symbol_ref_db: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
@@ -69,6 +73,7 @@ impl NormalizedScanStageOutput {
           .collect::<Vec<_>>();
         IndexVec::from_vec(index_ecma_ast)
       },
+      stmt_infos: self.stmt_infos.clone(),
       entry_points: self.entry_points.clone(),
       symbol_ref_db: self.symbol_ref_db.clone_without_scoping(),
       runtime: self.runtime.clone(),
@@ -98,9 +103,15 @@ impl TryFrom<ScanStageOutput> for NormalizedScanStageOutput {
       HybridIndexVec::Map(_) => return Err("index_ecma_ast must be normalized to IndexVec first"),
     };
 
+    let stmt_infos = match value.stmt_infos {
+      HybridIndexVec::IndexVec(stmt_infos) => stmt_infos,
+      HybridIndexVec::Map(_) => return Err("stmt_infos must be normalized to IndexVec first"),
+    };
+
     Ok(Self {
       module_table,
       index_ecma_ast,
+      stmt_infos,
       entry_points: value.entry_points,
       symbol_ref_db: value.symbol_ref_db,
       runtime: value.runtime,
@@ -120,6 +131,7 @@ impl TryFrom<ScanStageOutput> for NormalizedScanStageOutput {
 pub struct ScanStageOutput {
   pub module_table: HybridIndexVec<ModuleIdx, Module>,
   pub index_ecma_ast: HybridIndexVec<ModuleIdx, Option<EcmaAst>>,
+  pub stmt_infos: HybridIndexVec<ModuleIdx, StmtInfos>,
   pub entry_points: Vec<EntryPoint>,
   pub symbol_ref_db: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
@@ -323,6 +335,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       runtime,
       warnings,
       index_ecma_ast,
+      stmt_infos,
       dynamic_import_exports_usage_map,
       new_added_modules_from_partial_scan: _,
       overrode_preserve_entry_signature_map,
@@ -335,6 +348,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
     ScanStageOutput {
       module_table,
       index_ecma_ast,
+      stmt_infos,
       entry_points,
       symbol_ref_db,
       runtime,

--- a/crates/rolldown/src/type_alias.rs
+++ b/crates/rolldown/src/type_alias.rs
@@ -1,5 +1,5 @@
 use oxc_index::IndexVec;
-use rolldown_common::{Asset, ChunkIdx, InsChunkIdx, InstantiatedChunk, ModuleIdx};
+use rolldown_common::{Asset, ChunkIdx, InsChunkIdx, InstantiatedChunk, ModuleIdx, StmtInfos};
 use rolldown_ecmascript::EcmaAst;
 use rolldown_utils::indexmap::FxIndexSet;
 
@@ -7,3 +7,4 @@ pub type IndexChunkToInstances = IndexVec<ChunkIdx, FxIndexSet<InsChunkIdx>>;
 pub type AssetVec = Vec<Asset>;
 pub type IndexInstantiatedChunks = IndexVec<InsChunkIdx, InstantiatedChunk>;
 pub type IndexEcmaAst = IndexVec<ModuleIdx, Option<EcmaAst>>;
+pub type IndexStmtInfos = IndexVec<ModuleIdx, StmtInfos>;

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -115,6 +115,10 @@ impl ScanStageCache {
         );
         cache.module_table.modules.push(new_module);
         cache.index_ecma_ast.push(scan_stage_output.index_ecma_ast.get_mut(new_idx).take());
+        cache.stmt_infos.push(std::mem::replace(
+          scan_stage_output.stmt_infos.get_mut(new_idx),
+          rolldown_common::StmtInfos::new(),
+        ));
         continue;
       }
       let old_has_tla = module_has_tla(&cache.module_table[idx]);
@@ -138,6 +142,10 @@ impl ScanStageCache {
       }
       cache.module_table[idx] = new_module;
       cache.index_ecma_ast[idx] = scan_stage_output.index_ecma_ast.get_mut(new_idx).take();
+      cache.stmt_infos[idx] = std::mem::replace(
+        scan_stage_output.stmt_infos.get_mut(new_idx),
+        rolldown_common::StmtInfos::new(),
+      );
       std::mem::swap(
         cache.symbol_ref_db.local_db_mut(idx),
         scan_stage_output.symbol_ref_db.local_db_mut(new_idx),
@@ -231,6 +239,7 @@ impl ScanStageCache {
           .collect::<Vec<_>>();
         IndexVec::from_vec(item)
       },
+      stmt_infos: cache.stmt_infos.clone(),
 
       // Since `AstScope` is immutable in following phase, move it to avoid clone
       entry_points: cache.entry_points.clone(),

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -9,7 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId, ModuleIdx,
-  NamedImport, ResolvedImportRecord, SourceMutation, StmtInfos, SymbolRef,
+  NamedImport, ResolvedImportRecord, SourceMutation, SymbolRef,
   side_effects::DeterminedSideEffects, types::source_mutation::ArcSourceMutation,
 };
 
@@ -68,8 +68,6 @@ pub struct EcmaView {
   pub namespace_object_ref: SymbolRef,
   pub named_imports: FxIndexMap<SymbolRef, NamedImport>,
   pub named_exports: FxHashMap<CompactStr, LocalExport>,
-  /// `stmt_infos[0]` represents the namespace binding statement
-  pub stmt_infos: StmtInfos,
   pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
   /// The key is the `Span` of `ImportDeclaration`, `ImportExpression`, `ExportNamedDeclaration`, `ExportAllDeclaration`
   /// and `CallExpression`(only when the callee is `require`).

--- a/crates/rolldown_common/src/module_loader/runtime_task_result.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_task_result.rs
@@ -1,7 +1,9 @@
 use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
 
-use crate::{ImportRecordIdx, NormalModule, RawImportRecord, ResolvedId, SymbolRefDbForModule};
+use crate::{
+  ImportRecordIdx, NormalModule, RawImportRecord, ResolvedId, StmtInfos, SymbolRefDbForModule,
+};
 
 use super::runtime_module_brief::RuntimeModuleBrief;
 
@@ -10,6 +12,7 @@ pub struct RuntimeModuleTaskResult {
   pub local_symbol_ref_db: SymbolRefDbForModule,
   pub ast: EcmaAst,
   pub module: NormalModule,
+  pub stmt_infos: StmtInfos,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
 }

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -1,7 +1,7 @@
 use crate::{
-  ImportRecordIdx, Module, ModuleId, ModuleIdx, RawImportRecord, ResolvedId, SymbolRefDbForModule,
-  dynamic_import_usage::DynamicImportExportsUsage, side_effects::DeterminedSideEffects,
-  types::lazy_barrel::BarrelInfo,
+  ImportRecordIdx, Module, ModuleId, ModuleIdx, RawImportRecord, ResolvedId, StmtInfos,
+  SymbolRefDbForModule, dynamic_import_usage::DynamicImportExportsUsage,
+  side_effects::DeterminedSideEffects, types::lazy_barrel::BarrelInfo,
 };
 use arcstr::ArcStr;
 use oxc::span::Span;
@@ -39,4 +39,9 @@ pub struct EcmaRelated {
   /// Whether JSX syntax is preserved for this module, determined per-module
   /// during transformation based on the resolved tsconfig.
   pub preserve_jsx: bool,
+  /// Per-module statement-info table. Held alongside `EcmaView` rather than on
+  /// it so the link stage can collect them into a side `IndexVec` without
+  /// `mem::replace` and so reads/writes during link/generate can split-borrow
+  /// from `metas`.
+  pub stmt_infos: StmtInfos,
 }


### PR DESCRIPTION
related to https://github.com/rolldown/rolldown/issues/9242

Stacked on #9274.

Routes per-module `StmtInfos` through a side `IndexVec<ModuleIdx, StmtInfos>` on `ScanStageOutput` / `NormalizedScanStageOutput` (carried via `EcmaRelated` and `RuntimeModuleTaskResult`) instead of storing it on each `EcmaView`.

After #9274, `EcmaView.stmt_infos` was just an empty `StmtInfos::new()` placeholder for the entire link/generate lifetime — `LinkStage::new` `mem::replace`d the real value out into `LinkStage.stmt_infos` immediately, and every reader went through the side table. This PR removes the field entirely.


Changes:
- `EcmaRelated` and `RuntimeModuleTaskResult` carry `stmt_infos: StmtInfos`.
- `IntermediateNormalModules` collects per-module `stmt_infos` parallel to `index_ecma_ast`; the module loader builds a side `HybridIndexVec<ModuleIdx, StmtInfos>` at output time (external modules get an empty `StmtInfos::new()` placeholder).
- `ScanStageOutput` / `NormalizedScanStageOutput` carry the side table; `ScanStageCache::merge` and `create_output` thread it through.
- `LinkStage::new` `mem::take`s `scan_stage_output.stmt_infos` directly (no per-module `mem::replace` walk).
- `defer_sync_scan_data` reads `&scan_stage_output.stmt_infos[module_idx]` instead of `&normal.stmt_infos`.
- `EcmaView.stmt_infos` field removed.