### PR TITLE
fix: prevent entries_aware subgroup merging from leaking side effects across entries

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -247,7 +247,18 @@ impl ManualSplitter<'_> {
     entries_aware_groups: Vec<ModuleGroup>,
     module_groups: &mut IndexVec<ModuleGroupIdx, ModuleGroup>,
   ) {
-    for group in entries_aware_groups {
+    for mut group in entries_aware_groups {
+      if group.modules.is_empty() {
+        continue;
+      }
+
+      // User-defined entry modules have a fixed destination (their entry chunk).
+      // Remove them so subgroup merging cannot combine entries with different
+      // bits into a single Common chunk, which would leak side effects across
+      // entry boundaries. Same pattern as `extract_runtime_chunk`.
+      for &entry_idx in &self.link_output.user_defined_entry_modules {
+        group.remove_module(entry_idx, &self.link_output.module_table);
+      }
       if group.modules.is_empty() {
         continue;
       }

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_config.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Same as entries_aware_side_effect_leak but entry-b uses a dynamic import for the shared module. This matches the original bug report where one entry statically imports and another dynamically imports the shared code.",
+  "config": {
+    "input": [
+      { "name": "entry-a", "import": "./entry-a.js" },
+      { "name": "entry-b", "import": "./entry-b.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "common",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_test.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const dist = path.join(import.meta.dirname, 'dist');
+const files = fs
+  .readdirSync(dist)
+  .filter((f) => f.endsWith('.js'))
+  .sort();
+
+const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
+const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
+
+assert.ok(
+  entryA.includes('side-effect-a'),
+  'entry-a.js should contain side-effect-a',
+);
+assert.ok(
+  entryB.includes('side-effect-b'),
+  'entry-b.js should contain side-effect-b',
+);
+
+// No single chunk should contain both entries' side effects
+for (const file of files) {
+  const content = fs.readFileSync(path.join(dist, file), 'utf-8');
+  const hasA = content.includes('side-effect-a');
+  const hasB = content.includes('side-effect-b');
+  assert.ok(
+    !(hasA && hasB),
+    `${file} contains both side-effect-a and side-effect-b — entry side effects leaked across entries`,
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/_test.mjs
@@ -11,14 +11,8 @@ const files = fs
 const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
 const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
 
-assert.ok(
-  entryA.includes('side-effect-a'),
-  'entry-a.js should contain side-effect-a',
-);
-assert.ok(
-  entryB.includes('side-effect-b'),
-  'entry-b.js should contain side-effect-b',
-);
+assert.ok(entryA.includes('side-effect-a'), 'entry-a.js should contain side-effect-a');
+assert.ok(entryB.includes('side-effect-b'), 'entry-b.js should contain side-effect-b');
 
 // No single chunk should contain both entries' side effects
 for (const file of files) {

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common~entry-a~shared.js
+
+```js
+//#region shared.js
+function foo() {
+	console.log("shared");
+}
+//#endregion
+export { foo as t };
+
+```
+
+## entry-a.js
+
+```js
+import { t as foo } from "./common~entry-a~shared.js";
+//#region entry-a.js
+foo();
+console.log("side-effect-a");
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+//#region entry-b.js
+(await import("./shared.js")).foo();
+console.log("side-effect-b");
+//#endregion
+
+```
+
+## shared.js
+
+```js
+import { t as foo } from "./common~entry-a~shared.js";
+export { foo };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/entry-a.js
@@ -1,0 +1,3 @@
+import { foo } from './shared.js';
+foo();
+console.log('side-effect-a');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/entry-b.js
@@ -1,0 +1,3 @@
+const module = await import('./shared.js');
+module.foo();
+console.log('side-effect-b');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/shared.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_entry_modules_with_dynamic_import/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  console.log('shared');
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_config.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "User-defined entry modules must not be merged into the same chunk via entriesAware subgroup merging. Without the fix, high entriesAwareMergeThreshold merges entry subgroups into one Common chunk, leaking side effects across entries.",
+  "config": {
+    "input": [
+      { "name": "entry-a", "import": "./entry-a.js" },
+      { "name": "entry-b", "import": "./entry-b.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "common",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_test.mjs
@@ -12,14 +12,8 @@ const files = fs
 const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
 const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
 
-assert.ok(
-  entryA.includes('side-effect-a'),
-  'entry-a.js should contain side-effect-a',
-);
-assert.ok(
-  entryB.includes('side-effect-b'),
-  'entry-b.js should contain side-effect-b',
-);
+assert.ok(entryA.includes('side-effect-a'), 'entry-a.js should contain side-effect-a');
+assert.ok(entryB.includes('side-effect-b'), 'entry-b.js should contain side-effect-b');
 
 // No single chunk should contain both entries' side effects
 for (const file of files) {

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/_test.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const dist = path.join(import.meta.dirname, 'dist');
+const files = fs
+  .readdirSync(dist)
+  .filter((f) => f.endsWith('.js'))
+  .sort();
+
+// Each entry chunk must contain its own side effect
+const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
+const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
+
+assert.ok(
+  entryA.includes('side-effect-a'),
+  'entry-a.js should contain side-effect-a',
+);
+assert.ok(
+  entryB.includes('side-effect-b'),
+  'entry-b.js should contain side-effect-b',
+);
+
+// No single chunk should contain both entries' side effects
+for (const file of files) {
+  const content = fs.readFileSync(path.join(dist, file), 'utf-8');
+  const hasA = content.includes('side-effect-a');
+  const hasB = content.includes('side-effect-b');
+  assert.ok(
+    !(hasA && hasB),
+    `${file} contains both side-effect-a and side-effect-b — entry side effects leaked across entries`,
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common~entry-a~entry-b.js
+
+```js
+//#region shared.js
+function foo() {
+	console.log("shared");
+}
+//#endregion
+export { foo as t };
+
+```
+
+## entry-a.js
+
+```js
+import { t as foo } from "./common~entry-a~entry-b.js";
+//#region entry-a.js
+foo();
+console.log("side-effect-a");
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+import { t as foo } from "./common~entry-a~entry-b.js";
+//#region entry-b.js
+foo();
+console.log("side-effect-b");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/entry-a.js
@@ -1,0 +1,3 @@
+import { foo } from './shared.js';
+foo();
+console.log('side-effect-a');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/entry-b.js
@@ -1,0 +1,3 @@
+import { foo } from './shared.js';
+foo();
+console.log('side-effect-b');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/shared.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_side_effect_leak/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  console.log('shared');
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/_config.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "With 3 entries and entriesAware merging, entry modules must stay in their own chunks. Shared code should be grouped by entry reachability without mixing entry side effects.",
+  "config": {
+    "input": [
+      { "name": "entry-a", "import": "./entry-a.js" },
+      { "name": "entry-b", "import": "./entry-b.js" },
+      { "name": "entry-c", "import": "./entry-c.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/_test.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const dist = path.join(import.meta.dirname, 'dist');
+const files = fs
+  .readdirSync(dist)
+  .filter((f) => f.endsWith('.js'))
+  .sort();
+
+const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
+const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
+const entryC = fs.readFileSync(path.join(dist, 'entry-c.js'), 'utf-8');
+
+// Each entry must contain its own side effect
+assert.ok(entryA.includes('side-effect-a'), 'entry-a.js should contain side-effect-a');
+assert.ok(entryB.includes('side-effect-b'), 'entry-b.js should contain side-effect-b');
+assert.ok(entryC.includes('side-effect-c'), 'entry-c.js should contain side-effect-c');
+
+// No single chunk should contain side effects from different entries
+const sideEffects = ['side-effect-a', 'side-effect-b', 'side-effect-c'];
+for (const file of files) {
+  const content = fs.readFileSync(path.join(dist, file), 'utf-8');
+  const found = sideEffects.filter((se) => content.includes(se));
+  assert.ok(
+    found.length <= 1,
+    `${file} contains side effects from multiple entries: [${found.join(', ')}]`,
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/artifacts.snap
@@ -1,0 +1,56 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+import { n as shared_ab, t as shared_abc } from "./vendor~entry-a~entry-b~entry-c.js";
+//#region entry-a.js
+shared_ab();
+shared_abc();
+console.log("side-effect-a");
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+import { n as shared_ab, t as shared_abc } from "./vendor~entry-a~entry-b~entry-c.js";
+//#region entry-b.js
+shared_ab();
+shared_abc();
+console.log("side-effect-b");
+//#endregion
+
+```
+
+## entry-c.js
+
+```js
+import { t as shared_abc } from "./vendor~entry-a~entry-b~entry-c.js";
+//#region entry-c.js
+shared_abc();
+console.log("side-effect-c");
+//#endregion
+
+```
+
+## vendor~entry-a~entry-b~entry-c.js
+
+```js
+//#region shared-ab.js
+function shared_ab() {
+	console.log("shared-ab");
+}
+//#endregion
+//#region shared-abc.js
+function shared_abc() {
+	console.log("shared-abc");
+}
+//#endregion
+export { shared_ab as n, shared_abc as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-a.js
@@ -1,0 +1,5 @@
+import { shared_ab } from './shared-ab.js';
+import { shared_abc } from './shared-abc.js';
+shared_ab();
+shared_abc();
+console.log('side-effect-a');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-b.js
@@ -1,0 +1,5 @@
+import { shared_ab } from './shared-ab.js';
+import { shared_abc } from './shared-abc.js';
+shared_ab();
+shared_abc();
+console.log('side-effect-b');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-c.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/entry-c.js
@@ -1,0 +1,3 @@
+import { shared_abc } from './shared-abc.js';
+shared_abc();
+console.log('side-effect-c');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/shared-ab.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/shared-ab.js
@@ -1,0 +1,3 @@
+export function shared_ab() {
+  console.log('shared-ab');
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/shared-abc.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_three_entries_no_leak/shared-abc.js
@@ -1,0 +1,3 @@
+export function shared_abc() {
+  console.log('shared-abc');
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/_config.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "When a test filter already excludes entry modules, the fix is a no-op. Shared code should still be grouped correctly by entry reachability.",
+  "config": {
+    "input": [
+      { "name": "entry-a", "import": "./entry-a.js" },
+      { "name": "entry-b", "import": "./entry-b.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/_test.mjs
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const dist = path.join(import.meta.dirname, 'dist');
+const files = fs
+  .readdirSync(dist)
+  .filter((f) => f.endsWith('.js'))
+  .sort();
+
+const entryA = fs.readFileSync(path.join(dist, 'entry-a.js'), 'utf-8');
+const entryB = fs.readFileSync(path.join(dist, 'entry-b.js'), 'utf-8');
+
+// Entries contain their own side effects
+assert.ok(entryA.includes('side-effect-a'), 'entry-a.js should contain side-effect-a');
+assert.ok(entryB.includes('side-effect-b'), 'entry-b.js should contain side-effect-b');
+
+// Shared code must be in vendor chunks, not in entry chunks
+const vendorFiles = files.filter((f) => f.startsWith('vendor'));
+assert.ok(vendorFiles.length > 0, 'should have at least one vendor chunk');
+
+// No chunk should contain side effects from different entries
+const sideEffects = ['side-effect-a', 'side-effect-b'];
+for (const file of files) {
+  const content = fs.readFileSync(path.join(dist, file), 'utf-8');
+  const found = sideEffects.filter((se) => content.includes(se));
+  assert.ok(
+    found.length <= 1,
+    `${file} contains side effects from multiple entries: [${found.join(', ')}]`,
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+import { n as shared_ab, t as shared_a } from "./vendor~entry-a~entry-b.js";
+//#region entry-a.js
+shared_ab();
+shared_a();
+console.log("side-effect-a");
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+import { n as shared_ab } from "./vendor~entry-a~entry-b.js";
+//#region entry-b.js
+shared_ab();
+console.log("side-effect-b");
+//#endregion
+
+```
+
+## vendor~entry-a~entry-b.js
+
+```js
+//#region shared-ab.js
+function shared_ab() {
+	console.log("shared-ab");
+}
+//#endregion
+//#region shared-a.js
+function shared_a() {
+	console.log("shared-a");
+}
+//#endregion
+export { shared_ab as n, shared_a as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/entry-a.js
@@ -1,0 +1,5 @@
+import { shared_ab } from './shared-ab.js';
+import { shared_a } from './shared-a.js';
+shared_ab();
+shared_a();
+console.log('side-effect-a');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/entry-b.js
@@ -1,0 +1,3 @@
+import { shared_ab } from './shared-ab.js';
+shared_ab();
+console.log('side-effect-b');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/shared-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/shared-a.js
@@ -1,0 +1,3 @@
+export function shared_a() {
+  console.log('shared-a');
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/shared-ab.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_with_test_filter_excludes_entries/shared-ab.js
@@ -1,0 +1,3 @@
+export function shared_ab() {
+  console.log('shared-ab');
+}


### PR DESCRIPTION
## Summary

Fixes #9450

When `codeSplitting.groups` is configured with `entriesAware: true` and a high `entriesAwareMergeThreshold` without a `test` filter, user-defined entry modules get captured into entries_aware groups. The merge logic (`merge_entries_aware_subgroups`) then combines small subgroups — including subgroups containing entry modules from different entries — into a single `ChunkKind::Common` chunk. This causes one entry's side effects to execute when loading a different entry.

**Before fix:** `entry-a.js` output contains both entries' side effects:
```js
console.log("side-effect-a");
console.log("side-effect-b"); // leaked from entry-b
```

**After fix:** each entry only contains its own side effects:
```
entry-a.js              -> side-effect-a only
entry-b.js              -> side-effect-b only
common~entry-a~entry-b.js -> shared code only
```

## Fix

Remove user-defined entry modules from entries_aware groups before subgroup splitting and merging in `process_entries_aware_groups()`. This follows the same pattern as `extract_runtime_chunk()`: modules with a fixed destination (their entry chunk) are removed from groups to prevent misplacement. Removed entry modules fall through to the normal assignment loop in `split_chunks()`.

- Only affects entries_aware groups (non-entries_aware groups like `basic` are unchanged)
- Uses `user_defined_entry_modules` (dynamic import entries can still be captured)

## Test plan

- [x] `entries_aware_side_effect_leak` -- core bug: 2 entries + high merge threshold + no test filter
- [x] `entries_aware_entry_modules_with_dynamic_import` -- static + dynamic import mix (original issue scenario)
- [x] `entries_aware_three_entries_no_leak` -- 3 entries with multiple shared dependency layers
- [x] `entries_aware_with_test_filter_excludes_entries` -- fix is a no-op when test filter already excludes entries
- [x] All 30 `advanced_chunks` tests pass (0 regressions)
- [x] All 17 `code_splitting` tests pass