### PR TITLE
refactor: distinguish `map: null` vs `map: undefined` in transform hook output

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
@@ -1,18 +1,21 @@
+use napi::{Either, bindgen_prelude::Null};
 use rolldown::ModuleType;
-use rolldown_plugin::HookTransformOutput;
+use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap};
 
 use super::binding_hook_side_effects::BindingHookSideEffects;
 use crate::types::binding_sourcemap::BindingSourcemap;
 
 // This struct is used to both pass to JS and receive from JS:
-// - Pass to JS: `From<HookTransformOutput>` impl (line 30) returned from builtin plugins
-// - Receive from JS: `TryFrom` impl (line 17) when JS plugins return transform results
+// - Pass to JS: `From<HookTransformOutput>` impl returned from builtin plugins
+// - Receive from JS: `TryFrom` impl when JS plugins return transform results
 #[napi_derive::napi(object)]
 #[derive(Default, derive_more::Debug)]
 pub struct BindingHookTransformOutput {
   pub code: Option<String>,
   pub module_side_effects: Option<BindingHookSideEffects>,
-  pub map: Option<BindingSourcemap>,
+  /// A sourcemap, or `null` to explicitly signal "no sourcemap" (distinct from
+  /// omitting the field, which mirrors Rollup's "possibly broken" semantics).
+  pub map: Option<Either<BindingSourcemap, Null>>,
   pub module_type: Option<String>,
 }
 
@@ -20,9 +23,16 @@ impl TryFrom<BindingHookTransformOutput> for HookTransformOutput {
   type Error = anyhow::Error;
 
   fn try_from(value: BindingHookTransformOutput) -> Result<Self, Self::Error> {
+    let map = match value.map {
+      Some(Either::A(map)) => HookTransformOutputMap::Sourcemap(
+        TryInto::<rolldown_sourcemap::SourceMap>::try_into(map)?.into(),
+      ),
+      Some(Either::B(_)) => HookTransformOutputMap::Null,
+      None => HookTransformOutputMap::Omitted,
+    };
     Ok(Self {
       code: value.code,
-      map: value.map.map(TryInto::try_into).transpose()?,
+      map,
       side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
       module_type: value.module_type.map(|ty| ModuleType::from_str_with_fallback(ty.as_str())),
     })
@@ -31,9 +41,14 @@ impl TryFrom<BindingHookTransformOutput> for HookTransformOutput {
 
 impl From<HookTransformOutput> for BindingHookTransformOutput {
   fn from(value: HookTransformOutput) -> Self {
+    let map = match value.map {
+      HookTransformOutputMap::Sourcemap(map) => Some(Either::A(map.to_json().into())),
+      HookTransformOutputMap::Null => Some(Either::B(Null)),
+      HookTransformOutputMap::Omitted => None,
+    };
     Self {
       code: value.code,
-      map: value.map.map(|v| v.to_json().into()),
+      map,
       module_side_effects: value.side_effects.map(Into::into),
       module_type: value.module_type.map(|v| v.to_string()),
     }

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -50,7 +50,7 @@ pub use crate::{
   types::hook_timing::HookTimingCollector,
   types::hook_transform_args::HookTransformArgs,
   types::hook_transform_ast_args::HookTransformAstArgs,
-  types::hook_transform_output::HookTransformOutput,
+  types::hook_transform_output::{HookTransformOutput, HookTransformOutputMap},
   types::hook_write_bundle_args::HookWriteBundleArgs,
   types::plugin_context_resolve_options::PluginContextResolveOptions,
   types::plugin_hook_meta::{PluginHookMeta, PluginOrder},

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -297,7 +297,9 @@ impl PluginDriver {
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
         original_sourcemap_chain = plugin_sourcemap_chain.into_inner();
-        if let Some(map) = self.normalize_transform_sourcemap(r.map, id, &code, r.code.as_ref()) {
+        if let Some(map) =
+          self.normalize_transform_sourcemap(r.map.into_sourcemap(), id, &code, r.code.as_ref())
+        {
           original_sourcemap_chain.push(SourcemapChainElement::Transform((plugin_idx, map)));
         }
         plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);

--- a/crates/rolldown_plugin/src/types/hook_transform_output.rs
+++ b/crates/rolldown_plugin/src/types/hook_transform_output.rs
@@ -2,10 +2,47 @@ use rolldown_common::ModuleType;
 use rolldown_common::side_effects::HookSideEffects;
 use rolldown_sourcemap::SourceMap;
 
+/// The sourcemap returned by a transform plugin's `map` field.
+///
+/// Mirrors Rollup's behavior where `null` and an omitted `map` field differ:
+///
+/// - [`Self::Omitted`]: the plugin returned a transform result without setting
+///   `map` (JS `undefined`). Treated as a possibly broken sourcemap.
+/// - [`Self::Null`]: the plugin returned `map: null` to explicitly signal that
+///   no sourcemap is intended for this transformation.
+/// - [`Self::Sourcemap`]: the plugin returned an actual sourcemap.
+#[derive(Debug, Default, Clone)]
+pub enum HookTransformOutputMap {
+  #[default]
+  Omitted,
+  Null,
+  Sourcemap(Box<SourceMap>),
+}
+
+impl HookTransformOutputMap {
+  /// Returns the sourcemap if one was provided.
+  pub fn into_sourcemap(self) -> Option<SourceMap> {
+    match self {
+      Self::Sourcemap(map) => Some(*map),
+      Self::Omitted | Self::Null => None,
+    }
+  }
+
+  pub fn from_if_enabled(enabled: bool, generate: impl FnOnce() -> SourceMap) -> Self {
+    if enabled { Self::Sourcemap(Box::new(generate())) } else { Self::Null }
+  }
+}
+
+impl From<SourceMap> for HookTransformOutputMap {
+  fn from(map: SourceMap) -> Self {
+    Self::Sourcemap(Box::new(map))
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct HookTransformOutput {
   pub code: Option<String>,
-  pub map: Option<SourceMap>,
+  pub map: HookTransformOutputMap,
   pub side_effects: Option<HookSideEffects>,
   pub module_type: Option<ModuleType>,
 }

--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -3,7 +3,9 @@ use std::ops::Range;
 use std::{cmp::Reverse, sync::Arc};
 
 use anyhow::Result;
-use rolldown_plugin::{HookRenderChunkOutput, HookTransformOutput, HookUsage, Plugin};
+use rolldown_plugin::{
+  HookRenderChunkOutput, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
+};
 use rustc_hash::FxHashMap;
 use string_wizard::{MagicString, SourceMapOptions};
 
@@ -193,7 +195,7 @@ impl Plugin for ReplacePlugin {
     if self.try_replace(args.code, &mut magic_string) {
       return Ok(Some(HookTransformOutput {
         code: Some(magic_string.to_string()),
-        map: self.sourcemap.then(|| {
+        map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {
           magic_string.source_map(SourceMapOptions {
             hires: string_wizard::Hires::True,
             include_content: false,

--- a/crates/rolldown_plugin_vite_css/src/lib.rs
+++ b/crates/rolldown_plugin_vite_css/src/lib.rs
@@ -1,6 +1,8 @@
 use std::{future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
-use rolldown_plugin::{HookLoadOutput, HookTransformOutput, HookUsage, LogWithoutPlugin, Plugin};
+use rolldown_plugin::{
+  HookLoadOutput, HookTransformOutput, HookTransformOutputMap, HookUsage, LogWithoutPlugin, Plugin,
+};
 use rolldown_plugin_utils::{
   FileToUrlEnv, PublicFileToBuiltUrlEnv, UsizeOrFunction, check_public_file,
   constants::CSSModuleCache, css::is_css_request, find_special_query, inject_query,
@@ -126,7 +128,11 @@ impl Plugin for ViteCSSPlugin {
       }
     }
 
-    Ok(Some(HookTransformOutput { code: Some(code), map, ..Default::default() }))
+    Ok(Some(HookTransformOutput {
+      code: Some(code),
+      map: if let Some(map) = map { map.into() } else { HookTransformOutputMap::Omitted },
+      ..Default::default()
+    }))
   }
 }
 

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -8,8 +8,8 @@ use oxc::ast_visit::Visit;
 use rolldown_common::ModuleType;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, HookTransformOutput, HookUsage, Plugin, PluginContext,
-  SharedLoadPluginContext,
+  HookResolveIdReturn, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
+  PluginContext, SharedLoadPluginContext,
 };
 use rolldown_utils::{
   futures::{block_on, block_on_spawn_all},
@@ -141,7 +141,7 @@ impl Plugin for ViteDynamicImportVarsPlugin {
         }
         return Ok(Some(HookTransformOutput {
           code: Some(magic_string.to_string()),
-          map: self.sourcemap.then(|| {
+          map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {
             magic_string.source_map(string_wizard::SourceMapOptions {
               hires: string_wizard::Hires::Boundary,
               source: args.id.into(),

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, path::PathBuf};
 
 use oxc::ast_visit::Visit;
 use rolldown_common::ModuleType;
-use rolldown_plugin::{HookTransformOutput, HookUsage, Plugin};
+use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
 use sugar_path::SugarPath as _;
 
 #[derive(Debug, Default)]
@@ -72,7 +72,7 @@ impl Plugin for ViteImportGlobPlugin {
       if let Some(magic_string) = visitor.magic_string {
         return Ok(Some(HookTransformOutput {
           code: Some(magic_string.to_string()),
-          map: self.sourcemap.then(|| {
+          map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {
             magic_string.source_map(string_wizard::SourceMapOptions {
               hires: string_wizard::Hires::Boundary,
               source: args.id.into(),

--- a/crates/rolldown_plugin_vite_json/src/lib.rs
+++ b/crates/rolldown_plugin_vite_json/src/lib.rs
@@ -62,7 +62,7 @@ impl Plugin for ViteJsonPlugin {
           serde_json::to_string(&json)?,
           ")"
         )),
-        map: Some(SourceMap::default()),
+        map: SourceMap::default().into(),
         module_type: Some(ModuleType::Js),
         ..Default::default()
       }));
@@ -71,7 +71,7 @@ impl Plugin for ViteJsonPlugin {
     let value = serde_json::from_str(code)?;
     Ok(Some(HookTransformOutput {
       code: Some(data_to_esm(&value, self.named_exports)),
-      map: Some(SourceMap::default()),
+      map: SourceMap::default().into(),
       module_type: Some(ModuleType::Js),
       ..Default::default()
     }))

--- a/crates/rolldown_plugin_vite_react_refresh_wrapper/src/lib.rs
+++ b/crates/rolldown_plugin_vite_react_refresh_wrapper/src/lib.rs
@@ -3,7 +3,8 @@ use std::{borrow::Cow, fmt::Write, sync::LazyLock};
 use arcstr::ArcStr;
 use regex::Regex;
 use rolldown_plugin::{
-  HookResolveIdOutput, HookTransformOutput, HookUsage, Plugin, PluginHookMeta, PluginOrder,
+  HookResolveIdOutput, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
+  PluginHookMeta, PluginOrder,
 };
 use rolldown_plugin_utils::to_string_literal;
 use rolldown_utils::pattern_filter::{FilterResult, StringOrRegex, filter};
@@ -137,7 +138,11 @@ impl Plugin for ViteReactRefreshWrapperPlugin {
     let Some(new_code) = self.add_refresh_wrapper(args.code, args.id) else {
       return Ok(None);
     };
-    Ok(Some(HookTransformOutput { code: Some(new_code), map: None, ..Default::default() }))
+    Ok(Some(HookTransformOutput {
+      code: Some(new_code),
+      map: HookTransformOutputMap::Null,
+      ..Default::default()
+    }))
   }
 
   fn register_hook_usage(&self) -> HookUsage {

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -9,7 +9,7 @@ use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
 use rolldown_ecmascript::semantic_builder_for_transform;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, EventKind, Severity};
-use rolldown_plugin::{HookUsage, Plugin, SharedTransformPluginContext};
+use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
 
 #[derive(Debug, Default)]
@@ -97,7 +97,7 @@ impl Plugin for ViteTransformPlugin {
     }
 
     Ok(Some(rolldown_plugin::HookTransformOutput {
-      map,
+      map: if let Some(map) = map { map.into() } else { HookTransformOutputMap::Omitted },
       code: Some(code),
       module_type: Some(ModuleType::Js),
       ..Default::default()

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2235,7 +2235,11 @@ export type BindingHookSideEffects =
 export interface BindingHookTransformOutput {
   code?: string
   moduleSideEffects?: BindingHookSideEffects
-  map?: BindingSourcemap
+  /**
+   * A sourcemap, or `null` to explicitly signal "no sourcemap" (distinct from
+   * omitting the field, which mirrors Rollup's "possibly broken" semantics).
+   */
+  map?: BindingSourcemap | null
   moduleType?: string
 }
 

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -287,7 +287,10 @@ export function bindingifyTransform(
 
       return {
         code: normalizedCode,
-        map: bindingifySourcemap(normalizeTransformHookSourcemap(id, code, map)),
+        // Preserve the `map: null` (intentional opt-out) vs `map: undefined`
+        map:
+          bindingifySourcemap(normalizeTransformHookSourcemap(id, code, map)) ??
+          (ret.map === null ? null : undefined),
         moduleSideEffects: moduleOption.moduleSideEffects ?? undefined,
         moduleType: ret.moduleType,
       };


### PR DESCRIPTION
To emit `SOURCEMAP_BROKEN` warning, we need to distinguish `map: null` and `map: undefined`.