### PR TITLE
release: v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,81 @@
 
+## [1.0.3] - 2026-05-27
+
+### 🚀 Features
+
+- transform: respect decorator strictNullChecks option (#9580) by @kylecannon
+- drop `defer` keyword (#9503) by @TheAlexLichter
+
+### 🐛 Bug Fixes
+
+- ci: create target dir before cargo release-oxc update (#9584) by @shulaoda
+- ci: reorder prepare-release steps to avoid dirty git check failure (#9583) by @shulaoda
+- testing: canonicalize temp dir early and use platform-specific separator in test262 (#9582) by @shulaoda
+- testing: resolve symlinked temp dir in test262 snapshot normalization (#9581) by @shulaoda
+- testing: canonicalize temp dir path in test262 snapshot normalization (#9579) by @shulaoda
+- dev: `onOutput` called twice when initial build fails (#9552) by @hyf0
+- dev: make `ensureCurrentBuildFinish` not returning error when engine closes (#9564) by @h-a-n-a
+- oxc-runtime: route require() to CJS helper variant (#9263) (#9526) by @IWANABETHATGUY
+- generator: use exporter chunk's export mode for CJS default re-exports (#9299) (#9529) by @IWANABETHATGUY
+- rolldown: always run reduced-atom static cycle check (#9441) (#9514) by @IWANABETHATGUY
+- apply transform.dropLabels before scanning (#9521) (#9522) by @IWANABETHATGUY
+- rolldown_watcher: take `rolldown` dep through the workspace (#9510) by @Boshen
+- cache: keep the scan-stage cache consistent when a build fails (#9495) by @h-a-n-a
+- skip JSON default-import namespace optimization for write targets (#9484) (#9489) by @IWANABETHATGUY
+- deps: skip pnpm frozen-lockfile on Netlify to dodge catalog mismatch bug (#9471) by @Boshen
+
+### 🚜 Refactor
+
+- oxc-runtime: use Cow for helper path construction (#9538) by @IWANABETHATGUY
+- fold import defer phase drop into PreProcessor (#9524) by @IWANABETHATGUY
+- distinguish `map: null` vs `map: undefined` in transform hook output (#9497) by @sapphi-red
+
+### 📚 Documentation
+
+- explain the policy for Rust crates (#9547) by @sapphi-red
+- cache: add design doc for cache (#9544) by @h-a-n-a
+- guide/troubleshooting: add TDZ error section (#9537) by @sapphi-red
+- dev-engine: add design doc for dev-engine (#9479) by @h-a-n-a
+- lazy-barrel: tweak some words (#9483) by @shulaoda
+- lazy-barrel: expand reasoning behind LARGE_BARREL_MODULES advice (#9477) by @shulaoda
+
+### ⚡ Performance
+
+- generate: thread ast_table by value into codegen consumer (#9555) by @Boshen
+- finalizers: replace `_reExport` construction with a direct call to avoid calling `clone_in` (#9501) by @Dunqing
+- reorder hot-path boolean checks to short-circuit on cheap predicates first (#9523) by @Boshen
+
+### 🧪 Testing
+
+- rolldown: regression fixture for #9401 (#9418) by @IWANABETHATGUY
+- failing test for #9441 (#9504) by @TheAlexLichter
+
+### ⚙️ Miscellaneous Tasks
+
+- deps: upgrade oxc to 0.133.0 (#9563) by @Dunqing
+- deps: update crate-ci/typos action to v1.46.3 (#9576) by @renovate[bot]
+- deps: update mimalloc-safe to 0.1.62 (#9577) by @shulaoda
+- mimalloc-safe: update to a bug-fix branch for verification (#9569) by @shulaoda
+- deps: update test262 submodule for tests (#9551) by @rolldown-guard[bot]
+- point published crates' readme to root README.md (#9553) by @Boshen
+- replace actions-cool/issues-helper with gh CLI (#9543) by @Boshen
+- deps: update cargo-shear to 1.12.4 (#9541) by @Boshen
+- deps: update taiki-e/install-action action to v2.79.4 (#9535) by @renovate[bot]
+- deps: update github actions (#9532) by @renovate[bot]
+- deps: update rust crates (#9534) by @renovate[bot]
+- deps: update npm packages (#9533) by @renovate[bot]
+- gate experimental/testing-only items to silence dead_code in publish builds (#9517) by @Boshen
+- docs: deploy to Void (#9509) by @Boshen
+- release: set up cargo-release-oxc for publishing crates (#9476) by @Boshen
+- rolldown_plugin_lazy_compilation: add missing description (#9507) by @Boshen
+- mimalloc-safe: update to a bug-fix branch for verification (#9506) by @shulaoda
+- deps: update crate-ci/typos action to v1.46.2 (#9468) by @renovate[bot]
+
+### ❤️ New Contributors
+
+* @kylecannon made their first contribution in [#9580](https://github.com/rolldown/rolldown/pull/9580)
+
+
 ## [1.0.2] - 2026-05-20
 
 ### 🚀 Features

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/browser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "keywords": [
     "bundler",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/debug",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://rolldown.rs/",
   "license": "MIT",
   "repository": {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolldown",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "keywords": [
     "bundler",

--- a/packages/rolldown/src/binding.cjs
+++ b/packages/rolldown/src/binding.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-android-arm64')
         const bindingPackageVersion = require('@rolldown/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-android-arm-eabi')
         const bindingPackageVersion = require('@rolldown/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@rolldown/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@rolldown/binding-darwin-universal')
       const bindingPackageVersion = require('@rolldown/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-darwin-x64')
         const bindingPackageVersion = require('@rolldown/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-darwin-arm64')
         const bindingPackageVersion = require('@rolldown/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-freebsd-x64')
         const bindingPackageVersion = require('@rolldown/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-freebsd-arm64')
         const bindingPackageVersion = require('@rolldown/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-x64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@rolldown/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@rolldown/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-arm64')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-x64')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-arm')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {


### PR DESCRIPTION
## [1.0.3] - 2026-05-27

### 🚀 Features

- transform: respect decorator strictNullChecks option (#9580) by @kylecannon
- drop `defer` keyword (#9503) by @TheAlexLichter

### 🐛 Bug Fixes

- ci: create target dir before cargo release-oxc update (#9584) by @shulaoda
- ci: reorder prepare-release steps to avoid dirty git check failure (#9583) by @shulaoda
- testing: canonicalize temp dir early and use platform-specific separator in test262 (#9582) by @shulaoda
- testing: resolve symlinked temp dir in test262 snapshot normalization (#9581) by @shulaoda
- testing: canonicalize temp dir path in test262 snapshot normalization (#9579) by @shulaoda
- dev: `onOutput` called twice when initial build fails (#9552) by @hyf0
- dev: make `ensureCurrentBuildFinish` not returning error when engine closes (#9564) by @h-a-n-a
- oxc-runtime: route require() to CJS helper variant (#9263) (#9526) by @IWANABETHATGUY
- generator: use exporter chunk's export mode for CJS default re-exports (#9299) (#9529) by @IWANABETHATGUY
- rolldown: always run reduced-atom static cycle check (#9441) (#9514) by @IWANABETHATGUY
- apply transform.dropLabels before scanning (#9521) (#9522) by @IWANABETHATGUY
- rolldown_watcher: take `rolldown` dep through the workspace (#9510) by @Boshen
- cache: keep the scan-stage cache consistent when a build fails (#9495) by @h-a-n-a
- skip JSON default-import namespace optimization for write targets (#9484) (#9489) by @IWANABETHATGUY
- deps: skip pnpm frozen-lockfile on Netlify to dodge catalog mismatch bug (#9471) by @Boshen

### 🚜 Refactor

- oxc-runtime: use Cow for helper path construction (#9538) by @IWANABETHATGUY
- fold import defer phase drop into PreProcessor (#9524) by @IWANABETHATGUY
- distinguish `map: null` vs `map: undefined` in transform hook output (#9497) by @sapphi-red

### 📚 Documentation

- explain the policy for Rust crates (#9547) by @sapphi-red
- cache: add design doc for cache (#9544) by @h-a-n-a
- guide/troubleshooting: add TDZ error section (#9537) by @sapphi-red
- dev-engine: add design doc for dev-engine (#9479) by @h-a-n-a
- lazy-barrel: tweak some words (#9483) by @shulaoda
- lazy-barrel: expand reasoning behind LARGE_BARREL_MODULES advice (#9477) by @shulaoda

### ⚡ Performance

- generate: thread ast_table by value into codegen consumer (#9555) by @Boshen
- finalizers: replace `_reExport` construction with a direct call to avoid calling `clone_in` (#9501) by @Dunqing
- reorder hot-path boolean checks to short-circuit on cheap predicates first (#9523) by @Boshen

### 🧪 Testing

- rolldown: regression fixture for #9401 (#9418) by @IWANABETHATGUY
- failing test for #9441 (#9504) by @TheAlexLichter

### ⚙️ Miscellaneous Tasks

- deps: upgrade oxc to 0.133.0 (#9563) by @Dunqing
- deps: update crate-ci/typos action to v1.46.3 (#9576) by @renovate[bot]
- deps: update mimalloc-safe to 0.1.62 (#9577) by @shulaoda
- mimalloc-safe: update to a bug-fix branch for verification (#9569) by @shulaoda
- deps: update test262 submodule for tests (#9551) by @rolldown-guard[bot]
- point published crates' readme to root README.md (#9553) by @Boshen
- replace actions-cool/issues-helper with gh CLI (#9543) by @Boshen
- deps: update cargo-shear to 1.12.4 (#9541) by @Boshen
- deps: update taiki-e/install-action action to v2.79.4 (#9535) by @renovate[bot]
- deps: update github actions (#9532) by @renovate[bot]
- deps: update rust crates (#9534) by @renovate[bot]
- deps: update npm packages (#9533) by @renovate[bot]
- gate experimental/testing-only items to silence dead_code in publish builds (#9517) by @Boshen
- docs: deploy to Void (#9509) by @Boshen
- release: set up cargo-release-oxc for publishing crates (#9476) by @Boshen
- rolldown_plugin_lazy_compilation: add missing description (#9507) by @Boshen
- mimalloc-safe: update to a bug-fix branch for verification (#9506) by @shulaoda
- deps: update crate-ci/typos action to v1.46.2 (#9468) by @renovate[bot]

### ❤️ New Contributors

* @kylecannon made their first contribution in [#9580](https://github.com/rolldown/rolldown/pull/9580)