### PR TITLE
perf(scoping): cache semantic Stats on AstScopes to speed up rebuilds

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -261,7 +261,8 @@ mod tests {
     let ret = Parser::new(allocator, source, source_type).parse();
     let program = ret.program;
     let semantic_ret = SemanticBuilder::new().build(&program);
-    (AstScopes::new(semantic_ret.semantic.into_scoping()), program)
+    let stats = semantic_ret.semantic.stats();
+    (AstScopes::new(semantic_ret.semantic.into_scoping(), stats), program)
   }
 
   fn extract_call_expr<'a>(

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -12,7 +12,7 @@ use const_eval::{ConstEvalCtx, try_extract_const_literal};
 use oxc::ast::ast::{BindingPattern, Expression, ImportExpression};
 use oxc::ast::{AstKind, ast};
 use oxc::ast_visit::walk;
-use oxc::semantic::{Reference, ReferenceId, ScopeFlags, Scoping};
+use oxc::semantic::{Reference, ReferenceId, ScopeFlags, Scoping, Stats};
 use oxc::span::SPAN;
 use oxc::{
   ast::{
@@ -177,6 +177,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn new(
     idx: ModuleIdx,
     scoping: Scoping,
+    stats: Stats,
     repr_name: &'me str,
     module_type: ModuleDefFormat,
     source: &'me ArcStr,
@@ -187,7 +188,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     flat_options: FlatOptions,
   ) -> Self {
     let root_scope_id = scoping.root_scope_id();
-    let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, idx, root_scope_id);
+    let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, idx, root_scope_id, stats);
     // This is used for converting "export default foo;" => "var default_symbol = foo;"
     let legitimized_repr_name = legitimize_identifier_name(repr_name);
     let default_export_ref = symbol_ref_db

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -581,8 +581,9 @@ mod test {
     let source_type = SourceType::tsx();
     let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
     let semantic = EcmaAst::make_semantic(ast.program(), false);
+    let stats = semantic.stats();
     let scoping = semantic.into_scoping();
-    let ast_scopes = AstScopes::new(scoping);
+    let ast_scopes = AstScopes::new(scoping, stats);
 
     let options = Arc::new(NormalizedBundlerOptions::default());
     let flags = FlatOptions::from_shared_options(&options);
@@ -597,8 +598,9 @@ mod test {
     let source_type = SourceType::tsx();
     let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
     let semantic = EcmaAst::make_semantic(ast.program(), false);
+    let stats = semantic.stats();
     let scoping = semantic.into_scoping();
-    let ast_scopes = AstScopes::new(scoping);
+    let ast_scopes = AstScopes::new(scoping, stats);
 
     let options = Arc::new(NormalizedBundlerOptions::default());
     let flags = FlatOptions::from_shared_options(&options);

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -34,6 +34,7 @@ pub async fn create_ecma_view(
   let ParseToEcmaAstResult {
     mut ast,
     scoping,
+    stats,
     has_lazy_export,
     warnings,
     preserve_jsx,
@@ -52,6 +53,7 @@ pub async fn create_ecma_view(
     let scanner = AstScanner::new(
       ctx.module_idx,
       scoping,
+      stats,
       &repr_name,
       ctx.resolved_id.module_def_format,
       fields.source,

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -9,8 +9,8 @@ use std::{
 use arcstr::ArcStr;
 use oxc_traverse::traverse_mut;
 use rolldown_common::{
-  ClientHmrInput, ClientHmrUpdate, HmrBoundary, HmrBoundaryOutput, HmrPatch, HmrUpdate, ImportKind,
-  Module, ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
+  ClientHmrInput, ClientHmrUpdate, GetLocalDb, HmrBoundary, HmrBoundaryOutput, HmrPatch, HmrUpdate,
+  ImportKind, Module, ModuleIdx, ModuleTable, ScanMode, SymbolRefDb, WatcherChangeKind,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
 use rolldown_ecmascript_utils::AstSnippet;
@@ -50,6 +50,10 @@ impl<Fs: FileSystem + Clone + 'static> HmrStageInput<'_, Fs> {
 
   pub fn index_ecma_ast(&self) -> &IndexEcmaAst {
     &self.cache.get_snapshot().index_ecma_ast
+  }
+
+  pub fn symbol_ref_db(&self) -> &SymbolRefDb {
+    &self.cache.get_snapshot().symbol_ref_db
   }
 }
 
@@ -432,6 +436,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         ModuleRenderInput {
           idx: affected_module.idx,
           ecma_ast: ecma_ast.clone_with_another_arena(),
+          stats: self.symbol_ref_db().local_db(affected_module.idx).ast_scopes.stats(),
         }
       })
       .collect::<Vec<_>>();
@@ -442,7 +447,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
+          render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {
@@ -455,7 +461,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+          let scoping = EcmaAst::make_scoping_using_stats(fields.program, stats);
 
           let mut finalizer = HmrAstFinalizer {
             modules,
@@ -673,6 +679,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         ModuleRenderInput {
           idx: affected_module.idx,
           ecma_ast: ecma_ast.clone_with_another_arena(),
+          stats: self.symbol_ref_db().local_db(affected_module.idx).ast_scopes.stats(),
         }
       })
       .collect::<Vec<_>>();
@@ -682,7 +689,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
+          render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {
@@ -695,7 +703,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+          let scoping = EcmaAst::make_scoping_using_stats(fields.program, stats);
 
           let mut finalizer = HmrAstFinalizer {
             modules,
@@ -865,6 +873,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         ModuleRenderInput {
           idx: affected_module.idx,
           ecma_ast: ecma_ast.clone_with_another_arena(),
+          stats: self.symbol_ref_db().local_db(affected_module.idx).ast_scopes.stats(),
         }
       })
       .collect::<Vec<_>>();
@@ -874,7 +883,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
+          render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {
@@ -887,7 +897,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+          let scoping = EcmaAst::make_scoping_using_stats(fields.program, stats);
 
           let mut finalizer = HmrAstFinalizer {
             modules,
@@ -1237,6 +1247,9 @@ impl PropagateUpdateStatus {
 struct ModuleRenderInput {
   pub idx: ModuleIdx,
   pub ecma_ast: EcmaAst,
+  /// Cached semantic stats from link-time scoping for this module, used to
+  /// pre-allocate when rebuilding scoping for the cloned AST in HMR.
+  pub stats: oxc::semantic::Stats,
 }
 
 impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -447,8 +447,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
-          render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } = render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {
@@ -689,8 +688,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
-          render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } = render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {
@@ -883,8 +881,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .into_par_iter()
       .enumerate()
       .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } =
-          render_input;
+        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast, stats } = render_input;
 
         let affected_module = &self.module_table().modules[affected_module_idx];
         let Module::Normal(affected_module) = affected_module else {

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arcstr::ArcStr;
 use futures::future::join_all;
 use itertools::Itertools;
-use oxc::semantic::{ScopeId, Scoping};
+use oxc::semantic::{ScopeId, Scoping, Stats};
 use oxc::span::Span;
 use oxc::transformer_plugins::ReplaceGlobalDefinesConfig;
 use oxc_allocator::Address;
@@ -558,7 +558,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
 
           self.symbol_ref_db.store_local_db(
             idx,
-            SymbolRefDbForModule::new(Scoping::default(), idx, ScopeId::new(0)),
+            SymbolRefDbForModule::new(Scoping::default(), idx, ScopeId::new(0), Stats::default()),
           );
           let symbol_ref = self.symbol_ref_db.create_facade_root_symbol_ref(idx, &identifier_name);
           let external_module = Module::External(Box::new(ExternalModule::new(

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -229,7 +229,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
       pre_processor.visit_program(fields.program);
     });
 
-    let scoping = ast.make_scoping();
+    let (scoping, stats) = ast.make_scoping_with_stats();
     let facade_path = RUNTIME_MODULE_ID;
     // Always respect annotations in the runtime module, regardless of user config.
     // The runtime is trusted internal code.
@@ -239,6 +239,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
       let scanner = AstScanner::new(
         self.module_idx,
         scoping,
+        stats,
         "rolldown_runtime",
         ModuleDefFormat::EsmMjs,
         source,

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -235,18 +235,19 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   let original_symbol_ref_db = std::mem::take(link_staged.symbols.local_db_mut(module_idx));
   // recreate semantic data
   #[expect(clippy::cast_possible_truncation)]
+  let stats = Stats {
+    nodes: declaration_binding_names.len().next_power_of_two() as u32,
+    scopes: 1,
+    symbols: declaration_binding_names.len() as u32,
+    references: declaration_binding_names.len() as u32 * 2u32,
+  };
   let scoping = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
-    SemanticBuilder::new().with_stats(Stats {
-      nodes: declaration_binding_names.len().next_power_of_two() as u32,
-      scopes: 1,
-      symbols: declaration_binding_names.len() as u32,
-      references: declaration_binding_names.len() as u32 * 2u32,
-    }),
+    SemanticBuilder::new().with_stats(stats),
   );
 
   // update semantic data of module
   let root_scope_id = scoping.root_scope_id();
-  let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, module_idx, root_scope_id);
+  let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, module_idx, root_scope_id, stats);
   // Re-create facade symbols in the new scoping. The JSON module was re-parsed above,
   // producing a new Scoping with fresh symbol IDs, so old facade IDs are invalid.
   // We allocate new IDs by name and update the module's references.

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Cow, path::Path};
 
 use json_escape_simd::escape;
-use oxc::{semantic::Scoping, span::SourceType as OxcSourceType};
+use oxc::{
+  semantic::{Scoping, Stats},
+  span::SourceType as OxcSourceType,
+};
 use oxc_str::CompactStr;
 use rolldown_common::{
   ConstExportMeta, ModuleDefFormat, ModuleType, NormalizedBundlerOptions, RUNTIME_MODULE_KEY,
@@ -38,6 +41,12 @@ fn pure_esm_js_oxc_source_type(module_def_format: ModuleDefFormat) -> OxcSourceT
 pub struct ParseToEcmaAstResult {
   pub ast: EcmaAst,
   pub scoping: Scoping,
+  /// Semantic stats captured at the final `recreate_scoping` rebuild in
+  /// `PreProcessEcmaAst::build`. Forwarded to `AstScopes` so later consumers
+  /// that need to rebuild scoping for the same AST (e.g. HMR finalization)
+  /// can pre-allocate via `SemanticBuilder::with_stats` instead of running a
+  /// full `Stats::count` traversal.
+  pub stats: Stats,
   pub has_lazy_export: bool,
   pub warnings: Vec<BuildDiagnostic>,
   /// Whether JSX syntax should be preserved in the output, determined per-module

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -249,6 +249,7 @@ impl PreProcessEcmaAst {
     Ok(ParseToEcmaAstResult {
       ast,
       scoping,
+      stats: self.stats,
       has_lazy_export,
       warnings,
       preserve_jsx,

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -1,15 +1,28 @@
-use oxc::semantic::{NodeId, Reference, ReferenceId, ScopeId, Scoping, SymbolFlags, SymbolId};
+use oxc::semantic::{NodeId, Reference, ReferenceId, ScopeId, Scoping, Stats, SymbolFlags, SymbolId};
 use oxc::span::SPAN;
 use oxc_str::Ident;
 
 #[derive(Debug)]
 pub struct AstScopes {
   scoping: Scoping,
+  /// Cached semantic stats from the last `SemanticBuilder::build` that produced
+  /// the current `scoping`. Used to pre-allocate when rebuilding scoping for
+  /// the same AST (e.g. HMR re-finalization) so `Stats::count` can be skipped.
+  stats: Stats,
 }
 
 impl AstScopes {
-  pub fn new(inner: Scoping) -> Self {
-    Self { scoping: inner }
+  pub fn new(inner: Scoping, stats: Stats) -> Self {
+    Self { scoping: inner, stats }
+  }
+
+  /// Stats captured when `scoping` was last built. Intended as a pre-allocation
+  /// hint for rebuilds via `SemanticBuilder::with_stats` — slightly stale is
+  /// fine (e.g. link-time facade symbols added via `create_facade_root_symbol_ref`
+  /// are not reflected here, so the count under-counts by the facade delta).
+  #[inline]
+  pub fn stats(&self) -> Stats {
+    self.stats
   }
 
   #[inline]
@@ -21,8 +34,9 @@ impl AstScopes {
     self.scoping
   }
 
-  pub fn set_scoping(&mut self, scoping: Scoping) {
+  pub fn set_scoping(&mut self, scoping: Scoping, stats: Stats) {
     self.scoping = scoping;
+    self.stats = stats;
   }
 
   pub fn is_unresolved(&self, reference_id: ReferenceId) -> bool {

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -1,4 +1,6 @@
-use oxc::semantic::{NodeId, Reference, ReferenceId, ScopeId, Scoping, Stats, SymbolFlags, SymbolId};
+use oxc::semantic::{
+  NodeId, Reference, ReferenceId, ScopeId, Scoping, Stats, SymbolFlags, SymbolId,
+};
 use oxc::span::SPAN;
 use oxc_str::Ident;
 

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use oxc::semantic::{ScopeId, Scoping, SymbolId};
+use oxc::semantic::{ScopeId, Scoping, Stats, SymbolId};
 use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_std_utils::OptionExt;
@@ -78,7 +78,7 @@ impl Default for SymbolRefDbForModule {
     Self {
       owner_idx: ModuleIdx::new(0),
       root_scope_id: ScopeId::new(0),
-      ast_scopes: AstScopes::new(Scoping::default()),
+      ast_scopes: AstScopes::new(Scoping::default(), Stats::default()),
       flags: FxHashMap::default(),
       classic_data: IndexVec::default(),
       #[cfg(debug_assertions)]
@@ -88,7 +88,12 @@ impl Default for SymbolRefDbForModule {
 }
 
 impl SymbolRefDbForModule {
-  pub fn new(scoping: Scoping, owner_idx: ModuleIdx, top_level_scope_id: ScopeId) -> Self {
+  pub fn new(
+    scoping: Scoping,
+    owner_idx: ModuleIdx,
+    top_level_scope_id: ScopeId,
+    stats: Stats,
+  ) -> Self {
     Self {
       owner_idx,
       root_scope_id: top_level_scope_id,
@@ -96,7 +101,7 @@ impl SymbolRefDbForModule {
         SymbolRefDataClassic::default();
         scoping.symbols_len()
       ]),
-      ast_scopes: AstScopes::new(scoping),
+      ast_scopes: AstScopes::new(scoping, stats),
       flags: FxHashMap::default(),
       #[cfg(debug_assertions)]
       create_reason: FxHashMap::default(),
@@ -149,8 +154,9 @@ impl SymbolRefDbForModule {
       }
     }
 
+    let stats = build_db.ast_scopes.stats();
     let scoping = build_db.ast_scopes.into_scoping();
-    self.ast_scopes.set_scoping(scoping);
+    self.ast_scopes.set_scoping(scoping, stats);
   }
 
   pub fn get_classic_data(&self, symbol_id: SymbolId) -> &SymbolRefDataClassic {
@@ -216,7 +222,7 @@ impl SymbolRefDb {
       vec.push(inner.as_ref().map(|inner| SymbolRefDbForModule {
         owner_idx: inner.owner_idx,
         root_scope_id: inner.root_scope_id,
-        ast_scopes: AstScopes::new(Scoping::default()),
+        ast_scopes: AstScopes::new(Scoping::default(), Stats::default()),
         flags: inner.flags.clone(),
         classic_data: inner.classic_data.clone(),
         #[cfg(debug_assertions)]

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -14,7 +14,6 @@ use oxc::transformer::{Helper, HelperLoaderOptions};
 use oxc::{
   codegen::{Codegen, CodegenOptions, CodegenReturn},
   isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
-  semantic::SemanticBuilder,
   span::SourceType,
   transformer::Transformer,
   transformer_plugins::{
@@ -334,6 +333,7 @@ pub fn enhanced_transform(
   let mut program = parse_ret.program;
 
   let semantic_ret = semantic_builder_for_transform().build(&program);
+  let mut stats = semantic_ret.semantic.stats();
   let mut scoping = Some(semantic_ret.semantic.into_scoping());
   if !semantic_ret.errors.is_empty() {
     append_oxc_diagnostics(semantic_ret.errors, &source, filename, &mut warnings, &mut errors);
@@ -386,9 +386,11 @@ pub fn enhanced_transform(
     }
   }
 
-  let scoping = scoping
-    .take()
-    .unwrap_or_else(|| semantic_builder_for_transform().build(&program).semantic.into_scoping());
+  let scoping = scoping.take().unwrap_or_else(|| {
+    let ret = semantic_builder_for_transform().with_stats(stats).build(&program).semantic;
+    stats = ret.stats();
+    ret.into_scoping()
+  });
 
   let transform_ret = Transformer::new(&allocator, Path::new(filename), &oxc_transform_options)
     .build_with_scoping(scoping, &mut program);
@@ -403,7 +405,8 @@ pub fn enhanced_transform(
     && !inject.is_empty()
   {
     let config = build_inject_config(inject);
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping =
+      semantic_builder_for_transform().with_stats(stats).build(&program).semantic.into_scoping();
     let _ = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
   }
 

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -1,6 +1,6 @@
 use oxc::{
   ast::ast::Program,
-  semantic::{Scoping, Semantic, SemanticBuilder},
+  semantic::{Scoping, Semantic, SemanticBuilder, Stats},
 };
 
 use crate::EcmaAst;
@@ -29,9 +29,24 @@ impl EcmaAst {
   }
 
   pub fn make_scoping(&self) -> Scoping {
+    self.make_scoping_with_stats().0
+  }
+
+  /// Build `Scoping` along with the `Stats` captured from the same `Semantic`,
+  /// so consumers that may later rebuild scoping for the same AST can re-use
+  /// the stats via `SemanticBuilder::with_stats` and skip `Stats::count`.
+  pub fn make_scoping_with_stats(&self) -> (Scoping, Stats) {
     self.program.with_dependent(|_owner, dep| {
-      Self::make_semantic(&dep.program, /*with_cfg*/ false).into_scoping()
+      let semantic = Self::make_semantic(&dep.program, /*with_cfg*/ false);
+      let stats = semantic.stats();
+      (semantic.into_scoping(), stats)
     })
+  }
+
+  /// Build `Scoping` re-using cached `Stats` from a previous build to skip
+  /// the `Stats::count` AST traversal that pre-allocates buffers.
+  pub fn make_scoping_using_stats(program: &Program<'_>, stats: Stats) -> Scoping {
+    SemanticBuilder::new().with_stats(stats).build(program).semantic.into_scoping()
   }
 
   pub fn make_symbol_table_and_scope_tree_with_semantic_builder<'a>(


### PR DESCRIPTION
## Summary

Each `SemanticBuilder::build` walks the AST twice — once via `Stats::count` to pre-allocate the symbol/scope/reference buffers, then again to actually populate them. `Stats::count` is roughly 30% of the build cost. When a prior build's `Stats` is fed back in via `.with_stats(...)`, that first walk is skipped.

`pre_process_ecma_ast.rs` already caches `Stats` on `PreProcessEcmaAst` and reuses it across the multiple in-pipeline rebuilds (transformer → inject → DCE → final). This change extends the same trick to downstream consumers that previously rebuilt scoping from scratch:

- **HMR finalization** (`hmr_stage.rs`, 3 sites — module invalidate / self-accepting / module update). `clone_with_another_arena` preserves semantic IDs, so the link-time scoping is logically valid for the cloned AST, but `oxc::semantic::Scoping` is not `Clone` (it contains a self-referential `ScopingCell`), so a rebuild is still required. Feeding the cached `Stats` through `ModuleRenderInput` skips `Stats::count` on every HMR cycle per affected module.
- **`enhanced_transform`** (the NAPI transform API). Two rebuilds used bare `SemanticBuilder::new()`: one in the take-or-rebuild fallback after the define plugin, and one before inject. The latter also silently dropped `with_enum_eval`, which is set by `semantic_builder_for_transform()` for the TS enum-lowering path. Both now go through `semantic_builder_for_transform().with_stats(...)`.

`AstScopes` gains a `stats` field and `stats()` getter; `AstScopes::new`, `SymbolRefDbForModule::new`, and `AstScanner::new` take `Stats`. `set_scoping` is extended to update stats alongside scoping so `merge_from_build` (used by the incremental-build cache) keeps the two in sync. `EcmaAst` gets `make_scoping_with_stats` / `make_scoping_using_stats` helpers.

`AstScopes::stats()` is documented as a pre-allocation hint, not an authoritative count: link-stage facade symbols created via `create_facade_root_symbol_ref` are not reflected, so the value may under-count by the facade delta. Slight under-allocation triggers a small reallocation during rebuild but is not a correctness issue.

## Not addressed

- The forced rebuilds in `pre_process_ecma_ast.rs` Steps 3–5 (after transformer / inject / DCE). Eliminating those requires the corresponding oxc APIs (`Transformer::build_with_scoping`, `Compressor::dead_code_elimination_with_scoping`, `InjectGlobalVariables::build`) to return `Scoping` instead of consuming it — an upstream oxc change.
- Eliminating the HMR rebuild entirely. Conceptually possible because `clone_with_another_arena` preserves semantic IDs, but blocked by `Scoping` not being `Clone`.

## Verification

- `cargo check --workspace` clean.
- `cargo test --workspace` passes (1713 rolldown tests + the rest of the workspace).
- Not profiled — the Rust HMR finalization path isn't exercised by `cargo test`. JS-side HMR e2e (`packages/rolldown-tests` / `pnpm test`) is the next step to confirm there's no behavioural regression and to quantify the improvement.