### PR TITLE
fix: handle slash-normalized ids with preserveModulesRoot

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -12,6 +12,7 @@ use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_std_utils::{
   PathBufExt as _, PathExt as _, representative_file_name_for_preserve_modules,
+  strip_path_prefix_to_slash,
 };
 use rolldown_utils::{
   dashmap::FxDashMap,
@@ -235,10 +236,13 @@ impl<'a> GenerateStage<'a> {
                 let p = PathBuf::from(sanitized_absolute_filename.as_str());
                 let relative_path = if p.is_absolute() {
                   if let Some(ref preserve_modules_root) = preserve_modules_root {
-                    if absolute_chunk_file_name.starts_with(preserve_modules_root.as_str()) {
-                      absolute_chunk_file_name[preserve_modules_root.len()..]
-                        .trim_start_matches(['/', '\\'])
-                        .to_string()
+                    // See meta/design/module-id.md: output paths may normalize separators even
+                    // when module ids keep native separators.
+                    if let Some(relative_path) = strip_path_prefix_to_slash(
+                      absolute_chunk_file_name.as_path(),
+                      preserve_modules_root.as_path(),
+                    ) {
+                      relative_path
                     } else {
                       p.relative(input_base.as_str()).to_slash_lossy().into_owned()
                     }

--- a/crates/rolldown/tests/rolldown/issues/9593/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9593/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const fixtureDir = dirname(fileURLToPath(import.meta.url));
+const dist = join(fixtureDir, 'dist');
+
+assert.ok(existsSync(join(dist, 'bin', 'index.js')), 'expected dist/bin/index.js to exist');
+assert.ok(existsSync(join(dist, 'lib', 'helper.js')), 'expected dist/lib/helper.js to exist');
+assert.ok(
+  !existsSync(join(dist, 'src', 'bin', 'index.js')),
+  'did not expect dist/src/bin/index.js',
+);
+assert.ok(
+  !existsSync(join(dist, 'src', 'lib', 'helper.js')),
+  'did not expect dist/src/lib/helper.js',
+);

--- a/crates/rolldown/tests/rolldown/issues/9593/assets/data.json
+++ b/crates/rolldown/tests/rolldown/issues/9593/assets/data.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "message": "ok"
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9593/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/9593/mod.rs
@@ -1,0 +1,74 @@
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+  sync::Arc,
+};
+
+use rolldown::{BundlerOptions, InputItem, OutputFormat};
+use rolldown_plugin::{
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, HookUsage, Plugin, PluginContext,
+};
+use rolldown_testing::{manual_integration_test, test_config::TestMeta};
+
+#[derive(Debug)]
+struct SlashNormalizedResolvePlugin;
+
+impl SlashNormalizedResolvePlugin {
+  fn resolve_file(cwd: &Path, args: &HookResolveIdArgs<'_>) -> Option<PathBuf> {
+    let specifier = Path::new(args.specifier);
+    let unresolved = if specifier.is_absolute() {
+      specifier.to_path_buf()
+    } else {
+      let base = args.importer.and_then(|importer| Path::new(importer).parent()).unwrap_or(cwd);
+      base.join(specifier)
+    };
+
+    if unresolved.extension().is_some() && unresolved.is_file() {
+      return dunce::canonicalize(unresolved).ok();
+    }
+
+    ["ts", "js", "json"].into_iter().find_map(|extension| {
+      let candidate = unresolved.with_extension(extension);
+      candidate.is_file().then(|| dunce::canonicalize(candidate).ok()).flatten()
+    })
+  }
+}
+
+impl Plugin for SlashNormalizedResolvePlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "slash-normalized-resolve".into()
+  }
+
+  async fn resolve_id(
+    &self,
+    ctx: &PluginContext,
+    args: &HookResolveIdArgs<'_>,
+  ) -> HookResolveIdReturn {
+    let Some(path) = Self::resolve_file(ctx.cwd(), args) else {
+      return Ok(None);
+    };
+    let id = path.to_string_lossy().replace('\\', "/");
+    Ok(Some(HookResolveIdOutput::from_id(id)))
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::ResolveId
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preserve_modules_root_with_slash_normalized_ids() {
+  manual_integration_test!()
+    .build(TestMeta { snapshot: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem { name: None, import: "./src/bin/index.ts".into() }]),
+        format: Some(OutputFormat::Esm),
+        preserve_modules: Some(true),
+        preserve_modules_root: Some("src".into()),
+        ..Default::default()
+      },
+      vec![Arc::new(SlashNormalizedResolvePlugin)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/issues/9593/src/bin/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/9593/src/bin/index.ts
@@ -1,0 +1,4 @@
+import { data } from '../../assets/data.json';
+import { helper } from '../lib/helper';
+
+console.log(helper(data));

--- a/crates/rolldown/tests/rolldown/issues/9593/src/lib/helper.ts
+++ b/crates/rolldown/tests/rolldown/issues/9593/src/lib/helper.ts
@@ -1,0 +1,3 @@
+export function helper(data: { message: string }) {
+  return data.message;
+}

--- a/crates/rolldown/tests/rolldown/issues/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/mod.rs
@@ -6,3 +6,5 @@ mod _4895;
 mod _5011;
 #[path = "./7833/mod.rs"]
 mod _7833;
+#[path = "./9593/mod.rs"]
+mod _9593;

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -16,7 +16,7 @@ pub mod types;
 
 use arcstr::ArcStr;
 use oxc_str::CompactStr;
-use rolldown_std_utils::PathExt;
+use rolldown_std_utils::{PathExt, strip_path_prefix_to_slash};
 use rolldown_utils::{
   BitSet,
   dashmap::FxDashMap,
@@ -245,10 +245,12 @@ impl Chunk {
     let p = PathBuf::from(chunk_name);
     let p = if p.is_absolute() {
       if let Some(ref preserve_modules_root) = options.preserve_modules_root {
-        if chunk_name.starts_with(preserve_modules_root) {
-          return Cow::Borrowed(
-            chunk_name[preserve_modules_root.len()..].trim_start_matches(['/', '\\']),
-          );
+        // See meta/design/module-id.md: output paths may normalize separators even when module
+        // ids keep native separators.
+        if let Some(relative_path) =
+          strip_path_prefix_to_slash(chunk_name.as_path(), preserve_modules_root.as_path())
+        {
+          return Cow::Owned(relative_path);
         }
       }
       p.relative(self.input_base.as_str())

--- a/crates/rolldown_std_utils/src/lib.rs
+++ b/crates/rolldown_std_utils/src/lib.rs
@@ -8,6 +8,6 @@ mod pretty_type_name;
 pub use crate::{
   option_ext::OptionExt,
   path_buf_ext::PathBufExt,
-  path_ext::{PathExt, representative_file_name_for_preserve_modules},
+  path_ext::{PathExt, representative_file_name_for_preserve_modules, strip_path_prefix_to_slash},
   pretty_type_name::pretty_type_name,
 };

--- a/crates/rolldown_std_utils/src/path_ext.rs
+++ b/crates/rolldown_std_utils/src/path_ext.rs
@@ -65,6 +65,10 @@ pub fn representative_file_name_for_preserve_modules(
   (file_name, ab_path, path.extension().map(|item| item.to_string_lossy()))
 }
 
+pub fn strip_path_prefix_to_slash(path: &Path, prefix: &Path) -> Option<String> {
+  path.strip_prefix(prefix).ok().map(PathExt::expect_to_slash)
+}
+
 #[test]
 fn test_representative_file_name() {
   let cwd = Path::new(".").join("project");
@@ -89,4 +93,23 @@ fn test_representative_file_name() {
     let path = cwd.join("src").join("vue.js");
     assert_eq!(representative_file_name_for_preserve_modules(&path).1, "./project/src/vue");
   }
+}
+
+#[test]
+fn test_strip_path_prefix_to_slash() {
+  let path = Path::new("/project/src/bin/index");
+  let prefix = Path::new("/project/src");
+  assert_eq!(strip_path_prefix_to_slash(path, prefix).as_deref(), Some("bin/index"));
+
+  let path = Path::new("/project/src2/bin/index");
+  let prefix = Path::new("/project/src");
+  assert_eq!(strip_path_prefix_to_slash(path, prefix), None);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_strip_path_prefix_to_slash_with_mixed_windows_separators() {
+  let path = Path::new(r"C:/project/src/bin/index");
+  let prefix = Path::new(r"C:\project\src");
+  assert_eq!(strip_path_prefix_to_slash(path, prefix).as_deref(), Some("bin/index"));
 }


### PR DESCRIPTION
Fixes #9593.

This replaces raw string prefix checks for `preserveModulesRoot` with path-aware prefix stripping, so Windows builds handle both native backslash paths and slash-normalized absolute ids. It also adds unit coverage for mixed separators and a Rust integration reproducer that asserts `src/` is stripped from emitted preserve-module paths.

Verification:
- `cargo test -p rolldown_std_utils strip`
- `cargo test -p rolldown --test integration 9593 -- --nocapture`
- `just lint-rust`