### PR TITLE
feat(rolldown): inline optional-chain enum access

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -482,7 +482,20 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           *expr = self.snippet.builder.expression_object(SPAN, self.snippet.builder.vec());
         }
       }
-      ast::Expression::ChainExpression(chain_expr) => {
+      ast::Expression::ChainExpression(_) => {
+        // Try inline as enum access first (`E?.x` → literal). Enum bindings are
+        // always defined (the IIFE produces `{}`, never null/undefined), so `?.`
+        // is equivalent to `.` here.
+        if self.ctx.has_enum_inlining
+          && let Some(new_expr) = self.try_inline_enum_access(expr)
+        {
+          *expr = new_expr;
+          self.rewrite_import_meta_hot(expr);
+          walk_mut::walk_expression(self, expr);
+          return;
+        }
+
+        let ast::Expression::ChainExpression(chain_expr) = expr else { unreachable!() };
         let chain_span = chain_expr.span;
         if let Some(new_expr) = chain_expr
           .expression

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -538,22 +538,29 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   /// - `Direction.Up` (static member with identifier object)
   /// - `ns.Direction.Up` (chained static member via namespace import)
   /// - `Direction["Up"]` (computed member with string literal key)
+  /// - `Direction?.Up` / `Direction?.["Up"]` (optional chain — enum bindings
+  ///   are always defined, so `?.` is equivalent to `.`)
   fn try_inline_enum_access(&self, expr: &ast::Expression<'_>) -> Option<ast::Expression<'ast>> {
-    match expr {
-      ast::Expression::StaticMemberExpression(member_expr) => {
-        if let ast::Expression::Identifier(ident) = &member_expr.object {
-          self.try_inline_enum_member(ident, &member_expr.property.name)
-        } else {
-          self.try_inline_chained_enum_member(member_expr)
-        }
+    let member = expr.get_member_expr()?;
+    let (object, property_name) = match member {
+      ast::MemberExpression::StaticMemberExpression(m) => (&m.object, m.property.name.as_str()),
+      ast::MemberExpression::ComputedMemberExpression(m) => {
+        let ast::Expression::StringLiteral(prop) = &m.expression else { return None };
+        (&m.object, prop.value.as_str())
       }
-      ast::Expression::ComputedMemberExpression(member_expr) => {
-        let ast::Expression::Identifier(ident) = &member_expr.object else { return None };
-        let ast::Expression::StringLiteral(prop) = &member_expr.expression else { return None };
-        self.try_inline_enum_member(ident, prop.value.as_str())
-      }
-      _ => None,
+      ast::MemberExpression::PrivateFieldExpression(_) => return None,
+    };
+    if let ast::Expression::Identifier(ident) = object {
+      return self.try_inline_enum_member(ident, property_name);
     }
+    // `ns.Direction.Up` — namespace-import resolution. Only for direct (non-chain)
+    // static access; the chained-namespace optional case isn't handled.
+    if !matches!(expr, ast::Expression::ChainExpression(_))
+      && let ast::MemberExpression::StaticMemberExpression(sm) = member
+    {
+      return self.try_inline_chained_enum_member(sm);
+    }
+    None
   }
 
   /// Try to inline an enum member access like `Direction.Up` → `0`.

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -963,7 +963,6 @@ pub fn include_statement(
             // like `E.member.something` which wouldn't be inlined.
             if !member_expr_ref.is_write
               && let [prop] = member_expr_ref.prop_and_span_list.as_slice()
-              && !prop.optional
               && members.contains_key(prop.name.as_str())
             {
               // This member access will be inlined — don't include the enum declaration.

--- a/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_access/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_access/artifacts.snap
@@ -7,25 +7,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region enums.ts
-let c_num = /* @__PURE__ */ function(c_num) {
-	c_num[c_num["x"] = 123] = "x";
-	return c_num;
-}({});
-let d_num = /* @__PURE__ */ function(d_num) {
-	d_num[d_num["x"] = 123] = "x";
-	return d_num;
-}({});
 let e_num = /* @__PURE__ */ function(e_num) {
 	e_num[e_num["x"] = 123] = "x";
 	return e_num;
-}({});
-let c_str = /* @__PURE__ */ function(c_str) {
-	c_str["x"] = "abc";
-	return c_str;
-}({});
-let d_str = /* @__PURE__ */ function(d_str) {
-	d_str["x"] = "abc";
-	return d_str;
 }({});
 let e_str = /* @__PURE__ */ function(e_str) {
 	e_str["x"] = "abc";
@@ -37,16 +21,13 @@ inlined = [
 	123,
 	123,
 	"abc",
+	"abc",
+	123,
+	123,
+	"abc",
 	"abc"
 ];
-not_inlined = [
-	c_num?.x,
-	d_num?.["x"],
-	e_num,
-	c_str?.x,
-	d_str?.["x"],
-	e_str
-];
+not_inlined = [e_num, e_str];
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_access/entry.ts
+++ b/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_access/entry.ts
@@ -9,14 +9,18 @@ inlined = [
 
 	a_str.x,
 	b_str['x'],
-]
 
-not_inlined = [
+	// Optional chain — enum bindings are always defined (the IIFE produces
+	// `{}`, never null/undefined), so `?.` is equivalent to `.` here.
 	c_num?.x,
 	d_num?.['x'],
-	e_num,
 
 	c_str?.x,
 	d_str?.['x'],
+]
+
+not_inlined = [
+	// Bare references — used opaquely, keep declarations alive.
+	e_num,
 	e_str,
 ]


### PR DESCRIPTION
We already implemented single file optional chaining inline in Oxc https://github.com/oxc-project/oxc/pull/21834

## Summary

Teaches the cross-module enum inliner to fold optional-chain access (`E?.x`, `E?.['x']`) to the same literal as `E.x` / `E['x']`. With that hole filled, the tree-shaker bypass added in #9229 no longer needs its `!prop.optional` guard.

## Why this is safe

Enum bindings are always defined — the generated IIFE initializes them to `{}` (never null/undefined), and const enums are removed entirely after inlining. So `?.` cannot short-circuit on an enum object: `E?.x` is observationally equivalent to `E.x`.

The TDZ assumption this relies on (an enum identifier reaching the finalizer is always bound to a real value) is the same one `E.x` inlining already makes — we just extend it to the optional form.

## What changed

- `crates/rolldown/src/module_finalizers/mod.rs` — `try_inline_enum_access` now also matches `ChainExpression { StaticMemberExpression | ComputedMemberExpression }`.
- `crates/rolldown/src/module_finalizers/impl_visit_mut.rs` — pre-match inline attempt for `ChainExpression`, done before the main `visit_expression` dispatch so `expr` can be passed to `try_inline_enum_access` without conflicting with the existing arm's mutable destructure of the inner chain.
- `crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs` — drops the `!prop.optional` guard from the enum-decl bypass. `!is_write` stays.
- `crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_access/` — moves the optional cases into the `inlined` group; snapshot now folds all 8 inlinable accesses to literals while keeping `e_num`/`e_str` (bare identifier references).

## Test plan

- [x] `cargo test -p rolldown --test integration ts_enum_cross_module_inlining_access`
- [x] `cargo test -p rolldown` (1703 passed, 0 failed)
- [x] `cargo test -p rolldown --test integration enum` (24 passed)
- [x] `cargo test -p rolldown --test integration chain` (25 passed)
- [x] Spot-checked single-module `enum E { x = 1 }; console.log(E?.x)` via CLI — now folds to `console.log(1)`
- [x] `just ued` — produced no additional snap-diff changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)