### PR TITLE
feat: add `SOURCEMAP_BROKEN` warning for transform hook

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -47,7 +47,7 @@ impl Generator for EcmaGenerator {
   #[expect(clippy::too_many_lines)]
   async fn instantiate_chunk(ctx: &mut GenerateContext<'_>) -> Result<BuildResult<GenerateOutput>> {
     let module_id_to_codegen_ret = std::mem::take(&mut ctx.module_id_to_codegen_ret);
-    let rendered_module_sources: RenderedModuleSources = ctx
+    let rendered_pairs: Vec<(RenderedModuleSource, Vec<BuildDiagnostic>)> = ctx
       .chunk
       .modules
       .par_iter()
@@ -59,14 +59,22 @@ impl Generator for EcmaGenerator {
           .map(|m| (m, codegen_ret.expect("should have codegen_ret")))
       })
       .map(|(m, codegen_ret)| {
-        RenderedModuleSource::new(
-          m.idx,
-          m.id.clone(),
-          m.exec_order,
-          render_ecma_module(m, ctx.options, codegen_ret),
+        let render = render_ecma_module(m, ctx.options, codegen_ret);
+        (
+          RenderedModuleSource::new(m.idx, m.id.clone(), m.exec_order, render.sources),
+          render.warnings,
         )
       })
       .collect::<Vec<_>>();
+
+    let mut sourcemap_broken_warnings: Vec<BuildDiagnostic> = Vec::new();
+    let rendered_module_sources: RenderedModuleSources = rendered_pairs
+      .into_iter()
+      .map(|(source, warnings)| {
+        sourcemap_broken_warnings.extend(warnings);
+        source
+      })
+      .collect();
 
     let rendered_modules: FxHashMap<ModuleId, RenderedModule> = rendered_module_sources
       .iter()
@@ -186,7 +194,7 @@ impl Generator for EcmaGenerator {
       None => None,
     };
 
-    let mut warnings = vec![];
+    let mut warnings = sourcemap_broken_warnings;
 
     // Warn when multiple shebang sources would produce duplicate shebangs in the output.
     // UMD format silently drops the entry hashbang, so it doesn't count as a shebang source.

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -583,7 +583,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             ast,
             raw_import_records,
             resolved_deps,
+            warnings,
           } = *task_result;
+          all_warnings.extend(warnings);
 
           let mut import_records = IndexVec::with_capacity(raw_import_records.len());
           for (raw_rec, info) in raw_import_records.into_iter().zip(resolved_deps) {

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -110,6 +110,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
 
     let mut sourcemap_chain = vec![];
     let mut hook_side_effects = self.resolved_id.side_effects.take();
+    let mut warnings = vec![];
     let (source, module_type) = self
       .load_source(&mut sourcemap_chain, &mut hook_side_effects, self.magic_string_tx.clone())
       .await?;
@@ -124,8 +125,6 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
         "Bundling CSS is no longer supported (experimental support has been removed). See https://github.com/rolldown/rolldown/issues/4271 for details.".to_string())
       )?;
     }
-
-    let mut warnings = vec![];
 
     let CreateEcmaViewReturn { mut ecma_view, ecma_related, raw_import_records, tla_keyword_span } =
       create_ecma_view(

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -211,6 +211,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
       resolved_deps,
       raw_import_records,
       local_symbol_ref_db: symbol_ref_db,
+      warnings: vec![],
     }));
 
     // If the main thread is dead, nothing we can do to handle these send failures.

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -265,24 +265,28 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
         for element in module.sourcemap_chain.drain(..) {
           match element {
             SourcemapChainElement::Load(_) => load_elements.push(element),
-            SourcemapChainElement::Transform(_) => transform_elements.push(element),
+            SourcemapChainElement::Transform(_) | SourcemapChainElement::Omitted { .. } => {
+              transform_elements.push(element);
+            }
           }
         }
 
         // Sort only Transform elements by plugin order
         transform_elements.sort_by(|a, b| {
-          if let (
-            SourcemapChainElement::Transform((a_plugin_idx, _)),
-            SourcemapChainElement::Transform((b_plugin_idx, _)),
-          ) = (a, b)
-          {
-            let a_order =
-              transform_plugin_order_map.get(a_plugin_idx).copied().unwrap_or(usize::MAX);
-            let b_order =
-              transform_plugin_order_map.get(b_plugin_idx).copied().unwrap_or(usize::MAX);
-            a_order.cmp(&b_order)
-          } else {
-            std::cmp::Ordering::Equal
+          let plugin_idx_of = |el: &SourcemapChainElement| match el {
+            SourcemapChainElement::Transform((plugin_idx, _))
+            | SourcemapChainElement::Omitted { plugin_idx, .. } => Some(*plugin_idx),
+            SourcemapChainElement::Load(_) => None,
+          };
+          match (plugin_idx_of(a), plugin_idx_of(b)) {
+            (Some(a_plugin_idx), Some(b_plugin_idx)) => {
+              let a_order =
+                transform_plugin_order_map.get(&a_plugin_idx).copied().unwrap_or(usize::MAX);
+              let b_order =
+                transform_plugin_order_map.get(&b_plugin_idx).copied().unwrap_or(usize::MAX);
+              a_order.cmp(&b_order)
+            }
+            _ => std::cmp::Ordering::Equal,
           }
         });
 

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -1,62 +1,89 @@
 use std::sync::Arc;
 
 use rolldown_common::{ModuleRenderOutput, NormalModule, NormalizedBundlerOptions};
-use rolldown_sourcemap::{Source, SourceMapSource, collapse_sourcemaps};
+use rolldown_error::BuildDiagnostic;
+use rolldown_sourcemap::{Source, SourceMapSource, collapse_sourcemaps, empty_sourcemap};
 use rolldown_utils::concat_string;
+
+pub struct RenderEcmaModuleOutput {
+  pub sources: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
+  /// `SOURCEMAP_BROKEN` warnings collected while collapsing this module's
+  /// sourcemap chain. Empty unless the module had `Omitted` chain entries
+  /// AND its code reached the chunk AND sourcemap output is enabled.
+  pub warnings: Vec<BuildDiagnostic>,
+}
 
 pub fn render_ecma_module(
   module: &NormalModule,
   options: &NormalizedBundlerOptions,
   render_output: ModuleRenderOutput,
-) -> Option<Arc<[Box<dyn Source + Send + Sync>]>> {
+) -> RenderEcmaModuleOutput {
   if render_output.code.is_empty() {
-    None
-  } else {
-    let mut sources: Vec<Box<dyn rolldown_sourcemap::Source + Send + Sync>> = Vec::with_capacity(6);
-    if options.experimental.is_attach_debug_info_enabled() {
-      sources.push(Box::new(concat_string!("//#region ", module.debug_id)));
-    }
+    return RenderEcmaModuleOutput { sources: None, warnings: vec![] };
+  }
+  let mut sources: Vec<Box<dyn rolldown_sourcemap::Source + Send + Sync>> = Vec::with_capacity(6);
+  if options.experimental.is_attach_debug_info_enabled() {
+    sources.push(Box::new(concat_string!("//#region ", module.debug_id)));
+  }
 
-    let enable_sourcemap = options.sourcemap.is_some() && !module.is_virtual();
+  let enable_sourcemap = options.sourcemap.is_some() && !module.is_virtual();
+  let mut warnings = vec![];
 
-    // Because oxc codegen sourcemap is last of sourcemap chain,
-    // If here no extra sourcemap need remapping, we using it as final module sourcemap.
-    // So here make sure using correct `source_name` and `source_content.
+  // Because oxc codegen sourcemap is last of sourcemap chain,
+  // If here no extra sourcemap need remapping, we using it as final module sourcemap.
+  // So here make sure using correct `source_name` and `source_content.
 
-    if enable_sourcemap {
-      let sourcemap = if module.sourcemap_chain.is_empty() {
-        render_output.map
-      } else {
-        let mut sourcemap_chain = module
-          .sourcemap_chain
-          .iter()
-          .map(|element| match element {
-            rolldown_common::SourcemapChainElement::Transform((_, sourcemap))
-            | rolldown_common::SourcemapChainElement::Load(sourcemap) => sourcemap,
-          })
-          .collect::<Vec<_>>();
-        if let Some(sourcemap) = render_output.map.as_ref() {
-          sourcemap_chain.push(sourcemap);
+  if enable_sourcemap {
+    let sourcemap = if module.sourcemap_chain.is_empty() {
+      render_output.map
+    } else {
+      // Materialize a sentinel sourcemap for each `Omitted` entry so we can
+      // pass `&SourceMap` references into `collapse_sourcemaps`. An empty
+      // sourcemap drops all subsequent token lookups — mirrors Rollup's
+      // empty-mappings `Link` for `{ missing: true }` entries.
+      let empty = empty_sourcemap();
+      let mut owned_chain: Vec<&rolldown_sourcemap::SourceMap> =
+        Vec::with_capacity(module.sourcemap_chain.len() + 1);
+      for element in &module.sourcemap_chain {
+        match element {
+          rolldown_common::SourcemapChainElement::Transform((_, sourcemap))
+          | rolldown_common::SourcemapChainElement::Load(sourcemap) => {
+            owned_chain.push(sourcemap);
+          }
+          rolldown_common::SourcemapChainElement::Omitted { plugin_name, .. } => {
+            owned_chain.push(&empty);
+            // Match Rollup: emit `SOURCEMAP_BROKEN` only when this module's
+            // transformed code actually contributes to a chunk and sourcemap
+            // output is enabled. Both are true here (`render_output.code` is
+            // non-empty, `enable_sourcemap` is true).
+            warnings.push(
+              BuildDiagnostic::sourcemap_broken(plugin_name.to_string(), module.id.to_string())
+                .with_severity_warning(),
+            );
+          }
         }
-        Some(collapse_sourcemaps(&sourcemap_chain))
-      };
-
-      if let Some(sourcemap) = sourcemap {
-        sources.push(Box::new(
-          SourceMapSource::new(render_output.code, sourcemap)
-            .with_pre_compute_sourcemap_data(options.is_sourcemap_enabled()),
-        ));
-      } else {
-        sources.push(Box::new(render_output.code));
       }
+      if let Some(sourcemap) = render_output.map.as_ref() {
+        owned_chain.push(sourcemap);
+      }
+      Some(collapse_sourcemaps(&owned_chain))
+    };
+
+    if let Some(sourcemap) = sourcemap {
+      sources.push(Box::new(
+        SourceMapSource::new(render_output.code, sourcemap)
+          .with_pre_compute_sourcemap_data(options.is_sourcemap_enabled()),
+      ));
     } else {
       sources.push(Box::new(render_output.code));
     }
-
-    if options.experimental.is_attach_debug_info_enabled() {
-      sources.push(Box::new("//#endregion"));
-    }
-
-    Some(Arc::from(sources.into_boxed_slice()))
+  } else {
+    sources.push(Box::new(render_output.code));
   }
+
+  if options.experimental.is_attach_debug_info_enabled() {
+    sources.push(Box::new("//#endregion"));
+  }
+
+  RenderEcmaModuleOutput { sources: Some(Arc::from(sources.into_boxed_slice())), warnings }
 }

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/mod.rs
@@ -1,3 +1,4 @@
 mod custom_arg_in_resolve;
 mod info_warn_debug;
 mod resolve_bare_relative;
+mod transform_hook_sourcemap_broken_warning;

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/entry.js
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/entry.js
@@ -1,0 +1,2 @@
+const greeting = 'hello world';
+console.log(greeting);

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/mod.rs
@@ -1,0 +1,209 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{Bundler, BundlerOptions, InputItem, SourceMapType};
+use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin};
+
+/// A plugin whose `transform` hook returns code without providing a sourcemap.
+/// `output_map` controls whether the result has `map: Omitted` (which triggers
+/// `SOURCEMAP_BROKEN` when sourcemap output is enabled) or `map: Null` (which
+/// always suppresses the warning). `mutate` controls whether the returned code
+/// differs from the input — `SOURCEMAP_BROKEN` fires either way, since Rollup
+/// keys off whether a map was provided, not whether the code changed.
+#[derive(Debug)]
+struct NoMapTransformPlugin {
+  output_map: fn() -> HookTransformOutputMap,
+  mutate: bool,
+}
+
+impl Plugin for NoMapTransformPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "no-map-transform".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform
+  }
+
+  async fn transform(
+    &self,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    // Only transform the entry module, not rolldown's internal runtime module,
+    // so each test produces exactly one `SOURCEMAP_BROKEN` warning.
+    if !args.id.ends_with("entry.js") {
+      return Ok(None);
+    }
+    let code = if self.mutate {
+      args.code.replace("'hello world'", "'hello from plugin'")
+    } else {
+      args.code.to_string()
+    };
+    Ok(Some(rolldown_plugin::HookTransformOutput {
+      code: Some(code),
+      map: (self.output_map)(),
+      ..Default::default()
+    }))
+  }
+}
+
+/// A captured `SOURCEMAP_BROKEN` warning: `(plugin, message, id)`.
+type CapturedWarning = (Option<String>, String, Option<String>);
+
+/// Builds `entry.js` with `NoMapTransformPlugin` and returns the `SOURCEMAP_BROKEN`
+/// warnings collected into `BundleOutput::warnings`. `sourcemap` controls whether
+/// sourcemap output is enabled; `mutate` controls whether the plugin's returned
+/// code differs from the input.
+async fn run(
+  output_map: fn() -> HookTransformOutputMap,
+  sourcemap: Option<SourceMapType>,
+  mutate: bool,
+) -> Vec<CapturedWarning> {
+  let mut bundler = Bundler::with_plugins(
+    BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "./entry.js".to_string(),
+      }]),
+      cwd: Some(
+        concat!(
+          env!("CARGO_MANIFEST_DIR"),
+          "/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning"
+        )
+        .into(),
+      ),
+      sourcemap,
+      ..Default::default()
+    },
+    vec![Arc::new(NoMapTransformPlugin { output_map, mutate })],
+  )
+  .expect("failed to create bundler");
+
+  let output = bundler.generate().await.expect("build should succeed");
+  output
+    .warnings
+    .iter()
+    .filter(|warning| warning.kind().to_string() == "SOURCEMAP_BROKEN")
+    .map(|warning| (warning.plugin(), warning.to_string(), warning.id()))
+    .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn omitted_map_emits_sourcemap_broken_warning() {
+  let warnings =
+    Box::pin(run(|| HookTransformOutputMap::Omitted, Some(SourceMapType::File), true)).await;
+  assert_eq!(warnings.len(), 1, "exactly one SOURCEMAP_BROKEN warning must be emitted");
+  let (plugin, message, id) = &warnings[0];
+  assert_eq!(plugin.as_deref(), Some("no-map-transform"));
+  assert!(
+    message.contains("didn't generate a sourcemap"),
+    "warning message should mention the missing sourcemap, got: {message}"
+  );
+  // The warning carries the id of the transformed module.
+  assert!(
+    id.as_deref().is_some_and(|id| id.ends_with("entry.js")),
+    "SOURCEMAP_BROKEN warning should carry the module id, got: {id:?}"
+  );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn omitted_map_emits_warning_even_when_code_unchanged() {
+  // Rollup emits `SOURCEMAP_BROKEN` whenever a transform hook returns code without
+  // a sourcemap, even if the returned code is identical to the input (see Rollup's
+  // `transform-without-sourcemap-render-chunk` fixture).
+  let warnings =
+    Box::pin(run(|| HookTransformOutputMap::Omitted, Some(SourceMapType::File), false)).await;
+  assert_eq!(
+    warnings.len(),
+    1,
+    "SOURCEMAP_BROKEN warning must be emitted when map is Omitted, even if code is unchanged"
+  );
+  assert_eq!(warnings[0].0.as_deref(), Some("no-map-transform"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn null_map_suppresses_sourcemap_broken_warning() {
+  let warnings =
+    Box::pin(run(|| HookTransformOutputMap::Null, Some(SourceMapType::File), true)).await;
+  assert!(warnings.is_empty(), "SOURCEMAP_BROKEN warning must not be emitted when map is Null");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn omitted_map_without_sourcemap_suppresses_warning() {
+  let warnings = Box::pin(run(|| HookTransformOutputMap::Omitted, None, true)).await;
+  assert!(
+    warnings.is_empty(),
+    "SOURCEMAP_BROKEN warning must not be emitted when sourcemap output is disabled, \
+     mirroring Rollup which only inspects the sourcemap chain while collapsing sourcemaps"
+  );
+}
+
+/// Mirrors Vite's `vite:build-html` plugin: a transform rewrites a module's
+/// body into a pure `import` (side-effect-only) so the module contributes no
+/// code to any final chunk. Rollup does NOT emit `SOURCEMAP_BROKEN` in that
+/// case because its warning fires during chunk sourcemap collapse, and a
+/// module whose body never reaches a chunk is never walked.
+#[derive(Debug)]
+struct RewriteToImportOnly;
+
+impl Plugin for RewriteToImportOnly {
+  fn name(&self) -> Cow<'static, str> {
+    "rewrite-to-import-only".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform
+  }
+
+  async fn transform(
+    &self,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !args.id.ends_with("entry.js") {
+      return Ok(None);
+    }
+    Ok(Some(rolldown_plugin::HookTransformOutput {
+      code: Some("import './reexport-target.js';".to_string()),
+      // Map omitted on purpose: Rollup pushes `{ missing: true }` into the
+      // chain here. We push `SourcemapChainElement::Omitted` and rely on the
+      // chunk-render-time check to skip the warning because the rewritten
+      // entry has no body left to contribute to the chunk.
+      map: HookTransformOutputMap::Omitted,
+      ..Default::default()
+    }))
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn omitted_map_suppressed_when_module_contributes_no_code_to_chunk() {
+  let mut bundler = Bundler::with_plugins(
+    BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "./entry.js".to_string(),
+      }]),
+      cwd: Some(
+        concat!(
+          env!("CARGO_MANIFEST_DIR"),
+          "/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning"
+        )
+        .into(),
+      ),
+      sourcemap: Some(SourceMapType::File),
+      ..Default::default()
+    },
+    vec![Arc::new(RewriteToImportOnly)],
+  )
+  .expect("failed to create bundler");
+
+  let output = bundler.generate().await.expect("build should succeed");
+  let warnings: Vec<_> =
+    output.warnings.iter().filter(|w| w.kind().to_string() == "SOURCEMAP_BROKEN").collect();
+  assert!(
+    warnings.is_empty(),
+    "SOURCEMAP_BROKEN must not fire when the transformed module's code does not reach a chunk \
+     (matches Rollup, where `collapseSourcemaps` only walks chains of modules in the chunk's \
+     `usedModules`). Got: {warnings:?}"
+  );
+}

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/reexport-target.js
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/transform_hook_sourcemap_broken_warning/reexport-target.js
@@ -1,0 +1,1 @@
+console.log('reexport target');

--- a/crates/rolldown_binding/src/generated/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/generated/binding_checks_options.rs
@@ -26,6 +26,7 @@ pub struct BindingChecksOptions {
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
   pub large_barrel_modules: Option<bool>,
+  pub sourcemap_broken: Option<bool>,
 }
 impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
   fn from(value: BindingChecksOptions) -> Self {
@@ -52,6 +53,7 @@ impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
       unsupported_tsconfig_option: value.unsupported_tsconfig_option,
       ineffective_dynamic_import: value.ineffective_dynamic_import,
       large_barrel_modules: value.large_barrel_modules,
+      sourcemap_broken: value.sourcemap_broken,
     }
   }
 }

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -84,7 +84,7 @@ pub async fn handle_warnings(
             exporter: warning.exporter(),
             code: Some(code),
             message: diag.to_color_string(),
-            plugin: None,
+            plugin: warning.plugin(),
             loc,
             pos,
             ids: warning.ids(),

--- a/crates/rolldown_common/src/generated/checks_options.rs
+++ b/crates/rolldown_common/src/generated/checks_options.rs
@@ -34,6 +34,7 @@ pub struct ChecksOptions {
   pub unsupported_tsconfig_option: Option<bool>,
   pub ineffective_dynamic_import: Option<bool>,
   pub large_barrel_modules: Option<bool>,
+  pub sourcemap_broken: Option<bool>,
 }
 impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
   fn from(value: ChecksOptions) -> Self {
@@ -117,6 +118,10 @@ impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
     flag.set(
       rolldown_error::EventKindSwitcher::LargeBarrelModules,
       value.large_barrel_modules.unwrap_or(true),
+    );
+    flag.set(
+      rolldown_error::EventKindSwitcher::SourcemapBroken,
+      value.sourcemap_broken.unwrap_or(true),
     );
     flag
   }

--- a/crates/rolldown_common/src/module_loader/runtime_task_result.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_task_result.rs
@@ -1,5 +1,6 @@
 use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
+use rolldown_error::BuildDiagnostic;
 
 use crate::{
   ImportRecordIdx, NormalModule, RawImportRecord, ResolvedId, StmtInfos, SymbolRefDbForModule,
@@ -15,4 +16,5 @@ pub struct RuntimeModuleTaskResult {
   pub stmt_infos: StmtInfos,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
+  pub warnings: Vec<BuildDiagnostic>,
 }

--- a/crates/rolldown_common/src/types/sourcemap_chain_element.rs
+++ b/crates/rolldown_common/src/types/sourcemap_chain_element.rs
@@ -1,3 +1,4 @@
+use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
 use crate::PluginIdx;
@@ -8,4 +9,15 @@ pub enum SourcemapChainElement {
   Transform((PluginIdx, SourceMap)),
   /// An inline source map represented as a JSON string.
   Load(SourceMap),
+  /// A transform hook returned changed code without a sourcemap.
+  ///
+  /// Mirrors Rollup's `{ missing: true, plugin }` chain entry: when this
+  /// element is collapsed during chunk generation, it breaks the chain
+  /// (behaves like an empty sourcemap) and emits a `SOURCEMAP_BROKEN`
+  /// warning — but only if the owning module's code actually contributes
+  /// to a rendered chunk and sourcemap output is enabled. Deferring the
+  /// warning to collapse time matches Rollup, which skips the warning for
+  /// modules whose transformed code never reaches a chunk (e.g. an HTML
+  /// entry rewritten to side-effect-only imports).
+  Omitted { plugin_idx: PluginIdx, plugin_name: ArcStr },
 }

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -36,6 +36,7 @@ use super::events::plugin_timings::{PluginTimingInfo, PluginTimings};
 use super::events::prefer_builtin_feature::PreferBuiltinFeature;
 use super::events::require_tla::RequireTla;
 use super::events::resolve_error::DiagnosableResolveError;
+use super::events::sourcemap_broken::SourcemapBroken;
 
 use super::events::tsconfig_error::TsConfigError;
 use super::events::unhandleable_error::UnhandleableError;
@@ -410,6 +411,10 @@ impl BuildDiagnostic {
 
   pub fn duplicate_shebang(filename: String, source: &str) -> Self {
     Self::new_inner(DuplicateShebang { filename, source: source.to_string() })
+  }
+
+  pub fn sourcemap_broken(plugin_name: String, id: String) -> Self {
+    Self::new_inner(SourcemapBroken { plugin_name, id })
   }
 
   pub fn tsconfig_error(file_path: String, reason: ResolveError) -> Self {

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -48,6 +48,7 @@ pub mod prefer_builtin_feature;
 pub mod require_tla;
 pub mod resolve_error;
 pub mod runtime_module_symbol_not_found;
+pub mod sourcemap_broken;
 pub mod tsconfig_error;
 pub mod unhandleable_error;
 pub mod unloadable_dependency;
@@ -66,6 +67,10 @@ pub trait BuildEvent: Debug + Sync + Send + AsAny + AsAnyMut {
   // extra properties to match RollupLog interface
   // https://rollupjs.org/configuration-options/#onlog
   fn id(&self) -> Option<String> {
+    None
+  }
+
+  fn plugin(&self) -> Option<String> {
     None
   }
 

--- a/crates/rolldown_error/src/build_diagnostic/events/sourcemap_broken.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/sourcemap_broken.rs
@@ -1,0 +1,30 @@
+use super::BuildEvent;
+use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::EventKind};
+
+#[derive(Debug)]
+pub struct SourcemapBroken {
+  pub plugin_name: String,
+  /// The id of the module whose transform broke the sourcemap chain.
+  pub id: String,
+}
+
+impl BuildEvent for SourcemapBroken {
+  fn kind(&self) -> EventKind {
+    EventKind::SourcemapBroken
+  }
+
+  fn id(&self) -> Option<String> {
+    Some(self.id.clone())
+  }
+
+  fn plugin(&self) -> Option<String> {
+    Some(self.plugin_name.clone())
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    format!(
+      "Sourcemap is likely to be incorrect: a plugin ({}) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help: https://rolldown.rs/guide/troubleshooting#warning-sourcemap-is-likely-to-be-incorrect",
+      self.plugin_name
+    )
+  }
+}

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -45,6 +45,10 @@ impl BuildDiagnostic {
     self.inner.id()
   }
 
+  pub fn plugin(&self) -> Option<String> {
+    self.inner.plugin()
+  }
+
   pub fn kind(&self) -> crate::types::event_kind::EventKind {
     self.inner.kind()
   }

--- a/crates/rolldown_error/src/generated/event_kind_switcher.rs
+++ b/crates/rolldown_error/src/generated/event_kind_switcher.rs
@@ -51,5 +51,6 @@ bitflags! {
     const IneffectiveDynamicImport = 1 << 44;
     const RequireTlaError = 1 << 45;
     const LargeBarrelModules = 1 << 46;
+    const SourcemapBroken = 1 << 47;
   }
 }

--- a/crates/rolldown_error/src/types/event_kind.rs
+++ b/crates/rolldown_error/src/types/event_kind.rs
@@ -126,6 +126,8 @@ pub enum EventKind {
   ///
   /// See [Large barrel modules](https://rolldown.rs/in-depth/lazy-barrel-optimization#large-barrel-modules) for more details.
   LargeBarrelModules = 46,
+  /// Whether to emit warnings when a plugin transforms code without generating a sourcemap.
+  SourcemapBroken = 47,
 }
 
 impl Display for EventKind {
@@ -187,6 +189,7 @@ impl Display for EventKind {
       EventKind::IneffectiveDynamicImport => write!(f, "INEFFECTIVE_DYNAMIC_IMPORT"),
       EventKind::RequireTlaError => write!(f, "REQUIRE_TLA"),
       EventKind::LargeBarrelModules => write!(f, "LARGE_BARREL_MODULES"),
+      EventKind::SourcemapBroken => write!(f, "SOURCEMAP_BROKEN"),
     }
   }
 }

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use crate::PluginContext;
 use arcstr::ArcStr;
 use rolldown_common::{ModuleIdx, PluginIdx, SourceMapGenMsg, SourcemapChainElement};
-use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
+use rolldown_sourcemap::{SourceMap, collapse_sourcemaps, empty_sourcemap};
 use rolldown_utils::unique_arc::WeakRef;
 use std::sync::mpsc;
 use string_wizard::{MagicString, SourceMapOptions};
@@ -34,23 +34,28 @@ impl TransformPluginContext {
 
   pub fn get_combined_sourcemap(&self) -> SourceMap {
     self.sourcemap_chain.with_inner(|sourcemap_chain| {
+      // Materialize a sentinel for any `Omitted` chain entry so we can pass
+      // `&SourceMap` references to `collapse_sourcemaps`. Mirrors Rollup's
+      // empty-mappings Link: tokens looked up through this map drop out,
+      // producing a "broken" combined sourcemap — the right signal for a
+      // plugin whose upstream transform threw away its sourcemap.
+      let empty_map = empty_sourcemap();
+      let resolve = |element: &SourcemapChainElement| -> SourceMap {
+        match element {
+          SourcemapChainElement::Transform((_, sourcemap))
+          | SourcemapChainElement::Load(sourcemap) => sourcemap.clone(),
+          SourcemapChainElement::Omitted { .. } => empty_map.clone(),
+        }
+      };
       if sourcemap_chain.is_empty() {
         self.create_sourcemap()
       } else if sourcemap_chain.len() == 1 {
-        match sourcemap_chain.first().expect("should have one sourcemap") {
-          SourcemapChainElement::Transform((_, sourcemap))
-          | SourcemapChainElement::Load(sourcemap) => sourcemap.clone(),
-        }
+        resolve(sourcemap_chain.first().expect("should have one sourcemap"))
       } else {
-        let sourcemap_chain = sourcemap_chain
-          .iter()
-          .map(|element| match element {
-            SourcemapChainElement::Transform((_, sourcemap))
-            | SourcemapChainElement::Load(sourcemap) => sourcemap,
-          })
-          .collect::<Vec<_>>();
+        let owned: Vec<SourceMap> = sourcemap_chain.iter().map(resolve).collect();
+        let refs: Vec<&SourceMap> = owned.iter().collect();
         // TODO Here could be cache result for pervious sourcemap_chain, only remapping new sourcemap chain
-        collapse_sourcemaps(&sourcemap_chain)
+        collapse_sourcemaps(&refs)
       }
     })
   }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -19,7 +19,6 @@ use rolldown_devtools::{action, trace_action};
 use rolldown_error::CausedPlugin;
 use rolldown_sourcemap::SourceMap;
 use rolldown_utils::{IndexBitSet, unique_arc::UniqueArc};
-use string_wizard::{MagicString, SourceMapOptions};
 use tracing::{Instrument, debug_span};
 
 impl PluginDriver {
@@ -297,10 +296,25 @@ impl PluginDriver {
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
         original_sourcemap_chain = plugin_sourcemap_chain.into_inner();
+        let map_was_omitted = matches!(r.map, crate::HookTransformOutputMap::Omitted);
+        let has_code = r.code.is_some();
         if let Some(map) =
           self.normalize_transform_sourcemap(r.map.into_sourcemap(), id, &code, r.code.as_ref())
         {
           original_sourcemap_chain.push(SourcemapChainElement::Transform((plugin_idx, map)));
+        } else if map_was_omitted && has_code {
+          // The plugin returned a transform result without setting `map`
+          // (JS `undefined`). Mirror Rollup's `{ missing: true, plugin }`
+          // chain entry: push a sentinel so that, at chunk-render time,
+          // sourcemap collapse can emit `SOURCEMAP_BROKEN` only if this
+          // module's transformed code actually contributes to a chunk.
+          // Eagerly warning here flagged transforms (e.g. `vite:build-html`)
+          // whose output never reaches a chunk, which Rollup does not warn
+          // about.
+          original_sourcemap_chain.push(SourcemapChainElement::Omitted {
+            plugin_idx,
+            plugin_name: plugin.call_name().as_ref().into(),
+          });
         }
         plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);
         if let Some(v) = r.side_effects {
@@ -347,36 +361,21 @@ impl PluginDriver {
     map: Option<SourceMap>,
     id: &str,
     original_code: &str,
-    code: Option<&String>,
+    _code: Option<&String>,
   ) -> Option<SourceMap> {
-    if let Some(mut map) = map {
-      // If sourcemap  hasn't `sources`, using original id to fill it.
-      let source = map.get_source(0);
-      if source.is_none_or(|s| s.is_empty())
-        || (map.get_sources().count() == 1 && (source.map(AsRef::as_ref) != Some(id)))
-      {
-        map.set_sources(vec![id]);
-      }
-      // If sourcemap hasn't `sourcesContent`, using original code to fill it.
-      if map.get_source_content(0).is_none_or(|s| s.is_empty()) {
-        map.set_source_contents(vec![Some(original_code)]);
-      }
-      Some(map)
-    } else if let Some(code) = code {
-      if original_code == code {
-        None
-      } else {
-        // If sourcemap is empty and code has changed, need to create one remapping original code.
-        let magic_string = MagicString::new(original_code);
-        Some(magic_string.source_map(SourceMapOptions {
-          hires: string_wizard::Hires::Boundary,
-          include_content: true,
-          source: id.into(),
-        }))
-      }
-    } else {
-      None
+    let mut map = map?;
+    // If sourcemap hasn't `sources`, using original id to fill it.
+    let source = map.get_source(0);
+    if source.is_none_or(|s| s.is_empty())
+      || (map.get_sources().count() == 1 && (source.map(AsRef::as_ref) != Some(id)))
+    {
+      map.set_sources(vec![id]);
     }
+    // If sourcemap hasn't `sourcesContent`, using original code to fill it.
+    if map.get_source_content(0).is_none_or(|s| s.is_empty()) {
+      map.set_source_contents(vec![Some(original_code)]);
+    }
+    Some(map)
   }
 
   #[tracing::instrument(

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -44,6 +44,16 @@ pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap
   )
 }
 
+/// Builds an empty sourcemap with no tokens, sources, names, or contents.
+///
+/// Used as a sentinel in `collapse_sourcemaps` for an `Omitted` chain element
+/// (a transform hook that changed code but returned no map). Token lookups
+/// through this map always fail, so the collapsed result loses all mappings
+/// up to that point — mirroring Rollup's empty-mappings `Link`.
+pub fn empty_sourcemap() -> SourceMap {
+  SourceMap::new(None, vec![], None, vec![], vec![], Box::new([]), None)
+}
+
 // <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
 pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
   debug_assert!(sourcemap_chain.len() > 1);

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1497,6 +1497,12 @@
             "boolean",
             "null"
           ]
+        },
+        "sourcemapBroken": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -194,3 +194,9 @@ console.log(bar());
 ```
 
 :::
+
+## Warning: "Sourcemap is likely to be incorrect"
+
+You'll see this warning if you generate a sourcemap with your bundle ([`sourcemap: true`](/reference/OutputOptions.sourcemap) or `sourcemap: 'inline'`) but you're using one or more plugins that transformed code without generating a sourcemap for the transformation.
+
+Usually, a plugin will only omit the sourcemap if it (the plugin, not the bundle) was configured with `sourcemap: false` - so all you need to do is change that. If the plugin doesn't generate a sourcemap, consider raising an issue with the plugin author.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1926,6 +1926,7 @@ export interface BindingChecksOptions {
   unsupportedTsconfigOption?: boolean
   ineffectiveDynamicImport?: boolean
   largeBarrelModules?: boolean
+  sourcemapBroken?: boolean
 }
 
 export interface BindingChunkImportMap {

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -181,4 +181,10 @@ export interface ChecksOptions {
    * @default true
    * */
   largeBarrelModules?: boolean;
+
+  /**
+   * Whether to emit warnings when a plugin transforms code without generating a sourcemap.
+   * @default true
+   * */
+  sourcemapBroken?: boolean;
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -423,6 +423,12 @@ const ChecksOptionsSchema = v.strictObject({
       'Whether to emit info logs when a barrel module has a very large number of re-exports (more than 5000)',
     ),
   ),
+  sourcemapBroken: v.pipe(
+    v.optional(v.boolean()),
+    v.description(
+      'Whether to emit warnings when a plugin transforms code without generating a sourcemap',
+    ),
+  ),
 });
 isTypeTrue<IsSchemaSubType<typeof ChecksOptionsSchema, ChecksOptions>>();
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -42,6 +42,7 @@ OPTIONS
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
   --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
   --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.sourcemap-broken   Whether to emit warnings when a plugin transforms code without generating a sourcemap.
   --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
   --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
@@ -188,6 +189,7 @@ OPTIONS
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
   --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
   --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.sourcemap-broken   Whether to emit warnings when a plugin transforms code without generating a sourcemap.
   --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
   --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
@@ -334,6 +336,7 @@ OPTIONS
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
   --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
   --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.sourcemap-broken   Whether to emit warnings when a plugin transforms code without generating a sourcemap.
   --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
   --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
@@ -480,6 +483,7 @@ OPTIONS
   --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
   --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
   --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.sourcemap-broken   Whether to emit warnings when a plugin transforms code without generating a sourcemap.
   --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
   --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -362,7 +362,6 @@
 
 ### The error/warning not implement
  - rollup@hooks@Throws when using the "sourcemapFile" option for multiple chunks (`INVALID_OPTION` error)
- - rollup@function@transform-without-sourcemap-render-chunk: preserves sourcemap chains when transforming (`SOURCEMAP_BROKEN` warning)
  - rollup@function@non-function-hook-async: throws when providing a value for an async function hook (expected `INVALID_PLUGIN_HOOK` error, but got `PLUGIN_ERROR`)
  - rollup@function@non-function-hook-sync: throws when providing a value for a sync function hook (`INVALID_PLUGIN_HOOK` error)
  - rollup@function@export-type-mismatch-b: export type must be auto, default, named or none (expected `INVALID_EXPORT_OPTION` error, but got `InvalidArg`)

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 281,
   "ignored": 103,
-  "ignored(unsupported features)": 323,
+  "ignored(unsupported features)": 322,
   "ignored(treeshaking)": 327,
   "ignored(behavior passed, snapshot different)": 160,
-  "passed": 1212
+  "passed": 1213
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 281 |
 | ignored | 103 |
-| ignored(unsupported features) | 323 |
+| ignored(unsupported features) | 322 |
 | ignored(treeshaking) | 327 |
 | ignored(behavior passed, snapshot different) | 160 |
-| passed | 1212 |
+| passed | 1213 |

--- a/packages/rollup-tests/test/utils.js
+++ b/packages/rollup-tests/test/utils.js
@@ -83,6 +83,11 @@ function normalizeError(error, locExpected) {
 		// but binding is set for errors created on JS side
 		delete clone.binding;
 	}
+	if (clone.code === 'SOURCEMAP_BROKEN') {
+		// Rolldown attaches the module id to this warning, but Rollup's
+		// `logSourcemapBroken` is emitted at chunk-collapse time and carries no id.
+		delete clone.id;
+	}
 	for (const key in clone) {
 		if (clone[key] === undefined) {
 			delete clone[key];


### PR DESCRIPTION
Add `SOURCEMAP_BROKEN` warning and emit it for transform hook calls.

refs #6780 