### PR TITLE
test: cover vite-alias regex capture-group expansion (#9602)

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/_config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { viteAliasPlugin } from 'rolldown/experimental';
+
+const appDir = path.resolve(import.meta.dirname, 'src/app').replaceAll(path.sep, '/');
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      viteAliasPlugin({
+        entries: [
+          {
+            find: /^@app(?!\/(?:excluded))(\/.*)?$/,
+            replacement: appDir + '$1',
+          },
+        ],
+      }),
+    ],
+  },
+  async afterTest() {
+    await import('./assert.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/assert.mjs
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import assert from 'node:assert';
+import { value } from './dist/main';
+
+assert.strictEqual(value, 'resolved');

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/main.js
@@ -1,0 +1,3 @@
+import { value } from '@app/utils';
+
+export { value };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/src/app/utils.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/capture-group-lookahead/src/app/utils.js
@@ -1,0 +1,1 @@
+export const value = 'resolved';


### PR DESCRIPTION
Add a fixture test verifying the `vite-alias` builtin plugin expands regex capture groups (`$1`) in alias replacements when the pattern uses a lookahead (forcing the `regress` path). Together with the parent refactor PR (#9607), this resolves the regression.

Fixes #9602
