### PR TITLE
chore(rolldown_plugin_lazy_compilation): add missing description

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rolldown_plugin_lazy_compilation/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Lazy-compilation plugin for Rolldown"
+publish = true
 
 [dependencies]
 arcstr = { workspace = true }


### PR DESCRIPTION
crates.io requires a `description` metadata field. Publishing this crate fails with:

```
the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description
```

Adds `description` and sets `publish = true` explicitly to match the other rolldown plugin crates.