### PR TITLE
fix(testing): resolve symlinked temp dir in test262 snapshot normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "commondir",
  "cow-utils",
  "dashmap",
+ "dunce",
  "futures",
  "indexmap",
  "insta",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -71,6 +71,7 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 cow-utils = { workspace = true }
+dunce = { workspace = true }
 insta = { workspace = true }
 regex = { workspace = true }
 rolldown_common = { workspace = true }

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -349,7 +349,6 @@ globalThis.$DONE = function(error) {
     if let Err(e) = std::fs::create_dir_all(&temp_dir) {
       return TestOutcome::RuntimeError(format!("Failed to create temp dir: {e}"));
     }
-    let temp_dir = temp_dir.canonicalize().unwrap_or(temp_dir);
     if let Err(e) = std::fs::write(temp_dir.join("package.json"), r#"{"type":"module"}"#) {
       return TestOutcome::RuntimeError(format!("Failed to write package.json: {e}"));
     }
@@ -378,8 +377,10 @@ globalThis.$DONE = function(error) {
 
     match std::process::Command::new("node").arg(&wrapper_file).output() {
       Ok(node_output) => {
-        _ = std::fs::remove_dir_all(&temp_dir);
-        self.process_node_output(&node_output, &temp_dir)
+        let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+        let result = self.process_node_output(&node_output, &canonical_temp_dir);
+        _ = std::fs::remove_dir_all(&canonical_temp_dir);
+        result
       }
       Err(e) => TestOutcome::RuntimeError(format!("Failed to execute Node.js: {e}")),
     }


### PR DESCRIPTION
An earlier attempt using `std::fs::canonicalize` inside `evaluate` broke Windows CI because it returns UNC paths (`\\?\C:\...`) that Node.js cannot handle (see [CI failure](https://github.com/rolldown/rolldown/actions/runs/26493005674/job/78014650761)).

Fix: use `dunce::canonicalize` (already a workspace dependency) to resolve the temp dir path once before Node.js execution. `dunce` resolves symlinks like `std::fs::canonicalize` but avoids the UNC prefix on Windows. The resolved path is passed to `normalize_output` for string replacement, while file operations are unaffected. Also update the snapshot to remove the baked-in `/private` prefix.