### PR TITLE
feat(devtools): make duplicate packages discoverable

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -433,7 +433,13 @@ impl<'a> GenerateStage<'a> {
       }
 
       let mut packages = package_infos.into_values().collect::<Vec<_>>();
-      packages.sort_unstable_by(|a, b| a.package_id.cmp(&b.package_id));
+      packages.sort_unstable_by(|a, b| {
+        a.name
+          .cmp(&b.name)
+          .then_with(|| a.version.cmp(&b.version))
+          .then_with(|| a.package_root.cmp(&b.package_root))
+          .then_with(|| a.package_id.cmp(&b.package_id))
+      });
 
       trace_action!(action::PackageGraphReady { action: "PackageGraphReady", packages });
     }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -58,6 +58,8 @@
       "ignoreUnresolved": ["./world"],
       "ignoreDependencies": [
         "@rolldown/test-side-effects-field", // used in packages/rolldown/tests/fixtures/plugin/context/resolve-side-effects
+        "duplicate-a", // fixture dependency in packages/rolldown/tests/behaviors/emit-debug-data
+        "duplicate-b", // fixture dependency in packages/rolldown/tests/behaviors/emit-debug-data
         "meta-info-lib", // fixture dependency in packages/rolldown/tests/behaviors/emit-debug-data
       ],
     },

--- a/meta/design/devtools.md
+++ b/meta/design/devtools.md
@@ -147,6 +147,8 @@ Each hook call pair gets a unique `call_id` (UUID v4) via its enclosing span.
 
 All actions except `StringRef` carry injected `session_id`, `build_id`, and `timestamp` fields. `StringRef` entries contain only `action`, `id`, and `content`.
 
+`PackageGraphReady.packages` is sorted by package name, version, package root, and package id. Rolldown does not emit a duplicate flag; consumers can identify duplicate packages by grouping non-null package names and checking whether a group contains multiple versions or package roots.
+
 ## TypeScript Codegen
 
 Action types are defined as Rust structs with `#[derive(ts_rs::TS, serde::Serialize)]`. The codegen pipeline:

--- a/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
@@ -75,6 +75,20 @@ test(`emit data for devtool`, async () => {
   expectPathToEndWith(metaInfoPackage.package_root, 'node_modules/meta-info-lib');
   expectPathToEndWith(metaInfoPackage.package_json_path, 'node_modules/meta-info-lib/package.json');
 
+  const duplicatePackages = packageGraphReady.packages.filter(
+    (pkg) => pkg.name === 'duplicate-lib',
+  );
+  expect(duplicatePackages).toHaveLength(2);
+  expect(duplicatePackages.map((pkg) => pkg.version)).toEqual(['1.0.0', '2.0.0']);
+  expect(new Set(duplicatePackages.map((pkg) => pkg.package_root)).size).toBe(2);
+  expectPathToEndWith(duplicatePackages[0].package_root, 'node_modules/duplicate-a');
+  expectPathToEndWith(duplicatePackages[1].package_root, 'node_modules/duplicate-b');
+
+  const duplicatePackageIndices = packageGraphReady.packages.flatMap((pkg, index) =>
+    pkg.name === 'duplicate-lib' ? [index] : [],
+  );
+  expect(duplicatePackageIndices[1]).toBe(duplicatePackageIndices[0] + 1);
+
   const metaContent = readFileSync(join(dotRolldownFileName, dotRolldownDir[0], 'meta.json'));
   for (const variable of variables) {
     expect(metaContent.includes(variable)).toBe(false);

--- a/packages/rolldown/tests/behaviors/emit-debug-data/index.ts
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/index.ts
@@ -1,7 +1,10 @@
 import { hello } from './hello';
+import { duplicateA } from 'duplicate-a';
+import { duplicateB } from 'duplicate-b';
 import { metaInfo } from 'meta-info-lib';
 
 console.log(hello());
+console.log(duplicateA, duplicateB);
 console.log(metaInfo);
 void import('./async');
 

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/index.d.ts
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/index.d.ts
@@ -1,0 +1,1 @@
+export declare const duplicateA: string;

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/index.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/index.js
@@ -1,0 +1,1 @@
+export const duplicateA = 'duplicate-a';

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/package.json
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "duplicate-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "import": "./index.js"
+  }
+}

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/index.d.ts
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/index.d.ts
@@ -1,0 +1,1 @@
+export declare const duplicateB: string;

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/index.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/index.js
@@ -1,0 +1,1 @@
+export const duplicateB = 'duplicate-b';

--- a/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/package.json
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/node_modules/duplicate-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "duplicate-lib",
+  "version": "2.0.0",
+  "type": "module",
+  "exports": {
+    "import": "./index.js"
+  }
+}


### PR DESCRIPTION
## Summary

- Sorts `PackageGraphReady.packages` by package name, version, package root, and package id so consumers can group duplicate package names without an explicit duplicate flag.
- Adds fixture coverage for two package roots that share a package name but expose different versions.

Stacked on #9421. Part of #9399.
