### PR TITLE
fix(chunk-optimization): publish absorbed dynamic-entry namespace cross-chunk

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -360,6 +360,36 @@ impl GenerateStage<'_> {
     index_imports_from_other_chunks: &mut IndexImportsFromOtherChunks,
     index_chunk_indirect_imports_from_external_modules: &mut IndexChunkAllImportsFromExternalModules,
   ) {
+    // For each module that has been absorbed as a facade namespace, we need to know
+    // which other modules dynamically import it so we can tell whether the absorbed
+    // namespace must be published cross-chunk. `EntryPoint::related_stmt_infos` only
+    // covers `DynamicImport`-kind entries; emitted entries that are also dynamically
+    // imported (e.g. via `this.emitFile` + `import()` in the same build) wouldn't be
+    // found that way. Walking import_records directly catches both.
+    let dynamic_importers_by_target: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>> = {
+      let mut map: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>> = FxHashMap::default();
+      let absorbed_targets: FxHashSet<ModuleIdx> = chunk_graph
+        .common_chunk_exported_facade_chunk_namespace
+        .values()
+        .flatten()
+        .copied()
+        .collect();
+      if !absorbed_targets.is_empty() {
+        for (importer_idx, module) in self.link_output.module_table.iter_enumerated() {
+          let Some(module) = module.as_normal() else { continue };
+          for rec in &module.import_records {
+            if rec.kind == ImportKind::DynamicImport
+              && let Some(resolved) = rec.resolved_module
+              && absorbed_targets.contains(&resolved)
+            {
+              map.entry(resolved).or_default().insert(importer_idx);
+            }
+          }
+        }
+      }
+      map
+    };
+
     chunk_graph
       .chunk_table
       .iter_enumerated()
@@ -374,84 +404,98 @@ impl GenerateStage<'_> {
           .unwrap_or(false)
       })
       .for_each(|(chunk_id, chunk)| {
-        match chunk.kind {
-          ChunkKind::EntryPoint { module: module_idx, meta, .. } => {
-            let is_dynamic_imported = meta.contains(ChunkMeta::DynamicImported);
-            let is_user_defined =
-              meta.intersects(ChunkMeta::UserDefinedEntry | ChunkMeta::EmittedChunk);
+        if let ChunkKind::EntryPoint { module: module_idx, meta, .. } = chunk.kind {
+          let is_dynamic_imported = meta.contains(ChunkMeta::DynamicImported);
+          let is_user_defined =
+            meta.intersects(ChunkMeta::UserDefinedEntry | ChunkMeta::EmittedChunk);
 
-            let normalized_entry_signatures = normalize_preserve_entry_signature(
-              &self.link_output.overrode_preserve_entry_signature_map,
-              self.options,
-              module_idx,
-            );
-            let needs_export_entry_signatures = if self.options.preserve_modules {
-              if is_user_defined {
-                !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
-              } else {
-                is_dynamic_imported
-              }
+          let normalized_entry_signatures = normalize_preserve_entry_signature(
+            &self.link_output.overrode_preserve_entry_signature_map,
+            self.options,
+            module_idx,
+          );
+          let needs_export_entry_signatures = if self.options.preserve_modules {
+            if is_user_defined {
+              !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
             } else {
               is_dynamic_imported
-                || !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
-            };
-            if needs_export_entry_signatures {
-              // If the entry point is external, we don't need to compute exports.
-              let meta = &self.link_output.metas[module_idx];
-              for (name, symbol) in meta
-                .referenced_canonical_exports_symbols(
-                  module_idx,
-                  if is_user_defined {
-                    EntryPointKind::UserDefined
-                  } else {
-                    EntryPointKind::DynamicImport
-                  },
-                  &self.link_output.dynamic_import_exports_usage_map,
-                  false,
-                )
-                .map(|(name, export)| (name, export.symbol_ref))
-              {
-                index_chunk_exported_symbols[chunk_id]
-                  .entry(symbol)
-                  .or_default()
-                  .push(name.clone());
-              }
+            }
+          } else {
+            is_dynamic_imported
+              || !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
+          };
+          if needs_export_entry_signatures {
+            // If the entry point is external, we don't need to compute exports.
+            let meta = &self.link_output.metas[module_idx];
+            for (name, symbol) in meta
+              .referenced_canonical_exports_symbols(
+                module_idx,
+                if is_user_defined {
+                  EntryPointKind::UserDefined
+                } else {
+                  EntryPointKind::DynamicImport
+                },
+                &self.link_output.dynamic_import_exports_usage_map,
+                false,
+              )
+              .map(|(name, export)| (name, export.symbol_ref))
+            {
+              index_chunk_exported_symbols[chunk_id].entry(symbol).or_default().push(name.clone());
             }
           }
-          ChunkKind::Common => {
-            if let Some(set) =
-              chunk_graph.common_chunk_exported_facade_chunk_namespace.get(&chunk_id)
-            {
-              for dynamic_entry_module in set {
-                let meta = &self.link_output.metas[*dynamic_entry_module];
-                match meta.wrap_kind() {
-                  WrapKind::Cjs => {
-                    // For CJS modules, export only wrapper_ref (require_xxx)
-                    // Generated code: `import('./chunk.js').then((n) => __toESM(n.require_xxx()))`
-                    if let Some(wrapper_ref) = meta.wrapper_ref {
-                      index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
-                    }
-                  }
-                  WrapKind::Esm => {
-                    // For ESM modules, export both wrapper_ref (init_xxx) and namespace
-                    // Generated code: `import('./chunk.js').then((n) => (n.init_xxx(), n.namespace))`
-                    if let Some(wrapper_ref) = meta.wrapper_ref {
-                      index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
-                    }
-                    let ns_ref = self.link_output.module_table[*dynamic_entry_module]
-                      .namespace_object_ref()
-                      .expect("dynamic entry should be normal module");
-                    index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
-                  }
-                  WrapKind::None => {
-                    // For non-wrapped modules, export only namespace
-                    // Generated code: `import('./chunk.js').then((n) => n.namespace)`
-                    let ns_ref = self.link_output.module_table[*dynamic_entry_module]
-                      .namespace_object_ref()
-                      .expect("dynamic entry should be normal module");
-                    index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
-                  }
+        }
+
+        // A chunk that absorbed a dynamic-entry facade must publish that absorbed
+        // entry's namespace/wrapper so the importer's rewritten dynamic import can
+        // extract it via `.then(n => n.<ns>)`. Applies regardless of chunk kind:
+        // a `DynamicEntryMergedIntoUserDefinedEntry` elimination puts the entry
+        // into a `ChunkKind::EntryPoint`, while a `DynamicEntryMergedIntoCommonChunk`
+        // elimination puts it into a `ChunkKind::Common`.
+        //
+        // We only publish the export when at least one dynamic importer lives in
+        // a different chunk. Same-chunk dynamic imports take the
+        // `Promise.resolve().then(() => (init_xxx(), namespace))` path in
+        // `rewrite_dynamic_import_for_merged_entry` and never read from the
+        // surrounding chunk's exports, so the export would otherwise be dead.
+        if let Some(set) = chunk_graph.common_chunk_exported_facade_chunk_namespace.get(&chunk_id) {
+          for dynamic_entry_module in set {
+            let has_external_dynamic_importer =
+              dynamic_importers_by_target.get(dynamic_entry_module).is_some_and(|importers| {
+                importers.iter().any(|importer_idx| {
+                  chunk_graph.module_to_chunk[*importer_idx]
+                    .is_some_and(|importer_chunk_idx| importer_chunk_idx != chunk_id)
+                })
+              });
+            if !has_external_dynamic_importer {
+              continue;
+            }
+            let meta = &self.link_output.metas[*dynamic_entry_module];
+            match meta.wrap_kind() {
+              WrapKind::Cjs => {
+                // For CJS modules, export only wrapper_ref (require_xxx)
+                // Generated code: `import('./chunk.js').then((n) => __toESM(n.require_xxx()))`
+                if let Some(wrapper_ref) = meta.wrapper_ref {
+                  index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
                 }
+              }
+              WrapKind::Esm => {
+                // For ESM modules, export both wrapper_ref (init_xxx) and namespace
+                // Generated code: `import('./chunk.js').then((n) => (n.init_xxx(), n.namespace))`
+                if let Some(wrapper_ref) = meta.wrapper_ref {
+                  index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
+                }
+                let ns_ref = self.link_output.module_table[*dynamic_entry_module]
+                  .namespace_object_ref()
+                  .expect("dynamic entry should be normal module");
+                index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
+              }
+              WrapKind::None => {
+                // For non-wrapped modules, export only namespace
+                // Generated code: `import('./chunk.js').then((n) => n.namespace)`
+                let ns_ref = self.link_output.module_table[*dynamic_entry_module]
+                  .namespace_object_ref()
+                  .expect("dynamic entry should be normal module");
+                index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
               }
             }
           }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -6,13 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## node0.js
 
 ```js
-import { t as __esmMin } from "./node1.js";
+import { r as __esmMin } from "./node1.js";
 //#region node0.js
 var node_0;
 //#endregion
 __esmMin((() => {
 	globalThis.__acyclic_output_fuzz_0 = 0;
-	import("./node1.js");
+	import("./node1.js").then((n) => (n.t(), n.n));
 	node_0 = {};
 	node_0.value = 0;
 }))();
@@ -22,8 +22,9 @@ __esmMin((() => {
 ## node1.js
 
 ```js
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
-var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+// HIDDEN [\0rolldown/runtime.js]
+//#region node2.js
+var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
 var node_2;
 var init_node2 = __esmMin((() => {
 	globalThis.__acyclic_output_fuzz_2 = 2;
@@ -40,6 +41,6 @@ var require_node1 = /* @__PURE__ */ __commonJSMin(((exports) => {
 }));
 //#endregion
 export default require_node1();
-export { __esmMin as t };
+export { node2_exports as n, __esmMin as r, init_node2 as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9446/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9446/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "server",
+        "import": "./index.ts"
+      }
+    ],
+    "experimental": {
+      "chunkOptimization": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9446/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9446/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+
+const server = await import('./dist/server.js');
+
+// The server entry's default and `routes` must work as before.
+assert.strictEqual(typeof server.default, 'function');
+assert.strictEqual(server.default(), 'server-entry-default Symbol(client-only)');
+
+// The dynamic route imports client-only.js. After chunk merging that target
+// became server.js — the bundler must rewrite the dynamic import so the
+// returned namespace is client-only's (not server's). `r.default || r` should
+// resolve to client-only's default export string, not to server's default
+// (the `entry` function).
+const route = await server.routes['/']();
+const value = await route.default.loadString();
+assert.strictEqual(value, 'default export');

--- a/crates/rolldown/tests/rolldown/issues/9446/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9446/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## route.js
+
+```js
+//#region route.js
+var route_default = { loadString: () => import("./server.js").then((n) => n.t).then((r) => r.default || r) };
+//#endregion
+export { route_default as default };
+
+```
+
+## server.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region client-only.js
+var client_only_exports = /* @__PURE__ */ __exportAll({
+	default: () => client_only_default,
+	sym: () => sym
+});
+const sym = Symbol("client-only");
+var client_only_default = "default export";
+//#endregion
+//#region index.ts
+function entry() {
+	return "server-entry-default " + String(sym);
+}
+const routes = { "/": () => import("./route.js") };
+//#endregion
+export { entry as default, routes, client_only_exports as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9446/client-only.js
+++ b/crates/rolldown/tests/rolldown/issues/9446/client-only.js
@@ -1,0 +1,3 @@
+export const sym = Symbol('client-only');
+
+export default 'default export';

--- a/crates/rolldown/tests/rolldown/issues/9446/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/9446/index.ts
@@ -1,0 +1,9 @@
+import { sym } from './client-only.js';
+
+export default function entry() {
+  return 'server-entry-default ' + String(sym);
+}
+
+export const routes = {
+  '/': () => import('./route.js'),
+};

--- a/crates/rolldown/tests/rolldown/issues/9446/route.js
+++ b/crates/rolldown/tests/rolldown/issues/9446/route.js
@@ -1,0 +1,3 @@
+export default {
+  loadString: () => import('./client-only.js').then((r) => r.default || r),
+};

--- a/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
@@ -11,7 +11,7 @@ console.log("dynamic no-treeshake");
 //#endregion
 //#region dynamic.js
 const lazyLoad = async () => {
-	await import("./main.js");
+	await import("./main.js").then((n) => n.t);
 	document.body.classList.add("loaded");
 };
 //#endregion
@@ -22,14 +22,18 @@ export { lazyLoad };
 ## main.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region static.no-treeshake.js
 console.log("static no-treeshake");
+//#endregion
+//#region static.js
+var static_exports = /* @__PURE__ */ __exportAll({ foo: () => "foo" });
 //#endregion
 //#region main.js
 import("./dynamic.js").then(async ({ lazyLoad }) => {
 	await lazyLoad();
 });
 //#endregion
+export { static_exports as t };
 
 ```


### PR DESCRIPTION
## Summary

closes #9446

When `chunkOptimization` absorbs a dynamic-entry facade into a user-defined entry chunk, the absorbed entry's namespace (and ESM/CJS wrapper) was never added to that chunk's cross-chunk exports -- only `ChunkKind::Common` consulted `common_chunk_exported_facade_chunk_namespace`. As a result, dynamic imports in other chunks targeting the absorbed module fell through the `rewrite_dynamic_import_for_merged_entry` rewrite (no `primary_export_name`), so they silently dropped the `.then(n => n.<ns>)` extraction and resolved against the absorbing chunk's own default. In #9446 `route.js`'s `r.default` returned the server's `entry` function instead of `client-only`'s `'default export'`.

This PR hoists the namespace-publication block to run for every chunk regardless of `ChunkKind`, and gates it on whether any dynamic importer of the absorbed module lives outside the absorbing chunk. The gate is computed once from `import_records` so it covers both `DynamicImport` and `EmittedUserDefined` entry kinds (the latter don't populate `EntryPoint::related_stmt_infos`). Same-chunk dynamic imports take the `Promise.resolve().then(() => (init_xxx(), namespace))` path in the finalizer and never read chunk exports, so the export would otherwise be dead.

## Test plan

- [x] New fixture `crates/rolldown/tests/rolldown/issues/9446/` with `_test.mjs` runtime assertion: `routes['/']()`'s `loadString()` resolves to `'default export'`, not the server's `entry` function.
- [x] Two legitimate snapshot updates (`issue_8910`, `issue_4682`) where cross-chunk dynamic imports targeting absorbed entries now correctly chain `.then(n => n.<ns>)`. No other chunk-merging snapshots changed.
- [x] Full integration suite: 1716 passed, 0 failed.
- [x] `just lint-rust` clean.
