### PR TITLE
feat(chunk-optimization): dedupe already-loaded dynamic deps

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -687,7 +687,7 @@ impl GenerateStage<'_> {
   /// new exports to the entry chunk. A module is safe to merge if:
   /// 1. It has no exports of its own (purely internal implementation code), OR
   /// 2. All its exports are already part of the entry's resolved exports (re-exported by the entry)
-  fn can_merge_without_changing_entry_signature(
+  pub(super) fn can_merge_without_changing_entry_signature(
     &self,
     chunk: &Chunk,
     modules: &[ModuleIdx],

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -845,6 +845,26 @@ impl GenerateStage<'_> {
       );
     }
 
+    let has_tla_or_tla_dependency =
+      self.link_output.metas.iter().any(|meta| meta.is_tla_or_contains_tla_dependency);
+    let allow_merge_common_chunks =
+      self.options.experimental.is_merge_common_chunks_enabled() && !has_tla_or_tla_dependency;
+    let allow_avoid_redundant_chunk_loads =
+      self.options.experimental.is_avoid_redundant_chunk_loads_enabled()
+        && !has_tla_or_tla_dependency;
+    // See meta/design/code-splitting.md#dynamic-already-loaded-analysis.
+    if allow_avoid_redundant_chunk_loads {
+      let entries_len: u32 = self
+        .link_output
+        .entries
+        .values()
+        .map(Vec::len)
+        .sum::<usize>()
+        .try_into()
+        .expect("Too many entries, u32 overflowed.");
+      self.optimize_dynamic_entry_bits(index_splitting_info, chunk_graph, entries_len);
+    }
+
     let mut module_is_assigned: IndexBitSet<ModuleIdx> =
       IndexBitSet::new(self.link_output.module_table.modules.len());
 
@@ -861,10 +881,8 @@ impl GenerateStage<'_> {
     // If it is allow to allow that entry chunks have the different exports as the underlying entry module.
     // This is used to generate less chunks when possible.
     // TODO: maybe we could bailout peer chunk?
-    let allow_chunk_optimization = self.options.experimental.is_chunk_optimization_enabled()
-      && !self.link_output.metas.iter().any(|meta| meta.is_tla_or_contains_tla_dependency);
     let mut temp_chunk_graph = ChunkOptimizationGraph::new(
-      allow_chunk_optimization,
+      allow_merge_common_chunks,
       chunk_graph,
       bits_to_chunk,
       &self.link_output.module_table,
@@ -898,14 +916,14 @@ impl GenerateStage<'_> {
           chunk_id,
           self.link_output.metas[normal_module.idx].depended_runtime_helper,
         );
-        if allow_chunk_optimization {
+        if allow_merge_common_chunks {
           temp_chunk_graph.add_module_to_chunk(
             normal_module.idx,
             chunk_id,
             &self.link_output.module_table,
           );
         }
-      } else if allow_chunk_optimization {
+      } else if allow_merge_common_chunks {
         temp_chunk_graph.init_module_assignment(
           normal_module.idx,
           bits,
@@ -928,7 +946,7 @@ impl GenerateStage<'_> {
       }
     }
 
-    if allow_chunk_optimization {
+    if allow_merge_common_chunks {
       temp_chunk_graph.calc_chunk_dependencies(&self.link_output.metas);
       self.try_insert_common_module_to_exist_chunk(
         chunk_graph,

--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -1,0 +1,480 @@
+use std::collections::VecDeque;
+
+use oxc_index::{IndexVec, index_vec};
+use rolldown_common::{
+  ChunkIdx, ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleIdx, PreserveEntrySignatures,
+  StmtInfoIdx,
+};
+use rolldown_utils::BitSet;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::chunk_graph::ChunkGraph;
+
+use super::{GenerateStage, code_splitting::IndexSplittingInfo};
+
+struct ChunkAtom {
+  modules: Vec<ModuleIdx>,
+  dependent_entries: BitSet,
+}
+
+struct DynamicEntryAnalysis {
+  dynamic_entry_indices: Vec<usize>,
+  dynamic_entry_modules_by_entry: Vec<Option<ModuleIdx>>,
+  dynamic_imports_by_entry: Vec<BitSet>,
+  dynamically_dependent_entries_by_dynamic_entry: Vec<BitSet>,
+}
+
+impl GenerateStage<'_> {
+  pub(super) fn optimize_dynamic_entry_bits(
+    &self,
+    index_splitting_info: &mut IndexSplittingInfo,
+    chunk_graph: &ChunkGraph,
+    entries_len: u32,
+  ) {
+    let DynamicEntryAnalysis {
+      dynamic_entry_indices,
+      dynamic_entry_modules_by_entry,
+      dynamic_imports_by_entry,
+      dynamically_dependent_entries_by_dynamic_entry,
+    } = self.analyze_dynamic_entries(index_splitting_info, entries_len);
+    if dynamic_entry_indices.is_empty() {
+      return;
+    }
+
+    let mut atoms = self.group_modules_by_dependent_entries(index_splitting_info);
+    if atoms.is_empty() {
+      return;
+    }
+    let module_to_atom_idx = self.compute_module_to_atom_idx(&atoms);
+    let atom_dependencies = self.compute_atom_dependencies(&atoms, &module_to_atom_idx);
+
+    let static_dependency_atoms_by_entry =
+      Self::compute_static_dependency_atoms_by_entry(entries_len as usize, &atoms);
+    let already_loaded_atoms_by_entry = Self::compute_already_loaded_atoms_by_entry(
+      &static_dependency_atoms_by_entry,
+      dynamically_dependent_entries_by_dynamic_entry,
+      &dynamic_imports_by_entry,
+      &dynamic_entry_indices,
+      atoms.len(),
+    );
+
+    let mut changed = false;
+    for atom_idx in 0..atoms.len() {
+      let original_dependent_entries = atoms[atom_idx].dependent_entries.clone();
+      let dependent_entries = atoms[atom_idx].dependent_entries.index_of_one().collect::<Vec<_>>();
+      let atom_bit: u32 = atom_idx.try_into().expect("Too many atoms, u32 overflowed.");
+      for entry_idx in dependent_entries {
+        if already_loaded_atoms_by_entry[entry_idx as usize].has_bit(atom_bit) {
+          atoms[atom_idx].dependent_entries.clear_bit(entry_idx);
+        }
+      }
+      if atoms[atom_idx].dependent_entries != original_dependent_entries
+        && self.can_use_reduced_dependent_entries(
+          &atoms[atom_idx],
+          &original_dependent_entries,
+          &atoms[atom_idx].dependent_entries,
+          chunk_graph,
+          &dynamic_entry_modules_by_entry,
+        )
+        && (!self.should_check_reduced_atom_static_cycle(
+          &original_dependent_entries,
+          &atoms[atom_idx].dependent_entries,
+          chunk_graph,
+        ) || !Self::reduced_atom_graph_has_static_cycle(&atoms, &atom_dependencies))
+      {
+        changed = true;
+      } else {
+        atoms[atom_idx].dependent_entries = original_dependent_entries;
+      }
+    }
+
+    if !changed {
+      return;
+    }
+
+    for atom in atoms {
+      let share_count = atom.dependent_entries.bit_count();
+      for module_idx in atom.modules {
+        index_splitting_info[module_idx].bits = atom.dependent_entries.clone();
+        index_splitting_info[module_idx].share_count = share_count;
+      }
+    }
+  }
+
+  fn can_use_reduced_dependent_entries(
+    &self,
+    atom: &ChunkAtom,
+    original_dependent_entries: &BitSet,
+    dependent_entries: &BitSet,
+    chunk_graph: &ChunkGraph,
+    dynamic_entry_modules_by_entry: &[Option<ModuleIdx>],
+  ) -> bool {
+    let bit_count = dependent_entries.bit_count();
+    if bit_count != 1 {
+      return bit_count > 1;
+    }
+
+    let Some(entry_bit) = dependent_entries.index_of_one().next() else {
+      return false;
+    };
+    let Some(chunk) = chunk_graph.chunk_table.get(ChunkIdx::from_raw(entry_bit)) else {
+      return false;
+    };
+
+    let can_merge_without_changing_entry_signature =
+      self.can_merge_without_changing_entry_signature(chunk, &atom.modules);
+    let is_runtime_only_atom = self.is_runtime_only_atom(atom);
+    let removed_entries_are_dynamic_entry_modules = Self::removed_entries_are_dynamic_entry_modules(
+      atom,
+      original_dependent_entries,
+      dependent_entries,
+      dynamic_entry_modules_by_entry,
+    );
+
+    if chunk.is_async_entry() {
+      return can_merge_without_changing_entry_signature
+        || is_runtime_only_atom
+        || removed_entries_are_dynamic_entry_modules;
+    }
+
+    !matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict))
+      || can_merge_without_changing_entry_signature
+      || is_runtime_only_atom
+      || removed_entries_are_dynamic_entry_modules
+  }
+
+  fn is_runtime_only_atom(&self, atom: &ChunkAtom) -> bool {
+    atom.modules.len() == 1 && atom.modules[0] == self.link_output.runtime.id()
+  }
+
+  fn removed_entries_are_dynamic_entry_modules(
+    atom: &ChunkAtom,
+    original_dependent_entries: &BitSet,
+    dependent_entries: &BitSet,
+    dynamic_entry_modules_by_entry: &[Option<ModuleIdx>],
+  ) -> bool {
+    let mut has_removed_dynamic_entry = false;
+    for removed_entry_idx in
+      original_dependent_entries.index_of_one().filter(|idx| !dependent_entries.has_bit(*idx))
+    {
+      let Some(dynamic_entry_module_idx) =
+        dynamic_entry_modules_by_entry.get(removed_entry_idx as usize).copied().flatten()
+      else {
+        return false;
+      };
+      has_removed_dynamic_entry = true;
+      if !atom.modules.contains(&dynamic_entry_module_idx) {
+        return false;
+      }
+    }
+    has_removed_dynamic_entry
+  }
+
+  fn should_check_reduced_atom_static_cycle(
+    &self,
+    original_dependent_entries: &BitSet,
+    dependent_entries: &BitSet,
+    chunk_graph: &ChunkGraph,
+  ) -> bool {
+    self.options.manual_code_splitting.is_some()
+      || original_dependent_entries.index_of_one().chain(dependent_entries.index_of_one()).any(
+        |entry_bit| {
+          chunk_graph.chunk_table.get(ChunkIdx::from_raw(entry_bit)).is_some_and(|chunk| {
+            matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict))
+          })
+        },
+      )
+  }
+
+  fn compute_module_to_atom_idx(&self, atoms: &[ChunkAtom]) -> IndexVec<ModuleIdx, Option<usize>> {
+    let mut module_to_atom_idx = index_vec![None; self.link_output.module_table.modules.len()];
+    for (atom_idx, atom) in atoms.iter().enumerate() {
+      for &module_idx in &atom.modules {
+        module_to_atom_idx[module_idx] = Some(atom_idx);
+      }
+    }
+    module_to_atom_idx
+  }
+
+  fn compute_atom_dependencies(
+    &self,
+    atoms: &[ChunkAtom],
+    module_to_atom_idx: &IndexVec<ModuleIdx, Option<usize>>,
+  ) -> Vec<Vec<usize>> {
+    atoms
+      .iter()
+      .enumerate()
+      .map(|(atom_idx, atom)| {
+        let mut dependencies = FxHashSet::default();
+        for &module_idx in &atom.modules {
+          for &dep_module_idx in &self.link_output.metas[module_idx].dependencies {
+            let Some(dep_atom_idx) = module_to_atom_idx[dep_module_idx] else {
+              continue;
+            };
+            if dep_atom_idx != atom_idx {
+              dependencies.insert(dep_atom_idx);
+            }
+          }
+        }
+        dependencies.into_iter().collect()
+      })
+      .collect()
+  }
+
+  fn reduced_atom_graph_has_static_cycle(
+    atoms: &[ChunkAtom],
+    atom_dependencies: &[Vec<usize>],
+  ) -> bool {
+    let mut chunk_idx_by_bits = FxHashMap::default();
+    let mut atom_to_chunk = Vec::with_capacity(atoms.len());
+    for atom in atoms {
+      let next_chunk_idx = chunk_idx_by_bits.len();
+      let chunk_idx = match chunk_idx_by_bits.entry(atom.dependent_entries.clone()) {
+        std::collections::hash_map::Entry::Occupied(occupied) => *occupied.get(),
+        std::collections::hash_map::Entry::Vacant(vacant) => {
+          vacant.insert(next_chunk_idx);
+          next_chunk_idx
+        }
+      };
+      atom_to_chunk.push(chunk_idx);
+    }
+
+    let mut chunk_dependencies = vec![FxHashSet::default(); chunk_idx_by_bits.len()];
+    for (atom_idx, dependencies) in atom_dependencies.iter().enumerate() {
+      let from_chunk_idx = atom_to_chunk[atom_idx];
+      for &dep_atom_idx in dependencies {
+        let to_chunk_idx = atom_to_chunk[dep_atom_idx];
+        if from_chunk_idx != to_chunk_idx {
+          chunk_dependencies[from_chunk_idx].insert(to_chunk_idx);
+        }
+      }
+    }
+
+    Self::chunk_dependency_graph_has_cycle(&chunk_dependencies)
+  }
+
+  fn chunk_dependency_graph_has_cycle(chunk_dependencies: &[FxHashSet<usize>]) -> bool {
+    let mut state = vec![0_u8; chunk_dependencies.len()];
+    for start_chunk_idx in 0..chunk_dependencies.len() {
+      if state[start_chunk_idx] != 0 {
+        continue;
+      }
+
+      let mut stack = vec![(start_chunk_idx, false)];
+      while let Some((chunk_idx, exiting)) = stack.pop() {
+        if exiting {
+          state[chunk_idx] = 2;
+          continue;
+        }
+
+        match state[chunk_idx] {
+          1 => return true,
+          2 => continue,
+          _ => {}
+        }
+
+        state[chunk_idx] = 1;
+        stack.push((chunk_idx, true));
+        for &dep_chunk_idx in &chunk_dependencies[chunk_idx] {
+          match state[dep_chunk_idx] {
+            1 => return true,
+            0 => stack.push((dep_chunk_idx, false)),
+            _ => {}
+          }
+        }
+      }
+    }
+
+    false
+  }
+
+  fn analyze_dynamic_entries(
+    &self,
+    index_splitting_info: &IndexSplittingInfo,
+    entries_len: u32,
+  ) -> DynamicEntryAnalysis {
+    let entries_count = entries_len as usize;
+    let mut dynamic_entry_indices = vec![];
+    let mut dynamic_entry_modules_by_entry = vec![None; entries_count];
+    let mut dynamic_imports_by_entry = vec![BitSet::new(entries_len); entries_count];
+    let mut dynamically_dependent_entries_by_dynamic_entry =
+      vec![BitSet::new(entries_len); entries_count];
+
+    for (dynamic_entry_idx, (dynamic_entry_module_idx, entry_point)) in self
+      .link_output
+      .entries
+      .iter()
+      .flat_map(|(&idx, entries)| entries.iter().map(move |entry| (idx, entry)))
+      .enumerate()
+    {
+      if !entry_point.kind.is_dynamic_import() {
+        continue;
+      }
+
+      dynamic_entry_indices.push(dynamic_entry_idx);
+      dynamic_entry_modules_by_entry[dynamic_entry_idx] = Some(dynamic_entry_module_idx);
+      let dynamic_entry_bit: u32 =
+        dynamic_entry_idx.try_into().expect("Too many entries, u32 overflowed.");
+
+      for (importer_idx, stmt_info_idx, _address, import_record_idx) in
+        &entry_point.related_stmt_infos
+      {
+        if !self.is_included_dynamic_import_record(
+          *importer_idx,
+          *stmt_info_idx,
+          *import_record_idx,
+          dynamic_entry_module_idx,
+        ) {
+          continue;
+        }
+
+        for importer_entry_idx in index_splitting_info[*importer_idx].bits.index_of_one() {
+          dynamically_dependent_entries_by_dynamic_entry[dynamic_entry_idx]
+            .set_bit(importer_entry_idx);
+          dynamic_imports_by_entry[importer_entry_idx as usize].set_bit(dynamic_entry_bit);
+        }
+      }
+    }
+
+    DynamicEntryAnalysis {
+      dynamic_entry_indices,
+      dynamic_entry_modules_by_entry,
+      dynamic_imports_by_entry,
+      dynamically_dependent_entries_by_dynamic_entry,
+    }
+  }
+
+  fn is_included_dynamic_import_record(
+    &self,
+    importer_idx: ModuleIdx,
+    stmt_info_idx: StmtInfoIdx,
+    import_record_idx: ImportRecordIdx,
+    dynamic_entry_module_idx: ModuleIdx,
+  ) -> bool {
+    if !self.link_output.metas[importer_idx].stmt_info_included.has_bit(stmt_info_idx) {
+      return false;
+    }
+
+    let Some(importer) = self.link_output.module_table[importer_idx].as_normal() else {
+      return false;
+    };
+    let Some(import_record) = importer.import_records.get(import_record_idx) else {
+      return false;
+    };
+
+    import_record.kind == ImportKind::DynamicImport
+      && import_record.resolved_module == Some(dynamic_entry_module_idx)
+      && !import_record.meta.contains(ImportRecordMeta::DeadDynamicImport)
+  }
+
+  fn group_modules_by_dependent_entries(
+    &self,
+    index_splitting_info: &IndexSplittingInfo,
+  ) -> Vec<ChunkAtom> {
+    let mut atoms = vec![];
+    let mut bits_to_atom_idx = FxHashMap::default();
+    for module_idx in &self.link_output.sorted_modules {
+      let Some(normal_module) = self.link_output.module_table[*module_idx].as_normal() else {
+        continue;
+      };
+      if !self.link_output.metas[normal_module.idx].is_included {
+        continue;
+      }
+
+      let bits = &index_splitting_info[normal_module.idx].bits;
+      if bits.is_empty() {
+        continue;
+      }
+
+      let atom_idx = match bits_to_atom_idx.entry(bits.clone()) {
+        std::collections::hash_map::Entry::Occupied(occupied) => *occupied.get(),
+        std::collections::hash_map::Entry::Vacant(vacant) => {
+          let atom_idx = atoms.len();
+          atoms.push(ChunkAtom { modules: vec![], dependent_entries: bits.clone() });
+          *vacant.insert(atom_idx)
+        }
+      };
+      atoms[atom_idx].modules.push(normal_module.idx);
+    }
+    atoms
+  }
+
+  fn compute_static_dependency_atoms_by_entry(
+    entries_count: usize,
+    atoms: &[ChunkAtom],
+  ) -> Vec<BitSet> {
+    let atom_count: u32 = atoms.len().try_into().expect("Too many atoms, u32 overflowed.");
+    let mut static_dependency_atoms_by_entry = vec![BitSet::new(atom_count); entries_count];
+    for (atom_idx, atom) in atoms.iter().enumerate() {
+      let atom_bit: u32 = atom_idx.try_into().expect("Too many atoms, u32 overflowed.");
+      for entry_idx in atom.dependent_entries.index_of_one() {
+        static_dependency_atoms_by_entry[entry_idx as usize].set_bit(atom_bit);
+      }
+    }
+    static_dependency_atoms_by_entry
+  }
+
+  fn compute_already_loaded_atoms_by_entry(
+    static_dependency_atoms_by_entry: &[BitSet],
+    mut dynamically_dependent_entries_by_dynamic_entry: Vec<BitSet>,
+    dynamic_imports_by_entry: &[BitSet],
+    dynamic_entry_indices: &[usize],
+    atom_count: usize,
+  ) -> Vec<BitSet> {
+    let entries_count = static_dependency_atoms_by_entry.len();
+    let atom_count: u32 = atom_count.try_into().expect("Too many atoms, u32 overflowed.");
+    let mut is_dynamic_entry = vec![false; entries_count];
+    for &dynamic_entry_idx in dynamic_entry_indices {
+      is_dynamic_entry[dynamic_entry_idx] = true;
+    }
+
+    let mut already_loaded_atoms_by_entry = is_dynamic_entry
+      .iter()
+      .map(|is_dynamic| if *is_dynamic { BitSet::all(atom_count) } else { BitSet::new(atom_count) })
+      .collect::<Vec<_>>();
+
+    let mut queued = vec![false; entries_count];
+    let mut queue = VecDeque::new();
+    for &dynamic_entry_idx in dynamic_entry_indices {
+      if !dynamically_dependent_entries_by_dynamic_entry[dynamic_entry_idx].is_empty() {
+        queued[dynamic_entry_idx] = true;
+        queue.push_back(dynamic_entry_idx);
+      }
+    }
+
+    while let Some(dynamic_entry_idx) = queue.pop_front() {
+      queued[dynamic_entry_idx] = false;
+      let known_loaded_atoms = already_loaded_atoms_by_entry[dynamic_entry_idx].clone();
+      let mut updated_loaded_atoms = known_loaded_atoms.clone();
+
+      for importer_entry_idx in
+        dynamically_dependent_entries_by_dynamic_entry[dynamic_entry_idx].index_of_one()
+      {
+        let importer_entry_idx = importer_entry_idx as usize;
+        let mut importer_loaded_atoms =
+          static_dependency_atoms_by_entry[importer_entry_idx].clone();
+        importer_loaded_atoms.union(&already_loaded_atoms_by_entry[importer_entry_idx]);
+        updated_loaded_atoms.intersect(&importer_loaded_atoms);
+      }
+
+      if updated_loaded_atoms == known_loaded_atoms {
+        continue;
+      }
+
+      already_loaded_atoms_by_entry[dynamic_entry_idx] = updated_loaded_atoms;
+      let dynamic_entry_bit: u32 =
+        dynamic_entry_idx.try_into().expect("Too many entries, u32 overflowed.");
+      for next_dynamic_entry_idx in dynamic_imports_by_entry[dynamic_entry_idx].index_of_one() {
+        let next_dynamic_entry_idx = next_dynamic_entry_idx as usize;
+        dynamically_dependent_entries_by_dynamic_entry[next_dynamic_entry_idx]
+          .set_bit(dynamic_entry_bit);
+        if !queued[next_dynamic_entry_idx] {
+          queued[next_dynamic_entry_idx] = true;
+          queue.push_back(next_dynamic_entry_idx);
+        }
+      }
+    }
+
+    already_loaded_atoms_by_entry
+  }
+}

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -52,6 +52,7 @@ mod chunk_optimizer;
 mod code_splitting;
 mod compute_cross_chunk_links;
 mod detect_ineffective_dynamic_imports;
+mod dynamic_already_loaded;
 mod finalize_modules;
 mod manual_code_splitting;
 mod minify_chunks;

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as n, __commonJSMin as t };
-
-```
-
 ## cjs.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./main.js";
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "cjs";
@@ -27,10 +19,10 @@ export default require_cjs();
 ## main.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 var main_default = import("./cjs.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 //#endregion
-export { main_default as default };
+export { main_default as default, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/code_splitting/import_export_unicode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/import_export_unicode/artifacts.snap
@@ -1,9 +1,18 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: foo.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
 # Assets
 
-## foo.js
+## main.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -11,16 +20,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = /* @__PURE__ */ __exportAll({ "😈": () => devil });
 const devil = "devil";
 //#endregion
-export { foo_exports as n, devil as t };
-
-```
-
-## main.js
-
-```js
-import { t as devil } from "./foo.js";
 //#region main.js
-const moduleFoo = import("./foo.js").then((n) => n.n);
+const moduleFoo = Promise.resolve().then(() => foo_exports);
 //#endregion
 export { moduleFoo, devil as "😈" };
 

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -50,7 +50,7 @@ load();
 
 ```
 
-# Variant: disableChunkOptimization: [chunk_optimization: false]
+# Variant: disableChunkOptimization: [chunk_optimization: Bool(false)]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/_config.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension"
+  },
+  "configVariants": [
+    {
+      "_configName": "disableAvoidRedundantChunkLoads",
+      "chunkOptimization": {
+        "mergeCommonChunks": false,
+        "avoidRedundantChunkLoads": false
+      }
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/_test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+const sharedHost = chunks.find((chunk) => chunk.includes('"shared"'));
+const dynamicChunk = chunks.find((chunk) => chunk.includes('"dynamic"'));
+const disablesAvoidRedundantChunkLoads =
+  globalThis.__configName === 'disableAvoidRedundantChunkLoads';
+
+if (disablesAvoidRedundantChunkLoads) {
+  assert.strictEqual(jsFiles.length, 3, `Expected 3 chunks but got: ${jsFiles.join(', ')}`);
+} else {
+  assert.strictEqual(jsFiles.length, 2, `Expected 2 chunks but got: ${jsFiles.join(', ')}`);
+}
+
+assert(sharedHost, 'shared module should be emitted');
+assert(dynamicChunk, 'dynamic module should be emitted');
+if (disablesAvoidRedundantChunkLoads) {
+  assert(
+    !sharedHost.includes('"main"'),
+    'shared module should stay in its own chunk when redundant chunk-load avoidance is disabled',
+  );
+} else {
+  assert(
+    sharedHost.includes('"main"'),
+    'shared module should be grouped with the statically importing entry',
+  );
+}
+assert(
+  !dynamicChunk.includes('"shared"'),
+  'dynamic chunk should import the already-loaded shared module instead of duplicating its chunk',
+);

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/artifacts.snap
@@ -1,0 +1,74 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dynamic.js
+
+```js
+import { t as value } from "./main.js";
+//#region dynamic.js
+console.log("dynamic", value);
+const dynamic = value;
+//#endregion
+export { dynamic };
+
+```
+
+## main.js
+
+```js
+//#region shared.js
+console.log("shared");
+const value = "shared";
+//#endregion
+//#region main.js
+console.log("main", value);
+function load() {
+	return import("./dynamic.js");
+}
+//#endregion
+export { load, value as t };
+
+```
+
+# Variant: disableAvoidRedundantChunkLoads: [chunk_optimization: Options(ChunkOptimizationOptions { merge_common_chunks: false, avoid_redundant_chunk_loads: false })]
+
+## Assets
+
+### dynamic.js
+
+```js
+import { t as value } from "./shared.js";
+//#region dynamic.js
+console.log("dynamic", value);
+const dynamic = value;
+//#endregion
+export { dynamic };
+
+```
+
+### main.js
+
+```js
+import { t as value } from "./shared.js";
+//#region main.js
+console.log("main", value);
+function load() {
+	return import("./dynamic.js");
+}
+//#endregion
+export { load };
+
+```
+
+### shared.js
+
+```js
+//#region shared.js
+console.log("shared");
+const value = "shared";
+//#endregion
+export { value as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/dynamic.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/dynamic.js
@@ -1,0 +1,4 @@
+import { value } from './shared.js';
+
+console.log('dynamic', value);
+export const dynamic = value;

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/main.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/main.js
@@ -1,0 +1,6 @@
+import { value } from './shared.js';
+
+console.log('main', value);
+export function load() {
+  return import('./dynamic.js');
+}

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/shared.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/shared.js
@@ -1,0 +1,2 @@
+console.log('shared');
+export const value = 'shared';

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/_config.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main1",
+        "import": "./main1.js"
+      },
+      {
+        "name": "main2",
+        "import": "./main2.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": {
+      "chunkOptimization": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+
+assert.strictEqual(jsFiles.length, 5, `Expected 5 chunks but got: ${jsFiles.join(', ')}`);
+
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+assert(
+  chunks.some((chunk) => chunk.includes('"all"') && chunk.includes('"main1 and main2"')),
+  'dependency loaded by both static entries should regroup with the other static-only dependency',
+);
+assert(
+  chunks.some((chunk) => chunk.includes('"main1 and dynamic"')),
+  'dependency not already loaded for every dynamic importer should remain separate',
+);

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/artifacts.snap
@@ -1,0 +1,63 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dynamic.js
+
+```js
+import { t as value1 } from "./from-main-1-and-dynamic.js";
+import "./from-main-1-and-2.js";
+//#region dynamic.js
+console.log("dynamic", value1, "all");
+//#endregion
+
+```
+
+## from-main-1-and-2.js
+
+```js
+//#region from-all.js
+const value2 = "all";
+//#endregion
+//#region from-main-1-and-2.js
+const value3 = "main1 and main2";
+//#endregion
+export { value2 as n, value3 as t };
+
+```
+
+## from-main-1-and-dynamic.js
+
+```js
+//#region from-main-1-and-dynamic.js
+const value1 = "main1 and dynamic";
+//#endregion
+export { value1 as t };
+
+```
+
+## main1.js
+
+```js
+import { t as value1 } from "./from-main-1-and-dynamic.js";
+import { n as value2, t as value3 } from "./from-main-1-and-2.js";
+//#region main1.js
+console.log("main1", value1, "all", value3);
+import("./dynamic.js");
+//#endregion
+export { value1, value2, value3 };
+
+```
+
+## main2.js
+
+```js
+import { n as value2, t as value3 } from "./from-main-1-and-2.js";
+//#region main2.js
+console.log("main2", "all", value3);
+import("./dynamic.js");
+//#endregion
+export { value2, value3 };
+
+```

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/dynamic.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/dynamic.js
@@ -1,0 +1,5 @@
+import { value1 } from './from-main-1-and-dynamic.js';
+import { value2 } from './from-all.js';
+
+console.log('dynamic', value1, value2);
+export { value1, value2 };

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-all.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-all.js
@@ -1,0 +1,1 @@
+export const value2 = 'all';

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-main-1-and-2.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-main-1-and-2.js
@@ -1,0 +1,1 @@
+export const value3 = 'main1 and main2';

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-main-1-and-dynamic.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/from-main-1-and-dynamic.js
@@ -1,0 +1,1 @@
+export const value1 = 'main1 and dynamic';

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/main1.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/main1.js
@@ -1,0 +1,8 @@
+import { value1 } from './from-main-1-and-dynamic.js';
+import { value2 } from './from-all.js';
+import { value3 } from './from-main-1-and-2.js';
+
+console.log('main1', value1, value2, value3);
+import('./dynamic.js');
+
+export { value1, value2, value3 };

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/main2.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_multi_entry/main2.js
@@ -1,0 +1,7 @@
+import { value2 } from './from-all.js';
+import { value3 } from './from-main-1-and-2.js';
+
+console.log('main2', value2, value3);
+import('./dynamic.js');
+
+export { value2, value3 };

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
@@ -42,7 +42,7 @@ console.log(a, b);
 
 ```
 
-# Variant: [chunk_optimization: false]
+# Variant: [chunk_optimization: Bool(false)]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
@@ -52,7 +52,7 @@ console.log("dyn-entry");
 ## shared.js
 
 ```js
-//! Common Chunk: [Shared-By: entry-a.js, entry-b.js, dyn-entry.js]
+//! Common Chunk: [Shared-By: entry-a.js, entry-b.js]
 //#region shared.js
 console.log("shared");
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -3,24 +3,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __exportAll as r, __commonJSMin as t };
-
-```
-
 ## node0.js
 
 ```js
-import { n as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./node1.js";
 //#region node0.js
 var node_0;
 //#endregion
 __esmMin((() => {
 	globalThis.__acyclic_output_fuzz_0 = 0;
-	import("./node2.js").then((n) => (n.t(), n.n));
+	import("./node1.js");
 	node_0 = {};
 	node_0.value = 0;
 }))();
@@ -30,25 +22,8 @@ __esmMin((() => {
 ## node1.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
-import { t as init_node2 } from "./node2.js";
-//#region node1.cjs
-var require_node1 = /* @__PURE__ */ __commonJSMin(((exports) => {
-	globalThis.__acyclic_output_fuzz_1 = 1;
-	init_node2();
-	exports.node_1 = 1;
-}));
-//#endregion
-export default require_node1();
-
-```
-
-## node2.js
-
-```js
-import { n as __esmMin, r as __exportAll } from "./chunk.js";
-//#region node2.js
-var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
+var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
 var node_2;
 var init_node2 = __esmMin((() => {
 	globalThis.__acyclic_output_fuzz_2 = 2;
@@ -57,6 +32,14 @@ var init_node2 = __esmMin((() => {
 	node_2.value = 2;
 }));
 //#endregion
-export { node2_exports as n, init_node2 as t };
+//#region node1.cjs
+var require_node1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__acyclic_output_fuzz_1 = 1;
+	init_node2();
+	exports.node_1 = 1;
+}));
+//#endregion
+export default require_node1();
+export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
@@ -1,63 +1,47 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: repro1.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: repro2.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: repro3.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
 # Assets
 
 ## main.js
 
 ```js
-import { t as clear } from "./repro1.js";
-import { n as clear$1$1, t as clear$1 } from "./repro2.js";
-import { n as clear$1$2, r as clear$2$1, t as clear$2 } from "./repro3.js";
-//#region main.js
-var main_default = [
-	clear,
-	clear$1,
-	clear$1$1,
-	clear$2,
-	clear$1$2,
-	clear$2$1,
-	() => import("./repro1.js").then((n) => n.n).then(console.log),
-	() => import("./repro2.js").then((n) => n.r).then(console.log),
-	() => import("./repro3.js").then((n) => n.i).then(console.log)
-];
-//#endregion
-export { main_default as default };
-
-```
-
-## repro1.js
-
-```js
-import { t as __exportAll } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region repro1.js
-var repro1_exports = /* @__PURE__ */ __exportAll({ clear: () => clear });
-const clear = "repro1_clear";
+var repro1_exports = /* @__PURE__ */ __exportAll({ clear: () => clear$4 });
+const clear$4 = "repro1_clear";
 //#endregion
-export { repro1_exports as n, clear as t };
-
-```
-
-## repro2.js
-
-```js
-import { t as __exportAll } from "./rolldown-runtime.js";
 //#region repro2.js
 var repro2_exports = /* @__PURE__ */ __exportAll({
-	clear: () => clear,
-	clear$1: () => clear$1
+	clear: () => clear$3,
+	clear$1: () => clear$1$1
 });
-const clear$1 = "repro2_clear$1";
-const clear = "repro2_clear";
+const clear$1$1 = "repro2_clear$1";
+const clear$3 = "repro2_clear";
 //#endregion
-export { clear$1 as n, repro2_exports as r, clear as t };
-
-```
-
-## repro3.js
-
-```js
-import { t as __exportAll } from "./rolldown-runtime.js";
 //#region repro3.js
 var repro3_exports = /* @__PURE__ */ __exportAll({
 	clear: () => clear,
@@ -68,14 +52,19 @@ const clear$2 = "repro3_clear$2";
 const clear$1 = "repro3_clear$1";
 const clear = "repro3_clear";
 //#endregion
-export { repro3_exports as i, clear$1 as n, clear$2 as r, clear as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as t };
+//#region main.js
+var main_default = [
+	clear$4,
+	clear$3,
+	clear$1$1,
+	clear,
+	clear$1,
+	clear$2,
+	() => Promise.resolve().then(() => repro1_exports).then(console.log),
+	() => Promise.resolve().then(() => repro2_exports).then(console.log),
+	() => Promise.resolve().then(() => repro3_exports).then(console.log)
+];
+//#endregion
+export { main_default as default };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8252/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8252/artifacts.snap
@@ -20,19 +20,6 @@ export { main };
 
 ```
 
-## resolve.js
-
-```js
-//#region resolve.js
-const counter = new SomethingNew();
-function resolveJsFrom(base, id) {
-	return counter;
-}
-//#endregion
-export { resolveJsFrom as t };
-
-```
-
 ## sorter.js
 
 ```js
@@ -44,7 +31,12 @@ export { createSorter };
 ## sorter2.js
 
 ```js
-import { t as resolveJsFrom } from "./resolve.js";
+//#region resolve.js
+const counter = new SomethingNew();
+function resolveJsFrom(base, id) {
+	return counter;
+}
+//#endregion
 //#region sorting.js
 function sort(input) {
 	return resolveJsFrom(input, "some-pkg");
@@ -58,14 +50,14 @@ function createSorter() {
 	};
 }
 //#endregion
-export { createSorter as t };
+export { resolveJsFrom as n, createSorter as t };
 
 ```
 
 ## v3.js
 
 ```js
-import { t as resolveJsFrom } from "./resolve.js";
+import { n as resolveJsFrom } from "./sorter2.js";
 //#region v3.js
 function loadV3() {
 	return resolveJsFrom("v3-dir", "v3-config");

--- a/crates/rolldown/tests/rolldown/issues/8361/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8361/_test.mjs
@@ -1,7 +1,12 @@
-import assert from 'node:assert';
-import { t as require_cjs } from './dist/cjs.js';
+import path from 'node:path';
+import { assertNoStaticImportCycle } from '../../_test_helpers/find-static-cycle.mjs';
 
 // The bug was `__commonJSMin is not a function` due to circular static imports
 // caused by chunk optimization merging the runtime into the entry chunk.
-// Verify the CJS module loads correctly and __commonJSMin is callable.
-assert.strictEqual(require_cjs(), 42);
+// The exact chunk shape may change as long as generated entry chunks do not
+// contain circular static references.
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));
+
+// The original bug surfaced as `__commonJSMin is not a function` at runtime,
+// so importing the entry must not throw.
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/issues/8361/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361/artifacts.snap
@@ -10,48 +10,27 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```
 
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: cjs.js is dynamically imported by b.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
 # Assets
-
-## b.js
-
-```js
-import { n as __exportAll, r as __toESM } from "./chunk.js";
-//#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({});
-import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
-Promise.resolve().then(() => b_exports);
-//#endregion
-export { b_exports as t };
-
-```
-
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __toESM as r, __commonJSMin as t };
-
-```
-
-## cjs.js
-
-```js
-import { t as __commonJSMin } from "./chunk.js";
-//#region cjs.js
-var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = 42;
-}));
-//#endregion
-export { require_cjs as t };
-
-```
 
 ## main.js
 
 ```js
-import { t as require_cjs } from "./cjs.js";
-import "./b.js";
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = 42;
+}));
 require_cjs();
+var b_exports = /* @__PURE__ */ __exportAll({});
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
+Promise.resolve().then(() => b_exports);
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8361_2/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8361_2/_test.mjs
@@ -1,7 +1,12 @@
-import assert from 'node:assert';
-import { t as require_cjs } from './dist/cjs.js';
+import path from 'node:path';
+import { assertNoStaticImportCycle } from '../../_test_helpers/find-static-cycle.mjs';
 
 // The bug was `__commonJSMin is not a function` due to circular static imports
 // caused by chunk optimization merging the runtime into the entry chunk.
-// Verify the CJS module loads correctly and __commonJSMin is callable.
-assert.strictEqual(require_cjs(), 42);
+// The exact chunk shape may change as long as generated entry chunks do not
+// contain circular static references.
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));
+
+// The original bug surfaced as `__commonJSMin is not a function` at runtime,
+// so importing the entry must not throw.
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
@@ -6,66 +6,44 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INEFFECTIVE_DYNAMIC_IMPORT
 
 ```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: a.js is dynamically imported by b.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
 [INEFFECTIVE_DYNAMIC_IMPORT] Warning: b.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: cjs.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
 
 ```
 
 # Assets
 
-## a.js
-
-```js
-import { n as __exportAll } from "./chunk.js";
-import { t as require_cjs } from "./cjs.js";
-import "./b.js";
-//#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({});
-require_cjs();
-//#endregion
-export { a_exports as t };
-
-```
-
-## b.js
-
-```js
-import { n as __exportAll, r as __toESM } from "./chunk.js";
-//#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ foo2: () => foo2 });
-function foo2() {
-	import("./a.js").then((n) => n.t);
-	Promise.resolve().then(() => b_exports);
-}
-import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
-//#endregion
-export { b_exports as t };
-
-```
-
-## chunk.js
+## main.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __toESM as r, __commonJSMin as t };
-
-```
-
-## cjs.js
-
-```js
-import { t as __commonJSMin } from "./chunk.js";
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 42;
 }));
+require_cjs();
+var b_exports = /* @__PURE__ */ __exportAll({ foo2: () => foo2 });
+function foo2() {
+	Promise.resolve().then(() => a_exports);
+	Promise.resolve().then(() => b_exports);
+}
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
 //#endregion
-export { require_cjs as t };
-
-```
-
-## main.js
-
-```js
-import "./a.js";
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({});
+//#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8595/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8595/artifacts.snap
@@ -1,6 +1,22 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: plugins/babel.mjs is dynamically imported by tt.mjs but also statically imported by tt.mjs, dynamic import will not move module into another chunk.
+
+```
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: plugins/postcss.mjs is dynamically imported by tt.mjs but also statically imported by tt.mjs, dynamic import will not move module into another chunk.
+
+```
+
 # Assets
 
 ## acorn.js
@@ -16,25 +32,7 @@ export { acorn_default as default };
 ## babel.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
-//#region plugins/babel.mjs
-var babel_exports = /* @__PURE__ */ __exportAll({
-	default: () => Ks,
-	parsers: () => ra
-});
-var Ks = {};
-var ra = {};
-Ks.parsers = ra;
-//#endregion
-export { babel_exports as t };
-
-```
-
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as t };
+import "./tt.js";
 
 ```
 
@@ -101,21 +99,28 @@ export { meriyah_default as default };
 ## postcss.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
-//#region plugins/postcss.mjs
-var postcss_exports = /* @__PURE__ */ __exportAll({ default: () => _l });
-var _l = {};
-_l.parsers = {};
-//#endregion
-export { postcss_exports as t };
+import "./tt.js";
 
 ```
 
 ## tt.js
 
 ```js
-import { t as babel_exports } from "./babel.js";
-import { t as postcss_exports } from "./postcss.js";
+// HIDDEN [\0rolldown/runtime.js]
+//#region plugins/babel.mjs
+var babel_exports = /* @__PURE__ */ __exportAll({
+	default: () => Ks,
+	parsers: () => ra
+});
+var Ks = {};
+var ra = {};
+Ks.parsers = ra;
+//#endregion
+//#region plugins/postcss.mjs
+var postcss_exports = /* @__PURE__ */ __exportAll({ default: () => _l });
+var _l = {};
+_l.parsers = {};
+//#endregion
 //#region tt.mjs
 import("./babel.js");
 import("./flow.js");
@@ -135,6 +140,6 @@ import("prettier-plugin-astro");
 import("prettier-plugin-marko");
 const options = [postcss_exports, babel_exports];
 //#endregion
-export { a, options };
+export { a, Ks as n, options, ra as r, _l as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8989/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8989/_test.mjs
@@ -1,51 +1,14 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import assert from 'node:assert';
+import { assertNoStaticImportCycle } from '../../_test_helpers/find-static-cycle.mjs';
 
 // Regression for #8989: facade chunk elimination used to add a runtime-helper
 // edge from entry2 → the chunk hosting the runtime, while that host chunk
 // already had a forward path entry2 → entry3 → node4 → entry2, closing a cycle.
-//
-// After the fix, the runtime is peeled out of its co-located host and placed
-// into a leaf chunk (here, node4.js). Both helper consumers (entry2 + node4)
-// must reach helpers via forward-only edges; no chunk that imports helpers
-// from another chunk may have a static import edge in the opposite direction.
+// The exact chunk shape may change as long as generated entry chunks do not
+// contain circular static references.
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));
 
-const distDir = path.join(import.meta.dirname, 'dist');
-const read = (name) => fs.readFileSync(path.join(distDir, name), 'utf8');
-
-const entry1 = read('entry1.js');
-const entry2 = read('entry2.js');
-const entry3 = read('entry3.js');
-const node4 = read('node4.js');
-
-// node4 is the leaf runtime host: no static imports from any other chunk.
-assert(
-  !/^import .* from ".\/(entry|node)/m.test(node4),
-  'node4.js must be a leaf chunk (no static imports from sibling chunks)',
-);
-
-// node4 hosts the runtime helpers and exports __exportAll for consumers.
-assert(node4.includes('rolldown/runtime.js'), 'node4.js should host the runtime module');
-assert(
-  /export \{[^}]*__exportAll/.test(node4),
-  'node4.js should re-export __exportAll for the other consumer chunks',
-);
-
-// entry2 needs __exportAll for node2_exports namespace materialization and
-// must import it from node4 (the leaf), not the other way around.
-assert(
-  /import \{[^}]*__exportAll[^}]*\} from "\.\/node4\.js"/.test(entry2),
-  'entry2.js should import __exportAll from node4.js',
-);
-assert(!entry2.includes('from "./entry2.js"'), 'entry2.js should not self-import');
-
-// entry3 statically depends on node4 (re-export of node_4) — this is the
-// forward edge. It must NOT have any back-edge to entry2 that would let
-// node4 → entry2 close a cycle.
-assert(/from "\.\/node4\.js"/.test(entry3), 'entry3.js should statically import from node4.js');
-
-// entry1 transitively reaches entry2 and entry3, both of which are forward
-// edges away from node4 — so the static graph must remain acyclic.
-assert(/from "\.\/entry2\.js"/.test(entry1), 'entry1.js should import from entry2.js');
-assert(/from "\.\/entry3\.js"/.test(entry1), 'entry1.js should import from entry3.js');
+// Runtime smoke test — every entry chunk must load without throwing.
+for (const entry of ['entry0.js', 'entry1.js', 'entry2.js', 'entry3.js']) {
+  await import(`./dist/${entry}`);
+}

--- a/crates/rolldown/tests/rolldown/issues/8989/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8989/artifacts.snap
@@ -1,6 +1,15 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: node4.js is dynamically imported by node3.js but also statically imported by node3.js, dynamic import will not move module into another chunk.
+
+```
+
 # Assets
 
 ## entry0.js
@@ -35,8 +44,7 @@ export { node_1, node_3 as reexport_1_3, use_1_2 };
 ## entry2.js
 
 ```js
-import { r as __exportAll } from "./node4.js";
-import { node_3 } from "./entry3.js";
+import { node_3, t as __exportAll } from "./entry3.js";
 
 //#region node2.js
 var node2_exports = /* @__PURE__ */ __exportAll({
@@ -54,21 +62,6 @@ export { node_2, node_3 as reexport_2_3, node2_exports as t };
 ## entry3.js
 
 ```js
-import { n as node_4 } from "./node4.js";
-
-//#region node3.js
-globalThis.__acyclic_output_fuzz_3 = 3;
-import("./node4.js").then((n) => n.t);
-var node_3 = {};
-node_3.value = 3;
-
-//#endregion
-export { node_3, node_4 as reexport_3_4 };
-```
-
-## node4.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region node4.js
 var node4_exports = /* @__PURE__ */ __exportAll({ node_4: () => node_4 });
@@ -77,5 +70,12 @@ var node_4 = {};
 node_4.value = 4;
 
 //#endregion
-export { node_4 as n, __exportAll as r, node4_exports as t };
+//#region node3.js
+globalThis.__acyclic_output_fuzz_3 = 3;
+Promise.resolve().then(() => node4_exports);
+var node_3 = {};
+node_3.value = 3;
+
+//#endregion
+export { node_3, node_4 as reexport_3_4, __exportAll as t };
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/_test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { assertNoStaticImportCycle } from '../../../_test_helpers/find-static-cycle.mjs';
+
+// Static import cycles cause TDZ hazards or "X is not a function" runtime
+// errors. Dynamic `import(...)` cycles cross async boundaries and are fine.
+const distDir = path.join(import.meta.dirname, 'dist');
+assertNoStaticImportCycle(distDir);
+
+// Verify the dynamic-import chain resolves end-to-end and the re-exported
+// value is correct while preserving dynamic1's observable namespace.
+const dynamic1 = await import('./dist/dynamic1.js');
+assert.ok(dynamic1.promise instanceof Promise, 'dynamic1 should export a promise');
+const dynamic2 = await dynamic1.promise;
+assert.strictEqual(dynamic2.sharedDynamic, true);
+
+// Running the entry chunk must complete without throwing.
+const distMain = path.join(distDir, 'main.js');
+const stdout = execFileSync('node', [distMain], { encoding: 'utf-8' });
+assert.strictEqual(stdout.trim(), 'true');

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/5197/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/5197/artifacts.snap
@@ -1,27 +1,27 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Assets
+# warnings
 
-## bar.js
+## INEFFECTIVE_DYNAMIC_IMPORT
 
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region bar.mjs
-var bar_exports = /* @__PURE__ */ __exportAll({ default: () => "bar" });
-var bar_default = "bar";
-//#endregion
-export { bar_exports as n, bar_default as t };
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: bar.mjs is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
 
 ```
+
+# Assets
 
 ## main.js
 
 ```js
-import "./bar.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region bar.mjs
+var bar_exports = /* @__PURE__ */ __exportAll({ default: () => "bar" });
+//#endregion
 //#region main.js
-const glob = { "./bar.css": () => import("./bar.js").then((n) => n.n) };
+const glob = { "./bar.css": () => Promise.resolve().then(() => bar_exports) };
 assert.strictEqual({ "./bar.css": "bar" }["./bar.css"], "bar");
 //#endregion
 export { glob };

--- a/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
@@ -11,7 +11,7 @@ console.log("dynamic no-treeshake");
 //#endregion
 //#region dynamic.js
 const lazyLoad = async () => {
-	await import("./static.js").then((n) => n.t);
+	await import("./main.js");
 	document.body.classList.add("loaded");
 };
 //#endregion
@@ -22,25 +22,14 @@ export { lazyLoad };
 ## main.js
 
 ```js
-import "./static.js";
+//#endregion
+//#region static.no-treeshake.js
+console.log("static no-treeshake");
+//#endregion
 //#region main.js
 import("./dynamic.js").then(async ({ lazyLoad }) => {
 	await lazyLoad();
 });
 //#endregion
-
-```
-
-## static.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region static.no-treeshake.js
-console.log("static no-treeshake");
-//#endregion
-//#region static.js
-var static_exports = /* @__PURE__ */ __exportAll({ foo: () => "foo" });
-//#endregion
-export { static_exports as t };
 
 ```

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -12,7 +12,7 @@ pub struct BindingExperimentalOptions {
   pub on_demand_wrapping: Option<bool>,
   pub incremental_build: Option<bool>,
   pub native_magic_string: Option<bool>,
-  pub chunk_optimization: Option<bool>,
+  pub chunk_optimization: Option<Either<bool, BindingChunkOptimizationOptions>>,
   pub lazy_barrel: Option<bool>,
 }
 
@@ -33,9 +33,28 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
       }),
       on_demand_wrapping: value.on_demand_wrapping,
       native_magic_string: value.native_magic_string,
-      chunk_optimization: value.chunk_optimization,
+      chunk_optimization: value.chunk_optimization.map(|v| match v {
+        Either::A(v) => rolldown_common::ChunkOptimizationOption::Bool(v),
+        Either::B(v) => rolldown_common::ChunkOptimizationOption::Options(v.into()),
+      }),
       lazy_barrel: value.lazy_barrel,
     })
+  }
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug, Default)]
+pub struct BindingChunkOptimizationOptions {
+  pub merge_common_chunks: Option<bool>,
+  pub avoid_redundant_chunk_loads: Option<bool>,
+}
+
+impl From<BindingChunkOptimizationOptions> for rolldown_common::ChunkOptimizationOptions {
+  fn from(value: BindingChunkOptimizationOptions) -> Self {
+    Self {
+      merge_common_chunks: value.merge_common_chunks.unwrap_or(true),
+      avoid_redundant_chunk_loads: value.avoid_redundant_chunk_loads.unwrap_or(true),
+    }
   }
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -8,6 +8,60 @@ use super::chunk_import_map::ChunkImportMap;
 use super::chunk_modules_order::ChunkModulesOrderBy;
 use super::dev_mode_options::DevModeOptions;
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields, default)
+)]
+pub struct ChunkOptimizationOptions {
+  pub merge_common_chunks: bool,
+  pub avoid_redundant_chunk_loads: bool,
+}
+
+impl Default for ChunkOptimizationOptions {
+  fn default() -> Self {
+    Self { merge_common_chunks: true, avoid_redundant_chunk_loads: true }
+  }
+}
+
+impl ChunkOptimizationOptions {
+  pub fn is_merge_common_chunks_enabled(&self) -> bool {
+    self.merge_common_chunks
+  }
+
+  pub fn is_avoid_redundant_chunk_loads_enabled(&self) -> bool {
+    self.avoid_redundant_chunk_loads
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(untagged)
+)]
+pub enum ChunkOptimizationOption {
+  Bool(bool),
+  Options(ChunkOptimizationOptions),
+}
+
+impl ChunkOptimizationOption {
+  pub fn is_merge_common_chunks_enabled(&self) -> bool {
+    match self {
+      Self::Bool(enabled) => *enabled,
+      Self::Options(options) => options.is_merge_common_chunks_enabled(),
+    }
+  }
+
+  pub fn is_avoid_redundant_chunk_loads_enabled(&self) -> bool {
+    match self {
+      Self::Bool(enabled) => *enabled,
+      Self::Options(options) => options.is_avoid_redundant_chunk_loads_enabled(),
+    }
+  }
+}
+
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
@@ -24,7 +78,7 @@ pub struct ExperimentalOptions {
   pub chunk_modules_order: Option<ChunkModulesOrderBy>,
   pub on_demand_wrapping: Option<bool>,
   pub native_magic_string: Option<bool>,
-  pub chunk_optimization: Option<bool>,
+  pub chunk_optimization: Option<ChunkOptimizationOption>,
   pub lazy_barrel: Option<bool>,
 }
 
@@ -54,8 +108,18 @@ impl ExperimentalOptions {
     self.native_magic_string.unwrap_or(false)
   }
 
-  pub fn is_chunk_optimization_enabled(&self) -> bool {
-    self.chunk_optimization.unwrap_or(true)
+  pub fn is_merge_common_chunks_enabled(&self) -> bool {
+    self
+      .chunk_optimization
+      .as_ref()
+      .is_none_or(ChunkOptimizationOption::is_merge_common_chunks_enabled)
+  }
+
+  pub fn is_avoid_redundant_chunk_loads_enabled(&self) -> bool {
+    self
+      .chunk_optimization
+      .as_ref()
+      .is_none_or(ChunkOptimizationOption::is_avoid_redundant_chunk_loads_enabled)
   }
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -34,7 +34,9 @@ pub mod bundler_options {
       dev_mode_options::DevModeOptions,
       devtools_options::DevtoolsOptions,
       es_module_flag::EsModuleFlag,
-      experimental_options::ExperimentalOptions,
+      experimental_options::{
+        ChunkOptimizationOption, ChunkOptimizationOptions, ExperimentalOptions,
+      },
       filename_template::{FilenameTemplate, is_path_fragment},
       generated_code_options::GeneratedCodeOptions,
       hash_characters::HashCharacters,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1028,9 +1028,13 @@
           ]
         },
         "chunkOptimization": {
-          "type": [
-            "boolean",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChunkOptimizationOption"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "lazyBarrel": {
@@ -1111,6 +1115,30 @@
         "execOrder",
         "moduleId"
       ]
+    },
+    "ChunkOptimizationOption": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/ChunkOptimizationOptions"
+        }
+      ]
+    },
+    "ChunkOptimizationOptions": {
+      "type": "object",
+      "properties": {
+        "mergeCommonChunks": {
+          "type": "boolean",
+          "default": true
+        },
+        "avoidRedundantChunkLoads": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
     },
     "SimpleMinifyOptions": {
       "description": "A simple minify option that can be either a boolean or a string, used for rolldown rust testing.",
@@ -1906,9 +1934,13 @@
           ]
         },
         "chunkOptimization": {
-          "type": [
-            "boolean",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChunkOptimizationOption"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "_snapshot": {

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
-  AddonOutputOption, BundlerOptions, CodeSplittingMode, CommentsOptions, ExperimentalOptions,
-  InlineConstOption, OptimizationOption, OutputExports, OutputFormat, PreserveEntrySignatures,
-  StrictMode, TreeshakeOptions, deserialize_inline_const,
+  AddonOutputOption, BundlerOptions, ChunkOptimizationOption, CodeSplittingMode, CommentsOptions,
+  ExperimentalOptions, InlineConstOption, OptimizationOption, OutputExports, OutputFormat,
+  PreserveEntrySignatures, StrictMode, TreeshakeOptions, deserialize_inline_const,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -36,7 +36,7 @@ pub struct ConfigVariant {
   pub intro: Option<String>,
   pub outro: Option<String>,
   pub comments: Option<CommentsOptions>,
-  pub chunk_optimization: Option<bool>,
+  pub chunk_optimization: Option<ChunkOptimizationOption>,
   // --- non-bundler options are start with `_`
   /// Whether to include the output in the snapshot for this config variant.
   #[serde(rename = "_snapshot")]

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -10,6 +10,16 @@ impl BitSet {
     Self { entries: vec![0; max_bit_count.div_ceil(8) as usize] }
   }
 
+  pub fn all(max_bit_count: u32) -> Self {
+    let mut entries = vec![u8::MAX; max_bit_count.div_ceil(8) as usize];
+    if let Some(last) = entries.last_mut()
+      && !max_bit_count.is_multiple_of(8)
+    {
+      *last = (1_u8 << (max_bit_count % 8)) - 1;
+    }
+    Self { entries }
+  }
+
   pub fn has_bit(&self, bit: u32) -> bool {
     let idx = bit as usize / 8;
     if idx >= self.entries.len() {
@@ -41,6 +51,15 @@ impl BitSet {
   pub fn union(&mut self, other: &Self) {
     for (i, &e) in other.entries.iter().enumerate() {
       self.entries[i] |= e;
+    }
+  }
+
+  pub fn intersect(&mut self, other: &Self) {
+    for (left, right) in self.entries.iter_mut().zip(&other.entries) {
+      *left &= right;
+    }
+    if self.entries.len() > other.entries.len() {
+      self.entries[other.entries.len()..].fill(0);
     }
   }
 
@@ -144,6 +163,25 @@ mod tests {
     //
     bs.union(&bs2);
     assert_eq!(bs.to_string(), "10000001_10000011");
+  }
+
+  #[test]
+  fn all() {
+    assert_eq!(BitSet::all(0).to_string(), "");
+    assert_eq!(BitSet::all(1).to_string(), "00000001");
+    assert_eq!(BitSet::all(8).to_string(), "11111111");
+    assert_eq!(BitSet::all(9).to_string(), "00000001_11111111");
+  }
+
+  #[test]
+  fn intersect() {
+    let mut bs = BitSet::all(16);
+    let mut bs2 = BitSet::new(16);
+    bs2.set_bit(1);
+    bs2.set_bit(8);
+    bs2.set_bit(15);
+    bs.intersect(&bs2);
+    assert_eq!(bs.index_of_one().collect::<Vec<_>>(), vec![1, 8, 15]);
   }
 
   #[test]

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -72,6 +72,7 @@ ChunkGraph
 **Key files:**
 
 - `crates/rolldown/src/stages/generate_stage/code_splitting.rs` — pipeline orchestration, `generate_chunks()`, `ensure_lazy_module_initialization_order()`
+- `crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs` — Rollup-style dynamic import already-loaded atom reduction
 - `crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs` — merge/optimization
 - `crates/rolldown/src/chunk_graph.rs` — output data structure
 - `crates/rolldown_utils/src/bitset.rs` — compact reachability representation
@@ -92,6 +93,16 @@ Dynamic imports are treated as entry points — they get bit positions and entry
 External modules are filtered out at the source — they never appear in `link_output.entries`. This is done in `module_loader.rs` where dynamic imports are collected as entry points: external modules are excluded from `dynamic_import_entry_ids`. User-defined and emitted entries are also safe because `load_entry_module()` rejects external resolutions with `entry_cannot_be_external`. This matches esbuild's approach where external modules never enter the entry list, and ensures that **bit positions directly equal chunk indices** — `ChunkIdx::from_raw(bit_position)` is always valid.
 
 See #8595 for the bug that motivated this filtering.
+
+### Dynamic Already-Loaded Analysis
+
+Before chunk materialization, Rolldown can reduce dynamic-entry bits for modules that are guaranteed to be loaded by every importer of that dynamic entry. This pass is controlled separately from common-chunk merging via `experimental.chunkOptimization: { mergeCommonChunks, avoidRedundantChunkLoads }`. The boolean form remains a compatibility alias for enabling or disabling both optimizers, while the object form allows each pass to be controlled independently. For example, when `main` statically imports `shared`, dynamically imports `route`, and `route` also imports `shared`, the `route` bit is removed from `shared` before modules are grouped into chunks.
+
+The pass groups modules into temporary atoms by their current dependent-entry bitset, computes the static atoms loaded by each entry, then runs a fixed-point propagation over dynamic imports. A dynamic entry's already-loaded atoms are the intersection of the static and already-loaded atoms of all entries that can reach its included dynamic importers. Any atom already loaded for a dynamic entry can drop that dynamic entry bit, and modules are then regrouped by the reduced bitsets during normal chunk creation.
+
+When the reduced bitset would put an atom into a single dynamic-entry chunk, the pass preserves that dynamic entry's observable namespace. The reduction is accepted only if the atom has no extra exports, its exports are already part of the dynamic entry's signature, it is runtime-only, or it is the removed dynamic-entry module itself. Otherwise the atom stays separate so `import("./entry.js")` does not expose helper exports needed only by other chunks.
+
+Top-level-await refinements are intentionally not modeled here yet. The existing chunk optimizer still bails out globally when any included module is TLA or contains a TLA dependency, so the awaited-dynamic-import safety path remains future work.
 
 ## Reachability Propagation
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1889,6 +1889,11 @@ export declare enum BindingChunkModuleOrderBy {
   ExecOrder = 1
 }
 
+export interface BindingChunkOptimizationOptions {
+  mergeCommonChunks?: boolean
+  avoidRedundantChunkLoads?: boolean
+}
+
 export interface BindingClientHmrUpdate {
   clientId: string
   update: BindingHmrUpdate
@@ -2131,7 +2136,7 @@ export interface BindingExperimentalOptions {
   onDemandWrapping?: boolean
   incrementalBuild?: boolean
   nativeMagicString?: boolean
-  chunkOptimization?: boolean
+  chunkOptimization?: boolean | BindingChunkOptimizationOptions
   lazyBarrel?: boolean
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -37,6 +37,29 @@ export type ExternalOptionFunction = (
 /** @inline */
 export type ExternalOption = StringOrRegExp | StringOrRegExp[] | ExternalOptionFunction;
 
+export interface ChunkOptimizationOptions {
+  /**
+   * Merge common chunks into existing entry chunks when it is safe.
+   *
+   * This can reduce the number of emitted chunks by moving shared/common modules
+   * into an entry chunk that already depends on them. Rolldown only applies the
+   * merge when it does not create a circular chunk dependency or change strict
+   * entry export signatures. This pass also covers safe empty-facade cleanup.
+   *
+   * @default true
+   */
+  mergeCommonChunks?: boolean;
+  /**
+   * Avoid emitting redundant chunk loads for dynamic entries.
+   *
+   * This pass can reduce dynamic-entry dependent chunks when the shared modules
+   * are guaranteed to be loaded by every importer of that dynamic entry.
+   *
+   * @default true
+   */
+  avoidRedundantChunkLoads?: boolean;
+}
+
 export type ModuleTypes = Record<
   string,
   | 'js'
@@ -670,18 +693,18 @@ export interface InputOptions {
      */
     nativeMagicString?: boolean;
     /**
-     * Control whether to optimize chunks by allowing entry chunks to have different exports than the underlying entry module.
-     * This optimization can reduce the number of generated chunks.
+     * Control chunk optimizations.
      *
-     * When enabled, rolldown will try to insert common modules directly into existing chunks rather than creating
-     * separate chunks for them, which can result in fewer output files and better performance.
+     * `true` enables both common-chunk merging and redundant dynamic chunk-load avoidance.
+     * `false` disables all chunk optimizations. Use the object form to control
+     * `mergeCommonChunks` and `avoidRedundantChunkLoads` separately.
      *
-     * This optimization is automatically disabled when any module uses top-level await (TLA) or contains TLA dependencies,
-     * as it could affect execution order guarantees.
+     * These optimizations are automatically disabled when any module uses top-level await (TLA) or contains TLA dependencies,
+     * as they could affect execution order guarantees.
      *
      * @default true
      */
-    chunkOptimization?: boolean;
+    chunkOptimization?: boolean | ChunkOptimizationOptions;
     /**
      * Control whether to enable lazy barrel optimization.
      *

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -630,7 +630,15 @@ const InputOptionsSchema = v.strictObject({
       onDemandWrapping: v.optional(v.boolean()),
       incrementalBuild: v.optional(v.boolean()),
       nativeMagicString: v.optional(v.boolean()),
-      chunkOptimization: v.optional(v.boolean()),
+      chunkOptimization: v.optional(
+        v.union([
+          v.boolean(),
+          v.strictObject({
+            mergeCommonChunks: v.optional(v.boolean()),
+            avoidRedundantChunkLoads: v.optional(v.boolean()),
+          }),
+        ]),
+      ),
       lazyBarrel: v.optional(v.boolean()),
     }),
   ),

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
@@ -1,13 +1,29 @@
-import { t as a_exports } from "./a.js";
-import { t as b_exports } from "./b.js";
-import { n as name$2, t as modules_exports } from "./modules.js";
-import { t as a_default } from "./a2.js";
-import { t as b_default } from "./b2.js";
+import { t as __exportAll } from "./chunk.js";
+import { t as a_exports$1 } from "./a.js";
+import { t as b_exports$1 } from "./b.js";
+//#region ../fixtures/a/modules/index.ts
+var modules_exports = /* @__PURE__ */ __exportAll({
+	a: () => "a",
+	b: () => "b",
+	default: () => modules_default,
+	name: () => name
+});
+const name = "index";
+var modules_default = "indexDefault";
+//#endregion
+//#region ../fixtures/a/modules/a.ts?raw
+var a_exports = /* @__PURE__ */ __exportAll({ default: () => a_default });
+var a_default = "export const name = 'a';\n";
+//#endregion
+//#region ../fixtures/a/modules/b.ts?raw
+var b_exports = /* @__PURE__ */ __exportAll({ default: () => b_default });
+var b_default = "export const name = 'b';\n";
+//#endregion
 //#region ../fixtures/a/index.ts
 const basic = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t)
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports)
 });
 const basicWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -17,11 +33,11 @@ const basicWithObjectKeys = Object.keys({
 const basicWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t),
 	() => import("./b.js").then((n) => n.t),
-	() => import("./modules.js").then((n) => n.t)
+	() => Promise.resolve().then(() => modules_exports)
 ]);
 const basicEager = /* @__PURE__ */ Object.assign({
-	"./modules/a.ts": a_exports,
-	"./modules/b.ts": b_exports,
+	"./modules/a.ts": a_exports$1,
+	"./modules/b.ts": b_exports$1,
 	"./modules/index.ts": modules_exports
 });
 const basicEagerWithObjectKeys = Object.keys({
@@ -30,8 +46,8 @@ const basicEagerWithObjectKeys = Object.keys({
 	"./modules/index.ts": 0
 });
 const basicEagerWithObjectValues = Object.values([
-	a_exports,
-	b_exports,
+	a_exports$1,
+	b_exports$1,
 	modules_exports
 ]);
 const ignore = /* @__PURE__ */ Object.assign({
@@ -46,7 +62,7 @@ const ignoreWithObjectValues = Object.values([() => import("./a.js").then((n) =>
 const namedEager = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": "a",
 	"./modules/b.ts": "b",
-	"./modules/index.ts": name$2
+	"./modules/index.ts": name
 });
 const namedEagerWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -56,12 +72,12 @@ const namedEagerWithObjectKeys = Object.keys({
 const namedEagerWithObjectValues = Object.values([
 	"a",
 	"b",
-	name$2
+	name
 ]);
 const namedDefault = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t).then((m) => m["default"])
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports).then((m) => m["default"])
 });
 const namedDefaultWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -71,15 +87,15 @@ const namedDefaultWithObjectKeys = Object.keys({
 const namedDefaultWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	() => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	() => import("./modules.js").then((n) => n.t).then((m) => m["default"])
+	() => Promise.resolve().then(() => modules_exports).then((m) => m["default"])
 ]);
 const eagerAs = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_default,
 	"./modules/b.ts": b_default
 });
 const rawImportModule = /* @__PURE__ */ Object.assign({
-	"./modules/a.ts": () => import("./a2.js").then((n) => n.n),
-	"./modules/b.ts": () => import("./b2.js").then((n) => n.n)
+	"./modules/a.ts": () => Promise.resolve().then(() => a_exports),
+	"./modules/b.ts": () => Promise.resolve().then(() => b_exports)
 });
 const excludeSelf = /* @__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling.js") });
 const excludeSelfRaw = /* @__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling2.js") });
@@ -94,24 +110,24 @@ const cleverCwd1 = /* @__PURE__ */ Object.assign({ "./node_modules/framework/pag
 const cleverCwd2 = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"../b/a.ts": () => import("./a3.js"),
-	"../b/b.ts": () => import("./b3.js")
+	"../b/a.ts": () => import("./a2.js"),
+	"../b/b.ts": () => import("./b2.js")
 });
 const customBase = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t),
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports),
 	"./sibling.ts": () => import("./sibling.js")
 });
 const customRootBase = /* @__PURE__ */ Object.assign({
-	"./a.ts": () => import("./a3.js"),
-	"./b.ts": () => import("./b3.js"),
-	"./index.ts": () => import("./b4.js")
+	"./a.ts": () => import("./a2.js"),
+	"./b.ts": () => import("./b2.js"),
+	"./index.ts": () => import("./b3.js")
 });
 const customBaseParent = /* @__PURE__ */ Object.assign({
-	"../b/a.ts": () => import("./a3.js"),
-	"../b/b.ts": () => import("./b3.js"),
-	"../b/index.ts": () => import("./b4.js")
+	"../b/a.ts": () => import("./a2.js"),
+	"../b/b.ts": () => import("./b2.js"),
+	"../b/index.ts": () => import("./b3.js")
 });
 //#endregion
 export { basic, basicEager, basicEagerWithObjectKeys, basicEagerWithObjectValues, basicWithObjectKeys, basicWithObjectValues, cleverCwd1, cleverCwd2, customBase, customBaseParent, customQueryString, customRootBase, eagerAs, excludeSelf, excludeSelfRaw, ignore, ignoreWithObjectKeys, ignoreWithObjectValues, namedDefault, namedDefaultWithObjectKeys, namedDefaultWithObjectValues, namedEager, namedEagerWithObjectKeys, namedEagerWithObjectValues, parent, rawImportModule, rootMixedRelative };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -1,13 +1,29 @@
-import { t as a_exports } from "./a.js";
-import { t as b_exports } from "./b.js";
-import { n as name$2, t as modules_exports } from "./modules.js";
-import { t as a_default } from "./a2.js";
-import { t as b_default } from "./b2.js";
+import { t as __exportAll } from "./chunk.js";
+import { t as a_exports$1 } from "./a.js";
+import { t as b_exports$1 } from "./b.js";
+//#region ../fixtures/a/modules/index.ts
+var modules_exports = /* @__PURE__ */ __exportAll({
+	a: () => "a",
+	b: () => "b",
+	default: () => modules_default,
+	name: () => name
+});
+const name = "index";
+var modules_default = "indexDefault";
+//#endregion
+//#region ../fixtures/a/modules/a.ts?raw
+var a_exports = /* @__PURE__ */ __exportAll({ default: () => a_default });
+var a_default = "export const name = 'a';\n";
+//#endregion
+//#region ../fixtures/a/modules/b.ts?raw
+var b_exports = /* @__PURE__ */ __exportAll({ default: () => b_default });
+var b_default = "export const name = 'b';\n";
+//#endregion
 //#region ../fixtures/a/index.ts
 const basic = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t)
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports)
 });
 const basicWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -17,11 +33,11 @@ const basicWithObjectKeys = Object.keys({
 const basicWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t),
 	() => import("./b.js").then((n) => n.t),
-	() => import("./modules.js").then((n) => n.t)
+	() => Promise.resolve().then(() => modules_exports)
 ]);
 const basicEager = /* @__PURE__ */ Object.assign({
-	"./modules/a.ts": a_exports,
-	"./modules/b.ts": b_exports,
+	"./modules/a.ts": a_exports$1,
+	"./modules/b.ts": b_exports$1,
 	"./modules/index.ts": modules_exports
 });
 const basicEagerWithObjectKeys = Object.keys({
@@ -30,8 +46,8 @@ const basicEagerWithObjectKeys = Object.keys({
 	"./modules/index.ts": 0
 });
 const basicEagerWithObjectValues = Object.values([
-	a_exports,
-	b_exports,
+	a_exports$1,
+	b_exports$1,
 	modules_exports
 ]);
 const ignore = /* @__PURE__ */ Object.assign({
@@ -46,7 +62,7 @@ const ignoreWithObjectValues = Object.values([() => import("./a.js").then((n) =>
 const namedEager = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": "a",
 	"./modules/b.ts": "b",
-	"./modules/index.ts": name$2
+	"./modules/index.ts": name
 });
 const namedEagerWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -56,12 +72,12 @@ const namedEagerWithObjectKeys = Object.keys({
 const namedEagerWithObjectValues = Object.values([
 	"a",
 	"b",
-	name$2
+	name
 ]);
 const namedDefault = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t).then((m) => m["default"])
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports).then((m) => m["default"])
 });
 const namedDefaultWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -71,47 +87,47 @@ const namedDefaultWithObjectKeys = Object.keys({
 const namedDefaultWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	() => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	() => import("./modules.js").then((n) => n.t).then((m) => m["default"])
+	() => Promise.resolve().then(() => modules_exports).then((m) => m["default"])
 ]);
 const eagerAs = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_default,
 	"./modules/b.ts": b_default
 });
 const rawImportModule = /* @__PURE__ */ Object.assign({
-	"./modules/a.ts": () => import("./a2.js").then((n) => n.n),
-	"./modules/b.ts": () => import("./b2.js").then((n) => n.n)
+	"./modules/a.ts": () => Promise.resolve().then(() => a_exports),
+	"./modules/b.ts": () => Promise.resolve().then(() => b_exports)
 });
 const excludeSelf = /* @__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling.js") });
 const excludeSelfRaw = /* @__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling3.js") });
 const customQueryString = /* @__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling2.js") });
 const parent = /* @__PURE__ */ Object.assign({});
 const rootMixedRelative = /* @__PURE__ */ Object.assign({
-	"/b/a.ts": () => import("./a4.js").then((m) => m["default"]),
-	"/b/b.ts": () => import("./b4.js").then((m) => m["default"]),
-	"/b/index.ts": () => import("./b6.js").then((m) => m["default"])
+	"/b/a.ts": () => import("./a3.js").then((m) => m["default"]),
+	"/b/b.ts": () => import("./b3.js").then((m) => m["default"]),
+	"/b/index.ts": () => import("./b5.js").then((m) => m["default"])
 });
 const cleverCwd1 = /* @__PURE__ */ Object.assign({ "./node_modules/framework/pages/hello.page.js": () => import("./hello.page.js") });
 const cleverCwd2 = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"../b/a.ts": () => import("./a3.js"),
-	"../b/b.ts": () => import("./b3.js")
+	"../b/a.ts": () => import("./a2.js"),
+	"../b/b.ts": () => import("./b2.js")
 });
 const customBase = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js").then((n) => n.t),
+	"./modules/index.ts": () => Promise.resolve().then(() => modules_exports),
 	"./sibling.ts": () => import("./sibling.js")
 });
 const customRootBase = /* @__PURE__ */ Object.assign({
-	"./a.ts": () => import("./a3.js"),
-	"./b.ts": () => import("./b3.js"),
-	"./index.ts": () => import("./b5.js")
+	"./a.ts": () => import("./a2.js"),
+	"./b.ts": () => import("./b2.js"),
+	"./index.ts": () => import("./b4.js")
 });
 const customBaseParent = /* @__PURE__ */ Object.assign({
-	"../b/a.ts": () => import("./a3.js"),
-	"../b/b.ts": () => import("./b3.js"),
-	"../b/index.ts": () => import("./b5.js")
+	"../b/a.ts": () => import("./a2.js"),
+	"../b/b.ts": () => import("./b2.js"),
+	"../b/index.ts": () => import("./b4.js")
 });
 //#endregion
 export { basic, basicEager, basicEagerWithObjectKeys, basicEagerWithObjectValues, basicWithObjectKeys, basicWithObjectValues, cleverCwd1, cleverCwd2, customBase, customBaseParent, customQueryString, customRootBase, eagerAs, excludeSelf, excludeSelfRaw, ignore, ignoreWithObjectKeys, ignoreWithObjectValues, namedDefault, namedDefaultWithObjectKeys, namedDefaultWithObjectValues, namedEager, namedEagerWithObjectKeys, namedEagerWithObjectValues, parent, rawImportModule, rootMixedRelative };

--- a/packages/rollup-tests/test/function/index.js
+++ b/packages/rollup-tests/test/function/index.js
@@ -122,10 +122,16 @@ runTestSuiteWithSamples(
 					config.options.optimization ??= {};
 					config.options.optimization.inlineConst ??= false;
 				}
-        if (directory.includes('nested-inlined-dynamic-import-2')) {
-          config.options ??= {};
-          config.options.checks ??= {};
-          config.options.checks.ineffectiveDynamicImport ??= false;
+				if (
+					[
+						'nested-inlined-dynamic-import-2',
+						'dynamic-import-mutate-namespace-await',
+						'dynamic-import-mutate-namespace-then'
+					].some(name => directory.includes(name))
+				) {
+					config.options ??= {};
+					config.options.checks ??= {};
+					config.options.checks.ineffectiveDynamicImport ??= false;
 				}
 
 				return rollup


### PR DESCRIPTION
Adds a pre-materialization chunk optimization pass that removes dynamic-entry dependency bits for modules already guaranteed to be loaded by every importer of that dynamic entry. This lets shared modules stay grouped with the static entry path instead of being split into extra chunks or pulled into dynamic chunks unnecessarily.

### Already-Loaded Algorithm

Consider this module graph:

```mermaid
flowchart LR
  main["main entry"]
  shared["shared.js"]
  route["route.js dynamic entry"]

  main -->|"static import"| shared
  main -.->|"dynamic import()"| route
  route -->|"static import"| shared
```

When `route.js` runs, `main` has already loaded `shared.js`. So `shared.js` does not need to keep the `route` entry bit.

Before reduction:

```txt
shared.js dependent entries = { main, route }
route.js  dependent entries = { route }
```

After reduction:

```txt
shared.js dependent entries = { main }
route.js  dependent entries = { route }
```

That lets normal chunk grouping put `shared.js` with `main`, while `route.js` imports the binding from the already-loaded chunk instead of forcing an extra shared chunk.

The pass works on temporary **atoms**, where each atom is a group of modules with the same dependent-entry bitset:

```txt
atom(shared.js) = {
  modules: [shared.js],
  dependentEntries: { main, route }
}
```

Then it computes the atoms loaded before each dynamic entry executes:

```txt
staticLoaded[entry] = atoms loaded by the entry's static dependency graph
alreadyLoaded[dynamicEntry] = intersection of loaded atoms from every importer entry
```

The key detail is the **intersection**. If `route.js` can be dynamically imported by both `main1` and `main2`, an atom can only drop the `route` bit if it is already loaded by **both** importers.

Pseudo-code:

```txt
atoms = groupModulesByDependentEntryBits()
staticLoaded = computeStaticLoadedAtomsForEachEntry()

for each included dynamic import:
  dynamicImporters[dynamicEntry].add(importerEntry)

queue = all dynamic entries

while queue is not empty:
  dynamicEntry = queue.pop()

  nextAlreadyLoaded = intersection over importerEntry in dynamicImporters[dynamicEntry] of:
    staticLoaded[importerEntry] union alreadyLoaded[importerEntry]

  if nextAlreadyLoaded changed:
    alreadyLoaded[dynamicEntry] = nextAlreadyLoaded

    for childDynamicEntry imported by dynamicEntry:
      dynamicImporters[childDynamicEntry].add(dynamicEntry)
      queue.push(childDynamicEntry)

for each atom:
  for each dynamicEntry bit in atom.dependentEntries:
    if alreadyLoaded[dynamicEntry] contains atom:
      remove dynamicEntry bit from atom
```

The reduced bits are only accepted when chunk safety is preserved. The pass still bails out for TLA, keeps strict entry signatures intact, handles runtime-only atoms and dynamic-entry modules specially, and checks static import cycles in risky cases such as manual chunks or strict signatures.

### Summary

- Add dynamic already-loaded analysis for `experimental.chunkOptimization`.
- Propagate already-loaded atoms across included dynamic imports with a fixed-point worklist.
- Preserve safety checks for TLA, strict entry signatures, manual chunking, and static import cycles.
- Add `BitSet::all` and `BitSet::intersect` helpers.
- Add basic and multi-entry dynamic already-loaded fixtures.
- Update affected snapshots and runtime/static-cycle assertions.
- Document the new analysis in `meta/design/code-splitting.md`.

### Tests

- Added fixture coverage under `function/chunk_optimization/dynamic_already_loaded_*`.
- Updated regression coverage for chunk merging/static import cycle cases affected by the new grouping.