### PR TITLE
perf: avoid unnecessary intermediate sourcemaps

### DIFF
--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -215,9 +215,11 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
         while let Ok(msg) = rx.recv() {
           match msg {
             SourceMapGenMsg::MagicString(v) => {
-              let (module_idx, plugin_idx, magic_string) = *v;
-              let generated_sourcemap =
-                magic_string.source_map(string_wizard::SourceMapOptions::default());
+              let (module_idx, plugin_idx, id, magic_string) = *v;
+              let generated_sourcemap = magic_string.source_map(string_wizard::SourceMapOptions {
+                source: id.as_str().into(),
+                ..Default::default()
+              });
               map
                 .entry(module_idx)
                 .or_default()
@@ -265,21 +267,27 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
         for element in module.sourcemap_chain.drain(..) {
           match element {
             SourcemapChainElement::Load(_) => load_elements.push(element),
-            SourcemapChainElement::Transform(_) => transform_elements.push(element),
+            SourcemapChainElement::Transform(_)
+            | SourcemapChainElement::Omitted { .. }
+            | SourcemapChainElement::Null { .. } => {
+              transform_elements.push(element);
+            }
           }
         }
 
         // Sort only Transform elements by plugin order
         transform_elements.sort_by(|a, b| {
-          if let (
-            SourcemapChainElement::Transform((a_plugin_idx, _)),
-            SourcemapChainElement::Transform((b_plugin_idx, _)),
-          ) = (a, b)
-          {
+          let plugin_idx_of = |el: &SourcemapChainElement| match el {
+            SourcemapChainElement::Transform((plugin_idx, _))
+            | SourcemapChainElement::Omitted { plugin_idx, .. }
+            | SourcemapChainElement::Null { plugin_idx, .. } => Some(*plugin_idx),
+            SourcemapChainElement::Load(_) => None,
+          };
+          if let (Some(a_plugin_idx), Some(b_plugin_idx)) = (plugin_idx_of(a), plugin_idx_of(b)) {
             let a_order =
-              transform_plugin_order_map.get(a_plugin_idx).copied().unwrap_or(usize::MAX);
+              transform_plugin_order_map.get(&a_plugin_idx).copied().unwrap_or(usize::MAX);
             let b_order =
-              transform_plugin_order_map.get(b_plugin_idx).copied().unwrap_or(usize::MAX);
+              transform_plugin_order_map.get(&b_plugin_idx).copied().unwrap_or(usize::MAX);
             a_order.cmp(&b_order)
           } else {
             std::cmp::Ordering::Equal

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rolldown_common::{ModuleRenderOutput, NormalModule, NormalizedBundlerOptions};
-use rolldown_sourcemap::{Source, SourceMapSource, collapse_sourcemaps};
+use rolldown_sourcemap::{Source, SourceMapSource, collapse_sourcemaps, empty_sourcemap};
 use rolldown_utils::concat_string;
 
 pub fn render_ecma_module(
@@ -27,18 +27,46 @@ pub fn render_ecma_module(
       let sourcemap = if module.sourcemap_chain.is_empty() {
         render_output.map
       } else {
-        let mut sourcemap_chain = module
-          .sourcemap_chain
-          .iter()
-          .map(|element| match element {
+        let empty = empty_sourcemap();
+        let mut owned_chain: Vec<&rolldown_sourcemap::SourceMap> =
+          Vec::with_capacity(module.sourcemap_chain.len() + 1);
+
+        let mut original_content: Option<&str> = None;
+        for element in &module.sourcemap_chain {
+          match element {
             rolldown_common::SourcemapChainElement::Transform((_, sourcemap))
-            | rolldown_common::SourcemapChainElement::Load(sourcemap) => sourcemap,
-          })
-          .collect::<Vec<_>>();
-        if let Some(sourcemap) = render_output.map.as_ref() {
-          sourcemap_chain.push(sourcemap);
+            | rolldown_common::SourcemapChainElement::Load(sourcemap) => {
+              owned_chain.push(sourcemap);
+            }
+            rolldown_common::SourcemapChainElement::Omitted { .. } => {
+              owned_chain.push(&empty);
+            }
+            rolldown_common::SourcemapChainElement::Null { original_content: content, .. } => {
+              // `map: null` does not remap positions, so it contributes nothing
+              // to `collapse_sourcemaps`. We only keep its pre-transform content as a
+              // fallback when there is no real map to provide one.
+              if original_content.is_none() {
+                original_content = Some(content);
+              }
+            }
+          }
         }
-        Some(collapse_sourcemaps(&sourcemap_chain))
+        if owned_chain.is_empty() {
+          // Only `map: null` transforms touched this module: keep the codegen
+          // map's positions but swap in the pre-transform source content so the
+          // transformed/injected code does not leak into `sourcesContent`.
+          render_output.map.map(|mut map| {
+            if let Some(content) = original_content {
+              map.set_source_contents(vec![Some(content)]);
+            }
+            map
+          })
+        } else {
+          if let Some(sourcemap) = render_output.map.as_ref() {
+            owned_chain.push(sourcemap);
+          }
+          Some(collapse_sourcemaps(&owned_chain))
+        }
       };
 
       if let Some(sourcemap) = sourcemap {

--- a/crates/rolldown_common/src/source_map_gen_msg.rs
+++ b/crates/rolldown_common/src/source_map_gen_msg.rs
@@ -1,9 +1,14 @@
+use arcstr::ArcStr;
 use string_wizard::MagicString;
 
 use crate::PluginIdx;
 
 #[derive(Debug)]
 pub enum SourceMapGenMsg {
-  MagicString(Box<(crate::ModuleIdx, PluginIdx, MagicString<'static>)>),
+  /// `(module_idx, plugin_idx, module_id, magic_string)`.
+  ///
+  /// `module_id` is carried so the sourcemap worker can fill the generated
+  /// map's `source` with it
+  MagicString(Box<(crate::ModuleIdx, PluginIdx, ArcStr, MagicString<'static>)>),
   Terminate,
 }

--- a/crates/rolldown_common/src/types/sourcemap_chain_element.rs
+++ b/crates/rolldown_common/src/types/sourcemap_chain_element.rs
@@ -1,3 +1,4 @@
+use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
 use crate::PluginIdx;
@@ -8,4 +9,9 @@ pub enum SourcemapChainElement {
   Transform((PluginIdx, SourceMap)),
   /// An inline source map represented as a JSON string.
   Load(SourceMap),
+  /// A transform hook returned changed code without a sourcemap.
+  Omitted { plugin_idx: PluginIdx, plugin_name: ArcStr },
+  /// A transform hook returned changed code together with an explicit
+  /// `map: null`.
+  Null { plugin_idx: PluginIdx, original_content: ArcStr },
 }

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use crate::PluginContext;
 use arcstr::ArcStr;
 use rolldown_common::{ModuleIdx, PluginIdx, SourceMapGenMsg, SourcemapChainElement};
-use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
+use rolldown_sourcemap::{SourceMap, collapse_sourcemaps, empty_sourcemap};
 use rolldown_utils::unique_arc::WeakRef;
 use std::sync::mpsc;
 use string_wizard::{MagicString, SourceMapOptions};
@@ -34,23 +34,21 @@ impl TransformPluginContext {
 
   pub fn get_combined_sourcemap(&self) -> SourceMap {
     self.sourcemap_chain.with_inner(|sourcemap_chain| {
-      if sourcemap_chain.is_empty() {
-        self.create_sourcemap()
-      } else if sourcemap_chain.len() == 1 {
-        match sourcemap_chain.first().expect("should have one sourcemap") {
+      let empty_map = empty_sourcemap();
+      let chain: Vec<&SourceMap> = sourcemap_chain
+        .iter()
+        .filter_map(|element| match element {
           SourcemapChainElement::Transform((_, sourcemap))
-          | SourcemapChainElement::Load(sourcemap) => sourcemap.clone(),
-        }
-      } else {
-        let sourcemap_chain = sourcemap_chain
-          .iter()
-          .map(|element| match element {
-            SourcemapChainElement::Transform((_, sourcemap))
-            | SourcemapChainElement::Load(sourcemap) => sourcemap,
-          })
-          .collect::<Vec<_>>();
+          | SourcemapChainElement::Load(sourcemap) => Some(sourcemap),
+          SourcemapChainElement::Omitted { .. } => Some(&empty_map),
+          SourcemapChainElement::Null { .. } => None,
+        })
+        .collect();
+      match chain.as_slice() {
+        [] => self.create_sourcemap(),
+        [single] => (*single).clone(),
         // TODO Here could be cache result for pervious sourcemap_chain, only remapping new sourcemap chain
-        collapse_sourcemaps(&sourcemap_chain)
+        _ => collapse_sourcemaps(&chain),
       }
     })
   }
@@ -93,6 +91,7 @@ impl TransformPluginContext {
       tx.send(SourceMapGenMsg::MagicString(Box::new((
         self.module_idx,
         self.plugin_idx,
+        self.id.clone(),
         magic_string,
       ))))
       .map(|()| None)

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -19,7 +19,6 @@ use rolldown_devtools::{action, trace_action};
 use rolldown_error::CausedPlugin;
 use rolldown_sourcemap::SourceMap;
 use rolldown_utils::{IndexBitSet, unique_arc::UniqueArc};
-use string_wizard::{MagicString, SourceMapOptions};
 use tracing::{Instrument, debug_span};
 
 impl PluginDriver {
@@ -297,10 +296,22 @@ impl PluginDriver {
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
         original_sourcemap_chain = plugin_sourcemap_chain.into_inner();
-        if let Some(map) =
-          self.normalize_transform_sourcemap(r.map.into_sourcemap(), id, &code, r.code.as_ref())
-        {
+        let map_was_omitted = matches!(r.map, crate::HookTransformOutputMap::Omitted);
+        let map_was_null = matches!(r.map, crate::HookTransformOutputMap::Null);
+        if let Some(map) = self.normalize_transform_sourcemap(r.map.into_sourcemap(), id, &code) {
           original_sourcemap_chain.push(SourcemapChainElement::Transform((plugin_idx, map)));
+        } else if map_was_omitted && r.code.is_some() {
+          original_sourcemap_chain.push(SourcemapChainElement::Omitted {
+            plugin_idx,
+            plugin_name: plugin.call_name().as_ref().into(),
+          });
+        } else if map_was_null && r.code.as_ref().is_some_and(|new_code| new_code != &code) {
+          // The plugin returned `map: null` together with changed code.
+          original_sourcemap_chain.push(SourcemapChainElement::Null {
+            plugin_idx,
+            // it will be restored as `sourcesContent` when the map is materialized.
+            original_content: ArcStr::from(code.as_str()),
+          });
         }
         plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);
         if let Some(v) = r.side_effects {
@@ -347,36 +358,20 @@ impl PluginDriver {
     map: Option<SourceMap>,
     id: &str,
     original_code: &str,
-    code: Option<&String>,
   ) -> Option<SourceMap> {
-    if let Some(mut map) = map {
-      // If sourcemap  hasn't `sources`, using original id to fill it.
-      let source = map.get_source(0);
-      if source.is_none_or(str::is_empty)
-        || (map.get_sources().count() == 1 && (source.map(AsRef::as_ref) != Some(id)))
-      {
-        map.set_sources(vec![id]);
-      }
-      // If sourcemap hasn't `sourcesContent`, using original code to fill it.
-      if map.get_source_content(0).is_none_or(str::is_empty) {
-        map.set_source_contents(vec![Some(original_code)]);
-      }
-      Some(map)
-    } else if let Some(code) = code {
-      if original_code == code {
-        None
-      } else {
-        // If sourcemap is empty and code has changed, need to create one remapping original code.
-        let magic_string = MagicString::new(original_code);
-        Some(magic_string.source_map(SourceMapOptions {
-          hires: string_wizard::Hires::Boundary,
-          include_content: true,
-          source: id.into(),
-        }))
-      }
-    } else {
-      None
+    let mut map = map?;
+    // If sourcemap hasn't `sources`, using original id to fill it.
+    let source = map.get_source(0);
+    if source.is_none_or(str::is_empty)
+      || (map.get_sources().count() == 1 && (source.map(AsRef::as_ref) != Some(id)))
+    {
+      map.set_sources(vec![id]);
     }
+    // If sourcemap hasn't `sourcesContent`, using original code to fill it.
+    if map.get_source_content(0).is_none_or(str::is_empty) {
+      map.set_source_contents(vec![Some(original_code)]);
+    }
+    Some(map)
   }
 
   #[tracing::instrument(

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -48,6 +48,11 @@ pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap
   )
 }
 
+/// Builds an empty sourcemap with no tokens, sources, names, or contents.
+pub fn empty_sourcemap() -> SourceMap {
+  SourceMap::new(None, vec![], None, vec![], vec![], Box::new([]), None)
+}
+
 // <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
 pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
   debug_assert!(sourcemap_chain.len() > 1);

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -273,6 +273,7 @@ export function bindingifyTransform(
 
       let normalizedCode: string | undefined = undefined;
       let map = ret.map;
+      let mapHandledByNativeChannel = false;
       if (typeof ret.code === 'string') {
         normalizedCode = ret.code;
       } else if (ret.code instanceof RolldownMagicString) {
@@ -282,6 +283,14 @@ export function bindingifyTransform(
         let fallbackSourcemap = ctx.sendMagicString(magicString);
         if (fallbackSourcemap != undefined) {
           map = fallbackSourcemap;
+        } else {
+          // `experimental.nativeMagicString` is enabled: the sourcemap is
+          // generated natively and delivered out-of-band via the magic-string
+          // channel. Signal `null` (an explicit "no map on this output object")
+          // rather than `undefined`, otherwise the Rust side treats this
+          // transform as a missing/broken sourcemap (`Omitted`) and the empty
+          // sentinel wipes out the real map produced by the channel.
+          mapHandledByNativeChannel = true;
         }
       }
 
@@ -290,7 +299,7 @@ export function bindingifyTransform(
         // Preserve the `map: null` (intentional opt-out) vs `map: undefined`
         map:
           bindingifySourcemap(normalizeTransformHookSourcemap(id, code, map)) ??
-          (ret.map === null ? null : undefined),
+          (mapHandledByNativeChannel || ret.map === null ? null : undefined),
         moduleSideEffects: moduleOption.moduleSideEffects ?? undefined,
         moduleType: ret.moduleType,
       };

--- a/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
@@ -11,6 +11,7 @@ export default defineTest({
         transform(code) {
           return {
             code: code + '\nconsole.log("added")',
+            map: null,
           };
         },
       },
@@ -24,6 +25,10 @@ export default defineTest({
     const map = getOutputAsset(output)[0].source as string;
     const smc = await new SourceMapConsumer(JSON.parse(map));
 
+    // When a transform hook returns `map: null` together with changed code,
+    // the module's original (pre-transform) code is preserved as the source
+    // content — the injected code must not leak into `sourcesContent` (#3092).
+    // The original code stays mapped, while the injected code is left unmapped.
     const generatedLoc = getLocation(code, code.indexOf(`"main"`));
     const originalLoc = smc.originalPositionFor(generatedLoc);
     expect(originalLoc.line).toBe(1);


### PR DESCRIPTION
Claude gave me the following result with #9621:

<details>

### Empirical before/after (threejs, ~600 modules, sourcemap = File, real-FS `Bundler`, default allocator, 8 iters/run)

| Mode (transform behavior)                        | Metric        | Before (`f6653cb7b^`) | After (`f6653cb7b`) | Δ                     |
| ------------------------------------------------ | ------------- | --------------------- | ------------------- | --------------------- |
| **omitted** (changed code, no map)               | peak RSS      | ~97–104 MiB           | **~73 MiB**         | **−25–30 MiB (~28%)** |
|                                                  | time (median) | ~60–62 ms             | ~52–58 ms           | ~8–12% faster         |
| **null** (changed code, `map: null`)             | peak RSS      | ~97 MiB               | **~80 MiB**         | **−16 MiB (~17%)**    |
|                                                  | time (median) | ~62 ms                | ~57 ms              | ~8% faster            |
| **none** (no map-omitting transform) — *control* | peak RSS      | ~80 MiB               | ~78–80 MiB          | within noise          |
|                                                  | time          | ~56 ms                | ~56 ms              | within noise          |

Numbers were stable across 3 repeat runs each.

**Key signal:** in the *before* build, the map-omitting transform inflates peak RSS from the ~80 MiB baseline (the `none` control) up to ~97–104 MiB — that ~17–24 MiB *is* the intermediate sourcemaps. In the *after* build, `omitted` drops back to ~73 MiB (at/below baseline): the overhead is eliminated. The `none` control is unchanged, confirming the optimization is correctly scoped and doesn't regress ordinary builds.

</details>


close https://github.com/rolldown/rolldown/issues/5062
