### PR TITLE
fix(testing): canonicalize temp dir early and use platform-specific separator in test262

### DIFF
--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -410,10 +410,12 @@ globalThis.$DONE = function(error) {
   /// - Replaces temp directory paths with `<temp>/`
   /// - Removes stack trace lines (lines starting with "at ")
   fn normalize_output(output: &str, temp_dir: &Path) -> String {
-    let pattern = format!("{}/", temp_dir.to_string_lossy());
-    let output = output.replace(&pattern, "<temp>/");
+    let temp_dir_str = temp_dir.to_string_lossy();
+    #[cfg(not(windows))]
+    let output = output.replace(&format!("{temp_dir_str}/"), "<temp>/");
+    #[cfg(windows)]
+    let output = output.replace(&format!("{temp_dir_str}\\"), "<temp>/");
 
-    // Remove stack trace lines (lines starting with whitespace followed by "at ")
     output
       .lines()
       .filter(|line| !line.trim_start().starts_with("at "))

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -349,6 +349,9 @@ globalThis.$DONE = function(error) {
     if let Err(e) = std::fs::create_dir_all(&temp_dir) {
       return TestOutcome::RuntimeError(format!("Failed to create temp dir: {e}"));
     }
+    // Canonicalize early so Node.js receives the resolved path and its error output
+    // matches the pattern we use for normalization (e.g. Windows 8.3 short names).
+    let temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
     if let Err(e) = std::fs::write(temp_dir.join("package.json"), r#"{"type":"module"}"#) {
       return TestOutcome::RuntimeError(format!("Failed to write package.json: {e}"));
     }
@@ -377,9 +380,8 @@ globalThis.$DONE = function(error) {
 
     match std::process::Command::new("node").arg(&wrapper_file).output() {
       Ok(node_output) => {
-        let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
-        let result = self.process_node_output(&node_output, &canonical_temp_dir);
-        _ = std::fs::remove_dir_all(&canonical_temp_dir);
+        let result = self.process_node_output(&node_output, &temp_dir);
+        _ = std::fs::remove_dir_all(&temp_dir);
         result
       }
       Err(e) => TestOutcome::RuntimeError(format!("Failed to execute Node.js: {e}")),

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -416,6 +416,7 @@ globalThis.$DONE = function(error) {
     #[cfg(windows)]
     let output = output.replace(&format!("{temp_dir_str}\\"), "<temp>/");
 
+    // Remove stack trace lines (lines starting with whitespace followed by "at ")
     output
       .lines()
       .filter(|line| !line.trim_start().starts_with("at "))


### PR DESCRIPTION
## Summary

- Move `dunce::canonicalize` from after Node.js execution to right after `create_dir_all`, so Node.js receives the resolved path (fixes Windows 8.3 short name mismatch, e.g. `RUNNER~1` vs `RUNNERADMIN`)
- Use platform-specific path separators in `normalize_output` — `/` on Unix, `\` on Windows — so the temp dir replacement actually matches Node.js error output

## Context

#9551 added `source-phase-import` test cases — the first tests whose Node.js error output contains a temp directory path. This exposed two independent bugs in `normalize_output`:

1. **Path content mismatch** (CI): `std::env::temp_dir()` can return an 8.3 short path on Windows, but `dunce::canonicalize` was called *after* Node.js execution, so the normalization pattern used the long path while Node.js had already printed the short path.

2. **Separator mismatch** (local Windows): `normalize_output` only replaced `{temp_dir}/` (forward slash), but Node.js on Windows outputs `{temp_dir}\` (backslash). The replacement never matched.

Neither bug was visible before #9551 because no prior test produced temp dir paths in its error output.

Ref: https://github.com/rolldown/rolldown/actions/runs/26496002954/job/78024279123