### PR TITLE
fix(common): include offending index in HybridIndexVec panic message

### DIFF
--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -57,7 +57,12 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
   pub fn get_mut(&mut self, i: I) -> &mut T {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &mut index_vec[i],
-      HybridIndexVec::Map(map) => map.get_mut(&i).expect("should have idx"),
+      HybridIndexVec::Map(map) => {
+        let len = map.len();
+        map
+          .get_mut(&i)
+          .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={len})"))
+      }
     }
   }
 
@@ -66,7 +71,9 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
   pub fn get(&self, i: I) -> &T {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &index_vec[i],
-      HybridIndexVec::Map(map) => map.get(&i).expect("should have idx"),
+      HybridIndexVec::Map(map) => map
+        .get(&i)
+        .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={})", map.len())),
     }
   }
 

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -58,9 +58,7 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &mut index_vec[i],
       HybridIndexVec::Map(map) => {
-        if !map.contains_key(&i) {
-          panic!("HybridIndexVec::Map missing idx {i:?} (len={})", map.len());
-        }
+        assert!(map.contains_key(&i), "HybridIndexVec::Map missing idx {i:?} (len={})", map.len());
         map.get_mut(&i).unwrap()
       }
     }

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -58,8 +58,10 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &mut index_vec[i],
       HybridIndexVec::Map(map) => {
-        assert!(map.contains_key(&i), "HybridIndexVec::Map missing idx {i:?} (len={})", map.len());
-        map.get_mut(&i).unwrap()
+        let len = map.len();
+        map
+          .get_mut(&i)
+          .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={len})"))
       }
     }
   }

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -58,10 +58,10 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &mut index_vec[i],
       HybridIndexVec::Map(map) => {
-        let len = map.len();
-        map
-          .get_mut(&i)
-          .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={len})"))
+        if !map.contains_key(&i) {
+          panic!("HybridIndexVec::Map missing idx {i:?} (len={})", map.len());
+        }
+        map.get_mut(&i).unwrap()
       }
     }
   }


### PR DESCRIPTION
The bare `expect("should have idx")` at `crates/rolldown_common/src/types/hybrid_index_vec.rs:69` (and the `get_mut` sibling on line 60) gives zero diagnostic context. When users hit this panic — e.g. the intermittent Vite `bundledDev` branch-switch crash in #9293 — the report carries only "should have idx" and a stripped napi backtrace, so triage cannot proceed without local repro.

This patch includes the missing `Idx` (via the trait's existing `Debug` bound) and the current map length in both panic messages, so future bug reports include `idx N (len=M)` directly.

No behavior change on the success path; panic-only diagnostic improvement.

Refs #9293