### PR TITLE
feat(code-splitting): support group-local `includeDependenciesRecursively`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -200,8 +200,10 @@ impl ManualSplitter<'_> {
         let entries_aware = match_group.entries_aware.unwrap_or(false);
         let module_group_id = ModuleGroupId { match_group_index, name: group_name.clone() };
 
-        let include_dependencies_recursively =
-          self.chunking_options.include_dependencies_recursively.unwrap_or(true);
+        let include_dependencies_recursively = match_group
+          .include_dependencies_recursively
+          .or(self.chunking_options.include_dependencies_recursively)
+          .unwrap_or(true);
 
         let group: &mut ModuleGroup = if entries_aware {
           let idx = match entries_aware_idx_by_id.entry(module_group_id) {

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -5,9 +5,9 @@ use itertools::Either;
 use oxc::{transformer::EngineTargets, transformer_plugins::InjectGlobalVariablesConfig};
 use rolldown_common::{
   AttachDebugInfo, CodeSplittingMode, GlobalsOutputOption, InjectImport, JsxOptions, JsxPreset,
-  LegalComments, MinifyOptions, ModuleType, NormalizedBundlerOptions, OutputFormat, Platform,
-  PreserveEntrySignatures, RawTransformOptions, TransformOptions, TreeshakeOptions, TsConfig,
-  merge_transform_options_with_tsconfig, normalize_optimization_option,
+  LegalComments, ManualCodeSplittingOptions, MinifyOptions, ModuleType, NormalizedBundlerOptions,
+  OutputFormat, Platform, PreserveEntrySignatures, RawTransformOptions, TransformOptions,
+  TreeshakeOptions, TsConfig, merge_transform_options_with_tsconfig, normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
 use rolldown_fs::{OsFileSystem, OxcResolverFileSystem as _};
@@ -23,6 +23,19 @@ pub struct PrepareBuildContext {
   pub resolver: SharedResolver<OsFileSystem>,
   pub options: Arc<NormalizedBundlerOptions>,
   pub warnings: Vec<BuildDiagnostic>,
+}
+
+fn has_non_recursive_dependency_capture(options: &ManualCodeSplittingOptions) -> bool {
+  match &options.groups {
+    Some(groups) if !groups.is_empty() => groups.iter().any(|group| {
+      !group
+        .include_dependencies_recursively
+        .or(options.include_dependencies_recursively)
+        .unwrap_or(true)
+    }),
+    // Without groups, the global option alone decides, defaulting to `true`.
+    _ => !options.include_dependencies_recursively.unwrap_or(true),
+  }
 }
 
 fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<BuildDiagnostic>> {
@@ -110,8 +123,8 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
       }
     }
 
-    // Check if `codeSplitting.include_dependencies_recursively` conflict with `preserveEntrySignatures`
-    if matches!(manual_code_splitting.include_dependencies_recursively, Some(false)) {
+    // Check if any group's effective `includeDependenciesRecursively` is false, which conflicts with `preserveEntrySignatures`
+    if has_non_recursive_dependency_capture(manual_code_splitting) {
       if let Some(preserve_signatures) = &raw_options.preserve_entry_signatures {
         if matches!(
           preserve_signatures,
@@ -140,7 +153,7 @@ pub fn prepare_build_context(
 
   let preserve_entry_signatures = if let Some(manual_code_splitting) =
     &raw_options.manual_code_splitting
-    && matches!(manual_code_splitting.include_dependencies_recursively, Some(false))
+    && has_non_recursive_dependency_capture(manual_code_splitting)
     && raw_options.preserve_entry_signatures.is_none()
   {
     warnings.push(

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -41,6 +41,7 @@ pub struct BindingMatchGroup {
   pub entries_aware: Option<bool>,
   pub entries_aware_merge_threshold: Option<f64>,
   pub tags: Option<Vec<String>>,
+  pub include_dependencies_recursively: Option<bool>,
 }
 
 #[napi_derive::napi]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -518,6 +518,7 @@ pub fn normalize_binding_options(
             entries_aware: item.entries_aware,
             entries_aware_merge_threshold: item.entries_aware_merge_threshold,
             tags: item.tags.map(|tags| tags.into_iter().map(ModuleTag::from).collect()),
+            include_dependencies_recursively: item.include_dependencies_recursively,
           })
           .collect::<Vec<_>>()
       }),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -74,6 +74,7 @@ pub struct MatchGroup {
     schemars(with = "Option<Vec<BuiltinModuleTag>>")
   )]
   pub tags: Option<Vec<ModuleTag>>,
+  pub include_dependencies_recursively: Option<bool>,
 }
 
 type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1349,6 +1349,12 @@
           "items": {
             "$ref": "#/$defs/BuiltinModuleTag"
           }
+        },
+        "includeDependenciesRecursively": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2429,6 +2429,7 @@ export interface BindingMatchGroup {
   entriesAware?: boolean
   entriesAwareMergeThreshold?: number
   tags?: Array<string>
+  includeDependenciesRecursively?: boolean
 }
 
 export interface BindingModulePreloadOptions {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -914,6 +914,20 @@ export type CodeSplittingGroup = {
    */
   entriesAwareMergeThreshold?: number;
   /**
+   * Whether to include captured modules' dependencies.
+   *
+   * Enabling this option reduces the chance of generating circular chunks.
+   *
+   * If you want to disable this behavior, it's recommended to both set
+   * - {@linkcode InputOptions.preserveEntrySignatures | preserveEntrySignatures}: `false | 'allow-extension'`
+   * - {@linkcode OutputOptions.strictExecutionOrder | strictExecutionOrder}: `true`
+   *
+   * to avoid generating invalid chunks.
+   *
+   * @default true
+   */
+  includeDependenciesRecursively?: boolean;
+  /**
    * Filter modules by tags. Only modules that have **all** specified tags
    * are captured by this group. Combines with `test` and other filters —
    * a module must match all criteria.
@@ -942,15 +956,7 @@ export type AdvancedChunksGroup = CodeSplittingGroup;
  */
 export type CodeSplittingOptions = {
   /**
-   * By default, each group will also include captured modules' dependencies. This reduces the chance of generating circular chunks.
-   *
-   * If you want to disable this behavior, it's recommended to both set
-   * - {@linkcode InputOptions.preserveEntrySignatures | preserveEntrySignatures}: `false | 'allow-extension'`
-   * - {@linkcode OutputOptions.strictExecutionOrder | strictExecutionOrder}: `true`
-   *
-   * to avoid generating invalid chunks.
-   *
-   * @default true
+   * Global fallback of {@linkcode CodeSplittingGroup.includeDependenciesRecursively | group.includeDependenciesRecursively}, if it's not specified in the group.
    */
   includeDependenciesRecursively?: boolean;
   /**

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -828,6 +828,7 @@ const AdvancedChunksSchema = v.strictObject({
         maxModuleSize: v.optional(v.number()),
         entriesAware: v.optional(v.boolean()),
         entriesAwareMergeThreshold: v.optional(v.number()),
+        includeDependenciesRecursively: v.optional(v.boolean()),
         tags: v.optional(v.array(v.string())),
       }),
     ),

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/_config.ts
@@ -1,0 +1,37 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      codeSplitting: {
+        groups: [
+          {
+            name: 'route-alpha',
+            test: /routes[\\/]alpha/,
+            includeDependenciesRecursively: false,
+          },
+          {
+            name: 'shared',
+            test: /shared[\\/]/,
+          },
+        ],
+      },
+    },
+  },
+  afterTest(output) {
+    const routeAlpha = output.output.find(
+      (chunk) => chunk.type === 'chunk' && chunk.fileName.startsWith('route-alpha-'),
+    );
+    if (routeAlpha?.type !== 'chunk') {
+      throw new Error('route-alpha chunk not found');
+    }
+    expect(routeAlpha.moduleIds).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/shared[\\/]util\.js$/)]),
+    );
+    expect(routeAlpha.moduleIds).toHaveLength(1);
+    expect(routeAlpha.moduleIds).toMatchObject([
+      expect.stringMatching(/routes[\\/]alpha[\\/]index\.js$/),
+    ]);
+  },
+});

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/main.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/main.js
@@ -1,0 +1,3 @@
+import { alpha } from './routes/alpha/index.js';
+import { util } from './shared/util.js';
+console.log(alpha, util);

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/routes/alpha/index.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/routes/alpha/index.js
@@ -1,0 +1,2 @@
+import { util } from '../../shared/util.js';
+export const alpha = 'alpha' + util;

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/shared/util.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/per-group-include-deps/shared/util.js
@@ -1,0 +1,1 @@
+export const util = 'util';

--- a/packages/rolldown/tests/fixtures/misc/error/per-group-include-deps-conflict/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/per-group-include-deps-conflict/_config.ts
@@ -1,0 +1,26 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+import { stripVTControlCharacters } from 'node:util';
+
+export default defineTest({
+  config: {
+    input: 'main.js',
+    output: {
+      preserveEntrySignatures: 'strict',
+      codeSplitting: {
+        groups: [
+          {
+            name: 'route',
+            test: /routes/,
+            includeDependenciesRecursively: false,
+          },
+        ],
+      },
+    },
+  },
+  catchError(e: any) {
+    const message = stripVTControlCharacters(e.message);
+    expect(message).toContain('includeDependenciesRecursively');
+    expect(message).toContain('preserveEntrySignatures');
+  },
+});

--- a/packages/rolldown/tests/fixtures/misc/error/per-group-include-deps-conflict/main.js
+++ b/packages/rolldown/tests/fixtures/misc/error/per-group-include-deps-conflict/main.js
@@ -1,0 +1,1 @@
+export const main = 'main';


### PR DESCRIPTION
## Summary

- Allow `includeDependenciesRecursively` on individual `codeSplitting.groups`, overriding the global value
- When omitted on a group, inherits `codeSplitting.includeDependenciesRecursively` (default `true`)
- Extends `preserveEntrySignatures` validation to check both global and per-group values

Closes #9467

Built on the exploration in #9488 — thank you @aminpaks for the thorough investigation and initial implementation! 🙏

## Changes

| Layer | File | Change |
|-------|------|--------|
| Rust types | `manual_code_splitting_options.rs` | Add `include_dependencies_recursively: Option<bool>` to `MatchGroup` |
| NAPI binding | `binding_manual_code_splitting_options.rs` | Add field to `BindingMatchGroup` |
| Binding conversion | `normalize_binding_options.rs` | Map new field |
| Chunk logic | `manual_code_splitting.rs` | Per-group fallback: group → global → `true` |
| Validation | `prepare_build_context.rs` | `has_non_recursive_dependency_capture()` helper, 2 callsites |
| TS types | `output-options.ts` | Add to `CodeSplittingGroup` with JSDoc |
| TS validator | `validator.ts` | Add to group schema |

## Example

```js
output: {
  codeSplitting: {
    includeDependenciesRecursively: true,
    groups: [
      {
        name: 'route-alpha',
        test: /routes\/alpha\//,
        includeDependenciesRecursively: false, // route-only, no sibling deps
      },
      {
        name: 'shared',
        test: /shared\//,
        // inherits global (true)
      },
    ],
  },
}
```

## Test plan

- [x] Chunking behavior test: group with `false` excludes transitive deps, group without inherits global
- [x] Validation test: per-group `false` + `preserveEntrySignatures: 'strict'` → error
- [x] All existing `advanced-chunks` tests pass
- [x] Full build (`just build-rolldown`) passes