### PR TITLE
ci: switch prepare-release to manual dispatch with version input

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,7 +37,9 @@ jobs:
           cache: true
 
       - name: Set version
-        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
 
       - run: just bump-packages ${VERSION}
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,8 +4,11 @@ permissions: {}
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 3' # Every Wednesday at 8am Shanghai time (UTC+8 = 00:00 UTC)
+    inputs:
+      version:
+        description: 'New version (e.g. 1.0.1)'
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -33,14 +36,8 @@ jobs:
         with:
           cache: true
 
-      - name: Get and bump version
-        run: |
-          VERSION=$(node -e "
-            const pkg = require('./packages/rolldown/package.json');
-            const [, base, rc] = pkg.version.match(/^(\d+\.\d+\.\d+)-rc\.(\d+)$/);
-            console.log(\`\${base}-rc.\${parseInt(rc) + 1}\`);
-          ")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Set version
+        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
       - run: just bump-packages ${VERSION}
 


### PR DESCRIPTION
## Summary

- The weekly `prepare-release` cron broke after the `1.0.0` release: the inline JS in the "Get and bump version" step assumed `^(\d+\.\d+\.\d+)-rc\.(\d+)$` and would throw `TypeError` on the destructure when matching against `1.0.0`.
- Drop the `schedule` trigger and make `workflow_dispatch` the only entrypoint, with a required `version` input. The job now takes the version straight from `inputs.version` and hands it to `just bump-packages`, which already validates semver via `scripts/misc/bump-version.js`.
- Post-RC, release cadence is no longer weekly, so a manual trigger fits better than a cron that has to guess the next version.