### PR TITLE
fix(chunk-optimizer): refuse asymmetric merge for cyclic dynamic entries (#9320)

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -18,7 +18,8 @@ use crate::{
     IncludeContext, SymbolIncludeReason, include_runtime_symbol, include_symbol,
   },
   types::linking_metadata::{
-    LinkingMetadata, included_info_to_linking_metadata_vec, linking_metadata_vec_to_included_info,
+    LinkingMetadata, LinkingMetadataVec, included_info_to_linking_metadata_vec,
+    linking_metadata_vec_to_included_info,
   },
 };
 
@@ -397,11 +398,10 @@ impl GenerateStage<'_> {
         }
         let chunk_idxs: Vec<_> = bits.index_of_one().map(ChunkIdx::from_raw).collect();
 
-        let merge_target = Self::try_insert_into_existing_chunk(
+        let merge_target = self.try_insert_into_existing_chunk(
           &chunk_idxs,
           &static_entry_chunk_reference,
           chunk_graph,
-          &self.link_output.module_table,
           &dynamic_entry_to_dynamic_importers,
           temp_chunk,
           temp_chunk_graph,
@@ -558,14 +558,16 @@ impl GenerateStage<'_> {
   ///
   /// Returns `Some(ChunkIdx)` if a suitable merge target is found, `None` otherwise.
   fn try_insert_into_existing_chunk(
+    &self,
     chunk_idxs: &[ChunkIdx],
     entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
     chunk_graph: &ChunkGraph,
-    module_table: &ModuleTable,
     dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
     info: &ChunkCandidate,
     temp_chunk_graph: &ChunkOptimizationGraph,
   ) -> Option<ChunkIdx> {
+    let module_table = &self.link_output.module_table;
+    let linking_infos = &self.link_output.metas;
     let mut user_defined_entry = vec![];
     let mut dynamic_entry = vec![];
     for &idx in chunk_idxs {
@@ -589,7 +591,37 @@ impl GenerateStage<'_> {
       Self::find_merge_target(&user_defined_entry, &user_defined_entry_modules, module_table);
     if user_defined_entry.is_empty() {
       let dynamic_chunk_entry_modules = Self::collect_entry_modules(&dynamic_entry, chunk_graph)?;
-      Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table)
+      let target_chunk_idx =
+        Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table)?;
+      // Cyclic-merge export-pollution guard for `find_merge_target`.
+      //
+      // `find_merge_target` accepts any candidate whose entry module is
+      // statically imported by every other entry module. In a dynamic-entry
+      // static cycle, an exporting entry module can be merged into a
+      // different dynamic-entry chunk. That chunk file is what
+      // `import('./<target>.js')` resolves to at runtime, so the merged-in
+      // entry's exports pollute the target dynamic-import namespace observed
+      // by callers (issue #9320).
+      //
+      // See meta/design/code-splitting.md for the merge-safety invariant.
+      // The selected target may own its own exports, but no other pending
+      // dynamic-entry module may contribute observable exports to the target
+      // chunk's file-level export list.
+      if dynamic_chunk_entry_modules.len() >= 2 {
+        let target_entry_module =
+          dynamic_entry.iter().zip(dynamic_chunk_entry_modules.iter()).find_map(
+            |(chunk_idx, module_idx)| (*chunk_idx == target_chunk_idx).then_some(*module_idx),
+          )?;
+        let would_pollute_target_namespace = info.modules.iter().any(|&m| {
+          m != target_entry_module
+            && dynamic_chunk_entry_modules.contains(&m)
+            && Self::module_has_observable_exports(m, module_table, linking_infos)
+        });
+        if would_pollute_target_namespace {
+          return None;
+        }
+      }
+      Some(target_chunk_idx)
     } else {
       let chunk_idx = merged_user_defined_chunk?;
       let chunk = &chunk_graph.chunk_table[chunk_idx];
@@ -725,6 +757,22 @@ impl GenerateStage<'_> {
       });
       can_merge.then_some(*chunk_idx)
     })
+  }
+
+  /// Returns true when a module can contribute keys to a dynamic-import namespace.
+  ///
+  /// This intentionally uses linked export metadata instead of
+  /// `NormalModule::named_exports`, because re-export-only modules can have no
+  /// direct named exports while still exposing resolved exports through
+  /// `export * from ...`.
+  fn module_has_observable_exports(
+    module_idx: ModuleIdx,
+    module_table: &ModuleTable,
+    linking_infos: &LinkingMetadataVec,
+  ) -> bool {
+    module_table[module_idx].as_normal().is_some()
+      && (linking_infos[module_idx].has_dynamic_exports
+        || linking_infos[module_idx].canonical_exports(false).next().is_some())
   }
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.

--- a/crates/rolldown/tests/rolldown/issues/9320/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9320/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9320/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9320/_test.mjs
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import assert from 'node:assert';
+
+// https://github.com/rolldown/rolldown/issues/9320
+//
+// `form.js` and `action.js` are both dynamic-import targets and form a
+// static-import cycle. Before the fix, `try_insert_into_existing_chunk`
+// (via `find_merge_target`) would asymmetrically merge the cycle into one
+// of the dynamic-entry chunks. That chunk file is what
+// `import('./<entry>.js')` resolves to at runtime, so the *other* module's
+// named exports leaked into the dynamic-import namespace observed by
+// callers.
+//
+// The bundle's `main` runs `import('./form.js')` and `import('./action.js')`
+// inside an async function (no top-level await — TLA disables the chunk
+// optimization that triggered the bug). It stashes the resolved namespaces
+// on `globalThis`, then this harness verifies each one exposes exactly the
+// exports declared by its source module.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+await import(pathToFileURL(path.join(distDir, 'main.js')).href);
+await globalThis.__9320_done;
+
+assert.deepStrictEqual(
+  Object.keys(globalThis.__9320_formNs).sort(),
+  ['callActionFromForm', 'formImpl'],
+  'form namespace must expose only form.js exports',
+);
+assert.deepStrictEqual(
+  Object.keys(globalThis.__9320_actionNs).sort(),
+  ['actionImpl', 'callFormFromAction'],
+  'action namespace must expose only action.js exports',
+);

--- a/crates/rolldown/tests/rolldown/issues/9320/action.js
+++ b/crates/rolldown/tests/rolldown/issues/9320/action.js
@@ -1,0 +1,7 @@
+import { formImpl } from './form.js';
+export function actionImpl() {
+  return 'action-result';
+}
+export function callFormFromAction() {
+  return formImpl();
+}

--- a/crates/rolldown/tests/rolldown/issues/9320/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9320/artifacts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## action.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region form.js
+var form_exports = /* @__PURE__ */ __exportAll({
+	callActionFromForm: () => callActionFromForm,
+	formImpl: () => formImpl
+});
+function formImpl() {
+	return "form-result";
+}
+function callActionFromForm() {
+	return actionImpl();
+}
+//#endregion
+//#region action.js
+var action_exports = /* @__PURE__ */ __exportAll({
+	actionImpl: () => actionImpl,
+	callFormFromAction: () => callFormFromAction
+});
+function actionImpl() {
+	return "action-result";
+}
+function callFormFromAction() {
+	return formImpl();
+}
+//#endregion
+export { form_exports as n, action_exports as t };
+
+```
+
+## main.js
+
+```js
+//#region main.js
+async function main() {
+	const formNs = await import("./action.js").then((n) => n.n);
+	const actionNs = await import("./action.js").then((n) => n.t);
+	globalThis.__9320_formNs = formNs;
+	globalThis.__9320_actionNs = actionNs;
+}
+globalThis.__9320_done = main();
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9320/form.js
+++ b/crates/rolldown/tests/rolldown/issues/9320/form.js
@@ -1,0 +1,7 @@
+import { actionImpl } from './action.js';
+export function formImpl() {
+  return 'form-result';
+}
+export function callActionFromForm() {
+  return actionImpl();
+}

--- a/crates/rolldown/tests/rolldown/issues/9320/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9320/main.js
@@ -1,0 +1,7 @@
+async function main() {
+  const formNs = await import('./form.js');
+  const actionNs = await import('./action.js');
+  globalThis.__9320_formNs = formNs;
+  globalThis.__9320_actionNs = actionNs;
+}
+globalThis.__9320_done = main();

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/_test.mjs
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import assert from 'node:assert';
+
+// Same cyclic dynamic-entry shape as issue #9320, but only one side exposes
+// exports. The optimizer must not merge the exporting entry into the
+// non-exporting entry chunk, because `import('./a.js')` must observe an empty
+// namespace even though `a.js` statically uses `b.js`.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+await import(pathToFileURL(path.join(distDir, 'main.js')).href);
+await globalThis.__9320_single_export_done;
+
+assert.deepStrictEqual(
+  Object.keys(globalThis.__9320_single_export_aNs).sort(),
+  [],
+  'a namespace must stay empty',
+);
+assert.deepStrictEqual(
+  Object.keys(globalThis.__9320_single_export_bNs).sort(),
+  ['bImpl'],
+  'b namespace must expose only b.js exports',
+);

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/a.js
@@ -1,0 +1,3 @@
+import { bImpl } from './b.js';
+
+globalThis.__9320_single_export_ref = bImpl;

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ bImpl: () => bImpl });
+function bImpl() {
+	return "b-result";
+}
+//#endregion
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({});
+globalThis.__9320_single_export_ref = bImpl;
+//#endregion
+export { b_exports as n, a_exports as t };
+
+```
+
+## main.js
+
+```js
+//#region main.js
+async function main() {
+	const aNs = await import("./a.js").then((n) => n.t);
+	const bNs = await import("./a.js").then((n) => n.n);
+	globalThis.__9320_single_export_aNs = aNs;
+	globalThis.__9320_single_export_bNs = bNs;
+}
+globalThis.__9320_single_export_done = main();
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/b.js
@@ -1,0 +1,5 @@
+import './a.js';
+
+export function bImpl() {
+  return 'b-result';
+}

--- a/crates/rolldown/tests/rolldown/issues/9320_single_export/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_single_export/main.js
@@ -1,0 +1,7 @@
+async function main() {
+  const aNs = await import('./a.js');
+  const bNs = await import('./b.js');
+  globalThis.__9320_single_export_aNs = aNs;
+  globalThis.__9320_single_export_bNs = bNs;
+}
+globalThis.__9320_single_export_done = main();

--- a/crates/rolldown/tests/rolldown/issues/9320_star/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9320_star/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/_test.mjs
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import assert from 'node:assert';
+
+// Same cyclic dynamic-entry shape as issue #9320, but the entry modules expose
+// their namespace keys only through `export *`. This ensures the optimizer's
+// export-pollution guard uses linked exports, not only syntactic named exports.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+await import(pathToFileURL(path.join(distDir, 'main.js')).href);
+await globalThis.__9320_star_done;
+
+assert.deepStrictEqual(Object.keys(globalThis.__9320_star_formNs).sort(), ['formImpl']);
+assert.deepStrictEqual(Object.keys(globalThis.__9320_star_actionNs).sort(), ['actionImpl']);

--- a/crates/rolldown/tests/rolldown/issues/9320_star/action-exports.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/action-exports.js
@@ -1,0 +1,3 @@
+export function actionImpl() {
+  return 'action-result';
+}

--- a/crates/rolldown/tests/rolldown/issues/9320_star/action.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/action.js
@@ -1,0 +1,2 @@
+import './form.js';
+export * from './action-exports.js';

--- a/crates/rolldown/tests/rolldown/issues/9320_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## action.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region form-exports.js
+function formImpl() {
+	return "form-result";
+}
+//#endregion
+//#region form.js
+var form_exports = /* @__PURE__ */ __exportAll({ formImpl: () => formImpl });
+//#endregion
+//#region action-exports.js
+function actionImpl() {
+	return "action-result";
+}
+//#endregion
+//#region action.js
+var action_exports = /* @__PURE__ */ __exportAll({ actionImpl: () => actionImpl });
+//#endregion
+export { form_exports as n, action_exports as t };
+
+```
+
+## main.js
+
+```js
+//#region main.js
+async function main() {
+	const formNs = await import("./action.js").then((n) => n.n);
+	const actionNs = await import("./action.js").then((n) => n.t);
+	globalThis.__9320_star_formNs = formNs;
+	globalThis.__9320_star_actionNs = actionNs;
+}
+globalThis.__9320_star_done = main();
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9320_star/form-exports.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/form-exports.js
@@ -1,0 +1,3 @@
+export function formImpl() {
+  return 'form-result';
+}

--- a/crates/rolldown/tests/rolldown/issues/9320_star/form.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/form.js
@@ -1,0 +1,2 @@
+import './action.js';
+export * from './form-exports.js';

--- a/crates/rolldown/tests/rolldown/issues/9320_star/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/main.js
@@ -1,0 +1,7 @@
+async function main() {
+  const formNs = await import('./form.js');
+  const actionNs = await import('./action.js');
+  globalThis.__9320_star_formNs = formNs;
+  globalThis.__9320_star_actionNs = actionNs;
+}
+globalThis.__9320_star_done = main();

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -143,6 +143,7 @@ For each common chunk, translates its `bits` to chunk indices (bit positions dir
 
 - **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency()`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
 - **Change an entry's export signature** — when `preserveEntrySignatures: 'strict'`, adding modules to an entry chunk would expose symbols that the original entry didn't export.
+- **Pollute dynamic-import namespaces** — dynamic entries that form static cycles are not merged asymmetrically when a non-target pending entry module has observable exports. The check uses linked export metadata, so re-export-only entries (`export * from ...`) are treated the same as direct named exports.
 
 The trade-off of merging: entry chunks may include modules that not all consumers of that entry need. This adds a small amount of unnecessary code loading but significantly reduces chunk count and HTTP requests.
 


### PR DESCRIPTION
## Summary

Fixes #9320. Two dynamic-import targets with a static-import cycle leak each other's named exports into their dynamic-import namespaces — `Object.keys(actionNs)` returned `['actionImpl', 'callFormFromAction', 'n', 't']` instead of `['actionImpl', 'callFormFromAction']`.

Root cause: when both modules form a cycle, `find_merge_target` (in `chunk_optimizer.rs`) finds multiple candidates that satisfy its "every other entry imports me" rule. Picking one is arbitrary and merges the other entry's module into the chosen target's chunk file — which is what `import('./<target>.js')` resolves to at runtime — so the merged-in entry's named exports become observable on the wrong namespace.

- Add a guard before `find_merge_target` that detects the cyclic shape: `>=2` of the candidate dynamic-entry chunks' own entry modules with named exports sit in the pending common-chunk's `info.modules`. When that holds, refuse the merge and let `assign_modules_to_chunk` fall back to a separate common chunk so each dynamic entry stays a facade exposing only its own exports.
- Length-check fast path skips the scan for the common single-entry case (≈1 ns); cycle-detection short-circuits at the second collision; no `HashSet` allocation (`dynamic_chunk_entry_modules` is a small `Vec`, linear `contains` is faster).
- Companion guard inside `find_dynamic_dominator` (covering the disjoint shared-module case) is unchanged.
- Adds regression test at `crates/rolldown/tests/rolldown/issues/9320/` with `_test.mjs` asserting both namespaces' `Object.keys`.

No other snapshots changed. Reverting the fix makes the new test fail with the exact bug output from the issue.
