### PR TITLE
fix(testing): remove unintended trigger_full_build from test harness

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -41,26 +41,36 @@ console.log("dep");
 
 ```
 
-## Build Output
+# HMR Step 1
 
-### Errors
+## Code
 
-#### PARSE_ERROR
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "dep";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
 
-```text
-[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[ dep.js:1:8 ]
-   │
- 1 │ invalid syntax
-   │        │ 
-   │        ╰─ 
-   │ 
-   │ Help: Try inserting a semicolon here
-───╯
-
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 
-# HMR Step 1
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
 
 ## Build Output
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
@@ -65,19 +65,36 @@ simulated post-link generate_bundle failure
 
 ```
 
-## Build Output
+# HMR Step 1
 
-### Errors
+## Code
 
-#### PLUGIN_ERROR
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "recovered";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
 
-```text
-[fail-generate-bundle-on-marker] Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
-simulated post-link generate_bundle failure
-
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 
-# HMR Step 1
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
 
 ## Build Output
 

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -260,15 +260,9 @@ impl IntegrationTest {
           )
           .await;
 
-        // Optionally wait for async builds to complete and force a rebuild
-        // to capture build output (ensure alone returns None in failed states).
+        // Optionally wait for async builds to complete
         if self.test_meta.dev.ensure_latest_build_output_for_each_step {
           dev_engine.ensure_latest_bundle_output().await.unwrap();
-          let state = dev_engine.get_bundle_state().await.unwrap();
-          if state.has_stale_output {
-            dev_engine.trigger_full_build().unwrap();
-            dev_engine.ensure_latest_bundle_output().await.unwrap();
-          }
         }
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #9552.

The `trigger_full_build` + `ensure_latest_bundle_output` composition added to `ensureLatestBuildOutputForEachStep` was causing unintended side effects:
- `recover_after_generate_bundle_error`: duplicate Build Output errors in Step 0, lost HMR Code/Meta in Step 1
- `from_rebuild_syntax_error`: extra Build Output from trigger that wasn't needed

Revert to only calling `ensure_latest_bundle_output` and restore snapshots to their correct state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)