### PR TITLE
refactor: use `ThreadsafeFunction::call_async_catch`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -14,7 +14,7 @@ use binding_make_absolute_externals_relative::BindingMakeAbsoluteExternalsRelati
 use binding_optimization::BindingOptimization;
 use derive_more::Debug;
 use napi::Either;
-use napi::bindgen_prelude::{FnArgs, Promise};
+use napi::bindgen_prelude::FnArgs;
 use rustc_hash::FxBuildHasher;
 use std::collections::HashMap;
 
@@ -32,7 +32,7 @@ use crate::types::{
   binding_log::BindingLog, binding_log_level::BindingLogLevel, js_callback::JsCallback,
 };
 
-pub type BindingOnLog = Option<JsCallback<FnArgs<(String, BindingLog)>, Promise<()>>>;
+pub type BindingOnLog = Option<JsCallback<FnArgs<(String, BindingLog)>, ()>>;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Default, Debug)]
@@ -76,7 +76,7 @@ pub struct BindingInputOptions<'env> {
   pub platform: Option<String>,
   pub log_level: BindingLogLevel,
   #[debug(skip)]
-  #[napi(ts_type = "(logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => Promise<void>")]
+  #[napi(ts_type = "(logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => void")]
   pub on_log: BindingOnLog,
   // extra
   pub cwd: String,

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -1,7 +1,7 @@
 use derive_more::Debug;
 use std::sync::Arc;
 
-use napi::bindgen_prelude::{FnArgs, Promise};
+use napi::bindgen_prelude::FnArgs;
 use rolldown_plugin_vite_resolve::{
   FinalizeBareSpecifierCallback, FinalizeOtherSpecifiersCallback, OnLogCallback,
   ViteResolveOptions, ViteResolveResolveOptions,
@@ -11,7 +11,7 @@ use crate::{
   options::plugin::types::binding_limited_boolean::BindingTrueValue,
   types::{
     binding_string_or_regex::{BindingStringOrRegex, bindingify_string_or_regex_array},
-    js_callback::{JsCallback, JsCallbackExt as _},
+    js_callback::{JsCallback, JsCallbackExt as _, MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt},
   },
 };
 
@@ -43,13 +43,13 @@ pub struct BindingViteResolvePluginConfig {
     ts_type = "(id: string, importer: string, isRequire: boolean, scan: boolean) => VoidNullable<string>"
   )]
   pub resolve_subpath_imports:
-    JsCallback<FnArgs<(String, Option<String>, bool, bool)>, Promise<Option<String>>>,
+    JsCallback<FnArgs<(String, Option<String>, bool, bool)>, Option<String>>,
   #[debug("{}", if on_warn.is_some() { "Some(<on_warn>)" } else { "None" })]
   #[napi(ts_type = "(message: string) => void")]
-  pub on_warn: Option<JsCallback<FnArgs<(String,)>, Promise<()>>>,
+  pub on_warn: Option<MaybeAsyncJsCallback<FnArgs<(String,)>, ()>>,
   #[debug("{}", if on_debug.is_some() { "Some(<on_debug>)" } else { "None" })]
   #[napi(ts_type = "(message: string) => void")]
-  pub on_debug: Option<JsCallback<FnArgs<(String,)>, Promise<()>>>,
+  pub on_debug: Option<MaybeAsyncJsCallback<FnArgs<(String,)>, ()>>,
   pub yarn_pnp: bool,
 }
 
@@ -115,7 +115,6 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
           Box::pin(async move {
             resolve_fn
               .invoke_async((id, importer, is_require, scan).into())
-              .await?
               .await
               .map_err(anyhow::Error::from)
           })
@@ -125,7 +124,7 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
         Arc::new(move |message: String| {
           let on_warn = Arc::clone(&on_warn);
           Box::pin(async move {
-            on_warn.invoke_async((message,).into()).await?.await.map_err(anyhow::Error::from)
+            on_warn.await_call((message,).into()).await.map_err(anyhow::Error::from)
           })
         })
       }),
@@ -133,7 +132,7 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
         Arc::new(move |message: String| {
           let on_debug = Arc::clone(&on_debug);
           Box::pin(async move {
-            on_debug.invoke_async((message,).into()).await?.await.map_err(anyhow::Error::from)
+            on_debug.await_call((message,).into()).await.map_err(anyhow::Error::from)
           })
         })
       }),

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -118,7 +118,7 @@ where
   napi::Either<Ret, InvalidReturnValue>: FromNapiValue,
 {
   async fn invoke_async(&self, args: Args) -> Result<Ret, napi::Error> {
-    match self.call_async(args).await? {
+    match self.call_async_catch(args).await? {
       Either::A(ret) => Ok(ret),
       Either::B(invalid) => Err(create_invalid_return_error(
         invalid.value_type,
@@ -171,7 +171,7 @@ where
   napi::Either<napi::Either<Promise<Ret>, Ret>, InvalidReturnValue>: FromNapiValue,
 {
   async fn await_call(&self, args: Args) -> Result<Ret, napi::Error> {
-    match self.call_async(args).await? {
+    match self.call_async_catch(args).await? {
       Either::A(Either::A(promise)) => promise.await,
       Either::A(Either::B(ret)) => Ok(ret),
       Either::B(invalid) => Err(create_invalid_return_error(

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -271,7 +271,6 @@ pub fn normalize_binding_options(
       Box::pin(async move {
         ts_fn
           .invoke_async((level.to_string(), log.into()).into())
-          .await?
           .await
           .map_err(anyhow::Error::from)
       })

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2272,7 +2272,7 @@ export interface BindingInputOptions {
   shimMissingExports?: boolean
   platform?: 'node' | 'browser' | 'neutral'
   logLevel: BindingLogLevel
-  onLog: (logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => Promise<void>
+  onLog: (logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => void
   cwd: string
   treeshake?: BindingTreeshake
   moduleTypes?: Record<string, string>

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -69,9 +69,6 @@ export function viteResolvePlugin(
 ): BuiltinPlugin {
   const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', {
     ...config,
-    async resolveSubpathImports(id: string, importer: string, isRequire: boolean, scan: boolean) {
-      return config.resolveSubpathImports(id, importer, isRequire, scan);
-    },
     // process is undefined for browser build
     yarnPnp: typeof process === 'object' && !!process.versions?.pnp,
   });

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -81,8 +81,7 @@ export function bindingifyInputOptions(
     platform: inputOptions.platform,
     shimMissingExports: inputOptions.shimMissingExports,
     logLevel: bindingifyLogLevel(logLevel),
-    // convert to async function to handle errors thrown in onLog
-    onLog: async (level, log) => onLog(level, log),
+    onLog,
     // After normalized, `false` will be converted to `undefined`, otherwise, default value will be assigned
     // Because it is hard to represent Enum in napi, ref: https://github.com/napi-rs/napi-rs/issues/507
     // So we use `undefined | NormalizedTreeshakingOptions` (or Option<NormalizedTreeshakingOptions> in Rust side), to represent `false | NormalizedTreeshakingOptions`


### PR DESCRIPTION
Use `ThreadsafeFunction::call_async_catch` added in https://github.com/napi-rs/napi-rs/pull/3291 so that we don't have to wrap values in promise on JS side.

refs https://github.com/rolldown/rolldown/pull/5931, https://github.com/rolldown/rolldown/pull/9355