### PR TITLE
refactor(ecma_ast): tighten allocator access to enforce Sync invariant

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -32,7 +32,7 @@ pub async fn create_ecma_view(
 ) -> BuildResult<CreateEcmaViewReturn> {
   let CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects } = args;
   let ParseToEcmaAstResult {
-    ast,
+    mut ast,
     scoping,
     has_lazy_export,
     warnings,
@@ -47,18 +47,22 @@ pub async fn create_ecma_view(
   let repr_name = module_id.as_path().representative_file_name();
   let repr_name = legitimize_identifier_name(&repr_name);
 
-  let scanner = AstScanner::new(
-    ctx.module_idx,
-    scoping,
-    &repr_name,
-    ctx.resolved_id.module_def_format,
-    ast.source(),
-    &module_id,
-    ast.comments(),
-    ctx.options,
-    ast.allocator(),
-    ctx.flat_options,
-  );
+  let scan_result = ast.program.with_mut(|fields| {
+    let program = &*fields.program;
+    let scanner = AstScanner::new(
+      ctx.module_idx,
+      scoping,
+      &repr_name,
+      ctx.resolved_id.module_def_format,
+      fields.source,
+      &module_id,
+      &program.comments,
+      ctx.options,
+      fields.allocator,
+      ctx.flat_options,
+    );
+    scanner.scan(program)
+  })?;
 
   let ScanResult {
     commonjs_exports,
@@ -89,7 +93,7 @@ pub async fn create_ecma_view(
     import_attribute_map,
     cjs_reexport_require_spans: _,
     cjs_reexport_import_record_ids,
-  } = scanner.scan(ast.program())?;
+  } = scan_result;
   // If a export symbol in commonjs defined in multiple time, we just bailout treeshake it.
   for (k, v) in commonjs_exports {
     if v.len() == 1 {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -234,19 +234,22 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
     // Always respect annotations in the runtime module, regardless of user config.
     // The runtime is trusted internal code.
     let runtime_flat_options = self.flat_options - FlatOptions::IgnoreAnnotations;
-    let scanner = AstScanner::new(
-      self.module_idx,
-      scoping,
-      "rolldown_runtime",
-      ModuleDefFormat::EsmMjs,
-      source,
-      &facade_path,
-      ast.comments(),
-      &self.ctx.options,
-      ast.allocator(),
-      runtime_flat_options,
-    );
-    let scan_result = scanner.scan(ast.program())?;
+    let scan_result = ast.program.with_mut(|fields| {
+      let program = &*fields.program;
+      let scanner = AstScanner::new(
+        self.module_idx,
+        scoping,
+        "rolldown_runtime",
+        ModuleDefFormat::EsmMjs,
+        source,
+        &facade_path,
+        &program.comments,
+        &self.ctx.options,
+        fields.allocator,
+        runtime_flat_options,
+      );
+      scanner.scan(program)
+    })?;
 
     Ok((ast, scan_result))
   }

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -45,10 +45,6 @@ impl EcmaAst {
     &self.program.borrow_owner().source
   }
 
-  pub fn allocator(&self) -> &Allocator {
-    &self.program.borrow_owner().allocator
-  }
-
   pub fn program(&self) -> &Program<'_> {
     &self.program.borrow_dependent().program
   }
@@ -65,7 +61,7 @@ impl EcmaAst {
     let program = ProgramCell::new(
       ProgramCellOwner {
         source: self.source().clone(),
-        allocator: Allocator::with_capacity(self.allocator().used_bytes()),
+        allocator: Allocator::with_capacity(self.program.borrow_owner().allocator.used_bytes()),
       },
       |owner| {
         let program = self.program().clone_in_with_semantic_ids(&owner.allocator);
@@ -88,5 +84,27 @@ impl Default for EcmaAst {
   }
 }
 
+// SAFETY: The `Allocator` (bumpalo `Bump`) is `Send` and the entire arena
+// moves with the `EcmaAst`. `Program<'static>` contains `NonNull` pointers
+// (via `oxc::allocator::Box`), but they all point into the bundled
+// `Allocator`, which moves alongside.
 unsafe impl Send for EcmaAst {}
+
+// SAFETY: `oxc::allocator::Allocator` is `!Sync` because allocation mutates
+// internal `Cell`s through `&self`. We assert `Sync` here under the
+// invariant: **the same `EcmaAst` must not have its bumpalo arena mutated
+// while another thread holds a shared reference to that `EcmaAst`**.
+//
+// This invariant is *not* fully enforced by the type system: `EcmaAst.program`
+// is `pub`, and `ProgramCell::borrow_owner` / `with_dependent` expose
+// `&ProgramCellOwner`, whose `allocator` field is `pub` — so safe code
+// holding `&EcmaAst` can construct an `oxc::ast::AstBuilder` that allocates
+// into the arena.
+//
+// [`ProgramCell::with_mut`] is the preferred access pattern because its
+// `&mut self` receiver makes the invariant statically checkable. Code that
+// reaches the allocator through `borrow_owner().allocator` must provide its
+// own synchronization or otherwise prove that each thread operates on a
+// distinct `EcmaAst` (for example, parallel chunk passes that index distinct
+// entries in `ast_table`).
 unsafe impl Sync for EcmaAst {}


### PR DESCRIPTION
Stacked on #9276.

Closed https://github.com/rolldown/rolldown/issues/9242

Replaces `EcmaAst::allocator(&self) -> &Allocator` with `with_fields(&mut self, |fields| ...)`, a closure-based accessor that bundles read-only access to `source`/`source_type`/`allocator`/`comments`/`program`. The `&mut self` receiver makes the soundness invariant of `unsafe impl Sync for EcmaAst` locally checkable.

## Why

`oxc::allocator::Allocator` is `!Sync` (it holds `Cell<NonNull<u8>>` and `Cell<Option<NonNull<ChunkFooter>>>` for bumpalo''s bump pointer). The `unsafe impl Sync for EcmaAst {}` is sound only by convention: `&EcmaAst` is treated as read-only at runtime. But `pub fn allocator(&self) -> &Allocator` punched a hole in that — anyone with a shared `&EcmaAst` (e.g., a rayon `par_iter` worker) could call `ast.allocator()` and then `Allocator::alloc` (which mutates internal `Cell`s through `&self`), racing with another worker.

`Sync` cannot be removed — it''s required by parallel chunk rendering in `render_chunk_to_assets.rs` and indirectly by `anyhow::Error::new(SendError<ModuleLoaderMsg>)` in `file_emitter.rs`. So the goal is to make the unsoundness statically harder to reach.

## Changes

- `EcmaAst::with_fields(&mut self, |fields| ...)` is the only public way to obtain `&Allocator`. Built on the existing `ProgramCell::with_mut`, reborrowed `&mut Program → &Program`.
- `pub fn allocator(&self)` removed. The 3 callers all migrate cleanly:
  - `clone_with_another_arena` reads `self.program.borrow_owner().allocator.used_bytes()` directly.
  - `ecma_module_view_factory::create_ecma_view` wraps the `AstScanner::new` + `scanner.scan` block in `ast.with_fields(...)`.
  - `runtime_module_task::make_ecma_ast` does the same.
- `unsafe impl Send for EcmaAst {}` and `unsafe impl Sync for EcmaAst {}` now have `// SAFETY:` blocks spelling out the invariant and naming the call sites that depend on `Sync`.

## Verification

- `cargo check --workspace --all-targets` clean.
- `cargo clippy --workspace --all-targets -- --deny warnings` clean.
- `cargo test -p rolldown --test integration -- --skip ''hmr''` — all 1666 non-HMR integration tests pass.
- `rg -n ''ast\.allocator\(\)'' crates/` — zero results.