### PR TITLE
fix(testing): canonicalize temp dir path in test262 snapshot normalization

### DIFF
--- a/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
+++ b/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
@@ -2460,7 +2460,7 @@ Result: FAIL
 Reason: source phase imports are not supported in Rolldown
 Expected: success
 Actual:
-Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from <temp>/main.js
+Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from /private<temp>/main.js
   code: 'ERR_MODULE_NOT_FOUND'
 }
 ---
@@ -2470,7 +2470,7 @@ Result: FAIL
 Reason: source phase imports are not supported in Rolldown
 Expected: success
 Actual:
-Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from <temp>/main.js
+Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from /private<temp>/main.js
   code: 'ERR_MODULE_NOT_FOUND'
 }
 ---

--- a/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
+++ b/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
@@ -2460,7 +2460,7 @@ Result: FAIL
 Reason: source phase imports are not supported in Rolldown
 Expected: success
 Actual:
-Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from /private<temp>/main.js
+Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from <temp>/main.js
   code: 'ERR_MODULE_NOT_FOUND'
 }
 ---
@@ -2470,7 +2470,7 @@ Result: FAIL
 Reason: source phase imports are not supported in Rolldown
 Expected: success
 Actual:
-Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from /private<temp>/main.js
+Runtime error: Failed to import test module: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '<module source>' imported from <temp>/main.js
   code: 'ERR_MODULE_NOT_FOUND'
 }
 ---

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -349,6 +349,7 @@ globalThis.$DONE = function(error) {
     if let Err(e) = std::fs::create_dir_all(&temp_dir) {
       return TestOutcome::RuntimeError(format!("Failed to create temp dir: {e}"));
     }
+    let temp_dir = temp_dir.canonicalize().unwrap_or_else(|_| temp_dir);
     if let Err(e) = std::fs::write(temp_dir.join("package.json"), r#"{"type":"module"}"#) {
       return TestOutcome::RuntimeError(format!("Failed to write package.json: {e}"));
     }
@@ -406,7 +407,6 @@ globalThis.$DONE = function(error) {
   /// - Replaces temp directory paths with `<temp>/`
   /// - Removes stack trace lines (lines starting with "at ")
   fn normalize_output(output: &str, temp_dir: &Path) -> String {
-    let temp_dir = temp_dir.canonicalize().unwrap_or_else(|_| temp_dir.to_path_buf());
     let pattern = format!("{}/", temp_dir.to_string_lossy());
     let output = output.replace(&pattern, "<temp>/");
 

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -349,7 +349,7 @@ globalThis.$DONE = function(error) {
     if let Err(e) = std::fs::create_dir_all(&temp_dir) {
       return TestOutcome::RuntimeError(format!("Failed to create temp dir: {e}"));
     }
-    let temp_dir = temp_dir.canonicalize().unwrap_or_else(|_| temp_dir);
+    let temp_dir = temp_dir.canonicalize().unwrap_or(temp_dir);
     if let Err(e) = std::fs::write(temp_dir.join("package.json"), r#"{"type":"module"}"#) {
       return TestOutcome::RuntimeError(format!("Failed to write package.json: {e}"));
     }

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -406,7 +406,7 @@ globalThis.$DONE = function(error) {
   /// - Replaces temp directory paths with `<temp>/`
   /// - Removes stack trace lines (lines starting with "at ")
   fn normalize_output(output: &str, temp_dir: &Path) -> String {
-    // Replace temp directory path with <temp>/
+    let temp_dir = temp_dir.canonicalize().unwrap_or_else(|_| temp_dir.to_path_buf());
     let pattern = format!("{}/", temp_dir.to_string_lossy());
     let output = output.replace(&pattern, "<temp>/");
 


### PR DESCRIPTION
On macOS, `/tmp` is a symlink to `/private/tmp`. Node.js resolves symlinks when reporting paths in error messages, so the runtime output contains `/private/tmp/...` while `temp_dir` is `/tmp/...`. This caused the `<temp>/` replacement to leave a `/private` prefix, making the snapshot differ between macOS and Linux (CI).

Fix by canonicalizing `temp_dir` right after `create_dir_all`, so the resolved path is used throughout the entire `evaluate` function (file writes, Node.js execution, and output normalization). Also update the snapshot to remove the `/private` prefix that was baked in from a macOS-generated run.

This was surfaced by #9551 which added new source-phase-import test262 tests that produce error messages containing temp directory paths. See [CI failure](https://github.com/rolldown/rolldown/actions/runs/26489497127/job/78004064541).