### PR TITLE
perf: reuse scoping rebuilds in preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,8 +1792,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fecf76aaae6c29dd8dcde82e8a526ba8e7859ecfa98a2b8b5d54fc17965a241"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1855,8 +1854,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b44db8e77f8ead7332d0dd95850d27fb7bb09f288761447e804be05ad2f89d3"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
@@ -1869,8 +1867,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b7d05623c5fb0a8e65ee6c1971811a6f5e2332711b14abbffd2d90fdb81786"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1887,8 +1884,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f585aec92e2bdd985857d9bf58ce6896b65ad4410cc24a9533a16b864b5de8d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1899,8 +1895,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56f75c8a3204594b0f2cf3334378de270b7cec98ed336c77f83ae39db5c088b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1911,8 +1906,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b86db2459847ed12bcd2dc5c0112b1a6403cf476e93a428ef6a4056df3eb1d"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "itertools",
@@ -1925,8 +1919,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c6d585bfae4599955634a307955afca907342694c62993a933216a9b6d170b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1947,8 +1940,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61ca5b1ae11fcbc50f71c221532b1d16385268c576420faabf1740f85158f9"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1960,8 +1952,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a67baa093fb2410302bb5bea3be60c6f4e9d9573fda9d8561691234cd6bfde"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "ropey",
 ]
@@ -1969,8 +1960,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd40c6b1e961ee7e9e00ba2c924b11259ad23aa306c349a48539344f266ef5c5"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1980,8 +1970,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32dfc8b140169c70350e98cbfee928be46ae60151c3af6e477521afae8288809"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1996,8 +1985,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13f41b137ab39f80c5ab3277e777302bfd8e9b937b760159bb0996e0b2467aa"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -2018,8 +2006,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cd8d61d9a651618aca97ca5b8b4264db6c47caffd1a427f64c416dccab5079"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2036,8 +2023,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bca092ed1567ab44a1dbcfea8fdce169ab8a8310f31ef99ca0130b3ea5b8f4"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2054,8 +2040,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277491ec9648e8ffb6c8b886abe243c71e228b1e5a3d5fc544bc2fc259c60dca"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2080,8 +2065,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b0a12d91111c5e4428076af916140ac6826e360ae15ada089fb5063c76d36"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "napi",
  "napi-build",
@@ -2100,8 +2084,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7185ed734c4140606fdb3156f07c06297c603d438895880ed6c1462dc7a8202f"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "napi",
  "napi-build",
@@ -2116,8 +2099,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5b9ce5228d670de1bbc5b8c02441d01358c0a97b0037b17c6a5385c0e14442"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2140,8 +2122,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0ea922c7ffccd29f315824e5321989a3ebe072445a46bc69051fd0ef990b5c"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "napi",
  "napi-build",
@@ -2157,8 +2138,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064f938a25efd15884b3e44565b903add1a762398420835a591bf9de41d27ee1"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2215,8 +2195,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278adff6dc2f02cf149b978ff1b326a4c22a2d26dacedb4a21310ee3af6c533d"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "itertools",
  "memchr",
@@ -2253,8 +2232,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8763b157864021a4a5ded33bd9e620e25d6e20552d11eefa5d3fa707663a3341"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2268,8 +2246,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9548a6a9ab4a6227e1d890d7d244a9b5eb427c6b46790c770f5914b565c52b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.0",
@@ -2281,8 +2258,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3eaa2b28010deb7648dbbbce940ea788164db602e6fe09d81792e97706f07"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2302,8 +2278,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9b35894d67fa2b111b78922a5fd95906588f9f310055c037598f4763c6c8ab"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "napi",
  "napi-build",
@@ -2317,8 +2292,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4de9e697f1d7325576a62c644a3f7c4bbb26c8c93a24f80f561477a97a2c812"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "base64",
  "compact_str",
@@ -2347,8 +2321,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152910d2c114c4e6c38ea49b77dd5a2d56b704c5fe0f81167759282dc0054e81"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2370,8 +2343,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c50dbc89637853b0cab15b93f19504f5d1539dc4ddbd7942f30ac7a43515ab6"
+source = "git+https://github.com/oxc-project/oxc.git?branch=codex%2Ffast-scoping-rebuilds#51cd80ca9fa177714f6a0c713b7e48d09ed099da"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,36 @@ oxc_resolver = { version = "11.19.1", features = [
 oxc_resolver_napi = { version = "11.19.1", default-features = false, features = ["yarn_pnp"] }
 oxc_sourcemap = { version = "6" } # https://github.com/oxc-project/oxc-sourcemap
 
+[patch.crates-io]
+oxc = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_ast = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_ast_macros = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_ast_visit = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_cfg = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_codegen = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_compat = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_data_structures = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_diagnostics = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_estree = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_isolated_declarations = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_mangler = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_minifier = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_parser = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_semantic = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_span = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_str = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_syntax = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_transformer = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_transformer_plugins = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc.git", branch = "codex/fast-scoping-rebuilds" }
+
 [profile.dev]
 # Minimal debug info to speed up local and CI builds.
 debug = "line-tables-only"

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -110,6 +110,7 @@ impl PreProcessEcmaAst {
 
     self.stats = semantic_ret.semantic.stats();
     let mut scoping = Some(semantic_ret.semantic.into_scoping());
+    let mut recycled_scoping = None;
 
     // Extract enum member values before the transformer converts enums.
     // This runs before Step 3 (transformer) because `optimize_const_enums` / `optimize_enums`
@@ -159,7 +160,9 @@ impl PreProcessEcmaAst {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let ret = ReplaceGlobalDefines::new(allocator, replace_global_define_config.clone())
           .build(scoping.take().unwrap(), program);
-        if !ret.changed {
+        if ret.changed {
+          recycled_scoping = Some(ret.scoping);
+        } else {
           scoping = Some(ret.scoping);
         }
       });
@@ -184,7 +187,7 @@ impl PreProcessEcmaAst {
           preserve_jsx = true;
         }
 
-        let scoping = self.recreate_scoping(&mut scoping, program);
+        let scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let ret = Transformer::new(allocator, Path::new(stable_id), &transform_options)
           .build_with_scoping(scoping, program);
 
@@ -206,6 +209,7 @@ impl PreProcessEcmaAst {
           Severity::Warning,
           EventKind::ToleratedTransform,
         ));
+        recycled_scoping = Some(ret.scoping);
         Ok(())
       })?;
     }
@@ -213,10 +217,12 @@ impl PreProcessEcmaAst {
     // Step 4: Run inject plugin.
     if !bundle_options.inject.is_empty() {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-        let new_scoping = self.recreate_scoping(&mut scoping, program);
+        let new_scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let inject_config = bundle_options.oxc_inject_global_variables_config.clone();
         let ret = InjectGlobalVariables::new(allocator, inject_config).build(new_scoping, program);
-        if !ret.changed {
+        if ret.changed {
+          recycled_scoping = Some(ret.scoping);
+        } else {
           scoping = Some(ret.scoping);
         }
       });
@@ -226,7 +232,7 @@ impl PreProcessEcmaAst {
     // Avoid DCE for lazy export.
     if bundle_options.treeshake.is_some() && !has_lazy_export {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-        let scoping = self.recreate_scoping(&mut scoping, program);
+        let scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let mut treeshake = TreeShakeOptions::from(&bundle_options.treeshake);
         treeshake.invalid_import_side_effects = true;
         // NOTE: `CompressOptions::dead_code_elimination` will remove `ParenthesizedExpression`s from the AST.
@@ -235,7 +241,9 @@ impl PreProcessEcmaAst {
           treeshake,
           ..CompressOptions::dce()
         };
-        Compressor::new(allocator).dead_code_elimination_with_scoping(program, scoping, options);
+        let (_, stale_scoping) = Compressor::new(allocator)
+          .dead_code_elimination_with_scoping_returning_scoping(program, scoping, options);
+        recycled_scoping = Some(stale_scoping);
       });
     }
 
@@ -243,7 +251,10 @@ impl PreProcessEcmaAst {
     let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
       let mut pre_processor = PreProcessor::new(allocator, bundle_options.keep_names);
       pre_processor.visit_program(program);
-      self.recreate_scoping(&mut None, program)
+      if let Some(stale_scoping) = scoping.take() {
+        recycled_scoping = Some(stale_scoping);
+      }
+      self.recreate_scoping(&mut scoping, &mut recycled_scoping, program)
     });
 
     Ok(ParseToEcmaAstResult {
@@ -256,16 +267,23 @@ impl PreProcessEcmaAst {
     })
   }
 
-  fn recreate_scoping(&mut self, scoping: &mut Option<Scoping>, program: &Program<'_>) -> Scoping {
+  fn recreate_scoping(
+    &mut self,
+    scoping: &mut Option<Scoping>,
+    recycled_scoping: &mut Option<Scoping>,
+    program: &Program<'_>,
+  ) -> Scoping {
     if let Some(scoping) = scoping.take() {
       return scoping;
     }
-    let ret = semantic_builder_for_transform()
+    let mut builder = semantic_builder_for_transform()
       // Preallocate memory for the underlying data structures.
-      .with_stats(self.stats)
-      .build(program)
-      .semantic;
-    self.stats = ret.stats();
-    ret.into_scoping()
+      .with_stats(self.stats);
+    if let Some(scoping) = recycled_scoping.take() {
+      builder = builder.with_recycled_scoping(scoping);
+    }
+    let ret = builder.build_scoping(program);
+    self.stats = ret.stats;
+    ret.scoping
   }
 }


### PR DESCRIPTION
## Summary
- Reuses stale `Scoping` storage during Rolldown preprocessing rebuilds through Oxc's conservative `build_scoping` API.
- Adds a `pre_process_ecma_ast` Criterion group so the PR benchmark run can measure preprocessing directly.
- Temporarily patches Oxc crates to `oxc-project/oxc@codex/fast-scoping-rebuilds` so this PR builds against oxc-project/oxc#22562 before the APIs are released; `Cargo.lock` currently pins Oxc commit `51cd80ca9fa177714f6a0c713b7e48d09ed099da`.
- Verified with `cargo check -p rolldown --lib` and `cargo check -p bench --bench bench --features codspeed`. Earlier short local benchmarks showed the node-skipping version was noisy; this version is intentionally lower risk so PR benchmark data can decide whether deeper optimization is worth a follow-up.
