### PR TITLE
fix: call `codeSplitting.groups[].name` in deterministic order

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use arcstr::ArcStr;
+use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
   Chunk, ChunkKind, ChunkingContext, EntryPoint, ManualCodeSplittingOptions, MatchGroup,
@@ -122,8 +123,20 @@ impl ManualSplitter<'_> {
     let mut entries_aware_groups: Vec<ModuleGroup> = Vec::new();
     let mut entries_aware_idx_by_id: FxHashMap<ModuleGroupId, usize> = FxHashMap::default();
 
-    for normal_module in self.link_output.module_table.modules.iter().filter_map(Module::as_normal)
-    {
+    // Sort modules by `stable_id` before iterating so that user-supplied
+    // `output.codeSplitting.groups[].name` functions are invoked in a deterministic order.
+    // Without this, a stateful function would produce different chunk assignments across runs
+    // because `ModuleIdx` is assigned in module-load completion order, which varies with
+    // parallel `resolveId`/`load`.
+    let sorted_normal_modules = self
+      .link_output
+      .module_table
+      .modules
+      .iter()
+      .filter_map(Module::as_normal)
+      .sorted_by(|a, b| a.stable_id.cmp(&b.stable_id));
+
+    for normal_module in sorted_normal_modules {
       if !metas[normal_module.idx].is_included {
         continue;
       }

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/_config.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// Regression test for the same class of bug fixed by Rollup PR #6362.
+//
+// `build_module_groups` (Rust side) used to iterate modules in `ModuleIdx`
+// allocation order — the order in which their parents finished
+// `resolveId`/`load`/`transform`. Under parallel I/O that order is
+// non-deterministic, so a stateful `name` function produced different chunk
+// assignments across runs.
+//
+// The fix sorts modules by `stable_id` before invoking the user function.
+// This test asserts the call order is alphabetical (by stable_id) — not the
+// source-import order, not the `ModuleIdx` allocation order — so any
+// regression to a different iteration order will trip it.
+
+const calls: string[] = [];
+
+export default defineTest({
+  config: {
+    input: path.join(__dirname, 'entry.js'),
+    cwd: __dirname,
+    output: {
+      codeSplitting: {
+        groups: [
+          {
+            name(id) {
+              calls.push(id);
+              // Return undefined: skip grouping, we only care about call order.
+              return undefined;
+            },
+          },
+        ],
+      },
+    },
+  },
+  afterTest() {
+    const fixtureCalls = calls
+      .filter((id) => id.includes('groups-name-fn-call-order'))
+      .map((id) => path.basename(id));
+
+    expect(fixtureCalls).toEqual(['a.js', 'entry.js', 'm.js', 'z.js']);
+  },
+});

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/a.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/a.js
@@ -1,0 +1,1 @@
+globalThis.__a = 'a';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/entry.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/entry.js
@@ -1,0 +1,5 @@
+// Source order is deliberately NOT alphabetical so we can tell apart
+// stable_id-sorted iteration from `ModuleIdx`/source-order iteration.
+import './z.js';
+import './a.js';
+import './m.js';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/m.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/m.js
@@ -1,0 +1,1 @@
+globalThis.__m = 'm';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/z.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-call-order/z.js
@@ -1,0 +1,1 @@
+globalThis.__z = 'z';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/_config.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// Regression test for the same class of bug fixed by Rollup PR #6362.
+//
+// `output.manualChunks` is a deprecated alias for
+// `output.codeSplitting.groups[].name`; both lower to the same Rust-side
+// `build_module_groups` iteration. Asserts the legacy alias also sees
+// modules in `stable_id` (alphabetical) order — not source-import order,
+// not `ModuleIdx` allocation order. See sibling `groups-name-fn-call-order`.
+
+const calls: string[] = [];
+
+export default defineTest({
+  config: {
+    input: path.join(__dirname, 'entry.js'),
+    cwd: __dirname,
+    output: {
+      manualChunks(id) {
+        calls.push(id);
+        return null;
+      },
+    },
+  },
+  afterTest() {
+    // Filter to the fixture's own files (drop the rolldown runtime and any
+    // tooling-injected modules) and normalize path separators.
+    const fixtureCalls = calls
+      .filter((id) => id.includes('manual-chunks-call-order'))
+      .map((id) => path.basename(id));
+
+    expect(fixtureCalls).toEqual(['a.js', 'entry.js', 'm.js', 'z.js']);
+  },
+});

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/a.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/a.js
@@ -1,0 +1,1 @@
+globalThis.__a = 'a';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/entry.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/entry.js
@@ -1,0 +1,5 @@
+// Source order is deliberately NOT alphabetical so we can tell apart
+// stable_id-sorted iteration from `ModuleIdx`/source-order iteration.
+import './z.js';
+import './a.js';
+import './m.js';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/m.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/m.js
@@ -1,0 +1,1 @@
+globalThis.__m = 'm';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/z.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/manual-chunks-call-order/z.js
@@ -1,0 +1,1 @@
+globalThis.__z = 'z';


### PR DESCRIPTION
`codeSplitting.groups[].name` was called in the order of `ModuleIdx` which is assigned in module-load completion order. This is a problem if `codeSplitting.groups[].name`behaves differently depending on the call order. While a stateful `codeSplitting.groups[].name`is not a good idea, it is also difficult to detect that and I think it's better to handle this on Rolldown side.

This PR makes `codeSplitting.groups[].name` to be called in the `stable_id` order so that the order is deterministic.

This PR is similar to the first part of https://github.com/rollup/rollup/pull/6362. (The second part was already handled)