### PR TITLE
refactor: fold import defer phase drop into PreProcessor

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -22,7 +22,7 @@ use rustc_hash::FxHashMap;
 use crate::types::oxc_parse_type::OxcParseType;
 
 use super::parse_to_ecma_ast::ParseToEcmaAstResult;
-use super::tweak_ast_for_scanning::{PreProcessor, drop_import_defer_phase};
+use super::tweak_ast_for_scanning::PreProcessor;
 
 #[derive(Default)]
 pub struct PreProcessEcmaAst {
@@ -43,9 +43,6 @@ impl PreProcessEcmaAst {
     has_lazy_export: bool,
   ) -> BuildResult<ParseToEcmaAstResult> {
     let source = ast.source().clone();
-
-    let import_defer_spans =
-      ast.program.with_mut(|WithMutFields { program, .. }| drop_import_defer_phase(program));
 
     // Step 0: Move directive comments attached to 0 so that it's not removed when the directives are removed
     if !ast.program().directives.is_empty() && !ast.program().comments.is_empty() {
@@ -90,21 +87,6 @@ impl PreProcessEcmaAst {
         EventKind::ParseError,
       ))?;
     };
-    warnings.extend(import_defer_spans.into_iter().map(|span| {
-      BuildDiagnostic::oxc_error(
-        source.clone(),
-        resolved_id.to_string(),
-        String::new(),
-        "`import defer` is currently lowered to a normal import. This changes execution timing because side effects run immediately instead of when the deferred import is first used.".to_string(),
-        vec![LabeledSpan::at(
-          span.start as usize..span.end as usize,
-          "The deferred phase is removed here.",
-        )],
-        EventKind::UnsupportedFeatureError,
-      )
-      .with_severity_warning()
-    }));
-
     // Surface invalid pure annotations flagged by oxc (issue #8898).
     // oxc marks `/* #__PURE__ */` / `/* @__PURE__ */` comments with
     // `CommentContent::PureNotApplied` when their position prevents the parser
@@ -257,12 +239,32 @@ impl PreProcessEcmaAst {
     }
 
     // Step 6: Modify AST for Rolldown.
-    let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
-      let mut pre_processor =
-        PreProcessor::new(allocator, bundle_options.keep_names, Some(&bundle_options.drop_labels));
-      pre_processor.visit_program(program);
-      self.recreate_scoping(&mut None, program)
-    });
+    let (scoping, import_defer_spans) =
+      ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
+        let mut pre_processor = PreProcessor::new(
+          allocator,
+          bundle_options.keep_names,
+          Some(&bundle_options.drop_labels),
+        );
+        pre_processor.visit_program(program);
+        let defer_spans = pre_processor.take_defer_spans();
+        (self.recreate_scoping(&mut None, program), defer_spans)
+      });
+
+    warnings.extend(import_defer_spans.into_iter().map(|span| {
+      BuildDiagnostic::oxc_error(
+        source.clone(),
+        resolved_id.to_string(),
+        String::new(),
+        "`import defer` is currently lowered to a normal import. This changes execution timing because side effects run immediately instead of when the deferred import is first used.".to_string(),
+        vec![LabeledSpan::at(
+          span.start as usize..span.end as usize,
+          "The deferred phase is removed here.",
+        )],
+        EventKind::UnsupportedFeatureError,
+      )
+      .with_severity_warning()
+    }));
 
     Ok(ParseToEcmaAstResult {
       ast,

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -7,34 +7,6 @@ use oxc::span::{GetSpanMut, SPAN, Span};
 use rolldown_ecmascript_utils::{AstSnippet, StatementExt};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-pub fn drop_import_defer_phase(program: &mut ast::Program<'_>) -> Vec<Span> {
-  let mut dropper = ImportDeferPhaseDropper { spans: vec![] };
-  dropper.visit_program(program);
-  dropper.spans
-}
-
-struct ImportDeferPhaseDropper {
-  spans: Vec<Span>,
-}
-
-impl<'ast> VisitMut<'ast> for ImportDeferPhaseDropper {
-  fn visit_import_declaration(&mut self, it: &mut ast::ImportDeclaration<'ast>) {
-    if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
-      self.spans.push(it.span);
-      it.phase = None;
-    }
-    walk_mut::walk_import_declaration(self, it);
-  }
-
-  fn visit_import_expression(&mut self, it: &mut ast::ImportExpression<'ast>) {
-    if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
-      self.spans.push(it.span);
-      it.phase = None;
-    }
-    walk_mut::walk_import_expression(self, it);
-  }
-}
-
 /// Pre-process is a essential step to make rolldown generate correct and efficient code.
 /// This also ensures span uniqueness in the AST.
 pub struct PreProcessor<'ast, 'a> {
@@ -52,6 +24,10 @@ pub struct PreProcessor<'ast, 'a> {
   // Fields for span uniqueness
   visited_spans: FxHashSet<Span>,
   next_unique_span_start: u32,
+  /// Spans of `import defer ...` statements / expressions whose `defer` phase
+  /// was lowered to a regular import. Read after `visit_program` to emit the
+  /// `UNSUPPORTED_FEATURE` warning.
+  defer_spans: Vec<Span>,
 }
 
 impl<'ast, 'a> PreProcessor<'ast, 'a> {
@@ -69,7 +45,12 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
       statement_replace_map: FxHashMap::default(),
       visited_spans: FxHashSet::from_iter([SPAN]),
       next_unique_span_start: 1,
+      defer_spans: vec![],
     }
+  }
+
+  pub fn take_defer_spans(&mut self) -> Vec<Span> {
+    std::mem::take(&mut self.defer_spans)
   }
 
   /// Replace `it` with an empty statement when it is a `LabeledStatement`
@@ -142,6 +123,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
 impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   fn visit_import_declaration(&mut self, it: &mut ast::ImportDeclaration<'ast>) {
     if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
+      self.defer_spans.push(it.span);
       it.phase = None;
     }
     walk_mut::walk_import_declaration(self, it);
@@ -283,6 +265,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
 
   fn visit_import_expression(&mut self, it: &mut ast::ImportExpression<'ast>) {
     if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
+      self.defer_spans.push(it.span);
       it.phase = None;
     }
     self.ensure_uniqueness(it.span_mut());


### PR DESCRIPTION
Consolidates the standalone `drop_import_defer_phase` pass added in #9503 into the existing `PreProcessor`.

`PreProcessor` already cleared `ImportPhase::Defer` redundantly; it now also records the spans, exposed via `take_defer_spans()` so `pre_process_ecma_ast.rs` can still emit the `UNSUPPORTED_FEATURE` warning after step 6.

Net effect: one less AST traversal per module, same observable behavior — verified by the `import_defer_phase` warning fixture and all 29 `warnings` integration tests.
