### PR TITLE
perf(binding): reduce plugin string clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,7 +3557,6 @@ name = "rolldown_plugin_vite_transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arcstr",
  "itertools",
  "memchr",
  "oxc",

--- a/crates/rolldown/src/utils/render_chunks.rs
+++ b/crates/rolldown/src/utils/render_chunks.rs
@@ -37,7 +37,7 @@ pub async fn render_chunks(
       if let InstantiationKind::Ecma(ecma_meta) = &asset.kind {
         let render_chunk_ret = plugin_driver
           .render_chunk(HookRenderChunkArgs {
-            code: std::mem::take(&mut asset.content).try_into_inner_string()?,
+            code: Arc::new(std::mem::take(&mut asset.content).try_into_inner_string()?),
             chunk: Arc::clone(
               chunks.get(&ecma_meta.rendered_chunk.filename).expect("should have chunk"),
             ),

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform_without_runtime_usage/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform_without_runtime_usage/mod.rs
@@ -22,7 +22,7 @@ impl Plugin for TransformWithoutRuntimeUsagePlugin {
     args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
     if args.id == RUNTIME_MODULE_KEY {
-      let mut code = args.code.clone();
+      let mut code = args.code.to_string();
       code.push_str("\nconsole.log(\"transform-without-usage\");\n");
       return Ok(Some(rolldown_plugin::HookTransformOutput {
         code: Some(code),

--- a/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
@@ -20,6 +20,7 @@ use crate::options::plugin::types::{
   binding_hook_side_effects::BindingHookSideEffects,
   binding_hook_transform_output::BindingHookTransformOutput,
   binding_plugin_transform_extra_args::BindingTransformHookExtraArgs,
+  binding_shared_string::BindingSharedString,
 };
 
 use super::{
@@ -150,10 +151,11 @@ impl BindingCallableBuiltinPlugin {
     let context = Arc::clone(&self.context);
     crate::start_async_runtime();
     AsyncBlockBuilder::with(async move {
+      let code_arc = ArcStr::from(code.as_str());
       plugin
         .call_transform(
           context,
-          &HookTransformArgs { id: &id, code: &code, module_type: &module_type },
+          &HookTransformArgs { id: &id, code: &code_arc, module_type: &module_type },
         )
         .await
         .map_err(AnyHowMaybeNapiError::into_napi_error)
@@ -236,7 +238,8 @@ impl From<HookResolveIdOutput> for BindingHookJsResolveIdOutput {
 
 #[napi_derive::napi(object, object_from_js = false)]
 pub struct BindingHookJsLoadOutput {
-  pub code: String,
+  #[napi(ts_type = "string")]
+  pub code: BindingSharedString,
   pub map: Option<String>,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
   pub module_side_effects: Option<BindingHookSideEffects>,
@@ -245,7 +248,7 @@ pub struct BindingHookJsLoadOutput {
 impl From<HookLoadOutput> for BindingHookJsLoadOutput {
   fn from(value: HookLoadOutput) -> Self {
     Self {
-      code: value.code.to_string(),
+      code: BindingSharedString::from(value.code),
       map: value.map.map(|map| map.to_json_string()),
       module_side_effects: value.side_effects.map(Into::into),
     }

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -26,6 +26,7 @@ use super::{
     binding_hook_transform_output::BindingHookTransformOutput,
     binding_plugin_transform_extra_args::BindingTransformHookExtraArgs,
     binding_render_chunk_meta_chunks::BindingRenderedChunkMeta,
+    binding_shared_string::BindingSharedString,
   },
 };
 
@@ -82,7 +83,12 @@ pub struct BindingPluginOptions {
   )]
   pub transform: Option<
     MaybeAsyncJsCallback<
-      FnArgs<(BindingTransformPluginContext, String, String, BindingTransformHookExtraArgs)>,
+      FnArgs<(
+        BindingTransformPluginContext,
+        BindingSharedString,
+        String,
+        BindingTransformHookExtraArgs,
+      )>,
       Option<BindingHookTransformOutput>,
     >,
   >,
@@ -110,7 +116,7 @@ pub struct BindingPluginOptions {
     MaybeAsyncJsCallback<
       FnArgs<(
         BindingPluginContext,
-        String,
+        BindingSharedString,
         BindingRenderedChunk,
         BindingNormalizedOptions,
         BindingRenderedChunkMeta,

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -21,6 +21,7 @@ use super::{
     binding_hook_resolve_id_extra_args::BindingHookResolveIdExtraArgs,
     binding_plugin_transform_extra_args::BindingTransformHookExtraArgs,
     binding_render_chunk_meta_chunks::BindingRenderedChunkMeta,
+    binding_shared_string::BindingSharedString,
   },
 };
 
@@ -213,7 +214,7 @@ impl Plugin for JsPlugin {
       if !filter_exprs_interpreter(
         v,
         Some(args.id),
-        Some(args.code),
+        Some(args.code.as_str()),
         Some(args.module_type.to_string().as_ref()),
         None,
         ctx.cwd().to_string_lossy().as_ref(),
@@ -227,7 +228,7 @@ impl Plugin for JsPlugin {
     cb.await_call(
       (
         BindingTransformPluginContext::new(Arc::clone(&ctx)),
-        args.code.clone(),
+        BindingSharedString::from(args.code.clone()),
         args.id.to_string(),
         extra_args,
       )
@@ -424,7 +425,7 @@ impl Plugin for JsPlugin {
       if !filter_exprs_interpreter(
         v,
         None,
-        Some(&args.code),
+        Some(args.code.as_str()),
         None,
         None,
         ctx.cwd().to_string_lossy().as_ref(),
@@ -436,7 +437,7 @@ impl Plugin for JsPlugin {
     cb.await_call(
       (
         ctx.clone().into(),
-        args.code.clone(),
+        BindingSharedString::from(Arc::clone(&args.code)),
         BindingRenderedChunk::new(Arc::clone(&args.chunk)),
         BindingNormalizedOptions::new(Arc::clone(args.options)),
         BindingRenderedChunkMeta::new(Arc::clone(&args.chunks)),

--- a/crates/rolldown_binding/src/options/plugin/types/binding_shared_string.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_shared_string.rs
@@ -1,0 +1,98 @@
+use std::{ptr, sync::Arc};
+
+use arcstr::ArcStr;
+use napi::{
+  Error, Result, Status,
+  bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue, ValueType},
+  sys,
+};
+
+#[derive(Debug, Clone)]
+pub struct BindingSharedString {
+  inner: SharedStringInner,
+}
+
+#[derive(Debug, Clone)]
+enum SharedStringInner {
+  ArcStr(ArcStr),
+  #[expect(clippy::rc_buffer, reason = "Arc<String> lets renderChunk recover owned code")]
+  String(Arc<String>),
+}
+
+impl BindingSharedString {
+  fn as_str(&self) -> &str {
+    match &self.inner {
+      SharedStringInner::ArcStr(value) => value.as_str(),
+      SharedStringInner::String(value) => value.as_str(),
+    }
+  }
+}
+
+impl From<ArcStr> for BindingSharedString {
+  fn from(value: ArcStr) -> Self {
+    Self { inner: SharedStringInner::ArcStr(value) }
+  }
+}
+
+impl From<Arc<String>> for BindingSharedString {
+  fn from(value: Arc<String>) -> Self {
+    Self { inner: SharedStringInner::String(value) }
+  }
+}
+
+unsafe fn create_napi_string(env: sys::napi_env, value: &str) -> Result<sys::napi_value> {
+  let mut ptr = ptr::null_mut();
+  let status = unsafe {
+    sys::napi_create_string_utf8(
+      env,
+      value.as_ptr().cast(),
+      value.len().cast_signed(),
+      &raw mut ptr,
+    )
+  };
+
+  if status != sys::Status::napi_ok {
+    return Err(Error::new(
+      Status::from(status),
+      "Failed to convert shared rust string into napi `string`",
+    ));
+  }
+
+  Ok(ptr)
+}
+
+impl TypeName for BindingSharedString {
+  fn type_name() -> &'static str {
+    "String"
+  }
+
+  fn value_type() -> ValueType {
+    ValueType::String
+  }
+}
+
+impl ValidateNapiValue for BindingSharedString {}
+
+impl FromNapiValue for BindingSharedString {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
+    Ok(Self::from(Arc::new(unsafe { String::from_napi_value(env, napi_val)? })))
+  }
+}
+
+impl ToNapiValue for &BindingSharedString {
+  unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> Result<sys::napi_value> {
+    unsafe { create_napi_string(env, value.as_str()) }
+  }
+}
+
+impl ToNapiValue for &mut BindingSharedString {
+  unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> Result<sys::napi_value> {
+    unsafe { ToNapiValue::to_napi_value(env, &*value) }
+  }
+}
+
+impl ToNapiValue for BindingSharedString {
+  unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> Result<sys::napi_value> {
+    unsafe { ToNapiValue::to_napi_value(env, &value) }
+  }
+}

--- a/crates/rolldown_binding/src/options/plugin/types/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/mod.rs
@@ -19,4 +19,5 @@ pub mod binding_plugin_transform_extra_args;
 pub mod binding_render_built_url;
 pub mod binding_render_chunk_meta_chunks;
 pub mod binding_resolved_external;
+pub mod binding_shared_string;
 pub mod binding_vite_plugin_custom;

--- a/crates/rolldown_binding/src/types/binding_module_info.rs
+++ b/crates/rolldown_binding/src/types/binding_module_info.rs
@@ -3,14 +3,21 @@ use std::sync::Arc;
 use napi_derive::napi;
 use rolldown_common::ExportsKind;
 
+use crate::options::plugin::types::binding_shared_string::BindingSharedString;
+
 #[napi]
 pub struct BindingModuleInfo {
   inner: Arc<rolldown_common::ModuleInfo>,
-  pub id: String,
-  pub importers: Vec<String>,
-  pub dynamic_importers: Vec<String>,
-  pub imported_ids: Vec<String>,
-  pub dynamically_imported_ids: Vec<String>,
+  #[napi(ts_type = "string")]
+  pub id: BindingSharedString,
+  #[napi(ts_type = "Array<string>")]
+  pub importers: Vec<BindingSharedString>,
+  #[napi(ts_type = "Array<string>")]
+  pub dynamic_importers: Vec<BindingSharedString>,
+  #[napi(ts_type = "Array<string>")]
+  pub imported_ids: Vec<BindingSharedString>,
+  #[napi(ts_type = "Array<string>")]
+  pub dynamically_imported_ids: Vec<BindingSharedString>,
   pub exports: Vec<String>,
   pub is_entry: bool,
   #[napi(ts_type = "'es' | 'cjs' | 'unknown'")]
@@ -26,14 +33,26 @@ impl BindingModuleInfo {
       ExportsKind::None => "unknown",
     };
     Self {
-      id: inner.id.to_string(),
-      importers: inner.importers.iter().map(ToString::to_string).collect(),
-      dynamic_importers: inner.dynamic_importers.iter().map(ToString::to_string).collect(),
-      imported_ids: inner.imported_ids.iter().map(ToString::to_string).collect(),
+      id: BindingSharedString::from(inner.id.as_arc_str().clone()),
+      importers: inner
+        .importers
+        .iter()
+        .map(|id| BindingSharedString::from(id.as_arc_str().clone()))
+        .collect(),
+      dynamic_importers: inner
+        .dynamic_importers
+        .iter()
+        .map(|id| BindingSharedString::from(id.as_arc_str().clone()))
+        .collect(),
+      imported_ids: inner
+        .imported_ids
+        .iter()
+        .map(|id| BindingSharedString::from(id.as_arc_str().clone()))
+        .collect(),
       dynamically_imported_ids: inner
         .dynamically_imported_ids
         .iter()
-        .map(ToString::to_string)
+        .map(|id| BindingSharedString::from(id.as_arc_str().clone()))
         .collect(),
       is_entry: inner.is_entry,
       exports: inner.exports.iter().map(ToString::to_string).collect(),

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -1,5 +1,9 @@
 use std::sync::Arc;
 
+use napi::{
+  Env,
+  bindgen_prelude::{BufferSlice, JsObjectValue, Object},
+};
 use napi_derive::napi;
 
 use crate::{
@@ -69,9 +73,18 @@ impl BindingOutputAsset {
     Ok(self.try_get_inner()?.original_file_names.iter().map(AsRef::as_ref).collect())
   }
 
-  #[napi]
-  pub fn get_source(&self) -> napi::Result<BindingAssetSource> {
-    Ok(self.try_get_inner()?.source.clone().into())
+  #[napi(ts_return_type = "BindingAssetSource")]
+  pub fn get_source<'env>(&self, env: &'env Env) -> napi::Result<Object<'env>> {
+    let mut source = Object::new(env)?;
+    match &self.try_get_inner()?.source {
+      rolldown_common::StrOrBytes::Str(value) => {
+        source.set_named_property("inner", env.create_string(value)?)?;
+      }
+      rolldown_common::StrOrBytes::Bytes(value) => {
+        source.set_named_property("inner", BufferSlice::copy_from(env, value)?)?;
+      }
+    }
+    Ok(source)
   }
 
   #[napi]

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -155,15 +155,36 @@ pub fn update_output_chunk(
   chunk: &mut Arc<rolldown_common::OutputChunk>,
   js_chunk: JsOutputChunk,
 ) -> anyhow::Result<()> {
-  let old_chunk = (**chunk).clone();
-  *chunk = Arc::new(rolldown_common::OutputChunk {
-    code: js_chunk.code,
-    map: js_chunk.map.map(TryInto::try_into).transpose()?,
-    imports: js_chunk.imports.into_iter().map(Into::into).collect(),
-    dynamic_imports: js_chunk.dynamic_imports.into_iter().map(Into::into).collect(),
-    is_entry: js_chunk.is_entry, // used by nuxt
-    filename: js_chunk.filename.into(),
-    ..old_chunk
-  });
+  let map = js_chunk.map.map(TryInto::try_into).transpose()?;
+  let imports = js_chunk.imports.into_iter().map(Into::into).collect();
+  let dynamic_imports = js_chunk.dynamic_imports.into_iter().map(Into::into).collect();
+  let filename = js_chunk.filename.into();
+
+  if let Some(chunk) = Arc::get_mut(chunk) {
+    chunk.code = js_chunk.code;
+    chunk.map = map;
+    chunk.imports = imports;
+    chunk.dynamic_imports = dynamic_imports;
+    chunk.is_entry = js_chunk.is_entry; // used by nuxt
+    chunk.filename = filename;
+  } else {
+    let old_chunk = Arc::as_ref(chunk);
+    *chunk = Arc::new(rolldown_common::OutputChunk {
+      name: old_chunk.name.clone(),
+      is_entry: js_chunk.is_entry, // used by nuxt
+      is_dynamic_entry: old_chunk.is_dynamic_entry,
+      facade_module_id: old_chunk.facade_module_id.clone(),
+      module_ids: old_chunk.module_ids.clone(),
+      exports: old_chunk.exports.clone(),
+      filename,
+      modules: old_chunk.modules.clone(),
+      imports,
+      dynamic_imports,
+      code: js_chunk.code,
+      map,
+      sourcemap_filename: old_chunk.sourcemap_filename.clone(),
+      preliminary_filename: old_chunk.preliminary_filename.clone(),
+    });
+  }
   Ok(())
 }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -10,6 +10,7 @@ use crate::{
   },
 };
 use anyhow::{Context, Result};
+use arcstr::ArcStr;
 use rolldown_common::{
   ModuleInfo, ModuleType, NormalModule, PluginIdx, SharedNormalizedBundlerOptions,
   SourcemapChainElement, side_effects::HookSideEffects,
@@ -267,6 +268,7 @@ impl PluginDriver {
       self.iter_plugin_with_context_by_order(&self.order_by_transform_meta)
     {
       let call_id = tracing::enabled!(tracing::Level::TRACE).then(rolldown_utils::uuid::uuid_v4);
+      let code_arc = ArcStr::from(code.as_str());
 
       trace_action!(action::HookTransformCallStart {
         action: "HookTransformCallStart",
@@ -282,13 +284,13 @@ impl PluginDriver {
           Arc::new(TransformPluginContext::new(
             ctx.clone(),
             plugin_sourcemap_chain.weak_ref(),
-            code.as_str().into(),
+            code_arc.clone(),
             id.into(),
             module_idx,
             plugin_idx,
             magic_string_tx.clone(),
           )),
-          &HookTransformArgs { id, code: &code, module_type: &*module_type },
+          &HookTransformArgs { id, code: &code_arc, module_type: &*module_type },
         )
         .await;
       self.record_timing(plugin_idx, start);

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -6,7 +6,7 @@ use crate::{HookAddonArgs, PluginDriver};
 use crate::{HookAugmentChunkHashReturn, HookNoopReturn, HookRenderChunkArgs};
 use anyhow::{Context, Ok, Result};
 use rolldown_common::{Output, RollupRenderedChunk, SharedNormalizedBundlerOptions};
-use rolldown_devtools::{action, trace_action};
+use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, CausedPlugin};
 use rolldown_sourcemap::SourceMap;
 use tracing::Instrument;
@@ -136,29 +136,33 @@ impl PluginDriver {
       self.iter_plugin_with_context_by_order(&self.order_by_render_chunk_meta)
     {
       async {
-        trace_action!(action::HookRenderChunkStart {
-          action: "HookRenderChunkStart",
-          plugin_name: plugin.call_name().to_string(),
-          plugin_id: plugin_idx.raw(),
-          call_id: "${call_id}",
-          content: args.code.clone(),
-        });
+        if trace_action_enabled!() {
+          trace_action!(action::HookRenderChunkStart {
+            action: "HookRenderChunkStart",
+            plugin_name: plugin.call_name().to_string(),
+            plugin_id: plugin_idx.raw(),
+            call_id: "${call_id}",
+            content: args.code.as_str().to_string(),
+          });
+        }
         let start = self.start_timing();
         let result = plugin.call_render_chunk(ctx, &args).await;
         self.record_timing(plugin_idx, start);
         if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
-          args.code = r.code;
+          args.code = Arc::new(r.code);
           if let Some(map) = r.map {
             sourcemap_chain.push(map);
           }
-          trace_action!(action::HookRenderChunkEnd {
-            action: "HookRenderChunkEnd",
-            plugin_name: plugin.call_name().to_string(),
-            plugin_id: plugin_idx.raw(),
-            call_id: "${call_id}",
-            content: Some(args.code.clone()),
-          });
-        } else {
+          if trace_action_enabled!() {
+            trace_action!(action::HookRenderChunkEnd {
+              action: "HookRenderChunkEnd",
+              plugin_name: plugin.call_name().to_string(),
+              plugin_id: plugin_idx.raw(),
+              call_id: "${call_id}",
+              content: Some(args.code.as_str().to_string()),
+            });
+          }
+        } else if trace_action_enabled!() {
           trace_action!(action::HookRenderChunkEnd {
             action: "HookRenderChunkEnd",
             plugin_name: plugin.call_name().to_string(),
@@ -176,7 +180,7 @@ impl PluginDriver {
       ))
       .await?;
     }
-    Ok((args.code, sourcemap_chain))
+    Ok((args.into_code(), sourcemap_chain))
   }
 
   #[tracing::instrument(

--- a/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
@@ -7,7 +7,15 @@ use rolldown_utils::indexmap::FxIndexMap;
 #[derive(Debug)]
 pub struct HookRenderChunkArgs<'a> {
   pub options: &'a SharedNormalizedBundlerOptions,
-  pub code: String,
+  // Keep `String` recoverable after hooks; `Arc<str>` would force a final full clone.
+  #[expect(clippy::rc_buffer, reason = "Arc<String> lets renderChunk recover owned code")]
+  pub code: Arc<String>,
   pub chunk: Arc<RollupRenderedChunk>,
   pub chunks: Arc<FxIndexMap<ArcStr, Arc<RollupRenderedChunk>>>,
+}
+
+impl HookRenderChunkArgs<'_> {
+  pub fn into_code(self) -> String {
+    Arc::try_unwrap(self.code).unwrap_or_else(|code| code.as_ref().clone())
+  }
 }

--- a/crates/rolldown_plugin/src/types/hook_transform_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_transform_args.rs
@@ -1,8 +1,9 @@
+use arcstr::ArcStr;
 use rolldown_common::ModuleType;
 
 #[derive(Debug)]
 pub struct HookTransformArgs<'a> {
   pub id: &'a str,
-  pub code: &'a String,
+  pub code: &'a ArcStr,
   pub module_type: &'a ModuleType,
 }

--- a/crates/rolldown_plugin_asset_module/src/lib.rs
+++ b/crates/rolldown_plugin_asset_module/src/lib.rs
@@ -69,7 +69,7 @@ impl Plugin for AssetModulePlugin {
     }
 
     let chunk_filename = &args.chunk.filename;
-    let code = &args.code;
+    let code = args.code.as_str();
     let mut magic_string = MagicString::new(code);
     let mut changed = false;
 

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -86,7 +86,7 @@ impl Plugin for ChunkImportMapPlugin {
       return Ok(None);
     }
 
-    let mut code = args.code.clone();
+    let mut code = args.code.as_ref().clone();
     for (start, end, placeholder) in placeholders {
       let hash = self.chunk_import_map.get(placeholder).expect("hash placeholder must exist");
       debug_assert_eq!(hash.len(), end - start, "hash length doesn't match placeholder size");

--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -151,7 +151,7 @@ impl Plugin for CopyModulePlugin {
     }
 
     let chunk_filename = &args.chunk.filename;
-    let code = &args.code;
+    let code = args.code.as_str();
     let mut magic_string = MagicString::new(code);
     let mut changed = false;
 

--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -211,8 +211,9 @@ impl Plugin for ReplacePlugin {
     _ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
-    let mut magic_string = MagicString::new(&args.code);
-    if self.try_replace(&args.code, &mut magic_string) {
+    let code = args.code.as_str();
+    let mut magic_string = MagicString::new(code);
+    if self.try_replace(code, &mut magic_string) {
       return Ok(Some(HookRenderChunkOutput {
         code: magic_string.to_string(),
         map: self.sourcemap.then(|| {

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -23,7 +23,7 @@ impl Plugin for TestPlugin {
     args: &HookTransformArgs<'_>,
   ) -> HookTransformReturn {
     let mut code = self.0.lock().unwrap();
-    *code = Some(args.code.clone());
+    *code = Some(args.code.to_string());
     Ok(None)
   }
 

--- a/crates/rolldown_plugin_vite_asset/src/lib.rs
+++ b/crates/rolldown_plugin_vite_asset/src/lib.rs
@@ -135,7 +135,7 @@ impl Plugin for ViteAssetPlugin {
   ) -> rolldown_plugin::HookRenderChunkReturn {
     let env = RenderAssetUrlInJsEnv {
       ctx,
-      code: &args.code,
+      code: args.code.as_str(),
       is_worker: self.is_worker,
       env: &ToOutputFilePathEnv {
         is_ssr: self.is_ssr,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -119,7 +119,7 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
       let is_modern = args.options.format.is_esm();
       let replacement = if is_modern { "true" } else { "false" };
 
-      let mut code = args.code.clone();
+      let mut code = args.code.as_ref().clone();
       for (index, _) in args.code.match_indices(IS_MODERN_FLAG) {
         let bytes = unsafe { code.as_bytes_mut() };
         let replacement_bytes = replacement.as_bytes();

--- a/crates/rolldown_plugin_vite_css_post/src/utils.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/utils.rs
@@ -90,7 +90,7 @@ impl ViteCSSPostPlugin {
     if css_url_iter.peek().is_some() {
       let indices = css_url_iter.map(|(index, _)| index).collect::<Vec<_>>();
       let magic_string =
-        magic_string.get_or_insert_with(|| string_wizard::MagicString::new(&ctx.args.code));
+        magic_string.get_or_insert_with(|| string_wizard::MagicString::new(ctx.args.code.as_str()));
 
       let url_cache = ctx.meta().get_or_insert_default::<CSSUrlCache>();
       for index in indices {
@@ -289,7 +289,7 @@ impl ViteCSSPostPlugin {
 
         #[expect(clippy::cast_possible_truncation)]
         magic_string
-          .get_or_insert_with(|| string_wizard::MagicString::new(&ctx.args.code))
+          .get_or_insert_with(|| string_wizard::MagicString::new(ctx.args.code.as_str()))
           .append_right(injection_point as u32, inject_code);
       }
     } else {

--- a/crates/rolldown_plugin_vite_transform/Cargo.toml
+++ b/crates/rolldown_plugin_vite_transform/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-arcstr = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -3,7 +3,6 @@ mod utils;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
-use arcstr::ArcStr;
 use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
 use oxc::parser::Parser;
 use oxc::transformer::Transformer;
@@ -64,7 +63,7 @@ impl Plugin for ViteTransformPlugin {
     if ret.panicked || !ret.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.errors,
-        &ArcStr::from(args.code.as_str()),
+        args.code,
         args.id,
         Severity::Error,
         EventKind::ParseError,
@@ -78,7 +77,7 @@ impl Plugin for ViteTransformPlugin {
     if !transformer_return.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         transformer_return.errors,
-        &ArcStr::from(args.code.as_str()),
+        args.code,
         args.id,
         Severity::Error,
         EventKind::ParseError,


### PR DESCRIPTION
## Summary

Reduce Rust-side full string clones across plugin and N-API binding paths.

This extends `BindingSharedString` so it can carry either `ArcStr` or `Arc<String>` into N-API string creation without first materializing an extra Rust `String`. JavaScript still receives normal strings; the change only reduces native allocation/copy pressure before crossing into JS.

The optimization now covers:

- transform and renderChunk hook code payloads
- callable builtin `load()` output code
- module info string fields and id arrays
- output asset source access
- output chunk updates, including in-place mutation when uniquely owned

## Impact

- Reduces redundant native string clones in hot plugin/binding paths.
- Keeps the JS plugin API behavior unchanged.
- Avoids external V8 strings or zero-copy JS string lifetime risks.

## Benchmarks

- apps/10000 clean public comparison: `1.334s ± 0.079s` public `rolldown@1.0.1` vs `1.249s ± 0.065s` local, about `1.07x` faster.
- LobeHub Electron renderer warmed comparison: `9.100s ± 0.289s` public `rolldown@1.0.1` vs `8.952s ± 0.042s` local, about `1.02x` faster.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p rolldown_binding`
- focused `cargo clippy` over affected Rolldown crates with `--deny warnings`
- `just build-rolldown-release`
- `vp run --filter rolldown build-types-check`
- focused fixture tests for sourcemap, renderChunk, emit-file, hybrid-plugin, generate-bundle, and free-external-memory coverage
- `cli/cli-e2e.test.ts`

Note: full `rolldown-tests test:types` is still blocked by an existing local missing dependency issue resolving `@rolldown/test-dev-server` in `dev/dev-watch.test.ts`; no TypeScript errors were reported before that resolution failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core plugin hook argument types (`transform` now uses `ArcStr`, `renderChunk` uses `Arc<String>`) and N-API binding parameter/return types, which could introduce subtle lifetime/ownership bugs or integration regressions despite no intended JS API change.
> 
> **Overview**
> Reduces native-side string cloning in hot plugin paths by switching hook payloads to shared string types: `HookTransformArgs.code` becomes `&ArcStr`, and `HookRenderChunkArgs.code` becomes `Arc<String>` with `into_code()` to recover ownership after hooks.
> 
> Updates the N-API binding layer to pass/return these shared strings via a new `BindingSharedString` wrapper (backed by `ArcStr` or `Arc<String>`), and adjusts JS plugin hook signatures (`transform`, `renderChunk`), callable builtin plugin `transform`, and callable builtin `load()` outputs accordingly.
> 
> Also optimizes output updates by mutating `OutputChunk` in-place when uniquely owned (`Arc::get_mut`) and tweaks `BindingOutputAsset.get_source()` to build the JS object directly for string/byte sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7905c07a573c50bd2cfe84770b729d537d87d1f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->