### PR TITLE
test(rolldown): regression fixture for #9401

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/9401/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9401/_config.json
@@ -1,0 +1,18 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry-0",
+        "import": "./node0.cjs"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": {
+      "chunkOptimization": {
+        "mergeCommonChunks": false,
+        "avoidRedundantChunkLoads": true
+      }
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9401/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9401/_test.mjs
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { assertNoStaticImportCycle } from '../../_test_helpers/find-static-cycle.mjs';
+
+// Regression for #9401: avoidRedundantChunkLoads must not reduce the
+// runtime-helper host into entry-0 when node3 also needs helpers and entry-0
+// already statically reaches node3 through a CJS require chain.
+assertNoStaticImportCycle(path.join(import.meta.dirname, 'dist'));
+
+// Runtime smoke test for the original failure:
+// TypeError: __exportAll is not a function.
+await import('./dist/entry-0.js');

--- a/crates/rolldown/tests/rolldown/issues/9401/node0.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9401/node0.cjs
@@ -1,0 +1,4 @@
+globalThis.__acyclic_output_fuzz_0 = 0;
+const imported_0_2 = require('./node2.cjs');
+exports.use_0_2 = imported_0_2;
+exports.node_0 = 0;

--- a/crates/rolldown/tests/rolldown/issues/9401/node1.js
+++ b/crates/rolldown/tests/rolldown/issues/9401/node1.js
@@ -1,0 +1,5 @@
+globalThis.__acyclic_output_fuzz_1 = 1;
+void import('./node3.js');
+var node_1 = {};
+node_1.value = 1;
+export { node_1 };

--- a/crates/rolldown/tests/rolldown/issues/9401/node2.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9401/node2.cjs
@@ -1,0 +1,3 @@
+globalThis.__acyclic_output_fuzz_2 = 2;
+void require('./node3.js');
+exports.node_2 = 2;

--- a/crates/rolldown/tests/rolldown/issues/9401/node3.js
+++ b/crates/rolldown/tests/rolldown/issues/9401/node3.js
@@ -1,0 +1,7 @@
+globalThis.__acyclic_output_fuzz_3 = 3;
+void import('./node0.cjs');
+void import('./node1.js');
+void import('./node2.cjs');
+var node_3 = {};
+node_3.value = 3;
+export { node_3 };


### PR DESCRIPTION
The bug is fixed by #9514, so this PR only adds the regression test.

close #9401

The fixture exercises the dynamic-import + CJS-require shape from the issue: a static `assertNoStaticImportCycle` check against the dist graph plus a runtime `await import('./dist/entry-0.js')` smoke to catch the original `TypeError: __exportAll is not a function`.

**Why a regression test still matters.** Any optimization that moves or merges the runtime host has to anticipate the static imports that follow. There is no type or invariant enforcing this — it lives entirely in the head of whoever wrote each optimization pass. Forgetting it silently introduces a circular import, which is exactly the bug in #9401.

**Planned follow-up.** A subsequent PR will restructure this: split the runtime module into a standalone chunk during optimization, then merge it into an existing chunk as a final step *after* helper usages are attached. Optimization will then see a complete graph, and the kind of ad-hoc guarding #9514 added can be removed.
