### PR TITLE
fix: apply transform.dropLabels before scanning (#9521)

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -317,13 +317,6 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn visit_statement(&mut self, it: &mut ast::Statement<'ast>) {
     _ = self.try_inline_json_module_prop(it);
 
-    if !self.ctx.options.drop_labels.is_empty() {
-      if let ast::Statement::LabeledStatement(stmt) = it {
-        if self.ctx.options.drop_labels.contains(stmt.label.name.as_str()) {
-          *it = self.snippet.builder.statement_empty(stmt.span);
-        }
-      }
-    }
     walk_mut::walk_statement(self, it);
 
     // transform top level `var a = 1, b = 1;` to `a = 1, b = 1`

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -225,7 +225,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
     let mut ast = EcmaCompiler::parse(filename, source.clone(), source_type)?;
 
     ast.program.with_mut(|fields| {
-      let mut pre_processor = PreProcessor::new(fields.allocator, false);
+      let mut pre_processor = PreProcessor::new(fields.allocator, false, None);
       pre_processor.visit_program(fields.program);
     });
 

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -241,7 +241,11 @@ impl PreProcessEcmaAst {
 
     // Step 6: Modify AST for Rolldown.
     let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-      let mut pre_processor = PreProcessor::new(allocator, bundle_options.keep_names);
+      let mut pre_processor = PreProcessor::new(
+        allocator,
+        bundle_options.keep_names,
+        Some(&bundle_options.drop_labels),
+      );
       pre_processor.visit_program(program);
       self.recreate_scoping(&mut None, program)
     });

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -241,11 +241,8 @@ impl PreProcessEcmaAst {
 
     // Step 6: Modify AST for Rolldown.
     let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-      let mut pre_processor = PreProcessor::new(
-        allocator,
-        bundle_options.keep_names,
-        Some(&bundle_options.drop_labels),
-      );
+      let mut pre_processor =
+        PreProcessor::new(allocator, bundle_options.keep_names, Some(&bundle_options.drop_labels));
       pre_processor.visit_program(program);
       self.recreate_scoping(&mut None, program)
     });

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -9,11 +9,16 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Pre-process is a essential step to make rolldown generate correct and efficient code.
 /// This also ensures span uniqueness in the AST.
-pub struct PreProcessor<'ast> {
+pub struct PreProcessor<'ast, 'a> {
   snippet: AstSnippet<'ast>,
   /// used to store none_hoisted statements.
   top_level_stmt_temp_storage: Vec<Statement<'ast>>,
   keep_names: bool,
+  /// Labels listed in `transform.dropLabels`. When non-empty, any matching
+  /// `LabeledStatement` is replaced with an empty statement before scanning,
+  /// so dynamic imports nested inside the dropped block never enter the
+  /// module graph.
+  drop_labels: Option<&'a FxHashSet<String>>,
   statement_stack: Vec<Address>,
   statement_replace_map: FxHashMap<Address, Vec<Statement<'ast>>>,
   // Fields for span uniqueness
@@ -21,17 +26,36 @@ pub struct PreProcessor<'ast> {
   next_unique_span_start: u32,
 }
 
-impl<'ast> PreProcessor<'ast> {
-  pub fn new(alloc: &'ast Allocator, keep_names: bool) -> Self {
+impl<'ast, 'a> PreProcessor<'ast, 'a> {
+  pub fn new(
+    alloc: &'ast Allocator,
+    keep_names: bool,
+    drop_labels: Option<&'a FxHashSet<String>>,
+  ) -> Self {
     Self {
       snippet: AstSnippet::new(alloc),
       top_level_stmt_temp_storage: vec![],
       keep_names,
+      drop_labels: drop_labels.filter(|set| !set.is_empty()),
       statement_stack: vec![],
       statement_replace_map: FxHashMap::default(),
       visited_spans: FxHashSet::from_iter([SPAN]),
       next_unique_span_start: 1,
     }
+  }
+
+  /// Replace `it` with an empty statement when it is a `LabeledStatement`
+  /// whose label name appears in `drop_labels`. Returns true if a replacement
+  /// was performed, so callers can skip walking into the dropped subtree.
+  fn try_drop_labeled(&self, it: &mut Statement<'ast>) -> bool {
+    let Some(labels) = self.drop_labels else { return false };
+    if let Statement::LabeledStatement(stmt) = it
+      && labels.contains(stmt.label.name.as_str())
+    {
+      *it = self.snippet.builder.statement_empty(stmt.span);
+      return true;
+    }
+    false
   }
 
   fn ensure_uniqueness(&mut self, span: &mut Span) {
@@ -87,7 +111,7 @@ impl<'ast> PreProcessor<'ast> {
   }
 }
 
-impl<'ast> VisitMut<'ast> for PreProcessor<'ast> {
+impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
     // Initialize next_unique_span_start for span uniqueness
     self.next_unique_span_start = program.span.end + 1;
@@ -99,6 +123,10 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast> {
     );
 
     for mut stmt in original_body {
+      if self.try_drop_labeled(&mut stmt) {
+        self.top_level_stmt_temp_storage.push(stmt);
+        continue;
+      }
       let stmt_addr = stmt.address();
       self.statement_stack.push(stmt_addr);
       walk_mut::walk_statement(self, &mut stmt);
@@ -124,6 +152,9 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast> {
   /// Will not reach `visit_statements`, so we need to handle it separately.
   /// Since we already intercept `visit_statements`, these two visitor now are mutually exclusive.
   fn visit_statement(&mut self, it: &mut Statement<'ast>) {
+    if self.try_drop_labeled(it) {
+      return;
+    }
     if self.keep_names {
       let stmt_addr = it.address();
       self.statement_stack.push(stmt_addr);
@@ -148,6 +179,10 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast> {
     if self.keep_names {
       let stmts = it.take_in(self.snippet.alloc());
       for mut stmt in stmts {
+        if self.try_drop_labeled(&mut stmt) {
+          it.push(stmt);
+          continue;
+        }
         let stmt_addr = stmt.address();
         self.statement_stack.push(stmt_addr);
         walk_mut::walk_statement(self, &mut stmt);

--- a/crates/rolldown/tests/esbuild/dce/drop_labels/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/drop_labels/artifacts.snap
@@ -6,19 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Could not resolve 'bar1' in entry.js
-   ╭─[ entry.js:2:17 ]
-   │
- 2 │ DROP_1: require('bar1')
-   │                 ───┬──  
-   │                    ╰──── Module not found, treating it as an external dependency
-───╯
-
-```
-
-## UNRESOLVED_IMPORT
-
-```text
 [UNRESOLVED_IMPORT] Could not resolve 'bar2' in entry.js
    ╭─[ entry.js:5:25 ]
    │
@@ -38,19 +25,6 @@ source: crates/rolldown_testing/src/integration_test.rs
  1 │ keep_1: require('foo1')
    │                 ───┬──  
    │                    ╰──── Module not found, treating it as an external dependency
-───╯
-
-```
-
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Could not resolve 'foo2' in entry.js
-   ╭─[ entry.js:4:25 ]
-   │
- 4 │     if (x) DROP_2: require('foo2')
-   │                            ───┬──  
-   │                               ╰──── Module not found, treating it as an external dependency
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/_config.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9521 — a dynamic import nested inside a dropped labeled block must not be added to the module graph, so its (potentially unresolvable) dependencies are never resolved.",
+  "config": {
+    "dropLabels": ["DEBUG"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/artifacts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+console.log("release");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/debug.js
+++ b/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/debug.js
@@ -1,0 +1,4 @@
+import { SomeClass } from 'some-uninstalled-package';
+export function init() {
+  return new SomeClass();
+}

--- a/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/main.js
+++ b/crates/rolldown/tests/rolldown/function/dropped_label_with_dynamic_import/main.js
@@ -1,0 +1,5 @@
+DEBUG: {
+  import('./debug.js').then(({ init }) => init());
+}
+
+console.log('release');


### PR DESCRIPTION
Move the transform.dropLabels pass from the module finalizer into PreProcessor so labeled statements are stripped before AstScanner::scan runs. Dynamic imports and require() calls nested inside dropped labels no longer enter the module graph, so unresolvable transitive deps stop breaking the build.

Closes #9521.

As a side effect, the redundant finalizer block is removed and spurious UNRESOLVED_IMPORT warnings for dropped-label requires disappear (see updated esbuild/dce/drop_labels snapshot).