### PR TITLE
chore(deps): pin libmimalloc-sys2 to 0.1.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys2"
-version = "0.1.55"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59567f2add52cb5a14b97e11ba4a20239fb93402fa99173347cbb689cd5330"
+checksum = "e8cac9b2d60928163027249a1ebd0ec8e6c58b66dca93cccf58ee618e66fc062"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
Related to #9361, see https://github.com/napi-rs/mimalloc-safe/issues/64

To resolve https://github.com/rolldown/rolldown/actions/runs/25723489236/job/75533705378