### PR TITLE
fix(cjs): rename CJS-wrapped locals that would shadow chunk-scope names

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -12,7 +12,7 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, TaggedSymbolRef, WrapKind,
 };
 use rolldown_utils::ecmascript::legitimize_identifier_name;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn deconflict_chunk_symbols(
@@ -90,6 +90,38 @@ pub fn deconflict_chunk_symbols(
     });
   }
 
+  // Collect the canonical names of things that are emitted at the chunk's root scope and thus
+  // captured by every CJS-wrapped module's `__commonJS((exports, module) => { ... })` closure.
+  // A real-AST root-scope binding inside the closure whose name matches one of these would
+  // shadow the captured value at runtime (issues #9055, #9375). We track only rolldown-emitted
+  // names — iife/umd factory params and `require_xxx` wrapper facades — and intentionally
+  // exclude the names of import bindings that get rewritten away at codegen time. We use the
+  // symbols' *original* names here: wrapper symbols haven't been renamed yet at this point, and
+  // if any of them ends up renamed in the loop below, the conflict that triggered the rename
+  // would have been the user-source local — which is exactly the case we want to catch.
+  let mut chunk_scope_captured_names: FxHashSet<CompactStr> = FxHashSet::default();
+  if matches!(format, OutputFormat::Iife | OutputFormat::Umd) {
+    // Mirror the set rendered as factory params by `render_chunk_external_imports` +
+    // `render_factory_parameters`.
+    for (external_idx, _) in &chunk.direct_imports_from_external_modules {
+      let Some(external) = link_output.module_table[*external_idx].as_external() else {
+        continue;
+      };
+      if let Some(name) = renamer.get_canonical_name(external.namespace_ref) {
+        chunk_scope_captured_names.insert(name.clone());
+      }
+    }
+  }
+  // CJS wrapper facades (e.g. `require_foo`) are rendered at chunk scope and captured by every
+  // CJS-wrapped module's closure in this chunk.
+  for module_idx in chunk.modules.iter().copied() {
+    if let Some(wrapper_ref) = link_output.metas[module_idx].wrapper_ref {
+      let canonical_ref = link_output.symbol_db.canonical_ref_for(wrapper_ref);
+      chunk_scope_captured_names
+        .insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
+    }
+  }
+
   chunk
     .modules
     .iter()
@@ -130,12 +162,17 @@ pub fn deconflict_chunk_symbols(
               // Note:
               // 1. Some facade symbols may originate from external modules (e.g., namespace objects for external imports).
               // 2. Since we merge external module symbols, external symbol declared in a cjs module also needs to be deconflicted
-              link_output.symbol_db.is_facade_symbol(canonical_ref)
+              let is_facade_or_external = link_output.symbol_db.is_facade_symbol(canonical_ref)
                 || stmt_info.import_records.iter().any(|import_rec_idx| {
                   module.import_records[*import_rec_idx]
                     .resolved_module
                     .is_some_and(|module_idx| link_output.module_table[module_idx].is_external())
-                })
+                });
+              // Deconflict bindings that would shadow a name captured by the enclosing
+              // `__commonJS` closure (issues #9055, #9375).
+              let shadows_chunk_scope_name =
+                chunk_scope_captured_names.contains(canonical_ref.name(&link_output.symbol_db));
+              is_facade_or_external || shadows_chunk_scope_name
             } else {
               true
             };

--- a/crates/rolldown/tests/rolldown/issues/9055/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9055/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "index", "import": "./index.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9055/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9055/artifacts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+import { strict } from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region greet.cjs
+var require_greet$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	function greet() {
+		return "hello from cjs-dependency";
+	}
+	exports.greet = greet;
+}));
+//#endregion
+//#region index.js
+var import_cjs_dependency = (/* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	exports.greet = require_greet$1().greet;
+})))();
+strict.strictEqual(typeof import_cjs_dependency.greet, "function");
+strict.strictEqual((0, import_cjs_dependency.greet)(), "hello from cjs-dependency");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9055/cjs-dependency.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9055/cjs-dependency.cjs
@@ -1,0 +1,3 @@
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+const require_greet = require('./greet.cjs');
+exports.greet = require_greet.greet;

--- a/crates/rolldown/tests/rolldown/issues/9055/greet.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9055/greet.cjs
@@ -1,0 +1,6 @@
+//#region src/greet.ts
+function greet() {
+  return 'hello from cjs-dependency';
+}
+//#endregion
+exports.greet = greet;

--- a/crates/rolldown/tests/rolldown/issues/9055/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9055/index.js
@@ -1,0 +1,8 @@
+import { greet } from './cjs-dependency.cjs';
+import { strict as assert } from 'node:assert';
+
+// Regression assertion: prior to the fix, the bundled `cjs-dependency.cjs` closure emitted
+// `const require_greet = require_greet();` where the local LHS shadowed the synthesized
+// chunk-scope `require_greet` wrapper, producing a TDZ ReferenceError at import time.
+assert.strictEqual(typeof greet, 'function');
+assert.strictEqual(greet(), 'hello from cjs-dependency');

--- a/crates/rolldown/tests/rolldown/issues/9375/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9375/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "input": [{ "name": "index", "import": "./index.ts" }],
+    "external": ["pinia"],
+    "format": "iife",
+    "name": "__expose__",
+    "globals": {
+      "pinia": "Pinia"
+    }
+  },
+  "configVariants": [
+    {
+      "format": "umd"
+    }
+  ],
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9375/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9375/_test.mjs
@@ -1,0 +1,22 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Mock the external `pinia` global the IIFE/UMD wrapper passes in as a factory parameter.
+globalThis.Pinia = { createPinia: () => ({ __mocked: 'pinia' }) };
+// `freeExports` is referenced as a top-level global by the source's environment-detection
+// pattern; short-circuit it to false so the rest of the chain isn't evaluated.
+globalThis.freeExports = false;
+
+// Read the compiled bundle from this variant's `dist/`. Each `configVariants` entry runs this
+// script once after `dist/` is re-populated, so both the iife and umd variants are exercised.
+const bundle = readFileSync(resolve(import.meta.dirname, 'dist/index.js'), 'utf-8');
+
+// Regression assertion: prior to the fix the inner `__commonJS` closure declared `var pinia`
+// which shadowed the captured factory param `pinia`, so `(0, pinia.createPinia)()` read
+// `undefined.createPinia` and threw at script-load time. After the fix the local is renamed
+// to `pinia$1` and the call resolves to the mock above.
+new Function(bundle)();
+
+// Reaching this line means the bundle ran without throwing → no shadowing.
+assert.ok(true);

--- a/crates/rolldown/tests/rolldown/issues/9375/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9375/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+var __expose__ = (function(pinia) {
+	// HIDDEN [\0rolldown/runtime.js]
+	return (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+		var freeModule = freeExports && typeof module == "object" && module && !module.nodeType && module;
+		var pinia$1 = (0, pinia.createPinia)();
+		console.log([pinia$1, freeModule]);
+	})))();
+})(Pinia);
+
+```
+
+# Variant: [format: Umd]
+
+## Assets
+
+### index.js
+
+```js
+(function(global, factory) {
+	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory(require("pinia")) : typeof define === "function" && define.amd ? define(["pinia"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.__expose__ = factory(global.Pinia));
+})(this, function(pinia) {
+	// HIDDEN [\0rolldown/runtime.js]
+	return (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+		var freeModule = freeExports && typeof module == "object" && module && !module.nodeType && module;
+		var pinia$1 = (0, pinia.createPinia)();
+		console.log([pinia$1, freeModule]);
+	})))();
+});
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9375/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/9375/index.ts
@@ -1,0 +1,4 @@
+import { createPinia } from 'pinia';
+var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module;
+var pinia = createPinia();
+console.log([pinia, freeModule]);


### PR DESCRIPTION
## Summary
- Closes #9375 and #9055.
- A CJS-wrapped module is emitted as `__commonJS((exports, module) => { ... })`. The closure captures the chunk's outer scope, so any user-source `var/const` declaration inside the closure that shares a name with something already at chunk scope shadows the captured value at runtime.
- The existing logic in `deconflict_chunk_symbols.rs` deliberately set `needs_deconflict=false` for non-facade real-AST symbols in CJS-wrapped modules ("they live inside the closure and don't pollute the chunk's root scope"). That reasoning ignored that the closure *captures* the chunk's root scope.

Examples of names captured at chunk scope:
- **iife/umd factory params** (#9375): `(function(pinia) { __commonJS(((exports, module) => { var pinia = (0, pinia.createPinia)(); ... })) })(Pinia)` — local `pinia` shadowed the iife factory param.
- **CJS wrapper facades** (#9055): `var require_greet = __commonJS(...); ... const require_greet = require_greet();` — local `const require_greet` shadowed the synthesized `require_greet` wrapper.

Fix: collect those two specific kinds of names into `chunk_scope_captured_names` (using the symbols' *original* names, since wrappers haven't been renamed at this point), and force `needs_deconflict=true` for any CJS-wrapped module's root-scope symbol whose name is in that set. Other names reserved in the renamer (e.g. ESM module import bindings that get rewritten to `import_x.default`) are intentionally left out because they don't actually render at chunk scope — including them would cause unnecessary renames in many existing fixtures.

## Test plan
- [x] Regression fixtures at `crates/rolldown/tests/rolldown/issues/9375/` (covers `iife` and `umd` via `configVariants`) and `crates/rolldown/tests/rolldown/issues/9055/`.
- [x] Full integration suite identical to baseline: 1711 passed, 64 pre-existing failures unrelated to this change.
- [x] No existing fixture snapshots regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)