### PR TITLE
ci: replace `igorskyflyer/action-readfile` with `cat`

### DIFF
--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -122,18 +122,11 @@ jobs:
         with:
           name: rolldown-version
 
-      - name: Read `rolldown-version.txt`
-        id: rolldown-version
-        uses: igorskyflyer/action-readfile@d38a0aef4a6ba5245f2a127705a8cdc8d5d5e702 # v1.0.0
-        with:
-          path: rolldown-version.txt
-
       - name: Canary/Nightly Versioning
         run: |
+          ROLLDOWN_VERSION=$(cat rolldown-version.txt)
           node --import @oxc-node/core/register ./scripts/misc/bump-version.js ${ROLLDOWN_VERSION}
           vp run --filter rolldown prepublishOnly --skip-optional-publish
-        env:
-          ROLLDOWN_VERSION: ${{ steps.rolldown-version.outputs.content }}
 
       - name: Copy Licenses
         run: |


### PR DESCRIPTION
Replace this action with `cat` to reduce attack surface.

refs #3128