### PR TITLE
refactor(treeshake): scan pure-annotated IIFE bodies for global reads

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -176,6 +176,21 @@ impl<'a> SideEffectDetector<'a> {
             self.detect_side_effect_of_expr(arg.to_expression()) - SideEffectDetail::Unknown;
         }
       }
+
+      // For pure-annotated IIFEs, the body still runs at module init. The
+      // annotation suppresses our boolean side-effect analysis of the call,
+      // but the body may read unresolved globals — those reads are an
+      // execution-order dependence (sibling modules may set the global),
+      // not a side effect. Propagate just `GlobalVarAccess`; we don't merge
+      // `Unknown` since the annotation already certified no side effect at
+      // the call level. See rolldown/rolldown#9425. Note: defaults on
+      // parameters can also evaluate globals (`((x = globalValue) => 1)()`)
+      // — not yet covered.
+      if is_pure_annotated && let Some(body) = iife_body(&expr.callee) {
+        for stmt in &body.statements {
+          detail |= self.detect_side_effect_of_stmt(stmt) & SideEffectDetail::GlobalVarAccess;
+        }
+      }
     }
     detail
   }
@@ -541,6 +556,17 @@ impl<'a> SideEffectDetector<'a> {
       }
     }
     detail
+  }
+}
+
+/// If `callee` is a function literal (an IIFE shape: `(() => ...)`,
+/// `(function() { ... })`), return its body. Transparent wrappers
+/// (`(callee)`, `callee as T`, etc.) are peeled first.
+fn iife_body<'a>(callee: &'a Expression<'a>) -> Option<&'a ast::FunctionBody<'a>> {
+  match callee.get_inner_expression() {
+    Expression::ArrowFunctionExpression(arrow) => Some(&arrow.body),
+    Expression::FunctionExpression(func) => func.body.as_deref(),
+    _ => None,
   }
 }
 
@@ -1212,33 +1238,38 @@ mod test {
   // in DCE mode).
   #[test]
   fn test_pure_annotation_propagates_through_compound_expr() {
+    // Pure-annotated IIFE reading an unresolved global now flags both
+    // `PureAnnotation` (annotation present) and `GlobalVarAccess` (the body
+    // scan picked up the `globalValue` read) — see `iife_body` scan in
+    // `detect_side_effect_of_call_expr`.
+    let pure_and_global = SideEffectDetail::PureAnnotation | SideEffectDetail::GlobalVarAccess;
     assert_eq!(
       get_statements_side_effect_details(
         "export default { foo: /* @__PURE__ */ (() => globalValue)() }"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details("export default [/* @__PURE__ */ (() => globalValue)()]"),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details(
         "export default (0, /* @__PURE__ */ (() => globalValue)())"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details(
         "export default true ? /* @__PURE__ */ (() => globalValue)() : null"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details(
         "export default true && /* @__PURE__ */ (() => globalValue)()"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     // BinaryExpression `===` does not ToPrimitive-coerce, so oxc returns
     // no own side effect and the metadata harvest can propagate.
@@ -1272,24 +1303,67 @@ mod test {
       get_statements_side_effect_details(
         "export default { a: { b: [/* @__PURE__ */ (() => globalValue)()] } }"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     // TS wrapper passthroughs (`SourceType::tsx()` in test helper).
     assert_eq!(
       get_statements_side_effect_details(
         "export default (/* @__PURE__ */ (() => globalValue)() as string)"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details(
         "export default (/* @__PURE__ */ (() => globalValue)() satisfies string)"
       ),
-      vec![SideEffectDetail::PureAnnotation]
+      vec![pure_and_global]
     );
     assert_eq!(
       get_statements_side_effect_details("export default /* @__PURE__ */ (() => globalValue)()!"),
+      vec![pure_and_global]
+    );
+  }
+
+  // Phase 1 IIFE body scan: a pure-annotated IIFE whose body reads an
+  // unresolved global must surface `GlobalVarAccess` so the module gets
+  // wrapped via the actual semantic (global read = execution-order
+  // dependence), not just via `PureAnnotation`. See discussion in
+  // rolldown/rolldown#9425.
+  #[test]
+  fn test_pure_iife_body_global_propagates_global_var_access() {
+    let pure_and_global = SideEffectDetail::PureAnnotation | SideEffectDetail::GlobalVarAccess;
+    // Arrow IIFE with expression body — the bare `globalValue` is wrapped in
+    // an ExpressionStatement by oxc's parser.
+    assert_eq!(
+      get_statements_side_effect_details("export default /* @__PURE__ */ (() => globalValue)()"),
+      vec![pure_and_global]
+    );
+    // Arrow IIFE with block body + explicit return.
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default /* @__PURE__ */ (() => { return globalValue })()"
+      ),
+      vec![pure_and_global]
+    );
+    // Function expression IIFE.
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default /* @__PURE__ */ (function() { return globalValue })()"
+      ),
+      vec![pure_and_global]
+    );
+    // Pure-annotated IIFE with body that does *not* read globals — should
+    // NOT gain `GlobalVarAccess`.
+    assert_eq!(
+      get_statements_side_effect_details("export default /* @__PURE__ */ (() => 1)()"),
       vec![SideEffectDetail::PureAnnotation]
+    );
+    // Member expression rooted at an unresolved global inside the body.
+    assert_eq!(
+      get_statements_side_effect_details(
+        "export default /* @__PURE__ */ (() => Reflect.something)()"
+      ),
+      vec![pure_and_global]
     );
   }
 


### PR DESCRIPTION
Stacked on #9431.

### Motivation

`SideEffectDetector::detect_side_effect_of_call_expr` treats pure-annotated calls as fully side-effect-free and **never recurses into the callee's body**. So a pure-annotated IIFE like `/* @__PURE__ */ (() => globalValue)()` loses the fact that its body reads an unresolved global.

That matters because the two concepts are orthogonal:

| | Side-effectful? | Execution-order-sensitive? |
|---|---|---|
| `/* @__PURE__ */ (() => 1)()` | No | No |
| `/* @__PURE__ */ (() => globalValue)()` | No (per annotation) | **Yes** (`globalValue` may be set by sibling module) |

Reading a top-level unresolved global IS an execution-order dependence even when the call is side-effect-free per the annotation. The current wrap trigger in `impl_visit.rs:92-98` papers over this by using `PureAnnotation` as a "be cautious" proxy, which over-marks (row 1 wraps too) while under-modeling (the actual signal — `GlobalVarAccess` from the body — is missing).

### Changes

- Add `iife_body()` free function: returns the `FunctionBody` if `callee.get_inner_expression()` is `ArrowFunctionExpression` or `FunctionExpression`. Transparent wrappers (`(callee)`, `callee as T`, etc.) are peeled by `get_inner_expression`.
- In `detect_side_effect_of_call_expr`, when the call is pure-annotated and `iife_body()` returns `Some`, walk each body statement through the existing detector and OR in only the `GlobalVarAccess` bit. `Unknown` is deliberately masked off — the annotation already certified no side effect at the call level; this scan exists strictly to harvest the order-sensitivity signal.

### Why no snapshot churn

Purely additive. The wrap trigger still intersects with `PureAnnotation`, so cases that previously wrapped continue to wrap. The new `GlobalVarAccess` signal sits alongside `PureAnnotation` for now.

### Phase 1 of a multi-step reconcile

This PR is the first of three steps to resolve a design tension in `SideEffectDetail::PureAnnotation`:

1. **This PR — produce `GlobalVarAccess` for pure-annotated IIFE bodies.** Additive. No behavior change.
2. **Follow-up — drop `PureAnnotation` from the wrap trigger** in `impl_visit.rs:92-98`. Reconciles with the sibling branch `fix/remove-pure-annotation-execution-order-sensitive`. Modules that were over-wrapping (pure call to local empty function with no globals) stop wrapping; modules that need wrapping (pure IIFE reading globals) keep wrapping via the `GlobalVarAccess` path this PR adds. Will have snapshot churn — that's the point.
3. **Cleanup — drop the `SideEffectDetail::PureAnnotation` flag entirely** if no consumer remains.

### Not addressed

Parameter defaults that evaluate globals at call time — `/* @__PURE__ */ ((x = globalValue) => 1)()`. The `x = globalValue` runs but isn't inside `body.statements`. Noted as a follow-up in the code comment. Probably a small extension to `iife_body()`-adjacent code; not blocking the Phase 1/2 reconcile.

### Tests

- `test_pure_annotation_propagates_through_compound_expr` — existing test, expectations updated. Cases that read `globalValue` now expect `PureAnnotation | GlobalVarAccess` (the new combined semantic). Cases with bodies that don't read globals (`(() => 2)()`, `(() => true)()`, `(() => 'k')()`) still expect just `PureAnnotation`.
- `test_pure_iife_body_global_propagates_global_var_access` — new test, direct coverage for the body scan: arrow with expression body, arrow with block + explicit return, function expression IIFE, pure IIFE with no globals (negative case), member expression rooted at an unresolved global.

```sh
cargo test --package rolldown --lib ast_scanner::side_effect_detector::test::
# 37 passed

cargo test --package rolldown --test integration -- strict_execution_order tree_shaking no_side_effects
# 102 passed, 0 failed
```