### PR TITLE
chore(typo): fix typo in watcher options comment

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -289,7 +289,7 @@ import { watch } from 'rolldown';
 
 const watcher = watch({
   /* option */
-}); // or watch([/* multiply option */] )
+}); // or watch([/* multiple option */] )
 
 watcher.on('event', () => {});
 


### PR DESCRIPTION
Pretty sure this is meant to be “multiple”