### PR TITLE
refactor: remove never-constructed `ImportStatus` variants

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -114,12 +114,6 @@ pub enum ImportStatus {
     commonjs_symbol: SymbolRef,
   },
 
-  /// The import was treated as a CommonJS import but the file is known to have no exports
-  _CommonJSWithoutExports,
-
-  /// The imported file was disabled by mapping it to false in the "browser" field of package.json
-  _Disabled,
-
   /// The imported file is external and has unknown exports
   External(SymbolRef),
 }
@@ -1168,12 +1162,6 @@ impl BindImportsAndExportsContext<'_> {
           }
 
           break MatchImportKind::Normal(MatchImportKindNormal { symbol, reexports });
-        }
-        ImportStatus::_CommonJSWithoutExports => {
-          panic!("`ImportStatus::_CommonJSWithoutExports` is not implemented yet")
-        }
-        ImportStatus::_Disabled => {
-          panic!("`ImportStatus::_Disabled` is not implemented yet")
         }
         ImportStatus::External(symbol_ref) => {
           if self.options.format.keep_esm_import_export_syntax() {


### PR DESCRIPTION
## What

Removes the two never-constructed `ImportStatus` variants and their stubbed `panic!` match arms in `bind_imports_and_exports.rs`:

- `ImportStatus::_CommonJSWithoutExports`
- `ImportStatus::_Disabled`

Both were ported from esbuild's `importStatus` enum but are never constructed in rolldown (hence the `_` prefix). Their match arms only held `panic!("... is not implemented yet")` stubs — originally `todo!()`, converted to `panic!()` in 71b870b4b to satisfy the new `clippy::todo` deny lint.

## Why removal (rather than wiring them up)

Both cases are already handled through other paths, so there is no functional gap to implement:

- **`_Disabled`** — a module mapped to `false` in package.json's `browser` field surfaces as `ResolveError::Ignored` in the resolver and is turned into a `ModuleType::Empty` module *before* the link stage runs.
- **`_CommonJSWithoutExports`** — covered by the existing `ImportStatus::CommonJS` arm plus the missing-export shimming path (which already special-cases `ModuleType::Empty`).

`ImportStatus` is matched in exactly one place, so removing the variants and their arms is the full scope. This is pure dead-code elimination with no behavior change.

The third TODO from the issue (`JSXMemberExpression::rewrite_ident_reference`) was already resolved in #9417.

Closes #9416