### PR TITLE
fix(dev/lazy): make `resolve_id` idempotent when the resolved id is already a lazy entry

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -107,7 +107,19 @@ impl Plugin for LazyCompilationPlugin {
         )
         .await??;
 
-      let lazy_id: ArcStr = format!("{}?rolldown-lazy=1", original_id.id).into();
+      // Idempotent: Calling `ctx.resolve` may trigger other plugins' resolve_id hooks,
+      // and these hooks may also call `ctx.resolve`,
+      // so it may cause `LazyCompilationPlugin::resolve_id` to be called multiple times for the same module
+      // so that the `original_id` may be marked as `rolldown-lazy=1` already.
+      //
+      // Here we check if the module has already been marked as a lazy entry.
+      // Otherwise, `delete modules[$STABLE_PROXY_MODULE_ID]` may not be aligned with the module ID,
+      // causing the bundler failing to invalidation downstream.
+      let lazy_id: ArcStr = if original_id.id.as_str().ends_with("?rolldown-lazy=1") {
+        original_id.id.as_str().into()
+      } else {
+        format!("{}?rolldown-lazy=1", original_id.id).into()
+      };
       self.lazy_entries.insert(lazy_id.clone());
 
       return Ok(Some(HookResolveIdOutput {

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -101,5 +101,9 @@
     "packages/test-dev-server/tests/playground/lazy-nested-dynamic-import": {
       "entry": ["dev.config.mjs", "app.js", "outer.js", "inner.js"], // Playwright test with dev config and source files
     },
+    "packages/test-dev-server/tests/playground/lazy-aliased-import": {
+      "entry": ["dev.config.mjs", "app.js", "lazy.js"], // Playwright test with dev config and source files
+      "ignoreDependencies": ["@lazy"], // alias resolved via dev.config.mjs
+    },
   },
 }

--- a/packages/test-dev-server/tests/browser.spec.ts
+++ b/packages/test-dev-server/tests/browser.spec.ts
@@ -4,6 +4,7 @@ import { CONFIG } from './src/config';
 import {
   editFile,
   editLazySharedModuleFile,
+  getLazyAliasedImportPage,
   getLazyPage,
   getLazySharedModulePage,
   getNestedLazyPage,
@@ -14,6 +15,7 @@ import {
 const LAZY_URL = `http://localhost:${CONFIG.ports.lazyCompilation}`;
 const LAZY_SHARED_MODULE_URL = `http://localhost:${CONFIG.ports.lazySharedModule}`;
 const NESTED_LAZY_URL = `http://localhost:${CONFIG.ports.lazyNestedDynamicImport}`;
+const LAZY_ALIASED_IMPORT_URL = `http://localhost:${CONFIG.ports.lazyAliasedImport}`;
 
 describe('hmr-full-bundle-mode', () => {
   test.sequential('should render initial content', async () => {
@@ -228,6 +230,34 @@ describe('lazy-nested-dynamic-import', () => {
       expect(log).toContain('outer.outerName = outer');
       expect(log).toContain('inner.foo = inner_foo');
       expect(log).toContain('inner.bar = inner_bar');
+      expect(log).not.toContain('UNDEFINED');
+    },
+  );
+});
+
+// Regression for vitejs/vite#22454. With `experimental.devMode.lazy: true` and
+// `viteAliasPlugin`, `import('@lazy')` used to produce a proxy module whose id
+// carried `?rolldown-lazy=1?rolldown-lazy=1` (suffix appended twice). The
+// doubled key broke `delete __rolldown_runtime__.modules[$STABLE_PROXY_MODULE_ID]`
+// in the proxy template (the template emits a SINGLE-suffix key), the dedup
+// gate skipped the fetched-template re-execution, the real module never
+// registered its named exports, and `mod.foo` / `mod.bar` came back undefined.
+// The fix in `crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs::resolve_id`
+// makes the marker append idempotent.
+describe('lazy-aliased-import', () => {
+  test.sequential(
+    'aliased dynamic import resolves named exports (#vite-22454)',
+    { retry: 0 },
+    async () => {
+      const page = getLazyAliasedImportPage();
+
+      await page.goto(LAZY_ALIASED_IMPORT_URL, { waitUntil: 'domcontentloaded' });
+      await page.click('#btn');
+      await expect.poll(() => page.textContent('#status')).toBe('done');
+
+      const log = (await page.textContent('#log')) ?? '';
+      expect(log).toContain('mod.foo = lazy_foo');
+      expect(log).toContain('mod.bar = lazy_bar');
       expect(log).not.toContain('UNDEFINED');
     },
   );

--- a/packages/test-dev-server/tests/playground/lazy-aliased-import/app.js
+++ b/packages/test-dev-server/tests/playground/lazy-aliased-import/app.js
@@ -1,0 +1,14 @@
+const log = (msg) => {
+  document.getElementById('log').textContent += msg + '\n';
+};
+
+log('app loaded.');
+
+document.getElementById('btn').addEventListener('click', async () => {
+  log('--- loading @lazy (lazy chunk via alias) ---');
+  const mod = await import('@lazy');
+  log(`mod.foo = ${mod.foo === undefined ? 'UNDEFINED' : mod.foo}`);
+  log(`mod.bar = ${mod.bar === undefined ? 'UNDEFINED' : mod.bar}`);
+
+  document.getElementById('status').textContent = 'done';
+});

--- a/packages/test-dev-server/tests/playground/lazy-aliased-import/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/lazy-aliased-import/dev.config.mjs
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import url from 'node:url';
+import { defineDevConfig } from '@rolldown/test-dev-server';
+import { viteAliasPlugin } from 'rolldown/experimental';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+// Regression for vitejs/vite#22454. With `experimental.devMode.lazy: true` and
+// `viteAliasPlugin`, a dynamic import that uses the alias used to produce a
+// proxy module whose id carried `?rolldown-lazy=1?rolldown-lazy=1` (suffix
+// appended twice). The doubled key then broke
+// `delete __rolldown_runtime__.modules[$STABLE_PROXY_MODULE_ID]` in the proxy
+// template (the template substitutes a SINGLE-suffix key), the dedup gate
+// skipped the fetched-template re-execution, the real module never registered
+// its named exports, and `import('@lazy')` resolved to `{}`.
+//
+// The cause: `viteAliasPlugin` rewrites `@lazy` -> absolute path and re-enters
+// the plugin pipeline via `ctx.resolve(...)`. `skip_self` only excludes
+// `viteAliasPlugin` itself from that nested run, so the lazy-compilation
+// plugin's `resolve_id` fires twice for the same user import. Each invocation
+// appends the marker. The fix in `lazy_compilation_plugin.rs:resolve_id` makes
+// the marker append idempotent.
+export default defineDevConfig({
+  platform: 'browser',
+  dev: {
+    port: 3640,
+  },
+  build: {
+    input: { main: 'app.js' },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: { lazy: true },
+    },
+    plugins: [
+      viteAliasPlugin({
+        entries: [{ find: '@lazy', replacement: path.resolve(__dirname, 'lazy.js') }],
+      }),
+    ],
+  },
+});

--- a/packages/test-dev-server/tests/playground/lazy-aliased-import/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-aliased-import/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>lazy-aliased-import</title>
+  </head>
+  <body>
+    <h1>lazy-aliased-import</h1>
+    <button id="btn">load</button>
+    <div id="status">pending</div>
+    <pre id="log"></pre>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/test-dev-server/tests/playground/lazy-aliased-import/lazy.js
+++ b/packages/test-dev-server/tests/playground/lazy-aliased-import/lazy.js
@@ -1,0 +1,2 @@
+export const foo = 'lazy_foo';
+export const bar = 'lazy_bar';

--- a/packages/test-dev-server/tests/playground/lazy-aliased-import/package.json
+++ b/packages/test-dev-server/tests/playground/lazy-aliased-import/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-lazy-aliased-import",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/src/config.ts
+++ b/packages/test-dev-server/tests/src/config.ts
@@ -22,11 +22,14 @@ export const CONFIG = {
       testsDir,
       'tmp-playground/lazy-nested-dynamic-import',
     ),
+    lazyAliasedImportDir: nodePath.join(testsDir, 'playground/lazy-aliased-import'),
+    tmpLazyAliasedImportDir: nodePath.join(testsDir, 'tmp-playground/lazy-aliased-import'),
   },
   ports: {
     hmrFullBundleMode: 3636,
     lazyCompilation: 3637,
     lazySharedModule: 3638,
     lazyNestedDynamicImport: 3639,
+    lazyAliasedImport: 3640,
   },
 };

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -101,6 +101,17 @@ export function getNestedLazyPage() {
   return page;
 }
 
+/**
+ * Get the Playwright page for the lazy-aliased-import regression test (vitejs/vite#22454).
+ */
+export function getLazyAliasedImportPage() {
+  const page = (global as any).__lazyAliasedImportPage;
+  if (!page) {
+    throw new Error('lazy-aliased-import page not initialized. Check vitest-setup-browser.ts');
+  }
+  return page;
+}
+
 interface DevStatus {
   hasStaleOutput: boolean;
   lastFullBuildFailed: boolean;

--- a/packages/test-dev-server/tests/vitest-setup-browser.ts
+++ b/packages/test-dev-server/tests/vitest-setup-browser.ts
@@ -17,6 +17,7 @@ let hmrPage: Page | null = null;
 let lazyPage: Page | null = null;
 let lazySharedModulePage: Page | null = null;
 let nestedLazyPage: Page | null = null;
+let lazyAliasedImportPage: Page | null = null;
 
 async function killPort(port: number): Promise<void> {
   try {
@@ -75,6 +76,7 @@ beforeAll(async () => {
     killPort(CONFIG.ports.lazyCompilation),
     killPort(CONFIG.ports.lazySharedModule),
     killPort(CONFIG.ports.lazyNestedDynamicImport),
+    killPort(CONFIG.ports.lazyAliasedImport),
   ]);
 
   // Always recreate tmp playground from source to pick up any fixture changes.
@@ -94,6 +96,7 @@ beforeAll(async () => {
   startDevServer(CONFIG.paths.tmpLazyCompilationDir);
   startDevServer(CONFIG.paths.tmpLazySharedModuleDir);
   startDevServer(CONFIG.paths.tmpLazyNestedDynamicImportDir);
+  startDevServer(CONFIG.paths.tmpLazyAliasedImportDir);
 
   // Wait for servers to be ready
   await Promise.all([
@@ -101,6 +104,7 @@ beforeAll(async () => {
     waitForDevServerReady(CONFIG.ports.lazyCompilation),
     waitForDevServerReady(CONFIG.ports.lazySharedModule),
     waitForDevServerReady(CONFIG.ports.lazyNestedDynamicImport),
+    waitForDevServerReady(CONFIG.ports.lazyAliasedImport),
   ]);
 
   // Launch browser and create pages
@@ -110,6 +114,7 @@ beforeAll(async () => {
   lazyPage = await browser.newPage();
   lazySharedModulePage = await browser.newPage();
   nestedLazyPage = await browser.newPage();
+  lazyAliasedImportPage = await browser.newPage();
 
   // Only navigate the HMR page here. The lazy page is NOT navigated in setup
   // to avoid warming the lazy-compilation server (main.js triggers a dynamic
@@ -125,6 +130,7 @@ beforeAll(async () => {
   (global as any).__lazyPage = lazyPage;
   (global as any).__lazySharedModulePage = lazySharedModulePage;
   (global as any).__nestedLazyPage = nestedLazyPage;
+  (global as any).__lazyAliasedImportPage = lazyAliasedImportPage;
 });
 
 beforeEach(async (ctx) => {
@@ -157,6 +163,10 @@ afterAll(async () => {
     await nestedLazyPage.close().catch(() => {});
     nestedLazyPage = null;
   }
+  if (lazyAliasedImportPage) {
+    await lazyAliasedImportPage.close().catch(() => {});
+    lazyAliasedImportPage = null;
+  }
   if (browser) {
     await browser.close().catch(() => {});
     browser = null;
@@ -169,5 +179,6 @@ afterAll(async () => {
     killPort(CONFIG.ports.lazyCompilation),
     killPort(CONFIG.ports.lazySharedModule),
     killPort(CONFIG.ports.lazyNestedDynamicImport),
+    killPort(CONFIG.ports.lazyAliasedImport),
   ]).catch(() => {});
 });


### PR DESCRIPTION
## Summary

This PR fixed an issue that `resolve_id` is not idempotent, causing lazy compilation to fail.

In `LazyCompilationPlugin::resolve_id`, calling `ctx.resolve` may trigger 
other plugins' resolve_id hooks (in this case, vite alias plugin), and these hooks may also call `ctx.resolve`,
so it may cause `LazyCompilationPlugin::resolve_id` to be called multiple times for the same module 
so that the `original_id` may be marked as `rolldown-lazy=1` already.

Here we changed this behavior and check if the module has already been marked as a lazy entry.
Otherwise, `delete modules[$STABLE_PROXY_MODULE_ID]` may not be aligned with the module ID.

closes https://github.com/vitejs/vite/issues/22454

## Test

Added `lazy-aliased-import` test.