### PR TITLE
test: add CJS namespace mutation repro

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ]
+  },
+  "expectExecuted": false,
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/_test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+
+const { result } = await import('./dist/main.js');
+
+assert.deepStrictEqual(result, {
+  existing: 'existing',
+  addedType: 'function',
+  defaultAddedType: 'function',
+});

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/augment.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/augment.cjs
@@ -1,0 +1,5 @@
+const target = require('./target.cjs');
+
+target.added = function added() {
+  return 'added';
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/main.js
@@ -1,0 +1,8 @@
+import * as target from './target.cjs';
+import './augment.cjs';
+
+export const result = {
+  existing: target.existing,
+  addedType: typeof target.added,
+  defaultAddedType: typeof target.default?.added,
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/target.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/target.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  existing: 'existing',
+};


### PR DESCRIPTION
This adds a minimal regression fixture for a CommonJS namespace import that is augmented by a later CommonJS side-effect import.

The fixture reproduces rolldown/rolldown#9512 without depending on Vite or Backbone. It currently fails because the generated namespace wrapper snapshots `module.exports` before `augment.cjs` mutates the same export object, while `target.default.added` still sees the mutation through the original object reference.

Expected result:

```js
{
  existing: 'existing',
  addedType: 'function',
  defaultAddedType: 'function',
}
```

Current result:

```js
{
  existing: 'existing',
  addedType: 'undefined',
  defaultAddedType: 'function',
}
```

Validation:

```sh
NEEDS_EXTENDED=false cargo run-fixture crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_namespace_late_mutation/_config.json
```

This PR is draft because the test is expected to fail until the namespace interop behavior is fixed.