### PR TITLE
fix(watch): avoid deadlock when closing from event callback

### DIFF
--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -109,6 +109,12 @@ impl BindingWatcher {
 
   #[tracing::instrument(level = "debug", skip_all)]
   #[napi]
+  pub fn request_close(&self) {
+    self.inner.request_close();
+  }
+
+  #[tracing::instrument(level = "debug", skip_all)]
+  #[napi]
   pub async fn close(&self) -> napi::Result<()> {
     self
       .inner

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -125,10 +125,15 @@ impl Watcher {
   /// Close the watcher and wait for the coordinator to finish.
   /// Must be called after `run()` — calling before `run()` will skip cleanup hooks.
   pub async fn close(&self) -> Result<()> {
-    self.closed.store(true, std::sync::atomic::Ordering::Relaxed);
-    let _ = self.tx.send(WatcherMsg::Close);
+    self.request_close();
     self.wait_for_close().await;
     Ok(())
+  }
+
+  /// Request watcher close without waiting for the coordinator to finish.
+  pub fn request_close(&self) {
+    self.closed.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _ = self.tx.send(WatcherMsg::Close);
   }
 
   fn create_tasks(

--- a/meta/design/watch-mode.md
+++ b/meta/design/watch-mode.md
@@ -265,6 +265,12 @@ watcher.close() sends WatcherMsg::Close (fire-and-forget)
       6. coordinator future completes → all wait_for_close() callers resolve
 ```
 
+When `watcher.close()` is called from inside a JS watcher event listener, the TypeScript layer uses
+the non-blocking `requestClose()` binding instead of awaiting the coordinator future directly. This
+avoids a self-deadlock: the coordinator is waiting for the JS listener to return, while the listener
+would otherwise be waiting for the same coordinator to finish closing. The queued close message is
+processed as soon as the current event dispatch returns.
+
 ### Error Recovery
 
 Build errors do **not** stop the watcher. On error, `event('ERROR')` is emitted with the error details and a `result` handle. The watcher continues watching — when the user fixes the error and saves, a rebuild triggers.
@@ -390,6 +396,10 @@ close() → inner.close()         // sends Close msg, awaits shared future
 ### Binding as Thin Wrapper
 
 `BindingWatcher` is intentionally a thin wrapper — it holds a `rolldown_watcher::Watcher` and delegates directly. No state machine, no locking, no logic beyond type conversion. All lifecycle management lives in the Rust core. The constructor takes both `options` and `listener`, creates the `NapiWatcherEventHandler`, and passes it to `Watcher::new()`. Each NAPI method (`run`, `waitForClose`, `close`) is a direct delegation to the inner watcher.
+
+`requestClose()` is the one non-awaiting lifecycle method. It only enqueues `WatcherMsg::Close` and
+marks the watcher as closing, which lets the JS layer break re-entrant close cycles from event
+listeners while keeping the actual close hooks and close event in the coordinator.
 
 ### Event Emitter
 

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -89,6 +89,11 @@ export interface RolldownWatcher {
 
 export class WatcherEmitter implements RolldownWatcher {
   private listeners = new Map<WatcherEvent, Array<(...parameters: any[]) => MaybePromise<void>>>();
+  private emittingDepth = 0;
+
+  get isEmitting(): boolean {
+    return this.emittingDepth > 0;
+  }
 
   on(event: WatcherEvent, listener: (...parameters: any[]) => MaybePromise<void>): this {
     const listeners = this.listeners.get(event);
@@ -117,10 +122,16 @@ export class WatcherEmitter implements RolldownWatcher {
    *  (e.g. `event.result.close()` triggering `closeBundle`) are visible to later handlers. */
   async emit(event: WatcherEvent, ...args: any[]): Promise<void> {
     const handlers = this.listeners.get(event);
-    if (handlers?.length) {
-      for (const h of handlers) {
-        await h(...args);
+    if (!handlers?.length) {
+      return;
+    }
+    this.emittingDepth++;
+    try {
+      for (const handler of handlers) {
+        await handler(...args);
       }
+    } finally {
+      this.emittingDepth--;
     }
   }
 

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -11,6 +11,10 @@ import {
 import { arraify } from '../../utils/misc';
 import type { WatcherEmitter } from './watch-emitter';
 
+type BindingWatcherWithRequestClose = BindingWatcher & {
+  requestClose(): void;
+};
+
 function createEventCallback(
   emitter: WatcherEmitter,
 ): (event: BindingWatcherEvent) => Promise<void> {
@@ -60,6 +64,7 @@ class Watcher {
   inner: BindingWatcher;
   emitter: WatcherEmitter;
   stopWorkers: ((() => Promise<void>) | undefined)[];
+  private closePromise: Promise<void> | undefined;
 
   constructor(
     emitter: WatcherEmitter,
@@ -83,19 +88,28 @@ class Watcher {
   }
 
   async close(): Promise<void> {
-    if (this.closed) return;
+    if (this.closePromise) return this.closePromise;
     this.closed = true;
-    for (const stop of this.stopWorkers) {
-      await stop?.();
-    }
-    await this.inner.close();
-    shutdownAsyncRuntime();
+    const isClosingFromEventCallback = this.emitter.isEmitting;
+    this.closePromise = (async () => {
+      for (const stop of this.stopWorkers) {
+        await stop?.();
+      }
+      if (isClosingFromEventCallback) {
+        (this.inner as BindingWatcherWithRequestClose).requestClose();
+      } else {
+        await this.inner.close();
+        shutdownAsyncRuntime();
+      }
+    })();
+    return this.closePromise;
   }
 
   private async run(): Promise<void> {
+    if (this.closed) return;
     await this.inner.run();
     // No `.await`: Create pending Promise to keep Node.js event loop alive
-    this.inner.waitForClose();
+    void this.inner.waitForClose().finally(() => shutdownAsyncRuntime());
   }
 }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1746,6 +1746,7 @@ export declare class BindingWatcher {
    * The Node.js layer relies on the pending Promise to keep the process from exiting.
    */
   waitForClose(): Promise<void>
+  requestClose(): void
   close(): Promise<void>
 }
 

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -177,6 +177,69 @@ test.concurrent(
 );
 
 test.concurrent(
+  'watcher.close() can be awaited inside an event callback',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { input, output, dir } = createTestInputAndOutput('watch-close-inside-event', retryCount);
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const closeWatcherFn = vi.fn();
+    const watcher = watch({
+      input,
+      output: { file: output },
+      plugins: [
+        {
+          name: 'test closeWatcher',
+          closeWatcher() {
+            closeWatcherFn();
+          },
+        },
+      ],
+    });
+
+    const closeFn = vi.fn();
+    watcher.on('close', closeFn);
+
+    let closing = false;
+    const closeFromEvent = new Promise<void>((resolve, reject) => {
+      watcher.on('event', async (event) => {
+        if (event.code !== 'BUNDLE_END' || closing) return;
+        closing = true;
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.race([
+            watcher.close(),
+            new Promise<never>((_, rejectTimeout) => {
+              timer = setTimeout(
+                () =>
+                  rejectTimeout(
+                    new Error('Timed out waiting for watcher.close() inside BUNDLE_END'),
+                  ),
+                5000,
+              );
+            }),
+          ]);
+          resolve();
+        } catch (error) {
+          reject(error);
+        } finally {
+          clearTimeout(timer);
+        }
+      });
+    });
+
+    await closeFromEvent;
+    await expect.poll(() => closeFn).toBeCalledTimes(1);
+    expect(closeWatcherFn).toBeCalledTimes(1);
+  },
+);
+
+test.concurrent(
   'watch event',
   { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
   async ({ task, expect, onTestFinished }) => {


### PR DESCRIPTION
## Root Cause

`watcher.close()` could deadlock when it was awaited inside a watcher event callback.

The Rust watch coordinator awaits the JS watcher listener while emitting events. If that JS listener calls and awaits `watcher.close()`, the previous implementation sends `WatcherMsg::Close` and then waits for the coordinator future to finish. At that point both sides are waiting on each other: the coordinator cannot process the queued close message until the current JS callback returns, while the JS callback cannot return because it is waiting for the coordinator to finish closing.

## Changes

- Add a non-blocking watcher close request path for re-entrant close calls from JS event listeners.
- Track whether `WatcherEmitter` is currently dispatching an event and use `requestClose()` when `watcher.close()` is awaited from inside that dispatch.
- Keep normal `watcher.close()` behavior unchanged outside event callbacks.
- Add a regression test for awaiting `watcher.close()` inside `BUNDLE_END`.
- Document the watch-mode lifecycle edge case.

Fixes #9462.

## Tests

- `PATH="$HOME/.cargo/bin:$PATH" just build-rolldown`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rolldown_watcher --lib`
- `PATH="$HOME/.cargo/bin:$PATH" RUST_BACKTRACE=1 ROLLDOWN_TEST=1 pnpm --filter rolldown-tests exec vitest run watch/watch.test.ts --reporter verbose --hideSkippedTests`
- Manual physical watcher test with `await watcher.close()` inside a `BUNDLE_END` callback
- `PATH="$HOME/.cargo/bin:$PATH" just lint-repo`
- `PATH="$HOME/.cargo/bin:$PATH" just roll` reached `lint-publint`; Rust tests, Node tests, watch/dev-watch tests, Rollup compatibility tests, formatting, and base lint passed. The final local failure was `@rolldown/browser` publint because `packages/browser/dist/*` was unavailable; rebuilding it was blocked by the local Rust toolchain not being able to install `wasm32-wasip1-threads` std for Rust 1.95.0.
