### PR TITLE
refactor(ecmascript): extract semantic_builder_for_transform helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,6 +3562,7 @@ dependencies = [
  "oxc",
  "oxc_resolver",
  "rolldown_common",
+ "rolldown_ecmascript",
  "rolldown_error",
  "rolldown_plugin",
  "rolldown_utils",

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -4,7 +4,7 @@ use oxc::ast::ast::Program;
 use oxc::ast_visit::VisitMut;
 use oxc::diagnostics::Severity as OxcSeverity;
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
-use oxc::semantic::{Scoping, SemanticBuilder, Stats};
+use oxc::semantic::{Scoping, Stats};
 use oxc::syntax::symbol::SymbolFlags;
 use oxc::transformer::Transformer;
 use oxc::transformer_plugins::{
@@ -13,7 +13,7 @@ use oxc::transformer_plugins::{
 use oxc_str::CompactStr;
 
 use rolldown_common::{ConstExportMeta, ConstantValue, NormalizedBundlerOptions};
-use rolldown_ecmascript::{EcmaAst, WithMutFields};
+use rolldown_ecmascript::{EcmaAst, WithMutFields, semantic_builder_for_transform};
 use rolldown_ecmascript_utils::contains_script_closing_tag;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, EventKind, Severity};
 use rustc_hash::FxHashMap;
@@ -63,7 +63,7 @@ impl PreProcessEcmaAst {
 
     // Step 1: Build initial semantic data and check for semantic errors.
     let semantic_ret = ast.program.with_dependent(|_owner, dep| {
-      SemanticBuilder::new().with_check_syntax_error(true).with_enum_eval(true).build(&dep.program)
+      semantic_builder_for_transform().with_check_syntax_error(true).build(&dep.program)
     });
 
     let (errors, warnings): (Vec<_>, Vec<_>) =
@@ -239,14 +239,9 @@ impl PreProcessEcmaAst {
     if let Some(scoping) = scoping.take() {
       return scoping;
     }
-    // Preserve enum_eval here so the transformer can resolve enum-member aliases
-    // when define has consumed the original scoping. After the transformer lowers
-    // enums to IIFEs, later callers of this fallback (inject / DCE / PreProcessor)
-    // no longer encounter TSEnumDeclaration nodes, so the eval pass is a no-op.
-    let ret = SemanticBuilder::new()
+    let ret = semantic_builder_for_transform()
       // Preallocate memory for the underlying data structures.
       .with_stats(self.stats)
-      .with_enum_eval(true)
       .build(program)
       .semantic;
     self.stats = ret.stats();

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -23,6 +23,7 @@ use oxc::{
   },
 };
 use oxc_resolver::TsConfig;
+use rolldown_ecmascript::semantic_builder_for_transform;
 use rolldown_error::{BuildDiagnostic, EventKind, Severity};
 use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
 use rustc_hash::FxHashMap;
@@ -332,10 +333,7 @@ pub fn enhanced_transform(
 
   let mut program = parse_ret.program;
 
-  // Pre-evaluate enum member values so the TS transformer can emit the correct
-  // forward-only assignment for string-enum aliases (e.g. `Default = Theme.Light`)
-  // instead of the wrong reverse-mapping form.
-  let semantic_ret = SemanticBuilder::new().with_enum_eval(true).build(&program);
+  let semantic_ret = semantic_builder_for_transform().build(&program);
   let mut scoping = Some(semantic_ret.semantic.into_scoping());
   if !semantic_ret.errors.is_empty() {
     append_oxc_diagnostics(semantic_ret.errors, &source, filename, &mut warnings, &mut errors);
@@ -388,9 +386,9 @@ pub fn enhanced_transform(
     }
   }
 
-  let scoping = scoping.take().unwrap_or_else(|| {
-    SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.into_scoping()
-  });
+  let scoping = scoping
+    .take()
+    .unwrap_or_else(|| semantic_builder_for_transform().build(&program).semantic.into_scoping());
 
   let transform_ret = Transformer::new(&allocator, Path::new(filename), &oxc_transform_options)
     .build_with_scoping(scoping, &mut program);

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -5,6 +5,20 @@ use oxc::{
 
 use crate::EcmaAst;
 
+/// Returns a [`SemanticBuilder`] pre-configured for any `Scoping` that will be
+/// passed to `Transformer::build_with_scoping`.
+///
+/// The TS transformer's enum lowering reads each member's constant value via
+/// `Scoping::get_enum_member_value`. That table is only populated when the
+/// builder has `enum_eval` enabled — without it, member aliases like
+/// `Default = Theme.Light` fall through to the buggy reverse-mapping form for
+/// string enums (`Foo[Foo["x"] = init] = "x"`), which corrupts the original
+/// member's reverse mapping. Callers may chain additional options (e.g.
+/// `with_check_syntax_error`, `with_stats`) on top.
+pub fn semantic_builder_for_transform<'a>() -> SemanticBuilder<'a> {
+  SemanticBuilder::new().with_enum_eval(true)
+}
+
 impl EcmaAst {
   pub fn is_body_empty(&self) -> bool {
     self.program().is_empty()

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -15,6 +15,7 @@ mod r#gen;
 mod helpers;
 pub mod program_cell;
 pub use r#gen::ToSourceString;
+pub use helpers::semantic_builder_for_transform;
 
 /// - To access `&mut ast::Program`, use `ast.program.with_mut(|fields| { fields.program; })`.
 pub struct EcmaAst {

--- a/crates/rolldown_ecmascript/src/lib.rs
+++ b/crates/rolldown_ecmascript/src/lib.rs
@@ -8,6 +8,8 @@ pub use crate::{
     CJS_REQUIRE_REF_STR, CJS_ROLLDOWN_EXPORTS_REF, CJS_ROLLDOWN_EXPORTS_REF_IDENT,
     CJS_ROLLDOWN_MODULE_REF, CJS_ROLLDOWN_MODULE_REF_IDENT,
   },
-  ecma_ast::{EcmaAst, ToSourceString, program_cell::WithMutFields},
+  ecma_ast::{
+    EcmaAst, ToSourceString, program_cell::WithMutFields, semantic_builder_for_transform,
+  },
   ecma_compiler::{EcmaCompiler, PrintCommentsOptions, PrintOptions},
 };

--- a/crates/rolldown_plugin_vite_transform/Cargo.toml
+++ b/crates/rolldown_plugin_vite_transform/Cargo.toml
@@ -25,6 +25,7 @@ memchr = { workspace = true }
 oxc = { workspace = true }
 oxc_resolver = { workspace = true }
 rolldown_common = { workspace = true }
+rolldown_ecmascript = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 use arcstr::ArcStr;
 use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
 use oxc::parser::Parser;
-use oxc::semantic::SemanticBuilder;
 use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
+use rolldown_ecmascript::semantic_builder_for_transform;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, EventKind, Severity};
 use rolldown_plugin::{HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
@@ -72,8 +72,7 @@ impl Plugin for ViteTransformPlugin {
     }
 
     let mut program = ret.program;
-    let scoping =
-      SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.into_scoping();
+    let scoping = semantic_builder_for_transform().build(&program).semantic.into_scoping();
     let transformer = Transformer::new(&allocator, Path::new(args.id), &transform_options);
     let transformer_return = transformer.build_with_scoping(scoping, &mut program);
     if !transformer_return.errors.is_empty() {


### PR DESCRIPTION

## Summary

Centralize the `with_enum_eval(true)` invariant required for any `Scoping` that will be passed to `Transformer::build_with_scoping`. After #9325 the same option needed to be set at five call sites; missing it at any one of them recreates the string-enum-alias bug. Wrapping it in a single helper makes the invariant a property of the function name instead of a footgun spread across crates.

## Cause

Five call sites that hand a `Scoping` to the transformer were each spelling out `SemanticBuilder::new().with_enum_eval(true)` (or worse, omitting the flag and silently producing the buggy reverse-mapping form for string-enum aliases). Adding a new transformer entry point in the future would require remembering this same invariant.

## Fix

Add `pub fn semantic_builder_for_transform()` in `crates/rolldown_ecmascript/src/ecma_ast/helpers.rs`, re-exported from `rolldown_ecmascript::*`. The doc comment on the helper captures the WHY (`get_enum_member_value` is only populated when `enum_eval` is on; without it, string-enum aliases get the corrupt `Foo[Foo["x"] = init] = "x"` form).

Migrate all five call sites to start from the helper:

- `crates/rolldown/src/utils/pre_process_ecma_ast.rs` — initial bundler build (chains `with_check_syntax_error`).
- `crates/rolldown/src/utils/pre_process_ecma_ast.rs::recreate_scoping` — post-define fallback (chains `with_stats`).
- `crates/rolldown_common/src/utils/enhanced_transform.rs` — initial build for `transformSync`.
- `crates/rolldown_common/src/utils/enhanced_transform.rs` — fallback rebuild after `ReplaceGlobalDefines`.
- `crates/rolldown_plugin_vite_transform/src/lib.rs` — vite TS transform plugin.

The post-transformer rebuild for `InjectGlobalVariables` (`enhanced_transform.rs:406`) is intentionally left as a bare `SemanticBuilder::new()` — enum_eval is semantically irrelevant after enums have been lowered.

Adds `rolldown_ecmascript = { workspace = true }` to `crates/rolldown_plugin_vite_transform/Cargo.toml` so the plugin can reach the helper.

## Test plan

- [x] No new test surface — covered by the regression tests already in #9325 (Rust fixture `rolldown/issues/9312/`, TS unit tests in `packages/rolldown/tests/utils/transform.test.ts`).
- [x] All 24 enum-related Rust tests, 38 define-related tests, and 49 `transform.test.ts` cases pass.
- [x] `cargo clippy -p rolldown_ecmascript -p rolldown_common -p rolldown_plugin_vite_transform -- -D warnings` clean.