### PR TITLE
fix(cache): keep the scan-stage cache consistent when a build fails

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -239,10 +239,17 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     if is_full_scan_mode {
       let mut output: NormalizedScanStageOutput =
         output.try_into().expect("Should be able to convert to NormalizedScanStageOutput");
-      defer_sync_scan_data(&self.options, &self.cache.module_id_to_idx, &mut output).await?;
+      // The scan produced a complete `output`; `defer_sync_scan_data` only
+      // mutates per-module `side_effects` best-effort, so its error doesn't
+      // invalidate `output`. Commit it rather than fall back to the stale prior
+      // snapshot.
+      // See meta/design/bundler-data-lifecycle.md ("Cache integrity on a failed build").
+      let result =
+        defer_sync_scan_data(&self.options, &self.cache.module_id_to_idx, &mut output).await;
       if is_incremental {
         self.cache.set_snapshot(output.make_copy());
       }
+      result?;
       return Ok(output);
     }
 
@@ -264,6 +271,12 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
       GenerateStage::new(&mut link_stage_output, &self.options, &self.plugin_driver)
         .generate()
         .await; // Notice we don't use `?` to break the control flow here.
+
+    // `create_output`/`make_copy` strip symbol-table scoping from the cache for
+    // performance; reinstate it here, before the fallible steps below, so the
+    // cache stays whole on their `Err` paths.
+    // See meta/design/bundler-data-lifecycle.md ("Cache integrity on a failed build").
+    self.merge_immutable_fields_for_cache(link_stage_output.symbol_db);
 
     if let Err(errors) = &bundle_output {
       debug_assert!(errors.iter().all(|e| e.severity() == Severity::Error));
@@ -295,8 +308,6 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     if let Some(invalidate_js_side_cache) = &self.options.invalidate_js_side_cache {
       invalidate_js_side_cache.call().await?;
     }
-
-    self.merge_immutable_fields_for_cache(link_stage_output.symbol_db);
 
     Ok(output)
   }

--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -13,9 +13,14 @@ impl Bundler {
   ) -> BuildResult<T> {
     let cache = mem::take(&mut self.cache);
     let mut bundle = self.bundle_factory.create_bundle(bundle_mode, Some(cache))?;
-    let ret = with_fn(&mut bundle).await?;
+    // Do NOT `?` the build result here. The cache must be moved back into the
+    // `Bundler` on every outcome; bailing on `Err` would drop `bundle` and leave
+    // `Bundler::cache` at the `default()` (snapshot = None) that `mem::take`
+    // installed above, making the next HMR cycle panic in `get_snapshot()`.
+    // See meta/design/bundler-data-lifecycle.md ("Cache integrity on a failed build").
+    let ret = with_fn(&mut bundle).await;
     self.cache = bundle.cache;
-    Ok(ret)
+    ret
   }
 
   #[cfg(feature = "experimental")]

--- a/crates/rolldown/src/module_loader/deferred_scan_data.rs
+++ b/crates/rolldown/src/module_loader/deferred_scan_data.rs
@@ -1,6 +1,6 @@
 use rolldown_common::ModuleId;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
-use rolldown_error::BuildResult;
+use rolldown_error::{BuildDiagnostic, BuildResult};
 use rustc_hash::FxHashMap;
 
 use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
@@ -16,7 +16,10 @@ pub async fn defer_sync_scan_data(
     return Ok(());
   };
 
-  for data in func.exec().await? {
+  let result = func.exec().await?;
+
+  let mut errors: Vec<BuildDiagnostic> = vec![];
+  for data in result {
     let source_id = ModuleId::new(data.id.as_str());
     let Some(state) = module_id_to_idx.get(&source_id) else {
       continue;
@@ -30,21 +33,29 @@ pub async fn defer_sync_scan_data(
     };
     // TODO: Document this and recommend user to return `moduleSideEffects` in hook return
     // value rather than mutate the `ModuleInfo`
-    normal.ecma_view.side_effects = match data.side_effects {
+    let side_effects = match data.side_effects {
       Some(HookSideEffects::False) => DeterminedSideEffects::UserDefined(false),
       Some(HookSideEffects::NoTreeshake) => DeterminedSideEffects::NoTreeshake,
       _ => {
         // for Some(HookSideEffects::True) and None,
         // we need to re analyze the side effects
-        normalize_side_effects(
+        match normalize_side_effects(
           options,
           &normal.originative_resolved_id,
           Some(&scan_stage_output.stmt_infos[module_idx]),
           data.side_effects,
         )
-        .await?
+        .await
+        {
+          Ok(side_effects) => side_effects,
+          Err(error) => {
+            errors.extend(error.into_vec());
+            continue;
+          }
+        }
       }
     };
+    normal.ecma_view.side_effects = side_effects;
   }
-  Ok(())
+  if errors.is_empty() { Ok(()) } else { Err(errors.into()) }
 }

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -48,10 +48,15 @@ impl ScanStageCache {
   }
 
   pub async fn update_defer_sync_data(&mut self, options: &SharedOptions) -> BuildResult<()> {
-    let snapshot = self.take_snapshot();
-    if let Some(mut snapshot) = snapshot {
-      defer_sync_scan_data(options, &self.module_id_to_idx, &mut snapshot).await?;
+    if let Some(mut snapshot) = self.take_snapshot() {
+      // `defer_sync_scan_data` mutates `snapshot` in place; restore it on every
+      // outcome. Bailing with `?` would drop it, leaving `self.snapshot == None`
+      // and panicking the next HMR cycle's `get_snapshot()`. A partially-synced
+      // snapshot is recoverable; a missing one is not.
+      // See meta/design/bundler-data-lifecycle.md ("Cache integrity on a failed build").
+      let result = defer_sync_scan_data(options, &self.module_id_to_idx, &mut snapshot).await;
       self.set_snapshot(snapshot);
+      result?;
     }
     Ok(())
   }

--- a/crates/rolldown/tests/rolldown/topics/hmr/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mod.rs
@@ -1,1 +1,2 @@
 mod add_watch_file;
+mod recover_after_generate_bundle_error;

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
@@ -1,0 +1,121 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => "dep" });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+if (dep_hot) dep_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+console.log("dep");
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "FAIL_GENERATE_BUNDLE";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
+
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
+
+## Build Output
+
+### Errors
+
+#### PLUGIN_ERROR
+
+```text
+[fail-generate-bundle-on-marker] Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
+simulated post-link generate_bundle failure
+
+```
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "recovered";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
+
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
+
+## Build Output
+
+### Assets
+
+#### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+const value = "recovered";
+if (dep_hot) dep_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+console.log(value);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.hmr-0.js
@@ -1,0 +1,5 @@
+export const value = 'FAIL_GENERATE_BUNDLE';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.hmr-1.js
@@ -1,0 +1,5 @@
+export const value = 'recovered';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/dep.js
@@ -1,0 +1,5 @@
+export const value = 'dep';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/main.js
@@ -1,0 +1,2 @@
+import { value } from './dep';
+console.log(value);

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/mod.rs
@@ -1,0 +1,88 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, DevModeOptions, ExperimentalOptions, InputItem};
+use rolldown_error::BatchedBuildDiagnostic;
+use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+use rolldown_testing::{
+  manual_integration_test,
+  test_config::{DevTestMeta, TestMeta},
+};
+
+/// When this string is found in any generated chunk, the plugin below fails its
+/// `generate_bundle` hook. `dep.hmr-0.js` embeds it so the first HMR rebuild
+/// fails; `dep.hmr-1.js` drops it so the next rebuild succeeds.
+const FAIL_MARKER: &[u8] = b"FAIL_GENERATE_BUNDLE";
+
+/// Fails the `generate_bundle` hook whenever a generated chunk contains
+/// `FAIL_MARKER`.
+///
+/// `generate_bundle` runs inside `bundle_up`, *after* `create_output` has torn
+/// the symbol-table scoping out of the long-lived scan cache. Failing here
+/// reproduces a post-link dev-rebuild error that used to leave `ScanStageCache`
+/// broken (either emptied or with torn scoping) and panic the next HMR cycle.
+#[derive(Debug)]
+struct FailGenerateBundleOnMarkerPlugin;
+
+impl Plugin for FailGenerateBundleOnMarkerPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "fail-generate-bundle-on-marker".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::GenerateBundle
+  }
+
+  async fn generate_bundle(
+    &self,
+    _ctx: &PluginContext,
+    args: &mut rolldown_plugin::HookGenerateBundleArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    let should_fail = args.bundle.iter().any(|output| {
+      output.content_as_bytes().windows(FAIL_MARKER.len()).any(|window| window == FAIL_MARKER)
+    });
+    if should_fail {
+      Err(BatchedBuildDiagnostic::new(vec![
+        anyhow::anyhow!("simulated post-link generate_bundle failure").into(),
+      ]))?;
+    }
+    Ok(())
+  }
+}
+
+/// Regression test: a dev rebuild that fails *after* the link stage must leave
+/// the scan cache whole, so the next HMR cycle recovers instead of panicking.
+///
+/// - Initial build succeeds and populates `ScanStageCache`.
+/// - HMR step 0 edits `dep.js` to embed `FAIL_MARKER`; the incremental rebuild
+///   fails in the `generate_bundle` hook (post-link).
+/// - HMR step 1 edits `dep.js` back to a clean state; the incremental rebuild
+///   must succeed.
+///
+/// Before the fix, the failed step-0 rebuild left the cache either empty
+/// (`with_cached_bundle` `?`-bailed and dropped it) or with torn symbol-table
+/// scoping (`merge_immutable_fields_for_cache` was skipped on the error path),
+/// and step 1 panicked in `get_snapshot()` / `oxc_semantic`.
+#[tokio::test(flavor = "multi_thread")]
+async fn recover_after_generate_bundle_error() {
+  manual_integration_test!()
+    .build(TestMeta {
+      expect_executed: false,
+      dev: DevTestMeta { ensure_latest_build_output_for_each_step: true, ..Default::default() },
+      ..Default::default()
+    })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem {
+          name: Some("entry".to_string()),
+          import: "./main.js".to_string(),
+        }]),
+        experimental: Some(ExperimentalOptions {
+          dev_mode: Some(DevModeOptions::default()),
+          ..Default::default()
+        }),
+        ..Default::default()
+      },
+      vec![Arc::new(FailGenerateBundleOnMarkerPlugin)],
+    )
+    .await;
+}

--- a/crates/rolldown_testing/src/test_config.rs
+++ b/crates/rolldown_testing/src/test_config.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 
 use jsonschema::{Draft, Validator};
 
-pub use rolldown_testing_config::{TestConfig, TestMeta};
+pub use rolldown_testing_config::{DevTestMeta, TestConfig, TestMeta};
 
 use rolldown_workspace::crate_dir;
 

--- a/crates/rolldown_testing_config/src/lib.rs
+++ b/crates/rolldown_testing_config/src/lib.rs
@@ -5,4 +5,7 @@ mod test_config;
 mod test_meta;
 mod utils;
 
-pub use crate::{config_variant::ConfigVariant, test_config::TestConfig, test_meta::TestMeta};
+pub use crate::{
+  config_variant::ConfigVariant, dev_test_meta::DevTestMeta, test_config::TestConfig,
+  test_meta::TestMeta,
+};

--- a/meta/design/bundler-data-lifecycle.md
+++ b/meta/design/bundler-data-lifecycle.md
@@ -85,6 +85,53 @@ Bundler.cache (ScanStageCache) ──(move)──> Bundle.cache (temporary holde
 | `module_idx_by_abs_path`  | Path-based lookup for watcher                       |
 | `module_idx_by_stable_id` | Stable ID lookup for HMR                            |
 
+### Cache integrity on a failed build
+
+`ScanStageCache` must survive a _failed_ build whole, not just a successful one
+— otherwise the next HMR/incremental build reads a broken cache and panics. The
+invariant is: **between builds, `Bundler::cache` is always whole** — `snapshot`
+is `Some` and its `symbol_ref_db` carries real scoping.
+
+A build mutates the cache through several non-atomic "tear → repair" steps. An
+early `?` return landing between a tear and its repair used to leave the cache
+permanently broken:
+
+| Step       | Tear                                                                                        | Repair                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Ownership  | `with_cached_bundle` `mem::take`s `Bundler::cache`, leaving `default()` (`snapshot: None`)  | moves `Bundle::cache` back into `Bundler`                                 |
+| Scoping    | `create_output` / `make_copy` clone `symbol_ref_db` _without_ scoping (a perf optimization) | `merge_immutable_fields_for_cache` reinstates scoping from the link stage |
+| Defer-sync | `ScanStageCache::update_defer_sync_data` `take`s the snapshot out                           | `set_snapshot` puts it back                                               |
+
+Each repair therefore runs **unconditionally**:
+
+- `with_cached_bundle` moves the cache back on every outcome — it never `?`-bails.
+- `bundle_up` runs `merge_immutable_fields_for_cache` right after the link
+  stage, _before_ the fallible `generate_bundle` / filename-check /
+  `invalidate_js_side_cache` steps.
+- `update_defer_sync_data` restores the snapshot before propagating an error.
+
+A build that fails _before_ touching the cache (e.g. a scan-stage parse error)
+needs no repair — `scan_modules` returns early and the cache is untouched.
+
+**Why keep a cache from a failed build at all?** Committing a _torn_ cache is
+worse than dropping it: an empty snapshot panics the next `get_snapshot()`, and
+torn scoping makes `oxc_semantic` index out of bounds during the next link. A
+whole-but-slightly-stale cache is recoverable; a broken one is not. The recovery
+`BundleMode` is `IncrementalFullBuild` (see the table below) — it re-scans
+everything, but still relies on the cache being structurally valid to merge into.
+
+**Presence is not freshness.** Restoring the snapshot guarantees it is _present_
+and _structurally valid_ — not that every field is current. `defer_sync_scan_data`
+(per-module side-effect re-analysis) is deliberately **best-effort**: a module
+that fails to re-analyze is skipped — it keeps its prior `side_effects` — its
+error is collected, and the remaining modules are still synced. So a failed
+build can leave a module with stale `side_effects`. That is safe _only_ because
+`side_effects` is an independent per-module field with no cross-module invariant:
+a stale value is still a valid value, and the next successful build re-syncs it.
+The general rule for a torn-window repair: restore a _structurally consistent_
+cache; where content freshness can't be guaranteed under partial failure,
+confine the staleness to fields that are safe to be stale.
+
 ## BundleMode
 
 `BundleMode` makes the three incremental states explicit. Before this enum, the code used `ScanMode` + `is_incremental_build_enabled` combinations that were ambiguous and bug-prone.


### PR DESCRIPTION
## Summary

In dev mode, `ScanStageCache` (`Bundler::cache`) is long-lived — it persists across rebuilds and every HMR cycle reads it. A build mutates it through several non-atomic *tear → repair* steps. If the build fails (`?`-returns) **between** a tear and its repair, the cache is left permanently broken, and the next HMR/incremental build panics on it:

```
panicked at crates/rolldown/src/types/scan_stage_cache.rs:
called `Option::unwrap()` on a `None` value
```

A failed build should be recoverable; the dev server must survive it.

## Root cause

A build temporarily tears the cache apart and puts it back, in three places. If it fails (`?`-returns) mid-way, the "put back" is skipped and the cache stays broken:

- **`with_cached_bundle`** — takes the cache out, must move it back
- **`bundle_up`** — strips symbol scoping from the cache, must reinstate it
- **`update_defer_sync_data`** — takes the snapshot out, must put it back

The next build then reads a broken cache and panics — on an empty snapshot (`get_snapshot()`) or a torn one (`oxc_semantic` on the next link).

## Fix

Make every repair run **unconditionally**:

- `with_cached_bundle` moves the cache back on every outcome.
- `bundle_up` runs `merge_immutable_fields_for_cache` right after the link stage, before the fallible steps.
- `update_defer_sync_data` restores the snapshot before propagating any error.

`defer_sync_scan_data` is also made best-effort: a per-module failure no longer aborts the loop — that module keeps its prior `side_effects`, errors are collected and returned batched. Safe because `side_effects` has no cross-module invariant and re-syncs on the next successful build.

The success path is unchanged.

## Test & docs

- New regression test `topics/hmr/recover_after_generate_bundle_error/` — a plugin fails `generate_bundle` post-link on one HMR step; the next step must recover. Verified to fail when the fix is reverted.
- `meta/design/bundler-data-lifecycle.md` gains a *"Cache integrity on a failed build"* section, referenced from all three fix sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
