### PR TITLE
chore(deps): update cargo-shear to 1.12.4

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,14 +23,14 @@ jobs:
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
           restore-cache: false
-          tools: cargo-shear@1.11.2
+          tools: cargo-shear@1.12.4
           components: rustfmt
 
       - name: cargo-shear
         id: shear
         shell: bash
         run: |
-          if ! cargo shear --fix; then
+          if ! cargo shear --fix --check-test-targets --deny-warnings --format=github; then
             echo "shear=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           cache-key: lint
           save-cache: false
-          tools: just,cargo-insta,typos-cli,cargo-shear@1.11.2
+          tools: just,cargo-insta,typos-cli,cargo-shear@1.12.4
           components: clippy rust-docs rustfmt
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ setup:
   just setup-vite-plus
   vp install
   cargo install cargo-binstall
-  cargo binstall cargo-insta cargo-deny cargo-shear@1.11.2 typos-cli -y
+  cargo binstall cargo-insta cargo-deny cargo-shear@1.12.4 typos-cli -y
   just setup-submodule
   just setup-bench
   @echo "✅✅✅ Setup complete!"
@@ -134,7 +134,7 @@ fix: fix-rust fix-node fix-repo
 # Fix formatting, linting and code fixing issues for Rust files.
 fix-rust:
   cargo fmt --all -- --emit=files
-  -cargo shear --fix # omit exit status with `-`
+  -cargo shear --fix --check-test-targets # omit exit status with `-`
   cargo fix --allow-dirty --allow-staged
 
 # Fix linting issues for Node.js files.


### PR DESCRIPTION
## Summary

Bump cargo-shear from 1.11.2 to 1.12.4 and enable new options:

- `--check-test-targets` in `just fix-rust` and CI to detect test/doctest flag mismatches with source content (new in 1.12.0).
- `--deny-warnings` and `--format=github` in autofix CI to fail on warnings and surface findings as inline PR annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)