### PR TITLE
fix(rolldown): remove empty common chunks for advanced chunking

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -5,9 +5,9 @@ use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkDebugInfo, ChunkIdx, ChunkKind, ChunkMeta, ChunkReasonType,
-  FacadeChunkEliminationReason, ImportKind, Module, ModuleIdx, ModuleNamespaceIncludedReason,
-  ModuleTable, PostChunkOptimizationOperation, PreserveEntrySignatures, RuntimeHelper, StmtInfos,
-  WrapKind,
+  FacadeChunkEliminationReason, ImportKind, ImportRecordMeta, Module, ModuleIdx,
+  ModuleNamespaceIncludedReason, ModuleTable, ModuleType, PostChunkOptimizationOperation,
+  PreserveEntrySignatures, RuntimeHelper, StmtInfos, WrapKind,
 };
 use rolldown_utils::{BitSet, IndexBitSet, indexmap::FxIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -37,6 +37,13 @@ struct FacadeChunkElimination {
 struct CommonChunkMerge {
   from_chunk_idx: ChunkIdx,
   to_chunk_idx: ChunkIdx,
+}
+
+struct EmptyCommonChunkElimination {
+  chunk_idx: ChunkIdx,
+  modules: Vec<ModuleIdx>,
+  replacement_chunks: Vec<ChunkIdx>,
+  importer_chunks: Vec<ChunkIdx>,
 }
 
 #[derive(Debug, Default)]
@@ -1091,6 +1098,216 @@ impl GenerateStage<'_> {
       &module_included_vec,
       &module_namespace_reason_vec,
     );
+  }
+
+  /// Remove non-entry chunks that only contain modules whose statements were fully
+  /// tree-shaken, while preserving the side-effect imports those modules forwarded.
+  pub(super) fn optimize_empty_common_chunks(&self, chunk_graph: &mut ChunkGraph) {
+    let mut removable_chunks = FxHashSet::default();
+    for (chunk_idx, chunk) in chunk_graph.chunk_table.iter_enumerated() {
+      if chunk_graph.post_chunk_optimization_operations.contains_key(&chunk_idx)
+        || !matches!(chunk.kind, ChunkKind::Common)
+        || chunk.modules.is_empty()
+        || !chunk.depended_runtime_helper.is_empty()
+      {
+        continue;
+      }
+
+      if chunk
+        .modules
+        .iter()
+        .all(|module_idx| self.can_remove_empty_common_chunk_module(*module_idx))
+      {
+        removable_chunks.insert(chunk_idx);
+      }
+    }
+
+    if removable_chunks.is_empty() {
+      return;
+    }
+
+    let mut eliminations = vec![];
+    for chunk_idx in chunk_graph.chunk_table.indices() {
+      if !removable_chunks.contains(&chunk_idx) {
+        continue;
+      }
+      let mut replacement_chunks = vec![];
+      Self::collect_empty_common_chunk_replacements(
+        chunk_idx,
+        chunk_graph,
+        &self.link_output.module_table,
+        &self.link_output.metas,
+        &removable_chunks,
+        &mut FxHashSet::default(),
+        &mut replacement_chunks,
+      );
+
+      let mut importer_chunks = vec![];
+      for &module_idx in &chunk_graph.chunk_table[chunk_idx].modules {
+        let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
+          continue;
+        };
+        for &importer_idx in &module.importers_idx {
+          let Some(importer_chunk_idx) = chunk_graph.module_to_chunk[importer_idx] else {
+            continue;
+          };
+          if importer_chunk_idx != chunk_idx
+            && !removable_chunks.contains(&importer_chunk_idx)
+            && !chunk_graph.post_chunk_optimization_operations.contains_key(&importer_chunk_idx)
+          {
+            Self::push_unique_chunk(&mut importer_chunks, importer_chunk_idx);
+          }
+        }
+      }
+
+      eliminations.push(EmptyCommonChunkElimination {
+        chunk_idx,
+        modules: chunk_graph.chunk_table[chunk_idx].modules.clone(),
+        replacement_chunks,
+        importer_chunks,
+      });
+    }
+
+    for elimination in eliminations {
+      chunk_graph
+        .post_chunk_optimization_operations
+        .insert(elimination.chunk_idx, PostChunkOptimizationOperation::Removed);
+
+      let primary_replacement = elimination.replacement_chunks.first().copied();
+      for module_idx in elimination.modules {
+        chunk_graph.module_to_chunk[module_idx] = primary_replacement;
+      }
+
+      for importer_chunk_idx in elimination.importer_chunks {
+        for &replacement_chunk_idx in &elimination.replacement_chunks {
+          if importer_chunk_idx == replacement_chunk_idx {
+            continue;
+          }
+          chunk_graph.chunk_table[importer_chunk_idx]
+            .imports_from_other_chunks
+            .entry(replacement_chunk_idx)
+            .or_default();
+        }
+      }
+    }
+  }
+
+  fn can_remove_empty_common_chunk_module(&self, module_idx: ModuleIdx) -> bool {
+    let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
+      return false;
+    };
+    let meta = &self.link_output.metas[module_idx];
+    if !meta.is_included
+      || !matches!(
+        module.module_type,
+        ModuleType::Js | ModuleType::Jsx | ModuleType::Ts | ModuleType::Tsx
+      )
+      || !matches!(meta.wrap_kind(), WrapKind::None)
+      || meta.has_side_effectful_runtime_dep
+      || !module.dynamic_importers.is_empty()
+      || !self.can_ignore_included_stmts_for_empty_common_chunk(module_idx)
+    {
+      return false;
+    }
+
+    module.import_records.iter().all(|rec| {
+      if rec.kind != ImportKind::Import {
+        return true;
+      }
+      let Some(importee_idx) = rec.resolved_module else {
+        return true;
+      };
+      matches!(
+        &self.link_output.module_table[importee_idx],
+        Module::Normal(importee) if importee.module_type != ModuleType::Css
+      )
+    })
+  }
+
+  fn can_ignore_included_stmts_for_empty_common_chunk(&self, module_idx: ModuleIdx) -> bool {
+    let meta = &self.link_output.metas[module_idx];
+    !meta.stmt_info_included.is_empty()
+      && meta.stmt_info_included.index_of_one().all(|stmt_idx| {
+        let stmt = &self.link_output.stmt_infos[module_idx][stmt_idx];
+        let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
+          return false;
+        };
+        !stmt.side_effect.has_side_effect()
+          && stmt.referenced_symbols.is_empty()
+          && stmt.meta.is_empty()
+          && stmt.import_records.iter().all(|record_idx| {
+            let record = &module.import_records[*record_idx];
+            record.kind == ImportKind::Import
+              && record
+                .meta
+                .intersects(ImportRecordMeta::IsReExportOnly | ImportRecordMeta::IsExportStar)
+          })
+          && stmt.declared_symbols.iter().all(|symbol_ref| {
+            symbol_ref.inner().canonical_ref(&self.link_output.symbol_db).owner != module_idx
+          })
+      })
+  }
+
+  fn collect_empty_common_chunk_replacements(
+    chunk_idx: ChunkIdx,
+    chunk_graph: &ChunkGraph,
+    module_table: &ModuleTable,
+    metas: &IndexVec<ModuleIdx, LinkingMetadata>,
+    removable_chunks: &FxHashSet<ChunkIdx>,
+    visiting: &mut FxHashSet<ChunkIdx>,
+    replacements: &mut Vec<ChunkIdx>,
+  ) {
+    if !visiting.insert(chunk_idx) {
+      return;
+    }
+
+    for &module_idx in &chunk_graph.chunk_table[chunk_idx].modules {
+      let Some(module) = module_table[module_idx].as_normal() else {
+        continue;
+      };
+      for rec in &module.import_records {
+        if rec.kind != ImportKind::Import {
+          continue;
+        }
+        let Some(importee_idx) = rec.resolved_module else {
+          continue;
+        };
+        if !metas[importee_idx].is_included
+          || !module_table[importee_idx].side_effects().has_side_effects()
+        {
+          continue;
+        }
+        let Some(importee_chunk_idx) = chunk_graph.module_to_chunk[importee_idx] else {
+          continue;
+        };
+        if importee_chunk_idx == chunk_idx
+          || chunk_graph.post_chunk_optimization_operations.contains_key(&importee_chunk_idx)
+        {
+          continue;
+        }
+        if removable_chunks.contains(&importee_chunk_idx) {
+          Self::collect_empty_common_chunk_replacements(
+            importee_chunk_idx,
+            chunk_graph,
+            module_table,
+            metas,
+            removable_chunks,
+            visiting,
+            replacements,
+          );
+        } else {
+          Self::push_unique_chunk(replacements, importee_chunk_idx);
+        }
+      }
+    }
+
+    visiting.remove(&chunk_idx);
+  }
+
+  fn push_unique_chunk(chunks: &mut Vec<ChunkIdx>, chunk_idx: ChunkIdx) {
+    if !chunks.contains(&chunk_idx) {
+      chunks.push(chunk_idx);
+    }
   }
 
   /// Re-home the runtime module to avoid closing a static import cycle when

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -163,9 +163,10 @@ impl GenerateStage<'_> {
           let module = self.link_output.module_table[item.owner].as_normal()?;
           self.link_output.metas[module.idx].is_included.then_some(item)
         })
-        .into_group_map_by(|item| {
-          chunk_graph.module_to_chunk[item.owner].expect("should have chunk idx")
+        .filter_map(|item| {
+          chunk_graph.module_to_chunk[item.owner].map(|chunk_idx| (chunk_idx, item))
         })
+        .into_group_map()
       {
         if group.len() <= 1 {
           continue;
@@ -963,6 +964,8 @@ impl GenerateStage<'_> {
         &temp_chunk_graph,
       );
     }
+
+    self.optimize_empty_common_chunks(chunk_graph);
 
     Ok(())
   }

--- a/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
+++ b/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
@@ -14,7 +14,10 @@ impl GenerateStage<'_> {
       return;
     }
 
-    for chunk in chunk_graph.chunk_table.iter() {
+    for (chunk_idx, chunk) in chunk_graph.chunk_table.iter_enumerated() {
+      if chunk_graph.post_chunk_optimization_operations.contains_key(&chunk_idx) {
+        continue;
+      }
       let pre_rendered_chunk =
         chunk.pre_rendered_chunk.as_ref().expect("Should have pre_rendered_chunk");
 

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -28,7 +28,9 @@ impl GenerateStage<'_> {
           let ast = ast.as_mut()?;
           let module = self.link_output.module_table[idx].as_normal().unwrap();
           let ast_scope = &self.link_output.symbol_db[idx].as_ref().unwrap().ast_scopes;
-          let chunk_idx = chunk_graph.module_to_chunk[idx].unwrap();
+          // Empty common chunk elimination can leave included renderless modules unassigned when
+          // there is no side-effect replacement chunk to retarget to. See meta/design/code-splitting.md.
+          let chunk_idx = chunk_graph.module_to_chunk[idx]?;
           let chunk = &chunk_graph.chunk_table[chunk_idx];
           let linking_info = &self.link_output.metas[module.idx];
           let ctx = ScopeHoistingFinalizerContext {

--- a/crates/rolldown/tests/rolldown/issues/6677/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677/_config.json
@@ -1,0 +1,35 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "./index.ts"
+      },
+      {
+        "name": "index-1",
+        "import": "./index-1.ts"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "test": "a\\.js",
+          "name": "bundle-a"
+        },
+        {
+          "test": "b\\.js",
+          "name": "bundle-b"
+        },
+        {
+          "test": "c\\.js",
+          "name": "bundle-c"
+        },
+        {
+          "test": "side\\.js",
+          "name": "bundle-side"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677/_test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert(!('components.js' in assets), 'the empty barrel facade should not be emitted');
+for (const [file, code] of Object.entries(assets)) {
+  assert(
+    !code.includes('./components.js'),
+    `${file} should not import the eliminated barrel facade`,
+  );
+}
+assert(
+  assets['index.js'].includes('./bundle-side.js'),
+  'side-effectful dependencies forwarded by the barrel should be retargeted to importers',
+);
+
+globalThis.__rolldownIssue6677SideEffects = [];
+await import('./dist/index.js');
+await import('./dist/index-1.js');
+assert.deepStrictEqual(globalThis.__rolldownIssue6677SideEffects, ['side']);

--- a/crates/rolldown/tests/rolldown/issues/6677/a.js
+++ b/crates/rolldown/tests/rolldown/issues/6677/a.js
@@ -1,0 +1,4 @@
+import { C } from './c.js';
+
+export const A = 'aaaaa';
+console.log(C);

--- a/crates/rolldown/tests/rolldown/issues/6677/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677/artifacts.snap
@@ -1,0 +1,72 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bundle-a.js
+
+```js
+//#region c.js
+const C = "ccccc";
+//#endregion
+//#region a.js
+const A = "aaaaa";
+console.log(C);
+//#endregion
+export { C as n, A as t };
+
+```
+
+## bundle-b.js
+
+```js
+//#region b.js
+const B = "bbbbb";
+//#endregion
+export { B as t };
+
+```
+
+## bundle-side.js
+
+```js
+//#region side.js
+globalThis.__rolldownIssue6677SideEffects ??= [];
+globalThis.__rolldownIssue6677SideEffects.push("side");
+//#endregion
+
+```
+
+## index-1.js
+
+```js
+import { n as C, t as A } from "./bundle-a.js";
+import { t as B } from "./bundle-b.js";
+import "./bundle-side.js";
+//#region index-1.ts
+console.log(B);
+console.log(A);
+console.log(C);
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { n as C, t as A } from "./bundle-a.js";
+import "./bundle-side.js";
+//#region index.ts
+console.log(A);
+console.log(C, 111);
+//#endregion
+
+```
+
+# Output Stats
+
+- bundle-a.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
+- bundle-b.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- bundle-side.js, is_entry false, is_dynamic_entry false, exports []
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/issues/6677/b.js
+++ b/crates/rolldown/tests/rolldown/issues/6677/b.js
@@ -1,0 +1,1 @@
+export const B = 'bbbbb';

--- a/crates/rolldown/tests/rolldown/issues/6677/c.js
+++ b/crates/rolldown/tests/rolldown/issues/6677/c.js
@@ -1,0 +1,1 @@
+export const C = 'ccccc';

--- a/crates/rolldown/tests/rolldown/issues/6677/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677/components.js
@@ -1,0 +1,4 @@
+export { A } from './a.js';
+export { B } from './b.js';
+export { C } from './c.js';
+export { S } from './side.js';

--- a/crates/rolldown/tests/rolldown/issues/6677/index-1.ts
+++ b/crates/rolldown/tests/rolldown/issues/6677/index-1.ts
@@ -1,0 +1,5 @@
+import { B, A, C } from './components.js';
+
+console.log(B);
+console.log(A);
+console.log(C);

--- a/crates/rolldown/tests/rolldown/issues/6677/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/6677/index.ts
@@ -1,0 +1,4 @@
+import { A, C } from './components.js';
+
+console.log(A);
+console.log(C, 111);

--- a/crates/rolldown/tests/rolldown/issues/6677/side.js
+++ b/crates/rolldown/tests/rolldown/issues/6677/side.js
@@ -1,0 +1,4 @@
+globalThis.__rolldownIssue6677SideEffects ??= [];
+globalThis.__rolldownIssue6677SideEffects.push('side');
+
+export const S = 'side';

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/_config.json
@@ -1,0 +1,9 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "index-1", "import": "./index-1.js" }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert('components.js' in assets, 'wrapped CommonJS barrels must remain emitted');
+assert(
+  assets['components.js'].includes('__commonJS'),
+  'the CommonJS wrapper should stay in the barrel chunk',
+);

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## components.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region components.js
+var require_components = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.A = "cjs-a";
+	exports.B = "cjs-b";
+}));
+//#endregion
+export { __toESM as n, require_components as t };
+
+```
+
+## index-1.js
+
+```js
+import { t as require_components } from "./components.js";
+require_components();
+console.log("cjs-b");
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { t as require_components } from "./components.js";
+require_components();
+console.log("cjs-a");
+//#endregion
+
+```
+
+# Output Stats
+
+- components.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/components.js
@@ -1,0 +1,2 @@
+exports.A = 'cjs-a';
+exports.B = 'cjs-b';

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/index-1.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/index-1.js
@@ -1,0 +1,3 @@
+import components from './components.js';
+
+console.log(components.B);

--- a/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_cjs_barrel/index.js
@@ -1,0 +1,3 @@
+import components from './components.js';
+
+console.log(components.A);

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/_config.json
@@ -1,0 +1,15 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "index-1", "import": "./index-1.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        { "test": "a\\.js", "name": "bundle-a" },
+        { "test": "b\\.js", "name": "bundle-b" }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert(
+  'components.js' in assets,
+  'barrels that are also dynamic import targets must remain emitted',
+);
+assert(
+  assets['index.js'].includes('import("./components.js")'),
+  'dynamic import boundary should still target the barrel chunk',
+);

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/a.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/a.js
@@ -1,0 +1,1 @@
+export const A = 'dynamic-a';

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/artifacts.snap
@@ -1,0 +1,70 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bundle-a.js
+
+```js
+//#region a.js
+const A = "dynamic-a";
+//#endregion
+export { A as t };
+
+```
+
+## bundle-b.js
+
+```js
+//#region b.js
+const B = "dynamic-b";
+//#endregion
+export { B as t };
+
+```
+
+## components.js
+
+```js
+import { t as A } from "./bundle-a.js";
+import { t as B } from "./bundle-b.js";
+// HIDDEN [\0rolldown/runtime.js]
+//#region components.js
+var components_exports = /* @__PURE__ */ __exportAll({
+	A: () => A,
+	B: () => B
+});
+//#endregion
+export { components_exports as t };
+
+```
+
+## index-1.js
+
+```js
+import { t as B } from "./bundle-b.js";
+//#region index-1.js
+console.log(B);
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { t as A } from "./bundle-a.js";
+//#region index.js
+console.log(A);
+const loadComponents = () => import("./components.js").then((n) => n.t);
+//#endregion
+export { loadComponents };
+
+```
+
+# Output Stats
+
+- bundle-a.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- bundle-b.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- components.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports ["loadComponents"]

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/b.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/b.js
@@ -1,0 +1,1 @@
+export const B = 'dynamic-b';

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/components.js
@@ -1,0 +1,2 @@
+export { A } from './a.js';
+export { B } from './b.js';

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/index-1.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/index-1.js
@@ -1,0 +1,3 @@
+import { B } from './components.js';
+
+console.log(B);

--- a/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_dynamic_importer/index.js
@@ -1,0 +1,4 @@
+import { A } from './components.js';
+
+console.log(A);
+export const loadComponents = () => import('./components.js');

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/_config.json
@@ -1,0 +1,16 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "index-1", "import": "./index-1.js" }
+    ],
+    "external": ["node:fs"],
+    "manualCodeSplitting": {
+      "groups": [
+        { "test": "a\\.js", "name": "bundle-a" },
+        { "test": "b\\.js", "name": "bundle-b" }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert('components.js' in assets, 'barrels with external side-effect imports must remain emitted');
+assert(
+  assets['components.js'].includes('node:fs'),
+  'the external side-effect import should stay anchored in the barrel chunk',
+);

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/a.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/a.js
@@ -1,0 +1,1 @@
+export const A = 'external-a';

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/artifacts.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bundle-a.js
+
+```js
+//#region a.js
+const A = "external-a";
+//#endregion
+export { A as t };
+
+```
+
+## bundle-b.js
+
+```js
+//#region b.js
+const B = "external-b";
+//#endregion
+export { B as t };
+
+```
+
+## components.js
+
+```js
+import "node:fs";
+
+```
+
+## index-1.js
+
+```js
+import { t as B } from "./bundle-b.js";
+import "./components.js";
+//#region index-1.js
+console.log(B);
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { t as A } from "./bundle-a.js";
+import "./components.js";
+//#region index.js
+console.log(A);
+//#endregion
+
+```
+
+# Output Stats
+
+- bundle-a.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- bundle-b.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- components.js, is_entry false, is_dynamic_entry false, exports []
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/b.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/b.js
@@ -1,0 +1,1 @@
+export const B = 'external-b';

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/components.js
@@ -1,0 +1,3 @@
+import 'node:fs';
+export { A } from './a.js';
+export { B } from './b.js';

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/index-1.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/index-1.js
@@ -1,0 +1,3 @@
+import { B } from './components.js';
+
+console.log(B);

--- a/crates/rolldown/tests/rolldown/issues/6677_external_import/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_external_import/index.js
@@ -1,0 +1,3 @@
+import { A } from './components.js';
+
+console.log(A);

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/_config.json
@@ -1,0 +1,15 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "index-1", "import": "./index-1.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        { "test": "a\\.js", "name": "bundle-a" },
+        { "test": "b\\.js", "name": "bundle-b" }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert(!('components.js' in assets), 'the pure empty barrel should be eliminated');
+for (const [file, code] of Object.entries(assets)) {
+  assert(!code.includes('./components.js'), `${file} should not import the eliminated pure barrel`);
+}
+
+await import('./dist/index.js');
+await import('./dist/index-1.js');

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/a.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/a.js
@@ -1,0 +1,1 @@
+export const A = 'pure-a';

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/artifacts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bundle-a.js
+
+```js
+//#region a.js
+const A = "pure-a";
+//#endregion
+export { A as t };
+
+```
+
+## bundle-b.js
+
+```js
+//#region b.js
+const B = "pure-b";
+//#endregion
+export { B as t };
+
+```
+
+## index-1.js
+
+```js
+import { t as A } from "./bundle-a.js";
+import { t as B } from "./bundle-b.js";
+//#region index-1.js
+console.log(B);
+console.log(A);
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { t as A } from "./bundle-a.js";
+//#region index.js
+console.log(A);
+//#endregion
+
+```
+
+# Output Stats
+
+- bundle-a.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- bundle-b.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/b.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/b.js
@@ -1,0 +1,1 @@
+export const B = 'pure-b';

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/components.js
@@ -1,0 +1,2 @@
+export { A } from './a.js';
+export { B } from './b.js';

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/index-1.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/index-1.js
@@ -1,0 +1,4 @@
+import { B, A } from './components.js';
+
+console.log(B);
+console.log(A);

--- a/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_pure_barrel/index.js
@@ -1,0 +1,3 @@
+import { A } from './components.js';
+
+console.log(A);

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/_config.json
@@ -1,0 +1,15 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "index-1", "import": "./index-1.js" }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        { "test": "a\\.js", "name": "bundle-a" },
+        { "test": "b\\.js", "name": "bundle-b" }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const assets = Object.fromEntries(
+  fs.readdirSync(distDir).map((file) => [file, fs.readFileSync(path.join(distDir, file), 'utf8')]),
+);
+
+assert('components.js' in assets, 'barrels that own runtime helper state must remain emitted');
+assert(
+  assets['components.js'].includes('__exportAll'),
+  'runtime helper usage should stay anchored in the barrel chunk',
+);

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/a.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/a.js
@@ -1,0 +1,1 @@
+export const A = 'runtime-a';

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/artifacts.snap
@@ -1,0 +1,77 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bundle-a.js
+
+```js
+//#region a.js
+const A = "runtime-a";
+//#endregion
+export { A as t };
+
+```
+
+## bundle-b.js
+
+```js
+//#region b.js
+const B = "runtime-b";
+//#endregion
+export { B as t };
+
+```
+
+## components.js
+
+```js
+import { t as __exportAll } from "./rolldown-runtime.js";
+import { t as A } from "./bundle-a.js";
+import { t as B } from "./bundle-b.js";
+//#region components.js
+var components_exports = /* @__PURE__ */ __exportAll({
+	A: () => A,
+	B: () => B
+});
+//#endregion
+export { components_exports as t };
+
+```
+
+## index-1.js
+
+```js
+import { t as components_exports } from "./components.js";
+//#region index-1.js
+console.log(components_exports);
+//#endregion
+
+```
+
+## index.js
+
+```js
+import { t as components_exports } from "./components.js";
+//#region index.js
+console.log(components_exports);
+//#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
+
+```
+
+# Output Stats
+
+- bundle-a.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- bundle-b.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- components.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- index-1.js, is_entry true, is_dynamic_entry false, exports []
+- index.js, is_entry true, is_dynamic_entry false, exports []
+- rolldown-runtime.js, is_entry false, is_dynamic_entry false, exports ["t"]

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/b.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/b.js
@@ -1,0 +1,1 @@
+export const B = 'runtime-b';

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/components.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/components.js
@@ -1,0 +1,2 @@
+export * from './a.js';
+export * from './b.js';

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/index-1.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/index-1.js
@@ -1,0 +1,3 @@
+import * as components from './components.js';
+
+console.log(components);

--- a/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6677_runtime_helper_barrel/index.js
@@ -1,0 +1,3 @@
+import * as components from './components.js';
+
+console.log(components);

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -155,6 +155,12 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
 
+### Empty Common Chunk Elimination (`optimize_empty_common_chunks`)
+
+Manual/advanced chunking can also leave a non-entry common chunk whose modules render no statements of their own, such as a barrel module whose re-export declarations canonicalize to symbols in other chunks. These chunks are removed only when every module is a JS/TS module, is still ESM-unwrapped, has no dynamic importers, has no side-effectful runtime dependency, has no static CSS import, and its included statements are side-effect-free re-export facades rather than declarations owned by the module itself. This guard relies on import-record metadata for re-export-only statements, not rendered source strings. Non-JS modules such as CSS can render empty JavaScript while still owning emitted assets, so they are not eligible.
+
+Before marking the chunk `Removed`, the optimizer preserves load-order side effects by retargeting static importers to the live chunks of any side-effectful dependencies forwarded by the removed chunk. If no side-effectful replacements exist, the removed modules intentionally remain unassigned in `module_to_chunk`; downstream finalization/rendering skips them because they have no emitted code. This keeps the removal graph-based and avoids source-string checks for pure re-exports.
+
 ### Runtime Module Placement
 
 Facade elimination can introduce **new runtime-helper consumers** after the merge phase has already placed the runtime module. Eliminating a dynamic-import facade runs two independent `wrap_kind`-gated branches on the target chunk, and either branch adds the chunk to `runtime_dependent_chunks`:
@@ -338,7 +344,7 @@ pub struct ChunkGraph {
 ```
 
 - `chunk_table` — All chunks, indexed by `ChunkIdx`. May contain removed chunks (marked in `post_chunk_optimization_operations`) since re-indexing would be expensive.
-- `module_to_chunk` — Which chunk each module belongs to. O(1) lookup.
+- `module_to_chunk` — Which chunk each module belongs to. O(1) lookup. `None` can mean not yet assigned, temporarily peeled for rehoming, or included but renderless after an optimized-away common chunk has no emitted replacement.
 
 ## Related
 


### PR DESCRIPTION
Manual/advanced chunking could leave a barrel module in its own common chunk after its re-export declarations resolved to symbols in other chunks. The chunk rendered as an empty JS file, but entry chunks still imported it.

This adds an empty-common-chunk optimization that removes only graph-proven ESM re-export facades. Before marking the chunk removed, the optimizer retargets importers to any live side-effectful dependencies forwarded through the removed chunk, so load-order side effects are preserved without source-string re-export detection.

Related: #8625 is an earlier attempt at the same #6677 issue. This PR takes a graph-level approach so chunk removal can stay conservative around side effects, dynamic imports, runtime helpers, CJS wrappers, externals, and CSS-owning modules.

Fixes #6677.

Disclosure: AI tools assisted with investigation and implementation. I reviewed, tested, and take responsibility for the submitted changes.
