### PR TITLE
chore(deps): update mimalloc-safe to 0.1.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,8 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys2"
-version = "0.1.57"
-source = "git+https://github.com/shulaoda/mimalloc-safe?branch=fix%2Fapple-thread-local-recurse-guard#155d823e9c818d59b33dfad2b5aad59bc4ddc0fb"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52406d0c46b81d2f65422a6d6086172f4e6b2753414cbee48be53850f90b804e"
 dependencies = [
  "cc",
  "cmake",
@@ -1481,8 +1482,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mimalloc-safe"
-version = "0.1.61"
-source = "git+https://github.com/shulaoda/mimalloc-safe?branch=fix%2Fapple-thread-local-recurse-guard#155d823e9c818d59b33dfad2b5aad59bc4ddc0fb"
+version = "0.1.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8b607e1874a1962cca1b926ffcf66c62aeda8cb62634acd904ee39582ed323"
 dependencies = [
  "libmimalloc-sys2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ json-escape-simd = "3"
 json-strip-comments = "3"
 jsonschema = { version = "0.46.5", default-features = false }
 memchr = "2.7.4"
-mimalloc-safe = { git = "https://github.com/shulaoda/mimalloc-safe", branch = "fix/apple-thread-local-recurse-guard" }
+mimalloc-safe = "0.1.62"
 mime = "0.3.17"
 nodejs-built-in-modules = "1.0.0"
 nom = "8.0.0"


### PR DESCRIPTION
See https://github.com/napi-rs/mimalloc-safe/pull/71 & https://github.com/rolldown/rolldown/actions/runs/26264825278/job/77305893292

Fixed a memory bug on macOS.