### PR TITLE
fix: do not inherit __toESM across chunks for named-only external imports (#9333)

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -4,6 +4,7 @@ use std::cmp::Reverse;
 use super::GenerateStage;
 use crate::chunk_graph::ChunkGraph;
 use crate::utils::chunk::normalize_preserve_entry_signature;
+use crate::utils::external_import_interop::external_import_needs_interop;
 use itertools::{Itertools, multizip};
 use oxc_index::{IndexVec, index_vec};
 use oxc_str::CompactStr;
@@ -57,6 +58,7 @@ impl GenerateStage<'_> {
     self.compute_chunk_imports(
       chunk_graph,
       &index_chunk_depended_symbols,
+      &index_chunk_direct_imports_from_external_modules,
       &mut index_chunk_exported_symbols,
       &mut index_cross_chunk_imports,
       &mut index_imports_from_other_chunks,
@@ -323,10 +325,12 @@ impl GenerateStage<'_> {
 
   /// - Filter out depended symbols to come from other chunks
   /// - Mark exports of importee chunks
+  #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
   fn compute_chunk_imports(
     &self,
     chunk_graph: &ChunkGraph,
     index_chunk_depended_symbols: &IndexChunkDependedSymbols,
+    index_chunk_direct_imports_from_external_modules: &IndexChunkImportsFromExternalModules,
     index_chunk_exported_symbols: &mut IndexChunkExportedSymbols,
     index_cross_chunk_imports: &mut IndexCrossChunkImports,
     index_imports_from_other_chunks: &mut IndexImportsFromOtherChunks,
@@ -443,17 +447,23 @@ impl GenerateStage<'_> {
               continue;
             }
 
-            // Note: the `__toESM` might have been referenced during `collect_depended_symbols` phase
-            // for namespace or default imports from external modules.
-            // For named-only imports, we don't use __toESM, so we should not try to resolve it.
-            // Check if __toESM is actually used before trying to resolve it.
+            if !index_chunk_direct_imports_from_external_modules[chunk_id]
+              .get(&import_ref.owner)
+              .is_some_and(|imports| external_import_needs_interop(imports))
+            {
+              continue;
+            }
+
+            // Note: `__toESM` might have been referenced during `collect_depended_symbols` for
+            // namespace or default imports from external modules. Named-only imports render as
+            // direct `require()` bindings and must not inherit another chunk's `__toESM`.
             let to_esm_ref = self.link_output.runtime.resolve_symbol("__toESM");
             if self.link_output.symbol_db.get(to_esm_ref).chunk_idx.is_some() {
               // __toESM is in a chunk, so it's being used
               to_esm_ref
             } else {
               // __toESM is not being used, so skip this import
-              // This happens for named-only imports from external modules where we don't need interop
+              // This happens when the interop helper was optimized away.
               continue;
             }
           } else {

--- a/crates/rolldown/tests/rolldown/issues/9333/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9333/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./main.js"
+      },
+      {
+        "import": "./worker.js"
+      }
+    ],
+    "external": ["node:path", "node:worker_threads"],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9333/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9333/artifacts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_path = require("node:path");
+node_path = __toESM(node_path);
+//#region main.js
+console.log(node_path.default.sep);
+//#endregion
+
+```
+
+## worker.js
+
+```js
+//#region worker.js
+require("node:worker_threads").parentPort?.postMessage("hi");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9333/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9333/main.js
@@ -1,0 +1,3 @@
+import path from 'node:path';
+
+console.log(path.sep);

--- a/crates/rolldown/tests/rolldown/issues/9333/worker.js
+++ b/crates/rolldown/tests/rolldown/issues/9333/worker.js
@@ -1,0 +1,3 @@
+import { parentPort } from 'node:worker_threads';
+
+parentPort?.postMessage('hi');


### PR DESCRIPTION
## Summary
Fixes #9333. Previously, when computing cross-chunk imports, any chunk that referenced an external module's namespace would unconditionally try to resolve the runtime `__toESM` helper. For named-only `require()` bindings in another chunk, this caused the chunk to inherit a different chunk's `__toESM` symbol, producing broken multi-entry CJS output (e.g. Electron main + worker).

The fix gates the `__toESM` fallback on whether the importing chunk actually needs interop for that external module, using `external_import_needs_interop` against `index_chunk_direct_imports_from_external_modules`.

## Test plan
- [x] Added integration test under `crates/rolldown/tests/rolldown/issues/9333` covering a multi-entry CJS build (`main.js` + `worker.js`) with `electron`, `node:path`, `node:worker_threads` as externals.
- [x] Snapshot in `artifacts.snap` confirms `__toESM` is applied only to the default import (`node:path`) and not to named-only imports.
