### PR TITLE
chore(release): set up cargo-release-oxc for publishing crates

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: cargo release-oxc update --release crates --version ${VERSION}
 
       - name: Update Cargo.lock after crate bump
-        run: cargo check --workspace
+        run: cargo check
 
       - name: Regenerate binding.js after version bump
         run: vp run --filter rolldown build-binding

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -49,7 +49,7 @@ jobs:
       - run: just bump-packages ${VERSION}
 
       - name: Bump crate versions
-        run: cargo release-oxc update --release crates
+        run: cargo release-oxc update --release crates --version ${VERSION}
 
       - name: Update Cargo.lock after crate bump
         run: cargo check --workspace

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,12 +36,23 @@ jobs:
         with:
           cache: true
 
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
+        with:
+          cache-key: warm
+          tools: cargo-release-oxc
+
       - name: Set version
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
 
       - run: just bump-packages ${VERSION}
+
+      - name: Bump crate versions
+        run: cargo release-oxc update --release crates
+
+      - name: Update Cargo.lock after crate bump
+        run: cargo check --workspace
 
       - name: Regenerate binding.js after version bump
         run: vp run --filter rolldown build-binding
@@ -72,6 +83,9 @@ jobs:
             CHANGELOG.md
             packages/**/package.json
             packages/rolldown/src/binding.cjs
+            Cargo.toml
+            Cargo.lock
+            crates/**/Cargo.toml
           commit-message: 'release: v${{ env.VERSION }}'
           body: ${{ steps.changelog.outputs.content }}
           branch: release-v${{ env.VERSION }}

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,38 @@
+name: Release Crates
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - crates/rolldown/Cargo.toml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    if: github.repository == 'rolldown/rolldown'
+    name: Release crates
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC token exchange (trusted publishing)
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
+        with:
+          cache-key: warm
+          tools: cargo-release-oxc
+
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo release-oxc publish --release crates

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -19,6 +19,7 @@ jobs:
     if: github.repository == 'rolldown/rolldown'
     name: Release crates
     runs-on: ubuntu-latest
+    environment: crates
     permissions:
       id-token: write # Required for OIDC token exchange (trusted publishing)
     steps:

--- a/crates/rolldown_filter_analyzer/Cargo.toml
+++ b/crates/rolldown_filter_analyzer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = true
+publish = false
 repository.workspace = true
 description = "Analyzer for filter patterns in Rolldown"
 

--- a/crates/rolldown_plugin_vite_css/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = true
+publish = false
 repository.workspace = true
 description = "Rolldown plugin for Vite CSS handling"
 

--- a/crates/rolldown_plugin_vite_css_post/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css_post/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = true
+publish = false
 repository.workspace = true
 description = "Rolldown plugin for Vite CSS post-processing"
 

--- a/crates/rolldown_plugin_vite_html/Cargo.toml
+++ b/crates/rolldown_plugin_vite_html/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = true
+publish = false
 repository.workspace = true
 description = "Rolldown plugin for Vite HTML handling"
 

--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -1,0 +1,7 @@
+# Configuration file for [cargo release oxc](https://github.com/oxc-project/cargo-release-oxc)
+
+# Release `--release crates`
+[[releases]]
+name = "crates"
+root_crate = "rolldown"
+versioned_files = ["Cargo.toml"]


### PR DESCRIPTION
Closes #6900.

## Summary

Wires up [cargo-release-oxc](https://github.com/oxc-project/cargo-release-oxc) so the existing release flow bumps Rust crates alongside the npm packages and a separate workflow publishes the crates to crates.io via trusted publishing.

One workflow input version drives both the npm bump (via `just bump-packages`) and the crate bump (via `cargo release-oxc update --release crates --version $VERSION`). Crates and npm stay in lockstep on a single version.

## Files

- `oxc_release.toml` — release set named `crates`, `root_crate = "rolldown"`, `versioned_files = ["Cargo.toml"]`. The workspace `Cargo.toml` is enough for `cargo-release-oxc` to walk every publishable workspace member.
- `.github/workflows/prepare-release.yml` — added:
  - `oxc-project/setup-rust` with `tools: cargo-release-oxc`.
  - `cargo release-oxc update --release crates --version ${VERSION}` after `just bump-packages`.
  - `cargo check` to refresh `Cargo.lock`.
  - Extended `add-paths` to include `Cargo.toml`, `Cargo.lock`, `crates/**/Cargo.toml`.
- `.github/workflows/release-crates.yml` — new. Fires on push to `main` when `crates/rolldown/Cargo.toml` changes. Runs the publish job inside the `crates` GitHub Actions environment, uses `rust-lang/crates-io-auth-action` for OIDC trusted publishing, and runs `cargo release-oxc publish --release crates`. No changelog, no GitHub release (the npm workflow already creates the shared tag for the version).

## Workspace cleanups

A few crates needed adjustments to fit `cargo-release-oxc`'s assumption that every publishable workspace member is consumed via `[workspace.dependencies]`:

- `rolldown_filter_analyzer`, `rolldown_plugin_vite_css`, `rolldown_plugin_vite_css_post`, `rolldown_plugin_vite_html` → flipped to `publish = false`. None of them are consumed in the workspace and none were ready to publish.

## Dependency

Depends on [oxc-project/cargo-release-oxc#237](https://github.com/oxc-project/cargo-release-oxc/pull/237) — adds the `--version` override on `update` and tolerates a missing `crates_v*` tag when `--version` is given. (PR #236, the `--changelog` opt-in, is already merged.)

#237 needs to be merged and a new `cargo-release-oxc` released before the workflow can use it.

## Before the first crates release

**Trusted publishing on crates.io** has already been registered for every publishable crate against `rolldown/rolldown` + `release-crates.yml` + `crates` environment.

The `crates` GitHub Actions environment must exist in repo settings (Settings → Environments → New environment → `crates`) so the OIDC subject claim matches what crates.io has registered.