### PR TITLE
chore: point published crates' readme to root README.md

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Fast JavaScript bundler in Rust, designed for the future of Vite"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_common"
 version = "0.1.0"
 publish = true
 description = "This crate is mostly for sharing code between rolldwon crates."
+readme = "../../README.md"
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_dev/Cargo.toml
+++ b/crates/rolldown_dev/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Dev mode orchestration for Rolldown bundler"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_dev_common/Cargo.toml
+++ b/crates/rolldown_dev_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_dev_common"
 version = "0.1.0"
 publish = true
 description = "Common types for rolldown dev mode"
+readme = "../../README.md"
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_devtools/Cargo.toml
+++ b/crates/rolldown_devtools/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "DevTools utilities for Rolldown"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_devtools_action/Cargo.toml
+++ b/crates/rolldown_devtools_action/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "DevTools action handlers for Rolldown"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_ecmascript"
 version = "0.1.0"
 publish = true
 description = "ECMAScript AST and parsing utilities for Rolldown"
+readme = "../../README.md"
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_ecmascript_utils/Cargo.toml
+++ b/crates/rolldown_ecmascript_utils/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Helper utilities for ECMAScript processing"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_error"
 version = "0.1.0"
 publish = true
 description = "rolldown_error"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Filesystem abstraction layer for Rolldown"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_fs_watcher/Cargo.toml
+++ b/crates/rolldown_fs_watcher/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Filesystem watching implementation for Rolldown"
+readme = "../../README.md"
 
 [dependencies]
 rolldown-notify = { workspace = true }

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Plugin interface for Rolldown bundler"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_asset_module/Cargo.toml
+++ b/crates/rolldown_plugin_asset_module/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown builtin plugin for handling asset modules"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
+++ b/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown plugin for analyzing bundle composition"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_chunk_import_map/Cargo.toml
+++ b/crates/rolldown_plugin_chunk_import_map/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown plugin for chunk import mapping"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_copy_module/Cargo.toml
+++ b/crates/rolldown_plugin_copy_module/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown builtin plugin implementing esbuild copy loader semantics"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown plugin for data URI handling"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_esm_external_require/Cargo.toml
+++ b/crates/rolldown_plugin_esm_external_require/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Rolldown plugin for ESM external require handling"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Rolldown plugin for Hot Module Replacement (HMR)"
+readme = "../../README.md"
 
 [dependencies]
 rolldown_common = { workspace = true }

--- a/crates/rolldown_plugin_isolated_declaration/Cargo.toml
+++ b/crates/rolldown_plugin_isolated_declaration/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Rolldown plugin for TypeScript isolated declarations"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rolldown_plugin_lazy_compilation/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Lazy-compilation plugin for Rolldown"
+readme = "../../README.md"
 publish = true
 
 [dependencies]

--- a/crates/rolldown_plugin_oxc_runtime/Cargo.toml
+++ b/crates/rolldown_plugin_oxc_runtime/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Rolldown plugin for OXC runtime helpers"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Rolldown plugin for string replacement"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Shared utilities for Rolldown plugins"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "Rolldown plugin for Vite module resolution"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_resolver"
 version = "0.1.0"
 publish = true
 description = "rolldown_resolver"
+readme = "../../README.md"
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_sourcemap"
 version = "0.1.0"
 publish = true
 description = "Source map generation and manipulation for Rolldown"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_std_utils/Cargo.toml
+++ b/crates/rolldown_std_utils/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Standard library utilities for Rolldown"
+readme = "../../README.md"
 
 [lints]
 workspace = true

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_tracing"
 version = "0.1.0"
 publish = true
 description = "rolldown_tracing"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_utils"
 version = "0.1.0"
 publish = true
 description = "General-purpose utilities for Rolldown"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Watcher for rolldown with state machine-based implementation"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/rolldown_workspace/Cargo.toml
+++ b/crates/rolldown_workspace/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = true
 repository.workspace = true
 description = "Workspace management utilities for Rolldown"
+readme = "../../README.md"
 
 [lib]
 doctest = false

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license = "MIT"
 publish = true
 description = "manipulate string like a wizard"
+readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

- Adds `readme = "../../README.md"` to every published crate in `crates/` (every crate without `publish = false`, 33 in total).
- At publish time, Cargo rewrites the path and copies the root `README.md` into the packaged tarball, so each crate's page on crates.io renders the project README instead of being empty.

Verified locally with `cargo package` on `rolldown`: the tarball contains `rolldown-0.1.0/README.md` and the packaged `Cargo.toml` is rewritten to `readme = "README.md"`.