### PR TITLE
fix(chunk-optimization): avoid unsafe dynamic-only merges

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -589,18 +589,7 @@ impl GenerateStage<'_> {
       Self::find_merge_target(&user_defined_entry, &user_defined_entry_modules, module_table);
     if user_defined_entry.is_empty() {
       let dynamic_chunk_entry_modules = Self::collect_entry_modules(&dynamic_entry, chunk_graph)?;
-      Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table).or_else(
-        || {
-          Self::find_dynamic_dominator(
-            &dynamic_entry,
-            &dynamic_chunk_entry_modules,
-            module_table,
-            dynamic_entry_to_dynamic_importers,
-            entry_chunk_reference,
-            &info.modules,
-          )
-        },
-      )
+      Self::find_merge_target(&dynamic_entry, &dynamic_chunk_entry_modules, module_table)
     } else {
       let chunk_idx = merged_user_defined_chunk?;
       let chunk = &chunk_graph.chunk_table[chunk_idx];
@@ -736,115 +725,6 @@ impl GenerateStage<'_> {
       });
       can_merge.then_some(*chunk_idx)
     })
-  }
-
-  /// Fallback merge-target search for the case where every chunk in `chunk_idxs`
-  /// is a dynamic entry (`find_merge_target` only inspects static
-  /// `importers_idx`, so it always fails here).
-  ///
-  /// Picks `D` from `dynamic_entry` such that the module-graph reachability
-  /// from `D`'s entry (following all import kinds) covers every other dynamic
-  /// entry in the set together with that entry's static and dynamic importers.
-  /// That guarantees every load path to those other entries goes through `D`,
-  /// so when shared modules are merged into `D`'s chunk and the other chunks
-  /// gain `D`'s chunk as a static dependency, no load can reach them without
-  /// `D` already being loaded.
-  ///
-  /// Two extra guards:
-  /// - **Export-pollution guard:** rejects the merge when any pending module
-  ///   has named exports. Those exports would still be needed cross-chunk by
-  ///   the other dynamic entries, forcing `D`'s chunk file to expose them at
-  ///   the file level — which is what `import('./D.js')` resolves to at
-  ///   runtime, polluting the dynamic-entry namespace observed by callers.
-  /// - **Side-effect leak guard:** rejects `D` when any user-defined entry
-  ///   reaches one of the covered dynamic entries without also reaching `D` —
-  ///   after the merge that other path would pull `D`'s chunk in as a static
-  ///   dep and run `D`'s side effects on a load that previously did not
-  ///   touch `D`.
-  fn find_dynamic_dominator(
-    dynamic_entry: &[ChunkIdx],
-    dynamic_entry_modules: &[ModuleIdx],
-    module_table: &ModuleTable,
-    dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
-    entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
-    pending_modules: &[ModuleIdx],
-  ) -> Option<ChunkIdx> {
-    if dynamic_entry.len() < 2 {
-      return None;
-    }
-    // Refuse the merge whenever any pending module exposes named exports. The
-    // other dynamic-entry chunks in `chunk_idxs` still need those exports
-    // cross-chunk, so after the merge the dominator's chunk would have to add
-    // them to its file-level export list — and that list is what
-    // `import('./dominator.js')` resolves to at runtime, polluting the
-    // dynamic-entry namespace observed by callers.
-    let exposes_exports = pending_modules
-      .iter()
-      .any(|m| module_table[*m].as_normal().is_some_and(|n| !n.named_exports.is_empty()));
-    if exposes_exports {
-      return None;
-    }
-    dynamic_entry.iter().zip(dynamic_entry_modules.iter()).find_map(
-      |(candidate_chunk_idx, candidate_module_idx)| {
-        let reach = Self::collect_module_graph_reach(*candidate_module_idx, module_table);
-
-        let dominates = dynamic_entry.iter().zip(dynamic_entry_modules.iter()).all(
-          |(other_chunk_idx, other_module_idx)| {
-            if other_chunk_idx == candidate_chunk_idx {
-              return true;
-            }
-            if !reach.contains(other_module_idx) {
-              return false;
-            }
-            let Some(other_module) = module_table[*other_module_idx].as_normal() else {
-              return false;
-            };
-            let static_importers_in_reach =
-              other_module.importers_idx.iter().all(|i| reach.contains(i));
-            let dynamic_importers_in_reach = dynamic_entry_to_dynamic_importers
-              .get(other_module_idx)
-              .is_none_or(|imps| imps.iter().all(|i| reach.contains(i)));
-            static_importers_in_reach && dynamic_importers_in_reach
-          },
-        );
-        if !dominates {
-          return None;
-        }
-
-        let leak = entry_chunk_reference.values().any(|reached_dynamic_chunks| {
-          if reached_dynamic_chunks.contains(candidate_chunk_idx) {
-            // The user-defined entry already loads the candidate before the
-            // other dynamic entries — no extra side effects can leak.
-            return false;
-          }
-          dynamic_entry
-            .iter()
-            .any(|other| other != candidate_chunk_idx && reached_dynamic_chunks.contains(other))
-        });
-        (!leak).then_some(*candidate_chunk_idx)
-      },
-    )
-  }
-
-  /// BFS the module graph from `start`, following every resolved import-record
-  /// edge regardless of import kind. Returns the set of modules transitively
-  /// reachable from `start`, including `start` itself.
-  fn collect_module_graph_reach(
-    start: ModuleIdx,
-    module_table: &ModuleTable,
-  ) -> FxHashSet<ModuleIdx> {
-    let mut reached = FxHashSet::default();
-    let mut queue = VecDeque::from([start]);
-    while let Some(cur) = queue.pop_front() {
-      if !reached.insert(cur) {
-        continue;
-      }
-      let Some(module) = module_table[cur].as_normal() else {
-        continue;
-      };
-      queue.extend(module.import_records.iter().filter_map(|rec| rec.resolved_module));
-    }
-    reached
   }
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.

--- a/crates/rolldown/tests/rolldown/issues/9350/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9350/_config.json
@@ -1,0 +1,17 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "experimental": {
+      "chunkOptimization": {
+        "mergeCommonChunks": true,
+        "avoidRedundantChunkLoads": false
+      }
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9350/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9350/_test.mjs
@@ -1,0 +1,16 @@
+import { strict as assert } from 'node:assert';
+
+const logs = [];
+const originalLog = console.log;
+console.log = (...args) => {
+  logs.push(args.join(' '));
+};
+
+try {
+  const main = await import('./dist/main.js');
+  await main.load2();
+
+  assert.deepEqual(logs, ['main', 'shared', 'd2']);
+} finally {
+  console.log = originalLog;
+}

--- a/crates/rolldown/tests/rolldown/issues/9350/d1.js
+++ b/crates/rolldown/tests/rolldown/issues/9350/d1.js
@@ -1,0 +1,8 @@
+import { marker } from './main.js';
+import './shared.js';
+
+console.log('d1', marker);
+
+export function load2FromD1() {
+  return import('./d2.js');
+}

--- a/crates/rolldown/tests/rolldown/issues/9350/d2.js
+++ b/crates/rolldown/tests/rolldown/issues/9350/d2.js
@@ -1,0 +1,3 @@
+import './shared.js';
+
+console.log('d2');

--- a/crates/rolldown/tests/rolldown/issues/9350/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9350/main.js
@@ -1,0 +1,11 @@
+export const marker = 'main';
+
+export function load1() {
+  return import('./d1.js');
+}
+
+export function load2() {
+  return import('./d2.js');
+}
+
+console.log('main');

--- a/crates/rolldown/tests/rolldown/issues/9350/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9350/shared.js
@@ -1,0 +1,1 @@
+console.log('shared');

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -144,6 +144,8 @@ For each common chunk, translates its `bits` to chunk indices (bit positions dir
 
 The trade-off of merging: entry chunks may include modules that not all consumers of that entry need. This adds a small amount of unnecessary code loading but significantly reduces chunk count and HTTP requests.
 
+For chunks shared only by dynamic entries, the optimizer does not infer a merge target from dynamic-import reachability alone. Sibling dynamic imports from the same loaded entry can be requested independently, so "the entry can reach both chunks" does not prove either dynamic chunk is already loaded before the other. In that case, Rolldown keeps a separate common chunk unless the existing static-import merge-target check proves a safe target.
+
 ### Facade Elimination (`optimize_facade_entry_chunks`)
 
 Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks by the optimizer. The optimizer identifies these and either:


### PR DESCRIPTION
### Root cause

PR #9270 added a dynamic-dominator fallback for common chunk merging. That fallback treated dynamic-import reachability as proof that one dynamic entry was already loaded before another.

That is unsound for sibling dynamic imports. A user entry can expose both `load1() => import('./d1')` and `load2() => import('./d2')`, but calling only `load2()` must not execute `d1` side effects.

The test case introduced by #9270 is already covered by #9305, so this PR does not add duplicate coverage for that path. Instead, it covers the sibling dynamic-import case where dynamic reachability does not imply execution order.

I verified this against #9270 directly:

- Parent of #9270 (`2b235157c`) passes the sibling dynamic repro.
- #9270 merge commit (`0b257a924`) fails with `['main', 'shared', 'd1 main', 'd2']`.
- The generated `d2.js` imports `./d1.js`, causing the side-effect leak.

### Changes

- Remove the dynamic-only dominator fallback from common chunk merge target selection.
- Keep dynamic-only shared modules in a separate common chunk unless the existing static `find_merge_target` proof can find a safe target.
- Add an `issues/9350` regression fixture that enables only `mergeCommonChunks` and asserts `main.load2()` does not execute `d1`.
- Document why dynamic-import reachability alone is not a safe merge proof.

### Tests

```sh
just t-run crates/rolldown/tests/rolldown/issues/9350/_config.json
just t-run crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_chain/_config.json
just t-run crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_siblings_no_merge/_config.json
just t-run crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_dominator_with_exports_no_merge/_config.json
```

closed #9350