### PR TITLE
ci: replace actions-cool/issues-helper with gh CLI

### DIFF
--- a/.github/workflows/automate-jobs.yml
+++ b/.github/workflows/automate-jobs.yml
@@ -13,9 +13,8 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'needs-triage'
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE_NUMBER" --remove-label needs-triage

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -11,9 +11,12 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'needs-reproduction'
-          inactive-day: 14
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cutoff=$(date -u -d "14 days ago" +%Y-%m-%dT%H:%M:%SZ)
+          gh issue list --label needs-reproduction --state open --limit 1000 \
+            --json number,updatedAt \
+            --jq ".[] | select(.updatedAt < \"$cutoff\") | .number" \
+            | xargs -r -I {} gh issue close {} --reason "not planned"


### PR DESCRIPTION
## Summary

- Replace `actions-cool/issues-helper` (banned) with the runner's built-in `gh` CLI in both workflows.
- `automate-jobs.yml`: `gh issue edit --remove-label needs-triage` when an issue is assigned.
- `issue-close-require.yml`: list open issues labeled `needs-reproduction` not updated in 14 days and close them with reason `not planned`.

Behavior note: the original close action used the default close reason (`completed`); this uses `not planned`, which fits the "no reproduction" case more accurately. Happy to drop `--reason` if you'd rather preserve the old default exactly.