### PR TITLE
fix(deps): skip pnpm frozen-lockfile on Netlify to dodge catalog mismatch bug

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -3,15 +3,21 @@
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
-# Netlify's build sandbox makes pnpm 11 fail to discover this repo's workspace root,
-# so `pnpm-workspace.yaml` (and thus the catalog: definitions) never reach pnpm's
-# config. That surfaces as either ERR_PNPM_LOCKFILE_CONFIG_MISMATCH (frozen mode)
-# or ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC (during resolution).
-# Pointing pnpm at the workspace root explicitly bypasses the broken discovery —
-# this env var is the one piece of pnpm config still read under the NPM_CONFIG_* prefix
-# (see pnpm/workspace/root-finder: WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR').
+# Workaround for pnpm 11 misbehaving in Netlify's build sandbox: the workspace
+# root isn't auto-discovered, so `pnpm-workspace.yaml` (and the catalog: block)
+# never reach pnpm's config. The symptom is either ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
+# (frozen mode) or ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC (during resolution).
+#
+# Two-pronged fix:
+#  1. NPM_CONFIG_WORKSPACE_DIR pins the workspace root explicitly. This env var
+#     keeps the NPM_CONFIG_* prefix even in pnpm v11 (see
+#     pnpm/workspace/root-finder: WORKSPACE_DIR_ENV_VAR).
+#  2. PNPM_CONFIG_FROZEN_LOCKFILE=false also disables the buggy catalog-mismatch
+#     check from https://github.com/pnpm/pnpm/issues/10258 so that if (1) doesn't
+#     fully take, we at least skip the false-positive guard.
 [build.environment]
 NPM_CONFIG_WORKSPACE_DIR = "/opt/build/repo"
+PNPM_CONFIG_FROZEN_LOCKFILE = "false"
 
 [[redirects]]
 from = "/about/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,7 +2,6 @@
 # only build on netlify if there are any change in docs
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
-command = "pnpm run docs:build"
 
 # Netlify's pre-install stage runs `pnpm install` with `--frozen-lockfile` and
 # trips https://github.com/pnpm/pnpm/issues/10258 (a false-positive catalog

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,6 +2,7 @@
 # only build on netlify if there are any change in docs
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
+command = "pnpm install --no-frozen-lockfile && pnpm run docs:build"
 
 # Workaround for pnpm 11 misbehaving in Netlify's build sandbox: the workspace
 # root isn't auto-discovered, so `pnpm-workspace.yaml` (and the catalog: block)

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -6,8 +6,9 @@ ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; els
 # Workaround for https://github.com/pnpm/pnpm/issues/10258 — pnpm >=10.24 (incl. 11.x)
 # spuriously throws ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on Netlify under --frozen-lockfile.
 # Drop frozen mode here so the buggy catalog comparison is skipped; CI elsewhere keeps it.
+# Note: pnpm 11 only honors PNPM_CONFIG_* env vars (NPM_CONFIG_* is no longer read).
 [build.environment]
-NPM_CONFIG_FROZEN_LOCKFILE = "false"
+PNPM_CONFIG_FROZEN_LOCKFILE = "false"
 
 [[redirects]]
 from = "/about/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -3,12 +3,15 @@
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
-# Workaround for https://github.com/pnpm/pnpm/issues/10258 — pnpm >=10.24 (incl. 11.x)
-# spuriously throws ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on Netlify under --frozen-lockfile.
-# Drop frozen mode here so the buggy catalog comparison is skipped; CI elsewhere keeps it.
-# Note: pnpm 11 only honors PNPM_CONFIG_* env vars (NPM_CONFIG_* is no longer read).
+# Netlify's build sandbox makes pnpm 11 fail to discover this repo's workspace root,
+# so `pnpm-workspace.yaml` (and thus the catalog: definitions) never reach pnpm's
+# config. That surfaces as either ERR_PNPM_LOCKFILE_CONFIG_MISMATCH (frozen mode)
+# or ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC (during resolution).
+# Pointing pnpm at the workspace root explicitly bypasses the broken discovery —
+# this env var is the one piece of pnpm config still read under the NPM_CONFIG_* prefix
+# (see pnpm/workspace/root-finder: WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR').
 [build.environment]
-PNPM_CONFIG_FROZEN_LOCKFILE = "false"
+NPM_CONFIG_WORKSPACE_DIR = "/opt/build/repo"
 
 [[redirects]]
 from = "/about/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -3,6 +3,12 @@
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
+# Workaround for https://github.com/pnpm/pnpm/issues/10258 — pnpm >=10.24 (incl. 11.x)
+# spuriously throws ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on Netlify under --frozen-lockfile.
+# Drop frozen mode here so the buggy catalog comparison is skipped; CI elsewhere keeps it.
+[build.environment]
+NPM_CONFIG_FROZEN_LOCKFILE = "false"
+
 [[redirects]]
 from = "/about/"
 to = "/guide/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,23 +2,15 @@
 # only build on netlify if there are any change in docs
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
-command = "pnpm install --no-frozen-lockfile && pnpm run docs:build"
+command = "pnpm run docs:build"
 
-# Workaround for pnpm 11 misbehaving in Netlify's build sandbox: the workspace
-# root isn't auto-discovered, so `pnpm-workspace.yaml` (and the catalog: block)
-# never reach pnpm's config. The symptom is either ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
-# (frozen mode) or ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC (during resolution).
-#
-# Two-pronged fix:
-#  1. NPM_CONFIG_WORKSPACE_DIR pins the workspace root explicitly. This env var
-#     keeps the NPM_CONFIG_* prefix even in pnpm v11 (see
-#     pnpm/workspace/root-finder: WORKSPACE_DIR_ENV_VAR).
-#  2. PNPM_CONFIG_FROZEN_LOCKFILE=false also disables the buggy catalog-mismatch
-#     check from https://github.com/pnpm/pnpm/issues/10258 so that if (1) doesn't
-#     fully take, we at least skip the false-positive guard.
+# Netlify's pre-install stage runs `pnpm install` with `--frozen-lockfile` and
+# trips https://github.com/pnpm/pnpm/issues/10258 (a false-positive catalog
+# mismatch). PNPM_FLAGS is forwarded to that pre-install invocation, so passing
+# `--no-frozen-lockfile` here bypasses the buggy guard before our build command
+# even runs.
 [build.environment]
-NPM_CONFIG_WORKSPACE_DIR = "/opt/build/repo"
-PNPM_CONFIG_FROZEN_LOCKFILE = "false"
+PNPM_FLAGS = "--no-frozen-lockfile"
 
 [[redirects]]
 from = "/about/"


### PR DESCRIPTION
## Summary

- Adds `PNPM_FLAGS = "--no-frozen-lockfile"` to `docs/netlify.toml` `[build.environment]`.
- Works around [pnpm/pnpm#10258](https://github.com/pnpm/pnpm/issues/10258) — pnpm >=10.24 (incl. 11.x) spuriously throws `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on Netlify under `--frozen-lockfile`, even when the workspace catalog and lockfile snapshot are byte-for-byte equivalent.

## Context

#9447 bumped `packageManager` from `pnpm@10.23.0` → `pnpm@11.1.2` and removed the pin from #9364. pnpm 11.x carries the same buggy `allCatalogsAreUpToDate` check introduced in pnpm 10.24.0 ([pnpm/pnpm#10231](https://github.com/pnpm/pnpm/pull/10231)), so Netlify deploys started failing again with the same false-positive catalog mismatch.

I confirmed locally that `pnpm install --frozen-lockfile` on this commit with pnpm 11.1.2 + Node 24.12.0 succeeds clean — the bug only fires inside Netlify's build sandbox. The upstream issue is still open with no maintainer activity and this repo as the reproduction.

## Approach

The failure occurs in Netlify's **pre-install stage** (before the project's build `command` runs), so any flag we put inside the build command is too late. Netlify forwards `PNPM_FLAGS` directly to that pre-install `pnpm install` invocation, so setting `PNPM_FLAGS = "--no-frozen-lockfile"` is enough to skip the buggy guard at the right step.

Earlier attempts to disable frozen mode via `NPM_CONFIG_FROZEN_LOCKFILE` / `PNPM_CONFIG_FROZEN_LOCKFILE` and to pin the workspace root via `NPM_CONFIG_WORKSPACE_DIR` were dropped — they either weren't honored by pnpm 11 (the v11 migration changed which prefixes settings are read from) or didn't address the pre-install stage at all. `PNPM_FLAGS` is Netlify's intended hook for this and turns out to be the minimal fix.

Scope is intentionally narrow:
- Only the Netlify env gets the flag (via `docs/netlify.toml`, not `.npmrc`).
- GitHub Actions CI keeps frozen-lockfile, so genuine drift is still caught upstream.
- `packageManager` stays on pnpm 11.1.2 — no rollback of #9447.
- The docs build `command` is unchanged; Netlify's own pre-install handles dependencies and the `--no-frozen-lockfile` flag rides along through `PNPM_FLAGS`.
