### PR TITLE
feat(code-splitting): add group-local recursive dependency control

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -200,8 +200,8 @@ impl ManualSplitter<'_> {
         let entries_aware = match_group.entries_aware.unwrap_or(false);
         let module_group_id = ModuleGroupId { match_group_index, name: group_name.clone() };
 
-        let include_dependencies_recursively =
-          self.chunking_options.include_dependencies_recursively.unwrap_or(true);
+        let effective_include_dependencies_recursively = match_group
+          .include_dependencies_recursively(self.chunking_options.include_dependencies_recursively);
 
         let group: &mut ModuleGroup = if entries_aware {
           let idx = match entries_aware_idx_by_id.entry(module_group_id) {
@@ -244,7 +244,7 @@ impl ManualSplitter<'_> {
           &self.link_output.metas,
           &self.link_output.module_table,
           &mut FxHashSet::default(),
-          include_dependencies_recursively,
+          effective_include_dependencies_recursively,
         );
       }
     }

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -5,9 +5,9 @@ use itertools::Either;
 use oxc::{transformer::EngineTargets, transformer_plugins::InjectGlobalVariablesConfig};
 use rolldown_common::{
   AttachDebugInfo, CodeSplittingMode, GlobalsOutputOption, InjectImport, JsxOptions, JsxPreset,
-  LegalComments, MinifyOptions, ModuleType, NormalizedBundlerOptions, OutputFormat, Platform,
-  PreserveEntrySignatures, RawTransformOptions, TransformOptions, TreeshakeOptions, TsConfig,
-  merge_transform_options_with_tsconfig, normalize_optimization_option,
+  LegalComments, ManualCodeSplittingOptions, MinifyOptions, ModuleType, NormalizedBundlerOptions,
+  OutputFormat, Platform, PreserveEntrySignatures, RawTransformOptions, TransformOptions,
+  TreeshakeOptions, TsConfig, merge_transform_options_with_tsconfig, normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
 use rolldown_fs::{OsFileSystem, OxcResolverFileSystem as _};
@@ -23,6 +23,19 @@ pub struct PrepareBuildContext {
   pub resolver: SharedResolver<OsFileSystem>,
   pub options: Arc<NormalizedBundlerOptions>,
   pub warnings: Vec<BuildDiagnostic>,
+}
+
+fn has_effective_include_dependencies_recursively_false(
+  manual_code_splitting: &ManualCodeSplittingOptions,
+) -> bool {
+  let Some(groups) = manual_code_splitting.groups.as_deref().filter(|groups| !groups.is_empty())
+  else {
+    return matches!(manual_code_splitting.include_dependencies_recursively, Some(false));
+  };
+
+  groups.iter().any(|group| {
+    !group.include_dependencies_recursively(manual_code_splitting.include_dependencies_recursively)
+  })
 }
 
 fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<BuildDiagnostic>> {
@@ -111,7 +124,7 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
     }
 
     // Check if `codeSplitting.include_dependencies_recursively` conflict with `preserveEntrySignatures`
-    if matches!(manual_code_splitting.include_dependencies_recursively, Some(false)) {
+    if has_effective_include_dependencies_recursively_false(manual_code_splitting) {
       if let Some(preserve_signatures) = &raw_options.preserve_entry_signatures {
         if matches!(
           preserve_signatures,
@@ -140,7 +153,7 @@ pub fn prepare_build_context(
 
   let preserve_entry_signatures = if let Some(manual_code_splitting) =
     &raw_options.manual_code_splitting
-    && matches!(manual_code_splitting.include_dependencies_recursively, Some(false))
+    && has_effective_include_dependencies_recursively_false(manual_code_splitting)
     && raw_options.preserve_entry_signatures.is_none()
   {
     warnings.push(

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "preserveEntrySignatures": "strict",
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "lib",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Invalid option combination detected:
+
+- codeSplitting.includeDependenciesRecursively = false
+- preserveEntrySignatures = "strict"
+
+To fix:
+
+- Set `preserveEntrySignatures` either to false or 'allow-extension'
+
+```

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] Invalid option combination detected:
 
-- codeSplitting.includeDependenciesRecursively = false
+- recursive dependency inclusion is disabled by codeSplitting.includeDependenciesRecursively or a group override
 - preserveEntrySignatures = "strict"
 
 To fix:

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/lib.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/lib.js
@@ -1,0 +1,5 @@
+export const value = 'library value';
+
+export function helper() {
+  return 'helper function';
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/main.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/group_include_dependencies_recursively_conflict_preserve_entry_signatures/main.js
@@ -1,0 +1,7 @@
+import { value } from './lib.js';
+
+console.log('Main entry:', value);
+
+export function main() {
+  return 'main function';
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] Invalid option combination detected:
 
-- codeSplitting.includeDependenciesRecursively = false
+- recursive dependency inclusion is disabled by codeSplitting.includeDependenciesRecursively or a group override
 - preserveEntrySignatures = "strict"
 
 To fix:

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "test": "foo\\.js",
+          "name": "vendor",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_foo, t as foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+//#region bar.js
+var init_bar = __esmMin((() => {}));
+//#endregion
+__esmMin((() => {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+}))();
+export { init_bar as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+## vendor.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bar } from "./main.js";
+//#region foo.js
+var foo;
+var init_foo = __esmMin((() => {
+	init_bar();
+	foo = "foo bar";
+}));
+//#endregion
+export { init_foo as n, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/bar.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/foo.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/foo.js
@@ -1,0 +1,2 @@
+import { bar } from './bar';
+export const foo = 'foo ' + bar;

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_false/main.js
@@ -1,0 +1,6 @@
+import nodeAssert from 'node:assert';
+import { foo } from './foo';
+
+nodeAssert.strictEqual(foo, 'foo bar');
+
+export {};

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "strictExecutionOrder": true,
+    "manualCodeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "test": "foo\\.js",
+          "name": "vendor",
+          "includeDependenciesRecursively": true
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_foo, t as foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+## vendor.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region bar.js
+var init_bar = __esmMin((() => {}));
+//#endregion
+//#region foo.js
+var foo;
+var init_foo = __esmMin((() => {
+	init_bar();
+	foo = "foo bar";
+}));
+//#endregion
+export { init_foo as n, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/bar.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/foo.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/foo.js
@@ -1,0 +1,2 @@
+import { bar } from './bar';
+export const foo = 'foo ' + bar;

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/group_local_true_overrides_global_false/main.js
@@ -1,0 +1,6 @@
+import nodeAssert from 'node:assert';
+import { foo } from './foo';
+
+nodeAssert.strictEqual(foo, 'foo bar');
+
+export {};

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "manualCodeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "test": "foo\\.js",
+          "name": "vendor"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_foo, t as foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+//#region bar.js
+var init_bar = __esmMin((() => {}));
+//#endregion
+__esmMin((() => {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+}))();
+export { init_bar as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+## vendor.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bar } from "./main.js";
+//#region foo.js
+var foo;
+var init_foo = __esmMin((() => {
+	init_bar();
+	foo = "foo bar";
+}));
+//#endregion
+export { init_foo as n, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/bar.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/foo.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/foo.js
@@ -1,0 +1,2 @@
+import { bar } from './bar';
+export const foo = 'foo ' + bar;

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively_inherited_false/main.js
@@ -1,0 +1,6 @@
+import nodeAssert from 'node:assert';
+import { foo } from './foo';
+
+nodeAssert.strictEqual(foo, 'foo bar');
+
+export {};

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
 
-- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- disabling recursive dependency inclusion requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- recursive dependency inclusion can be disabled by `codeSplitting.includeDependenciesRecursively` or a group override
 
 To fix:
 

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
 
-- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- disabling recursive dependency inclusion requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- recursive dependency inclusion can be disabled by `codeSplitting.includeDependenciesRecursively` or a group override
 
 To fix:
 

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
+
+- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+
+To fix:
+
+- Set `preserveEntrySignatures` either to `false` or 'allow-extension' in your config
+
+```
+
+# Assets
+
+## main.js
+
+```js
+import { t as sharedValue } from "./vendor.js";
+//#region main.js
+console.log("Main entry with shared:", sharedValue);
+function mainFunc() {
+	return "main function";
+}
+//#endregion
+export { mainFunc };
+
+```
+
+## vendor.js
+
+```js
+//#region shared.js
+const sharedValue = "shared module value";
+//#endregion
+export { sharedValue as t };
+
+```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/main.js
@@ -1,0 +1,7 @@
+import { sharedValue } from './shared.js';
+
+console.log('Main entry with shared:', sharedValue);
+
+export function mainFunc() {
+  return 'main function';
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/shared.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/group_include_dependencies_recursively_implicit_preserve_entry_signatures/shared.js
@@ -1,0 +1,5 @@
+export const sharedValue = 'shared module value';
+
+export function sharedHelper() {
+  return 'shared helper';
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
 
-- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- disabling recursive dependency inclusion requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- recursive dependency inclusion can be disabled by `codeSplitting.includeDependenciesRecursively` or a group override
 
 To fix:
 

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -38,6 +38,7 @@ pub struct BindingMatchGroup {
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
   pub max_size: Option<f64>,
+  pub include_dependencies_recursively: Option<bool>,
   pub entries_aware: Option<bool>,
   pub entries_aware_merge_threshold: Option<f64>,
   pub tags: Option<Vec<String>>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -515,6 +515,7 @@ pub fn normalize_binding_options(
             max_module_size: item.max_module_size,
             min_module_size: item.min_module_size,
             max_size: item.max_size,
+            include_dependencies_recursively: item.include_dependencies_recursively,
             entries_aware: item.entries_aware,
             entries_aware_merge_threshold: item.entries_aware_merge_threshold,
             tags: item.tags.map(|tags| tags.into_iter().map(ModuleTag::from).collect()),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -64,6 +64,7 @@ pub struct MatchGroup {
   pub min_share_count: Option<u32>,
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
+  pub include_dependencies_recursively: Option<bool>,
   pub entries_aware: Option<bool>,
   /// Only effective when `entriesAware` is set to `true`.
   pub entries_aware_merge_threshold: Option<f64>,
@@ -74,6 +75,12 @@ pub struct MatchGroup {
     schemars(with = "Option<Vec<BuiltinModuleTag>>")
   )]
   pub tags: Option<Vec<ModuleTag>>,
+}
+
+impl MatchGroup {
+  pub fn include_dependencies_recursively(&self, global_fallback: Option<bool>) -> bool {
+    self.include_dependencies_recursively.or(global_fallback).unwrap_or(true)
+  }
 }
 
 type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -55,7 +55,7 @@ impl BuildEvent for InvalidOption {
           [
             "Invalid option combination detected:",
             "",
-            "- codeSplitting.includeDependenciesRecursively = false",
+            "- recursive dependency inclusion is disabled by codeSplitting.includeDependenciesRecursively or a group override",
             &format!("- preserveEntrySignatures = \"{value}\""),
             "",
             "To fix:",
@@ -67,7 +67,8 @@ impl BuildEvent for InvalidOption {
           [
             "`preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown",
             "",
-            "- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'",
+            "- disabling recursive dependency inclusion requires `preserveEntrySignatures` to be either `false` or 'allow-extension'",
+            "- recursive dependency inclusion can be disabled by `codeSplitting.includeDependenciesRecursively` or a group override",
             "",
             "To fix:",
             "",

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1326,6 +1326,12 @@
           ],
           "format": "double"
         },
+        "includeDependenciesRecursively": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "entriesAware": {
           "type": [
             "boolean",

--- a/docs/in-depth/manual-code-splitting.md
+++ b/docs/in-depth/manual-code-splitting.md
@@ -401,11 +401,13 @@ export const value = 'a' + value;
 
 You could see, to make `a.js` work, we have to change the export signature of the entry chunk `entry.js` and add an additional export `value`. This totally violates the original intention of the code, which is to only export `foo` from `entry.js`.
 
-If you don't want this behavior, you could use [`codeSplitting.includeDependenciesRecursively: false`](/reference/OutputOptions.codeSplitting#includedependenciesrecursively) to disable it.
+If you don't want this behavior, you could use [`codeSplitting.includeDependenciesRecursively: false`](/reference/OutputOptions.codeSplitting#includedependenciesrecursively) to disable it for all groups, or set `codeSplitting.groups[].includeDependenciesRecursively: false` to disable it for a specific group.
+
+When both are set, the group value wins. Groups without a local value inherit `codeSplitting.includeDependenciesRecursively`, which defaults to `true`.
 
 :::warning Caveats
 
-With `includeDependenciesRecursively: false`, depended modules of a group might be left in the entry chunks. It's invalid to export non-entry module from an entry chunk. To avoid this, Rolldown will implicitly set `preserveEntrySignatures: 'allow-extension'` if you didn't set it explicitly.
+With `includeDependenciesRecursively: false`, depended modules of a group might be left in the entry chunks. Another group may still capture those dependencies according to group priority and assignment order. It's invalid to export non-entry module from an entry chunk. To avoid this, Rolldown will implicitly set `preserveEntrySignatures: 'allow-extension'` if you didn't set it explicitly.
 
 - [`InputOptions.preserveEntrySignatures: false | 'allow-extension'`](/reference/InputOptions.preserveEntrySignatures)
 

--- a/meta/design/manual-code-splitting.md
+++ b/meta/design/manual-code-splitting.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Manual code splitting lets users define chunk boundaries via `manualCodeSplitting.groups`. Each group has a `name`, a `test` pattern to match modules, and optional size/priority controls. Matched modules (and optionally their dependencies) are pulled into dedicated chunks instead of being split by the automatic algorithm.
+Manual code splitting lets users define chunk boundaries via `manualCodeSplitting.groups`. Each group has a `name`, a `test` pattern to match modules, and optional size/priority controls. Matched modules (and optionally their dependencies) are pulled into dedicated chunks instead of being split by the automatic algorithm. Dependency capture can be configured globally with `codeSplitting.includeDependenciesRecursively` or per group with `groups[].includeDependenciesRecursively`; the group value wins, otherwise the global value is used, otherwise the default is `true`.
 
 ## Important features
 
@@ -47,7 +47,7 @@ Entry A loads all three vendor chunks. Entry B loads the first two. Entry C load
 
 #### Why flat-then-split matters
 
-The split must happen **after** collecting all modules into a flat group. If subgroups are created during the build phase (per module's own bits), `includeDependenciesRecursively` adds shared dependencies to each subgroup independently:
+The split must happen **after** collecting all modules into a flat group. Group-local `includeDependenciesRecursively` is still resolved while building that flat group; the `entriesAware` split happens afterward. If subgroups are created during the build phase (per module's own bits), `includeDependenciesRecursively` adds shared dependencies to each subgroup independently:
 
 ```
 BAD: subgroups during build (dependencies duplicated)

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2375,6 +2375,7 @@ export interface BindingMatchGroup {
   minModuleSize?: number
   maxModuleSize?: number
   maxSize?: number
+  includeDependenciesRecursively?: boolean
   entriesAware?: boolean
   entriesAwareMergeThreshold?: number
   tags?: Array<string>

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -884,6 +884,15 @@ export type CodeSplittingGroup = {
    */
   minModuleSize?: number;
   /**
+   * Whether this group also captures dependencies of matched modules recursively.
+   *
+   * By default, this inherits from {@linkcode CodeSplittingOptions.includeDependenciesRecursively | codeSplitting.includeDependenciesRecursively}, which defaults to `true`.
+   * Set this to `false` to make only this group capture explicitly matched modules while other groups keep their inherited behavior.
+   *
+   * Disabling this option has the same safety caveats as disabling {@linkcode CodeSplittingOptions.includeDependenciesRecursively | codeSplitting.includeDependenciesRecursively} globally.
+   */
+  includeDependenciesRecursively?: boolean;
+  /**
    * When `false` (default), all matching modules are merged into a single chunk.
    * Every entry that uses any of these modules must load the entire chunk — even
    * modules it doesn't need.
@@ -942,9 +951,11 @@ export type AdvancedChunksGroup = CodeSplittingGroup;
  */
 export type CodeSplittingOptions = {
   /**
+   * Global fallback of {@linkcode CodeSplittingGroup.includeDependenciesRecursively | group.includeDependenciesRecursively}, if it's not specified in the group.
+   *
    * By default, each group will also include captured modules' dependencies. This reduces the chance of generating circular chunks.
    *
-   * If you want to disable this behavior, it's recommended to both set
+   * If you want to disable this behavior for any group, it's recommended to both set
    * - {@linkcode InputOptions.preserveEntrySignatures | preserveEntrySignatures}: `false | 'allow-extension'`
    * - {@linkcode OutputOptions.strictExecutionOrder | strictExecutionOrder}: `true`
    *

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -816,6 +816,7 @@ const AdvancedChunksSchema = v.strictObject({
         maxSize: v.optional(v.number()),
         minModuleSize: v.optional(v.number()),
         maxModuleSize: v.optional(v.number()),
+        includeDependenciesRecursively: v.optional(v.boolean()),
         entriesAware: v.optional(v.boolean()),
         entriesAwareMergeThreshold: v.optional(v.number()),
         tags: v.optional(v.array(v.string())),

--- a/packages/rolldown/tests/utils/bindingify-code-splitting.test.ts
+++ b/packages/rolldown/tests/utils/bindingify-code-splitting.test.ts
@@ -134,6 +134,29 @@ test('advancedChunks without codeSplitting shows deprecation warning', async () 
   );
 });
 
+test('advancedChunks supports group-local includeDependenciesRecursively', async () => {
+  const bundle = await rolldown({
+    input: './fixtures/tree-shake/inline-dynamic-imports/main.js',
+    cwd: import.meta.dirname + '/..',
+    preserveEntrySignatures: 'allow-extension',
+  });
+  const result = await bundle.generate({
+    advancedChunks: {
+      groups: [
+        {
+          name: 'main-group',
+          test: /main/,
+          includeDependenciesRecursively: false,
+        },
+      ],
+    },
+  });
+  expect(result.output.length).toBeGreaterThan(0);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    '`advancedChunks` option is deprecated, please use `codeSplitting` instead.',
+  );
+});
+
 test('manualChunks without codeSplitting works', async () => {
   const bundle = await rolldown({
     input: './fixtures/tree-shake/inline-dynamic-imports/main.js',

--- a/packages/rolldown/tests/validate-option.test.ts
+++ b/packages/rolldown/tests/validate-option.test.ts
@@ -42,6 +42,29 @@ test('validate output option', async () => {
   );
 });
 
+test('allows group-local includeDependenciesRecursively', async () => {
+  const consoleSpy = vi.spyOn(console, 'warn');
+  const bundle = await rolldown({
+    input: './build-api/main.js',
+    cwd: import.meta.dirname,
+    preserveEntrySignatures: 'allow-extension',
+  });
+  await bundle.write({
+    codeSplitting: {
+      groups: [
+        {
+          name: 'main-group',
+          test: /main/,
+          includeDependenciesRecursively: false,
+        },
+      ],
+    },
+  });
+  expect(consoleSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining('includeDependenciesRecursively'),
+  );
+});
+
 test('give a warning for hoistTransitiveImports: true', async () => {
   const consoleSpy = vi.spyOn(console, 'warn');
   const bundle = await rolldown({


### PR DESCRIPTION
## What

Adds `includeDependenciesRecursively` to manual code-splitting groups.

A group-local value overrides the top-level `codeSplitting.includeDependenciesRecursively`; omitted group values inherit the top-level option, and the default remains `true`.

This updates the Rust options, NAPI binding normalization, generated binding types, TypeScript public types, option validation, JSON config schema, docs, and regression fixtures.

Fixes #9467.

## Why

Some manual code-splitting groups need to capture only the modules they directly match, while other groups should keep Rolldown’s existing recursive dependency capture behavior.

The existing top-level option can only disable recursive dependency capture globally, which changes every manual group at once. Making the option group-local allows targeted opt-outs without changing unrelated groups.

The preserve-entry-signature validation now uses the effective group/global value, so non-recursive groups keep the same safety checks as the existing top-level option.

## Tophat

Validated locally with:

- `cargo fmt --all -- --emit=files`
- `cargo check -q`
- `CI=true just build-rolldown`
- targeted `cargo run-fixture` coverage for:
  - group-local `includeDependenciesRecursively: false`
  - inherited top-level `includeDependenciesRecursively: false`
  - group-local `true` overriding top-level `false`
  - preserve-entry-signature error/warning paths

A full `just test-update` run was attempted; this local checkout could not complete the full workspace run because the `test262` submodule is not initialized.

## AI disclosure

AI assistance was used while developing this change. I reviewed, tested, and validated the implementation before submission.