### PR TITLE
refactor(binding): drop unsafe napi string helper, hoist transform ArcStr

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_shared_string.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_shared_string.rs
@@ -1,8 +1,8 @@
-use std::{ptr, sync::Arc};
+use std::sync::Arc;
 
 use arcstr::ArcStr;
 use napi::{
-  Error, Result, Status,
+  Result,
   bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue, ValueType},
   sys,
 };
@@ -40,27 +40,6 @@ impl From<Arc<String>> for BindingSharedString {
   }
 }
 
-unsafe fn create_napi_string(env: sys::napi_env, value: &str) -> Result<sys::napi_value> {
-  let mut ptr = ptr::null_mut();
-  let status = unsafe {
-    sys::napi_create_string_utf8(
-      env,
-      value.as_ptr().cast(),
-      value.len().cast_signed(),
-      &raw mut ptr,
-    )
-  };
-
-  if status != sys::Status::napi_ok {
-    return Err(Error::new(
-      Status::from(status),
-      "Failed to convert shared rust string into napi `string`",
-    ));
-  }
-
-  Ok(ptr)
-}
-
 impl TypeName for BindingSharedString {
   fn type_name() -> &'static str {
     "String"
@@ -81,7 +60,7 @@ impl FromNapiValue for BindingSharedString {
 
 impl ToNapiValue for &BindingSharedString {
   unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> Result<sys::napi_value> {
-    unsafe { create_napi_string(env, value.as_str()) }
+    unsafe { ToNapiValue::to_napi_value(env, value.as_str()) }
   }
 }
 

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -262,13 +262,14 @@ impl PluginDriver {
     code_changed_by_plugins: &mut Option<Vec<String>>,
   ) -> Result<String> {
     let mut code = original_code;
+    let mut code_arc: Option<ArcStr> = None;
     let mut original_sourcemap_chain = std::mem::take(sourcemap_chain);
     let mut plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_transform_meta)
     {
       let call_id = tracing::enabled!(tracing::Level::TRACE).then(rolldown_utils::uuid::uuid_v4);
-      let code_arc = ArcStr::from(code.as_str());
+      let code_arc_ref = code_arc.get_or_insert_with(|| ArcStr::from(code.as_str()));
 
       trace_action!(action::HookTransformCallStart {
         action: "HookTransformCallStart",
@@ -284,13 +285,13 @@ impl PluginDriver {
           Arc::new(TransformPluginContext::new(
             ctx.clone(),
             plugin_sourcemap_chain.weak_ref(),
-            code_arc.clone(),
+            code_arc_ref.clone(),
             id.into(),
             module_idx,
             plugin_idx,
             magic_string_tx.clone(),
           )),
-          &HookTransformArgs { id, code: &code_arc, module_type: &*module_type },
+          &HookTransformArgs { id, code: code_arc_ref, module_type: &*module_type },
         )
         .await;
       self.record_timing(plugin_idx, start);
@@ -310,6 +311,7 @@ impl PluginDriver {
             }
           }
           code = v;
+          code_arc = None;
           trace_action!(action::HookTransformCallEnd {
             action: "HookTransformCallEnd",
             module_id: id.to_string(),

--- a/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
@@ -16,6 +16,6 @@ pub struct HookRenderChunkArgs<'a> {
 
 impl HookRenderChunkArgs<'_> {
   pub fn into_code(self) -> String {
-    Arc::try_unwrap(self.code).unwrap_or_else(|code| code.as_ref().clone())
+    Arc::unwrap_or_clone(self.code)
   }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanups to #9436:

- **Lazy-init `ArcStr::from(code.as_str())` in the transform hook** (`build_hooks.rs`). Before this PR, `transform` allocated one `ArcStr` per plugin per module. The first pass of this PR hoisted that alloc out of the loop — but still paid one allocation per module even when no transform plugins were registered (regression vs. main). Now `code_arc` is an `Option<ArcStr>` initialized on first iteration and reset to `None` when a plugin replaces `code`, so the no-transform path stays a no-op and multi-plugin modules pay one alloc per code revision.
- **Use `Arc::unwrap_or_clone`** in `HookRenderChunkArgs::into_code`.
- **Drop the `create_napi_string` unsafe helper** in `BindingSharedString` — napi-rs already provides `impl ToNapiValue for &str` doing the same `napi_create_string_utf8` call.

Codex review surfaced two issues with an earlier `Arc::make_mut` change in `update_output_chunk` (non-atomic on sourcemap conversion failure; full struct clone including the large `code: String` when the Arc is shared with the JS-side `BindingOutputChunk`). That change has been dropped from this PR.

## Test plan

- [x] `cargo check -p rolldown_binding -p rolldown_plugin` passes
- [x] `cargo clippy -p rolldown_binding -p rolldown_plugin` passes (no new lints)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)