### PR TITLE
chore(mimalloc-safe): update to a bug-fix branch for verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,8 +1408,7 @@ dependencies = [
 [[package]]
 name = "libmimalloc-sys2"
 version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c601df46d9245293af01d2e82529bef06fd46d7428cd079ba2ab73fe452e9fb"
+source = "git+https://github.com/shulaoda/mimalloc-safe?branch=fix%2Fapple-thread-local-recurse-guard#cdec41d4459bb6c9f6c3a091b62aed58e0c77e73"
 dependencies = [
  "cc",
  "cmake",
@@ -1483,8 +1482,7 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 [[package]]
 name = "mimalloc-safe"
 version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339faed83010f7e29846491de7db305c2624384271776cb27e08c9e44ee692c0"
+source = "git+https://github.com/shulaoda/mimalloc-safe?branch=fix%2Fapple-thread-local-recurse-guard#cdec41d4459bb6c9f6c3a091b62aed58e0c77e73"
 dependencies = [
  "libmimalloc-sys2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ json-escape-simd = "3"
 json-strip-comments = "3"
 jsonschema = { version = "0.46.5", default-features = false }
 memchr = "2.7.4"
-mimalloc-safe = "0.1.61"
+mimalloc-safe = { git = "https://github.com/shulaoda/mimalloc-safe", branch = "fix/apple-thread-local-recurse-guard" }
 mime = "0.3.17"
 nodejs-built-in-modules = "1.0.0"
 nom = "8.0.0"


### PR DESCRIPTION
See https://github.com/napi-rs/mimalloc-safe/pull/71 & https://github.com/rolldown/rolldown/actions/runs/26264825278/job/77305893292

This is temporarily merged to allow upgrade and integration, and will be validated in subsequent CI runs. It has already been confirmed to work in the current PR. It will be reverted before the next release, and mimalloc-safe will switch back to the official release version for production use.