### PR TITLE
perf: reuse scoping rebuilds in preprocessing via Scoping::reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -690,7 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "itertools",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1940,7 +1940,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "ropey",
 ]
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "napi",
  "napi-build",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "itertools",
  "memchr",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2248,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.0",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "base64",
  "compact_str",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3736,7 +3736,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3798,7 +3798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4111,7 +4111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4591,7 +4591,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,8 +1792,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fecf76aaae6c29dd8dcde82e8a526ba8e7859ecfa98a2b8b5d54fc17965a241"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1855,8 +1854,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b44db8e77f8ead7332d0dd95850d27fb7bb09f288761447e804be05ad2f89d3"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
@@ -1869,8 +1867,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b7d05623c5fb0a8e65ee6c1971811a6f5e2332711b14abbffd2d90fdb81786"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1887,8 +1884,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f585aec92e2bdd985857d9bf58ce6896b65ad4410cc24a9533a16b864b5de8d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1899,8 +1895,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56f75c8a3204594b0f2cf3334378de270b7cec98ed336c77f83ae39db5c088b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1911,8 +1906,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b86db2459847ed12bcd2dc5c0112b1a6403cf476e93a428ef6a4056df3eb1d"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "itertools",
@@ -1925,8 +1919,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c6d585bfae4599955634a307955afca907342694c62993a933216a9b6d170b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1947,8 +1940,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61ca5b1ae11fcbc50f71c221532b1d16385268c576420faabf1740f85158f9"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1960,8 +1952,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a67baa093fb2410302bb5bea3be60c6f4e9d9573fda9d8561691234cd6bfde"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "ropey",
 ]
@@ -1969,8 +1960,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd40c6b1e961ee7e9e00ba2c924b11259ad23aa306c349a48539344f266ef5c5"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1980,8 +1970,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32dfc8b140169c70350e98cbfee928be46ae60151c3af6e477521afae8288809"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1996,8 +1985,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13f41b137ab39f80c5ab3277e777302bfd8e9b937b760159bb0996e0b2467aa"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -2018,8 +2006,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cd8d61d9a651618aca97ca5b8b4264db6c47caffd1a427f64c416dccab5079"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2036,8 +2023,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bca092ed1567ab44a1dbcfea8fdce169ab8a8310f31ef99ca0130b3ea5b8f4"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2054,8 +2040,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277491ec9648e8ffb6c8b886abe243c71e228b1e5a3d5fc544bc2fc259c60dca"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2100,8 +2085,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7185ed734c4140606fdb3156f07c06297c603d438895880ed6c1462dc7a8202f"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "napi",
  "napi-build",
@@ -2116,8 +2100,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5b9ce5228d670de1bbc5b8c02441d01358c0a97b0037b17c6a5385c0e14442"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2157,8 +2140,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064f938a25efd15884b3e44565b903add1a762398420835a591bf9de41d27ee1"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2215,8 +2197,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278adff6dc2f02cf149b978ff1b326a4c22a2d26dacedb4a21310ee3af6c533d"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "itertools",
  "memchr",
@@ -2253,8 +2234,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8763b157864021a4a5ded33bd9e620e25d6e20552d11eefa5d3fa707663a3341"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2268,8 +2248,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9548a6a9ab4a6227e1d890d7d244a9b5eb427c6b46790c770f5914b565c52b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.0",
@@ -2281,8 +2260,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3eaa2b28010deb7648dbbbce940ea788164db602e6fe09d81792e97706f07"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2317,8 +2295,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4de9e697f1d7325576a62c644a3f7c4bbb26c8c93a24f80f561477a97a2c812"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "base64",
  "compact_str",
@@ -2347,8 +2324,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152910d2c114c4e6c38ea49b77dd5a2d56b704c5fe0f81167759282dc0054e81"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2370,8 +2346,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c50dbc89637853b0cab15b93f19504f5d1539dc4ddbd7942f30ac7a43515ab6"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#180aa9f21c4d85b14e1d6fe8dfd718dcaab12184"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -690,7 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "itertools",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1940,7 +1940,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "ropey",
 ]
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "napi",
  "napi-build",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "itertools",
  "memchr",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2248,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.0",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "base64",
  "compact_str",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.132.0"
-source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#2b6ee676dec0762e6afb9e8cc1d2c0e27637a6d7"
+source = "git+https://github.com/oxc-project/oxc.git?branch=claude%2Fsemantic-faster-rebuild#23ba41f97f7c1ca3b0ccd09575cd9d905dc894d7"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3736,7 +3736,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3798,7 +3798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4111,7 +4111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4591,7 +4591,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,33 @@ oxc_resolver = { version = "11.19.1", features = [
 oxc_resolver_napi = { version = "11.19.1", default-features = false, features = ["yarn_pnp"] }
 oxc_sourcemap = { version = "6" } # https://github.com/oxc-project/oxc-sourcemap
 
+[patch.crates-io]
+oxc = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_ast = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_ast_macros = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_ast_visit = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_cfg = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_codegen = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_compat = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_data_structures = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_diagnostics = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_estree = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_isolated_declarations = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_mangler = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_minifier = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_parser = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_regular_expression = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_semantic = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_span = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_str = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_syntax = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_transformer = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_transformer_plugins = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc.git", branch = "claude/semantic-faster-rebuild" }
+
 [profile.dev]
 # Minimal debug info to speed up local and CI builds.
 debug = "line-tables-only"

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -110,6 +110,7 @@ impl PreProcessEcmaAst {
 
     self.stats = semantic_ret.semantic.stats();
     let mut scoping = Some(semantic_ret.semantic.into_scoping());
+    let mut recycled_scoping = None;
 
     // Extract enum member values before the transformer converts enums.
     // This runs before Step 3 (transformer) because `optimize_const_enums` / `optimize_enums`
@@ -159,7 +160,9 @@ impl PreProcessEcmaAst {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let ret = ReplaceGlobalDefines::new(allocator, replace_global_define_config.clone())
           .build(scoping.take().unwrap(), program);
-        if !ret.changed {
+        if ret.changed {
+          recycled_scoping = Some(ret.scoping);
+        } else {
           scoping = Some(ret.scoping);
         }
       });
@@ -184,7 +187,7 @@ impl PreProcessEcmaAst {
           preserve_jsx = true;
         }
 
-        let scoping = self.recreate_scoping(&mut scoping, program);
+        let scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let ret = Transformer::new(allocator, Path::new(stable_id), &transform_options)
           .build_with_scoping(scoping, program);
 
@@ -206,6 +209,7 @@ impl PreProcessEcmaAst {
           Severity::Warning,
           EventKind::ToleratedTransform,
         ));
+        recycled_scoping = Some(ret.scoping);
         Ok(())
       })?;
     }
@@ -213,10 +217,12 @@ impl PreProcessEcmaAst {
     // Step 4: Run inject plugin.
     if !bundle_options.inject.is_empty() {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-        let new_scoping = self.recreate_scoping(&mut scoping, program);
+        let new_scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let inject_config = bundle_options.oxc_inject_global_variables_config.clone();
         let ret = InjectGlobalVariables::new(allocator, inject_config).build(new_scoping, program);
-        if !ret.changed {
+        if ret.changed {
+          recycled_scoping = Some(ret.scoping);
+        } else {
           scoping = Some(ret.scoping);
         }
       });
@@ -226,7 +232,7 @@ impl PreProcessEcmaAst {
     // Avoid DCE for lazy export.
     if bundle_options.treeshake.is_some() && !has_lazy_export {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-        let scoping = self.recreate_scoping(&mut scoping, program);
+        let scoping = self.recreate_scoping(&mut scoping, &mut recycled_scoping, program);
         let mut treeshake = TreeShakeOptions::from(&bundle_options.treeshake);
         treeshake.invalid_import_side_effects = true;
         // NOTE: `CompressOptions::dead_code_elimination` will remove `ParenthesizedExpression`s from the AST.
@@ -235,7 +241,9 @@ impl PreProcessEcmaAst {
           treeshake,
           ..CompressOptions::dce()
         };
-        Compressor::new(allocator).dead_code_elimination_with_scoping(program, scoping, options);
+        let (_, stale_scoping) = Compressor::new(allocator)
+          .dead_code_elimination_with_scoping_returning_scoping(program, scoping, options);
+        recycled_scoping = Some(stale_scoping);
       });
     }
 
@@ -243,7 +251,10 @@ impl PreProcessEcmaAst {
     let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
       let mut pre_processor = PreProcessor::new(allocator, bundle_options.keep_names);
       pre_processor.visit_program(program);
-      self.recreate_scoping(&mut None, program)
+      if let Some(stale_scoping) = scoping.take() {
+        recycled_scoping = Some(stale_scoping);
+      }
+      self.recreate_scoping(&mut scoping, &mut recycled_scoping, program)
     });
 
     Ok(ParseToEcmaAstResult {
@@ -256,15 +267,23 @@ impl PreProcessEcmaAst {
     })
   }
 
-  fn recreate_scoping(&mut self, scoping: &mut Option<Scoping>, program: &Program<'_>) -> Scoping {
+  fn recreate_scoping(
+    &mut self,
+    scoping: &mut Option<Scoping>,
+    recycled_scoping: &mut Option<Scoping>,
+    program: &Program<'_>,
+  ) -> Scoping {
     if let Some(scoping) = scoping.take() {
       return scoping;
     }
-    let ret = semantic_builder_for_transform()
+    let mut builder = semantic_builder_for_transform()
       // Preallocate memory for the underlying data structures.
-      .with_stats(self.stats)
-      .build(program)
-      .semantic;
+      .with_stats(self.stats);
+    if let Some(mut stale) = recycled_scoping.take() {
+      stale.reset();
+      builder = builder.with_scoping(stale);
+    }
+    let ret = builder.build(program).semantic;
     self.stats = ret.stats();
     ret.into_scoping()
   }


### PR DESCRIPTION
## Summary

Threads a `recycled_scoping: Option<Scoping>` through `PreProcessEcmaAst::build` so the stale `Scoping` after each AST-mutating pass (transformer / define / inject / DCE) can be recycled. The next `recreate_scoping` call uses `Scoping::reset` to clear it in place — preserving the bumpalo arena's chunks and the flat-table heap capacity — and feeds it back to `SemanticBuilder::with_scoping`. This avoids the allocator init cost on each rebuild (3-4 times per file).

DCE is switched from `dead_code_elimination_with_scoping` (consumes the scoping) to `dead_code_elimination_with_scoping_returning_scoping` so the post-DCE scoping can be recycled too.

The initial Step 1 build (`with_check_syntax_error(true)`) is unchanged — the syntax checker still uses the default builder.

## Benchmark

`cargo bench -p bench`, this branch vs `origin/main`:

| Bench | main | this PR | Δ |
|---|---|---|---|
| threejs | 23.27 ms | 22.35 ms | **−4.0%** |
| threejs-sourcemap | 27.82 ms | 27.38 ms | **−1.6%** |
| rome_ts | 44.54 ms | 43.31 ms | **−2.8%** |
| multi-duplicated-top-level-symbol | 19.42 ms | 19.94 ms | +2.7% (noisy, criterion interval [19.26, 21.0]) |

Three out of four show clear wins.

## Depends on

Upstream oxc PR adding the APIs: https://github.com/oxc-project/oxc/pull/22571. The `[patch.crates-io]` section in this PR points at that branch; remove the patch once oxc 0.133.0 (or whichever version the APIs land in) is published.

## Test Plan

- [x] `cargo test -p rolldown --lib` — 56 tests pass

AI disclosure: drafted with Claude Code, reviewed manually.