### PR TITLE
refactor(ecmascript_utils): split rewrite_ident_reference off JsxExt trait

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -16,7 +16,7 @@ use oxc::{
 use oxc_str::CompactStr;
 use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKind, WrapKind};
 use rolldown_ecmascript::ToSourceString;
-use rolldown_ecmascript_utils::{ExpressionExt, JsxExt};
+use rolldown_ecmascript_utils::{ExpressionExt, JsxExt, JsxMemberExpressionObjectExt};
 
 use crate::hmr::utils::HmrAstBuilder;
 use crate::module_finalizers::{KeepNameId, TraverseState};

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
@@ -5,7 +5,6 @@ use oxc::ast::ast::{
 
 pub trait JsxExt<'ast> {
   type AstKind;
-  fn rewrite_ident_reference(&mut self, ident_ref: JSXMemberExpressionObject<'ast>);
   fn from_ast(
     member_expr: Self::AstKind,
     allocator: &'ast oxc::allocator::Allocator,
@@ -14,8 +13,11 @@ pub trait JsxExt<'ast> {
     Self: Sized;
 }
 
-impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
-  type AstKind = Expression<'ast>;
+pub trait JsxMemberExpressionObjectExt<'ast> {
+  fn rewrite_ident_reference(&mut self, ident_ref: JSXMemberExpressionObject<'ast>);
+}
+
+impl<'ast> JsxMemberExpressionObjectExt<'ast> for JSXMemberExpressionObject<'ast> {
   fn rewrite_ident_reference(&mut self, ident_ref: JSXMemberExpressionObject<'ast>) {
     let mut object = self;
     loop {
@@ -31,6 +33,10 @@ impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
       }
     }
   }
+}
+
+impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
+  type AstKind = Expression<'ast>;
 
   fn from_ast(
     member_expr: Expression<'ast>,
@@ -52,9 +58,6 @@ impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
 
 impl<'ast> JsxExt<'ast> for JSXMemberExpression<'ast> {
   type AstKind = StaticMemberExpression<'ast>;
-  fn rewrite_ident_reference(&mut self, _ident_ref: JSXMemberExpressionObject<'ast>) {
-    panic!("`JSXMemberExpression::rewrite_ident_reference` is not implemented yet")
-  }
 
   fn from_ast(
     member_expr: StaticMemberExpression<'ast>,

--- a/crates/rolldown_ecmascript_utils/src/lib.rs
+++ b/crates/rolldown_ecmascript_utils/src/lib.rs
@@ -7,7 +7,10 @@ pub use crate::{
   ast_snippet::AstSnippet,
   extensions::ast_ext::{
     binding_pattern_ext::BindingPatternExt, call_expression_ext::CallExpressionExt,
-    expression_ext::ExpressionExt, function::FunctionExt, jsx::JsxExt, statement_ext::StatementExt,
+    expression_ext::ExpressionExt,
+    function::FunctionExt,
+    jsx::{JsxExt, JsxMemberExpressionObjectExt},
+    statement_ext::StatementExt,
   },
   scope::is_top_level,
   source_utils::contains_script_closing_tag,

--- a/crates/rolldown_ecmascript_utils/src/lib.rs
+++ b/crates/rolldown_ecmascript_utils/src/lib.rs
@@ -6,7 +6,8 @@ mod source_utils;
 pub use crate::{
   ast_snippet::AstSnippet,
   extensions::ast_ext::{
-    binding_pattern_ext::BindingPatternExt, call_expression_ext::CallExpressionExt,
+    binding_pattern_ext::BindingPatternExt,
+    call_expression_ext::CallExpressionExt,
     expression_ext::ExpressionExt,
     function::FunctionExt,
     jsx::{JsxExt, JsxMemberExpressionObjectExt},


### PR DESCRIPTION
Move rewrite_ident_reference out of JsxExt into a new single-method trait JsxMemberExpressionObjectExt implemented only for JSXMemberExpressionObject — the only type that ever needed it. Drops the dead stub on JSXMemberExpression flagged as TODO #3 in #9416.