### PR TITLE
feat(dev): support watcher options `include` and `exclude`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ dependencies = [
  "derive_more",
  "rolldown_common",
  "rolldown_error",
+ "rolldown_utils",
  "schemars",
  "serde",
 ]

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -37,15 +37,27 @@ impl BindingDevEngine {
 
     let rebuild_strategy =
       dev_options.as_ref().and_then(|opts| opts.rebuild_strategy).map(Into::into);
-    let watch_options = dev_options.as_ref().and_then(|opts| opts.watch.as_ref());
-    let skip_write = watch_options.and_then(|watch| watch.skip_write);
-    let use_polling = watch_options.and_then(|watch| watch.use_polling);
-    let poll_interval = watch_options.and_then(|watch| watch.poll_interval);
-    let use_debounce = watch_options.and_then(|watch| watch.use_debounce);
-    let debounce_duration = watch_options.and_then(|watch| watch.debounce_duration);
+    // Take ownership of watch so we can consume Vec fields (include/exclude).
+    let watch_options = dev_options.and_then(|opts| opts.watch);
+    let skip_write = watch_options.as_ref().and_then(|watch| watch.skip_write);
+    let use_polling = watch_options.as_ref().and_then(|watch| watch.use_polling);
+    let poll_interval = watch_options.as_ref().and_then(|watch| watch.poll_interval);
+    let use_debounce = watch_options.as_ref().and_then(|watch| watch.use_debounce);
+    let debounce_duration = watch_options.as_ref().and_then(|watch| watch.debounce_duration);
     let compare_contents_for_polling =
-      watch_options.and_then(|watch| watch.compare_contents_for_polling);
-    let debounce_tick_rate = watch_options.and_then(|watch| watch.debounce_tick_rate);
+      watch_options.as_ref().and_then(|watch| watch.compare_contents_for_polling);
+    let debounce_tick_rate = watch_options.as_ref().and_then(|watch| watch.debounce_tick_rate);
+    let (watch_include, watch_exclude) = watch_options
+      .map(|watch| {
+        let include = watch
+          .include
+          .map(crate::types::binding_string_or_regex::bindingify_string_or_regex_array);
+        let exclude = watch
+          .exclude
+          .map(crate::types::binding_string_or_regex::bindingify_string_or_regex_array);
+        (include, exclude)
+      })
+      .unwrap_or((None, None));
 
     // Create bundler config
     let bundler_config = create_bundler_config_from_binding_options(options)?;
@@ -104,6 +116,8 @@ impl BindingDevEngine {
       || debounce_duration.is_some()
       || compare_contents_for_polling.is_some()
       || debounce_tick_rate.is_some()
+      || watch_include.is_some()
+      || watch_exclude.is_some()
     {
       Some(rolldown_dev::DevWatchOptions {
         disable_watcher: None,
@@ -114,6 +128,8 @@ impl BindingDevEngine {
         debounce_duration: debounce_duration.map(u64::from),
         compare_contents_for_polling,
         debounce_tick_rate: debounce_tick_rate.map(u64::from),
+        include: watch_include,
+        exclude: watch_exclude,
       })
     } else {
       None

--- a/crates/rolldown_binding/src/binding_dev_options.rs
+++ b/crates/rolldown_binding/src/binding_dev_options.rs
@@ -1,6 +1,7 @@
 use crate::types::binding_client_hmr_update::BindingClientHmrUpdate;
 use crate::types::binding_outputs::BindingOutputs;
 use crate::types::binding_rebuild_strategy::BindingRebuildStrategy;
+use crate::types::binding_string_or_regex::BindingStringOrRegex;
 use crate::types::error::BindingResult;
 use crate::types::js_callback::JsCallback;
 use napi::bindgen_prelude::FnArgs;
@@ -14,6 +15,8 @@ pub struct BindingDevWatchOptions {
   pub debounce_duration: Option<u32>,
   pub compare_contents_for_polling: Option<bool>,
   pub debounce_tick_rate: Option<u32>,
+  pub include: Option<Vec<BindingStringOrRegex>>,
+  pub exclude: Option<Vec<BindingStringOrRegex>>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -11,7 +11,7 @@ use notify::EventKind;
 use rolldown_common::WatcherChangeKind;
 use rolldown_error::BuildResult;
 use rolldown_fs_watcher::{DynFsWatcher, FsEventResult, RecursiveMode};
-use rolldown_utils::{dashmap::FxDashSet, indexmap::FxIndexMap};
+use rolldown_utils::{dashmap::FxDashSet, indexmap::FxIndexMap, pattern_filter};
 use sugar_path::SugarPath;
 use tokio::sync::Mutex;
 
@@ -450,12 +450,18 @@ impl BundleCoordinator {
   async fn update_watch_paths(&self) -> BuildResult<()> {
     let bundler = self.bundler.lock().await;
     let watch_files = bundler.watch_files();
+    let cwd = bundler.options().cwd.to_string_lossy().to_string();
+
+    let include = self.ctx.options.watch_include.as_deref();
+    let exclude = self.ctx.options.watch_exclude.as_deref();
 
     let mut watcher = self.watcher.lock().ok().context("Failed to acquire watcher lock")?;
     let mut paths_mut = watcher.paths_mut();
     for watch_file in watch_files.iter() {
       let watch_file = &**watch_file;
-      if !self.watched_files.contains(watch_file) {
+      if !self.watched_files.contains(watch_file)
+        && pattern_filter::filter(exclude, include, watch_file, &cwd).inner()
+      {
         self.watched_files.insert(watch_file.to_string().into());
         paths_mut.add(watch_file.as_path(), RecursiveMode::NonRecursive)?;
       }

--- a/crates/rolldown_dev_common/Cargo.toml
+++ b/crates/rolldown_dev_common/Cargo.toml
@@ -25,5 +25,6 @@ deserialize_dev_options = ["dep:schemars", "dep:serde"]
 derive_more = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
+rolldown_utils = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/rolldown_dev_common/src/types/dev_options.rs
+++ b/crates/rolldown_dev_common/src/types/dev_options.rs
@@ -1,6 +1,7 @@
 use derive_more::Debug;
 use rolldown_common::ClientHmrUpdate;
 use rolldown_error::BuildResult;
+use rolldown_utils::pattern_filter::StringOrRegex;
 use std::sync::Arc;
 
 #[cfg(feature = "deserialize_dev_options")]
@@ -51,6 +52,8 @@ pub struct NormalizedDevOptions {
   pub debounce_duration: u64,
   pub compare_contents_for_polling: bool,
   pub debounce_tick_rate: Option<u64>,
+  pub watch_include: Option<Vec<StringOrRegex>>,
+  pub watch_exclude: Option<Vec<StringOrRegex>>,
 }
 
 pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
@@ -67,5 +70,7 @@ pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
     debounce_duration: watch_options.debounce_duration.unwrap_or(10),
     compare_contents_for_polling: watch_options.compare_contents_for_polling.unwrap_or(false),
     debounce_tick_rate: watch_options.debounce_tick_rate,
+    watch_include: watch_options.include,
+    watch_exclude: watch_options.exclude,
   }
 }

--- a/crates/rolldown_dev_common/src/types/dev_watch_options.rs
+++ b/crates/rolldown_dev_common/src/types/dev_watch_options.rs
@@ -1,7 +1,8 @@
+use rolldown_utils::pattern_filter::StringOrRegex;
 #[cfg(feature = "deserialize_dev_options")]
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_dev_options")]
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "deserialize_dev_options", derive(Deserialize, JsonSchema))]
@@ -26,4 +27,31 @@ pub struct DevWatchOptions {
   pub compare_contents_for_polling: Option<bool>,
   /// Tick rate in milliseconds for debounced watchers (only used when use_debounce is true)
   pub debounce_tick_rate: Option<u64>,
+  /// Filter to limit which discovered files are registered with the file watcher.
+  /// Strings are treated as glob patterns.
+  #[cfg_attr(
+    feature = "deserialize_dev_options",
+    serde(default, deserialize_with = "deserialize_string_or_regex"),
+    schemars(with = "Option<Vec<String>>")
+  )]
+  pub include: Option<Vec<StringOrRegex>>,
+  /// Filter to prevent discovered files from being registered with the file watcher.
+  /// Strings are treated as glob patterns.
+  #[cfg_attr(
+    feature = "deserialize_dev_options",
+    serde(default, deserialize_with = "deserialize_string_or_regex"),
+    schemars(with = "Option<Vec<String>>")
+  )]
+  pub exclude: Option<Vec<StringOrRegex>>,
+}
+
+#[cfg(feature = "deserialize_dev_options")]
+fn deserialize_string_or_regex<'de, D>(
+  deserializer: D,
+) -> Result<Option<Vec<StringOrRegex>>, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let deserialized = Option::<Vec<String>>::deserialize(deserializer)?;
+  Ok(deserialized.map(|v| v.into_iter().map(StringOrRegex::String).collect::<Vec<_>>()))
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -2135,6 +2135,26 @@
           ],
           "format": "uint64",
           "minimum": 0
+        },
+        "include": {
+          "description": "Filter to limit which discovered files are registered with the file watcher.\nStrings are treated as glob patterns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "description": "Filter to prevent discovered files from being registered with the file watcher.\nStrings are treated as glob patterns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -11,6 +11,7 @@ import type { OutputOptions } from '../../options/output-options';
 import { PluginDriver } from '../../plugin/plugin-driver';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
 import { normalizeBindingResult } from '../../utils/error';
+import { normalizedStringOrRegex } from '../../utils/normalize-string-or-regex';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 import type { DevOptions } from './dev-options';
 
@@ -72,6 +73,8 @@ export class DevEngine {
         debounceDuration: devOptions.watch.debounceDuration,
         compareContentsForPolling: devOptions.watch.compareContentsForPolling,
         debounceTickRate: devOptions.watch.debounceTickRate,
+        include: normalizedStringOrRegex(devOptions.watch.include),
+        exclude: normalizedStringOrRegex(devOptions.watch.exclude),
       },
     };
 

--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -1,5 +1,6 @@
 import type { BindingClientHmrUpdate } from '../../binding.cjs';
 import type { RolldownOutput } from '../../types/rolldown-output';
+import type { StringOrRegExp } from '../../types/utils';
 
 type DevOnHmrUpdates = (
   result:
@@ -51,6 +52,22 @@ export interface DevWatchOptions {
    * @default undefined (auto-select)
    */
   debounceTickRate?: number;
+  /**
+   * Filter to limit which discovered files are registered with the file watcher.
+   *
+   * Strings are treated as glob patterns.
+   *
+   * @default []
+   */
+  include?: StringOrRegExp | StringOrRegExp[];
+  /**
+   * Filter to prevent discovered files from being registered with the file watcher.
+   *
+   * Strings are treated as glob patterns.
+   *
+   * @default []
+   */
+  exclude?: StringOrRegExp | StringOrRegExp[];
 }
 
 export interface DevOptions {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1952,6 +1952,8 @@ export interface BindingDevWatchOptions {
   debounceDuration?: number
   compareContentsForPolling?: boolean
   debounceTickRate?: number
+  include?: Array<BindingStringOrRegex>
+  exclude?: Array<BindingStringOrRegex>
 }
 
 export interface BindingEmittedAsset {

--- a/packages/rolldown/tests/dev/dev-watch.test.ts
+++ b/packages/rolldown/tests/dev/dev-watch.test.ts
@@ -1,0 +1,202 @@
+import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { InputOptions, OutputOptions } from 'rolldown';
+import type { DevEngine, DevOptions } from 'rolldown/experimental';
+import { dev as _dev } from 'rolldown/experimental';
+import { sleep } from 'rolldown-tests/utils';
+import { test, vi } from 'vitest';
+
+const TEST_RETRY = 3;
+const TEST_TIMEOUT = 60_000;
+
+// Wrap dev() to inject usePolling for CI stability.
+// PollWatcher uses whole-second mtime comparison, so file edits
+// must use editFile() to ensure mtime crosses a second boundary.
+function dev(
+  inputOptions: InputOptions,
+  outputOptions: OutputOptions,
+  devOptions: DevOptions,
+): Promise<DevEngine> {
+  return _dev(inputOptions, outputOptions, {
+    ...devOptions,
+    watch: {
+      ...getDevWatchOptionsForCi(),
+      ...devOptions.watch,
+    },
+  });
+}
+
+// Write a file with a 1s sleep beforehand to ensure the PollWatcher's
+// whole-second mtime comparison detects the change.
+async function editFile(filePath: string, content: string) {
+  await sleep(1000);
+  fs.writeFileSync(filePath, content);
+}
+
+test.concurrent(
+  'dev watch exclude',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { input, outputDir, dir } = createTestInputAndOutput('dev-include-exclude', retryCount);
+
+    const onOutput = vi.fn();
+    const onHmrUpdates = vi.fn();
+    const engine = await dev(
+      {
+        input,
+        experimental: { devMode: true },
+      },
+      { dir: outputDir },
+      {
+        onOutput,
+        onHmrUpdates,
+        watch: {
+          exclude: '**/main.js',
+        },
+      },
+    );
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await expect.poll(() => onOutput).toHaveBeenCalled();
+
+    // edit file
+    onOutput.mockClear();
+    onHmrUpdates.mockClear();
+    await editFile(input, 'console.log(2)');
+    // The input is excluded, so no rebuild or HMR update should fire.
+    await sleep(1000);
+    expect(onOutput).not.toHaveBeenCalled();
+    expect(onHmrUpdates).not.toHaveBeenCalled();
+  },
+);
+
+test.concurrent(
+  'dev watch exclude sanity',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { input, outputDir, dir } = createTestInputAndOutput(
+      'dev-include-exclude-sanity',
+      retryCount,
+    );
+
+    const onOutput = vi.fn();
+    const onHmrUpdates = vi.fn();
+    const engine = await dev(
+      {
+        input,
+        experimental: { devMode: true },
+      },
+      { dir: outputDir },
+      {
+        onOutput,
+        onHmrUpdates,
+        watch: {
+          exclude: '**/unrelated.js',
+        },
+      },
+    );
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await expect.poll(() => onOutput).toHaveBeenCalled();
+
+    // edit file
+    onHmrUpdates.mockClear();
+    await editFile(input, 'console.log(2)');
+    // The input is not excluded, so an HMR update should fire.
+    await expect.poll(() => onHmrUpdates).toHaveBeenCalled();
+  },
+);
+
+test.concurrent(
+  'dev watch include',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir: cwd } = createTestWithMultiFiles('dev-include', retryCount, {
+      'main.js': `import './dep.js'\nconsole.log(1)`,
+      'dep.js': `export const dep = 1`,
+    });
+
+    const onOutput = vi.fn();
+    const onHmrUpdates = vi.fn();
+    const engine = await dev(
+      {
+        cwd,
+        input: 'main.js',
+        experimental: { devMode: true },
+      },
+      { dir: path.join(cwd, 'dist') },
+      {
+        onOutput,
+        onHmrUpdates,
+        watch: {
+          // Only main.js is watched; dep.js falls outside the allowlist.
+          include: '**/main.js',
+        },
+      },
+    );
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await expect.poll(() => onOutput).toHaveBeenCalled();
+
+    // edit file not matching include
+    onHmrUpdates.mockClear();
+    await editFile(path.join(cwd, 'dep.js'), `export const dep = 2`);
+    // dep.js is outside the include allowlist, so no HMR update should fire.
+    await sleep(1000);
+    expect(onHmrUpdates).not.toHaveBeenCalled();
+
+    // edit file matching include
+    await editFile(path.join(cwd, 'main.js'), `import './dep.js'\nconsole.log(2)`);
+    // main.js matches include, so an HMR update should fire.
+    await expect.poll(() => onHmrUpdates).toHaveBeenCalled();
+  },
+);
+
+function createTestInputAndOutput(testLabel: string, retryCount: number) {
+  const uniqueId = crypto.randomUUID().slice(0, 8);
+  const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;
+  const dir = path.join(import.meta.dirname, 'temp', dirname);
+  fs.mkdirSync(dir, { recursive: true });
+  const input = path.join(dir, 'main.js');
+  fs.writeFileSync(input, 'console.log(1)');
+  const outputDir = path.join(dir, 'dist');
+  return { input, outputDir, dir };
+}
+
+function createTestWithMultiFiles(
+  testLabel: string,
+  retryCount: number,
+  files: Record<string, string>,
+) {
+  const uniqueId = crypto.randomUUID().slice(0, 8);
+  const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;
+  const dir = path.join(import.meta.dirname, 'temp', dirname);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [fileName, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, fileName), content);
+  }
+  return { dir };
+}

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -15,8 +15,8 @@
     }
   },
   "scripts": {
-    "test:main": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests",
-    "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts --reporter verbose --hideSkippedTests",
+    "test:main": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --exclude '**/dev-watch.test.ts' --reporter verbose --hideSkippedTests",
+    "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts dev-watch.test.ts --reporter verbose --hideSkippedTests",
     "test:cli": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run cli-e2e.test.ts --reporter verbose --hideSkippedTests",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
     "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests"
@@ -27,6 +27,7 @@
     "vitest": "catalog:"
   },
   "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*",
     "@rolldown/test-side-effects-field": "link:./package-fixtures/test-side-effects-field",
     "@rolldown/test-side-effects-field-glob": "file:./package-fixtures/test-side-effects-field-glob",
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,6 +613,9 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.3)(vite@8.0.11(@types/node@24.10.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
     devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../test-dev-server
       '@rolldown/test-side-effects-field':
         specifier: link:./package-fixtures/test-side-effects-field
         version: link:package-fixtures/test-side-effects-field


### PR DESCRIPTION
## Summary

This PR adds `include` and `exclude` support for dev engine. The API is aligned with `watch.include` and `watch.exclude`.

Considering of the fact that `DevEngine` is a Vite-integrated feature,
we're not going to expose any of the options from Rolldown side except for the change of `dev` API.

## Test

Added new tests under `packages/rolldown/tests/dev`