### PR TITLE
fix(bundler): prune stale runtime helpers after flattening entry-level external re-exports

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -13,7 +13,7 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
   ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
   ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
-  SymbolRef, WrapKind,
+  RuntimeHelper, StmtInfoMeta, StmtInfos, SymbolRef, WrapKind,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{
@@ -654,21 +654,32 @@ impl GenerateStage<'_> {
       vec.sort_by_key(|idx| self.link_output.module_table[*idx].exec_order());
       chunk_graph.chunk_table[chunk_idx].entry_level_external_module_idx = vec;
     }
-    // re propagate `meta.has_dynamic_exports` for affect modules
+    // Extend `invalidated_modules` with every transitive importer of the
+    // directly-affected modules: a module's `has_dynamic_exports` is derived
+    // from its importees' values, so importers must be revisited too.
     let mut q = invalidated_modules.iter().copied().collect::<VecDeque<_>>();
+    let mut walk_visited = FxHashSet::default();
     while let Some(idx) = q.pop_front() {
-      if !invalidated_modules.insert(idx) {
+      if !walk_visited.insert(idx) {
         continue;
       }
       let Module::Normal(module) = &self.link_output.module_table[idx] else {
         continue;
       };
-      q.extend(module.importers_idx.iter());
+      for &importer_idx in &module.importers_idx {
+        if invalidated_modules.insert(importer_idx) {
+          q.push_back(importer_idx);
+        }
+      }
     }
 
     if invalidated_modules.is_empty() {
       return;
     }
+
+    // Snapshot the set before `propagate_has_dynamic_exports` drains it, so
+    // the cleanup pass below knows which modules to revisit.
+    let modules_to_revisit: Vec<ModuleIdx> = invalidated_modules.iter().copied().collect();
 
     let mut visited = FxHashSet::with_capacity(invalidated_modules.len());
     for module_idx in invalidated_modules.clone() {
@@ -679,6 +690,78 @@ impl GenerateStage<'_> {
         &mut visited,
         &mut invalidated_modules,
       );
+    }
+
+    self.prune_stale_dynamic_reexport_refs(&modules_to_revisit, chunk_graph);
+  }
+
+  /// Drop the namespace stmt, `export * from './foo'` stmts, and runtime
+  /// helper bits that `reference_needed_symbols` eagerly wired up to support
+  /// `__reExport(my_ns, importee_ns)` propagation, for modules whose
+  /// `has_dynamic_exports` was just flipped to `false` by
+  /// `find_entry_level_external_module`.
+  ///
+  /// Without this, the namespace stmt stays "included" and keeps `__exportAll`
+  /// / `__reExport` in `used_symbol_refs` even though the finalizer no longer
+  /// emits the call (it gates on `has_dynamic_exports`). The dead helpers then
+  /// leak into the runtime chunk and get re-exported across chunks.
+  fn prune_stale_dynamic_reexport_refs(
+    &mut self,
+    modules_to_revisit: &[ModuleIdx],
+    chunk_graph: &mut ChunkGraph,
+  ) {
+    let mut chunks_to_recompute_helpers: FxHashSet<ChunkIdx> = FxHashSet::default();
+    for &module_idx in modules_to_revisit {
+      let meta = &self.link_output.metas[module_idx];
+      if meta.has_dynamic_exports {
+        continue;
+      }
+      // The namespace is still needed for its own sake (e.g. `import * as ns`),
+      // so we mustn't touch any of the refs that support it.
+      if meta.module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown) {
+        continue;
+      }
+      let only_ns_for_reexport = meta
+        .module_namespace_included_reason
+        .contains(ModuleNamespaceIncludedReason::ReExportDynamicExports);
+
+      // Stmts flagged with `ReExportDynamicExports` were marked side-effectful
+      // in `reference_needed_symbols` purely to wire `__reExport(my_ns, importee_ns)`
+      // and are the only contributors of `ReExport` to this module's helper bit.
+      let reexport_dyn_stmt_idxs: Vec<_> = self.link_output.stmt_infos[module_idx]
+        .iter_enumerated()
+        .filter(|(_, info)| info.meta.contains(StmtInfoMeta::ReExportDynamicExports))
+        .map(|(idx, _)| idx)
+        .collect();
+
+      let meta_mut = &mut self.link_output.metas[module_idx];
+      if only_ns_for_reexport {
+        meta_mut.stmt_info_included.clear_bit(StmtInfos::NAMESPACE_STMT_IDX);
+      }
+      let cleared_any_reexport_dyn = !reexport_dyn_stmt_idxs.is_empty();
+      for stmt_idx in reexport_dyn_stmt_idxs {
+        meta_mut.stmt_info_included.clear_bit(stmt_idx);
+      }
+      if cleared_any_reexport_dyn {
+        meta_mut.depended_runtime_helper.remove(RuntimeHelper::ReExport);
+      }
+
+      if let Some(chunk_idx) = chunk_graph.module_to_chunk[module_idx] {
+        chunks_to_recompute_helpers.insert(chunk_idx);
+      }
+    }
+
+    // Per-module helper bits drive `chunk.depended_runtime_helper` via
+    // `add_module_to_chunk`, which has already run. Re-aggregate from the
+    // updated per-module sets so `compute_cross_chunk_links` doesn't keep
+    // pulling `__reExport` into other chunks.
+    for chunk_idx in chunks_to_recompute_helpers {
+      let new_helper = chunk_graph.chunk_table[chunk_idx]
+        .modules
+        .iter()
+        .map(|m| self.link_output.metas[*m].depended_runtime_helper)
+        .fold(RuntimeHelper::default(), |acc, h| acc | h);
+      chunk_graph.chunk_table[chunk_idx].depended_runtime_helper = new_helper;
     }
   }
 

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -13,7 +13,7 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
   ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
   ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
-  SymbolRef, WrapKind,
+  RuntimeHelper, StmtInfoMeta, StmtInfos, SymbolRef, WrapKind,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{
@@ -651,21 +651,32 @@ impl GenerateStage<'_> {
       vec.sort_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order());
       chunk_graph.chunk_table[chunk_idx].entry_level_external_module_idx = vec;
     }
-    // re propagate `meta.has_dynamic_exports` for affect modules
+    // Extend `invalidated_modules` with every transitive importer of the
+    // directly-affected modules: a module's `has_dynamic_exports` is derived
+    // from its importees' values, so importers must be revisited too.
     let mut q = invalidated_modules.iter().copied().collect::<VecDeque<_>>();
+    let mut walk_visited = FxHashSet::default();
     while let Some(idx) = q.pop_front() {
-      if !invalidated_modules.insert(idx) {
+      if !walk_visited.insert(idx) {
         continue;
       }
       let Module::Normal(module) = &self.link_output.module_table[idx] else {
         continue;
       };
-      q.extend(module.importers_idx.iter());
+      for &importer_idx in &module.importers_idx {
+        if invalidated_modules.insert(importer_idx) {
+          q.push_back(importer_idx);
+        }
+      }
     }
 
     if invalidated_modules.is_empty() {
       return;
     }
+
+    // Snapshot the set before `propagate_has_dynamic_exports` drains it, so
+    // the cleanup pass below knows which modules to revisit.
+    let modules_to_revisit: Vec<ModuleIdx> = invalidated_modules.iter().copied().collect();
 
     let mut visited = FxHashSet::with_capacity(invalidated_modules.len());
     for module_idx in invalidated_modules.clone() {
@@ -676,6 +687,78 @@ impl GenerateStage<'_> {
         &mut visited,
         &mut invalidated_modules,
       );
+    }
+
+    self.prune_stale_dynamic_reexport_refs(&modules_to_revisit, chunk_graph);
+  }
+
+  /// Drop the namespace stmt, `export * from './foo'` stmts, and runtime
+  /// helper bits that `reference_needed_symbols` eagerly wired up to support
+  /// `__reExport(my_ns, importee_ns)` propagation, for modules whose
+  /// `has_dynamic_exports` was just flipped to `false` by
+  /// `find_entry_level_external_module`.
+  ///
+  /// Without this, the namespace stmt stays "included" and keeps `__exportAll`
+  /// / `__reExport` in `used_symbol_refs` even though the finalizer no longer
+  /// emits the call (it gates on `has_dynamic_exports`). The dead helpers then
+  /// leak into the runtime chunk and get re-exported across chunks.
+  fn prune_stale_dynamic_reexport_refs(
+    &mut self,
+    modules_to_revisit: &[ModuleIdx],
+    chunk_graph: &mut ChunkGraph,
+  ) {
+    let mut chunks_to_recompute_helpers: FxHashSet<ChunkIdx> = FxHashSet::default();
+    for &module_idx in modules_to_revisit {
+      let meta = &self.link_output.metas[module_idx];
+      if meta.has_dynamic_exports {
+        continue;
+      }
+      // The namespace is still needed for its own sake (e.g. `import * as ns`),
+      // so we mustn't touch any of the refs that support it.
+      if meta.module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown) {
+        continue;
+      }
+      let only_ns_for_reexport = meta
+        .module_namespace_included_reason
+        .contains(ModuleNamespaceIncludedReason::ReExportDynamicExports);
+
+      // Stmts flagged with `ReExportDynamicExports` were marked side-effectful
+      // in `reference_needed_symbols` purely to wire `__reExport(my_ns, importee_ns)`
+      // and are the only contributors of `ReExport` to this module's helper bit.
+      let reexport_dyn_stmt_idxs: Vec<_> = self.link_output.stmt_infos[module_idx]
+        .iter_enumerated()
+        .filter(|(_, info)| info.meta.contains(StmtInfoMeta::ReExportDynamicExports))
+        .map(|(idx, _)| idx)
+        .collect();
+
+      let meta_mut = &mut self.link_output.metas[module_idx];
+      if only_ns_for_reexport {
+        meta_mut.stmt_info_included.clear_bit(StmtInfos::NAMESPACE_STMT_IDX);
+      }
+      let cleared_any_reexport_dyn = !reexport_dyn_stmt_idxs.is_empty();
+      for stmt_idx in reexport_dyn_stmt_idxs {
+        meta_mut.stmt_info_included.clear_bit(stmt_idx);
+      }
+      if cleared_any_reexport_dyn {
+        meta_mut.depended_runtime_helper.remove(RuntimeHelper::ReExport);
+      }
+
+      if let Some(chunk_idx) = chunk_graph.module_to_chunk[module_idx] {
+        chunks_to_recompute_helpers.insert(chunk_idx);
+      }
+    }
+
+    // Per-module helper bits drive `chunk.depended_runtime_helper` via
+    // `add_module_to_chunk`, which has already run. Re-aggregate from the
+    // updated per-module sets so `compute_cross_chunk_links` doesn't keep
+    // pulling `__reExport` into other chunks.
+    for chunk_idx in chunks_to_recompute_helpers {
+      let new_helper = chunk_graph.chunk_table[chunk_idx]
+        .modules
+        .iter()
+        .map(|m| self.link_output.metas[*m].depended_runtime_helper)
+        .fold(RuntimeHelper::default(), |acc, h| acc | h);
+      chunk_graph.chunk_table[chunk_idx].depended_runtime_helper = new_helper;
     }
   }
 

--- a/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 export * from "external";
+//#endregion
+//#region main.js
 let foo;
 //#endregion
 export { foo };

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -6,25 +6,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll, __reExport };
+//#endregion
 
 ```
 
 ## main.js
 
 ```js
-import "./_virtual/_rolldown/runtime.js";
 import "./server/index.js";
 export * from "@sentry/node";
-//#endregion
 
 ```
 
 ## server/index.js
 
 ```js
-import "../_virtual/_rolldown/runtime.js";
 export * from "@sentry/node";
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
@@ -6,18 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
+//#endregion
 
 ```
 
 ## main.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
-//#endregion
 var external_lib = require("external-lib");
 Object.keys(external_lib).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
@@ -33,7 +29,6 @@ Object.keys(external_lib).forEach(function(k) {
 ## server.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 var external_lib = require("external-lib");
 Object.keys(external_lib).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -6,9 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
+//#endregion
 
 ```
 
@@ -16,10 +14,8 @@ exports.__reExport = __reExport;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {
@@ -46,7 +42,6 @@ Object.keys(zod).forEach(function(k) {
 ## server.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 let zod = require("zod");
 Object.keys(zod).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -6,9 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
+//#endregion
 
 ```
 
@@ -16,10 +14,8 @@ exports.__reExport = __reExport;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {
@@ -46,7 +42,6 @@ Object.keys(zod).forEach(function(k) {
 ## server.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {
 	enumerable: true,

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -6,9 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
+//#endregion
 
 ```
 
@@ -16,10 +14,8 @@ exports.__reExport = __reExport;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./middle.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {
@@ -46,7 +42,6 @@ Object.keys(zod).forEach(function(k) {
 ## middle.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
 Object.keys(zod).forEach(function(k) {

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -6,9 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## _virtual/_rolldown/runtime.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
+//#endregion
 
 ```
 
@@ -16,10 +14,8 @@ exports.__reExport = __reExport;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./middle.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {
@@ -46,7 +42,6 @@ Object.keys(zod).forEach(function(k) {
 ## middle.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {

--- a/crates/rolldown/tests/rolldown/issues/9374/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9374/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "hiddenRuntimeModule": false,
+  "config": {
+    "input": [
+      { "name": "entry_a", "import": "./entry_a.js" },
+      { "name": "entry_b", "import": "./entry_b.js" }
+    ],
+    "external": ["external"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_a.js
+
+```js
+import { t as b } from "./entry_b2.js";
+export * from "external";
+//#region entry_a.js
+const a = "a";
+//#endregion
+export { a, b };
+
+```
+
+## entry_b.js
+
+```js
+import { t as b } from "./entry_b2.js";
+export * from "external";
+export { b };
+
+```
+
+## entry_b2.js
+
+```js
+//#endregion
+//#region entry_b.js
+const b = "b";
+//#endregion
+export { b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_a.js
+
+```js
+import { b } from "./entry_b.js";
+export * from "external";
+//#region entry_a.js
+const a = "a";
+//#endregion
+export { a, b };
+
+```
+
+## entry_b.js
+
+```js
+export * from "external";
+//#region entry_b.js
+const b = "b";
+//#endregion
+export { b };
+
+```
+
+## rolldown-runtime.js
+
+```js
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9374/entry_a.js
+++ b/crates/rolldown/tests/rolldown/issues/9374/entry_a.js
@@ -1,0 +1,3 @@
+export * from './entry_b.js';
+
+export const a = 'a';

--- a/crates/rolldown/tests/rolldown/issues/9374/entry_b.js
+++ b/crates/rolldown/tests/rolldown/issues/9374/entry_b.js
@@ -1,0 +1,3 @@
+export * from 'external';
+
+export const b = 'b';

--- a/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/_config.json
@@ -1,0 +1,9 @@
+{
+  "expectExecuted": false,
+  "hiddenRuntimeModule": false,
+  "config": {
+    "platform": "node",
+    "input": [{ "name": "entry", "import": "./entry.js" }],
+    "external": ["external"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+export * from "external";
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region esm_dyn.js
+var import_cjs_re = (/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.c = "c";
+})))();
+const e = "e";
+//#endregion
+//#region entry.js
+const own = "own";
+const cVal = import_cjs_re.c;
+//#endregion
+export { cVal, e, own };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/cjs_re.js
+++ b/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/cjs_re.js
@@ -1,0 +1,1 @@
+exports.c = 'c';

--- a/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/entry.js
@@ -1,0 +1,6 @@
+import { c } from './cjs_re.js';
+export * from './esm_dyn.js';
+export * from './cjs_re.js';
+
+export const own = 'own';
+export const cVal = c;

--- a/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/esm_dyn.js
+++ b/crates/rolldown/tests/rolldown/issues/9374_cjs_mix/esm_dyn.js
@@ -1,0 +1,3 @@
+export * from 'external';
+
+export const e = 'e';


### PR DESCRIPTION
Hi! I'm new to Rust and not deeply familiar with this codebase, so I worked on this fix together with Claude. The changes look fairly targeted to me and the test coverage seems solid - hopefully the code quality meets the bar. Happy to iterate on any feedback.

## Summary

Fixes #9374. When an entry's `export * from 'external'` is flattened by `find_entry_level_external_module` (so the re-export is emitted literally at chunk-render time instead of via `__reExport(my_ns, importee_ns)`), the runtime helpers (`__exportAll`, `__reExport`) and their support code stayed in `used_symbol_refs` / `chunk.depended_runtime_helper`, so dead helper declarations leaked into the runtime chunk and got re-exported across chunks (`as n`, `as r`).

## Root cause

`reference_needed_symbols` eagerly references `__reExport`, the namespace object, and the importee's namespace ref on every `export * from './foo'` where the importee has `has_dynamic_exports = true`. Later, `find_entry_level_external_module` flips `has_dynamic_exports` to `false` for the affected modules - the finalizer correctly skips emitting the `__reExport(...)` call (it gates on `has_dynamic_exports`), but the helper symbols stay marked as used and the runtime stmts stay included, producing dead code.

Additionally, the existing importer-walk loop in `find_entry_level_external_module` was a no-op: `if !invalidated_modules.insert(idx) { continue; }` short-circuited every initial item because `q` was seeded from the same set, so transitive importers were never invalidated and their `has_dynamic_exports` was never recomputed.

## Fix

In `find_entry_level_external_module`, after `propagate_has_dynamic_exports` runs:

1. Fix the importer-walk loop with a separate `walk_visited` set so `invalidated_modules` actually grows to cover transitive importers.
2. For each module whose `has_dynamic_exports` was just cleared and whose `module_namespace_included_reason` doesn't contain `Unknown` (so the namespace isn't needed for `import * as ns`):
   - Clear `NAMESPACE_STMT_IDX` from `stmt_info_included` if it was included solely via `ReExportDynamicExports`.
   - Clear `ReExportDynamicExports`-flagged stmts (their side-effect flag and helper push were gated on `has_dynamic_exports = true`).
   - Drop `RuntimeHelper::ReExport` from `meta.depended_runtime_helper`.
3. Re-aggregate `chunk.depended_runtime_helper` from the updated per-module bitsets for affected chunks.

Extracted into `prune_stale_dynamic_reexport_refs` to keep `find_entry_level_external_module` focused.

## Tests

- `crates/rolldown/tests/rolldown/issues/9374` - regression test reproducing the exact REPL output from the issue.
- `crates/rolldown/tests/rolldown/issues/9374_cjs_mix` - edge case where an entry mixes ESM-dynamic re-export and CJS re-export. `has_dynamic_exports` stays `true` (because CJS importees short-circuit propagation to `true`), so the cleanup correctly skips this module and the `RuntimeHelper::ReExport` bit pushed by the CJS path (which doesn't set `ReExportDynamicExports` meta) is preserved.
- Updated snapshots in `issues/6992`, `7115`, `7233`, `7233_chain` - these tests previously froze the same bug in their expected output; the diff shows the dead `__exportAll`/`__reExport` exports and `import "./_virtual/_rolldown/runtime.js"` lines being removed.
- One cosmetic snapshot diff in `issues/5923` - extra `//#region`/`//#endregion` markers around `main.js`, unrelated functionally. Same artifact as the existing `5923` snapshot has on its own (empty runtime chunk markers).

All 1714 integration tests pass; clippy clean.
