### PR TITLE
feat(binding): call moduleParsed hook in ParallelJsPlugin

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -131,6 +131,20 @@ impl Plugin for ParallelJsPlugin {
     }
   }
 
+  async fn module_parsed(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    module_info: Arc<rolldown_common::ModuleInfo>,
+    normal_module: &rolldown_common::NormalModule,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().module_parsed.is_some() {
+      self
+        .run_all(|plugin| plugin.call_module_parsed(ctx, Arc::clone(&module_info), normal_module))
+        .await?;
+    }
+    Ok(())
+  }
+
   async fn build_end(
     &self,
     ctx: &rolldown_plugin::PluginContext,


### PR DESCRIPTION
## Summary

`ParallelJsPlugin` was missing the `moduleParsed` hook, so JS plugins that rely on it silently received nothing whenever they ran in parallel mode. This PR wires the hook through to every parallel plugin instance.

## Why

`crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs` implements the `Plugin` trait but only forwards 8 of the 20 hooks that `JsPlugin` supports. `register_hook_usage` returns `HookUsage::all()`, so the plugin driver thinks every hook is wired even though the missing ones currently fall through to the default no-op `Plugin` impl. `moduleParsed` is the first of those gaps to close.

Same pattern can be applied to the remaining missing hooks (`renderStart`, `renderError`, `closeBundle`, `watchChange`, `closeWatcher`, addon hooks, etc.) — happy to follow up in subsequent PRs.

## Implementation note — feedback wanted

I went with `run_all` (every worker's plugin instance is notified per parsed module), matching the convention used by other notification hooks like `buildStart` / `buildEnd`. The alternative is `run_single`, which is what the throughput hooks (`resolveId`, `load`, `transform`, `renderChunk`) use.

- `run_all` is safer for plugins that maintain per-instance state (e.g. tracking all parsed modules), since every instance sees the same stream.
- `run_all` holds every worker permit per call, which can serialize workers if there are many modules. `run_single` would avoid that but breaks state consistency across instances.

Happy to switch to `run_single` if maintainers prefer the throughput trade-off.

## Test plan

- [x] `cargo check -p rolldown_binding` passes
- [ ] Add an integration test that asserts a parallel JS plugin's `moduleParsed` is called for each module — pointer to an existing parallel-plugin test fixture appreciated if there is one.

## AI Usage Disclosure

Used Claude (Anthropic) to navigate the codebase and identify the gap between `Plugin` trait coverage in `JsPlugin` vs `ParallelJsPlugin`. The 14-line patch was reviewed and adapted by me; I verified the design choice (`run_all` vs `run_single`) against the existing patterns in the same file.