### PR TITLE
docs: restructure top navigation around Learn vs Reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,7 +8,7 @@ import { addOgImage } from 'vitepress-plugin-og';
 import { graphvizMarkdownPlugin } from 'vitepress-plugin-graphviz';
 import { createHooksGraphProcessor } from './markdown-hooks-graph.ts';
 
-const sidebarForUserGuide: DefaultTheme.SidebarItem[] = [
+const sidebarForGuide: DefaultTheme.SidebarItem[] = [
   {
     text: 'Guide',
     items: [
@@ -22,9 +22,47 @@ const sidebarForUserGuide: DefaultTheme.SidebarItem[] = [
     ],
   },
   {
-    text: 'APIs',
+    text: 'In-Depth',
+    collapsed: true,
     items: [
-      { text: 'Configuration Options', link: '/reference' },
+      { text: 'Why Bundlers', link: '/in-depth/why-bundlers.md' },
+      {
+        text: 'Why Plugin Hook Filter',
+        link: '/in-depth/why-plugin-hook-filter.md',
+      },
+      { text: 'Module Types', link: '/in-depth/module-types.md' },
+      { text: 'External Modules', link: '/in-depth/external-modules.md' },
+      { text: 'Directives', link: '/in-depth/directives.md' },
+      { text: 'Automatic Code Splitting', link: '/in-depth/automatic-code-splitting.md' },
+      { text: 'Manual Code Splitting', link: '/in-depth/manual-code-splitting.md' },
+      { text: 'Bundling CJS', link: '/in-depth/bundling-cjs.md' },
+      {
+        text: 'Non ESM Output Formats',
+        link: '/in-depth/non-esm-output-formats.md',
+      },
+      { text: 'Top Level Await', link: '/in-depth/tla-in-rolldown.md' },
+      { text: 'Dead Code Elimination', link: '/in-depth/dead-code-elimination.md' },
+      { text: 'Lazy Barrel Optimization', link: '/in-depth/lazy-barrel-optimization.md' },
+      { text: 'Native MagicString', link: '/in-depth/native-magic-string.md' },
+    ],
+  },
+  {
+    text: 'Glossary',
+    collapsed: true,
+    items: [
+      { text: 'Barrel Module', link: '/glossary/barrel-module.md' },
+      { text: 'Entry', link: '/glossary/entry.md' },
+      { text: 'Entry Chunk', link: '/glossary/entry-chunk.md' },
+      { text: 'Entry Name', link: '/glossary/entry-name.md' },
+      { text: 'User-defined Entry', link: '/glossary/user-defined-entry.md' },
+    ],
+  },
+];
+
+const sidebarForApi: DefaultTheme.SidebarItem[] = [
+  {
+    text: 'API',
+    items: [
       { text: 'Bundler API', link: '/apis/bundler-api.md' },
       {
         text: 'Plugin API',
@@ -42,8 +80,11 @@ const sidebarForUserGuide: DefaultTheme.SidebarItem[] = [
       { text: 'Command Line Interface', link: '/apis/cli.md' },
     ],
   },
+];
+
+const sidebarForPlugins: DefaultTheme.SidebarItem[] = [
   {
-    text: 'Builtin Plugins',
+    text: 'Built-in Plugins',
     items: [
       {
         text: 'Introduction',
@@ -57,33 +98,6 @@ const sidebarForUserGuide: DefaultTheme.SidebarItem[] = [
         text: 'builtin:replace',
         link: '/builtin-plugins/replace.md',
       },
-    ],
-  },
-];
-
-const sidebarForInDepth: DefaultTheme.SidebarItem[] = [
-  {
-    text: 'In-Depth',
-    items: [
-      { text: 'Why Bundlers', link: '/in-depth/why-bundlers.md' },
-      { text: 'Module Types', link: '/in-depth/module-types.md' },
-      { text: 'Top Level Await', link: '/in-depth/tla-in-rolldown.md' },
-      { text: 'Automatic Code Splitting', link: '/in-depth/automatic-code-splitting.md' },
-      { text: 'Manual Code Splitting', link: '/in-depth/manual-code-splitting.md' },
-      { text: 'Bundling CJS', link: '/in-depth/bundling-cjs.md' },
-      {
-        text: 'Non ESM Output Formats',
-        link: '/in-depth/non-esm-output-formats.md',
-      },
-      { text: 'Dead Code Elimination', link: '/in-depth/dead-code-elimination.md' },
-      { text: 'Lazy Barrel Optimization', link: '/in-depth/lazy-barrel-optimization.md' },
-      { text: 'Native MagicString', link: '/in-depth/native-magic-string.md' },
-      {
-        text: 'Why Plugin Hook Filter',
-        link: '/in-depth/why-plugin-hook-filter.md',
-      },
-      { text: 'External Modules', link: '/in-depth/external-modules.md' },
-      { text: 'Directives', link: '/in-depth/directives.md' },
     ],
   },
 ];
@@ -198,19 +212,6 @@ const sidebarForDevGuide: DefaultTheme.SidebarItem[] = [
   },
 ];
 
-const sidebarForGlossary: DefaultTheme.SidebarItem[] = [
-  {
-    text: 'Glossary',
-    items: [
-      { text: 'Barrel Module', link: '/glossary/barrel-module.md' },
-      { text: 'Entry', link: '/glossary/entry.md' },
-      { text: 'Entry Chunk', link: '/glossary/entry-chunk.md' },
-      { text: 'Entry Name', link: '/glossary/entry-name.md' },
-      { text: 'User-defined Entry', link: '/glossary/user-defined-entry.md' },
-    ],
-  },
-];
-
 const sidebarForResources: DefaultTheme.SidebarItem[] = [
   {
     text: 'Team',
@@ -292,27 +293,21 @@ const config = defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       {
-        text: 'Docs',
-        activeMatch: '/(guide|in-depth|glossary|apis|builtin-plugins)',
-        items: [
-          {
-            text: 'Guide',
-            activeMatch: '/(guide|apis|builtin-plugins)',
-            link: '/guide/getting-started.md',
-          },
-          {
-            text: 'In-Depth',
-            activeMatch: '/in-depth',
-            link: '/in-depth/why-bundlers.md',
-          },
-          {
-            text: 'Glossary',
-            activeMatch: '/glossary',
-            link: '/glossary/',
-          },
-        ],
+        text: 'Guide',
+        activeMatch: '/(guide|in-depth|glossary)',
+        link: '/guide/getting-started.md',
       },
-      { text: 'Options & APIs', activeMatch: '/reference', link: '/reference' },
+      { text: 'Reference', activeMatch: '/reference', link: '/reference' },
+      {
+        text: 'Plugins',
+        activeMatch: '/builtin-plugins',
+        link: '/builtin-plugins/',
+      },
+      {
+        text: 'API',
+        activeMatch: '/apis',
+        link: '/apis/bundler-api.md',
+      },
       { text: 'REPL', link: 'https://repl.rolldown.rs/' },
       {
         text: 'Resources',
@@ -320,35 +315,38 @@ const config = defineConfig({
         items: [
           {
             text: 'Team',
-            activeMatch: '/(team|acknowledgements)',
+            activeMatch: '/team',
             link: '/team.md',
           },
           {
             text: 'Contribute',
             activeMatch: '/(contribution-guide|development-guide)',
-
             link: '/contribution-guide/',
           },
-
           {
             text: 'Roadmap',
             link: 'https://github.com/rolldown/rolldown/discussions/153',
+          },
+          {
+            text: 'Acknowledgements',
+            activeMatch: '/acknowledgements',
+            link: '/acknowledgements.md',
           },
         ],
       },
     ],
 
     sidebar: {
-      // --- Guide ---
-      '/guide/': sidebarForUserGuide,
-      '/apis/': sidebarForUserGuide,
-      '/builtin-plugins/': sidebarForUserGuide,
-      // --- In-Depth ---
-      '/in-depth/': sidebarForInDepth,
-      // --- Reference ---
+      // --- Guide (includes In-Depth and Glossary as collapsed sections) ---
+      '/guide/': sidebarForGuide,
+      '/in-depth/': sidebarForGuide,
+      '/glossary/': sidebarForGuide,
+      // --- Reference (options + typedoc dictionary) ---
       '/reference/': sidebarForReference,
-      // --- Glossary ---
-      '/glossary/': sidebarForGlossary,
+      // --- Plugins ---
+      '/builtin-plugins/': sidebarForPlugins,
+      // --- API ---
+      '/apis/': sidebarForApi,
       // --- Contribute ---
       '/contribution-guide/': sidebarForDevGuide,
       '/development-guide/': sidebarForDevGuide,
@@ -374,8 +372,9 @@ const config = defineConfig({
           title: 'Rolldown',
           items: [
             { text: 'Guide', link: '/guide/getting-started' },
-            { text: 'Options & APIs', link: '/reference' },
+            { text: 'Reference', link: '/reference' },
             { text: 'Plugins', link: '/builtin-plugins/' },
+            { text: 'API', link: '/apis/bundler-api' },
             { text: 'Contribute', link: '/contribution-guide/' },
             { text: 'REPL', link: 'https://repl.rolldown.rs/' },
           ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -315,7 +315,7 @@ const config = defineConfig({
         items: [
           {
             text: 'Team',
-            activeMatch: '/team',
+            activeMatch: '/(team|acknowledgements)',
             link: '/team.md',
           },
           {
@@ -326,11 +326,6 @@ const config = defineConfig({
           {
             text: 'Roadmap',
             link: 'https://github.com/rolldown/rolldown/discussions/153',
-          },
-          {
-            text: 'Acknowledgements',
-            activeMatch: '/acknowledgements',
-            link: '/acknowledgements.md',
           },
         ],
       },


### PR DESCRIPTION
## Summary

Restructures the docs site's top navigation so each top-level entry maps to a single user intent. The change is config-only: no markdown files are moved or renamed, no URLs change.

## Why

Audited the current nav and found a few issues that hurt discoverability and intuition:

1. **The "Docs" dropdown is a redundant wrapper.** Users had to click `Docs → Guide` to reach the entry-point doc; peer projects (Vite, Oxc) put `Guide` at the top level directly.
2. **"Options & APIs" conflates two different audiences.** Options are user-facing config; APIs are programmatic surfaces — and the page it linked to (`/reference/`) is the auto-generated typedoc dictionary, which is distinct from the narrative API guide under `/apis/`.
3. **Built-in Plugins and the programmatic/plugin API guide were buried.** Both were sub-sections inside the shared Guide sidebar (`sidebarForUserGuide`), invisible from the top nav. Plugin authors and integrators had to drill into Guide and scroll the sidebar to find them — a real discoverability gap given that plugins and programmatic API are core to Rolldown's value proposition.
4. **In-Depth was a separate sidebar context.** Navigating from `/guide/` to `/in-depth/` swapped the entire sidebar, even though the two are a continuous learning path.

## What changed

### Top navigation

| Before | After |
|---|---|
| Docs (dropdown: Guide / In-Depth / Glossary) | **Guide** |
| Options & APIs | **Reference** |
| REPL | **Plugins** |
| Resources (dropdown) | **API** |
| | REPL |
| | Resources (dropdown) |

The ordering follows the user journey from broad to specialized:

- **Guide** — narrative learning path: Getting Started → In-Depth → Glossary
- **Reference** — auto-generated dictionary of every option, function, interface, type
- **Plugins** — Rolldown's built-in plugins (product docs)
- **API** — programmatic usage: Bundler API, Plugin API (with sub-topics), CLI
- **REPL** — external link
- **Resources** — Team / Contribute / Roadmap

The Guide → Reference adjacency mirrors Vite and Rspack, where users learn the basics in Guide and then look up specific options in the second slot.

### Sidebars

- **Guide** absorbs In-Depth and Glossary as collapsed sections. Reading flows from `/guide/getting-started` through `/in-depth/*` to `/glossary/*` without losing sidebar context.
- **In-Depth ordering** within the Guide sidebar: concept-style articles (Why Bundlers, Why Plugin Hook Filter, Module Types, External Modules, Directives) come first; feature deep-dives (code splitting, CJS bundling, TLA, DCE, lazy barrel, etc.) follow. The grouping is implicit through ordering, not split into separate sub-headers (avoids forcing users to identify "is this a concept or a feature?").
- **API**, **Plugins**, and **Reference** each get their own sidebar so the route's surrounding context matches its top-nav identity.
- The redundant `Configuration Options → /reference` entry inside the API sidebar is removed (Reference is now its own top-level entry).

### Footer

The "Rolldown" footer column is updated to mirror the new top-nav (`Guide · Reference · Plugins · API · Contribute · REPL`).

## What did NOT change

- No markdown files moved or renamed.
- All existing URLs (`/guide/*`, `/in-depth/*`, `/glossary/*`, `/apis/*`, `/builtin-plugins/*`, `/reference/*`) continue to resolve.
- `/reference/` content (auto-generated by typedoc) is untouched.
- The Resources dropdown items (Team / Contribute / Roadmap) and their `activeMatch` patterns are unchanged.
