### PR TITLE
chore(renovate): disable automerge to require manual approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate"],
+  "automerge": false,
   "ignorePaths": ["**/node_modules/**", "**/examples/**", "**/crates/rolldown/tests/**"],
   "packageRules": [
     {


### PR DESCRIPTION
 The `Boshen/renovate` preset enables `automerge: true`, which let PR #9385 merge without any human review. Override it to false so all Renovate PRs wait for an approving review before merging.