### PR TITLE
fix(generator): use exporter chunk's export mode for CJS default re-exports (#9299)

### DIFF
--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -79,16 +79,26 @@ impl GenerateContext<'_> {
           let require_binding = &self.chunk_graph.chunk_table[cur_chunk_idx]
             .require_binding_names_for_other_chunks[&chunk_idx_of_canonical_symbol];
 
-          let exported_name = &self.chunk_graph.chunk_table[chunk_idx_of_canonical_symbol]
-            .exports_to_other_chunks[&canonical_ref][0];
+          let exporter_chunk = &self.chunk_graph.chunk_table[chunk_idx_of_canonical_symbol];
+          let exported_name = &exporter_chunk.exports_to_other_chunks[&canonical_ref][0];
           if exported_name == "default" {
-            match self.options.exports {
-              OutputExports::Auto => require_binding.clone(),
-              OutputExports::Default | OutputExports::Named => {
+            // Use the exporter chunk's actual `output_exports`, not the user-level
+            // `options.exports`. Each chunk decides its own export mode (e.g. under
+            // `preserveModules`, non-input modules are forced to `Named` and emit
+            // `exports.default = ...`), so the access pattern must match what the
+            // exporter actually renders.
+            match exporter_chunk.output_exports {
+              OutputExports::Default => require_binding.clone(),
+              OutputExports::Named => {
                 rolldown_utils::ecmascript::property_access_str(require_binding, exported_name)
               }
-              // Already validated at https://github.com/rolldown/rolldown/blob/e50d4419df86af63b25b4b8d40035dad2478a3fe/crates/rolldown/src/utils/chunk/determine_export_mode.rs#L8-L66
-              OutputExports::None => unreachable!(),
+              // `Auto` is always resolved away by `determine_export_mode`. `None`
+              // is unreachable here because we just indexed
+              // `exports_to_other_chunks[canonical_ref]` successfully — a non-empty
+              // entry means the chunk has at least one cross-chunk export, which
+              // forces `output_exports` to `Default` or `Named` (entry chunks via
+              // `determine_export_mode`; common chunks are unconditionally `Named`).
+              OutputExports::Auto | OutputExports::None => unreachable!(),
             }
           } else {
             rolldown_utils::ecmascript::property_access_str(require_binding, exported_name)

--- a/crates/rolldown/tests/rolldown/issues/9299/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9299/_config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Test for issue #9299: With preserveModules, CJS emit should forward `.default` for `export { default as X } from './X.js'`, not the namespace wrapper",
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "./index.ts"
+      }
+    ],
+    "format": "cjs",
+    "preserveModules": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9299/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9299/_test.mjs
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module';
+import assert from 'node:assert';
+
+const require = createRequire(import.meta.url);
+const { v4 } = require('./dist/index.js');
+
+assert.strictEqual(typeof v4, 'function', 'v4 should be a function, not the namespace wrapper');
+assert.strictEqual(v4(), 'uuid-here');

--- a/crates/rolldown/tests/rolldown/issues/9299/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9299/artifacts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_v4 = require("./v4.js");
+exports.v4 = require_v4.default;
+
+```
+
+## v4.js
+
+```js
+//#region v4.ts
+function v4() {
+	return "uuid-here";
+}
+//#endregion
+exports.default = v4;
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9299/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/9299/index.ts
@@ -1,0 +1,1 @@
+export { default as v4 } from './v4.ts';

--- a/crates/rolldown/tests/rolldown/issues/9299/v4.ts
+++ b/crates/rolldown/tests/rolldown/issues/9299/v4.ts
@@ -1,0 +1,3 @@
+export default function v4() {
+  return 'uuid-here';
+}


### PR DESCRIPTION
Under `preserveModules` with `cjs` format, `export { default as X } from './X.js'` was forwarding the namespace wrapper (e.g. `require_v4`) instead of `require_v4.default`. The CJS generator was consulting the user-level `options.exports` to decide the access pattern, but each chunk has its own `output_exports` (forced to `Named` for non-input modules under `preserveModules`). The fix reads `output_exports` from the exporter chunk so the access pattern matches what the exporter actually renders.

Fixes #9299.
