### PR TITLE
ci: replace action-semantic-pull-request with inline regex

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -14,27 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed (newline-delimited).
-          # Derived from https://github.com/commitizen/conventional-commit-types
-          types: |
-            fix
-            feat
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
-            release
-          # Configure that a scope must always be provided.
-          requireScope: false
-          # Configure additional validation for the subject based on a regex.
-          ignoreLabels: |
-            bot
+      - env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z0-9/_-]+\))?!?: .+'
+          if ! printf '%s' "$TITLE" | grep -Eq "$PATTERN"; then
+            {
+              echo "::error title=Invalid PR title::PR title must follow Conventional Commits."
+              echo ""
+              echo "Got:      $TITLE"
+              echo "Expected: <type>(<scope>): <subject>    e.g.  fix(parser): handle trailing comma"
+              echo "          <type>: <subject>             e.g.  fix: handle trailing comma"
+              echo ""
+              echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, release, revert, style, test"
+              echo "Scope:         optional; chars a-z 0-9 / _ -"
+              echo "Breaking:      append ! before the colon (e.g. feat(ast)!: ... or feat!: ...)"
+            } >&2
+            exit 1
+          fi


### PR DESCRIPTION
Since https://github.com/rolldown/rolldown/pull/9188 replaced `pull_request_target` with `pull_request` trigger, `amannn/action-semantic-pull-request` no longer works. To fix that, this PR replaces that with a bash script using grep.

refs https://github.com/oxc-project/oxc/pull/21631