### PR TITLE
fix(linking): initialize wrapped ESM re-export owners

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -179,6 +179,125 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
   }
 
+  fn collect_wrapped_esm_init_modules_for_import_record(
+    &self,
+    rec_idx: ImportRecordIdx,
+  ) -> FxIndexSet<ModuleIdx> {
+    // See meta/design/linking/reference-needed-symbols.md for why this follows
+    // canonical owners through non-wrapped barrel modules.
+    let mut init_modules = FxIndexSet::default();
+    let rec = &self.ctx.module.import_records[rec_idx];
+    let Some(importee_idx) = rec.resolved_module else { return init_modules };
+    let importee_linking_info = &self.ctx.linking_infos[importee_idx];
+
+    if rec.meta.contains(ImportRecordMeta::IsExportStar) {
+      for resolved_export in importee_linking_info.resolved_exports.values() {
+        self.add_wrapped_esm_init_module_for_symbol(resolved_export.symbol_ref, &mut init_modules);
+      }
+      return init_modules;
+    }
+
+    for named_import in
+      self.ctx.module.named_imports.values().filter(|item| item.record_idx == rec_idx)
+    {
+      match &named_import.imported {
+        Specifier::Star => {
+          for resolved_export in importee_linking_info.resolved_exports.values() {
+            self.add_wrapped_esm_init_module_for_symbol(
+              resolved_export.symbol_ref,
+              &mut init_modules,
+            );
+          }
+        }
+        Specifier::Literal(name) => {
+          if let Some(resolved_export) = importee_linking_info.resolved_exports.get(name) {
+            self.add_wrapped_esm_init_module_for_symbol(
+              resolved_export.symbol_ref,
+              &mut init_modules,
+            );
+          } else {
+            self
+              .add_wrapped_esm_init_module_for_symbol(named_import.imported_as, &mut init_modules);
+          }
+        }
+      }
+    }
+
+    init_modules
+  }
+
+  fn add_wrapped_esm_init_module_for_symbol(
+    &self,
+    symbol_ref: SymbolRef,
+    init_modules: &mut FxIndexSet<ModuleIdx>,
+  ) {
+    let canonical_ref = self.ctx.symbol_db.canonical_ref_resolving_namespace(symbol_ref);
+    let meta = &self.ctx.linking_infos[canonical_ref.owner];
+    if matches!(meta.wrap_kind(), WrapKind::Esm)
+      && meta.wrapper_ref.is_some()
+      && !matches!(meta.concatenated_wrapped_module_kind, ConcatenateWrappedModuleKind::Inner)
+    {
+      init_modules.insert(canonical_ref.owner);
+    }
+  }
+
+  fn wrapped_esm_init_stmt_for_import_record(
+    &mut self,
+    rec_idx: ImportRecordIdx,
+  ) -> Option<Statement<'ast>> {
+    let init_modules = self
+      .collect_wrapped_esm_init_modules_for_import_record(rec_idx)
+      .into_iter()
+      .collect::<Vec<_>>();
+    if init_modules.is_empty() {
+      return None;
+    }
+
+    let init_exprs = init_modules.into_iter().filter_map(|module_idx| {
+      if !self.generated_init_esm_importee_ids.insert(module_idx) {
+        return None;
+      }
+
+      let importee_linking_info = &self.ctx.linking_infos[module_idx];
+      let wrapper_ref = importee_linking_info.wrapper_ref?;
+      let is_tla_or_contains_tla_dependency =
+        importee_linking_info.is_tla_or_contains_tla_dependency;
+      let (wrapper_ref_expr, _) = self.finalized_expr_for_symbol_ref(wrapper_ref, false, false);
+
+      let init_call = ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression(
+        SPAN,
+        wrapper_ref_expr,
+        NONE,
+        self.snippet.builder.vec(),
+        false,
+      ));
+
+      Some(if is_tla_or_contains_tla_dependency {
+        ast::Expression::AwaitExpression(
+          self.snippet.builder.alloc_await_expression(SPAN, init_call),
+        )
+      } else {
+        init_call
+      })
+    });
+
+    let init_exprs = init_exprs.collect::<Vec<_>>();
+    match init_exprs.len() {
+      0 => None,
+      1 => init_exprs
+        .into_iter()
+        .next()
+        .map(|init_expr| self.snippet.builder.statement_expression(SPAN, init_expr)),
+      _ => {
+        let builder = self.builder();
+        Some(builder.statement_expression(
+          SPAN,
+          builder.expression_sequence(SPAN, builder.vec_from_iter(init_exprs)),
+        ))
+      }
+    }
+  }
+
   /// If return true the import stmt should be removed,
   /// or transform the import stmt to target form.
   fn transform_or_remove_import_export_stmt(
@@ -194,6 +313,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let importee_linking_info = &self.ctx.linking_infos[importee.idx];
     match importee_linking_info.wrap_kind() {
       WrapKind::None => {
+        if let Some(init_stmt) = self.wrapped_esm_init_stmt_for_import_record(rec_idx) {
+          *stmt = init_stmt;
+          return false;
+        }
         // Remove this statement by ignoring it
       }
       WrapKind::Cjs => {
@@ -1480,6 +1603,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             match &self.ctx.modules[module_idx] {
               Module::Normal(importee) => {
                 let importee_linking_info = &self.ctx.linking_infos[importee.idx];
+                if matches!(importee_linking_info.wrap_kind(), WrapKind::None)
+                  && let Some(init_stmt) = self.wrapped_esm_init_stmt_for_import_record(rec_idx)
+                {
+                  program.body.push(init_stmt);
+                }
+
                 if matches!(importee_linking_info.wrap_kind(), WrapKind::Esm)
                 // If it is a inner concatenated module, we should not call its wrapper here
                   && !matches!(

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -237,14 +237,20 @@ impl GenerateStage<'_> {
               stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
                 match reference_ref {
                   rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
-                    depended_symbols.insert(symbols.canonical_ref_resolving_namespace(*referenced));
+                    self.add_depended_symbol_with_wrapped_esm_init(
+                      depended_symbols,
+                      symbols.canonical_ref_resolving_namespace(*referenced),
+                    );
                   }
                   rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
                     match member_expr.represent_symbol_ref(
                       &self.link_output.metas[module.idx].resolved_member_expr_refs,
                     ) {
                       Some(sym_ref) => {
-                        depended_symbols.insert(symbols.canonical_ref_resolving_namespace(sym_ref));
+                        self.add_depended_symbol_with_wrapped_esm_init(
+                          depended_symbols,
+                          symbols.canonical_ref_resolving_namespace(sym_ref),
+                        );
                       }
                       _ => {
                         // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
@@ -272,8 +278,10 @@ impl GenerateStage<'_> {
               // out a exported symbol that came from a cjs module.
               .filter(|resolved_export| !resolved_export.came_from_commonjs)
             {
-              depended_symbols
-                .insert(symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref));
+              self.add_depended_symbol_with_wrapped_esm_init(
+                depended_symbols,
+                symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref),
+              );
             }
           }
 
@@ -320,6 +328,22 @@ impl GenerateStage<'_> {
         let symbol_data = symbols.get_mut(declared);
         symbol_data.chunk_idx = Some(chunk_idx);
       }
+    }
+  }
+
+  fn add_depended_symbol_with_wrapped_esm_init(
+    &self,
+    depended_symbols: &mut FxIndexSet<SymbolRef>,
+    symbol_ref: SymbolRef,
+  ) {
+    depended_symbols.insert(symbol_ref);
+
+    let meta = &self.link_output.metas[symbol_ref.owner];
+    if matches!(meta.wrap_kind(), WrapKind::Esm)
+      && let Some(wrapper_ref) = meta.wrapper_ref
+      && wrapper_ref != symbol_ref
+    {
+      depended_symbols.insert(wrapper_ref);
     }
   }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -10,7 +10,7 @@ use rolldown_common::{
   ModuleNamespaceIncludedReason, ModuleType, NormalModule, NormalizedBundlerOptions,
   RUNTIME_HELPER_NAMES, RUNTIME_MODULE_ID, RuntimeHelper, RuntimeModuleBrief, SideEffectDetail,
   StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
-  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  UsedSymbolRefs, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
   side_effects::DeterminedSideEffects,
 };
 #[cfg(not(target_family = "wasm"))]
@@ -804,6 +804,17 @@ pub fn include_symbol(
 
   ctx.used_symbol_refs.insert(canonical_ref);
   if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
+    let wrapper_ref = {
+      let meta = &ctx.metas[canonical_ref.owner];
+      matches!(meta.wrap_kind(), WrapKind::Esm)
+        .then_some(meta.wrapper_ref)
+        .flatten()
+        .filter(|wrapper_ref| *wrapper_ref != canonical_ref)
+    };
+    if let Some(wrapper_ref) = wrapper_ref {
+      include_symbol(ctx, wrapper_ref, SymbolIncludeReason::Normal);
+    }
+
     if !include_reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference)
       && module.module_type == ModuleType::Json
     {

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -16,6 +16,7 @@ var init_lib = __esmMin((() => {}));
 init_lib();
 //#endregion
 //#region log.js
+init_lib();
 assert.strictEqual(1, 1);
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_lib(), __toCommonJS(lib_exports));

--- a/crates/rolldown/tests/rolldown/issues/8950/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8950/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry1",
+        "import": "./entry1.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./entry2.js"
+      }
+    ],
+    "minify": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8950/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8950/artifacts.snap
@@ -1,0 +1,48 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## createIcon.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region createIcon.js
+var createIcon_exports = /* @__PURE__ */ __exportAll({
+	SvgIcon: () => SvgIcon,
+	createIcon: () => createIcon
+});
+function createIcon(name) {
+	return SvgIcon.muiName + "-" + name;
+}
+var SvgIcon;
+var init_createIcon = __esmMin((() => {
+	SvgIcon = { muiName: "SvgIcon" };
+}));
+
+//#endregion
+export { createIcon_exports as n, init_createIcon as r, createIcon as t };
+```
+
+## entry1.js
+
+```js
+import { r as init_createIcon, t as createIcon } from "./createIcon.js";
+
+//#region entry1.js
+init_createIcon();
+console.log(createIcon("Arrow"));
+
+//#endregion
+```
+
+## entry2.js
+
+```js
+import { n as createIcon_exports, r as init_createIcon } from "./createIcon.js";
+
+//#region entry2.js
+init_createIcon();
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/8950/createIcon.js
+++ b/crates/rolldown/tests/rolldown/issues/8950/createIcon.js
@@ -1,0 +1,5 @@
+export const SvgIcon = { muiName: 'SvgIcon' };
+
+export function createIcon(name) {
+  return SvgIcon.muiName + '-' + name;
+}

--- a/crates/rolldown/tests/rolldown/issues/8950/entry1.js
+++ b/crates/rolldown/tests/rolldown/issues/8950/entry1.js
@@ -1,0 +1,2 @@
+import { createIcon } from './reexport.js';
+console.log(createIcon('Arrow'));

--- a/crates/rolldown/tests/rolldown/issues/8950/entry2.js
+++ b/crates/rolldown/tests/rolldown/issues/8950/entry2.js
@@ -1,0 +1,2 @@
+require('./createIcon.js');
+// console.log(createIcon('Star'));

--- a/crates/rolldown/tests/rolldown/issues/8950/reexport.js
+++ b/crates/rolldown/tests/rolldown/issues/8950/reexport.js
@@ -1,0 +1,1 @@
+export { createIcon } from './createIcon.js';

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -22,6 +22,7 @@ var init_lib_impl = __esmMin((() => {
 init_lib_impl();
 //#endregion
 //#region trigger-error.js
+init_lib_impl();
 nodeAssert(foo() === 1, "foo() should return 1");
 //#endregion
 //#region trigger-wrapping.js

--- a/meta/design/linking/reference-needed-symbols.md
+++ b/meta/design/linking/reference-needed-symbols.md
@@ -33,7 +33,7 @@ For each `(importer, stmt_info, rec)` triple this pass dispatches on `rec.kind`,
 
 ### `Module::Normal` importees
 
-- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call.
+- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call. Later stages still must check the canonical owner of live imported symbols: a non-wrapped barrel can forward a binding from a wrapped ESM module, and that owner still needs its `init_*()` call before the binding is read.
 
   ```js
   // foo.js: export const x = 1;


### PR DESCRIPTION
Fixes #8950.

This fixes missing `init_*()` calls when an entry reads a binding re-exported through a non-wrapped ESM barrel, while the canonical owner of that binding is a wrapped ESM module split into another chunk. In the MUI dep-optimizer case, the generated icon chunk could call `createSvgIcon()` before `SvgIcon` had been initialized, causing `Cannot read properties of undefined (reading 'muiName')`.

Changes:
- include wrapped ESM wrapper symbols when live symbols are marked and cross-chunk dependencies are computed
- emit `init_*()` calls for imported/re-exported bindings whose canonical owner is wrapped, even when the import record itself points at a flat barrel
- add a regression fixture for #8950 and update snapshots where the extra init call is now required