### PR TITLE
fix: Fix same-target common chunk merge cycle check

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -192,49 +192,45 @@ impl ChunkOptimizationGraph {
     }
   }
 
-  /// Checks if merging `source_chunk` into `target_chunk` would create a circular dependency.
-  ///
-  /// Returns `true` if the merge would create a cycle, `false` if it's safe to merge.
-  ///
-  /// After merging, the combined chunk has deps = `source.deps ∪ target.deps`, and any chunk
-  /// that previously depended on `source` now depends on `target`. A cycle exists iff `target`
-  /// is reachable from `source.deps ∪ target.deps` in the resulting graph.
-  ///
-  /// We approximate this by doing a BFS from `source.deps ∪ target.deps`, treating any chunk
-  /// that depends on `source` as also pointing to `target` (since after the merge they would).
-  /// If `target` is reachable, the merge would create a cycle.
-  ///
-  /// This is similar to Rollup's check in `getAdditionalSizeIfNoTransitiveDependencyOrNonCorrelatedSideEffect`.
+  /// Checks if merging `source_chunk_idx` into `target_chunk_idx` would create a circular dependency.
   pub fn would_create_circular_dependency(
     &self,
     source_chunk_idx: ChunkIdx,
     target_chunk_idx: ChunkIdx,
+    same_target_merges: Option<&FxHashSet<ChunkIdx>>,
   ) -> bool {
-    // Start BFS from the combined deps of source and target.
-    let mut queue: VecDeque<ChunkIdx> = self.chunks[source_chunk_idx]
-      .dependencies
-      .iter()
-      .chain(self.chunks[target_chunk_idx].dependencies.iter())
-      .copied()
-      .collect();
-    let mut visited = FxHashSet::default();
+    let mut merged_chunks = FxHashSet::default();
+    merged_chunks.insert(target_chunk_idx);
+    merged_chunks.insert(source_chunk_idx);
+    if let Some(same_target_merges) = same_target_merges {
+      merged_chunks.extend(same_target_merges.iter().copied());
+    }
 
+    let mut queue = VecDeque::new();
+    for chunk_idx in &merged_chunks {
+      queue.extend(
+        self.chunks[*chunk_idx]
+          .dependencies
+          .iter()
+          .filter_map(|dep| if merged_chunks.contains(dep) { None } else { Some(*dep) }),
+      );
+    }
+
+    let mut visited = FxHashSet::default();
     while let Some(chunk_idx) = queue.pop_front() {
-      if chunk_idx == target_chunk_idx {
+      if merged_chunks.contains(&chunk_idx) {
         return true;
       }
       if !visited.insert(chunk_idx) {
         continue;
       }
       for &dep in &self.chunks[chunk_idx].dependencies {
+        if merged_chunks.contains(&dep) {
+          return true;
+        }
         if !visited.contains(&dep) {
           queue.push_back(dep);
         }
-      }
-      // Any chunk that depends on source will depend on target after the merge.
-      // Simulate this by also queuing target when we encounter such a chunk.
-      if self.chunks[chunk_idx].dependencies.contains(&source_chunk_idx) {
-        queue.push_back(target_chunk_idx);
       }
     }
 
@@ -411,13 +407,33 @@ impl GenerateStage<'_> {
       })
       .collect();
 
+    let merge_groups = assignments.iter().fold(
+      FxHashMap::<ChunkIdx, FxHashSet<ChunkIdx>>::default(),
+      |mut acc, (_, temp_chunk_idx, _, merge_target)| {
+        if let Some(target_chunk_idx) = merge_target {
+          let temp_chunk = &temp_chunk_graph.chunks[*temp_chunk_idx];
+          if self.can_merge_modules_into_existing_chunk(
+            chunk_graph,
+            *target_chunk_idx,
+            &temp_chunk.modules,
+          ) {
+            acc.entry(*target_chunk_idx).or_default().insert(*temp_chunk_idx);
+          }
+        }
+        acc
+      },
+    );
+
     // Second pass: apply chunk assignments
     for (bits, temp_chunk_idx, chunk_idxs, merge_target) in assignments {
       // Check if merging would create a circular dependency
       let merge_target = match merge_target {
         Some(target_chunk_idx)
-          if temp_chunk_graph
-            .would_create_circular_dependency(temp_chunk_idx, target_chunk_idx) =>
+          if temp_chunk_graph.would_create_circular_dependency(
+            temp_chunk_idx,
+            target_chunk_idx,
+            merge_groups.get(&target_chunk_idx),
+          ) =>
         {
           // Skip merge if it would create a circular dependency
           None
@@ -462,27 +478,11 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
   ) -> ChunkAssignment {
     match merge_target {
-      Some(chunk_idx) => {
-        let chunk = &chunk_graph.chunk_table[chunk_idx];
-        let is_async_entry_only = matches!(chunk.kind, ChunkKind::EntryPoint { meta, .. } if meta == ChunkMeta::DynamicImported);
-        if matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict)) {
-          // We can safely merge into this chunk in two scenarios:
-          // 1. The target chunk is an async entry - dynamic chunks are not restricted by `PreserveEntrySignatures`.
-          // 2. The target chunk has strict signature preservation, but the modules being merged won't alter
-          //    the entry's exported interface (they either have no exports or only re-export existing entry symbols).
-          if is_async_entry_only || self.can_merge_without_changing_entry_signature(chunk, modules)
-          {
-            self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
-            ChunkAssignment::Merged(chunk_idx)
-          } else {
-            let new_chunk_id =
-              self.create_common_chunk(modules, bits, chunk_graph, bits_to_chunk, input_base);
-            ChunkAssignment::Created(new_chunk_id)
-          }
-        } else {
-          self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
-          ChunkAssignment::Merged(chunk_idx)
-        }
+      Some(chunk_idx)
+        if self.can_merge_modules_into_existing_chunk(chunk_graph, chunk_idx, modules) =>
+      {
+        self.merge_modules_into_existing_chunk(chunk_idx, chunk_idxs, modules, chunk_graph);
+        ChunkAssignment::Merged(chunk_idx)
       }
       _ => {
         let new_chunk_id =
@@ -490,6 +490,21 @@ impl GenerateStage<'_> {
         ChunkAssignment::Created(new_chunk_id)
       }
     }
+  }
+
+  fn can_merge_modules_into_existing_chunk(
+    &self,
+    chunk_graph: &ChunkGraph,
+    chunk_idx: ChunkIdx,
+    modules: &[ModuleIdx],
+  ) -> bool {
+    let chunk = &chunk_graph.chunk_table[chunk_idx];
+    if !matches!(chunk.preserve_entry_signature, Some(PreserveEntrySignatures::Strict)) {
+      return true;
+    }
+
+    let is_async_entry_only = matches!(chunk.kind, ChunkKind::EntryPoint { meta, .. } if meta == ChunkMeta::DynamicImported);
+    is_async_entry_only || self.can_merge_without_changing_entry_signature(chunk, modules)
   }
 
   /// Merges modules into an existing entry chunk.

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/_config.json
@@ -1,0 +1,15 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ],
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  },
+  "snapshotOutputStats": true
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/artifacts.snap
@@ -1,0 +1,70 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## child.js
+
+```js
+//! Dynamic Entry: [Entry-Module-Id: child.js] [Name: None]
+import { t as require_jsx_runtime } from "./entry.js";
+//#region child.js
+var import_jsx_runtime = require_jsx_runtime();
+console.log("child", (0, import_jsx_runtime.jsx)("child", {}));
+//#endregion
+
+```
+
+## entry.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry.js] [Name: Some("entry")]
+// HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/react/cjs/react.production.js
+var require_react_production = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.version = "19";
+}));
+//#endregion
+//#region node_modules/react/index.js
+var require_react = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = require_react_production();
+}));
+//#endregion
+//#region node_modules/react/cjs/react-jsx-runtime.production.js
+var require_react_jsx_runtime_production = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.jsx = (type) => ({ type });
+	exports.jsxs = exports.jsx;
+	exports.Fragment = Symbol.for("react.fragment");
+}));
+//#endregion
+//#region node_modules/react/jsx-runtime.js
+var require_jsx_runtime = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = require_react_jsx_runtime_production();
+}));
+require_react();
+var import_jsx_runtime = require_jsx_runtime();
+console.log("entry", "19", (0, import_jsx_runtime.jsx)("main", {}));
+import("./route.js");
+//#endregion
+export { require_react as n, __toESM as r, require_jsx_runtime as t };
+
+```
+
+## route.js
+
+```js
+//! Dynamic Entry: [Entry-Module-Id: route.js] [Name: None]
+import { n as require_react, t as require_jsx_runtime } from "./entry.js";
+require_react();
+var import_jsx_runtime = require_jsx_runtime();
+console.log("route", "19", (0, import_jsx_runtime.jsx)("route", {}));
+import("./child.js");
+//#endregion
+
+```
+
+# Output Stats
+
+- child.js, is_entry false, is_dynamic_entry true, exports []
+- entry.js, is_entry true, is_dynamic_entry false, exports ["n", "r", "t"]
+- route.js, is_entry false, is_dynamic_entry true, exports []

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/child.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/child.js
@@ -1,3 +1,3 @@
-import { jsx } from 'react/jsx-runtime'
+import { jsx } from 'react/jsx-runtime';
 
-console.log('child', jsx('child', {}))
+console.log('child', jsx('child', {}));

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/child.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/child.js
@@ -1,0 +1,3 @@
+import { jsx } from 'react/jsx-runtime'
+
+console.log('child', jsx('child', {}))

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/entry.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/entry.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { jsx } from 'react/jsx-runtime'
+import React from 'react';
+import { jsx } from 'react/jsx-runtime';
 
-console.log('entry', React.version, jsx('main', {}))
-import('./route.js')
+console.log('entry', React.version, jsx('main', {}));
+import('./route.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/entry.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/entry.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import { jsx } from 'react/jsx-runtime'
+
+console.log('entry', React.version, jsx('main', {}))
+import('./route.js')

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/cjs/react-jsx-runtime.production.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/cjs/react-jsx-runtime.production.js
@@ -1,0 +1,5 @@
+'use strict'
+
+exports.jsx = (type) => ({ type })
+exports.jsxs = exports.jsx
+exports.Fragment = Symbol.for('react.fragment')

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/cjs/react.production.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/cjs/react.production.js
@@ -1,0 +1,3 @@
+'use strict'
+
+exports.version = '19'

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/index.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./cjs/react.production.js')

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/jsx-runtime.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/jsx-runtime.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./cjs/react-jsx-runtime.production.js')

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/package.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/node_modules/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "react",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./jsx-runtime": "./jsx-runtime.js"
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/route.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/route.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import { jsx } from 'react/jsx-runtime'
+
+console.log('route', React.version, jsx('route', {}))
+import('./child.js')

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/route.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/react_jsx_runtime_cjs_reexport_merges_into_entry/route.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { jsx } from 'react/jsx-runtime'
+import React from 'react';
+import { jsx } from 'react/jsx-runtime';
 
-console.log('route', React.version, jsx('route', {}))
-import('./child.js')
+console.log('route', React.version, jsx('route', {}));
+import('./child.js');


### PR DESCRIPTION
# Fix common chunk merge false positive for same-target merges

Fixes a chunk optimizer case where multiple pending common chunks that should all merge into the same entry could block each other via a transient circular-dependency check.

This showed up with React's CJS `react/jsx-runtime` facade:

```js
module.exports = require('./cjs/react-jsx-runtime.production.js')
```

In a graph with one user entry and nested dynamic imports, Rolldown could emit a separate `jsx-runtime` common chunk even though all consumers are reachable through the same entry. The optimizer now treats other valid same-target pending merges as internal to the target when checking for cycles.

created using GPT 5.5
