### PR TITLE
docs: add Vite+ tab to getting-started snippets

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,6 +14,10 @@ For library bundling, check out [tsdown](https://tsdown.dev/).
 
 ::: code-group
 
+```sh [vp]
+$ vp add -D rolldown
+```
+
 ```sh [npm]
 $ npm install -D rolldown
 ```
@@ -129,9 +133,9 @@ $ node bundle.js
 
 You should see `Hello Rolldown!` printed.
 
-### Using the CLI in npm scripts
+### Adding a package.json build script
 
-To avoid typing the long command, we can move it inside an npm script:
+To avoid typing the long command, we can move it inside a `package.json` script:
 
 ```json{5} [package.json]
 {
@@ -148,9 +152,29 @@ To avoid typing the long command, we can move it inside an npm script:
 
 Now we can run the build with just:
 
-```sh
+::: code-group
+
+```sh [vp]
+$ vp run build
+```
+
+```sh [npm]
 $ npm run build
 ```
+
+```sh [pnpm]
+$ pnpm run build
+```
+
+```sh [yarn]
+$ yarn build
+```
+
+```sh [bun]
+$ bun run build
+```
+
+:::
 
 ## Using the Config File
 


### PR DESCRIPTION
## Summary

Updates the Getting Started page to feature Vite+ as a first-class option in the package-manager code groups, and renames the script section to drop npm-specific phrasing now that the same snippets list five package managers.

## Why

Two small inconsistencies on the Getting Started page:

1. **Vite+ was missing from the package-manager picker.** The install code group offered npm / pnpm / yarn / bun. With Vite+ in alpha (and the docs site already running a Vite+ banner), it should be available alongside the others — and ideally first, since `vp` is the recommended workflow going forward.
2. **The build step wasn't a code group at all** — it was a single `npm run build` snippet, which (a) broke the visual consistency with the install group above, and (b) implicitly suggested npm only.
3. **The heading "Using the CLI in npm scripts" was over-specific.** The `scripts` field is a `package.json` feature, universal across all PMs. Calling it "npm scripts" was colloquial, but inconsistent with a section that lists five PMs underneath. The heading also repeated its parent heading "Using the CLI".

## What changed

### Install code group (`### Installation`)

Added a `vp` tab as the first entry:

```sh
$ vp add -D rolldown
```

The four existing tabs (npm / pnpm / yarn / bun) are unchanged.

### Build snippet (`### Adding a package.json build script`)

Replaced this:

````md
```sh
$ npm run build
```
````

With a five-tab code group:

```
vp     →  $ vp run build
npm    →  $ npm run build
pnpm   →  $ pnpm run build
yarn   →  $ yarn build
bun    →  $ bun run build
```

`vp` first to mirror the install group.

### Heading and inline description

- Heading: `Using the CLI in npm scripts` → `Adding a package.json build script`
- Inline description: `we can move it inside an npm script` → `we can move it inside a \`package.json\` script`