### PR TITLE
fix(deps): pin pnpm to 10.23.0 to work around catalog mismatch on Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@10.23.0",
   "pnpm": {
     "overrides": {
       "vitepress>vite": "npm:rolldown-vite@latest"


### PR DESCRIPTION
## Summary

Pin `packageManager` back to `pnpm@10.23.0` to unblock Netlify docs deploys.

## Context

After #9347 bumped pnpm `10.23.0` → `10.33.4`, every Netlify deploy started failing during `pnpm install` with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "catalogs" configuration doesn't match the value found in the lockfile
Update your lockfile using "pnpm install --no-frozen-lockfile"
```

Root cause: pnpm **10.24.0** added a strict catalog comparison for `--frozen-lockfile` mode via [pnpm/pnpm#10231](https://github.com/pnpm/pnpm/pull/10231). The comparison logic (`allCatalogsAreUpToDate`) is buggy — it reports a mismatch even though the workspace catalog and lockfile snapshot are identical, and `pnpm install --no-frozen-lockfile` locally produces zero diff.

This is the same issue [sapphi-red](https://github.com/sapphi-red) already filed against pnpm using this repo as the reproduction: [pnpm/pnpm#10258](https://github.com/pnpm/pnpm/issues/10258) (still open, no comments from maintainers).

`#9343` (the npm packages renovate PR that changed `valibot` and `vitepress-plugin-graphviz` in the catalog) only made the failure visible — the regression was introduced by the pnpm bump.