### PR TITLE
fix(dev): make `ensureCurrentBuildFinish` not returning error when engine closes

### DIFF
--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -138,21 +138,31 @@ impl DevEngine {
     Ok(())
   }
 
-  // Wait for ongoing bundle to finish if there is one
+  /// Wait for ongoing bundle to finish if there is one.
+  ///
+  /// If the `DevEngine` is closed while waiting, this method will return early without error.
   pub async fn wait_for_ongoing_bundle(&self) -> BuildResult<()> {
-    self.create_error_if_closed()?;
+    if self.is_closed() {
+      return Ok(());
+    }
 
     let (reply_sender, reply_receiver) = tokio::sync::oneshot::channel();
-    self
-      .coordinator_sender
-      .send(CoordinatorMsg::GetState { reply: reply_sender })
-      .map_err_to_unhandleable()
-      .context("DevEngine: failed to send GetState to coordinator")?;
+    if let Err(err) = self.coordinator_sender.send(CoordinatorMsg::GetState { reply: reply_sender })
+    {
+      if self.is_closed() {
+        return Ok(());
+      }
+      return (Err(err))
+        .map_err_to_unhandleable()
+        .context("DevEngine: failed to send GetState to coordinator")?;
+    }
 
-    let status = reply_receiver
-      .await
-      .map_err_to_unhandleable()
-      .context("DevEngine: coordinator closed before responding to GetStatus")?;
+    let Ok(status) = reply_receiver.await else {
+      if self.is_closed() {
+        return Ok(());
+      }
+      return Err(anyhow::anyhow!("DevEngine: coordinator closed before responding to GetState"))?;
+    };
 
     if let Some(bundling_future) = status.running_future {
       bundling_future.await;

--- a/packages/rolldown/tests/dev/dev-close.test.ts
+++ b/packages/rolldown/tests/dev/dev-close.test.ts
@@ -1,0 +1,88 @@
+import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { InputOptions, OutputOptions } from 'rolldown';
+import type { DevEngine, DevOptions } from 'rolldown/experimental';
+import { dev as _dev } from 'rolldown/experimental';
+import { expect, test } from 'vitest';
+
+const TEST_TIMEOUT = 60_000;
+
+function dev(
+  inputOptions: InputOptions,
+  outputOptions: OutputOptions,
+  devOptions: DevOptions,
+): Promise<DevEngine> {
+  return _dev(inputOptions, outputOptions, {
+    ...devOptions,
+    watch: {
+      ...getDevWatchOptionsForCi(),
+      ...devOptions.watch,
+    },
+  });
+}
+
+// Regression test for https://github.com/rolldown/rolldown/issues/9365
+//
+// When the initial build fails, Vite's `waitForInitialBuildFinish` polls
+// `ensureCurrentBuildFinish()` in a loop. If the user edits `vite.config.ts`
+// during that loop, Vite restarts the server and closes the dev engine, but
+// the polling loop is left running in the old environment. The old loop's
+// next `ensureCurrentBuildFinish()` call then ran on a closed engine and
+// rejected with `Dev engine is closed`. Vite's loop has no `.catch()`, so the
+// rejection became an unhandled rejection and crashed the process.
+//
+// Fix: after `close()`, `ensureCurrentBuildFinish()` is a no-op rather than
+// an error — there is no ongoing bundle to wait for.
+test(
+  'ensureCurrentBuildFinish after close resolves instead of rejecting',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-close-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const input = path.join(dir, 'main.js');
+    fs.writeFileSync(input, 'console.log(1)');
+
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const engine = await dev(
+      {
+        input,
+        experimental: { devMode: true },
+        plugins: [
+          {
+            name: 'force-failure',
+            load() {
+              // Reproduce the failing-load-hook from the original issue's
+              // vite.config.ts so the initial build is in the "failed" state
+              // at the moment of close.
+              throw new Error('test error');
+            },
+          },
+        ],
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    // Mirror Vite: kick off run() without awaiting, so the initial build is
+    // in flight (and failing) when close() races with the next call.
+    engine.run().catch(() => {});
+
+    // Let the build fail at least once before closing.
+    await engine.ensureCurrentBuildFinish();
+
+    await engine.close();
+
+    // After close, this call must resolve rather than reject. Vite calls it
+    // from a polling loop without a `.catch()` handler — a rejection here
+    // surfaces as an unhandled promise rejection that crashes the host.
+    await expect(engine.ensureCurrentBuildFinish()).resolves.toBeUndefined();
+  },
+);


### PR DESCRIPTION
## Summary

In Vite, `waitForInitialBuildFinish` loops `devEngine.ensureCurrentBuildFinish` if no memory files are written, this means that the loop will never stop even when build fails. In rolldown, `ensureCurrentBuildFinish` immediately returns an error if `DevEngine` is closed. 

That said, if an error was emitted for the first build and the server restarts because of updating `vite.config` (like it is in https://github.com/rolldown/rolldown/issues/9365) while the loop continues, it will cause an error in Vite, which is not recoverable because of lacking `catch` after `waitForInitialBuildFinish` ([see](https://github.com/vitejs/vite/blob/b089c2bab9a92543678e07af6997435542d738c5/packages/vite/src/node/server/environments/fullBundleEnvironment.ts#L184)).

This PR updates `ensureCurrentBuildFinish` to not return error when engine closes.

closes https://github.com/rolldown/rolldown/issues/9365

## Test

Added `packages/rolldown/tests/dev/dev-close.test.ts`


