### PR TITLE
chore: deny `todo`, `unimplemented`, and `print_stderr` clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ repository = "https://github.com/rolldown/rolldown"
 #   - https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
 
 # --- restriction https://doc.rust-lang.org/clippy/usage.html#clippyrestriction
-allow_attributes = "deny"
 dbg_macro = "deny"
-print_stdout = "deny"
+todo = "deny"
+unimplemented = "deny"
+print_stdout = "deny" # Must be opt-in
+print_stderr = "deny" # Must be opt-in
+allow_attributes = "deny"
 
 # I like the explicitness of this rule as it removes confusion around `clone`.
 # This increases readability, avoids `clone` mindlessly and heap allocating on accident.

--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::print_stdout, clippy::print_stderr)]
+
 use std::sync::Arc;
 
 use rolldown::{BundlerOptions, ExperimentalOptions};
@@ -6,7 +8,6 @@ use sugar_path::SugarPath;
 
 // RD_LOG=rolldown::dev=trace cargo run --example dev
 
-#[expect(clippy::print_stdout)]
 #[tokio::main]
 async fn main() {
   let bundler_config = BundlerConfig::new(

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -369,16 +369,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     } else {
       match self.ctx.options.format {
         rolldown_common::OutputFormat::Cjs => {
-          let chunk_idx_of_canonical_symbol =
-            canonical_symbol.chunk_idx.unwrap_or_else(|| {
-              // Scoped symbols don't get assigned a `ChunkIdx`. There are skipped for performance reason, because they are surely
-              // belong to the chunk they are declared in and won't link to other chunks.
-              let symbol_name = canonical_ref.name(self.ctx.symbol_db);
-              eprintln!(
-                "{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected",
-              );
-              panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected");
-            });
+          let chunk_idx_of_canonical_symbol = canonical_symbol.chunk_idx.unwrap_or_else(|| {
+            // Scoped symbols don't get assigned a `ChunkIdx`. There are skipped for performance reason, because they are surely
+            // belong to the chunk they are declared in and won't link to other chunks.
+            let symbol_name = canonical_ref.name(self.ctx.symbol_db);
+            panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected");
+          });
           let cur_chunk_idx = self.ctx.chunk_graph.module_to_chunk[self.ctx.idx]
             .expect("This module should be in a chunk");
           let is_symbol_in_other_chunk = cur_chunk_idx != chunk_idx_of_canonical_symbol;

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -1062,8 +1062,12 @@ impl BindImportsAndExportsContext<'_> {
 
           break MatchImportKind::Normal(MatchImportKindNormal { symbol, reexports });
         }
-        ImportStatus::_CommonJSWithoutExports => todo!(),
-        ImportStatus::_Disabled => todo!(),
+        ImportStatus::_CommonJSWithoutExports => {
+          panic!("`ImportStatus::_CommonJSWithoutExports` is not implemented yet")
+        }
+        ImportStatus::_Disabled => {
+          panic!("`ImportStatus::_Disabled` is not implemented yet")
+        }
         ImportStatus::External(symbol_ref) => {
           if self.options.format.keep_esm_import_export_syntax() {
             // Imports from external modules should not be converted to CommonJS

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::print_stderr)]
+
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::print_stderr)]
 // Allow type complexity rule, because NAPI-RS requires the direct types to generate the TypeScript definitions.
 #![allow(clippy::type_complexity)]
 // Due to the bound of NAPI-RS, we need to use `String` though we only need `&str`.

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::print_stderr)]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/rolldown_common/src/generated/runtime_helper.rs
+++ b/crates/rolldown_common/src/generated/runtime_helper.rs
@@ -1,6 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/generator/src/generators/runtime_helper.rs`
 
+#![expect(clippy::print_stderr)]
+
 use bitflags::bitflags;
 bitflags! {
   #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -188,7 +188,7 @@ impl BundleCoordinator {
         self.handle_file_changes(changed_files).await;
       }
       Err(e) => {
-        eprintln!("notify error: {e:?}");
+        tracing::error!("notify error: {e:?}");
       }
     }
   }

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -62,7 +62,7 @@ impl BundlingTask {
     if let Err(err) = &task_run_result {
       tracing::error!("[BundlingTask] fails to run");
       // FIXME: Should handle the error properly.
-      eprintln!("Bundling task run with error: {err}"); // FIXME: handle this error
+      tracing::error!("Bundling task run with error: {err}"); // FIXME: handle this error
     }
 
     let has_generated_bundle_output = self.has_rebuild_happen;

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -193,7 +193,7 @@ impl DevEngine {
             "[DevEngine] ensure_latest_bundle_output has looped {loop_count} times, something is definitely wrong",
           );
         } else {
-          eprintln!(
+          tracing::warn!(
             "[DevEngine] ensure_latest_bundle_output has looped {loop_count} times, something might be wrong",
           );
         }

--- a/crates/rolldown_dev/src/types/task_input.rs
+++ b/crates/rolldown_dev/src/types/task_input.rs
@@ -92,7 +92,7 @@ impl TaskInput {
       }
       // All other combinations should have been filtered by is_mergeable_with
       _ => {
-        eprintln!("Debug: Attempted to merge incompatible tasks. This should be unreachable.");
+        tracing::debug!("Attempted to merge incompatible tasks. This should be unreachable.");
       }
     }
   }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
@@ -53,7 +53,7 @@ impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
 impl<'ast> JsxExt<'ast> for JSXMemberExpression<'ast> {
   type AstKind = StaticMemberExpression<'ast>;
   fn rewrite_ident_reference(&mut self, _ident_ref: JSXMemberExpressionObject<'ast>) {
-    todo!()
+    panic!("`JSXMemberExpression::rewrite_ident_reference` is not implemented yet")
   }
 
   fn from_ast(

--- a/crates/rolldown_error/src/utils/is_context_too_long.rs
+++ b/crates/rolldown_error/src/utils/is_context_too_long.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::print_stderr)]
+
 use arcstr::ArcStr;
 use ariadne::{Label, Span};
 use rustc_hash::FxHashMap;

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -55,9 +55,7 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
       Some(Box::new(guard))
     }
     "json" => {
-      // We gonna use this feature to implement something like https://github.com/antfu-collective/vite-plugin-inspect
-      // See `crates/rolldown_devtools`
-      unimplemented!()
+      panic!("`json` output mode is not implemented yet");
     }
     "readable" => {
       tracing_subscriber::registry()

--- a/tasks/generator/src/generators/mod.rs
+++ b/tasks/generator/src/generators/mod.rs
@@ -15,7 +15,7 @@ pub use runtime_helper::RuntimeHelperGenerator;
 /// Trait to define a generator.
 pub trait Generator: Runner {
   fn generate(&self, _ctx: &Context) -> Output {
-    unimplemented!()
+    panic!("`generate` must be implemented")
   }
 
   fn generate_many(&self, ctx: &Context) -> Result<Vec<Output>> {

--- a/tasks/generator/src/generators/runtime_helper.rs
+++ b/tasks/generator/src/generators/runtime_helper.rs
@@ -50,6 +50,8 @@ fn generate_hook_usage_rs() -> String {
   }
   let runtime_helper_flag = format!(
     r"
+  #![expect(clippy::print_stderr)]
+
   use bitflags::bitflags;
   bitflags! {{
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]

--- a/tasks/ls_lint/src/main.rs
+++ b/tasks/ls_lint/src/main.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::print_stderr)]
+
 use std::collections::HashMap;
 
 use anyhow::Result;


### PR DESCRIPTION
## Summary

- Add `todo`, `unimplemented`, and `print_stderr` to the workspace's denied clippy restriction lints so accidental scaffolding code and stray stderr prints can't slip into production.
- Replace existing `todo!()` / `unimplemented!()` calls with explicit `panic!("… is not implemented yet")` messages.
- Route most `eprintln!`s through `tracing` (error/warn/debug levels), and `#[expect]` the legitimate cases (panic hook in the napi binding, `debug_print` helpers, integration tests, the example, `tasks/ls_lint`).