### PR TITLE
refactor(test): extract reusable static-import-cycle helper

### DIFF
--- a/crates/rolldown/tests/rolldown/_test_helpers/find-static-cycle.mjs
+++ b/crates/rolldown/tests/rolldown/_test_helpers/find-static-cycle.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Match static `import`/`export ... from "./x"` and bare `import "./x"`.
+// The `\s+` after `import`/`export` excludes dynamic `import("./x")`.
+const STATIC_IMPORT_RE = /(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']\.\/([^"']+)["']/g;
+
+function buildStaticImportGraph(distDir) {
+  const jsFiles = fs
+    .readdirSync(distDir)
+    .filter((file) => file.endsWith('.js'))
+    .sort();
+
+  const graph = Object.fromEntries(
+    jsFiles.map((file) => {
+      const code = fs.readFileSync(path.join(distDir, file), 'utf8');
+      const imports = [...code.matchAll(STATIC_IMPORT_RE)].map((match) => match[1]);
+      return [file, imports];
+    }),
+  );
+
+  return { jsFiles, graph };
+}
+
+// Returns the first cycle as an array of file names (e.g. ['a.js', 'b.js', 'a.js'])
+// or `null` if the static import graph is acyclic. Dynamic `import("./x")` is
+// intentionally excluded because async boundaries break TDZ hazards.
+export function findStaticImportCycle(distDir) {
+  const { jsFiles, graph } = buildStaticImportGraph(distDir);
+
+  const seen = new Set();
+  function dfs(file, stack) {
+    if (seen.has(file)) return null;
+    const stackIndex = stack.indexOf(file);
+    if (stackIndex !== -1) return stack.slice(stackIndex).concat(file);
+    for (const dep of graph[file] ?? []) {
+      const cycle = dfs(dep, stack.concat(file));
+      if (cycle) return cycle;
+    }
+    seen.add(file);
+    return null;
+  }
+
+  for (const file of jsFiles) {
+    const cycle = dfs(file, []);
+    if (cycle) return { cycle, graph };
+  }
+  return { cycle: null, graph };
+}
+
+// Asserts the static import graph in `distDir` has no cycles. Throws via
+// `node:assert` with the offending cycle and the full graph on failure.
+export function assertNoStaticImportCycle(distDir) {
+  const { cycle, graph } = findStaticImportCycle(distDir);
+  assert.strictEqual(
+    cycle,
+    null,
+    cycle
+      ? `Static import graph must be acyclic, found: ${cycle.join(' -> ')}\nGraph: ${JSON.stringify(graph)}`
+      : '',
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_test.mjs
@@ -1,60 +1,17 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import assert from 'node:assert';
+import path from 'node:path';
+import { assertNoStaticImportCycle } from '../../../../_test_helpers/find-static-cycle.mjs';
 
-const dist = path.join(import.meta.dirname, 'dist');
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));
 
-// Parse static imports from a chunk's source code
-function getStaticImports(source) {
-  const imports = [];
-  const re = /(?:import|export)\s+.*?from\s+["']\.\/([^"']+)["']/g;
-  let m;
-  while ((m = re.exec(source)) !== null) {
-    imports.push(m[1]);
-  }
-  return imports;
+// Runtime check: importing the entry must run node1 → init_node2 → (async) node0
+// without throwing, and every fuzz counter must end up assigned.
+await import('./dist/node1.js');
+await new Promise((resolve) => setImmediate(resolve));
+for (const idx of [0, 1, 2]) {
+  assert.strictEqual(
+    globalThis[`__acyclic_output_fuzz_${idx}`],
+    idx,
+    `node${idx} body must have executed and set its fuzz counter`,
+  );
 }
-
-// Build a dependency graph of static imports between output chunks
-const files = fs.readdirSync(dist).filter((f) => f.endsWith('.js'));
-const graph = {};
-for (const file of files) {
-  const source = fs.readFileSync(path.join(dist, file), 'utf-8');
-  graph[file] = getStaticImports(source);
-}
-
-// Detect cycles in the static import graph using DFS
-function findCycle(graph) {
-  const visited = new Set();
-  const inStack = new Set();
-
-  function dfs(node, pathSoFar) {
-    if (inStack.has(node)) {
-      const cycleStart = pathSoFar.indexOf(node);
-      return pathSoFar.slice(cycleStart).concat(node);
-    }
-    if (visited.has(node)) return null;
-
-    visited.add(node);
-    inStack.add(node);
-    for (const dep of graph[node] || []) {
-      const cycle = dfs(dep, [...pathSoFar, node]);
-      if (cycle) return cycle;
-    }
-    inStack.delete(node);
-    return null;
-  }
-
-  for (const node of Object.keys(graph)) {
-    const cycle = dfs(node, []);
-    if (cycle) return cycle;
-  }
-  return null;
-}
-
-const cycle = findCycle(graph);
-assert.strictEqual(
-  cycle,
-  null,
-  `Output chunks must not have circular static imports, but found: ${cycle ? cycle.join(' -> ') : 'none'}`,
-);

--- a/crates/rolldown/tests/rolldown/issues/8595/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/_test.mjs
@@ -1,18 +1,7 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import assert from 'node:assert';
+import { assertNoStaticImportCycle } from '../../_test_helpers/find-static-cycle.mjs';
 
-// Before the fix, external dynamic imports (@prettier/plugin-oxc, etc.)
-// caused bit-position/chunk-index mismatches, producing a circular static
-// import: babel.js <-> tt.js
-//
-// Expected: tt.js imports babel.js (not the reverse).
-// babel.js should import from chunk.js (the runtime chunk), not tt.js.
-
-const distDir = path.join(import.meta.dirname, 'dist');
-const babel = fs.readFileSync(path.join(distDir, 'babel.js'), 'utf8');
-
-assert(
-  !babel.includes('from "./tt.js"'),
-  'babel.js should not import from tt.js (would create a cycle)',
-);
+// Original bug (#8595): external dynamic imports caused bit-position/chunk-index
+// mismatches that produced a circular static import babel.js <-> tt.js.
+// Static import cycles cause TDZ hazards, so verify the static graph is acyclic.
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));


### PR DESCRIPTION
Pulls the DFS-based static-import-cycle detection out of issue_8910 into
crates/rolldown/tests/rolldown/_test_helpers/find-static-cycle.mjs and
tightens issue_8595''s assertion (the previous string check missed bare
side-effect imports).