### PR TITLE
fix(ci): create target dir before cargo release-oxc update

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,7 +47,9 @@ jobs:
         run: echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
 
       - name: Bump crate versions
-        run: cargo release-oxc update --release crates --version ${VERSION}
+        run: |
+          mkdir -p target
+          cargo release-oxc update --release crates --version ${VERSION}
 
       - name: Update Cargo.lock after crate bump
         run: cargo check


### PR DESCRIPTION
## Summary

`cargo release-oxc update` writes a version file to `./target/CRATES_VERSION` internally, but does not create the `target` directory if it doesn't exist. In CI, no cargo command has run before this step, so the directory is missing, causing `No such file or directory (os error 2)`.

Add `mkdir -p target` before the command as a workaround.

Fixes https://github.com/rolldown/rolldown/actions/runs/26504477971/job/78053156564