### PR TITLE
feat(chunking): add min chunk size common chunk merging

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -43,14 +43,23 @@ struct CommonChunkMerge {
 /// A lightweight representation of a chunk used during optimization passes.
 struct ChunkCandidate {
   modules: Vec<ModuleIdx>,
+  bits: BitSet,
+  approx_size: u32,
   /// Whether this chunk needs to be created in the final chunk graph.
   needs_creation: bool,
+  /// Redirect target when this temporary chunk was merged into another
+  /// temporary chunk before materialization.
+  merged_into: Option<ChunkIdx>,
   dependencies: FxHashSet<ChunkIdx>,
   /// Whether any module in this chunk has side effects.
   has_side_effects: bool,
 }
 
 type TempIndexChunks = IndexVec<ChunkIdx, ChunkCandidate>;
+
+fn module_size(module_table: &ModuleTable, module_idx: ModuleIdx) -> u32 {
+  u32::try_from(module_table[module_idx].size()).unwrap_or(u32::MAX)
+}
 
 /// A temporary structure for managing chunk graph optimizations.
 /// Only store simplified information needed during optimization passes.
@@ -95,8 +104,13 @@ impl ChunkOptimizationGraph {
           .iter()
           .any(|&module_idx| module_table[module_idx].side_effects().has_side_effects());
         ChunkCandidate {
+          approx_size: item.modules.iter().fold(0, |size, &module_idx| {
+            size.saturating_add(module_size(module_table, module_idx))
+          }),
           modules: item.modules.clone(),
+          bits: item.bits.clone(),
           needs_creation: false,
+          merged_into: None,
           dependencies: FxHashSet::default(),
           has_side_effects,
         }
@@ -124,12 +138,17 @@ impl ChunkOptimizationGraph {
     let module_has_side_effects = module_table[module_idx].side_effects().has_side_effects();
     if let Some(&chunk_idx) = self.bits_to_chunk_idx.get(bits) {
       self.chunks[chunk_idx].modules.push(module_idx);
+      self.chunks[chunk_idx].approx_size =
+        self.chunks[chunk_idx].approx_size.saturating_add(module_size(module_table, module_idx));
       self.chunks[chunk_idx].has_side_effects |= module_has_side_effects;
       self.module_to_chunk[module_idx] = Some(chunk_idx);
     } else {
       let temp_chunk = ChunkCandidate {
         modules: vec![module_idx],
+        bits: bits.clone(),
+        approx_size: module_size(module_table, module_idx),
         needs_creation: true,
+        merged_into: None,
         dependencies: FxHashSet::default(),
         has_side_effects: module_has_side_effects,
       };
@@ -146,6 +165,8 @@ impl ChunkOptimizationGraph {
     module_table: &ModuleTable,
   ) {
     self.chunks[chunk_idx].modules.push(module_idx);
+    self.chunks[chunk_idx].approx_size =
+      self.chunks[chunk_idx].approx_size.saturating_add(module_size(module_table, module_idx));
     self.chunks[chunk_idx].has_side_effects |=
       module_table[module_idx].side_effects().has_side_effects();
     self.module_to_chunk[module_idx] = Some(chunk_idx);
@@ -282,6 +303,180 @@ impl ChunkOptimizationGraph {
     self.chunks[target_chunk_idx].dependencies.remove(&target_chunk_idx);
     self.chunks[target_chunk_idx].has_side_effects |= source_has_side_effects;
   }
+
+  pub fn merge_side_effect_free_common_chunks(&mut self, min_chunk_size: u32) {
+    if min_chunk_size == 0 {
+      return;
+    }
+
+    let closure_has_side_effects = self.compute_closure_side_effects();
+    let mut small_sources: Vec<_> = self
+      .chunks
+      .indices()
+      .filter(|&idx| {
+        self.is_live_auto_common(idx)
+          && self.chunks[idx].approx_size < min_chunk_size
+          && !closure_has_side_effects[idx]
+      })
+      .collect();
+    small_sources.sort_by_key(|&idx| (self.chunks[idx].approx_size, idx.raw()));
+
+    for source_chunk_idx in small_sources {
+      if !self.is_live_auto_common(source_chunk_idx)
+        || self.chunks[source_chunk_idx].approx_size >= min_chunk_size
+        || closure_has_side_effects[source_chunk_idx]
+      {
+        continue;
+      }
+
+      let mut best_target = None;
+      let mut best_key = (u64::MAX, u32::MAX, u32::MAX);
+      for target_chunk_idx in self.chunks.indices() {
+        if source_chunk_idx == target_chunk_idx
+          || !self.is_live_auto_common(target_chunk_idx)
+          || closure_has_side_effects[target_chunk_idx]
+          || !Self::bits_intersect(
+            &self.chunks[source_chunk_idx].bits,
+            &self.chunks[target_chunk_idx].bits,
+          )
+          || self.merged_bits_would_collide(source_chunk_idx, target_chunk_idx)
+        {
+          continue;
+        }
+
+        let added_bytes = Self::estimate_added_bytes(
+          &self.chunks[source_chunk_idx],
+          &self.chunks[target_chunk_idx],
+        );
+        let target_key =
+          (added_bytes, self.chunks[target_chunk_idx].approx_size, target_chunk_idx.raw());
+        if target_key >= best_key
+          || self.would_create_circular_dependency(source_chunk_idx, target_chunk_idx)
+        {
+          continue;
+        }
+        best_key = target_key;
+        best_target = Some(target_chunk_idx);
+      }
+
+      if let Some(target_chunk_idx) = best_target {
+        self.merge_temp_chunks(source_chunk_idx, target_chunk_idx);
+      }
+    }
+  }
+
+  fn is_live_auto_common(&self, chunk_idx: ChunkIdx) -> bool {
+    let chunk = &self.chunks[chunk_idx];
+    chunk.needs_creation && chunk.merged_into.is_none() && !chunk.modules.is_empty()
+  }
+
+  fn compute_closure_side_effects(&self) -> IndexVec<ChunkIdx, bool> {
+    self
+      .chunks
+      .indices()
+      .map(|chunk_idx| self.chunk_dependency_closure_has_side_effects(chunk_idx))
+      .collect()
+  }
+
+  fn chunk_dependency_closure_has_side_effects(&self, chunk_idx: ChunkIdx) -> bool {
+    let mut queue: VecDeque<ChunkIdx> = VecDeque::from_iter([chunk_idx]);
+    let mut visited = FxHashSet::default();
+
+    while let Some(current_idx) = queue.pop_front() {
+      if !visited.insert(current_idx) {
+        continue;
+      }
+      let chunk = &self.chunks[current_idx];
+      if chunk.has_side_effects {
+        return true;
+      }
+      queue.extend(chunk.dependencies.iter().copied());
+    }
+
+    false
+  }
+
+  fn merged_bits_would_collide(
+    &self,
+    source_chunk_idx: ChunkIdx,
+    target_chunk_idx: ChunkIdx,
+  ) -> bool {
+    let mut merged_bits = self.chunks[target_chunk_idx].bits.clone();
+    merged_bits.union(&self.chunks[source_chunk_idx].bits);
+    self.bits_to_chunk_idx.get(&merged_bits).is_some_and(|&existing_chunk_idx| {
+      existing_chunk_idx != source_chunk_idx
+        && existing_chunk_idx != target_chunk_idx
+        && self.chunks[existing_chunk_idx].merged_into.is_none()
+    })
+  }
+
+  fn bits_intersect(left: &BitSet, right: &BitSet) -> bool {
+    left.index_of_one().any(|bit| right.has_bit(bit))
+  }
+
+  fn estimate_added_bytes(source: &ChunkCandidate, target: &ChunkCandidate) -> u64 {
+    let source_only_entries = source.bits.index_of_one().filter(|bit| !target.bits.has_bit(*bit));
+    let target_only_entries = target.bits.index_of_one().filter(|bit| !source.bits.has_bit(*bit));
+    u64::from(source.approx_size) * target_only_entries.count() as u64
+      + u64::from(target.approx_size) * source_only_entries.count() as u64
+  }
+
+  fn merge_temp_chunks(&mut self, source_chunk_idx: ChunkIdx, target_chunk_idx: ChunkIdx) {
+    debug_assert_ne!(source_chunk_idx, target_chunk_idx);
+    debug_assert!(self.is_live_auto_common(source_chunk_idx));
+    debug_assert!(self.is_live_auto_common(target_chunk_idx));
+
+    let source_bits = self.chunks[source_chunk_idx].bits.clone();
+    let target_bits = self.chunks[target_chunk_idx].bits.clone();
+    let mut merged_bits = target_bits.clone();
+    merged_bits.union(&source_bits);
+
+    let source_modules = std::mem::take(&mut self.chunks[source_chunk_idx].modules);
+    let source_dependencies = std::mem::take(&mut self.chunks[source_chunk_idx].dependencies);
+    let source_approx_size = self.chunks[source_chunk_idx].approx_size;
+    let source_has_side_effects = self.chunks[source_chunk_idx].has_side_effects;
+
+    for &module_idx in &source_modules {
+      self.module_to_chunk[module_idx] = Some(target_chunk_idx);
+    }
+    self.chunks[target_chunk_idx].modules.extend(source_modules);
+    self.chunks[target_chunk_idx].approx_size =
+      self.chunks[target_chunk_idx].approx_size.saturating_add(source_approx_size);
+    self.chunks[target_chunk_idx].bits = merged_bits.clone();
+    self.chunks[target_chunk_idx].has_side_effects |= source_has_side_effects;
+
+    for dep_chunk_idx in source_dependencies {
+      if dep_chunk_idx != source_chunk_idx && dep_chunk_idx != target_chunk_idx {
+        self.chunks[target_chunk_idx].dependencies.insert(dep_chunk_idx);
+      }
+    }
+
+    for chunk_idx in self.chunks.indices().collect::<Vec<_>>() {
+      if chunk_idx == source_chunk_idx {
+        continue;
+      }
+      if self.chunks[chunk_idx].dependencies.remove(&source_chunk_idx)
+        && chunk_idx != target_chunk_idx
+      {
+        self.chunks[chunk_idx].dependencies.insert(target_chunk_idx);
+      }
+    }
+    self.chunks[target_chunk_idx].dependencies.remove(&source_chunk_idx);
+    self.chunks[target_chunk_idx].dependencies.remove(&target_chunk_idx);
+    self.chunks[source_chunk_idx].merged_into = Some(target_chunk_idx);
+    self.chunks[source_chunk_idx].approx_size = 0;
+
+    self.bits_to_chunk_idx.shift_remove(&source_bits);
+    self.bits_to_chunk_idx.shift_remove(&target_bits);
+    self.bits_to_chunk_idx.insert(merged_bits, target_chunk_idx);
+    self.bits_to_chunk_idx.sort_unstable_keys();
+
+    debug_assert!(self.chunks.indices().all(|idx| {
+      idx == source_chunk_idx
+        || self.chunks[idx].merged_into.is_some()
+        || !self.chunks[idx].dependencies.contains(&source_chunk_idx)
+    }));
+  }
 }
 
 /// Result of assigning modules during chunk optimization.
@@ -391,8 +586,12 @@ impl GenerateStage<'_> {
       .iter()
       .filter_map(|(bits, temp_chunk_idx)| {
         let temp_chunk = &temp_chunk_graph.chunks[*temp_chunk_idx];
-        // Skip those chunks that are already created in chunk graph
-        if !temp_chunk.needs_creation {
+        // Skip chunks that are already created in chunk graph or were merged away before
+        // materialization.
+        if !temp_chunk.needs_creation
+          || temp_chunk.merged_into.is_some()
+          || temp_chunk.modules.is_empty()
+        {
           return None;
         }
         let chunk_idxs: Vec<_> = bits.index_of_one().map(ChunkIdx::from_raw).collect();
@@ -1300,5 +1499,127 @@ impl GenerateStage<'_> {
         runtime_dependent_chunks.insert(merge.to_chunk_idx);
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn bits(entries: &[u32]) -> BitSet {
+    let mut bits = BitSet::new(8);
+    for &entry in entries {
+      bits.set_bit(entry);
+    }
+    bits
+  }
+
+  fn candidate(
+    module_idx: ModuleIdx,
+    bits: BitSet,
+    approx_size: u32,
+    dependencies: &[ChunkIdx],
+  ) -> ChunkCandidate {
+    ChunkCandidate {
+      modules: vec![module_idx],
+      bits,
+      approx_size,
+      needs_creation: true,
+      merged_into: None,
+      dependencies: dependencies.iter().copied().collect(),
+      has_side_effects: false,
+    }
+  }
+
+  #[test]
+  fn min_size_common_merge_retargets_incoming_edges_and_unions_outgoing_dependencies() {
+    let source_idx = ChunkIdx::from_raw(0);
+    let target_idx = ChunkIdx::from_raw(1);
+    let dependency_idx = ChunkIdx::from_raw(2);
+    let incoming_idx = ChunkIdx::from_raw(3);
+    let source_module_idx = ModuleIdx::from_usize(0);
+    let target_module_idx = ModuleIdx::from_usize(1);
+    let dependency_module_idx = ModuleIdx::from_usize(2);
+    let incoming_module_idx = ModuleIdx::from_usize(3);
+    let source_bits = bits(&[0, 1]);
+    let target_bits = bits(&[1, 2]);
+    let dependency_bits = bits(&[0, 1, 3]);
+
+    let mut graph = ChunkOptimizationGraph {
+      chunks: index_vec![
+        candidate(source_module_idx, source_bits.clone(), 1, &[dependency_idx]),
+        candidate(target_module_idx, target_bits.clone(), 10, &[]),
+        candidate(dependency_module_idx, dependency_bits.clone(), 100, &[]),
+        ChunkCandidate {
+          modules: vec![incoming_module_idx],
+          bits: bits(&[0]),
+          approx_size: 100,
+          needs_creation: false,
+          merged_into: None,
+          dependencies: std::iter::once(source_idx).collect(),
+          has_side_effects: false,
+        },
+      ],
+      bits_to_chunk_idx: FxIndexMap::from_iter([
+        (source_bits.clone(), source_idx),
+        (target_bits.clone(), target_idx),
+        (dependency_bits, dependency_idx),
+      ]),
+      module_to_chunk: index_vec![
+        Some(source_idx),
+        Some(target_idx),
+        Some(dependency_idx),
+        Some(incoming_idx),
+      ],
+      chunk_idx_to_temp_chunk_idx: FxHashMap::default(),
+    };
+
+    graph.merge_side_effect_free_common_chunks(50);
+
+    let mut expected_merged_bits = target_bits.clone();
+    expected_merged_bits.union(&source_bits);
+    assert_eq!(graph.chunks[source_idx].merged_into, Some(target_idx));
+    assert_eq!(graph.module_to_chunk[source_module_idx], Some(target_idx));
+    assert_eq!(graph.chunks[target_idx].bits, expected_merged_bits);
+    assert!(graph.chunks[target_idx].dependencies.contains(&dependency_idx));
+    assert!(!graph.chunks[target_idx].dependencies.contains(&source_idx));
+    assert!(!graph.chunks[target_idx].dependencies.contains(&target_idx));
+    assert!(!graph.chunks[incoming_idx].dependencies.contains(&source_idx));
+    assert!(graph.chunks[incoming_idx].dependencies.contains(&target_idx));
+    assert_eq!(graph.bits_to_chunk_idx.get(&expected_merged_bits), Some(&target_idx));
+    assert!(!graph.bits_to_chunk_idx.contains_key(&source_bits));
+    assert!(!graph.bits_to_chunk_idx.contains_key(&target_bits));
+  }
+
+  #[test]
+  fn min_size_common_merge_keeps_chunks_separate_when_merge_would_create_cycle() {
+    let source_idx = ChunkIdx::from_raw(0);
+    let target_idx = ChunkIdx::from_raw(1);
+    let source_module_idx = ModuleIdx::from_usize(0);
+    let target_module_idx = ModuleIdx::from_usize(1);
+    let source_bits = bits(&[0, 1]);
+    let target_bits = bits(&[1, 2]);
+
+    let mut graph = ChunkOptimizationGraph {
+      chunks: index_vec![
+        candidate(source_module_idx, source_bits.clone(), 1, &[target_idx]),
+        candidate(target_module_idx, target_bits.clone(), 100, &[]),
+      ],
+      bits_to_chunk_idx: FxIndexMap::from_iter([
+        (source_bits.clone(), source_idx),
+        (target_bits.clone(), target_idx),
+      ]),
+      module_to_chunk: index_vec![Some(source_idx), Some(target_idx)],
+      chunk_idx_to_temp_chunk_idx: FxHashMap::default(),
+    };
+
+    graph.merge_side_effect_free_common_chunks(50);
+
+    assert_eq!(graph.chunks[source_idx].merged_into, None);
+    assert_eq!(graph.chunks[target_idx].merged_into, None);
+    assert_eq!(graph.module_to_chunk[source_module_idx], Some(source_idx));
+    assert_eq!(graph.module_to_chunk[target_module_idx], Some(target_idx));
+    assert_eq!(graph.bits_to_chunk_idx.get(&source_bits), Some(&source_idx));
+    assert_eq!(graph.bits_to_chunk_idx.get(&target_bits), Some(&target_idx));
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -849,6 +849,10 @@ impl GenerateStage<'_> {
       self.link_output.metas.iter().any(|meta| meta.is_tla_or_contains_tla_dependency);
     let allow_merge_common_chunks =
       self.options.experimental.is_merge_common_chunks_enabled() && !has_tla_or_tla_dependency;
+    let min_chunk_size = self.options.experimental.min_chunk_size();
+    let allow_min_size_common_chunk_merge = min_chunk_size > 0
+      && allow_merge_common_chunks
+      && self.options.manual_code_splitting.is_none();
     let allow_avoid_redundant_chunk_loads =
       self.options.experimental.is_avoid_redundant_chunk_loads_enabled()
         && !has_tla_or_tla_dependency;
@@ -948,6 +952,9 @@ impl GenerateStage<'_> {
 
     if allow_merge_common_chunks {
       temp_chunk_graph.calc_chunk_dependencies(&self.link_output.metas);
+      if allow_min_size_common_chunk_merge {
+        temp_chunk_graph.merge_side_effect_free_common_chunks(min_chunk_size);
+      }
       self.try_insert_common_module_to_exist_chunk(
         chunk_graph,
         bits_to_chunk,

--- a/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/chunk_optimization/dynamic_already_loaded_basic/artifacts.snap
@@ -32,7 +32,7 @@ export { load, value as t };
 
 ```
 
-# Variant: disableAvoidRedundantChunkLoads: [chunk_optimization: Options(ChunkOptimizationOptions { merge_common_chunks: false, avoid_redundant_chunk_loads: false })]
+# Variant: disableAvoidRedundantChunkLoads: [chunk_optimization: Options(ChunkOptimizationOptions { merge_common_chunks: false, avoid_redundant_chunk_loads: false, min_chunk_size: 0 })]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/_config.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "page-a",
+        "import": "./src/page-a.js"
+      },
+      {
+        "name": "page-b",
+        "import": "./src/page-b.js"
+      },
+      {
+        "name": "page-c",
+        "import": "./src/page-c.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": {
+      "chunkOptimization": {
+        "minChunkSize": 10000
+      }
+    }
+  },
+  "expectExecuted": false,
+  "configVariants": [
+    {
+      "_configName": "disabled-zero",
+      "chunkOptimization": {
+        "minChunkSize": 0
+      }
+    },
+    {
+      "_configName": "disabled-false",
+      "chunkOptimization": false
+    },
+    {
+      "_configName": "disabled-merge-common-chunks-false",
+      "chunkOptimization": {
+        "mergeCommonChunks": false,
+        "minChunkSize": 10000
+      }
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/_test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+const mergedCommonChunkCount = chunks.filter(
+  (chunk) => chunk.includes('common1 marker') && chunk.includes('common2 marker'),
+).length;
+
+if (globalThis.__configName?.startsWith('disabled-')) {
+  assert.strictEqual(
+    jsFiles.length,
+    5,
+    `Expected minChunkSize to be disabled: ${jsFiles.join(', ')}`,
+  );
+  assert.strictEqual(
+    mergedCommonChunkCount,
+    0,
+    'common chunks should not be coalesced when disabled',
+  );
+} else {
+  assert.strictEqual(
+    jsFiles.length,
+    4,
+    `Expected 3 entries + 1 common chunk: ${jsFiles.join(', ')}`,
+  );
+  assert.strictEqual(
+    mergedCommonChunkCount,
+    1,
+    'common1/common2 should be coalesced into one chunk',
+  );
+}

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/artifacts.snap
@@ -1,0 +1,212 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common2.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common1 as n, common2 as t };
+
+```
+
+## page-a.js
+
+```js
+import { n as common1 } from "./common2.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+## page-b.js
+
+```js
+import { n as common1, t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+## page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```
+
+# Variant: disabled-zero: [chunk_optimization: Options(ChunkOptimizationOptions { merge_common_chunks: true, avoid_redundant_chunk_loads: true, min_chunk_size: 0 })]
+
+## Assets
+
+### common1.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+### common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+### page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+### page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+### page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```
+
+# Variant: disabled-false: [chunk_optimization: Bool(false)]
+
+## Assets
+
+### common1.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+### common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+### page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+### page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+### page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```
+
+# Variant: disabled-merge-common-chunks-false: [chunk_optimization: Options(ChunkOptimizationOptions { merge_common_chunks: false, avoid_redundant_chunk_loads: true, min_chunk_size: 10000 })]
+
+## Assets
+
+### common1.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+### common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+### page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+### page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+### page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/common1.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/common1.js
@@ -1,0 +1,1 @@
+export const common1 = 'common1 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/common2.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/common2.js
@@ -1,0 +1,1 @@
+export const common2 = 'common2 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-a.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-a.js
@@ -1,0 +1,2 @@
+import { common1 } from './common1.js';
+console.log('page-a', common1);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-b.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-b.js
@@ -1,0 +1,3 @@
+import { common1 } from './common1.js';
+import { common2 } from './common2.js';
+console.log('page-b', common1, common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-c.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size/src/page-c.js
@@ -1,0 +1,2 @@
+import { common2 } from './common2.js';
+console.log('page-c', common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/_config.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "page-a",
+        "import": "./src/page-a.js"
+      },
+      {
+        "name": "page-b",
+        "import": "./src/page-b.js"
+      },
+      {
+        "name": "page-c",
+        "import": "./src/page-c.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "manual-unused",
+          "test": "never-matches"
+        }
+      ]
+    },
+    "experimental": {
+      "chunkOptimization": {
+        "minChunkSize": 10000
+      }
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+
+assert.strictEqual(
+  jsFiles.length,
+  5,
+  `Expected manual chunking config to disable minChunkSize: ${jsFiles.join(', ')}`,
+);
+assert(
+  !chunks.some((chunk) => chunk.includes('common1 marker') && chunk.includes('common2 marker')),
+  'minChunkSize should not coalesce common chunks when manual chunking is configured',
+);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/artifacts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common1.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+## common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+## page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+## page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+## page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/common1.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/common1.js
@@ -1,0 +1,1 @@
+export const common1 = 'common1 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/common2.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/common2.js
@@ -1,0 +1,1 @@
+export const common2 = 'common2 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-a.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-a.js
@@ -1,0 +1,2 @@
+import { common1 } from './common1.js';
+console.log('page-a', common1);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-b.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-b.js
@@ -1,0 +1,3 @@
+import { common1 } from './common1.js';
+import { common2 } from './common2.js';
+console.log('page-b', common1, common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-c.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_manual_gate/src/page-c.js
@@ -1,0 +1,2 @@
+import { common2 } from './common2.js';
+console.log('page-c', common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/_config.json
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "page-a",
+        "import": "./src/page-a.js"
+      },
+      {
+        "name": "page-b",
+        "import": "./src/page-b.js"
+      },
+      {
+        "name": "page-c",
+        "import": "./src/page-c.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": {
+      "chunkOptimization": {
+        "minChunkSize": 10000
+      }
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+
+assert.strictEqual(
+  jsFiles.length,
+  5,
+  `Expected side-effect closure to block coalescing: ${jsFiles.join(', ')}`,
+);
+assert(
+  !chunks.some((chunk) => chunk.includes('common1 marker') && chunk.includes('common2 marker')),
+  'common chunks with an effectful static dependency closure must not be coalesced',
+);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/artifacts.snap
@@ -1,0 +1,58 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common1.js
+
+```js
+//#region src/effect.js
+console.log("effectful dependency");
+//#endregion
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+## common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+## page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/page-a.js
+console.log("page-a", common1);
+//#endregion
+
+```
+
+## page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+## page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/common1.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/common1.js
@@ -1,0 +1,2 @@
+import './effect.js';
+export const common1 = 'common1 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/common2.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/common2.js
@@ -1,0 +1,1 @@
+export const common2 = 'common2 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/effect.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/effect.js
@@ -1,0 +1,1 @@
+console.log('effectful dependency');

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-a.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-a.js
@@ -1,0 +1,2 @@
+import { common1 } from './common1.js';
+console.log('page-a', common1);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-b.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-b.js
@@ -1,0 +1,3 @@
+import { common1 } from './common1.js';
+import { common2 } from './common2.js';
+console.log('page-b', common1, common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-c.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_side_effect/src/page-c.js
@@ -1,0 +1,2 @@
+import { common2 } from './common2.js';
+console.log('page-c', common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_config.json
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "page-a",
+        "import": "./src/page-a.js"
+      },
+      {
+        "name": "page-b",
+        "import": "./src/page-b.js"
+      },
+      {
+        "name": "page-c",
+        "import": "./src/page-c.js"
+      }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": {
+      "chunkOptimization": {
+        "minChunkSize": 10000
+      }
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(import.meta.dirname, 'dist');
+const jsFiles = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+const chunks = jsFiles.map((file) => readFileSync(join(distDir, file), 'utf8'));
+
+assert.strictEqual(
+  jsFiles.length,
+  5,
+  `Expected TLA bailout to block coalescing: ${jsFiles.join(', ')}`,
+);
+assert(
+  !chunks.some((chunk) => chunk.includes('common1 marker') && chunk.includes('common2 marker')),
+  'common chunks must not be coalesced when any module has TLA or a TLA dependency',
+);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/artifacts.snap
@@ -1,0 +1,58 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common1.js
+
+```js
+//#region src/common1.js
+const common1 = "common1 marker";
+//#endregion
+export { common1 as t };
+
+```
+
+## common2.js
+
+```js
+//#region src/common2.js
+const common2 = "common2 marker";
+//#endregion
+export { common2 as t };
+
+```
+
+## page-a.js
+
+```js
+import { t as common1 } from "./common1.js";
+//#region src/tla.js
+await Promise.resolve();
+//#endregion
+//#region src/page-a.js
+console.log("page-a", common1, "tla marker");
+//#endregion
+
+```
+
+## page-b.js
+
+```js
+import { t as common1 } from "./common1.js";
+import { t as common2 } from "./common2.js";
+//#region src/page-b.js
+console.log("page-b", common1, common2);
+//#endregion
+
+```
+
+## page-c.js
+
+```js
+import { t as common2 } from "./common2.js";
+//#region src/page-c.js
+console.log("page-c", common2);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/common1.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/common1.js
@@ -1,0 +1,1 @@
+export const common1 = 'common1 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/common2.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/common2.js
@@ -1,0 +1,1 @@
+export const common2 = 'common2 marker';

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-a.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-a.js
@@ -1,0 +1,3 @@
+import { tla } from './tla.js';
+import { common1 } from './common1.js';
+console.log('page-a', common1, tla);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-b.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-b.js
@@ -1,0 +1,3 @@
+import { common1 } from './common1.js';
+import { common2 } from './common2.js';
+console.log('page-b', common1, common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-c.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/page-c.js
@@ -1,0 +1,2 @@
+import { common2 } from './common2.js';
+console.log('page-c', common2);

--- a/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/tla.js
+++ b/crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/src/tla.js
@@ -1,0 +1,2 @@
+await Promise.resolve();
+export const tla = 'tla marker';

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -47,6 +47,7 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
 pub struct BindingChunkOptimizationOptions {
   pub merge_common_chunks: Option<bool>,
   pub avoid_redundant_chunk_loads: Option<bool>,
+  pub min_chunk_size: Option<u32>,
 }
 
 impl From<BindingChunkOptimizationOptions> for rolldown_common::ChunkOptimizationOptions {
@@ -54,6 +55,7 @@ impl From<BindingChunkOptimizationOptions> for rolldown_common::ChunkOptimizatio
     Self {
       merge_common_chunks: value.merge_common_chunks.unwrap_or(true),
       avoid_redundant_chunk_loads: value.avoid_redundant_chunk_loads.unwrap_or(true),
+      min_chunk_size: value.min_chunk_size.unwrap_or(0),
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -17,11 +17,14 @@ use super::dev_mode_options::DevModeOptions;
 pub struct ChunkOptimizationOptions {
   pub merge_common_chunks: bool,
   pub avoid_redundant_chunk_loads: bool,
+  /// Approximate source-byte threshold for opt-in side-effect-free common chunk coalescing.
+  /// `0` disables the pass.
+  pub min_chunk_size: u32,
 }
 
 impl Default for ChunkOptimizationOptions {
   fn default() -> Self {
-    Self { merge_common_chunks: true, avoid_redundant_chunk_loads: true }
+    Self { merge_common_chunks: true, avoid_redundant_chunk_loads: true, min_chunk_size: 0 }
   }
 }
 
@@ -32,6 +35,10 @@ impl ChunkOptimizationOptions {
 
   pub fn is_avoid_redundant_chunk_loads_enabled(&self) -> bool {
     self.avoid_redundant_chunk_loads
+  }
+
+  pub fn min_chunk_size(&self) -> u32 {
+    self.min_chunk_size
   }
 }
 
@@ -58,6 +65,13 @@ impl ChunkOptimizationOption {
     match self {
       Self::Bool(enabled) => *enabled,
       Self::Options(options) => options.is_avoid_redundant_chunk_loads_enabled(),
+    }
+  }
+
+  pub fn min_chunk_size(&self) -> u32 {
+    match self {
+      Self::Bool(_) => 0,
+      Self::Options(options) => options.min_chunk_size(),
     }
   }
 }
@@ -120,6 +134,10 @@ impl ExperimentalOptions {
       .chunk_optimization
       .as_ref()
       .is_none_or(ChunkOptimizationOption::is_avoid_redundant_chunk_loads_enabled)
+  }
+
+  pub fn min_chunk_size(&self) -> u32 {
+    self.chunk_optimization.as_ref().map_or(0, ChunkOptimizationOption::min_chunk_size)
   }
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1136,6 +1136,13 @@
         "avoidRedundantChunkLoads": {
           "type": "boolean",
           "default": true
+        },
+        "minChunkSize": {
+          "description": "Approximate source-byte threshold for opt-in side-effect-free common chunk coalescing.\n`0` disables the pass.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 0
         }
       },
       "additionalProperties": false

--- a/docs/in-depth/automatic-code-splitting.md
+++ b/docs/in-depth/automatic-code-splitting.md
@@ -274,6 +274,8 @@ For this output, executing each entry will output `['ab', 'bc', 'abc']`. However
 - `entry-b.js`: `['ab', 'bc', 'abc']`
 - `entry-c.js`: `['bc', 'abc']`
 
+If the shared modules have no side effects, you can opt into coalescing small common chunks with `experimental.chunkOptimization.minChunkSize`. The threshold is based on approximate source bytes, and Rolldown only merges automatically generated common chunks whose static dependency closure is side-effect-free. The pass is disabled by default (`0`), and it does not run when manual chunking is configured.
+
 ## Module Placing Order
 
 Rolldown tries to place your modules in the order declared in the original code.

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -144,6 +144,18 @@ For each common chunk, translates its `bits` to chunk indices (bit positions dir
 
 The trade-off of merging: entry chunks may include modules that not all consumers of that entry need. This adds a small amount of unnecessary code loading but significantly reduces chunk count and HTTP requests.
 
+### Minimum Common Chunk Size (`experimental.chunkOptimization.minChunkSize`)
+
+When `experimental.chunkOptimization.minChunkSize` is positive, the optimizer can also coalesce automatically generated common chunks into other common chunks before materialization. This is an opt-in exception to the initial "identical BitSet means one chunk" grouping: modules are still emitted once, but the merged common chunk's reachability BitSet becomes the union of the source and target common chunks.
+
+The pass is intentionally conservative:
+
+- It only considers automatically generated common temporary chunks (`needs_creation == true`), never entry chunks or user-created/manual chunks.
+- It is disabled when manual/advanced chunking is configured, when `mergeCommonChunks` is disabled, or when the existing top-level-await global bailout applies.
+- The threshold uses approximate source bytes from `Module::size()`, not rendered/minified/compressed output bytes.
+- Source and target chunks must have no side effects in their static dependency closure, using the same static chunk dependencies computed for common-chunk merging. Dynamic imports stay loading boundaries.
+- Each merge is checked with `would_create_circular_dependency()`, and deterministic source/target tie-breakers keep output stable.
+
 For chunks shared only by dynamic entries, the optimizer does not infer a merge target from dynamic-import reachability alone. Sibling dynamic imports from the same loaded entry can be requested independently, so "the entry can reach both chunks" does not prove either dynamic chunk is already loaded before the other. In that case, Rolldown keeps a separate common chunk unless the existing static-import merge-target check proves a safe target.
 
 ### Facade Elimination (`optimize_facade_entry_chunks`)

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1894,6 +1894,7 @@ export declare enum BindingChunkModuleOrderBy {
 export interface BindingChunkOptimizationOptions {
   mergeCommonChunks?: boolean
   avoidRedundantChunkLoads?: boolean
+  minChunkSize?: number
 }
 
 export interface BindingClientHmrUpdate {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -58,6 +58,18 @@ export interface ChunkOptimizationOptions {
    * @default true
    */
   avoidRedundantChunkLoads?: boolean;
+  /**
+   * Merge side-effect-free automatically generated common chunks smaller than
+   * this approximate source-byte threshold. `0` disables this pass.
+   *
+   * The threshold is based on module source sizes available during chunk
+   * optimization, not final rendered/minified/compressed output size.
+   *
+   * This pass is opt-in and does not run when manual/advanced chunking is configured.
+   *
+   * @default 0
+   */
+  minChunkSize?: number;
 }
 
 export type ModuleTypes = Record<
@@ -697,7 +709,8 @@ export interface InputOptions {
      *
      * `true` enables both common-chunk merging and redundant dynamic chunk-load avoidance.
      * `false` disables all chunk optimizations. Use the object form to control
-     * `mergeCommonChunks` and `avoidRedundantChunkLoads` separately.
+     * `mergeCommonChunks`, `avoidRedundantChunkLoads`, and opt-in `minChunkSize`
+     * coalescing separately.
      *
      * These optimizations are automatically disabled when any module uses top-level await (TLA) or contains TLA dependencies,
      * as they could affect execution order guarantees.

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -648,6 +648,7 @@ const InputOptionsSchema = v.strictObject({
           v.strictObject({
             mergeCommonChunks: v.optional(v.boolean()),
             avoidRedundantChunkLoads: v.optional(v.boolean()),
+            minChunkSize: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
           }),
         ]),
       ),

--- a/packages/rolldown/tests/build-api/min-chunk-size.test.ts
+++ b/packages/rolldown/tests/build-api/min-chunk-size.test.ts
@@ -1,0 +1,50 @@
+import type { OutputChunk, Plugin } from 'rolldown';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+const modules: Record<string, string> = {
+  '/page-a.js': "import { common1 } from '/common1.js'; console.log('page-a', common1);",
+  '/page-b.js':
+    "import { common1 } from '/common1.js'; import { common2 } from '/common2.js'; console.log('page-b', common1, common2);",
+  '/page-c.js': "import { common2 } from '/common2.js'; console.log('page-c', common2);",
+  '/common1.js': "export const common1 = 'common1 marker';",
+  '/common2.js': "export const common2 = 'common2 marker';",
+};
+
+const virtualPlugin: Plugin = {
+  name: 'virtual-min-chunk-size',
+  resolveId(id) {
+    if (id in modules) return id;
+  },
+  load(id) {
+    return modules[id];
+  },
+};
+
+async function build(minChunkSize: number) {
+  const bundle = await rolldown({
+    input: ['/page-a.js', '/page-b.js', '/page-c.js'],
+    plugins: [virtualPlugin],
+    experimental: {
+      chunkOptimization: {
+        minChunkSize,
+      },
+    },
+  });
+  const output = await bundle.generate({ format: 'esm' });
+  await bundle.close();
+  return output.output.filter((chunk): chunk is OutputChunk => chunk.type === 'chunk');
+}
+
+test('experimental.chunkOptimization.minChunkSize is passed through the JS API and NAPI binding', async () => {
+  const disabledChunks = await build(0);
+  const enabledChunks = await build(10_000);
+
+  expect(disabledChunks).toHaveLength(5);
+  expect(enabledChunks).toHaveLength(4);
+  expect(
+    enabledChunks.filter(
+      (chunk) => chunk.code.includes('common1 marker') && chunk.code.includes('common2 marker'),
+    ),
+  ).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

Addresses #4788.

Adds opt-in `experimental.chunkOptimization.minChunkSize` support for coalescing small, side-effect-free, automatically generated common chunks before chunk materialization.

The default is `0`, so existing output is unchanged unless users explicitly opt in.

## Details

Example usage:

```ts
experimental: {
  chunkOptimization: {
    minChunkSize: 10_000,
  },
}
```

The new pass is intentionally conservative:

- only runs when `minChunkSize > 0`
- only considers automatically generated common chunks
- does not run when manual/advanced chunking is configured
- is disabled by `chunkOptimization: false` or `mergeCommonChunks: false`
- uses approximate source bytes as the threshold
- requires the source chunk and its static dependency closure to be side-effect-free
- keeps dynamic imports as loading boundaries
- bails out under the existing TLA safety gate
- rejects merges that would create a static chunk cycle

This implements the safe common-to-common case from #4788 without claiming full Rollup `experimentalMinChunkSize` parity.

## Testing

- `cargo test -p rolldown min_size_common_merge --lib -- --nocapture`
- `cargo test -p rolldown --test integration 4788_min_chunk_size -- --nocapture`
- `cargo test -p rolldown --test integration 4788_min_chunk_size_tla_bailout -- --nocapture`
- `cargo fmt --all --check`
- `vp run --filter rolldown-tests test:main build-api/min-chunk-size.test.ts`
- `vp check packages/rolldown/src/options/input-options.ts packages/rolldown/tests/build-api/min-chunk-size.test.ts crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_test.mjs crates/rolldown/tests/rolldown/issues/4788_min_chunk_size_tla_bailout/_config.json`

## AI disclosure

AI assistance was used while developing and reviewing this change. I reviewed the implementation, validated the behavior locally, and am responsible for the submitted PR.
