### PR TITLE
fix(ci): reorder prepare-release steps to avoid dirty git check failure

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,13 +46,13 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
 
-      - run: just bump-packages ${VERSION}
-
       - name: Bump crate versions
         run: cargo release-oxc update --release crates --version ${VERSION}
 
       - name: Update Cargo.lock after crate bump
         run: cargo check
+
+      - run: just bump-packages ${VERSION}
 
       - name: Regenerate binding.js after version bump
         run: vp run --filter rolldown build-binding


### PR DESCRIPTION
## Summary

`cargo release-oxc update` calls `git diff --exit-code` before running, which fails when there are uncommitted changes in the working tree. Since `just bump-packages` was running first and modifying `packages/*/package.json`, the subsequent `cargo release-oxc update` step always saw a dirty tree and bailed out with "Uncommitted changes found".

Fix by swapping the two steps: run `cargo release-oxc update` while the tree is still clean, then run `just bump-packages` afterwards. The two operations are independent, so the order does not matter for correctness.

Fixes https://github.com/rolldown/rolldown/actions/runs/26502749460/job/78047180423