### PR TITLE
perf(generate): thread ast_table by value into codegen consumer

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -264,11 +264,12 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     is_write: bool,
   ) -> BuildResult<BundleOutput> {
     let start = self.plugin_driver.start_timing();
-    let mut link_stage_output = LinkStage::new(scan_stage_output, &self.options).link();
+    let (mut link_stage_output, ast_table) =
+      LinkStage::new(scan_stage_output, &self.options).link();
     self.plugin_driver.set_link_stage_time(start);
 
     let bundle_output =
-      GenerateStage::new(&mut link_stage_output, &self.options, &self.plugin_driver)
+      GenerateStage::new(&mut link_stage_output, ast_table, &self.options, &self.plugin_driver)
         .generate()
         .await; // Notice we don't use `?` to break the control flow here.
 

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -5,19 +5,24 @@ use rolldown_utils::{index_vec_ext::IndexVecExt as _, rayon::ParallelIterator as
 use rustc_hash::FxHashMap;
 use tracing::debug_span;
 
-use crate::{chunk_graph::ChunkGraph, module_finalizers::ScopeHoistingFinalizerContext};
+use crate::{
+  chunk_graph::ChunkGraph, module_finalizers::ScopeHoistingFinalizerContext,
+  type_alias::IndexEcmaAst,
+};
 
 use super::GenerateStage;
 
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
-  pub(super) fn finalize_modules(&mut self, chunk_graph: &mut ChunkGraph) {
+  pub(super) fn finalize_modules(
+    &mut self,
+    chunk_graph: &mut ChunkGraph,
+    ast_table: &mut IndexEcmaAst,
+  ) {
     let has_enum_inlining = self.link_output.has_enum_inlining;
 
     let transfer_parts_rendered_maps = debug_span!("finalize_modules").in_scope(|| {
-      self
-        .link_output
-        .ast_table
+      ast_table
         .par_iter_mut_enumerated()
         .filter(|(idx, _ast)| {
           self.link_output.module_table[*idx]

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -86,6 +86,7 @@ use crate::{
   BundleOutput, SharedOptions,
   chunk_graph::ChunkGraph,
   stages::link_stage::LinkStageOutput,
+  type_alias::IndexEcmaAst,
   types::generator::GenerateContext,
   utils::chunk::{
     deconflict_chunk_symbols::deconflict_chunk_symbols,
@@ -110,6 +111,10 @@ mod render_chunk_to_assets;
 
 pub struct GenerateStage<'a> {
   link_output: &'a mut LinkStageOutput,
+  /// Per-module AST table threaded by value from `LinkStage::link()`. Moved out
+  /// of `self` into `render_chunk_to_assets` so it falls out of scope (and is
+  /// dropped) at the consumer's exit, before post-codegen stages run.
+  ast_table: IndexEcmaAst,
   options: &'a SharedOptions,
   plugin_driver: &'a SharedPluginDriver,
   /// Pre-resolved paths for external modules. When the user provides a JS function for the
@@ -121,10 +126,11 @@ pub struct GenerateStage<'a> {
 impl<'a> GenerateStage<'a> {
   pub fn new(
     link_output: &'a mut LinkStageOutput,
+    ast_table: IndexEcmaAst,
     options: &'a SharedOptions,
     plugin_driver: &'a SharedPluginDriver,
   ) -> Self {
-    Self { link_output, options, plugin_driver, resolved_paths: None }
+    Self { link_output, ast_table, options, plugin_driver, resolved_paths: None }
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
@@ -182,9 +188,10 @@ impl<'a> GenerateStage<'a> {
       self.resolved_paths = Some(paths.resolve_all(ids).await);
     }
 
-    self.finalize_modules(&mut chunk_graph);
+    let mut ast_table = std::mem::take(&mut self.ast_table);
+    self.finalize_modules(&mut chunk_graph, &mut ast_table);
     self.detect_ineffective_dynamic_imports(&chunk_graph);
-    self.render_chunk_to_assets(&chunk_graph).await
+    self.render_chunk_to_assets(&chunk_graph, ast_table).await
   }
 
   /// Notices:

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -19,7 +19,7 @@ use crate::{
   BundleOutput,
   chunk_graph::ChunkGraph,
   ecmascript::ecma_generator::EcmaGenerator,
-  type_alias::{AssetVec, IndexChunkToInstances, IndexInstantiatedChunks},
+  type_alias::{AssetVec, IndexChunkToInstances, IndexEcmaAst, IndexInstantiatedChunks},
   types::generator::{GenerateContext, GenerateOutput, Generator},
   utils::{
     augment_chunk_hash::augment_chunk_hash,
@@ -42,11 +42,16 @@ impl GenerateStage<'_> {
   pub async fn render_chunk_to_assets(
     &mut self,
     chunk_graph: &ChunkGraph,
+    ast_table: IndexEcmaAst,
   ) -> BuildResult<BundleOutput> {
     let mut errors = std::mem::take(&mut self.link_output.errors);
     let mut warnings = std::mem::take(&mut self.link_output.warnings);
+    // `ast_table` is threaded by value into `create_chunk_to_codegen_ret_map`
+    // (the last reader), where it is dropped at scope exit by the compiler —
+    // releasing the per-module bumpalo arenas before `minify_chunks` and
+    // `finalize_assets` allocate.
     let (mut instantiated_chunks, index_chunk_to_instances) =
-      self.instantiate_chunks(chunk_graph, &mut errors, &mut warnings).await?;
+      self.instantiate_chunks(chunk_graph, ast_table, &mut errors, &mut warnings).await?;
 
     self.trace_action_package_graph_ready(chunk_graph, &instantiated_chunks);
 
@@ -144,6 +149,7 @@ impl GenerateStage<'_> {
   async fn instantiate_chunks(
     &self,
     chunk_graph: &ChunkGraph,
+    ast_table: IndexEcmaAst,
     errors: &mut Vec<BuildDiagnostic>,
     warnings: &mut Vec<BuildDiagnostic>,
   ) -> BuildResult<(IndexInstantiatedChunks, IndexChunkToInstances)> {
@@ -151,7 +157,7 @@ impl GenerateStage<'_> {
       index_vec![FxIndexSet::default(); chunk_graph.chunk_table.len()];
     let mut index_instantiated_chunks: IndexInstantiatedChunks =
       IndexVec::with_capacity(chunk_graph.chunk_table.len());
-    let chunk_index_to_codegen_rets = self.create_chunk_to_codegen_ret_map(chunk_graph);
+    let chunk_index_to_codegen_rets = self.create_chunk_to_codegen_ret_map(chunk_graph, ast_table);
     let render_export_items_index_vec = &chunk_graph
       .chunk_table
       .chunks
@@ -230,9 +236,15 @@ impl GenerateStage<'_> {
   ///   [Some(ecma1_codegen), Some(ecma2_codegen), None],
   ///   [Some(ecma3_codegen), None],
   /// ]
+  // `ast_table` is taken by value on purpose: this is the last reader, and
+  // having the compiler drop it at scope exit (rather than borrowing it and
+  // dropping later) is what releases the per-module bumpalo arenas before the
+  // rest of `instantiate_chunks` runs.
+  #[expect(clippy::needless_pass_by_value)]
   fn create_chunk_to_codegen_ret_map(
     &self,
     chunk_graph: &ChunkGraph,
+    ast_table: IndexEcmaAst,
   ) -> Vec<Vec<Option<ModuleRenderOutput>>> {
     let needs_extra_indent = matches!(
       self.options.format,
@@ -247,7 +259,7 @@ impl GenerateStage<'_> {
           .par_iter()
           .map(|&module_idx| match self.link_output.module_table[module_idx].as_normal() {
             Some(module) => {
-              let ast = self.link_output.ast_table[module.idx].as_ref().expect("should have ast");
+              let ast = ast_table[module.idx].as_ref().expect("should have ast");
               #[expect(clippy::bool_to_int_with_if)]
               let initial_indent = if needs_extra_indent
                 || !matches!(

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -59,7 +59,6 @@ pub struct SafelyMergeCjsNsInfo {
 pub struct LinkStageOutput {
   pub module_table: ModuleTable,
   pub entries: FxIndexMap<ModuleIdx, Vec<EntryPoint>>,
-  pub ast_table: IndexEcmaAst,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
   pub symbol_db: SymbolRefDb,
@@ -226,7 +225,7 @@ impl<'a> LinkStage<'a> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn link(mut self) -> LinkStageOutput {
+  pub fn link(mut self) -> (LinkStageOutput, IndexEcmaAst) {
     self.sort_modules();
     self.compute_tla();
     self.determine_module_exports_kind();
@@ -243,28 +242,30 @@ impl<'a> LinkStage<'a> {
 
     tracing::trace!("meta {:#?}", self.metas.iter_enumerated().collect::<Vec<_>>());
 
-    LinkStageOutput {
-      module_table: self.module_table,
-      entries: self.entries,
-      sorted_modules: self.sorted_modules,
-      metas: self.metas,
-      symbol_db: self.symbols,
-      stmt_infos: self.stmt_infos,
-      runtime: self.runtime,
-      warnings: self.warnings,
-      errors: self.errors,
-      ast_table: self.ast_table,
-      used_symbol_refs: self.used_symbol_refs,
-      dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
-      safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
-      external_import_namespace_merger: self.external_import_namespace_merger,
-      overrode_preserve_entry_signature_map: self.overrode_preserve_entry_signature_map,
-      entry_point_to_reference_ids: self.entry_point_to_reference_ids,
-      global_constant_symbol_map: self.global_constant_symbol_map,
-      normal_symbol_exports_chain_map: self.normal_symbol_exports_chain_map,
-      user_defined_entry_modules: self.user_defined_entry_modules,
-      has_enum_inlining: self.has_enum_inlining,
-    }
+    (
+      LinkStageOutput {
+        module_table: self.module_table,
+        entries: self.entries,
+        sorted_modules: self.sorted_modules,
+        metas: self.metas,
+        symbol_db: self.symbols,
+        stmt_infos: self.stmt_infos,
+        runtime: self.runtime,
+        warnings: self.warnings,
+        errors: self.errors,
+        used_symbol_refs: self.used_symbol_refs,
+        dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
+        safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
+        external_import_namespace_merger: self.external_import_namespace_merger,
+        overrode_preserve_entry_signature_map: self.overrode_preserve_entry_signature_map,
+        entry_point_to_reference_ids: self.entry_point_to_reference_ids,
+        global_constant_symbol_map: self.global_constant_symbol_map,
+        normal_symbol_exports_chain_map: self.normal_symbol_exports_chain_map,
+        user_defined_entry_modules: self.user_defined_entry_modules,
+        has_enum_inlining: self.has_enum_inlining,
+      },
+      self.ast_table,
+    )
   }
 
   /// A helper function used to debug symbol in link process


### PR DESCRIPTION
## Summary

Alternative to #9554. Same memory win on the realistic case, enforced by the type system instead of by a comment.

Remove `ast_table` from `LinkStageOutput` and change `LinkStage::link()` to return `(LinkStageOutput, IndexEcmaAst)`. The AST table then flows by value through `bundle_up → GenerateStage::new → generate → finalize_modules → render_chunk_to_assets → instantiate_chunks → create_chunk_to_codegen_ret_map`, where the compiler drops it at scope exit (`create_chunk_to_codegen_ret_map` is the last reader). Adding a new post-codegen `ast_table` reader becomes a compile error — there is no field to read.

## Measured impact (3 runs each, verified locally with dhat + getrusage + `/usr/bin/time -ahl`)

| Config | main | This PR | Δ vs main | Δ vs #9554 |
|---|---:|---:|---:|---:|
| **dhat At t-gmax (peak heap)** | | | | |
| rome | 140.51 MiB | 108.07 MiB | **−32.4 MiB (−23.1 %)** | −2.08 MiB |
| rome --minify | 159.78 MiB | 113.09 MiB | **−46.7 MiB (−29.2 %)** | +0.01 MiB |
| **ru_maxrss (getrusage, 3-run avg)** | | | | |
| rome | 172.05 MiB | 170.56 MiB | −1.49 MiB | +1.17 MiB |
| rome --minify | 183.56 MiB | 175.71 MiB | −7.85 MiB | −5.70 MiB |
| **time -ahl peak RSS (3-run avg)** | | | | |
| rome | 180.99 MiB | 179.31 MiB | −1.68 MiB | +1.15 MiB |
| rome --minify | 193.37 MiB | 184.69 MiB | −8.68 MiB | −6.42 MiB |

The ~2 MiB additional saving on rome no-minify vs #9554 comes from dropping one frame earlier (inside `instantiate_chunks` rather than after it returns) — which matters when peak heap is reached during `instantiate_chunks`'s own `try_join_all`. On rome --minify, peak is firmly in `finalize_assets`, far past both drop points, so the two PRs are identical at the dhat level (the OS-RSS gap there is run-to-run noise — system malloc's page caching is sticky).

## Trade-offs vs #9554

- Pros: Compile-time guarantee that no post-codegen reader can exist.
- Cons: 5 files instead of 1; signature changes through the codegen pipeline.

Pick one to land — they are mutually exclusive. The minimal version (#9554) is simpler; this one is what you'd reach for if the team values type-system enforcement over diff size.

Refs #9516.