### PR TITLE
fix(treeshake): propagate pure annotation through compound exprs

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -266,12 +266,16 @@ impl<'a> SideEffectDetector<'a> {
         expr,
         // `p.computed == true` => `p.key` is always an Expression variant
         // (oxc's parser only emits Static/PrivateIdentifier for `key:` syntax).
-        obj.properties.iter().flat_map(|prop| match prop {
-          ast::ObjectPropertyKind::ObjectProperty(p) => {
-            [p.computed.then(|| p.key.to_expression()), Some(&p.value)]
-          }
-          ast::ObjectPropertyKind::SpreadProperty(s) => [Some(&s.argument), None],
-        }).flatten(),
+        obj
+          .properties
+          .iter()
+          .flat_map(|prop| match prop {
+            ast::ObjectPropertyKind::ObjectProperty(p) => {
+              [p.computed.then(|| p.key.to_expression()), Some(&p.value)]
+            }
+            ast::ObjectPropertyKind::SpreadProperty(s) => [Some(&s.argument), None],
+          })
+          .flatten(),
       ),
       Expression::ArrayExpression(arr) => self.fold_compound(
         expr,

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -190,6 +190,9 @@ impl<'a> SideEffectDetector<'a> {
   }
 
   fn detect_side_effect_of_expr(&self, expr: &Expression) -> SideEffectDetail {
+    // Peel transparent wrappers (`(x)`, `x as T`, `x satisfies T`, `x!`, `<T>x`, `x<T>`)
+    // — they add no runtime semantics, so we recurse into the inner expression.
+    let expr = expr.get_inner_expression();
     match expr {
       // --- Bundler-specific overrides (metadata or custom logic) ---
       oxc::ast::match_member_expression!(Expression) => {
@@ -251,12 +254,72 @@ impl<'a> SideEffectDetector<'a> {
         detail
       }
       Expression::CallExpression(expr) => self.detect_side_effect_of_call_expr(expr),
+
+      // Transparent wrappers: oxc validates the boolean side-effect status,
+      // we then recurse children to harvest metadata flags
+      // (`PureAnnotation`, `GlobalVarAccess`). Without this, a pure-annotated
+      // call buried inside `export default { foo: /* @__PURE__ */ ... }`
+      // loses its annotation at the catch-all and the bundler emits the
+      // module's var-init at top level rather than wrapping it.
+      // See rolldown/rolldown#9425.
+      Expression::ObjectExpression(obj) => self.fold_compound(
+        expr,
+        // `p.computed == true` => `p.key` is always an Expression variant
+        // (oxc's parser only emits Static/PrivateIdentifier for `key:` syntax).
+        obj.properties.iter().flat_map(|prop| match prop {
+          ast::ObjectPropertyKind::ObjectProperty(p) => {
+            [p.computed.then(|| p.key.to_expression()), Some(&p.value)]
+          }
+          ast::ObjectPropertyKind::SpreadProperty(s) => [Some(&s.argument), None],
+        }).flatten(),
+      ),
+      Expression::ArrayExpression(arr) => self.fold_compound(
+        expr,
+        arr.elements.iter().filter_map(|elem| match elem {
+          ast::ArrayExpressionElement::SpreadElement(s) => Some(&s.argument),
+          ast::ArrayExpressionElement::Elision(_) => None,
+          e => Some(e.to_expression()),
+        }),
+      ),
+      Expression::SequenceExpression(s) => self.fold_compound(expr, &s.expressions),
+      Expression::TemplateLiteral(t) => self.fold_compound(expr, &t.expressions),
+      Expression::ConditionalExpression(c) => {
+        self.fold_compound(expr, [&c.test, &c.consequent, &c.alternate])
+      }
+      Expression::LogicalExpression(e) => self.fold_compound(expr, [&e.left, &e.right]),
+      Expression::BinaryExpression(e) => self.fold_compound(expr, [&e.left, &e.right]),
+      Expression::UnaryExpression(e) => self.fold_compound(expr, [&e.argument]),
+
       // Everything else: delegate entirely to Oxc.
-      // This covers literals, object/array/class expressions, unary/binary/logical/
-      // conditional/sequence/template/tagged-template/parenthesized expressions,
-      // TS/JSX syntax, await/import/yield, and any future expression types.
+      // Covers literals, function/arrow/class expressions (bodies not evaluated
+      // here), await/import/yield (inherently side-effectful), tagged-template
+      // (handled like a call by oxc; no `pure` flag), JSX, V8 intrinsics, etc.
       _ => expr.may_have_side_effects(self).into(),
     }
+  }
+
+  /// Gate-then-fold helper for transparent compound expressions: ask oxc
+  /// whether the whole expression has any side effect (fast path, covers
+  /// computed keys / spread reads / etc.), and if not, fold metadata flags
+  /// (`PureAnnotation`, `GlobalVarAccess`) from the child expressions.
+  /// Strips `Unknown` from the fold result because oxc already certified the
+  /// parent has no side effect — only metadata bits should propagate.
+  fn fold_compound<'e>(
+    &self,
+    expr: &Expression,
+    children: impl IntoIterator<Item = &'e Expression<'e>>,
+  ) -> SideEffectDetail {
+    if expr.may_have_side_effects(self) {
+      return true.into();
+    }
+    let mut detail = SideEffectDetail::empty();
+    for child in children {
+      detail |= self.detect_side_effect_of_expr(child);
+      if detail.has_side_effect() {
+        break;
+      }
+    }
+    detail - SideEffectDetail::Unknown
   }
 
   fn detect_side_effect_of_var_decl(
@@ -1132,6 +1195,124 @@ mod test {
     // Oxc is more permissive about computed property keys (ignores ToPrimitive side effects).
     // `{}` has a known toString(), so Oxc considers this side-effect-free.
     assert!(!get_statements_side_effect("const of = { [{}]: 'hi'}"));
+  }
+
+  // https://github.com/rolldown/rolldown/issues/9425
+  // PureAnnotation / GlobalVarAccess on a nested call must propagate up through
+  // transparent compound expressions (Object, Array, Sequence, Conditional,
+  // Logical, Binary, Unary, Template, TaggedTemplate, TS wrappers). Otherwise
+  // a module whose only "side effect" is a pure-annotated IIFE buried inside
+  // `export default { ... }` is never marked ExecutionOrderSensitive and the
+  // bundler emits its var-init at top level, before sibling modules that the
+  // IIFE depends on (regression after oxc 0.131 stopped inlining pure IIFEs
+  // in DCE mode).
+  #[test]
+  fn test_pure_annotation_propagates_through_compound_expr() {
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default { foo: /* @__PURE__ */ (() => globalValue)() }"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details("export default [/* @__PURE__ */ (() => globalValue)()]"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default (0, /* @__PURE__ */ (() => globalValue)())"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default true ? /* @__PURE__ */ (() => globalValue)() : null"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default true && /* @__PURE__ */ (() => globalValue)()"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // BinaryExpression `===` does not ToPrimitive-coerce, so oxc returns
+    // no own side effect and the metadata harvest can propagate.
+    assert_eq!(
+      get_statements_side_effect_details("export default /* @__PURE__ */ (() => 2)() === 1"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // `typeof` never has side effects per spec.
+    assert_eq!(
+      get_statements_side_effect_details("export default typeof /* @__PURE__ */ (() => true)()"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // Computed key with a pure-annotated call must propagate too.
+    assert_eq!(
+      get_statements_side_effect_details("export default { [/* @__PURE__ */ (() => 'k')()]: 1 }"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // GlobalVarAccess on a bare member-expr buried in a compound wrapper
+    // must also propagate (same mechanism, different flag).
+    assert_eq!(
+      get_statements_side_effect_details("let a = { x: Proxy }"),
+      vec![SideEffectDetail::GlobalVarAccess]
+    );
+    assert_eq!(
+      get_statements_side_effect_details("let a = [JSON.stringify]"),
+      vec![SideEffectDetail::GlobalVarAccess]
+    );
+    // Nested compound: array inside object inside object — propagation must
+    // walk through every layer.
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default { a: { b: [/* @__PURE__ */ (() => globalValue)()] } }"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // TS wrapper passthroughs (`SourceType::tsx()` in test helper).
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default (/* @__PURE__ */ (() => globalValue)() as string)"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default (/* @__PURE__ */ (() => globalValue)() satisfies string)"
+      ),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    assert_eq!(
+      get_statements_side_effect_details("export default /* @__PURE__ */ (() => globalValue)()!"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+  }
+
+  // Function bodies are not evaluated at the statement level — a pure
+  // annotation inside an arrow/function body must NOT propagate up.
+  #[test]
+  fn test_pure_annotation_not_propagated_through_function_body() {
+    assert_eq!(
+      get_statements_side_effect_details("export default () => /* @__PURE__ */ pureCall()"),
+      vec![SideEffectDetail::empty()]
+    );
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default { foo: () => /* @__PURE__ */ pureCall() }"
+      ),
+      vec![SideEffectDetail::empty()]
+    );
+  }
+
+  // A real side effect anywhere in a compound expression must surface as
+  // Unknown — the new metadata-propagation arms must not weaken this.
+  #[test]
+  fn test_compound_expr_side_effectful_operand_still_unknown() {
+    assert!(get_statements_side_effect("let a = { foo: globalCall() }"));
+    assert!(get_statements_side_effect("let a = [globalCall()]"));
+    assert!(get_statements_side_effect("let a = (globalCall(), 1)"));
+    assert!(get_statements_side_effect("let a = true ? globalCall() : null"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -306,8 +306,13 @@ impl<'a> SideEffectDetector<'a> {
   /// whether the whole expression has any side effect (fast path, covers
   /// computed keys / spread reads / etc.), and if not, fold metadata flags
   /// (`PureAnnotation`, `GlobalVarAccess`) from the child expressions.
-  /// Strips `Unknown` from the fold result because oxc already certified the
-  /// parent has no side effect — only metadata bits should propagate.
+  ///
+  /// The trailing `- Unknown` is load-bearing: rolldown's detector can be
+  /// more conservative than oxc for some sub-expressions (e.g. CJS-export
+  /// assignments via [`check_pure_cjs_export`], or future bundler-specific
+  /// overrides). Once oxc has certified the parent side-effect-free at the
+  /// gate, we trust that judgment for the parent and strip any `Unknown`
+  /// that a child contributed — only metadata bits should propagate.
   fn fold_compound<'e>(
     &self,
     expr: &Expression,
@@ -1289,6 +1294,16 @@ mod test {
     );
     assert_eq!(
       get_statements_side_effect_details("export default /* @__PURE__ */ (() => globalValue)()!"),
+      vec![SideEffectDetail::PureAnnotation]
+    );
+    // TSInstantiationExpression `f<T>` — must be peeled like the other TS
+    // wrappers. (`<T>x` TSTypeAssertion is ambiguous with JSX under tsx()
+    // and can't be expressed in this harness; `get_inner_expression()`
+    // peels it identically in non-tsx contexts.)
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default /* @__PURE__ */ ((() => globalValue) as any)<string>()"
+      ),
       vec![SideEffectDetail::PureAnnotation]
     );
   }


### PR DESCRIPTION
### Root cause

`SideEffectDetector::detect_side_effect_of_expr`'s catch-all arm collapses any compound expression (`ObjectExpression`, `ArrayExpression`, `SequenceExpression`, `Conditional`/`Logical`/`Binary`/`Unary` expressions, `TemplateLiteral`) into a plain bool via `From<bool> for SideEffectDetail`:

```rust
impl From<bool> for SideEffectDetail {
  fn from(value: bool) -> Self {
    if value { SideEffectDetail::Unknown } else { SideEffectDetail::empty() }
  }
}
```

That conversion can only encode `Unknown` or `empty`. The `PureAnnotation` and `GlobalVarAccess` metadata bits on a buried call are silently dropped at the catch-all and never reach the statement-level intersection that drives `EcmaViewMeta::ExecutionOrderSensitive`.

Concretely, `export default { foo: /* @__PURE__ */ (() => globalValue)() }` reaches statement level with `SideEffectDetail::empty()`. `wrap_modules` (`crates/rolldown/src/stages/link_stage/wrapping.rs`) takes the `avoid_wrapping` branch, `WrapKind::None` is emitted, and the module's top-level `var foo_inner_default = ...` runs at chunk top level — before sibling modules like `setup.js` that the IIFE depends on:

```js
var foo_inner_default = { foo: /* @__PURE__ */ (() => globalValue)() };  // globalValue is undefined here
__esmMin((() => {
  globalThis.globalValue = "foo";
  // ...
}))();
```

### Why this was latent before oxc 0.131

oxc 0.130's DCE pass unconditionally inlined `/* @__PURE__ */ (() => globalValue)()` down to a bare `globalValue` identifier. After inlining, the detector's `Identifier` arm independently flagged the unresolved global via `GlobalVarAccess` (a code path separate from `PureAnnotation`), the module was marked `ExecutionOrderSensitive`, and wrapping kicked in. Wrap-correctness was accidentally riding on oxc's IIFE inlining.

oxc 0.131 (oxc-project/oxc#22349) intentionally **preserves** pure-annotated IIFEs in DCE-only mode so downstream tree-shakers can see the annotation. That is the right call on oxc's side — but it removes the inline-to-bare-global behavior rolldown was implicitly leaning on, exposing this detector gap.

### Changes

- Add explicit arms in `detect_side_effect_of_expr` for the transparent compound expression types so metadata propagates: `ObjectExpression`, `ArrayExpression`, `SequenceExpression`, `ConditionalExpression`, `LogicalExpression`, `BinaryExpression`, `UnaryExpression`, `TemplateLiteral`.
- Each arm goes through a single helper `fold_compound(expr, children)` that:
  1. Asks oxc's `may_have_side_effects` for the spec-level boolean (handles ToPrimitive coercion, getter triggers in spread, Symbol checks in templates, etc.). If oxc says yes, return `Unknown` and stop.
  2. Otherwise recurses through the children via rolldown's own detector to harvest `PureAnnotation` / `GlobalVarAccess` flags.
  3. Strips `Unknown` from the harvested result since oxc already certified the parent has no side effect — only metadata bits should propagate.
- Peel transparent syntactic wrappers (`(x)`, `x as T`, `x satisfies T`, `x!`, `<T>x`, `x<T>`) at the top of `detect_side_effect_of_expr` via `Expression::get_inner_expression()` — they add no runtime semantics, so a single peel covers all five wrapper variants (and any future ones oxc adds to that method).

This mirrors the existing gate-and-harvest pattern already used by `detect_side_effect_of_call_expr` and the `NewExpression` arm.

### Tests

New unit tests in `side_effect_detector::test`:

- `test_pure_annotation_propagates_through_compound_expr` — covers `PureAnnotation` propagation through `Object`/`Array`/`Sequence`/`Conditional`/`Logical`/`Binary` (`===`) / `Unary` (`typeof`) / computed-key / nested compound, plus `GlobalVarAccess` propagation through compound, plus TS wrapper passthroughs (`as`, `satisfies`, `!`).
- `test_pure_annotation_not_propagated_through_function_body` — verifies a pure annotation inside an arrow/function body does **not** propagate to the statement level (function bodies aren't evaluated at module init).
- `test_compound_expr_side_effectful_operand_still_unknown` — verifies a real side effect anywhere in a compound expression still surfaces as `Unknown`; the new arms don't weaken side-effect detection.

Existing integration suites kept green without snapshot changes:

```sh
cargo test --package rolldown --lib ast_scanner::side_effect_detector::test::
cargo test --package rolldown --test integration -- strict_execution_order  # 24 passed
cargo test --package rolldown --test integration -- tree_shaking             # 72 passed
```

The two pre-existing integration fixtures called out in the issue (`function/experimental/strict_execution_order/concatenate_wrapped_modules` and `.../issue_5303`) pass with their current snapshots — those snapshots already encode the wrapped behavior, so this PR restores conformance to them after the oxc 0.131 bump (rolldown/rolldown#9424) would otherwise break them.

Closes #9425.