### PR TITLE
chore: gate experimental/testing-only items to silence dead_code in publish builds

### DIFF
--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -15,6 +15,7 @@ impl Deref for Bundler {
 pub struct Bundler {
   pub(super) session: rolldown_devtools::Session,
   pub(super) bundle_factory: BundleFactory,
+  #[cfg_attr(not(feature = "experimental"), allow(dead_code))]
   pub(super) cache: ScanStageCache,
   pub(super) closed: bool,
 }

--- a/crates/rolldown/src/bundler/impl_bundler_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_build.rs
@@ -1,5 +1,7 @@
 use crate::types::bundle_output::BundleOutput;
-use rolldown_common::{BundleMode, ScanMode};
+use rolldown_common::BundleMode;
+#[cfg(feature = "experimental")]
+use rolldown_common::ScanMode;
 use rolldown_error::BuildResult;
 
 use super::bundler::Bundler;

--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -1,14 +1,22 @@
+#[cfg(feature = "experimental")]
 use super::Bundler;
+#[cfg(feature = "experimental")]
 use crate::hmr::hmr_stage::{HmrStage, HmrStageInput};
+#[cfg(feature = "experimental")]
 use rolldown_common::WatcherChangeKind;
+#[cfg(feature = "experimental")]
 use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrUpdate};
+#[cfg(feature = "experimental")]
 use rolldown_error::BuildResult;
+#[cfg(feature = "experimental")]
 use rolldown_utils::indexmap::FxIndexMap;
+#[cfg(feature = "experimental")]
 use rustc_hash::FxHashSet;
+#[cfg(feature = "experimental")]
 use std::sync::{Arc, atomic::AtomicU32};
 
+#[cfg(feature = "experimental")]
 impl Bundler {
-  #[cfg(feature = "experimental")]
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn compute_hmr_update_for_file_changes(
     &mut self,
@@ -32,7 +40,6 @@ impl Bundler {
     hmr_stage.compute_hmr_update_for_file_changes(changed_file_paths, clients).await
   }
 
-  #[cfg(feature = "experimental")]
   pub async fn compute_update_for_calling_invalidate(
     &mut self,
     invalidate_caller: String,
@@ -69,7 +76,6 @@ impl Bundler {
   /// This is called when a dynamically imported module is first requested at runtime.
   /// The module was previously stubbed with a proxy, and now we need to compile the
   /// actual module and its dependencies.
-  #[cfg(feature = "experimental")]
   pub async fn compile_lazy_entry(
     &mut self,
     module_id: String,

--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -1,10 +1,17 @@
+#[cfg(feature = "experimental")]
 use super::Bundler;
+#[cfg(feature = "experimental")]
 use crate::{Bundle, types::bundle_output::BundleOutput};
+#[cfg(feature = "experimental")]
 use arcstr::ArcStr;
+#[cfg(feature = "experimental")]
 use rolldown_common::{BundleMode, ScanMode};
+#[cfg(feature = "experimental")]
 use rolldown_error::BuildResult;
+#[cfg(feature = "experimental")]
 use std::mem;
 
+#[cfg(feature = "experimental")]
 impl Bundler {
   pub(crate) async fn with_cached_bundle<T>(
     &mut self,
@@ -23,7 +30,6 @@ impl Bundler {
     ret
   }
 
-  #[cfg(feature = "experimental")]
   pub async fn with_cached_bundle_experimental<T>(
     &mut self,
     bundle_mode: BundleMode,
@@ -32,7 +38,6 @@ impl Bundler {
     self.with_cached_bundle(bundle_mode, with_fn).await
   }
 
-  #[cfg(feature = "experimental")]
   pub async fn incremental_write(
     &mut self,
     scan_mode: ScanMode<ArcStr>,
@@ -40,7 +45,6 @@ impl Bundler {
     self.incremental_bundle(true, scan_mode).await
   }
 
-  #[cfg(feature = "experimental")]
   pub async fn incremental_generate(
     &mut self,
     scan_mode: ScanMode<ArcStr>,

--- a/crates/rolldown/src/hmr/mod.rs
+++ b/crates/rolldown/src/hmr/mod.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "experimental")]
 pub mod hmr_ast_finalizer;
+#[cfg(feature = "experimental")]
 pub mod hmr_stage;
+#[cfg(feature = "experimental")]
 pub mod impl_traverse_for_hmr_ast_finalizer;
 pub mod utils;

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -3,11 +3,17 @@ use oxc::{
   span::SPAN,
 };
 use rolldown_common::NormalModule;
-use rolldown_ecmascript::{CJS_MODULE_REF, CJS_ROLLDOWN_MODULE_REF};
+use rolldown_ecmascript::CJS_MODULE_REF;
+#[cfg(feature = "experimental")]
+use rolldown_ecmascript::CJS_ROLLDOWN_MODULE_REF;
 
-use crate::{hmr::hmr_ast_finalizer::HmrAstFinalizer, module_finalizers::ScopeHoistingFinalizer};
+#[cfg(feature = "experimental")]
+use crate::hmr::hmr_ast_finalizer::HmrAstFinalizer;
+use crate::module_finalizers::ScopeHoistingFinalizer;
 
+#[cfg(feature = "experimental")]
 pub static MODULE_EXPORTS_NAME_FOR_ESM: &str = "__rolldown_exports__";
+#[cfg(feature = "experimental")]
 pub static MODULE_ID_PARAM_FOR_HMR: &str = "__rolldown_module_id__";
 
 pub trait HmrAstBuilder<'any, 'ast> {
@@ -141,6 +147,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
   }
 }
 
+#[cfg(feature = "experimental")]
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
   fn builder(&self) -> &oxc::ast::AstBuilder<'ast> {
     self.builder

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -104,6 +104,7 @@ impl BundleCoordinator {
         CoordinatorMsg::BundleCompleted { has_encountered_error, has_generated_bundle_output } => {
           self.handle_bundle_completed(has_encountered_error, has_generated_bundle_output).await;
         }
+        #[cfg(feature = "testing")]
         CoordinatorMsg::ScheduleBuildIfStale { reply } => {
           let result = self.schedule_build_if_stale().await;
           let _ = reply.send(result);
@@ -116,6 +117,7 @@ impl BundleCoordinator {
           let result = self.ensure_latest_bundle_output().await;
           let _ = reply.send(result);
         }
+        #[cfg(feature = "testing")]
         CoordinatorMsg::GetWatchedFiles { reply } => {
           let result = self.watched_files.iter().map(|s| s.to_string()).collect();
           let _ = reply.send(result);

--- a/crates/rolldown_dev/src/type_aliases.rs
+++ b/crates/rolldown_dev/src/type_aliases.rs
@@ -1,19 +1,22 @@
+#[cfg(feature = "testing")]
 use rustc_hash::FxHashSet;
 use tokio::sync::{
   mpsc::{UnboundedReceiver, UnboundedSender},
   oneshot,
 };
 
+#[cfg(feature = "testing")]
+use super::types::schedule_build_return::ScheduleBuildReturn;
 use super::types::{
   coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot,
   ensure_latest_bundle_output_return::EnsureLatestBundleOutputReturn,
-  schedule_build_return::ScheduleBuildReturn,
 };
 
 // GetBuildStatus message
 pub type GetStateSender = oneshot::Sender<CoordinatorStateSnapshot>;
 
 // ScheduleBuild message
+#[cfg(feature = "testing")]
 pub type ScheduleBuildIfStaleSender = oneshot::Sender<Option<ScheduleBuildReturn>>;
 
 // Coordinator channel
@@ -22,4 +25,5 @@ pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;
 
 pub type EnsureLatestBundleOutputSender = oneshot::Sender<Option<EnsureLatestBundleOutputReturn>>;
 
+#[cfg(feature = "testing")]
 pub type GetWatchedFilesSender = oneshot::Sender<FxHashSet<String>>;

--- a/crates/rolldown_dev/src/types/coordinator_msg.rs
+++ b/crates/rolldown_dev/src/types/coordinator_msg.rs
@@ -1,8 +1,8 @@
 use rolldown_fs_watcher::FsEventResult;
 
-use crate::type_aliases::{
-  EnsureLatestBundleOutputSender, GetStateSender, GetWatchedFilesSender, ScheduleBuildIfStaleSender,
-};
+use crate::type_aliases::{EnsureLatestBundleOutputSender, GetStateSender};
+#[cfg(feature = "testing")]
+use crate::type_aliases::{GetWatchedFilesSender, ScheduleBuildIfStaleSender};
 
 /// Messages sent to the BundleCoordinator
 #[derive(Debug)]
@@ -12,6 +12,7 @@ pub enum CoordinatorMsg {
     has_encountered_error: bool,
     has_generated_bundle_output: bool,
   },
+  #[cfg(feature = "testing")]
   ScheduleBuildIfStale {
     reply: ScheduleBuildIfStaleSender,
   },
@@ -21,6 +22,7 @@ pub enum CoordinatorMsg {
   EnsureLatestBundleOutput {
     reply: EnsureLatestBundleOutputSender,
   },
+  #[cfg(feature = "testing")]
   GetWatchedFiles {
     reply: GetWatchedFilesSender,
   },


### PR DESCRIPTION
## Summary
- `cargo publish` builds each crate in isolation without workspace feature unification, so items only constructed under a `testing` or `experimental` feature elsewhere in the workspace look dead. The recent v1.0.0 publish (run [26274921497](https://github.com/rolldown/rolldown/actions/runs/26274921497/job/77336783019)) surfaced two such variants in `rolldown_dev::CoordinatorMsg`.
- Running `cargo hack check --each-feature --no-dev-deps --workspace` revealed 14 such warnings across `rolldown`, `rolldown_dev`, and (transitively) `rolldown_binding`.
- Gate every offender behind the same cfg as its constructor so the no-feature build is self-consistent.

## Changes
- `rolldown_dev`: gate `ScheduleBuildIfStale` / `GetWatchedFiles` variants, their match arms in `bundle_coordinator`, and the matching sender type aliases behind `feature = "testing"`.
- `rolldown`: gate `hmr::hmr_stage`, `hmr::hmr_ast_finalizer`, `hmr::impl_traverse_for_hmr_ast_finalizer`, the `HmrAstFinalizer` trait impl in `hmr::utils`, the `incremental_*` / `with_cached_bundle*` impls, and the `Bundler::cache` field behind `feature = "experimental"`.

After this change, `cargo hack check --each-feature --no-dev-deps --workspace` reports 0 warnings.