### PR TITLE
feat(plugin-vite-resolve): support custom tsconfig path via TsconfigDiscovery::Manual

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -1,10 +1,10 @@
 use derive_more::Debug;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use napi::bindgen_prelude::FnArgs;
 use rolldown_plugin_vite_resolve::{
   FinalizeBareSpecifierCallback, FinalizeOtherSpecifiersCallback, OnLogCallback,
-  ViteResolveOptions, ViteResolveResolveOptions,
+  TsconfigPathsOption, ViteResolveOptions, ViteResolveResolveOptions,
 };
 
 use crate::{
@@ -143,6 +143,12 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
+pub struct BindingTsconfigPathsOptions {
+  pub config_file: String,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug)]
 #[expect(clippy::struct_excessive_bools)]
 pub struct BindingViteResolvePluginResolveOptions {
   pub is_build: bool,
@@ -160,11 +166,17 @@ pub struct BindingViteResolvePluginResolveOptions {
   pub try_index: bool,
   pub try_prefix: Option<String>,
   pub preserve_symlinks: bool,
-  pub tsconfig_paths: bool,
+  #[napi(ts_type = "boolean | BindingTsconfigPathsOptions")]
+  pub tsconfig_paths: napi::Either<bool, BindingTsconfigPathsOptions>,
 }
 
 impl From<BindingViteResolvePluginResolveOptions> for ViteResolveResolveOptions {
   fn from(value: BindingViteResolvePluginResolveOptions) -> Self {
+    let tsconfig_paths = match value.tsconfig_paths {
+      napi::Either::A(false) => TsconfigPathsOption::Disabled,
+      napi::Either::A(true) => TsconfigPathsOption::Auto,
+      napi::Either::B(opts) => TsconfigPathsOption::Manual(PathBuf::from(opts.config_file)),
+    };
     Self {
       is_build: value.is_build,
       is_production: value.is_production,
@@ -181,7 +193,7 @@ impl From<BindingViteResolvePluginResolveOptions> for ViteResolveResolveOptions 
       try_index: value.try_index,
       try_prefix: value.try_prefix,
       preserve_symlinks: value.preserve_symlinks,
-      tsconfig_paths: value.tsconfig_paths,
+      tsconfig_paths,
     }
   }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/lib.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/lib.rs
@@ -8,6 +8,7 @@ mod utils_filter;
 mod vite_resolve_plugin;
 
 pub use external::{ResolveOptionsExternal, ResolveOptionsNoExternal};
+pub use resolver::TsconfigPathsOption;
 pub use vite_resolve_plugin::{
   FinalizeBareSpecifierCallback, FinalizeOtherSpecifiersCallback, OnLogCallback,
   ResolveIdOptionsScan, ViteResolveOptions, ViteResolvePlugin, ViteResolveResolveOptions,

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -5,7 +5,7 @@ use std::{
   sync::Arc,
 };
 
-use oxc_resolver::{PackageJson, ResolveOptions, TsconfigDiscovery};
+use oxc_resolver::{PackageJson, ResolveOptions, TsconfigDiscovery, TsconfigOptions};
 use rolldown_common::side_effects::HookSideEffects;
 use rolldown_plugin::{HookResolveIdOutput, HookResolveIdReturn};
 use rolldown_utils::{dashmap::FxDashSet, url::clean_url};
@@ -21,6 +21,19 @@ use crate::{
   },
 };
 
+/// Controls how `tsconfig.json` is loaded for path-mapping resolution.
+#[derive(Debug, Clone, Default)]
+pub enum TsconfigPathsOption {
+  /// `tsconfig.json` resolution is disabled.
+  #[default]
+  Disabled,
+  /// Walk up parent directories from each resolved file to find the nearest
+  /// `tsconfig.json`.
+  Auto,
+  /// Load the specified `tsconfig.json` file. The path must be absolute.
+  Manual(PathBuf),
+}
+
 #[derive(Debug, Clone)]
 pub struct BaseOptions<'a> {
   pub main_fields: &'a Vec<String>,
@@ -32,7 +45,7 @@ pub struct BaseOptions<'a> {
   pub as_src: bool,
   pub root: PathBuf,
   pub preserve_symlinks: bool,
-  pub tsconfig_paths: bool,
+  pub tsconfig_paths: TsconfigPathsOption,
   pub yarn_pnp: bool,
 }
 
@@ -171,7 +184,14 @@ fn get_resolve_options(
   let main_fields = base_options.main_fields.clone();
 
   oxc_resolver::ResolveOptions {
-    tsconfig: base_options.tsconfig_paths.then_some(TsconfigDiscovery::Auto),
+    tsconfig: match &base_options.tsconfig_paths {
+      TsconfigPathsOption::Disabled => None,
+      TsconfigPathsOption::Auto => Some(TsconfigDiscovery::Auto),
+      TsconfigPathsOption::Manual(config_file) => Some(TsconfigDiscovery::Manual(TsconfigOptions {
+        config_file: config_file.clone(),
+        references: oxc_resolver::TsconfigReferences::Auto,
+      })),
+    },
     alias_fields: if base_options.main_fields.iter().any(|field| field == "browser") {
       vec![vec!["browser".to_string()]]
     } else {

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -187,10 +187,12 @@ fn get_resolve_options(
     tsconfig: match &base_options.tsconfig_paths {
       TsconfigPathsOption::Disabled => None,
       TsconfigPathsOption::Auto => Some(TsconfigDiscovery::Auto),
-      TsconfigPathsOption::Manual(config_file) => Some(TsconfigDiscovery::Manual(TsconfigOptions {
-        config_file: config_file.clone(),
-        references: oxc_resolver::TsconfigReferences::Auto,
-      })),
+      TsconfigPathsOption::Manual(config_file) => {
+        Some(TsconfigDiscovery::Manual(TsconfigOptions {
+          config_file: config_file.clone(),
+          references: oxc_resolver::TsconfigReferences::Auto,
+        }))
+      }
     },
     alias_fields: if base_options.main_fields.iter().any(|field| field == "browser") {
       vec![vec!["browser".to_string()]]

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -27,7 +27,7 @@ use crate::{
   builtin::{BuiltinChecker, is_node_like_builtin},
   external::{self, ExternalDecider, ExternalDeciderOptions},
   file_url::file_url_str_to_path_and_postfix,
-  resolver::{self, AdditionalOptions, Resolvers},
+  resolver::{self, AdditionalOptions, Resolvers, TsconfigPathsOption},
   utils::{
     BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, is_bare_import, is_windows_drive_path,
     normalize_leading_slashes, normalize_path,
@@ -103,7 +103,7 @@ pub struct ViteResolveResolveOptions {
   pub try_index: bool,
   pub try_prefix: Option<String>,
   pub preserve_symlinks: bool,
-  pub tsconfig_paths: bool,
+  pub tsconfig_paths: TsconfigPathsOption,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -152,7 +152,7 @@ impl ViteResolvePlugin {
       as_src: options.resolve_options.as_src,
       root: PathBuf::from(&options.resolve_options.root),
       preserve_symlinks: options.resolve_options.preserve_symlinks,
-      tsconfig_paths: options.resolve_options.tsconfig_paths,
+      tsconfig_paths: options.resolve_options.tsconfig_paths.clone(),
       yarn_pnp: options.yarn_pnp,
     };
     let builtin_checker = Arc::new(BuiltinChecker::new(options.builtins));

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2689,6 +2689,10 @@ export interface BindingTsconfigCompilerOptions {
   importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
 }
 
+export interface BindingTsconfigPathsOptions {
+  configFile: string
+}
+
 /**
  * Raw tsconfig options for inline configuration.
  *
@@ -2824,7 +2828,7 @@ export interface BindingViteResolvePluginResolveOptions {
   tryIndex: boolean
   tryPrefix?: string
   preserveSymlinks: boolean
-  tsconfigPaths: boolean
+  tsconfigPaths: boolean | BindingTsconfigPathsOptions
 }
 
 export interface BindingViteTransformPluginConfig {


### PR DESCRIPTION
## Summary

Rust is not my strong suit, so please review the implementation of this PR. I was having some issues regarding my CI usage where I had to use a different tsconfig.json, and I found that there was an implementation in rolldown for that, but that is not exposed to the Vite side.

I did some changes where I widened the `viteResolvePlugin` napi binding so `tsconfigPaths` accepts `boolean | { configFile: string }` instead of only a `bool`, and route the manual path through to
  `oxc_resolver::TsconfigDiscovery::Manual`.

## Motivation

The Rust scaffolding for a manually-specified tsconfig already exists everywhere except the vite-resolve plugin boundary:

  - `oxc_resolver::TsconfigDiscovery::Manual(TsconfigOptions { config_file, references })` — supported.
  - `rolldown_common::TsConfig::{Auto, Manual}` at
  [`crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs#L12-L15`](crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs#L12-L15) — used by the transform
  pipeline at [`crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs#L41-L48`](crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs#L41-L48)
  and the standalone resolver at [`crates/rolldown_resolver/src/resolver_config.rs#L100-L108`](crates/rolldown_resolver/src/resolver_config.rs#L100-L108).
  - `ResolverFactory`'s napi binding already exposes `tsconfig?: 'auto' | TsconfigOptions` to JS.

  The only thing missing was the `viteResolvePlugin` field. It was hardcoded to `bool` and `.then_some(TsconfigDiscovery::Auto)`, so the `Manual` arm was unreachable from JS:

  ```rust
  // crates/rolldown_plugin_vite_resolve/src/resolver.rs (before)
  tsconfig: base_options.tsconfig_paths.then_some(TsconfigDiscovery::Auto),
  ```

  ## Changes

  - `crates/rolldown_plugin_vite_resolve/src/resolver.rs` — added `TsconfigPathsOption { Disabled, Auto, Manual(PathBuf) }`; mapped the `Manual` arm to
  `TsconfigDiscovery::Manual(TsconfigOptions { config_file, references: Auto })` in `get_resolve_options`.
  - `crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs` — same field-type swap on `ViteResolveResolveOptions`.
  - `crates/rolldown_plugin_vite_resolve/src/lib.rs` — re-export `TsconfigPathsOption`.
  - `crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs` — new `BindingTsconfigPathsOptions { config_file: String }` napi struct; changed the field to
  `napi::Either<bool, BindingTsconfigPathsOptions>` and converted into the new enum in the `From` impl.

  Generated TS:

  ```ts
  interface BindingTsconfigPathsOptions {
    configFile: string
  }
  // in BindingViteResolvePluginResolveOptions:
  tsconfigPaths: boolean | BindingTsconfigPathsOptions
  ```

  `true` / `false` semantics are unchanged.

  ## Related

  - vitejs/vite#22112 — feature request for `resolve.tsconfigPaths` to accept a config object so consumers can stop depending on `vite-tsconfig-paths`. Blocks on this PR.
  - vitest-dev/vitest#10176 — downstream pain point: users dynamically switching between `tsconfig.json` and `tsconfig.prod.json` (the old `esbuild.tsconfigRaw` workaround broke when
  vitest moved off esbuild).
  - vitejs/vite#22533 — PR on vite side

  ## Test plan

  - [ ] `cargo check --workspace` passes
  - [ ] `pnpm --filter rolldown build-native:debug` regenerates `binding.d.cts` with the new union type
  - [ ] Existing tests pass; `tsconfigPaths: true`/`false` still behave the same
  - [ ] Manual smoke: passing `{ configFile: '/abs/path/tsconfig.prod.json' }` to `viteResolvePlugin` no longer throws `Failed to convert napi value into rust type 'bool'`