### PR TITLE
fix(finalizers): hoist top-level classes as `let`, not `var`

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1284,7 +1284,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     (original_name != canonical_name).then_some((original_name, canonical_name))
   }
 
-  /// rewrite toplevel `class ClassName {}` to `var ClassName = class {}`
+  /// rewrite toplevel `class ClassName {}` to `let ClassName = class {}`.
+  /// `let` preserves the lexical-binding / TDZ semantics of the original
+  /// `class` declaration; `var` would hoist the binding as `undefined` and
+  /// silence forward-reference errors.
   fn get_transformed_class_decl(
     &self,
     class: &mut allocator::Box<'ast, ast::Class<'ast>>,
@@ -1310,10 +1313,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     Some(self.snippet.builder.declaration_variable(
       class.span,
-      VariableDeclarationKind::Var,
+      VariableDeclarationKind::Let,
       self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
         SPAN,
-        VariableDeclarationKind::Var,
+        VariableDeclarationKind::Let,
         ast::BindingPattern::BindingIdentifier(self.snippet.builder.alloc(id)),
         NONE,
         Some(Expression::ClassExpression(ArenaBox::new_in(

--- a/crates/rolldown/tests/esbuild/dce/dce_of_experimental_decorators/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_of_experimental_decorators/artifacts.snap
@@ -16,13 +16,13 @@ const fn = () => {
 //#region keep-these.ts
 let Class = class Class {};
 Class = __decorate([fn], Class);
-var Field = class {};
+let Field = class {};
 __decorate([fn], Field.prototype, "field", void 0);
-var Method = class {
+let Method = class {
 	method() {}
 };
 __decorate([fn], Method.prototype, "method", null);
-var Accessor = class {
+let Accessor = class {
 	#_accessor_accessor_storage;
 	get accessor() {
 		return this.#_accessor_accessor_storage;
@@ -32,13 +32,13 @@ var Accessor = class {
 	}
 };
 __decorate([fn], Accessor.prototype, "accessor", null);
-var Parameter = class {
+let Parameter = class {
 	foo(bar) {}
 };
 __decorate([__decorateParam(0, fn)], Parameter.prototype, "foo", null);
-var StaticField = class {};
+let StaticField = class {};
 __decorate([fn], StaticField, "field", void 0);
-var StaticMethod = class {
+let StaticMethod = class {
 	static method() {}
 };
 __decorate([fn], StaticMethod, "method", null);
@@ -51,7 +51,7 @@ __decorate([fn], class StaticAccessor {
 		StaticAccessor.#_accessor_accessor_storage = value;
 	}
 }, "accessor", null);
-var StaticParameter = class {
+let StaticParameter = class {
 	static foo(bar) {}
 };
 __decorate([__decorateParam(0, fn)], StaticParameter, "foo", null);

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_import_identifier/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_import_identifier/artifacts.snap
@@ -7,10 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region b.js
-var Base = class {};
+let Base = class {};
 //#endregion
 //#region a.js
-var Keep = class extends Base {};
+let Keep = class extends Base {};
 //#endregion
 //#region entry.js
 new Keep();

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/artifacts.snap
@@ -11,15 +11,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.js
-var REMOVE_ME = class {};
+let REMOVE_ME = class {};
 _defineProperty(REMOVE_ME, "x", "x");
 _defineProperty(REMOVE_ME, "y", "y");
 _defineProperty(REMOVE_ME, "z", "z");
-var KeepMe1 = class {};
+let KeepMe1 = class {};
 _defineProperty(KeepMe1, "x", "x");
 _defineProperty(KeepMe1, "y", sideEffects());
 _defineProperty(KeepMe1, "z", "z");
-var KeepMe2 = class {};
+let KeepMe2 = class {};
 _defineProperty(KeepMe2, "x", "x");
 _defineProperty(KeepMe2, "y", "y");
 _defineProperty(KeepMe2, "z", "z");

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/diff.md
@@ -21,15 +21,15 @@ new KeepMe2();
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.js
-var REMOVE_ME = class {};
+let REMOVE_ME = class {};
 _defineProperty(REMOVE_ME, "x", "x");
 _defineProperty(REMOVE_ME, "y", "y");
 _defineProperty(REMOVE_ME, "z", "z");
-var KeepMe1 = class {};
+let KeepMe1 = class {};
 _defineProperty(KeepMe1, "x", "x");
 _defineProperty(KeepMe1, "y", sideEffects());
 _defineProperty(KeepMe1, "z", "z");
-var KeepMe2 = class {};
+let KeepMe2 = class {};
 _defineProperty(KeepMe2, "x", "x");
 _defineProperty(KeepMe2, "y", "y");
 _defineProperty(KeepMe2, "z", "z");

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment/artifacts.snap
@@ -7,15 +7,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.ts
-var KeepMe1 = class {};
+let KeepMe1 = class {};
 KeepMe1.x = "x";
 KeepMe1.y = "y";
 KeepMe1.z = "z";
-var KeepMe2 = class {};
+let KeepMe2 = class {};
 KeepMe2.x = "x";
 KeepMe2.y = sideEffects();
 KeepMe2.z = "z";
-var KeepMe3 = class {};
+let KeepMe3 = class {};
 KeepMe3.x = "x";
 KeepMe3.y = "y";
 KeepMe3.z = "z";

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	static y = sideEffects();
 	static z = "z";
 });
-var KeepMe2 = class {
+let KeepMe2 = class {
 	static x = "x";
 	static y = "y";
 	static z = "z";

--- a/crates/rolldown/tests/esbuild/default/argument_default_value_scope_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/argument_default_value_scope_no_bundle/artifacts.snap
@@ -11,7 +11,7 @@ function a(x = foo) {
 	var foo;
 	return x;
 }
-var b = class {
+let b = class {
 	fn(x = foo) {
 		var foo;
 		return x;

--- a/crates/rolldown/tests/esbuild/default/avoid_tdz/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/avoid_tdz/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class Foo {
+let Foo = class Foo {
 	static foo = new Foo();
 };
 let foo = Foo.foo;
 assert(foo instanceof Foo, true);
-var Bar = class {};
+let Bar = class {};
 let bar = 123;
 //#endregion
 export { Bar, bar };

--- a/crates/rolldown/tests/esbuild/default/avoid_tdz_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/avoid_tdz_no_bundle/artifacts.snap
@@ -10,7 +10,7 @@ let foo = class Foo {
 	static foo = new Foo();
 }.foo;
 console.log(foo);
-var Bar = class {};
+let Bar = class {};
 let bar = 123;
 //#endregion
 export { Bar, bar };

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -19,7 +19,7 @@ var v = 234;
 let l = 234;
 const c = 234;
 function Fn() {}
-var Class = class {};
+let Class = class {};
 //#endregion
 export { Class as C, Class, Fn, abc, b_exports as b, c, entry_default as default, l, v };
 

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -33,7 +33,7 @@ var globalName = (function(exports) {
 	let l = 234;
 	const c = 234;
 	function Fn() {}
-	var Class = class {};
+	let Class = class {};
 	//#endregion
 	exports.C = Class;
 	exports.Class = Class;

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -13,9 +13,9 @@ var varName = 234;
 let letName = 234;
 const constName = 234;
 function Func2() {}
-var Class2 = class {};
+let Class2 = class {};
 function Func() {}
-var Class = class {};
+let Class = class {};
 //#endregion
 export { Class, Class as Cls, Class2 as Cls2, Func2 as Fn2, Func, constName, a_default as default, b_exports as fromB, letName, varName };
 
@@ -55,7 +55,7 @@ export { foo as default };
 
 ```js
 //#region d.js
-var d_default = class {};
+let d_default = class {};
 //#endregion
 export { d_default as default };
 
@@ -65,7 +65,7 @@ export { d_default as default };
 
 ```js
 //#region e.js
-var Foo = class {};
+let Foo = class {};
 //#endregion
 export { Foo as default };
 

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/diff.md
@@ -26,9 +26,9 @@ var varName = 234;
 let letName = 234;
 const constName = 234;
 function Func2() {}
-var Class2 = class {};
+let Class2 = class {};
 function Func() {}
-var Class = class {};
+let Class = class {};
 //#endregion
 export { Class, Class as Cls, Class2 as Cls2, Func2 as Fn2, Func, constName, a_default as default, b_exports as fromB, letName, varName };
 
@@ -119,7 +119,7 @@ export default class {
 ### rolldown
 ```js
 //#region d.js
-var d_default = class {};
+let d_default = class {};
 //#endregion
 export { d_default as default };
 
@@ -144,7 +144,7 @@ export default class o {
 ### rolldown
 ```js
 //#region e.js
-var Foo = class {};
+let Foo = class {};
 //#endregion
 export { Foo as default };
 

--- a/crates/rolldown/tests/esbuild/default/jsx_dev_self_edge_cases/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_dev_self_edge_cases/artifacts.snap
@@ -24,7 +24,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region class-this.jsx
 var _jsxFileName = "class-this.jsx";
-var Foo = class {
+let Foo = class {
 	foo() {
 		return /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -44,7 +44,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor-arg.jsx
 var _jsxFileName = "derived-constructor-arg.jsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor(foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 		fileName: _jsxFileName,
 		lineNumber: 1,
@@ -64,7 +64,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor-field.tsx
 var _jsxFileName = "derived-constructor-field.tsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor(..._args) {
 		super(..._args);
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
@@ -85,7 +85,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor.jsx
 var _jsxFileName = "derived-constructor.jsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor() {
 		super(/* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -128,7 +128,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor-arg.jsx
 var _jsxFileName = "normal-constructor-arg.jsx";
-var Foo = class {
+let Foo = class {
 	constructor(foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 		fileName: _jsxFileName,
 		lineNumber: 1,
@@ -146,7 +146,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor-field.tsx
 var _jsxFileName = "normal-constructor-field.tsx";
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -166,7 +166,7 @@ export { Foo };
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor.jsx
 var _jsxFileName = "normal-constructor.jsx";
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -187,7 +187,7 @@ import { jsxDEV } from "react/jsx-dev-runtime";
 //#region static-field.jsx
 var _jsxFileName = "static-field.jsx";
 var _Foo;
-var Foo = class {};
+let Foo = class {};
 _Foo = Foo;
 Foo.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 	fileName: _jsxFileName,

--- a/crates/rolldown/tests/esbuild/default/jsx_dev_self_edge_cases/diff.md
+++ b/crates/rolldown/tests/esbuild/default/jsx_dev_self_edge_cases/diff.md
@@ -21,7 +21,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region class-this.jsx
 var _jsxFileName = "class-this.jsx";
-var Foo = class {
+let Foo = class {
 	foo() {
 		return /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -76,7 +76,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor-arg.jsx
 var _jsxFileName = "derived-constructor-arg.jsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor(foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 		fileName: _jsxFileName,
 		lineNumber: 1,
@@ -131,7 +131,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor-field.tsx
 var _jsxFileName = "derived-constructor-field.tsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor(..._args) {
 		super(..._args);
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
@@ -198,7 +198,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region derived-constructor.jsx
 var _jsxFileName = "derived-constructor.jsx";
-var Foo = class extends Object {
+let Foo = class extends Object {
 	constructor() {
 		super(/* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -313,7 +313,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor-arg.jsx
 var _jsxFileName = "normal-constructor-arg.jsx";
-var Foo = class {
+let Foo = class {
 	constructor(foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 		fileName: _jsxFileName,
 		lineNumber: 1,
@@ -365,7 +365,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor-field.tsx
 var _jsxFileName = "normal-constructor-field.tsx";
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -420,7 +420,7 @@ export {
 import { jsxDEV } from "react/jsx-dev-runtime";
 //#region normal-constructor.jsx
 var _jsxFileName = "normal-constructor.jsx";
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 			fileName: _jsxFileName,
@@ -475,7 +475,7 @@ import { jsxDEV } from "react/jsx-dev-runtime";
 //#region static-field.jsx
 var _jsxFileName = "static-field.jsx";
 var _Foo;
-var Foo = class {};
+let Foo = class {};
 _Foo = Foo;
 Foo.foo = /* @__PURE__ */ jsxDEV("div", {}, void 0, false, {
 	fileName: _jsxFileName,

--- a/crates/rolldown/tests/esbuild/default/keep_names_tree_shaking/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/keep_names_tree_shaking/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 function fnStmtKeep() {}
 x = fnStmtKeep;
 x = function keep() {};
-var clsStmtKeep = class {};
+let clsStmtKeep = class {};
 new clsStmtKeep();
 new class keep {}();
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/mangle_props_lowered_class_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_lowered_class_fields/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	foo_ = 123;
 	static bar_ = 234;
 };

--- a/crates/rolldown/tests/esbuild/default/mangle_props_type_script_features/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_type_script_features/artifacts.snap
@@ -118,7 +118,7 @@ console.log({
 
 ```js
 //#region parameter-properties.ts
-var Foo = class {
+let Foo = class {
 	constructor(KEEP_FIELD, MANGLE_FIELD_) {
 		this.KEEP_FIELD = KEEP_FIELD;
 		this.MANGLE_FIELD_ = MANGLE_FIELD_;

--- a/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 new ((/* @__PURE__ */ __commonJSMin(((exports, module) => {
-	var Foo = class {};
+	let Foo = class {};
 	module.exports = { Foo };
 })))()).Foo();
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/this_inside_function/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/this_inside_function/artifacts.snap
@@ -13,7 +13,7 @@ function foo(x = this) {
 const objFoo = { foo(x = this) {
 	console.log(this);
 } };
-var Foo = class {
+let Foo = class {
 	x = this;
 	static y = this.z;
 	foo(x = this) {

--- a/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo.js
-var MustStartWithUpperCaseLetter = class {};
+let MustStartWithUpperCaseLetter = class {};
 //#endregion
 //#region entry.jsx
 console.log(<MustStartWithUpperCaseLetter />);

--- a/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter_minify/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter_minify/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-var e=class{};console.log(<e tag-must-start-with-capital-letter/>);
+let e=class{};console.log(<e tag-must-start-with-capital-letter/>);
 ```

--- a/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter_minify/diff.md
+++ b/crates/rolldown/tests/esbuild/loader/jsx_preserve_capital_letter_minify/diff.md
@@ -10,7 +10,7 @@ console.log(<Y tag-must-start-with-capital-letter />);
 ```
 ### rolldown
 ```js
-var e=class{};console.log(<e tag-must-start-with-capital-letter/>);
+let e=class{};console.log(<e tag-must-start-with-capital-letter/>);
 ```
 ### diff
 ```diff
@@ -25,7 +25,7 @@ var e=class{};console.log(<e tag-must-start-with-capital-letter/>);
 -// entry.jsx
 -console.log(<Y tag-must-start-with-capital-letter />);
 \ No newline at end of file
-+var e=class{};console.log(<e tag-must-start-with-capital-letter/>);
++let e=class{};console.log(<e tag-must-start-with-capital-letter/>);
 \ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.ts
-var A = class {};
-var B = class extends A {
+let A = class {};
+let B = class extends A {
 	#e;
 	constructor(c) {
 		super();

--- a/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2021/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2021/artifacts.snap
@@ -17,11 +17,11 @@ three(), six();
 ```js
 //#region ts-assign/ts-assign.ts
 three(), six();
-var StaticNormal = class {
+let StaticNormal = class {
 	static accessor a = b;
 };
 StaticNormal.c = d;
-var StaticPrivate = class {
+let StaticPrivate = class {
 	static accessor #a = b;
 };
 StaticPrivate.c = d;
@@ -38,11 +38,11 @@ StaticPrivate.c = d;
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region ts-define/ts-define.ts
 three(), six();
-var StaticNormal = class {
+let StaticNormal = class {
 	static accessor a = b;
 };
 _defineProperty(StaticNormal, "c", d);
-var StaticPrivate = class {
+let StaticPrivate = class {
 	static accessor #a = b;
 };
 _defineProperty(StaticPrivate, "c", d);

--- a/crates/rolldown/tests/esbuild/lower/java_script_decorators_es_next/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_decorators_es_next/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = @x.y() @(new y.x()) class Foo {
+let Foo = @x.y() @(new y.x()) class Foo {
 	@x @y mUndef;
 	@x @y mDef = 1;
 	@x @y method() {

--- a/crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/artifacts.snap
@@ -11,7 +11,7 @@ async function foo(bar) {
 	await bar;
 	return [this, arguments];
 }
-var Foo = class {
+let Foo = class {
 	async foo() {}
 };
 var entry_default = [

--- a/crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/artifacts.snap
@@ -11,7 +11,7 @@ async function foo(bar) {
 	await bar;
 	return arguments;
 }
-var Foo = class {
+let Foo = class {
 	async foo() {}
 };
 var entry_default = [

--- a/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_es2016/artifacts.snap
@@ -7,62 +7,62 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	foo1() {
 		return async () => super.foo("foo1");
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	foo2() {
 		return async () => () => super.foo("foo2");
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	foo3() {
 		return () => async () => super.foo("foo3");
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	foo4() {
 		return async () => async () => super.foo("foo4");
 	}
 };
 //#endregion
 //#region bar1.js
-var bar1_default = class extends x {
+let bar1_default = class extends x {
 	bar1 = async () => super.foo("bar1");
 };
 //#endregion
 //#region bar2.js
-var bar2_default = class extends x {
+let bar2_default = class extends x {
 	bar2 = async () => () => super.foo("bar2");
 };
 //#endregion
 //#region bar3.js
-var bar3_default = class extends x {
+let bar3_default = class extends x {
 	bar3 = () => async () => super.foo("bar3");
 };
 //#endregion
 //#region bar4.js
-var bar4_default = class extends x {
+let bar4_default = class extends x {
 	bar4 = async () => async () => super.foo("bar4");
 };
 //#endregion
 //#region baz1.js
-var baz1_default = class extends x {
+let baz1_default = class extends x {
 	async baz1() {
 		return () => super.foo("baz1");
 	}
 };
 //#endregion
 //#region baz2.js
-var baz2_default = class extends x {
+let baz2_default = class extends x {
 	async baz2() {
 		return () => () => super.foo("baz2");
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_setter_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_setter_es2016/artifacts.snap
@@ -7,62 +7,62 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	foo1() {
 		return async () => super.foo = "foo1";
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	foo2() {
 		return async () => () => super.foo = "foo2";
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	foo3() {
 		return () => async () => super.foo = "foo3";
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	foo4() {
 		return async () => async () => super.foo = "foo4";
 	}
 };
 //#endregion
 //#region bar1.js
-var bar1_default = class extends x {
+let bar1_default = class extends x {
 	bar1 = async () => super.foo = "bar1";
 };
 //#endregion
 //#region bar2.js
-var bar2_default = class extends x {
+let bar2_default = class extends x {
 	bar2 = async () => () => super.foo = "bar2";
 };
 //#endregion
 //#region bar3.js
-var bar3_default = class extends x {
+let bar3_default = class extends x {
 	bar3 = () => async () => super.foo = "bar3";
 };
 //#endregion
 //#region bar4.js
-var bar4_default = class extends x {
+let bar4_default = class extends x {
 	bar4 = async () => async () => super.foo = "bar4";
 };
 //#endregion
 //#region baz1.js
-var baz1_default = class extends x {
+let baz1_default = class extends x {
 	async baz1() {
 		return () => super.foo = "baz1";
 	}
 };
 //#endregion
 //#region baz2.js
-var baz2_default = class extends x {
+let baz2_default = class extends x {
 	async baz2() {
 		return () => () => super.foo = "baz2";
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_class_field_strict_tsconfig_json2020/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_class_field_strict_tsconfig_json2020/artifacts.snap
@@ -7,12 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region loose/index.js
-var loose_default = class {
+let loose_default = class {
 	foo;
 };
 //#endregion
 //#region strict/index.js
-var strict_default = class {
+let strict_default = class {
 	foo;
 };
 //#endregion

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.js
 var _a = /* @__PURE__ */ new WeakMap();
-var A = class {
+let A = class {
 	constructor() {
 		_classPrivateFieldInitSpec(this, _a, void 0);
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_accessor_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_accessor_order/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	bar = this.#foo;
 	get #foo() {
 		return 123;

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_field_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_field_order/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	#foo = 123;
 	bar = this.#foo;
 };

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_field_static_issue1424/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_field_static_issue1424/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var T = class {
+let T = class {
 	#a() {
 		return "a";
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_method_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_method_order/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	bar = this.#foo();
 	#foo() {
 		return 123;

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_static_accessor_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_static_accessor_order/artifacts.snap
@@ -8,14 +8,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class Foo {
+let Foo = class Foo {
 	static bar = Foo.#foo;
 	static get #foo() {
 		return 123;
 	}
 };
 assert.equal(Foo.bar, 123);
-var FooThis = class {
+let FooThis = class {
 	static bar = this.#foo;
 	static get #foo() {
 		return 123;

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_static_field_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_static_field_order/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 //#region entry.js
-var Foo = class Foo {
+let Foo = class Foo {
 	static #foo = 123;
 	static bar = Foo.#foo;
 };
 assert.equal(Foo.bar, 123);
-var FooThis = class {
+let FooThis = class {
 	static #foo = 123;
 	static bar = this.#foo;
 };

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_static_method_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_static_method_order/artifacts.snap
@@ -13,7 +13,7 @@ assert(class Foo {
 		return 123;
 	}
 }.bar === 123);
-var FooThis = class {
+let FooThis = class {
 	static bar = this.#foo();
 	static #foo() {
 		return 123;

--- a/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2015/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2015/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	get #foo() {
 		return this.foo;
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2019/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2019/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	get #foo() {
 		return this.foo;
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2020/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2020/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	get #foo() {
 		return this.foo;
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter_next/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_getter_setter_next/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	get #foo() {
 		return this.foo;
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_method2019/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_method2019/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	#field;
 	#method() {}
 	baseline() {

--- a/crates/rolldown/tests/esbuild/lower/lower_private_method2020/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_method2020/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	#field;
 	#method() {}
 	baseline() {

--- a/crates/rolldown/tests/esbuild/lower/lower_private_method_next/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_method_next/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	#field;
 	#method() {}
 	baseline() {

--- a/crates/rolldown/tests/esbuild/lower/lower_private_method_with_modifiers2020/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_method_with_modifiers2020/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class {
+let Foo = class {
 	*#g() {}
 	async #a() {}
 	async *#ag() {}

--- a/crates/rolldown/tests/esbuild/lower/lower_private_super_es2021/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_super_es2021/artifacts.snap
@@ -7,56 +7,56 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	#foo() {
 		super.foo();
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	#foo() {
 		super.foo++;
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	static #foo() {
 		super.foo();
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	static #foo() {
 		super.foo++;
 	}
 };
 //#endregion
 //#region foo5.js
-var foo5_default = class extends x {
+let foo5_default = class extends x {
 	#foo = () => {
 		super.foo();
 	};
 };
 //#endregion
 //#region foo6.js
-var foo6_default = class extends x {
+let foo6_default = class extends x {
 	#foo = () => {
 		super.foo++;
 	};
 };
 //#endregion
 //#region foo7.js
-var foo7_default = class extends x {
+let foo7_default = class extends x {
 	static #foo = () => {
 		super.foo();
 	};
 };
 //#endregion
 //#region foo8.js
-var foo8_default = class extends x {
+let foo8_default = class extends x {
 	static #foo = () => {
 		super.foo++;
 	};

--- a/crates/rolldown/tests/esbuild/lower/lower_private_super_es2022/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_super_es2022/artifacts.snap
@@ -7,56 +7,56 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	#foo() {
 		super.foo();
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	#foo() {
 		super.foo++;
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	static #foo() {
 		super.foo();
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	static #foo() {
 		super.foo++;
 	}
 };
 //#endregion
 //#region foo5.js
-var foo5_default = class extends x {
+let foo5_default = class extends x {
 	#foo = () => {
 		super.foo();
 	};
 };
 //#endregion
 //#region foo6.js
-var foo6_default = class extends x {
+let foo6_default = class extends x {
 	#foo = () => {
 		super.foo++;
 	};
 };
 //#endregion
 //#region foo7.js
-var foo7_default = class extends x {
+let foo7_default = class extends x {
 	static #foo = () => {
 		super.foo();
 	};
 };
 //#endregion
 //#region foo8.js
-var foo8_default = class extends x {
+let foo8_default = class extends x {
 	static #foo = () => {
 		super.foo++;
 	};

--- a/crates/rolldown/tests/esbuild/lower/lower_private_super_static_bundle_issue2158/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_super_static_bundle_issue2158/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var Foo = class extends Object {
+let Foo = class extends Object {
 	static FOO;
 	constructor() {
 		super();

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_es2016/artifacts.snap
@@ -7,62 +7,62 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	static foo1() {
 		return async () => super.foo("foo1");
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	static foo2() {
 		return async () => () => super.foo("foo2");
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	static foo3() {
 		return () => async () => super.foo("foo3");
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	static foo4() {
 		return async () => async () => super.foo("foo4");
 	}
 };
 //#endregion
 //#region bar1.js
-var bar1_default = class extends x {
+let bar1_default = class extends x {
 	static bar1 = async () => super.foo("bar1");
 };
 //#endregion
 //#region bar2.js
-var bar2_default = class extends x {
+let bar2_default = class extends x {
 	static bar2 = async () => () => super.foo("bar2");
 };
 //#endregion
 //#region bar3.js
-var bar3_default = class extends x {
+let bar3_default = class extends x {
 	static bar3 = () => async () => super.foo("bar3");
 };
 //#endregion
 //#region bar4.js
-var bar4_default = class extends x {
+let bar4_default = class extends x {
 	static bar4 = async () => async () => super.foo("bar4");
 };
 //#endregion
 //#region baz1.js
-var baz1_default = class extends x {
+let baz1_default = class extends x {
 	static async baz1() {
 		return () => super.foo("baz1");
 	}
 };
 //#endregion
 //#region baz2.js
-var baz2_default = class extends x {
+let baz2_default = class extends x {
 	static async baz2() {
 		return () => () => super.foo("baz2");
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_setter_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_setter_es2016/artifacts.snap
@@ -7,62 +7,62 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region foo1.js
-var foo1_default = class extends x {
+let foo1_default = class extends x {
 	static foo1() {
 		return async () => super.foo = "foo1";
 	}
 };
 //#endregion
 //#region foo2.js
-var foo2_default = class extends x {
+let foo2_default = class extends x {
 	static foo2() {
 		return async () => () => super.foo = "foo2";
 	}
 };
 //#endregion
 //#region foo3.js
-var foo3_default = class extends x {
+let foo3_default = class extends x {
 	static foo3() {
 		return () => async () => super.foo = "foo3";
 	}
 };
 //#endregion
 //#region foo4.js
-var foo4_default = class extends x {
+let foo4_default = class extends x {
 	static foo4() {
 		return async () => async () => super.foo = "foo4";
 	}
 };
 //#endregion
 //#region bar1.js
-var bar1_default = class extends x {
+let bar1_default = class extends x {
 	static bar1 = async () => super.foo = "bar1";
 };
 //#endregion
 //#region bar2.js
-var bar2_default = class extends x {
+let bar2_default = class extends x {
 	static bar2 = async () => () => super.foo = "bar2";
 };
 //#endregion
 //#region bar3.js
-var bar3_default = class extends x {
+let bar3_default = class extends x {
 	static bar3 = () => async () => super.foo = "bar3";
 };
 //#endregion
 //#region bar4.js
-var bar4_default = class extends x {
+let bar4_default = class extends x {
 	static bar4 = async () => async () => super.foo = "bar4";
 };
 //#endregion
 //#region baz1.js
-var baz1_default = class extends x {
+let baz1_default = class extends x {
 	static async baz1() {
 		return () => super.foo = "baz1";
 	}
 };
 //#endregion
 //#region baz2.js
-var baz2_default = class extends x {
+let baz2_default = class extends x {
 	static async baz2() {
 		return () => () => super.foo = "baz2";
 	}

--- a/crates/rolldown/tests/esbuild/lower/lower_using_hoisting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_hoisting/artifacts.snap
@@ -18,10 +18,10 @@ using a = b;
 ```js
 //#region hoist-export-class-direct.js
 using a = b;
-var Foo1 = class {
+let Foo1 = class {
 	ac = [a, c];
 };
-var Bar1 = class Bar1 {
+let Bar1 = class Bar1 {
 	ac = [
 		a,
 		c,
@@ -39,10 +39,10 @@ export { Bar1, Foo1 };
 ```js
 //#region hoist-export-class-indirect.js
 using a = b;
-var Foo1 = class {
+let Foo1 = class {
 	ac = [a, c];
 };
-var Bar1 = class Bar1 {
+let Bar1 = class Bar1 {
 	ac = [
 		a,
 		c,
@@ -71,7 +71,7 @@ export { a, c as "c!" };
 ```js
 //#region hoist-export-default-class-anonymous.js
 using a = b;
-var hoist_export_default_class_anonymous_default = class {
+let hoist_export_default_class_anonymous_default = class {
 	ac = [a, c];
 };
 using c = d;
@@ -85,7 +85,7 @@ export { hoist_export_default_class_anonymous_default as default };
 ```js
 //#region hoist-export-default-class-name-unused.js
 using a = b;
-var Foo = class {
+let Foo = class {
 	ac = [a, c];
 };
 using c = d;
@@ -99,7 +99,7 @@ export { Foo as default };
 ```js
 //#region hoist-export-default-class-name-used.js
 using a = b;
-var Foo = class Foo {
+let Foo = class Foo {
 	ac = [
 		a,
 		c,

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region entry.ts
 var _foo = /* @__PURE__ */ new WeakMap();
 var _bar = /* @__PURE__ */ new WeakMap();
-var Foo = class {
+let Foo = class {
 	constructor() {
 		_classPrivateFieldInitSpec(this, _foo, 123);
 		_classPrivateFieldInitSpec(this, _bar, void 0);

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_class_field_strict_tsconfig_json2020/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_class_field_strict_tsconfig_json2020/artifacts.snap
@@ -7,14 +7,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region loose/index.ts
-var loose_default = class {};
+let loose_default = class {};
 //#endregion
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region strict/index.ts
-var strict_default = class {
+let strict_default = class {
 	constructor() {
 		_defineProperty(this, "foo", void 0);
 	}

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_private_field_and_method_avoid_name_collision2015/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_private_field_and_method_avoid_name_collision2015/artifacts.snap
@@ -7,10 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.ts
-var WeakMap = class {
+let WeakMap = class {
 	#x;
 };
-var WeakSet = class {
+let WeakSet = class {
 	#y() {}
 };
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/this_inside_function_ts/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/this_inside_function_ts/artifacts.snap
@@ -13,7 +13,7 @@ function foo(x = this) {
 const objFoo = { foo(x = this) {
 	console.log(this);
 } };
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.x = this;
 	}

--- a/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_no_bundle/artifacts.snap
@@ -13,7 +13,7 @@ function foo(x = this) {
 const objFoo = { foo(x = this) {
 	console.log(this);
 } };
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.x = this;
 	}

--- a/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_no_bundle_use_define_for_class_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_no_bundle_use_define_for_class_fields/artifacts.snap
@@ -13,7 +13,7 @@ function foo(x = this) {
 const objFoo = { foo(x = this) {
 	console.log(this);
 } };
-var Foo = class {
+let Foo = class {
 	x = this;
 	static y = this.z;
 	foo(x = this) {

--- a/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_use_define_for_class_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/this_inside_function_ts_use_define_for_class_fields/artifacts.snap
@@ -13,7 +13,7 @@ function foo(x = this) {
 const objFoo = { foo(x = this) {
 	console.log(this);
 } };
-var Foo = class {
+let Foo = class {
 	x = this;
 	static y = this.z;
 	foo(x = this) {

--- a/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_assign/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_assign/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-var Foo = class {};
+let Foo = class {};
 (() => new Foo())();
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_define/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_define/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region entry.ts
 const keepThisToo = Symbol("keepThisToo");
-var Foo = class {
+let Foo = class {
 	keepThis;
 	[keepThisToo];
 };

--- a/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_false/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_false/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
 let _r, _y;
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this[_r] = s;
 		this[_y] = z;

--- a/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_true/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_true/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
 var _x, _y;
-var Foo = class {
+let Foo = class {
 	[q];
 	[r] = s;
 	[_x = x];

--- a/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_true_lower/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_computed_class_field_use_define_true_lower/artifacts.snap
@@ -18,7 +18,7 @@ _q = q;
 _r = r;
 _x2 = _x = x;
 _y2 = _y = y;
-var Foo = class {
+let Foo = class {
 	constructor() {
 		_defineProperty(this, _q, void 0);
 		_defineProperty(this, _r, s);

--- a/crates/rolldown/tests/esbuild/ts/ts_declare_class_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_declare_class_fields/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region define-false/index.ts
-var Foo = class {
+let Foo = class {
 	static {
 		c, d, C, D;
 	}
@@ -15,7 +15,7 @@ var Foo = class {
 (() => new Foo())();
 //#endregion
 //#region define-true/index.ts
-var Bar = class {
+let Bar = class {
 	a;
 	[c];
 	static A;

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorator_scope_issue2147/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorator_scope_issue2147/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
 let foo = 1;
-var Foo = class {
+let Foo = class {
 	method1(foo = 2) {}
 	method2(foo = 3) {}
 };

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators/artifacts.snap
@@ -61,7 +61,7 @@ var all_default = Foo$1;
 //#region all_computed.ts
 var _ref, _ref2;
 let _mDef, _xDef, _yDef, _sDef;
-var Foo = class Foo {
+let Foo = class Foo {
 	constructor() {
 		this[_mDef] = 1;
 		this[_xDef] = 2;
@@ -209,18 +209,18 @@ h = _h = __decorate([x(() => 0), y(() => 1)], h);
 var h_default = h;
 //#endregion
 //#region i.ts
-var i_class = class {};
+let i_class = class {};
 __decorate([x(() => 0), y(() => 1)], i_class.prototype, "foo", void 0);
 let i = i_class;
 //#endregion
 //#region j.ts
-var j = class {
+let j = class {
 	foo() {}
 };
 __decorate([x(() => 0), y(() => 1)], j.prototype, "foo", null);
 //#endregion
 //#region k.ts
-var _default = class {
+let _default = class {
 	foo(x) {}
 };
 __decorate([__decorateParam(0, x(() => 0)), __decorateParam(0, y(() => 1))], _default.prototype, "foo", null);

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_assign_semantics/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_assign_semantics/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
-var Foo = class {
+let Foo = class {
 	constructor() {
 		this.prop1 = null;
 		this.prop2_ = null;

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_define_semantics/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_define_semantics/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
-var Foo = class {
+let Foo = class {
 	prop1 = null;
 	prop2_ = null;
 	["prop3"] = null;

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_methods/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_methods/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
-var Foo = class {
+let Foo = class {
 	prop1() {}
 	prop2_() {}
 	["prop3"]() {}

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_define_semantics/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_define_semantics/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
-var Foo = class {
+let Foo = class {
 	static prop1 = null;
 	static prop2_ = null;
 	static ["prop3"] = null;

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_methods/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_methods/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
-var Foo = class {
+let Foo = class {
 	static prop1() {}
 	static prop2_() {}
 	static ["prop3"]() {}

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_no_config/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_no_config/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.ts
-var Foo = @x.y() @(new y.x()) class Foo {
+let Foo = @x.y() @(new y.x()) class Foo {
 	constructor() {
 		this.mDef = 1;
 		this.#mDef = 1;

--- a/crates/rolldown/tests/esbuild/ts/ts_export_namespace/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_namespace/artifacts.snap
@@ -35,7 +35,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region b.ts
-var Foo = class {};
+let Foo = class {};
 (function(_Foo) {
 	_Foo.foo = 1;
 })(Foo || (Foo = {}));

--- a/crates/rolldown/tests/esbuild/ts/ts_import_vs_local_collision_all_types/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_vs_local_collision_all_types/artifacts.snap
@@ -11,7 +11,7 @@ let a;
 const b = 0;
 var c;
 function d() {}
-var e = class {};
+let e = class {};
 console.log(a, b, c, d, e);
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/ts/ts_import_vs_local_collision_mixed/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_vs_local_collision_mixed/artifacts.snap
@@ -11,7 +11,7 @@ let a;
 const b = 0;
 var c;
 function d() {}
-var e = class {};
+let e = class {};
 console.log(a, b, c, d, e, 123);
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/function/top_level_var/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/top_level_var/artifacts.snap
@@ -10,11 +10,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 let firstLevelLet = "let";
 var firstLevelVar = "var";
 const firstLevelConst = "const";
-var FirstLevelClass = class {};
+let FirstLevelClass = class {};
 console.log(firstLevelLet, firstLevelVar, firstLevelConst, new FirstLevelClass());
 const exportedConst = "exported_const";
 let exportedLet = "exported_let";
-var ExportedClass = class {};
+let ExportedClass = class {};
 function exportedFunction() {}
 console.log("let");
 function second_level() {
@@ -41,11 +41,11 @@ export { ExportedClass, exportedConst, exportedFunction, exportedLet };
 var firstLevelLet = "let";
 var firstLevelVar = "var";
 var firstLevelConst = "const";
-var FirstLevelClass = class {};
+let FirstLevelClass = class {};
 console.log(firstLevelLet, firstLevelVar, firstLevelConst, new FirstLevelClass());
 var exportedConst = "exported_const";
 var exportedLet = "exported_let";
-var ExportedClass = class {};
+let ExportedClass = class {};
 function exportedFunction() {}
 console.log("let");
 function second_level() {

--- a/crates/rolldown/tests/rolldown/issues/4006/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4006/artifacts.snap
@@ -16,7 +16,7 @@ function a() {}
 /**
 * default export class
 */
-var b = class {};
+let b = class {};
 //#endregion
 //#region main.js
 /**
@@ -28,7 +28,7 @@ function foo() {
 /**
 * named export class
 */
-var Bar = class {};
+let Bar = class {};
 /**
 * named export const decl
 */

--- a/crates/rolldown/tests/rolldown/issues/4491/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4491/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-function e(){}var t=class{foo(){console.log(``,e,``)}bar(){console.log(`bar`)}};export{t as default};
+function e(){}let t=class{foo(){console.log(``,e,``)}bar(){console.log(`bar`)}};export{t as default};
 ```

--- a/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 let node_process = require("node:process");
 //#region lib.js
-var VFile = class {
+let VFile = class {
 	constructor() {
 		console.log(node_process.default);
 	}

--- a/crates/rolldown/tests/rolldown/issues/5139/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5139/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
-var Foo = class {};
+let Foo = class {};
 function foo() {}
 const baz = function() {};
 function __name() {
@@ -17,7 +17,7 @@ function __name() {
 __name();
 //#endregion
 //#region main.js
-var Foo$1 = class {
+let Foo$1 = class {
 	static {
 		__name$1(this, "Foo");
 	}

--- a/crates/rolldown/tests/rolldown/issues/6097/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6097/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 var Message$1 = 1;
 //#endregion
 //#region main.js
-var Message = class {
+let Message = class {
 	id;
 	constructor(id) {
 		this.id = id;

--- a/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
@@ -19,7 +19,7 @@ new utilityClass(helper());
 function helper() {
 	return "help";
 }
-var utilityClass = class {
+let utilityClass = class {
 	constructor(value) {
 		this.value = value;
 	}

--- a/crates/rolldown/tests/rolldown/issues/7150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7150/artifacts.snap
@@ -23,7 +23,7 @@ function dep_default() {
 __name(dep_default, "default");
 //#endregion
 //#region dep-class.js
-var dep_class_default = class {
+let dep_class_default = class {
 	static {
 		__name(this, "default");
 	}
@@ -36,7 +36,7 @@ var dep_class_default = class {
 var count = 100;
 assert.strictEqual(dep_default.name, "default", "Anonymous default export function name should be \"default\"");
 assert.strictEqual(dep_class_default.name, "default", "Anonymous default export class name should be \"default\"");
-var main_default = class {
+let main_default = class {
 	static {
 		__name(this, "default");
 	}

--- a/crates/rolldown/tests/rolldown/issues/9263/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9263/artifacts.snap
@@ -14,7 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region index.cjs
 var require__9263 = /* @__PURE__ */ __commonJSMin((() => {
 	var _defineProperty = require_defineProperty();
-	var Foo = class {
+	let Foo = class {
 		constructor() {
 			_defineProperty(this, "foo", 1);
 		}

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_593/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import { n as setInnerHtml, t as htmlEscape } from "./shared.js";
 //#region component.js
-var Component = class {
+let Component = class {
 	constructor(name) {
 		this.name = name;
 	}
@@ -38,7 +38,7 @@ function isIE() {
 }
 //#endregion
 //#region safehtml.js
-var SafeHtml = class {
+let SafeHtml = class {
 	constructor(html) {
 		this.html = html;
 		this.isIE = isIE();

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/preserve_default_export_instead_of_named_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/preserve_default_export_instead_of_named_export/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region class.js
-var class_default = class {};
+let class_default = class {};
 //#endregion
 export { class_default as default };
 

--- a/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.js
-var BaseNode = class extends Callable {
+let BaseNode = class extends Callable {
 	referencesById = children.reduce((result, child) => Object.assign(result, child.referencesById), { [this.id]: this });
 	[(void 0).id] = this;
 };

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
@@ -14,7 +14,7 @@ function LogMethod(target, propertyKey, descriptor) {
 	console.log(propertyKey);
 	console.log(descriptor);
 }
-var Demo = class {
+let Demo = class {
 	foo(bar) {}
 };
 __decorate([

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
@@ -18,7 +18,7 @@ function add(a, b) {
 function first() {
 	return function(...args) {};
 }
-var Foo = class {
+let Foo = class {
 	method(test) {
 		return test;
 	}

--- a/crates/rolldown/tests/rolldown/topics/deconflict/umd_external_namespace_shadowing/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/umd_external_namespace_shadowing/artifacts.snap
@@ -33,7 +33,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	// HIDDEN [\0rolldown/runtime.js]
 	quill = __toESM(quill);
 	//#region test.js
-	var Editor = class {
+	let Editor = class {
 		constructor(quill$1) {
 			if (typeof quill.default != "undefined") throw new Error("Quill should not be shadowed by local quill");
 			console.log(quill.default, quill$1);

--- a/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "tsconfig": "tsconfig.json",
+    "external": [
+      "reflect-metadata",
+      "@oxc-project/runtime/helpers/decorate",
+      "@oxc-project/runtime/helpers/decorateMetadata"
+    ]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/artifacts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import "reflect-metadata";
+import _decorateMetadata from "@oxc-project/runtime/helpers/decorateMetadata";
+import _decorate from "@oxc-project/runtime/helpers/decorate";
+//#region main.ts
+function D() {
+	return () => {};
+}
+let Source = class {
+	laterRef;
+};
+_decorate([D(), _decorateMetadata("design:type", typeof LaterClass === "undefined" ? Object : LaterClass)], Source.prototype, "laterRef", void 0);
+let LaterClass = class {
+	tag = "later";
+};
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/main.ts
@@ -1,0 +1,12 @@
+import 'reflect-metadata';
+function D(): PropertyDecorator {
+  return () => {};
+}
+
+class Source {
+  @D() laterRef!: LaterClass;
+}
+
+class LaterClass {
+  tag = 'later';
+}

--- a/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "target": "ES2022"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -34,7 +34,7 @@ var require_cjs_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
 	exports.foo = "foo";
 	exports.bar = "bar";
-	var Noop = class {
+	let Noop = class {
 		static baz2 = this.baz3 = "wrong";
 		static {
 			this.baz = "bar";

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region a.js
-var Foo$1 = class Foo$1 {
+let Foo$1 = class Foo$1 {
 	static {
 		__name(this, "Foo");
 	}
@@ -17,7 +17,7 @@ var Foo$1 = class Foo$1 {
 };
 //#endregion
 //#region main.js
-var Foo = class Foo {
+let Foo = class Foo {
 	static self = Foo;
 };
 assert.strictEqual(Foo$1.name, "Foo");

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 //#region a.js
 function test$1() {}
 __name(test$1, "test");
-var Foo$1 = class {
+let Foo$1 = class {
 	static {
 		__name(this, "Foo");
 	}
@@ -19,7 +19,7 @@ var Foo$1 = class {
 //#endregion
 //#region main.js
 const test = 10;
-var Foo = class extends Foo$1 {};
+let Foo = class extends Foo$1 {};
 console.log(`test: `, test);
 assert.strictEqual(Foo.name, "Foo");
 assert.strictEqual(Foo$1.name, "Foo");

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/artifacts.snap
@@ -34,7 +34,7 @@ assert.strictEqual(_Fn$1(), 1);
 assert.strictEqual(_ArrowFn$1(), 2);
 //#endregion
 //#region lib.js
-var _Test = class {};
+let _Test = class {};
 let _Fn = function() {};
 let _ArrowFn = () => {};
 assert.strictEqual(_Test.name, "_Test");

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region url.js
-var URL = class {};
+let URL = class {};
 //#endregion
 //#region main.js
 function createURL() {

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_decl/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_decl/artifacts.snap
@@ -25,7 +25,7 @@ Object.defineProperties(exports, {
 	[Symbol.toStringTag]: { value: "Module" }
 });
 //#region main.js
-var Main = class {};
+let Main = class {};
 //#endregion
 exports.default = Main;
 

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
@@ -11,7 +11,7 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const short1 = "";
 let short2 = "";
 function short3() {}
-var short4 = class {};
+let short4 = class {};
 let nonShort1 = "";
 nonShort1 = "";
 function nonShort2() {}

--- a/crates/rolldown_plugin_isolated_declaration/tests/strip_internal/artifacts.snap
+++ b/crates/rolldown_plugin_isolated_declaration/tests/strip_internal/artifacts.snap
@@ -16,7 +16,7 @@ export declare class A {
 
 ```js
 //#region main.ts
-var A = class {
+let A = class {
 	foo = 1;
 	/** @internal */
 	bar = 2;


### PR DESCRIPTION
## Summary

When a top-level `class X {}` is rewritten so its name binding can participate in the bundler's symbol table, `ScopeHoistingFinalizer::get_transformed_class_decl` was lowering it to `var X = class X {}`. That silently changes the binding from lexical (TDZ) to function-scoped (hoisted as `undefined`), which breaks any reference that relies on the class being unreachable before its declaration.

This PR emits `let` instead of `var` so the bundled output preserves the TDZ semantics of the original `class` keyword.

## The bug

The most visible breakage is decorator metadata under `emitDecoratorMetadata`. OXC's legacy decorator transform wraps forward-referenced class identifiers in a guard so the metadata expression evaluates safely at decoration time:

```js
_decorateMetadata("design:type", typeof LaterClass === "undefined" ? Object : LaterClass)
```

With a `let` binding, `typeof T` on a TDZ identifier throws `ReferenceError` and the application surfaces the real ordering problem. With `var`, the hoisted binding evaluates to `undefined`, the guard short-circuits to `Object`, and the metadata is silently wrong forever — frameworks like NestJS that consume `design:type` at DI resolution then resolve the wrong dependency.

The same hazard applies to any non-decorator forward reference:

```ts
class A { static b = new B() } // bundled as `var A = class { static b = new B() }`
class B {}                     // bundled as `var B = class {}` — hoisted as `undefined`
```

Under `var`, `new B()` observes `B` as `undefined` and throws `TypeError: B is not a constructor` at runtime instead of the `ReferenceError` the original source guaranteed.

## How tsc and babel handle this (reference)

Given the same source:

```ts
class Source {
  @D() laterRef!: LaterClass;
}
class LaterClass {
  tag = 'later';
}
```

**Babel** (`@babel/plugin-proposal-decorators` legacy + `babel-plugin-transform-typescript-metadata`) emits:

```js
let Source = (_dec = D(), _dec2 = Reflect.metadata("design:type", typeof LaterClass === "undefined" ? Object : LaterClass), _class = class Source { ... }, ...);
class LaterClass { ... }
```

Both bindings stay lexical — `Source` as a `let`, `LaterClass` left as a class declaration. The metadata call runs at module-init time, `LaterClass` is in TDZ at that moment, `typeof` throws `ReferenceError: Cannot access 'LaterClass' before initialization`, and the developer immediately learns about the ordering bug.

**tsc** (`experimentalDecorators` + `emitDecoratorMetadata`) emits the same structure: `class Source { ... }` interleaved with the `__decorate` / `__metadata` calls and `class LaterClass { ... }` after, again all lexical. Same `ReferenceError` surfaces.

**rolldown before this PR** lowered both top-level classes to `var Source = class { ... }` / `var LaterClass = class { ... }`. The `var`-hoisted `LaterClass` binding evaluated to `undefined` at decoration time, the `typeof X === "undefined" ? Object : X` guard short-circuited to `Object`, and the bug went silent.

**rolldown after this PR** lowers to `let Source = class { ... }` / `let LaterClass = class { ... }` — matching babel's semantics. The `typeof` guard now throws `ReferenceError` from TDZ exactly like babel and tsc, instead of silently producing `Object` metadata.

## Fix

```diff
-  /// rewrite toplevel `class ClassName {}` to `var ClassName = class {}`
+  /// rewrite toplevel `class ClassName {}` to `let ClassName = class {}`.
+  /// `let` preserves the lexical-binding / TDZ semantics of the original
+  /// `class` declaration; `var` would hoist the binding as `undefined` and
+  /// silence forward-reference errors.
   fn get_transformed_class_decl(...) -> ... {
     ...
     Some(self.snippet.builder.declaration_variable(
       class.span,
-      VariableDeclarationKind::Var,
+      VariableDeclarationKind::Let,
       self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
         SPAN,
-        VariableDeclarationKind::Var,
+        VariableDeclarationKind::Let,
         ...
```

The inner class expression still carries its own name binding (`class X { ... }`), so self-references like `class Foo { static foo = new Foo() }` continue to work — this is confirmed by `tests/esbuild/default/avoid_tdz` and `keep_names/class_decl_self_ref_deconflict`, both of which still pass with the `var` → `let` swap.

## Test plan

- [x] New regression fixture at `crates/rolldown/tests/rolldown/topics/decorator_metadata_forward_ref/` pins the forward-referenced decorator-metadata case, locking the emit to `let Source = class { ... }` and `let LaterClass = class { ... }`.
- [x] 75 pre-existing snapshots updated mechanically (`var X = class` → `let X = class`); no other content changed in those files.
- [x] Bug reproduction confirmed on this branch's base (`upstream/main`) by temporarily reverting the source change and re-running the new fixture: emit was `var Source = class` / `var LaterClass = class`, matching the broken behaviour described above.
- [x] Local CI parity: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- --deny warnings`, `cargo check --workspace --all-features --all-targets`, `cargo ls-lint`, `cargo run --bin generator` (clean diff), `vp lint`, `vp run --filter rolldown-tests test:types`, `vp run lint-publint`, `vp run lint-knip` all clean.
- [x] `INSTA_UPDATE=no cargo test --workspace --exclude rolldown_binding --exclude bench`: 1725 passed (the 2 local failures are environmental — test262 submodule not cloned, and `external_module_exclusion_package` snapshot expects the `aws-sdk` import to stay unresolved but the local `pnpm install` made it resolvable; both pass on CI).

## AI usage disclosure

Per the [AI Usage Policy](https://rolldown.rs/contribution-guide#ai-usage-policy): AI assistance (Claude Code) was used to implement and verify this change. I have reviewed and tested it locally.