### PR TITLE
fix(netlify): work around pnpm 11.1.2 catalogs hash mismatch on docs build

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -3,6 +3,12 @@
 # COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
+[build.environment]
+# Workaround for pnpm/pnpm#10258: pnpm 11.1.2 frozen install spuriously fails
+# with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on this workspace's catalogs config.
+# Netlify forwards NPM_FLAGS to the underlying pnpm install invocation.
+NPM_FLAGS = "--no-frozen-lockfile"
+
 [[redirects]]
 from = "/about/"
 to = "/guide/"


### PR DESCRIPTION
### Problem

Netlify docs previews fail at the install step with:

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "catalogs" configuration doesn't match the value found in the lockfile
```

This blocks every PR's docs preview build, even PRs that only touch `.md`
files (e.g. #9435).

### Root cause

Upstream pnpm bug: [pnpm/pnpm#10258](https://github.com/pnpm/pnpm/issues/10258).
pnpm 11.1.2 mis-hashes the `catalogs` section against the lockfile snapshot
under certain conditions, so `pnpm install --frozen-lockfile` reports a
mismatch even when the lockfile was generated by the same version. CI on
GitHub Actions doesn't hit it because the Node 20 matrix is pinned to
`pnpm@10.33.4`, but Netlify follows the root `packageManager` field and
runs `pnpm@11.1.2`.

### Fix

Add `NPM_FLAGS = "--no-frozen-lockfile"` under `[build.environment]` in
`docs/netlify.toml`. Netlify forwards `NPM_FLAGS` to the underlying
`pnpm install` invocation, so installs become non-frozen on Netlify only.

### Scope / safety

- Only affects Netlify's docs-site build. GitHub Actions still uses frozen
  installs, so the lockfile remains authoritative for everything that ships.
- The docs site is not published as a package, so a non-frozen install on
  preview builds carries no supply-chain risk.
- Root `packageManager`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` are
  untouched.

### Cleanup

Once pnpm ships a fix for #10258 and we bump `packageManager` to it, drop
the `[build.environment]` block from `docs/netlify.toml`.
