### PR TITLE
chore(deps): bump oxc + oxc_sourcemap to git refs; migrate to OwnedSourceMap

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
@@ -3,7 +3,7 @@ use oxc_allocator::AllocatorPool;
 use rolldown_common::{MinifyOptions, NormalizedBundlerOptions};
 use rolldown_ecmascript::EcmaCompiler;
 use rolldown_error::BuildResult;
-use rolldown_sourcemap::collapse_sourcemaps;
+use rolldown_sourcemap::collapse_sourcemaps_owned;
 use rolldown_utils::rayon::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::type_alias::IndexInstantiatedChunks;
@@ -56,12 +56,15 @@ impl GenerateStage<'_> {
             codegen_options,
           );
           chunk.content = minified_content.into();
-          match (&chunk.map, &new_map) {
+          match (chunk.map.take(), &new_map) {
             (Some(origin_map), Some(new_map)) => {
-              chunk.map = Some(collapse_sourcemaps(&[origin_map, new_map]));
+              chunk.map = Some(collapse_sourcemaps_owned(origin_map, &[new_map]));
             }
-            _ => {
+            (origin_map, _) => {
+              // Minify produced no new map (or there was none to begin with);
+              // restore whatever we took.
               // TODO: Map is dirty. Should we reset the `chunk.map` to `None`?
+              chunk.map = origin_map;
             }
           }
         }

--- a/crates/rolldown/src/utils/render_chunks.rs
+++ b/crates/rolldown/src/utils/render_chunks.rs
@@ -8,7 +8,7 @@ use rolldown_common::{
 };
 use rolldown_error::BuildDiagnostic;
 use rolldown_plugin::{HookRenderChunkArgs, SharedPluginDriver};
-use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
+use rolldown_sourcemap::{SourceMap, collapse_sourcemaps_owned};
 use rolldown_utils::indexmap::FxIndexMap;
 
 use crate::type_alias::IndexInstantiatedChunks;
@@ -61,11 +61,11 @@ pub async fn render_chunks(
     let asset = &mut assets[index];
     asset.content = code.into();
     if !sourcemaps.is_empty() {
-      if let Some(asset_map) = &asset.map {
-        let mut sourcemap_chain = Vec::with_capacity(sourcemaps.len() + 1);
-        sourcemap_chain.push(asset_map);
-        sourcemap_chain.extend(sourcemaps.iter());
-        asset.map = Some(collapse_sourcemaps(&sourcemap_chain));
+      if let Some(asset_map) = asset.map.take() {
+        // Move `asset_map` into the collapse so its (chunk-sized) `source_contents`
+        // is reused rather than cloned; the plugin-returned maps remap on top.
+        let rest: Vec<&SourceMap> = sourcemaps.iter().collect();
+        asset.map = Some(collapse_sourcemaps_owned(asset_map, &rest));
       }
     }
     warnings.extend(chunk_warnings);

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintOptions};
-use rolldown_sourcemap::{OwnedSourceMap, collapse_sourcemaps};
+use rolldown_sourcemap::{OwnedSourceMap, collapse_sourcemaps_owned};
 use rolldown_utils::IndexBitSet;
 use rustc_hash::FxHashSet;
 use string_wizard::SourceMapOptions;
@@ -234,7 +234,7 @@ impl NormalModule {
           });
           let map = render_output
             .map
-            .map(|original| collapse_sourcemaps(&[&original.into_inner(), &mutated_map]));
+            .map(|original| collapse_sourcemaps_owned(original.into_inner(), &[&mutated_map]));
           return ModuleRenderOutput { code, map };
         }
         ModuleRenderOutput {

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -25,7 +25,7 @@ use oxc::{
 use oxc_resolver::TsConfig;
 use rolldown_ecmascript::semantic_builder_for_transform;
 use rolldown_error::{BuildDiagnostic, EventKind, Severity};
-use rolldown_sourcemap::{OwnedSourceMap, SourceMap, collapse_sourcemaps};
+use rolldown_sourcemap::{OwnedSourceMap, SourceMap, collapse_sourcemaps_owned};
 use rustc_hash::FxHashMap;
 
 use crate::inner_bundler_options::types::transform_option::{
@@ -415,7 +415,8 @@ pub fn enhanced_transform(
     .build(&program);
 
   let output_map = match (input_map, codegen_ret.map.map(OwnedSourceMap::into_inner)) {
-    (Some(im), Some(om)) => Some(collapse_sourcemaps(&[&im, &om])),
+    // `im` is owned and dropped here, so move it into the collapse.
+    (Some(im), Some(om)) => Some(collapse_sourcemaps_owned(im, &[&om])),
     (None, map) => map,
     (Some(_), None) => None,
   };

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -3,7 +3,7 @@ mod source_joiner;
 
 use std::borrow::Cow;
 
-use oxc_sourcemap::Token;
+use oxc_sourcemap::{SourceMapParts, Token};
 
 pub use oxc_sourcemap::{JSONSourceMap, OwnedSourceMap, SourceMapBuilder, SourcemapVisualizer};
 pub use source_joiner::SourceJoiner;
@@ -13,6 +13,19 @@ pub use source_joiner::SourceJoiner;
 pub type SourceMap = oxc_sourcemap::SourceMap<'static>;
 
 pub use crate::source::{Source, SourceMapSource};
+
+/// Rebuilds an owned `SourceMap` from `parts`, swapping in freshly computed
+/// `tokens`. Drops the metadata that no longer matches the new token array:
+/// `token_chunks` (its chunk boundaries index the old tokens) and the
+/// per-encode `x_google_ignore_list`/`debug_id`. The string tables and
+/// `file`/`source_root` are left exactly as the caller set them in `parts`.
+fn rebuild_with_tokens(mut parts: SourceMapParts<'static>, tokens: Box<[Token]>) -> SourceMap {
+  parts.tokens = tokens;
+  parts.token_chunks = None;
+  parts.x_google_ignore_list = None;
+  parts.debug_id = None;
+  SourceMap::from_parts(parts)
+}
 
 /// Strips the first `lines` destination lines from the sourcemap, decrementing all remaining
 /// destination line numbers accordingly. Used to re-anchor a sourcemap after removing a
@@ -37,15 +50,12 @@ pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap
     })
     .collect();
 
-  SourceMap::new(
-    sourcemap.get_file().map(|f| Cow::Owned(f.to_owned())),
-    sourcemap.get_names().map(|n| Cow::Owned(n.to_owned())).collect(),
-    sourcemap.get_source_root().map(|s| Cow::Owned(s.to_owned())),
-    sourcemap.get_sources().map(|s| Cow::Owned(s.to_owned())).collect(),
-    sourcemap.get_source_contents().map(|c| c.map(|s| Cow::Owned(s.to_owned()))).collect(),
-    tokens,
-    None,
-  )
+  // The input map is owned, so move its `file`/`names`/`sources`/`source_contents`
+  // (notably the full source text in `source_contents`) into the result instead of
+  // re-cloning every string through the accessors. Only `tokens` is rebuilt — its
+  // dst lines shifted — keeping `file`/`source_root` since the code is unchanged
+  // apart from the stripped prefix.
+  rebuild_with_tokens(sourcemap.into_parts(), tokens)
 }
 
 /// Builds an empty sourcemap with no tokens, sources, names, or contents.
@@ -53,16 +63,12 @@ pub fn empty_sourcemap() -> SourceMap {
   SourceMap::new(None, vec![], None, vec![], vec![], Box::new([]), None)
 }
 
-// <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
-pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
-  debug_assert!(sourcemap_chain.len() > 1);
-  if sourcemap_chain.len() == 1 {
-    // If there's only one sourcemap, return it as is.
-    return sourcemap_chain[0].clone();
-  }
-
+/// Walks every destination token of the chain's last map back through the
+/// preceding maps, producing the collapsed token list. The resulting tokens'
+/// `source_id`/`name_id` index into the chain's *first* map, so callers pair
+/// these tokens with the first map's `names`/`sources`/`source_contents`.
+fn collapse_chain_tokens(sourcemap_chain: &[&SourceMap]) -> Box<[Token]> {
   let last_map = sourcemap_chain.last().expect("sourcemap_chain should not be empty");
-  let first_map = sourcemap_chain.first().expect("sourcemap_chain should not be empty");
   let chain_without_last = &sourcemap_chain[..sourcemap_chain.len() - 1];
 
   // Pre-compute lookup tables in reverse order so we avoid reversing on every token lookup.
@@ -72,7 +78,7 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
     .map(|sourcemap| (*sourcemap, sourcemap.generate_lookup_table()))
     .collect();
 
-  let tokens: Box<[Token]> = last_map
+  last_map
     .get_source_view_tokens()
     .filter_map(|token| {
       let original_token =
@@ -94,7 +100,19 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
         )
       })
     })
-    .collect();
+    .collect()
+}
+
+// <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
+pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
+  debug_assert!(sourcemap_chain.len() > 1);
+  if sourcemap_chain.len() == 1 {
+    // If there's only one sourcemap, return it as is.
+    return sourcemap_chain[0].clone();
+  }
+
+  let first_map = sourcemap_chain.first().expect("sourcemap_chain should not be empty");
+  let tokens = collapse_chain_tokens(sourcemap_chain);
 
   SourceMap::new(
     None,
@@ -107,9 +125,37 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
   )
 }
 
+/// Like [`collapse_sourcemaps`] but consumes the chain's first map (`first_map`,
+/// followed by `rest_maps`), moving its `names`/`sources`/`source_contents` into
+/// the result instead of cloning them.
+///
+/// The collapsed result always reuses the *first* map's strings, so when the
+/// caller owns that map this avoids duplicating `source_contents` — the full
+/// original source text. For chunk-level maps that is the concatenation of every
+/// module in the chunk and dominates sourcemap memory, so prefer this whenever
+/// the first map can be given up.
+pub fn collapse_sourcemaps_owned(first_map: SourceMap, rest_maps: &[&SourceMap]) -> SourceMap {
+  if rest_maps.is_empty() {
+    // Nothing to remap against; the first map is already the result.
+    return first_map;
+  }
+
+  let mut sourcemap_chain = Vec::with_capacity(rest_maps.len() + 1);
+  sourcemap_chain.push(&first_map);
+  sourcemap_chain.extend(rest_maps.iter().copied());
+  let tokens = collapse_chain_tokens(&sourcemap_chain);
+  // The `sourcemap_chain` borrow of `first_map` ends at its last use above, so
+  // `first_map` can now be moved. Reuse its strings; only `tokens` is replaced.
+  // Like `collapse_sourcemaps`, a collapsed map has no single `file`/`source_root`.
+  let mut parts = first_map.into_parts();
+  parts.file = None;
+  parts.source_root = None;
+  rebuild_with_tokens(parts, tokens)
+}
+
 #[test]
 fn test_collapse_sourcemaps() {
-  use crate::{SourceJoiner, SourceMapSource, collapse_sourcemaps};
+  use crate::{SourceJoiner, SourceMapSource, collapse_sourcemaps, collapse_sourcemaps_owned};
   use oxc::{
     allocator::Allocator,
     codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions},
@@ -186,6 +232,12 @@ fn test_collapse_sourcemaps() {
 (0:30) ");\n" --> (3:15) ");\n"
 "#
   );
+
+  // The owned variant moves the first map's strings instead of cloning them, but
+  // must produce a byte-identical map for the same chain.
+  let (first, rest) = sourcemap_chain.split_first().unwrap();
+  let owned_map = collapse_sourcemaps_owned((*first).clone(), rest);
+  assert_eq!(owned_map.to_json_string(), map.to_json_string());
 }
 
 /// Test for https://github.com/rollup/rollup/issues/5955


### PR DESCRIPTION
## Summary

Pin `oxc_sourcemap` to https://github.com/oxc-project/oxc-sourcemap rev [`abae0f7`](https://github.com/oxc-project/oxc-sourcemap/commit/abae0f7) (current main) to pick up:

- the `SourceMap<'a>` / `OwnedSourceMap` lifetime API — zero-copy borrow-parsed sourcemaps plus a lifetime-free owned wrapper for downstream struct fields
- the visualizer perf/correctness fix in [oxc-sourcemap#344](https://github.com/oxc-project/oxc-sourcemap/pull/344) — O(n²) `chars().nth()` scan that also misread CRLF after multi-byte UTF-8

And bump `oxc` (+ sibling crates) to the matching PR branch in [oxc#22742](https://github.com/oxc-project/oxc/pull/22742), which migrates `oxc_codegen::CodegenReturn::map` to the new API. Both pins revert to crates.io versions once oxc-sourcemap cuts the next release and oxc cuts a release containing #22742.

**Draft** because it depends on those two upstream landings.

## Rolldown migration

- `rolldown_sourcemap` re-exports `OwnedSourceMap as SourceMap` so downstream users get the lifetime-free wrapper transparently.
- `adjust_sourcemap_dst_lines` uses `into_parts()` / `from_parts()`, moving names/sources/sourcesContent out of the input instead of re-allocating per string.
- `collapse_sourcemaps` borrows names/sources/sourcesContent from the first input via `Cow::Borrowed`, then detaches with `into_owned_sourcemap()` — no per-string allocations on the hot path.
- `string_wizard::SourcemapBuilder::into_source_map` and `MagicString::source_map` return `OwnedSourceMap`.
- `rolldown_ecmascript::EcmaCompiler::dce_or_minify` returns `Option<OwnedSourceMap>` via the bumped `oxc::codegen::CodegenReturn`.
- `binding_magic_string` drops the `Arc`-based `SourceMap::new` round-trip that was used to attach `file` and just calls `OwnedSourceMap::set_file` in place.

## Drive-by oxc 0.133-dev API-drift fixes

Required to compile against the bumped `oxc`, orthogonal to the sourcemap change:

- `DecoratorOptions::from` adds `..Default::default()` for the new `strict_null_checks` field.
- `oxc_minify_napi::CodegenOptions` initializer adds `..Default::default()` for the new `legal_comments` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)