### PR TITLE
fix(transform): enable `enum_eval` for `transformSync` and vite TS transform

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -239,9 +239,14 @@ impl PreProcessEcmaAst {
     if let Some(scoping) = scoping.take() {
       return scoping;
     }
+    // Preserve enum_eval here so the transformer can resolve enum-member aliases
+    // when define has consumed the original scoping. After the transformer lowers
+    // enums to IIFEs, later callers of this fallback (inject / DCE / PreProcessor)
+    // no longer encounter TSEnumDeclaration nodes, so the eval pass is a no-op.
     let ret = SemanticBuilder::new()
       // Preallocate memory for the underlying data structures.
       .with_stats(self.stats)
+      .with_enum_eval(true)
       .build(program)
       .semantic;
     self.stats = ret.stats();

--- a/crates/rolldown/tests/rolldown/issues/9312/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9312/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.ts" }],
+    "define": {
+      "process.env.NODE_ENV": "\"production\""
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9312/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9312/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.ts
+console.log("production");
+let Theme = /* @__PURE__ */ function(Theme) {
+	Theme["Light"] = "Light";
+	Theme["Dark"] = "Dark";
+	Theme["Default"] = "Light";
+	return Theme;
+}({});
+//#endregion
+export { Theme };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9312/main.ts
+++ b/crates/rolldown/tests/rolldown/issues/9312/main.ts
@@ -1,0 +1,11 @@
+// The `define` plugin consumes the original Scoping; the transformer
+// must still receive a Scoping built with `enum_eval` so it resolves
+// the string-enum alias below to its constant value.
+const env = process.env.NODE_ENV;
+console.log(env);
+
+export enum Theme {
+  Light = 'Light',
+  Dark = 'Dark',
+  Default = Theme.Light,
+}

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -332,7 +332,10 @@ pub fn enhanced_transform(
 
   let mut program = parse_ret.program;
 
-  let semantic_ret = SemanticBuilder::new().build(&program);
+  // Pre-evaluate enum member values so the TS transformer can emit the correct
+  // forward-only assignment for string-enum aliases (e.g. `Default = Theme.Light`)
+  // instead of the wrong reverse-mapping form.
+  let semantic_ret = SemanticBuilder::new().with_enum_eval(true).build(&program);
   let mut scoping = Some(semantic_ret.semantic.into_scoping());
   if !semantic_ret.errors.is_empty() {
     append_oxc_diagnostics(semantic_ret.errors, &source, filename, &mut warnings, &mut errors);
@@ -385,9 +388,9 @@ pub fn enhanced_transform(
     }
   }
 
-  let scoping = scoping
-    .take()
-    .unwrap_or_else(|| SemanticBuilder::new().build(&program).semantic.into_scoping());
+  let scoping = scoping.take().unwrap_or_else(|| {
+    SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.into_scoping()
+  });
 
   let transform_ret = Transformer::new(&allocator, Path::new(filename), &oxc_transform_options)
     .build_with_scoping(scoping, &mut program);

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -72,7 +72,8 @@ impl Plugin for ViteTransformPlugin {
     }
 
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping =
+      SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.into_scoping();
     let transformer = Transformer::new(&allocator, Path::new(args.id), &transform_options);
     let transformer_return = transformer.build_with_scoping(scoping, &mut program);
     if !transformer_return.errors.is_empty() {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/assert.mjs
@@ -1,6 +1,11 @@
 // @ts-nocheck
 import assert from 'node:assert';
-import { a, b } from './dist/main';
+import { a, b, Theme } from './dist/main';
 
 assert.strictEqual(a, 1);
 assert.strictEqual(b, 2);
+
+// Theme.Light must still equal "Light" — the bug overwrote its value with "Default".
+assert.strictEqual(Theme.Light, 'Light');
+assert.strictEqual(Theme.Dark, 'Dark');
+assert.strictEqual(Theme.Default, 'Light');

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/main.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/main.ts
@@ -1,4 +1,15 @@
 interface Foo {}
 const a = 1;
 const b = 2;
-export { a, b };
+
+// Regression for https://github.com/rolldown/rolldown/issues/9312:
+// a string-enum alias (`Default = Theme.Light`) must lower to the
+// forward-only assignment `Theme["Default"] = "Light"`, not the
+// reverse-mapping form that would overwrite `Theme["Light"]`.
+enum Theme {
+  Light = 'Light',
+  Dark = 'Dark',
+  Default = Theme.Light,
+}
+
+export { a, b, Theme };

--- a/packages/rolldown/tests/utils/transform.test.ts
+++ b/packages/rolldown/tests/utils/transform.test.ts
@@ -500,6 +500,40 @@ describe('enhanced transform', () => {
     });
   });
 
+  describe('enum', () => {
+    // Regression for https://github.com/rolldown/rolldown/issues/9312
+    // String-enum alias members must produce forward-only `X["Default"] = "Light"`
+    // assignment, not the buggy reverse-mapping form
+    // `X[X["Default"] = X.Light] = "Default"` which overwrites the original
+    // member's reverse mapping.
+    it('emits forward-only assignment for string-enum alias members', () => {
+      const code = `
+export enum Theme {
+  Light = "Light",
+  Dark = "Dark",
+  Default = Theme.Light,
+}
+`;
+      const result = transformSync('test.ts', code);
+      expect(result.errors).toHaveLength(0);
+      expect(result.code).toContain('Theme["Default"] = "Light";');
+      expect(result.code).not.toContain('Theme[Theme["Default"]');
+    });
+
+    it('keeps reverse mapping for numeric-enum alias members', () => {
+      const code = `
+export enum Num {
+  A = 1,
+  B = 2,
+  C = A,
+}
+`;
+      const result = transformSync('test.ts', code);
+      expect(result.errors).toHaveLength(0);
+      expect(result.code).toContain('Num[Num["C"] = 1] = "C";');
+    });
+  });
+
   describe('inputMap', () => {
     // Use TypeScript code so the transformation actually produces meaningful sourcemaps.
     // This simulates: original.ts (TS) -> intermediate.js (via previous tool) -> final.js (via transform)


### PR DESCRIPTION
Related: https://github.com/oxc-project/oxc/pull/22252

## Summary

Fixes the bug where `transformSync`, the vite TS transform plugin, and the bundler (when `define` triggers a program mutation) emitted a corrupt reverse-mapping line for string-enum alias members. For input

```ts
enum Theme {
  Light = "Light",
  Dark = "Dark",
  Default = Theme.Light,
}
```

rolldown produced

```js
Theme[Theme["Default"] = Theme.Light] = "Default";
```

which overwrites `Theme["Light"]`'s reverse mapping with `"Default"`. Expected (matching `tsc`):

```js
Theme["Default"] = "Light";
```

## Cause

The oxc TS transformer's enum lowering looks up each member's constant value via `Scoping::get_enum_member_value` (`crates/oxc_transformer/src/typescript/enum.rs:310`). That table is only populated when the `SemanticBuilder` is built with `with_enum_eval(true)`. When it isn't, every member returns `None`, so the transformer takes the non-string-init branch and emits the `Foo[Foo["x"] = init] = "x"` reverse-mapping form regardless of whether `init` is statically a string.

The bundler's initial build (`crates/rolldown/src/utils/pre_process_ecma_ast.rs:66`) already enables `enum_eval`, but four other call sites that hand a `Scoping` to `Transformer::build_with_scoping` did not:

- `transformSync` (`crates/rolldown_common/src/utils/enhanced_transform.rs`) — initial build and the fallback used after `ReplaceGlobalDefines` consumes the scoping.
- The vite TS transform plugin (`crates/rolldown_plugin_vite_transform/src/lib.rs`).
- The bundler's `recreate_scoping` (`crates/rolldown/src/utils/pre_process_ecma_ast.rs:238`), which feeds the transformer when the define plugin has consumed the original scoping.

## Fix

Add `.with_enum_eval(true)` to all four call sites:

- `crates/rolldown_common/src/utils/enhanced_transform.rs` — initial build before transformer.
- `crates/rolldown_common/src/utils/enhanced_transform.rs` — fallback rebuild when `ReplaceGlobalDefines` consumed the original scoping.
- `crates/rolldown_plugin_vite_transform/src/lib.rs` — vite TS transform plugin.
- `crates/rolldown/src/utils/pre_process_ecma_ast.rs` — `recreate_scoping`, the fallback used by step 3 (transformer) when define has consumed scoping. Later callers of `recreate_scoping` (inject / DCE / PreProcessor) run after enums have been lowered to IIFEs, so the eval pass is a no-op there.

Closes #9312

## Test plan

- [x] Added two `transformSync` regression tests in `packages/rolldown/tests/utils/transform.test.ts` (string-enum alias forward-only, numeric-enum alias reverse-mapping retained).
- [x] Added a bundler fixture under `crates/rolldown/tests/rolldown/issues/9312/` covering define + string-enum-alias.
- [x] All 24 existing enum-related Rust integration tests pass.
- [x] All 38 define-related tests pass.
- [x] `cargo clippy -p rolldown_common -p rolldown_plugin_vite_transform -- -D warnings` clean.
- [x] Verified the issue's exact `transformSync` repro (string, numeric, mixed enums) matches `tsc` output.