### PR TITLE
fix(dev): handle the remaining errors in dev

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 use rolldown_dev::{BundleState, BundlingFuture, OnHmrUpdatesCallback, OnOutputCallback};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::binding_dev_options::BindingDevOptions;
@@ -15,6 +15,7 @@ use napi::{Either, Env, threadsafe_function::ThreadsafeFunctionCallMode};
 #[napi]
 pub struct BindingDevEngine {
   inner: rolldown_dev::DevEngine,
+  cwd: Arc<Path>,
   _session_id: Arc<str>,
   _session: rolldown_devtools::Session,
 }
@@ -33,7 +34,7 @@ impl BindingDevEngine {
     let on_hmr_updates_callback = dev_options.as_ref().and_then(|opts| opts.on_hmr_updates.clone());
     let on_output_callback = dev_options.as_ref().and_then(|opts| opts.on_output.clone());
 
-    let cwd = Arc::new(PathBuf::from(options.input_options.cwd.clone()));
+    let cwd: Arc<Path> = Arc::from(PathBuf::from(options.input_options.cwd.clone()));
 
     let rebuild_strategy =
       dev_options.as_ref().and_then(|opts| opts.rebuild_strategy).map(Into::into);
@@ -64,7 +65,7 @@ impl BindingDevEngine {
 
     // If callback is provided, wrap it to convert BuildResult<(Vec<ClientHmrUpdate>, Vec<String>)> to BindingResult<(Vec<BindingClientHmrUpdate>, Vec<String>)>
     let on_hmr_updates = on_hmr_updates_callback.map(|js_callback| {
-      let cwd = Arc::<std::path::PathBuf>::clone(&cwd);
+      let cwd = Arc::<Path>::clone(&cwd);
       Arc::new(
         move |result: rolldown_error::BuildResult<(
           Vec<rolldown_common::ClientHmrUpdate>,
@@ -93,7 +94,7 @@ impl BindingDevEngine {
 
     // If callback is provided, wrap it to convert BuildResult<BundleOutput> to BindingResult<BindingOutputs>
     let on_output = on_output_callback.map(|js_callback| {
-      let cwd = Arc::<std::path::PathBuf>::clone(&cwd);
+      let cwd = Arc::<Path>::clone(&cwd);
       Arc::new(move |result: rolldown_error::BuildResult<rolldown::BundleOutput>| {
         let binding_result: BindingResult<BindingOutputs> = match result {
           Ok(bundle_output) => Either::B(BindingOutputs::from(bundle_output.assets)),
@@ -145,7 +146,7 @@ impl BindingDevEngine {
     let inner = rolldown_dev::DevEngine::new(bundler_config, rolldown_dev_options)
       .map_err(|e| napi::Error::from_reason(format!("Fail to create dev engine: {e:#?}")))?;
 
-    Ok(Self { inner, _session_id: session_id, _session: session })
+    Ok(Self { inner, cwd, _session_id: session_id, _session: session })
   }
 
   #[napi]
@@ -175,9 +176,17 @@ impl BindingDevEngine {
   }
 
   #[napi]
-  pub async fn ensure_latest_build_output(&self) -> napi::Result<()> {
-    self.inner.ensure_latest_bundle_output().await.expect("Should handle this error");
-    Ok(())
+  pub async fn ensure_latest_build_output(&self) -> napi::Result<BindingResult<()>> {
+    match self.inner.ensure_latest_bundle_output().await {
+      Ok(()) => Ok(Either::B(())),
+      Err(errors) => {
+        let binding_errors: Vec<_> = errors
+          .iter()
+          .map(|diagnostic| to_binding_error(diagnostic, self.cwd.to_path_buf()))
+          .collect();
+        Ok(Either::A(BindingErrors::new(binding_errors)))
+      }
+    }
   }
 
   #[napi]
@@ -190,11 +199,21 @@ impl BindingDevEngine {
     &self,
     caller: String,
     first_invalidated_by: Option<String>,
-  ) -> napi::Result<Vec<BindingClientHmrUpdate>> {
-    let updates =
-      self.inner.invalidate(caller, first_invalidated_by).await.expect("Should handle this error");
-    let binding_updates = updates.into_iter().map(BindingClientHmrUpdate::from).collect();
-    Ok(binding_updates)
+  ) -> napi::Result<BindingResult<Vec<BindingClientHmrUpdate>>> {
+    match self.inner.invalidate(caller, first_invalidated_by).await {
+      Ok(updates) => {
+        let binding_updates =
+          updates.into_iter().map(BindingClientHmrUpdate::from).collect::<Vec<_>>();
+        Ok(Either::B(binding_updates))
+      }
+      Err(errors) => {
+        let binding_errors: Vec<_> = errors
+          .iter()
+          .map(|diagnostic| to_binding_error(diagnostic, self.cwd.to_path_buf()))
+          .collect();
+        Ok(Either::A(BindingErrors::new(binding_errors)))
+      }
+    }
   }
 
   #[napi]

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use rolldown_common::{ClientHmrInput, ScanMode};
-use rolldown_error::BuildResult;
 use rolldown_utils::indexmap::FxIndexMap;
 use tokio::sync::Mutex;
 
@@ -57,16 +56,10 @@ impl BundlingTask {
 
   pub async fn run(mut self) {
     tracing::trace!("[BundlingTask] starts to run.\n - Task Input: {:#?}", self.input);
-    let task_run_result = self.run_inner().await;
-
-    if let Err(err) = &task_run_result {
-      tracing::error!("[BundlingTask] fails to run");
-      // FIXME: Should handle the error properly.
-      tracing::error!("Bundling task run with error: {err}"); // FIXME: handle this error
-    }
+    self.run_inner().await;
 
     let has_generated_bundle_output = self.has_rebuild_happen;
-    let has_encountered_error = self.has_encountered_error || task_run_result.is_err();
+    let has_encountered_error = self.has_encountered_error;
 
     tracing::trace!(
       "[BundlingTask] completed\n - has_generated_bundle_output: {has_generated_bundle_output:?}",
@@ -80,14 +73,22 @@ impl BundlingTask {
     );
   }
 
-  async fn run_inner(&mut self) -> BuildResult<()> {
+  async fn run_inner(&mut self) {
     {
       let bundler = self.bundler.lock().await;
       for (changed_file, event) in self.input.changed_files() {
         if let Some(plugin_driver) =
           bundler.last_bundle_handle.as_ref().map(rolldown::BundleHandle::plugin_driver)
         {
-          plugin_driver.watch_change(changed_file.to_str().unwrap(), *event).await?;
+          if let Err(err) = plugin_driver.watch_change(changed_file.to_str().unwrap(), *event).await
+          {
+            tracing::error!("[BundlingTask] watchChange hook failed: {err:?}");
+            self.has_encountered_error = true;
+            if let Some(on_output) = self.dev_context.options.on_output.as_ref() {
+              on_output(Err(err.into()));
+            }
+            return;
+          }
         }
       }
     }
@@ -95,10 +96,16 @@ impl BundlingTask {
     let mut has_full_reload_update = false;
     if self.input.require_generate_hmr_update() {
       tracing::trace!("[BundlingTask] starts to generate HMR updates");
-      self.generate_hmr_updates(&mut has_full_reload_update).await?;
+      let may_continue = self.generate_hmr_updates(&mut has_full_reload_update).await;
       tracing::trace!(
         "[BundlingTask] completed generating HMR updates\n - has_full_reload_update: {has_full_reload_update}"
       );
+      // Stop only when HMR errored AND no callback was registered to receive
+      // the error — preserving the pre-refactor `?` short-circuit. When the
+      // consumer was informed via callback, the rebuild still runs.
+      if !may_continue {
+        return;
+      }
     }
 
     // If the rebuild strategy is auto and there's a full reload update, we need to rebuild.
@@ -115,17 +122,14 @@ impl BundlingTask {
 
     if self.input.requires_rebuild() {
       self.has_rebuild_happen = true;
-      self.rebuild().await?;
+      self.rebuild().await;
     }
-
-    Ok(())
   }
 
+  /// Returns `true` if subsequent build stages may continue.
+  /// Callers should skip subsequent build stages on `false`.
   #[tracing::instrument(level = "trace", skip(self))]
-  pub async fn generate_hmr_updates(
-    &mut self,
-    has_full_reload_update: &mut bool,
-  ) -> BuildResult<()> {
+  pub async fn generate_hmr_updates(&mut self, has_full_reload_update: &mut bool) -> bool {
     let mut bundler = self.bundler.lock().await;
     let changed_files = self
       .input
@@ -161,6 +165,8 @@ impl BundlingTask {
       }
     }
 
+    let succeeded = hmr_result.is_ok();
+    let has_callback = self.dev_context.options.on_hmr_updates.is_some();
     if let Err(err) = &hmr_result {
       tracing::error!("[BundlingTask] failed to generate HMR updates: {:?}", err);
       self.has_encountered_error = true;
@@ -168,25 +174,18 @@ impl BundlingTask {
 
     // Call on_hmr_updates callback if provided
     if let Some(on_hmr_updates) = self.dev_context.options.on_hmr_updates.as_ref() {
-      match hmr_result {
-        Ok(client_updates) => {
-          on_hmr_updates(Ok((
-            client_updates,
-            changed_files.iter().map(|(p, _)| p.clone()).collect(),
-          )));
-        }
-        Err(e) => {
-          on_hmr_updates(Err(e));
-        }
-      }
-      Ok(())
-    } else {
-      hmr_result.map(|_| ())
+      on_hmr_updates(hmr_result.map(|client_updates| {
+        (client_updates, changed_files.iter().map(|(p, _)| p.clone()).collect())
+      }));
     }
+
+    // Continue when HMR succeeded, or when the consumer was informed of the
+    // failure via the callback. Stop only on an undeliverable error.
+    succeeded || has_callback
   }
 
   #[tracing::instrument(level = "trace", skip_all)]
-  async fn rebuild(&mut self) -> BuildResult<()> {
+  async fn rebuild(&mut self) {
     let mut bundler = self.bundler.lock().await;
 
     // TODO: hyf0 `skip_write` in watch mode won't trigger generate stage, need to investigate why.
@@ -218,7 +217,5 @@ impl BundlingTask {
     if let Some(on_output) = self.dev_context.options.on_output.as_ref() {
       on_output(build_result);
     }
-
-    Ok(())
   }
 }

--- a/meta/design/dev-engine.md
+++ b/meta/design/dev-engine.md
@@ -799,7 +799,260 @@ synthetic file changes and inspect coordinator state.
 
 ---
 
-## 16. Quick reference — concept-to-file map
+## 16. Error handling
+
+The dev engine has three error audiences. Naming them is important because
+they want different handling and the same `Result` can't be all things to
+all of them. The categories of error and the delivery channels then split by
+audience.
+
+### 16a. The three audiences
+
+- **End user** — the application developer using a framework built on top
+  of `rolldown_dev` (typically Vite). Writes source code and plugins. Sees
+  errors that originate from their own work — build errors, plugin
+  failures.
+- **Binding consumer** — the framework or tool integrating `rolldown_dev`
+  (typically Vite). Owns the engine lifecycle: constructs it, calls `run`,
+  routes HMR client messages into `invalidate`, calls `close` on shutdown.
+  Sees errors when it calls the engine at the wrong time (`invalidate`
+  after `close`, `ensure_latest_build_output` before `run`, etc.). They
+  are responsible for sequencing correctly; we surface the misuse so they
+  can detect their own bug.
+- **Us** — `rolldown_dev` itself. Sees invariant violations as panics
+  (§16g). These are bugs we shipped; neither user can recover from them
+  and a panic is the right way to make them loud.
+
+Errors split by audience:
+
+- **Build errors** → end user.
+- **Lifecycle errors** → binding consumer.
+- **Invariant violations** → panic (us).
+
+#### Build errors (end user)
+
+`BuildResult<T>` / `BatchedBuildDiagnostic` produced inside the bundler.
+Originate in user code or plugins (resolve, load, transform, plugin
+lifecycle hooks).
+
+Examples:
+
+- `Bundler::compute_hmr_update_for_file_changes` — diagnostics from HMR
+  computation, surfaced inside `BundlingTask::generate_hmr_updates`.
+- `Bundler::compute_update_for_calling_invalidate` — diagnostics from the
+  programmatic `invalidate()` path, surfaced by `DevEngine::invalidate`.
+- `Bundler::incremental_write` / `incremental_generate` — diagnostics from a
+  rebuild, surfaced inside `BundlingTask::rebuild`.
+- `plugin_driver.watch_change` — an `anyhow::Error` from a plugin's
+  `watchChange` hook, lifted into `BatchedBuildDiagnostic` at the
+  `BundlingTask::run_inner` call site.
+
+#### Lifecycle errors (binding consumer)
+
+`BuildResult<T>` produced by the `DevEngine` itself, not by the bundler.
+Originate from the engine's state machine: a method was called against a
+closed engine, the coordinator's mpsc channel was dropped mid-operation, an
+internal oneshot reply never arrived because the coordinator went away.
+
+Examples:
+
+- `create_error_if_closed()?` at the top of every `DevEngine` method that
+  touches the coordinator (`dev_engine.rs`).
+- `coordinator_sender.send(...).map_err_to_unhandleable().context(...)?`
+  after the engine has been closed.
+- `reply_receiver.await.map_err_to_unhandleable().context(...)?` when the
+  coordinator has shut down before responding.
+
+These are the binding consumer's responsibility — Vite must sequence its
+calls so they don't race with `close()`. When the race happens anyway we
+report rather than swallow (§16d), so the consumer can detect and fix the
+ordering bug.
+
+The two categories share the `BuildResult<T>` type today — there is no
+static distinction. Code that needs to react differently must inspect
+`DevEngine::is_closed()` first.
+
+### 16b. The two delivery channels
+
+**Throw (synchronous API)** — public napi methods that take a single caller
+and return a single result use `BindingResult<T> = Either<BindingErrors, T>`
+on the boundary, and the JS wrapper calls `unwrapBindingResult` to either
+return the success value or throw a `BundleError`.
+
+Used by: `invalidate`, `ensureLatestBuildOutput`, `getBundleState`,
+`waitForOngoingBundle`. The thrown error reaches whichever audience called
+the method:
+
+- `invalidate` is typically called by the binding consumer's HMR layer in
+  response to an end-user HMR client message. The thrown error is observed
+  by the consumer; whether to propagate it to the end user is the
+  consumer's decision.
+- `ensureLatestBuildOutput` is called by the consumer's dev-server
+  middleware before serving a request. The consumer handles or propagates.
+- `close`, `run`, lifecycle-shaped methods are consumer-driven by
+  construction.
+
+**Callback (async lifecycle)** — work that happens asynchronously inside a
+`BundlingTask` is reported through the `on_output` / `on_hmr_updates`
+callbacks registered when the engine was constructed (see §10).
+
+Used by: every error produced inside `BundlingTask::run_inner` —
+`watch_change`, `generate_hmr_updates`, `rebuild`. The consumer subscribes
+once at engine creation and is notified for every build's result. These
+callbacks are the canonical channel for build errors reaching the end user
+(via the consumer forwarding them into its own error overlay / HMR error
+display).
+
+Rule for picking the channel: **if the consumer cannot have set up a callback
+in advance (because the error originates from a one-shot call), throw;
+otherwise deliver to the callback**.
+
+### 16c. Error routing inside `BundlingTask`
+
+`run_inner` has three error-producing phases. Each phase owns the routing
+decision for its own errors; `run_inner` itself does not have a top-level
+error handler.
+
+| Phase                  | Callback used    | If callback registered     | If not registered      |
+| ---------------------- | ---------------- | -------------------------- | ---------------------- |
+| `watch_change` hooks   | `on_output`      | deliver, then return early | log only, return early |
+| `generate_hmr_updates` | `on_hmr_updates` | deliver, then may continue | log only, may stop     |
+| `rebuild`              | `on_output`      | deliver                    | log only               |
+
+A failure in any phase sets `self.has_encountered_error = true`, reported to
+the coordinator via `BundleCompleted { has_encountered_error, ... }`. The
+coordinator uses this to transition into `FullBuildFailed` / `Failed` (§11)
+regardless of whether a callback was registered to receive the error itself.
+
+`generate_hmr_updates` returns `bool` — "may subsequent stages continue?" —
+preserving the pre-`BuildResult` short-circuit: rebuild is skipped only when
+an HMR error had no callback to surface it through (matching how the older
+`?` propagation behaved).
+
+`watch_change` is short-circuiting: if a plugin's `watchChange` hook fails,
+neither HMR generation nor rebuild can proceed safely, so `run_inner` returns
+early.
+
+### 16d. Engine-closed: surface to the binding consumer by default
+
+Lifecycle errors (engine closed, coordinator gone, channel dropped) are
+surfaced **to the binding consumer**, not silently swallowed. Vite needs
+to see that it called `invalidate` after `close` so it can fix the
+sequencing; swallowing hides the misuse and lets it metastasize.
+
+**Per-method exception**: a method MAY return `Ok` instead of the lifecycle
+error when "nothing to do, return" is the obviously correct answer for
+that method's semantics. The exception applies when:
+
+- The method is doing waiting / observation, not requesting work.
+- "The thing you were waiting on can no longer happen" is a complete and
+  honest answer.
+- A throw would force the consumer to write `try/catch` around a normal
+  shutdown event with no useful recovery action.
+
+Current methods that take the exception:
+
+- `DevEngine::wait_for_ongoing_bundle` (`dev_engine.rs:144-172`) — waiting
+  for an in-flight build that just won't happen anymore; returning `Ok` is
+  semantically correct. The doc comment on the method spells this out.
+- `BindingDevEngine::ensure_current_build_finish` (the napi wrapper used
+  by `DevEngine.ensureCurrentBuildFinish` in JS) — same shape, PR #9564.
+
+Every other lifecycle error path should surface. When adding a new method,
+**default to surfacing**; only take the exception when there's an
+affirmative semantic reason and document it on the method.
+
+### 16e. The conversion path: `BuildResult` → `BindingResult` → JS
+
+Three stops:
+
+1. **`BuildResult<T>`** (`Result<T, BatchedBuildDiagnostic>`) — the bundler's
+   native error type, used everywhere inside the rust crates.
+   `BatchedBuildDiagnostic` carries one or more `BuildDiagnostic`s.
+
+2. **`BindingResult<T>`** (`Either<BindingErrors, T>`,
+   `crates/rolldown_binding/src/types/error/mod.rs`) — the napi boundary
+   type. On the `Err` side, each `BuildDiagnostic` is converted to a
+   `BindingError` via `to_binding_error(diagnostic, cwd)`
+   (`crates/rolldown_binding/src/types/binding_outputs.rs:79`). The `cwd`
+   is required for `DiagnosticOptions` to format paths relative to the
+   project root. `BindingDevEngine` stores `cwd: Arc<Path>` so the struct
+   methods and the two callback closures share one allocation.
+
+3. **JS layer** (`packages/rolldown/src/utils/error.ts`) —
+   `unwrapBindingResult(container)` returns `T` on success or throws a
+   `BundleError` aggregating the individual `BindingError`s.
+   `normalizeBindingResult(container)` returns `T | Error` without throwing,
+   used by callbacks that don't have a useful `throw` semantic.
+
+### 16f. Conventions
+
+- **No `.expect()` / `.unwrap()` on `BuildResult` or any consumer-reachable
+  `Result`.** A panic crosses the napi FFI boundary and can crash the Node
+  process. `match` and route through the appropriate channel instead.
+- **`create_error_if_closed()` is the entry guard.** Every `DevEngine`
+  method that touches the coordinator runs it first. By default the
+  resulting error is surfaced to the binding consumer (§16d); methods that
+  take the "swallow as `Ok`" exception (§16d) must also handle the
+  mid-call closed-race at every `.send(...)` and `.recv()` site.
+- **Plugin errors are user-visible.** Never silently drop them; they always
+  reach `on_output` or `on_hmr_updates`.
+- **Each phase owns its delivery.** Inside `BundlingTask`, each phase
+  function handles its own error delivery; `run_inner` is not a centralized
+  error handler.
+- **`has_encountered_error` is the coordinator signal, callbacks are the
+  consumer signal.** Both are set on every error; one drives the state
+  machine, the other notifies the user.
+
+### 16g. When to panic
+
+Not every `Result` in the dev engine should be routed. Some `.expect(...)` /
+`.unwrap()` calls are correct: they assert internal invariants — properties
+our own code guarantees — and a panic surfaces a programming bug rather than
+a runtime condition.
+
+The rule:
+
+- **Panic on invariant violations.** The codepath should be unreachable if
+  our own state-machine logic, shutdown ordering, or message-protocol
+  contracts are correct. If it fires we shipped a bug, and the panic makes
+  it loud rather than swallowing it into a silent log.
+- **Route runtime conditions.** Anything that depends on user code, plugin
+  behavior, filesystem state, network, races with consumer-driven lifecycle
+  events (e.g. `close()`), or input validation — route through the channels
+  in §16b. A panic on these would crash the Node process for something the
+  consumer must be able to observe and recover from.
+
+A useful test when deciding: _could this error be triggered by anything
+outside our crate?_ If yes, route it. If no, panic.
+
+Existing panic sites in `rolldown_dev` that are intentional, not punts:
+
+- `crates/rolldown_dev/src/watcher_event_handler.rs:10` —
+  `coordinator_tx.send(...).expect(...)`. The coordinator's mpsc receiver is
+  owned by the coordinator task, which only shuts down on the `Close`
+  message. The fs watcher cannot trigger that path; if its `send` fails, our
+  shutdown ordering is wrong.
+- `crates/rolldown_dev/src/bundling_task.rs:71` — same pattern on the final
+  `BundleCompleted` send. The coordinator awaits any in-flight `BundlingTask`
+  before processing `Close` (§4), so by construction the receiver is alive
+  when this send runs.
+- `crates/rolldown_dev/src/bundle_coordinator.rs:323, 420` —
+  `current_bundling_future.clone().unwrap()` is reachable only in states
+  `*InProgress`, where the state machine guarantees `Some(_)`. A `None` here
+  means a transition was missed.
+- `crates/rolldown_dev/src/dev_engine.rs:117` — `join_handle.await.unwrap()`
+  on the coordinator task. The coordinator's `run()` is internal code that
+  must not panic; a `JoinError` here means we introduced a panic in
+  coordinator logic and should fix _that_, not paper over the symptom.
+
+When adding new panic sites, document the invariant being asserted in the
+`.expect(...)` message so the next reader sees the contract without having to
+reconstruct it.
+
+---
+
+## 17. Quick reference — concept-to-file map
 
 | Concept                                        | File                                                            |
 | ---------------------------------------------- | --------------------------------------------------------------- |

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -10,7 +10,7 @@ import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import { PluginDriver } from '../../plugin/plugin-driver';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
-import { normalizeBindingResult } from '../../utils/error';
+import { normalizeBindingResult, unwrapBindingResult } from '../../utils/error';
 import { normalizedStringOrRegex } from '../../utils/normalize-string-or-regex';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 import type { DevOptions } from './dev-options';
@@ -107,7 +107,7 @@ export class DevEngine {
   }
 
   async ensureLatestBuildOutput(): Promise<void> {
-    await this.#inner.ensureLatestBuildOutput();
+    unwrapBindingResult(await this.#inner.ensureLatestBuildOutput());
   }
 
   triggerFullBuild(): void {
@@ -115,7 +115,7 @@ export class DevEngine {
   }
 
   async invalidate(file: string, firstInvalidatedBy?: string): Promise<BindingClientHmrUpdate[]> {
-    return this.#inner.invalidate(file, firstInvalidatedBy);
+    return unwrapBindingResult(await this.#inner.invalidate(file, firstInvalidatedBy));
   }
 
   async registerModules(clientId: string, modules: string[]): Promise<void> {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1532,9 +1532,9 @@ export declare class BindingDevEngine {
   run(): Promise<void>
   ensureCurrentBuildFinish(): Promise<void>
   getBundleState(): Promise<BindingBundleState>
-  ensureLatestBuildOutput(): Promise<void>
+  ensureLatestBuildOutput(): Promise<BindingResult<undefined>>
   triggerFullBuild(): void
-  invalidate(caller: string, firstInvalidatedBy?: string | undefined | null): Promise<Array<BindingClientHmrUpdate>>
+  invalidate(caller: string, firstInvalidatedBy?: string | undefined | null): Promise<BindingResult<Array<BindingClientHmrUpdate>>>
   registerModules(clientId: string, modules: Array<string>): Promise<void>
   removeClient(clientId: string): Promise<void>
   close(): Promise<void>


### PR DESCRIPTION
This PR handles the remaining errors in dev. 

`BundlingTask::run_inner` previously returned `Result`. In this PR, the function signature of this method, `generate_hmr_updates`, `rebuild` are all replaced from `Result` with empty return value.

This PR also populates `plugin_driver.watch_change` errors to `on_output` hook.

closes https://github.com/rolldown/rolldown/issues/6319