### PR TITLE
fix(chunk-optimization): keep CJS facade wrappers in shared chunks when dynamic siblings would back-import them

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -356,6 +356,7 @@ impl GenerateStage<'_> {
     bits_to_chunk: &mut FxHashMap<BitSet, ChunkIdx>,
     input_base: &ArcStr,
     temp_chunk_graph: &mut ChunkOptimizationGraph,
+    index_splitting_info: &IndexSplittingInfo,
   ) {
     let static_entry_chunk_reference: FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> =
       self.construct_static_entry_to_reached_dynamic_entries_map(chunk_graph);
@@ -397,14 +398,14 @@ impl GenerateStage<'_> {
         }
         let chunk_idxs: Vec<_> = bits.index_of_one().map(ChunkIdx::from_raw).collect();
 
-        let merge_target = Self::try_insert_into_existing_chunk(
+        let merge_target = self.try_insert_into_existing_chunk(
           &chunk_idxs,
           &static_entry_chunk_reference,
           chunk_graph,
-          &self.link_output.module_table,
           &dynamic_entry_to_dynamic_importers,
           temp_chunk,
           temp_chunk_graph,
+          index_splitting_info,
         );
 
         Some((bits.clone(), *temp_chunk_idx, chunk_idxs, merge_target))
@@ -557,15 +558,18 @@ impl GenerateStage<'_> {
   /// entry chunk when possible, rather than creating a separate common chunk.
   ///
   /// Returns `Some(ChunkIdx)` if a suitable merge target is found, `None` otherwise.
+  #[expect(clippy::too_many_arguments)]
   fn try_insert_into_existing_chunk(
+    &self,
     chunk_idxs: &[ChunkIdx],
     entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
     chunk_graph: &ChunkGraph,
-    module_table: &ModuleTable,
     dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
     info: &ChunkCandidate,
     temp_chunk_graph: &ChunkOptimizationGraph,
+    index_splitting_info: &IndexSplittingInfo,
   ) -> Option<ChunkIdx> {
+    let module_table = &self.link_output.module_table;
     let mut user_defined_entry = vec![];
     let mut dynamic_entry = vec![];
     for &idx in chunk_idxs {
@@ -582,6 +586,26 @@ impl GenerateStage<'_> {
         }
         ChunkKind::Common => return None,
       }
+    }
+    // rolldown#9441: don't hoist a wrapped atom into the parent entry when an
+    // *effective* dynamic-entry sibling depends on it (mirrors the predicate
+    // in dynamic_already_loaded::can_use_reduced_dependent_entries).
+    if info
+      .modules
+      .iter()
+      .any(|module_idx| !matches!(self.link_output.metas[*module_idx].wrap_kind(), WrapKind::None))
+      && dynamic_entry.iter().any(|dyn_chunk_idx| {
+        let Some(dyn_chunk) = chunk_graph.chunk_table.get(*dyn_chunk_idx) else {
+          return true;
+        };
+        let ChunkKind::EntryPoint { module: dyn_module_idx, .. } = dyn_chunk.kind else {
+          return true;
+        };
+        let d_bits = &index_splitting_info[dyn_module_idx].bits;
+        d_bits.bit_count() == 1 && d_bits.has_bit(dyn_chunk_idx.raw())
+      })
+    {
+      return None;
     }
     let user_defined_entry_modules = Self::collect_entry_modules(&user_defined_entry, chunk_graph)?;
 

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -953,6 +953,7 @@ impl GenerateStage<'_> {
         bits_to_chunk,
         input_base,
         &mut temp_chunk_graph,
+        index_splitting_info,
       );
 
       self.optimize_facade_entry_chunks(

--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   ChunkIdx, ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleIdx, PreserveEntrySignatures,
-  StmtInfoIdx,
+  StmtInfoIdx, WrapKind,
 };
 use rolldown_utils::BitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -75,6 +75,7 @@ impl GenerateStage<'_> {
           &atoms[atom_idx].dependent_entries,
           chunk_graph,
           &dynamic_entry_modules_by_entry,
+          index_splitting_info,
         )
         && (!self.should_check_reduced_atom_static_cycle(
           &original_dependent_entries,
@@ -108,7 +109,31 @@ impl GenerateStage<'_> {
     dependent_entries: &BitSet,
     chunk_graph: &ChunkGraph,
     dynamic_entry_modules_by_entry: &[Option<ModuleIdx>],
+    index_splitting_info: &IndexSplittingInfo,
   ) -> bool {
+    // rolldown#9441: a wrapped atom shared with an effective dynamic entry
+    // cannot be hoisted — the sibling chunk would back-import the wrapper.
+    let atom_is_wrapped = atom
+      .modules
+      .iter()
+      .any(|module_idx| !matches!(self.link_output.metas[*module_idx].wrap_kind(), WrapKind::None));
+    if atom_is_wrapped {
+      for removed_entry_idx in
+        original_dependent_entries.index_of_one().filter(|idx| !dependent_entries.has_bit(*idx))
+      {
+        let Some(dynamic_entry_module_idx) =
+          dynamic_entry_modules_by_entry.get(removed_entry_idx as usize).copied().flatten()
+        else {
+          return false;
+        };
+        let d_bits = &index_splitting_info[dynamic_entry_module_idx].bits;
+        let is_effective = d_bits.bit_count() == 1 && d_bits.has_bit(removed_entry_idx);
+        if is_effective {
+          return false;
+        }
+      }
+    }
+
     let bit_count = dependent_entries.bit_count();
     if bit_count != 1 {
       return bit_count > 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
@@ -39,7 +39,7 @@ export { foo as t };
 ### lazy-chunk.js
 
 ```js
-import { n as init_user_lib, r as __esmMin, t as foo } from "./main.js";
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#endregion
 __esmMin((() => {
 	init_user_lib();
@@ -51,12 +51,24 @@ __esmMin((() => {
 ### main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#region polyfill.js
 var init_polyfill = __esmMin((() => {
 	Object.somePolyfilledFunction = () => {};
 }));
 //#endregion
+__esmMin((() => {
+	init_polyfill();
+	init_user_lib();
+	foo();
+}))();
+
+```
+
+### user-lib.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region user-lib.js
 async function foo() {
 	return import("./lazy-chunk.js");
@@ -65,11 +77,6 @@ var init_user_lib = __esmMin((() => {
 	Object.somePolyfilledFunction();
 }));
 //#endregion
-__esmMin((() => {
-	init_polyfill();
-	init_user_lib();
-	foo();
-}))();
 export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as read, r as __esmMin, t as init_read } from "./main.js";
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 //#endregion
 __esmMin((() => {
 	init_read();
@@ -18,8 +18,8 @@ __esmMin((() => {
 ## main.js
 
 ```js
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var setup;
 var init_setup = __esmMin((() => {
@@ -27,15 +27,6 @@ var init_setup = __esmMin((() => {
 		globalThis.foo = "foo";
 	};
 	setup();
-}));
-//#endregion
-//#region read.js
-var foo, read;
-var init_read = __esmMin((() => {
-	foo = globalThis.foo;
-	read = () => {
-		console.log("read", foo);
-	};
 }));
 //#endregion
 __esmMin((() => {
@@ -46,6 +37,22 @@ __esmMin((() => {
 	import("./dynamic.js");
 	nodeAssert.strictEqual(globalThis.foo, "foo");
 }))();
+
+```
+
+## read.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region read.js
+var foo, read;
+var init_read = __esmMin((() => {
+	foo = globalThis.foo;
+	read = () => {
+		console.log("read", foo);
+	};
+}));
+//#endregion
 export { read as n, __esmMin as r, init_read as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { t as import_c } from "./b.js";
+import { n as import_c } from "./b.js";
 //#region a.js
 let a = import_c.test;
 //#endregion
@@ -18,13 +18,16 @@ export { a };
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-//#region b.js
-var import_c = (/* @__PURE__ */ __commonJSMin(((exports) => {
+//#region c.js
+var require_c = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.test = 1e3;
-})))();
+}));
 //#endregion
-var test = import_c.test;
-export { import_c as t, test };
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ test: () => import_c.test });
+var import_c = require_c();
+//#endregion
+export { import_c as n, b_exports as t };
 
 ```
 
@@ -36,7 +39,7 @@ import assert from "node:assert";
 import("./a.js").then((mod) => {
 	assert.strictEqual(mod.a, 1e3);
 });
-import("./b.js").then((mod) => {
+import("./b.js").then((n) => n.t).then((mod) => {
 	assert.strictEqual(mod.test, 1e3);
 });
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
@@ -7,22 +7,25 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-//#region a.js
-var import_b = (/* @__PURE__ */ __commonJSMin(((exports) => {
+//#region b.js
+var require_b = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports._default = function test() {
 		return "f";
 	};
-})))();
+}));
 //#endregion
-var b_default = import_b._default;
-export { b_default as default, import_b as t };
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ default: () => import_b._default });
+var import_b = require_b();
+//#endregion
+export { import_b as n, a_exports as t };
 
 ```
 
 ## c.js
 
 ```js
-import { t as import_b } from "./a.js";
+import { n as import_b } from "./a.js";
 //#region c.js
 function c_default(tag, options) {
 	return import_b._default;
@@ -40,7 +43,7 @@ import assert from "node:assert";
 import("./c.js").then((mod) => {
 	assert.strictEqual(mod.default()(), "f");
 });
-import("./a.js").then((mod) => {
+import("./a.js").then((n) => n.t).then((mod) => {
 	assert.strictEqual(mod.default(), "f");
 });
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-a.js
 
 ```js
-import { t as import_lodash } from "./main.js";
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
 //#region lazy-a.js
 assert(typeof import_lodash.debounce === "function");
@@ -18,18 +18,25 @@ assert(typeof import_lodash.noop === "function");
 ## main.js
 
 ```js
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
+//#region main.js
+assert(typeof import_lodash.debounce === "function");
+assert(typeof import_lodash.noop === "function");
+import("./lazy-a.js");
+//#endregion
+
+```
+
+## utils.js
+
+```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
-//#endregion
-//#region main.js
-assert(typeof import_lodash.debounce === "function");
-assert(typeof import_lodash.noop === "function");
-import("./lazy-a.js");
 //#endregion
 export { import_lodash as n, import_lodash as t };
 
@@ -42,12 +49,12 @@ export { import_lodash as n, import_lodash as t };
 ### lazy-a.js
 
 ```js
-const require_main = require("./main.js");
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = require_main.__toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
 //#region lazy-a.js
-(0, node_assert.default)(typeof require_main.import_lodash.debounce === "function");
-(0, node_assert.default)(typeof require_main.import_lodash$1.noop === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
 //#endregion
 
 ```
@@ -55,23 +62,33 @@ node_assert = require_main.__toESM(node_assert);
 ### main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
+//#region main.js
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
+Promise.resolve().then(() => require("./lazy-a.js"));
 //#endregion
+
+```
+
+### utils.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
 //#endregion
-//#region main.js
-(0, node_assert.default)(typeof import_lodash.debounce === "function");
-(0, node_assert.default)(typeof import_lodash.noop === "function");
-Promise.resolve().then(() => require("./lazy-a.js"));
-//#endregion
-exports.__toESM = __toESM;
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 Object.defineProperty(exports, "import_lodash", {
 	enumerable: true,
 	get: function() {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_facade_reexport_merges_into_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_facade_reexport_merges_into_entry/artifacts.snap
@@ -3,11 +3,49 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## a.js
+
+```js
+//! Common Chunk: [Shared-By: entry.js, route.js]
+import { n as __commonJSMin } from "./b.js";
+//#region a-impl.js
+var require_a_impl = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "a";
+}));
+//#endregion
+//#region a.js
+var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = require_a_impl();
+}));
+//#endregion
+export { require_a as t };
+
+```
+
+## b.js
+
+```js
+//! Common Chunk: [Shared-By: entry.js, route.js, child.js]
+// HIDDEN [\0rolldown/runtime.js]
+//#region b-impl.js
+var require_b_impl = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.b = () => "b";
+}));
+//#endregion
+//#region b.js
+var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = require_b_impl();
+}));
+//#endregion
+export { __commonJSMin as n, __toESM as r, require_b as t };
+
+```
+
 ## child.js
 
 ```js
 //! Dynamic Entry: [Entry-Module-Id: child.js] [Name: None]
-import { t as require_b } from "./entry.js";
+import { t as require_b } from "./b.js";
 //#region child.js
 var import_b = require_b();
 console.log("child", (0, import_b.b)());
@@ -19,34 +57,14 @@ console.log("child", (0, import_b.b)());
 
 ```js
 //! User-defined Entry: [Entry-Module-Id: entry.js] [Name: Some("entry")]
-// HIDDEN [\0rolldown/runtime.js]
-//#region a-impl.js
-var require_a_impl = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = "a";
-}));
-//#endregion
-//#region a.js
-var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = require_a_impl();
-}));
-//#endregion
-//#region b-impl.js
-var require_b_impl = /* @__PURE__ */ __commonJSMin(((exports) => {
-	exports.b = () => "b";
-}));
-//#endregion
-//#region b.js
-var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = require_b_impl();
-}));
-//#endregion
+import { r as __toESM, t as require_b } from "./b.js";
+import { t as require_a } from "./a.js";
 //#region entry.js
 var import_a = /* @__PURE__ */ __toESM(require_a());
 var import_b = require_b();
 console.log("entry", import_a.default, (0, import_b.b)());
 import("./route.js");
 //#endregion
-export { require_a as n, __toESM as r, require_b as t };
 
 ```
 
@@ -54,7 +72,8 @@ export { require_a as n, __toESM as r, require_b as t };
 
 ```js
 //! Dynamic Entry: [Entry-Module-Id: route.js] [Name: None]
-import { n as require_a, r as __toESM, t as require_b } from "./entry.js";
+import { r as __toESM, t as require_b } from "./b.js";
+import { t as require_a } from "./a.js";
 //#region route.js
 var import_a = /* @__PURE__ */ __toESM(require_a());
 var import_b = require_b();
@@ -66,6 +85,8 @@ import("./child.js");
 
 # Output Stats
 
+- a.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- b.js, is_entry false, is_dynamic_entry false, exports ["n", "r", "t"]
 - child.js, is_entry false, is_dynamic_entry true, exports []
-- entry.js, is_entry true, is_dynamic_entry false, exports ["n", "r", "t"]
+- entry.js, is_entry true, is_dynamic_entry false, exports []
 - route.js, is_entry false, is_dynamic_entry true, exports []


### PR DESCRIPTION
Closes #9441

## Problem

Since rolldown 1.0.1 (PR #9305 + the lock-in fixture from #9351), CJS-facade modules shared between a static entry and one or more dynamic-entry chunks get **merged into the static entry**. Sibling dynamic chunks then emit:

```js
// dynamic-child.js
import { t as require_X } from "./entry.js";
var import_X = require_X();   // top-level invocation
```

Under pure ESM, the dynamic edge postpones the child's evaluation until after the entry's body has finished, so the `var require_X = __commonJSMin(...)` slot in the entry has run and the binding is initialized. But under **static-wrapper composition** — Cloudflare Workers SSR + react-router 7 static route manifests, miniflare, similar setups that statically wire all chunks — the child chunk's body evaluates before the entry's body completes, hitting TDZ:

```
TypeError: require_X is not a function
```

Manifests as `Cloudflare 1101` in real apps and `__exportAll is not a function` / `e is not a function` etc. in the issue reports collected on #9441.

## Minimal reproduction

https://github.com/kjanoudi/rolldown-9441-repro — the source is lifted verbatim from this repo's regression-lock fixture `crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_facade_reexport_merges_into_entry/`. Two CJS facades (`a.js`, `b.js`), each `module.exports = require('./X-impl.js')`; entry statically imports both and dynamically imports a route chunk that also imports both.

- vite 8.0.13 (rolldown 1.0.1) → both facades merged into entry, route + child statically back-import wrappers from entry.
- vite 8.0.12 (rolldown 1.0.0) → `b` facade has its own chunk, no back-import.

## Discriminator

PR #9305 specifically fixed #8361 — a different cycle pattern where a CJS facade chunk had a static back-edge into the main chunk. A blanket "don't dedupe wrapped atoms" gate re-introduces that 8361 cycle. The two cycle patterns differ in whether the dropped dynamic entries are **effective** or **ineffective**:

- **#8361 / #8361_2**: dynamic imports collapse via `INEFFECTIVE_DYNAMIC_IMPORT` because the dynamic-entry's own module body is also statically reachable from the surviving parent. No separate sibling chunk emerges → no back-import → safe to reduce.
- **#9441**: dynamic entries are effective (reached only via `import()`). The sibling chunks emerge separately and statically back-import the wrapper from the parent → unsafe.

The pre-chunk-formation equivalent of `detect_ineffective_dynamic_imports.rs`'s check is: the dynamic-entry's module carries more than just its own entry bit in `index_splitting_info[d_module].bits`. At dedupe time the splitting-info writes are deferred to the post-loop assignment, so this view is still the un-reduced one.

## Fix — two gates, same predicate

### 1. `dynamic_already_loaded.rs::can_use_reduced_dependent_entries`

Before falling through to the existing checks, if the atom contains any wrapped module (`wrap_kind != WrapKind::None`), refuse the reduction when **any** removed dynamic-entry is effective (its module body has bits beyond its own entry bit).

This keeps the wrapper atom at multi-entry bits, so the chunker doesn't collapse it into the static entry's chunk.

### 2. `chunk_optimizer.rs::try_insert_into_existing_chunk`

The downstream common-chunk-merge pass would still hoist the temp common chunk into the user-defined entry chunk. Refuse this merge when the candidate `info.modules` contain any wrapped module **and** a dynamic-entry chunk depends on the candidate.

Both gates target the same "wrapped + effective dynamic sibling" hazard. Pure-ESM atoms are untouched. The #8361 / #8361_2 cycles remain fixed.

## Result

The lock-in fixture's `artifacts.snap` now emits:

```
a.js   Common Chunk: [Shared-By: entry.js, route.js]
b.js   Common Chunk: [Shared-By: entry.js, route.js, child.js]
entry.js  imports require_a from a.js, require_b from b.js  ← leaf imports
route.js  imports require_a from a.js, require_b from b.js  ← leaf imports
child.js  imports require_b from b.js                       ← leaf import
```

No entry↔leaf back-edges. Cycle eliminated.

Other affected snapshots (5 fixtures: `2038/b`, `2085`, `8053`, `strict_execution_order/{esbuild_issue_2598,issue_4684}`) are the same pattern — a wrapped module that PR #9305 had hoisted into a parent chunk now lives in a dedicated common chunk. All test executions still pass (cycle assertions in `issues/8361`, `issues/8361_2` remain green).

## Test plan

- [x] `pnpm install && cargo test --test integration -p rolldown` → 1715 passing, 0 failing (only `test262::test262_module_code` fails — unrelated, requires the test262 submodule).
- [x] `issues/8361` and `issues/8361_2` cycle assertions remain green (PR #9305's intent preserved).
- [x] Lock-in fixture `cjs_facade_reexport_merges_into_entry` snap updated — no more back-imports.

Marked as draft to allow maintainer review of the predicate's wording before landing.