### PR TITLE
docs: remove `output.comments` warning as all issues have been resolved

### DIFF
--- a/packages/rolldown/src/options/docs/output-comments.md
+++ b/packages/rolldown/src/options/docs/output-comments.md
@@ -1,3 +1,0 @@
-::: warning
-Some comments may be still removed due to some known bugs: [#7257](https://github.com/rolldown/rolldown/issues/7257), [#7387](https://github.com/rolldown/rolldown/issues/7387)
-:::

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -629,8 +629,6 @@ export interface OutputOptions {
    *
    * When both `legalComments` and `comments.legal` are set, `comments.legal` takes priority.
    *
-   * {@include ./docs/output-comments.md}
-   *
    * @default true
    */
   comments?: boolean | CommentsOptions;


### PR DESCRIPTION
Both issues have been resolved