### PR TITLE
docs: clarify scope of `topLevelVar`

### DIFF
--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -674,9 +674,18 @@ export interface OutputOptions {
    */
   preserveModulesRoot?: string;
   /**
-   * Whether to use `var` declarations at the top level scope instead of function / class / let / const expressions.
+   * Whether to convert top-level `let` and `const` declarations into `var` declarations.
    *
-   * Enabling this option can improve runtime performance of the generated code in certain environments.
+   * Enabling this option can improve runtime performance of the generated code in
+   * certain environments by avoiding Temporal Dead Zone (TDZ) checks. Only declarations
+   * in the module's top-level scope are rewritten — declarations inside nested scopes
+   * (functions, blocks, etc.) are left as-is.
+   *
+   * Note:
+   * - Top-level `class X {}` declarations are always emitted as `var X = class {}` so
+   *   rolldown can hoist them alongside other top-level bindings; this transform is
+   *   independent of `topLevelVar`.
+   * - Top-level `function` declarations are never rewritten.
    *
    * @default false
    *


### PR DESCRIPTION
The JSDoc for `output.topLevelVar` claimed it controls `function / class / let / const` declarations, which is misleading on two counts:

- Top-level `class X {}` is always rewritten to `var X = class {}` regardless of this flag — rolldown does this unconditionally so classes hoist alongside other top-level bindings (see `module_finalizers::get_transformed_class_decl`).
- Top-level `function` declarations are never rewritten.

In practice the flag only converts top-level `let` / `const` to `var`. Update the JSDoc to say so, and add notes covering the class hoisting behavior and the function carve-out so users hitting the surprise in #9377 can find the actual contract.

Closes #9377