### PR TITLE
perf(generate): drop ast_table after instantiate_chunks

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -48,6 +48,12 @@ impl GenerateStage<'_> {
     let (mut instantiated_chunks, index_chunk_to_instances) =
       self.instantiate_chunks(chunk_graph, &mut errors, &mut warnings).await?;
 
+    // `instantiate_chunks` is the last reader of `ast_table`. Release the
+    // per-module bumpalo arenas now so the heap dip is in place before
+    // `minify_chunks` re-parses chunk output into fresh arenas (~30 MiB peak
+    // heap reduction on rome).
+    drop(std::mem::take(&mut self.link_output.ast_table));
+
     self.trace_action_package_graph_ready(chunk_graph, &instantiated_chunks);
 
     render_chunks(self.plugin_driver, &mut instantiated_chunks, self.options).await?;


### PR DESCRIPTION
## Summary

Per-module bumpalo arenas live in `LinkStageOutput.ast_table` and dominate rolldown's peak heap during bundling (~62 % on the rome benchmark, 1,193 modules). `instantiate_chunks` is the last reader of those ASTs — nothing between it and end-of-bundle needs the per-module ASTs, but they currently survive past `minify_chunks` (which re-parses chunk output into fresh arenas) and `finalize_assets` (which allocates large output buffers).

This PR drops `ast_table` immediately after `instantiate_chunks` returns, freeing the bumpalo arenas before the post-codegen stages allocate.

## Measured impact (3 runs each, verified locally with dhat + getrusage + `/usr/bin/time -ahl`)

| Config | main | This PR | Δ |
|---|---:|---:|---:|
| **dhat At t-gmax (peak heap)** | | | |
| rome | 140.51 MiB | 110.15 MiB | **−30.4 MiB (−21.6 %)** |
| rome --minify | 159.78 MiB | 113.08 MiB | **−46.7 MiB (−29.2 %)** |
| **ru_maxrss (getrusage, 3-run avg)** | | | |
| rome | 172.05 MiB | 169.39 MiB | −2.66 MiB |
| rome --minify | 183.56 MiB | 181.41 MiB | −2.15 MiB |
| **time -ahl peak RSS (3-run avg)** | | | |
| rome | 180.99 MiB | 178.16 MiB | −2.83 MiB |
| rome --minify | 193.37 MiB | 191.11 MiB | −2.26 MiB |

Larger synthetic and minify workloads from the issue (#9516) scale similarly: ~−24 % on synth 2000 --minify, ~−26 % on synth 5000 --minify. threejs r108 sees no change because its peak is at link, not post-codegen.

`ru_maxrss` deltas are smaller because both the system allocator and mimalloc retain freed pages, but the heap-level reduction is what matters for memory-pressure scheduling and steady-state RSS across multiple builds (watch mode, dev server).

## Alternative considered

A type-system-enforced version (#9555) threads `IndexEcmaAst` by value from `LinkStage::link()` through `generate → finalize_modules → render_chunk_to_assets → instantiate_chunks → create_chunk_to_codegen_ret_map`, removing `ast_table` from `LinkStageOutput` entirely. It touches 5 files and saves ~2 MiB more on rome (no minify); **identical** results on rome --minify. The compile-time guarantee guards against a future reader being reintroduced after codegen — but the practical risk is essentially zero, so this minimal version is preferred.

Refs #9516.