### PR TITLE
fix(finalizer): skip redundant init call when barrel executes in same chunk

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -245,6 +245,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     &mut self,
     rec_idx: ImportRecordIdx,
   ) -> Option<Statement<'ast>> {
+    let rec = &self.ctx.module.import_records[rec_idx];
+    // If the non-wrapped forwarding module is emitted in this chunk, its own
+    // lowered statement already preserves the required init call in execution
+    // order. This fallback is only for barrels that do not execute here.
+    if rec.resolved_module.is_some_and(|importee_idx| {
+      let importee_linking_info = &self.ctx.linking_infos[importee_idx];
+      matches!(importee_linking_info.wrap_kind(), WrapKind::None)
+        && importee_linking_info.is_included
+        && self.ctx.chunk_graph.module_to_chunk[importee_idx] == Some(self.ctx.chunk_idx)
+    }) {
+      return None;
+    }
+
     let init_modules = self
       .collect_wrapped_esm_init_modules_for_import_record(rec_idx)
       .into_iter()

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -16,7 +16,6 @@ var init_lib = __esmMin((() => {}));
 init_lib();
 //#endregion
 //#region log.js
-init_lib();
 assert.strictEqual(1, 1);
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_lib(), __toCommonJS(lib_exports));

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -22,7 +22,6 @@ var init_lib_impl = __esmMin((() => {
 init_lib_impl();
 //#endregion
 //#region trigger-error.js
-init_lib_impl();
 nodeAssert(foo() === 1, "foo() should return 1");
 //#endregion
 //#region trigger-wrapping.js

--- a/meta/design/linking/reference-needed-symbols.md
+++ b/meta/design/linking/reference-needed-symbols.md
@@ -33,7 +33,7 @@ For each `(importer, stmt_info, rec)` triple this pass dispatches on `rec.kind`,
 
 ### `Module::Normal` importees
 
-- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call. Later stages still must check the canonical owner of live imported symbols: a non-wrapped barrel can forward a binding from a wrapped ESM module, and that owner still needs its `init_*()` call before the binding is read.
+- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call. Later stages still must check the canonical owner of live imported symbols: a non-wrapped barrel can forward a binding from a wrapped ESM module, and that owner still needs its `init_*()` call before the binding is read when the barrel does not execute in the same chunk.
 
   ```js
   // foo.js: export const x = 1;


### PR DESCRIPTION
When lowering an import from a non-wrapped barrel that forwards a binding from a wrapped-ESM module, the finalizer was emitting a fallback `init_*()` call. If the barrel itself is included and emitted in the current chunk, its own lowered statement already preserves the init call in execution order, making the fallback a duplicate. The finalizer now skips the fallback in that case; two integration snapshots lose their redundant `init_lib()` / `init_lib_impl()` lines.
