### PR TITLE
test(mcs): cover require() in `$initial` group

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_test.mjs
@@ -5,17 +5,22 @@ import assert from 'node:assert';
 const dist = path.join(import.meta.dirname, 'dist');
 const files = fs
   .readdirSync(dist)
-  .filter((f) => f !== 'package.json')
+  .filter((f) => f !== 'package.json' && f !== 'rolldown-runtime.js')
   .sort();
 
-// tags: ['$initial'] should capture modules in the static import chain of the entry
-// but NOT modules only reachable via dynamic import
+// `tags: ['$initial']` should capture every module in the entry's initial
+// execution chain — static ESM imports (shared.js) and `require()` edges
+// (required.js) — but not modules only reachable via dynamic import (lazy-dep.js).
 assert.deepStrictEqual(files, ['initial-deps.js', 'lazy.js', 'main.js']);
 
 const initialDeps = fs.readFileSync(path.join(dist, 'initial-deps.js'), 'utf-8');
 assert.ok(
   initialDeps.includes('shared.js'),
   'initial-deps should contain shared.js (statically imported)',
+);
+assert.ok(
+  initialDeps.includes('required.js'),
+  'initial-deps should contain required.js (require()d from main)',
 );
 assert.ok(
   !initialDeps.includes('lazy-dep.js'),
@@ -25,3 +30,4 @@ assert.ok(
 const lazyChunk = fs.readFileSync(path.join(dist, 'lazy.js'), 'utf-8');
 assert.ok(lazyChunk.includes('lazy-dep.js'), 'lazy chunk should contain lazy-dep.js');
 assert.ok(!lazyChunk.includes('shared.js'), 'lazy chunk should NOT contain shared.js');
+assert.ok(!lazyChunk.includes('required.js'), 'lazy chunk should NOT contain required.js');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/artifacts.snap
@@ -6,13 +6,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## initial-deps.js
 
 ```js
+import { n as __exportAll, r as __toCommonJS, t as __esmMin } from "./rolldown-runtime.js";
 //#region shared.js
 const shared = "shared-initial";
 //#endregion
+//#region required.js
+var required_exports = /* @__PURE__ */ __exportAll({ required: () => required$1 });
+var required$1;
+//#endregion
 //#region main.js
+const required = (__esmMin((() => {
+	required$1 = "required-value";
+}))(), __toCommonJS(required_exports));
 const lazy = import("./lazy.js");
 //#endregion
-export { shared as n, lazy as t };
+export { required as n, shared as r, lazy as t };
 
 ```
 
@@ -29,7 +37,15 @@ export { lazyDep };
 ## main.js
 
 ```js
-import { n as shared, t as lazy } from "./initial-deps.js";
-export { lazy, shared };
+import { n as required, r as shared, t as lazy } from "./initial-deps.js";
+export { lazy, required, shared };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __toCommonJS as r, __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/main.js
@@ -1,3 +1,4 @@
 import { shared } from './shared.js';
-export { shared };
+const required = require('./required.js');
+export { shared, required };
 export const lazy = import('./lazy.js');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/required.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/required.js
@@ -1,0 +1,1 @@
+export const required = 'required-value';


### PR DESCRIPTION
## Summary
- Extends the `tags_initial` fixture so a module reached from a user entry only via `require()` (`required.js`) is asserted to land in the `$initial`-tagged chunk, alongside the statically imported `shared.js`.
- The dynamic-only `lazy-dep.js` is still asserted to stay out.
- Pins down the current behavior: `link_stage/mod.rs` filters `Require` out of `meta.dependencies`, but `patch_module_dependencies` re-adds those edges via referenced symbols, so the `$initial` BFS still visits `require()` targets. Without this test, a future cleanup of either side could silently drop `require()` targets from `$initial` chunks.

## Test plan
- [x] `cargo test -p rolldown --test integration -- --ignored tags_initial` passes
- [x] Snapshot (`artifacts.snap`) reflects `required.js` placed inside `initial-deps.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)