### PR TITLE
refactor: identify AST nodes by NodeId instead of Span/Address

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -1,9 +1,8 @@
-use oxc::allocator::{GetAddress, UnstableAddress};
 use oxc::ast::{
   AstKind, MemberExpressionKind,
   ast::{self, AssignmentExpression, Expression, IdentifierReference, PropertyKey},
 };
-use oxc::span::Span;
+use oxc::semantic::NodeId;
 use oxc_str::CompactStr;
 use rolldown_common::{AstScopes, EcmaModuleAstUsage};
 use rolldown_ecmascript_utils::ExpressionExt;
@@ -42,7 +41,7 @@ pub enum CommonJsAstType {
   /// `console.log(exports)`
   ExportsRead,
   EsModuleFlag,
-  Reexport(Span),
+  Reexport(NodeId),
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
@@ -77,7 +76,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               if call_expr
                 .arguments
                 .first()
-                .is_some_and(|arg| arg.address() == parent.address()) =>
+                .is_some_and(|arg| arg.node_id() == parent.node_id()) =>
             {
               self.check_object_define_property(call_expr)
             }
@@ -95,10 +94,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         }
       },
       AstKind::CallExpression(call_expr)
-        if call_expr
-          .arguments
-          .first()
-          .is_some_and(|arg| arg.address() == ident_ref.unstable_address()) =>
+        if call_expr.arguments.first().is_some_and(|arg| arg.node_id() == ident_ref.node_id()) =>
       {
         // one scenario:
         // 1. Object.defineProperty(exports, "__esModule", { value: true });
@@ -119,9 +115,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       Some(CommonJsAstType::ExportsPropWrite(prop)) if prop == "*" => {
         self.result.ast_usage.remove(EcmaModuleAstUsage::AllStaticExportPropertyAccess);
       }
-      Some(CommonJsAstType::Reexport(span)) => {
+      Some(CommonJsAstType::Reexport(node_id)) => {
         self.result.ast_usage.insert(EcmaModuleAstUsage::IsCjsReexport);
-        self.result.cjs_reexport_require_spans.push(*span);
+        self.result.cjs_reexport_require_node_ids.push(*node_id);
       }
       _ => {}
     }
@@ -181,7 +177,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       .as_expression()?
       .as_string_literal()
       .is_some()
-      .then_some(CommonJsAstType::Reexport(call_expr.span))
+      .then_some(CommonJsAstType::Reexport(call_expr.node_id()))
   }
 }
 

--- a/crates/rolldown/src/ast_scanner/hmr.rs
+++ b/crates/rolldown/src/ast_scanner/hmr.rs
@@ -38,6 +38,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           self.add_import_record(
             &string_literal.value,
             ImportKind::HotAccept,
+            string_literal.span,
             call_expr.span,
             ImportRecordMeta::empty(),
             None,
@@ -52,17 +53,18 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             .iter()
             .filter_map(|element| {
               if let ast::ArrayExpressionElement::StringLiteral(string_literal) = element {
-                Some(string_literal.value)
+                Some((string_literal.value, string_literal.span))
               } else {
                 None
               }
             })
-            .map(|lit| {
+            .map(|(lit, span)| {
               (
                 lit.as_str().into(),
                 self.add_import_record(
                   &lit,
                   ImportKind::HotAccept,
+                  span,
                   call_expr.span,
                   ImportRecordMeta::empty(),
                   None,

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,4 +1,3 @@
-use oxc::allocator::{GetAddress, UnstableAddress};
 use oxc::{
   ast::{
     AstKind,
@@ -13,8 +12,9 @@ use oxc::{
 };
 use rolldown_common::{
   ConstExportMeta, EcmaModuleAstUsage, EcmaViewMeta, ImportKind, ImportRecordMeta, LocalExport,
-  MemberExprObjectReferencedType, OutputFormat, RUNTIME_MODULE_KEY, SideEffectDetail, StmtInfoIdx,
-  StmtInfoMeta, SymbolRefFlags, dynamic_import_usage::DynamicImportExportsUsage,
+  MemberExprObjectReferencedType, MemberExprRef, OutputFormat, RUNTIME_MODULE_KEY,
+  SideEffectDetail, StmtInfoIdx, StmtInfoMeta, SymbolRefFlags,
+  dynamic_import_usage::DynamicImportExportsUsage,
 };
 #[cfg(debug_assertions)]
 use rolldown_ecmascript::ToSourceString;
@@ -192,6 +192,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         request.as_str(),
         ImportKind::DynamicImport,
         expr.source.span(),
+        expr.span,
         {
           let mut meta = ImportRecordMeta::empty();
           meta.set(ImportRecordMeta::IsTopLevel, self.is_root_scope());
@@ -199,10 +200,10 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           meta.set(ImportRecordMeta::InTryCatchBlock, self.in_side_try_catch_block());
           meta
         },
-        Some(expr.unstable_address()),
+        Some(expr.node_id()),
       );
       self.init_dynamic_import_binding_usage_info(import_rec_idx);
-      self.result.imports.insert(expr.span, import_rec_idx);
+      self.result.imports.insert(expr.node_id(), import_rec_idx);
     } else if matches!(self.immutable_ctx.options.format, OutputFormat::Cjs)
       && !self.immutable_ctx.options.dynamic_import_in_cjs
     {
@@ -309,7 +310,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_this_expression(&mut self, it: &ast::ThisExpression) {
     if !self.is_this_nested() {
-      self.top_level_this_expr_set.insert(it.span);
+      self.top_level_this_expr_set.insert(it.node_id());
     }
     walk::walk_this_expression(self, it);
   }
@@ -561,7 +562,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 self.result.ast_usage.insert(EcmaModuleAstUsage::UnknownExportsRead);
               }
               None => match self.try_extract_parent_static_member_expr_chain(1) {
-                Some((_span, prop)) => {
+                Some((_node_id, _span, prop)) => {
                   self.cjs_named_exports_usage.entry(prop[0].name.clone()).or_default().read += 1;
                 }
                 _ => {
@@ -588,7 +589,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 .polyfill_require_for_esm_format_with_node_platform()
             {
               self.current_stmt_info.meta.insert(StmtInfoMeta::HasDummyRecord);
-              self.result.dummy_record_set.insert(ident_ref.span);
+              self.result.dummy_record_set.insert(ident_ref.node_id());
             }
           }
           _ => {}
@@ -615,7 +616,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               (MemberExprObjectReferencedType::Named, usize::MAX)
             }
           };
-          if let Some((span, props)) =
+          if let Some((node_id, span, props)) =
             self.try_extract_parent_static_member_expr_chain(max_tract_len)
           {
             if !span.is_unspanned() {
@@ -632,14 +633,15 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 let symbol_ref_flags = root_symbol_id.flags_mut(&mut self.result.symbol_ref_db);
                 *symbol_ref_flags |= SymbolRefFlags::HasComputedMemberWrite;
               }
-              self.add_member_expr_reference(
+              self.add_member_expr_reference(MemberExprRef::new(
                 root_symbol_id,
                 props,
+                node_id,
                 span,
                 ty,
                 ident_ref.reference_id.get(),
                 is_member_write,
-              );
+              ));
             }
           } else if is_member_write
             && matches!(
@@ -701,7 +703,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     if let AstKind::CallExpression(call_expr) = parent {
       if ident_ref.name == "eval"
         && !call_expr.optional
-        && call_expr.callee.address() == ident_ref.unstable_address()
+        && call_expr.callee.node_id() == ident_ref.node_id()
       {
         // TODO: esbuild track has_eval for each scope, this could reduce bailout range, and may
         // improve treeshaking performance. https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast.go#L1288-L1291
@@ -769,8 +771,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     };
     let in_side_try_catch_block = self.in_side_try_catch_block();
     init_meta.set(ImportRecordMeta::InTryCatchBlock, in_side_try_catch_block);
-    let id = self.add_import_record(value.as_ref(), ImportKind::Require, span, init_meta, None);
-    self.result.imports.insert(expr.span, id);
+    let id =
+      self.add_import_record(value.as_ref(), ImportKind::Require, span, expr.span, init_meta, None);
+    self.result.imports.insert(expr.node_id(), id);
     true
   }
 

--- a/crates/rolldown/src/ast_scanner/import_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/import_analyzer.rs
@@ -1,5 +1,4 @@
 use oxc::{
-  allocator::{GetAddress, UnstableAddress},
   ast::{
     AstKind, MemberExpressionKind,
     ast::{Expression, IdentifierReference, UnaryOperator},
@@ -25,10 +24,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         if let Some(parent) = self.visit_path.last() {
           let expr_span = match parent {
             AstKind::CallExpression(call_expr) => {
-              (call_expr.callee.address() == ident.unstable_address()).then_some(call_expr.span)
+              (call_expr.callee.node_id() == ident.node_id()).then_some(call_expr.span)
             }
             AstKind::TaggedTemplateExpression(call_expr) => {
-              (call_expr.tag.address() == ident.unstable_address()).then_some(call_expr.span)
+              (call_expr.tag.node_id() == ident.node_id()).then_some(call_expr.span)
             }
             _ => None,
           };

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -12,7 +12,7 @@ use const_eval::{ConstEvalCtx, try_extract_const_literal};
 use oxc::ast::ast::{BindingPattern, Expression, ImportExpression};
 use oxc::ast::{AstKind, ast};
 use oxc::ast_visit::walk;
-use oxc::semantic::{Reference, ReferenceId, ScopeFlags, Scoping};
+use oxc::semantic::{NodeId, Reference, ScopeFlags, Scoping};
 use oxc::span::SPAN;
 use oxc::{
   ast::{
@@ -26,17 +26,16 @@ use oxc::{
   semantic::SymbolId,
   span::{GetSpan, Span},
 };
-use oxc_allocator::Address;
 use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_common::dynamic_import_usage::{DynamicImportExportsUsage, DynamicImportUsageInfo};
 use rolldown_common::{
   ConstExportMeta, ConstantValue, DynamicImportExprInfo, EcmaModuleAstUsage, EcmaViewMeta,
   ExportsKind, FlatOptions, HmrInfo, ImportAttribute, ImportKind, ImportRecordIdx,
-  ImportRecordMeta, LocalExport, MemberExprObjectReferencedType, MemberExprProp, MemberExprRef,
-  ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord, SideEffectDetail, Specifier,
-  StmtInfo, StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags,
-  TaggedSymbolRef, ThisExprReplaceKind, generate_replace_this_expr_map,
+  ImportRecordMeta, LocalExport, MemberExprProp, MemberExprRef, ModuleDefFormat, ModuleId,
+  ModuleIdx, NamedImport, RawImportRecord, SideEffectDetail, Specifier, StmtInfo, StmtInfoIdx,
+  StmtInfoMeta, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags, TaggedSymbolRef,
+  ThisExprReplaceKind, generate_replace_this_expr_map,
 };
 use rolldown_ecmascript_utils::FunctionExt;
 use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
@@ -84,8 +83,8 @@ pub struct ScanResult {
   pub default_export_ref: SymbolRef,
   /// Represents [Module Namespace Object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
   pub namespace_object_ref: SymbolRef,
-  pub imports: FxHashMap<Span, ImportRecordIdx>,
-  pub dummy_record_set: FxHashSet<Span>,
+  pub imports: FxHashMap<NodeId, ImportRecordIdx>,
+  pub dummy_record_set: FxHashSet<NodeId>,
   pub exports_kind: ExportsKind,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
@@ -114,16 +113,16 @@ pub struct ScanResult {
   /// temporarily
   pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
   /// `new URL('...', import.meta.url)`
-  pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
-  pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
+  pub new_url_references: FxHashMap<NodeId, ImportRecordIdx>,
+  pub this_expr_replace_map: FxHashMap<NodeId, ThisExprReplaceKind>,
   pub hmr_info: HmrInfo,
   pub hmr_hot_ref: Option<SymbolRef>,
   pub directive_range: Vec<Span>,
   pub constant_export_map: FxHashMap<SymbolId, ConstExportMeta>,
   pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
-  /// Temporary storage for spans of `require()` calls in `module.exports = require(...)` patterns.
+  /// Temporary storage for node IDs of `require()` calls in `module.exports = require(...)` patterns.
   /// Resolved to `cjs_reexport_import_record_ids` after scanning completes.
-  pub cjs_reexport_require_spans: Vec<Span>,
+  pub cjs_reexport_require_node_ids: Vec<NodeId>,
   /// Import record indices for `module.exports = require(...)` patterns.
   pub cjs_reexport_import_record_ids: Vec<ImportRecordIdx>,
 }
@@ -156,8 +155,8 @@ pub struct AstScanner<'me, 'ast> {
   /// so each import record doesn't allocate a fresh `String` just to hand a `&str` to oxc.
   namespace_name_buf: String,
   dynamic_import_usage_info: DynamicImportUsageInfo,
-  /// "top level" `this` AstNode range in source code
-  top_level_this_expr_set: FxHashSet<Span>,
+  /// Node IDs of top-level `this` expressions.
+  top_level_this_expr_set: FxHashSet<NodeId>,
   /// A flag to resolve `this` appear with propertyKey in class
   is_nested_this_inside_class: bool,
   /// Used in commonjs module it self
@@ -231,7 +230,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       constant_export_map: FxHashMap::default(),
       ecma_view_meta: EcmaViewMeta::default(),
       import_attribute_map: FxHashMap::default(),
-      cjs_reexport_require_spans: Vec::new(),
+      cjs_reexport_require_node_ids: Vec::new(),
       cjs_reexport_import_record_ids: Vec::new(),
     };
 
@@ -367,12 +366,12 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
     self.result.exports_kind = exports_kind;
 
-    // Resolve CJS re-export require spans to import record indices
+    // Resolve CJS re-export require node IDs to import record indices.
     self.result.cjs_reexport_import_record_ids = self
       .result
-      .cjs_reexport_require_spans
+      .cjs_reexport_require_node_ids
       .iter()
-      .filter_map(|span| self.result.imports.get(span).copied())
+      .filter_map(|node_id| self.result.imports.get(node_id).copied())
       .collect();
 
     // If some commonjs module facade exports was used locally, we need to explicitly mark them as
@@ -482,16 +481,17 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
   /// `is_dummy` means if it the import record is created during ast transformation.
   ///
-  /// `import_expression_address` - The AST address of the ImportExpression node,
+  /// `import_expression_node_id` - The AST node ID of the ImportExpression node,
   /// required for dynamic imports to track their position for optimization purposes.
-  /// Should be `None` for static imports and `Some(addr)` for dynamic imports.
+  /// Should be `None` for static imports and `Some(node_id)` for dynamic imports.
   fn add_import_record(
     &mut self,
     module_request: &str,
     kind: ImportKind,
     span: Span,
+    importer_span: Span,
     init_meta: ImportRecordMeta,
-    import_expression_address: Option<Address>,
+    import_expression_node_id: Option<NodeId>,
   ) -> ImportRecordIdx {
     // If 'foo' in `import ... from 'foo'` is finally a commonjs module, we will convert the import statement
     // to `var import_foo = __toESM(require_foo())`, so we create a symbol for `import_foo` here. Notice that we
@@ -507,11 +507,12 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       kind,
       namespace_ref,
       span,
+      importer_span,
       None,
       // The first index stmt is reserved for the facade statement that constructs Module Namespace
       // Object
-      import_expression_address.map(|address| {
-        Box::new(DynamicImportExprInfo { stmt_info_idx: self.current_stmt_idx, address })
+      import_expression_node_id.map(|node_id| {
+        Box::new(DynamicImportExprInfo { stmt_info_idx: self.current_stmt_idx, node_id })
       }),
     )
     .with_meta(init_meta);
@@ -687,6 +688,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       decl.source.value.as_str(),
       ImportKind::Import,
       decl.source.span(),
+      decl.span,
       if decl.source.span().is_empty() {
         ImportRecordMeta::IsUnspannedImport
       } else {
@@ -703,7 +705,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       self.result.import_records[id].meta.insert(ImportRecordMeta::IsExportStar);
       self.result.ecma_view_meta.insert(EcmaViewMeta::HasStarExport);
     }
-    self.result.imports.insert(decl.span, id);
+    self.result.imports.insert(decl.node_id(), id);
     if let Some(ref with_clause) = decl.with_clause {
       self.result.import_attribute_map.insert(id, ImportAttribute::from_with_clause(with_clause));
     }
@@ -728,6 +730,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         source.value.as_str(),
         ImportKind::Import,
         source.span(),
+        decl.span,
         if source.span().is_empty() {
           ImportRecordMeta::IsUnspannedImport
         } else {
@@ -749,7 +752,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           .import_attribute_map
           .insert(record_idx, ImportAttribute::from_with_clause(with_clause));
       }
-      self.result.imports.insert(decl.span, record_idx);
+      self.result.imports.insert(decl.node_id(), record_idx);
       self.result.import_records[record_idx].meta.insert(ImportRecordMeta::IsReExportOnly);
     } else {
       decl.specifiers.iter().for_each(|spec| {
@@ -911,6 +914,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       decl.source.value.as_str(),
       ImportKind::Import,
       decl.source.span(),
+      decl.span,
       if decl.source.span().is_empty() {
         ImportRecordMeta::IsUnspannedImport
       } else {
@@ -925,7 +929,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         .import_attribute_map
         .insert(rec_id, ImportAttribute::from_with_clause(with_clause));
     }
-    self.result.imports.insert(decl.span, rec_id);
+    self.result.imports.insert(decl.node_id(), rec_id);
 
     let Some(specifiers) = &decl.specifiers else { return };
     specifiers.iter().for_each(|spec| match spec {
@@ -980,26 +984,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   }
 
   #[inline]
-  pub fn add_member_expr_reference(
-    &mut self,
-    object_ref: SymbolRef,
-    prop_and_span_list: Vec<MemberExprProp>,
-    span: Span,
-    obj_ref_type: MemberExprObjectReferencedType,
-    reference_id: Option<ReferenceId>,
-    is_write: bool,
-  ) {
-    self.current_stmt_info.referenced_symbols.push(
-      MemberExprRef::new(
-        object_ref,
-        prop_and_span_list,
-        span,
-        obj_ref_type,
-        reference_id,
-        is_write,
-      )
-      .into(),
-    );
+  pub fn add_member_expr_reference(&mut self, member_expr_ref: MemberExprRef) {
+    self.current_stmt_info.referenced_symbols.push(member_expr_ref.into());
   }
 
   /// Check if this identifier reference is the object of a member expression in a write context
@@ -1051,12 +1037,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn try_extract_parent_static_member_expr_chain(
     &self,
     max_len: usize,
-  ) -> Option<(Span, Vec<MemberExprProp>)> {
+  ) -> Option<(NodeId, Span, Vec<MemberExprProp>)> {
+    let mut node_id = NodeId::DUMMY;
     let mut span = SPAN;
     let mut props = vec![];
     for ancestor_ast in self.visit_path.iter().rev().take(max_len) {
       match ancestor_ast {
         AstKind::StaticMemberExpression(expr) => {
+          node_id = ancestor_ast.node_id();
           span = ancestor_ast.span();
           props.push(MemberExprProp {
             name: expr.property.name.as_str().into(),
@@ -1066,6 +1054,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         }
         AstKind::ComputedMemberExpression(expr) => {
           if let Some(name) = expr.static_property_name() {
+            node_id = ancestor_ast.node_id();
             span = ancestor_ast.span();
             props.push(MemberExprProp {
               name: name.into(),
@@ -1079,7 +1068,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         _ => break,
       }
     }
-    (!props.is_empty()).then_some((span, props))
+    (!props.is_empty()).then_some((node_id, span, props))
   }
 
   // `console` in `console.log` is a global reference

--- a/crates/rolldown/src/ast_scanner/new_url.rs
+++ b/crates/rolldown/src/ast_scanner/new_url.rs
@@ -62,10 +62,11 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       path,
       ImportKind::NewUrl,
       first_arg_span,
+      expr.span,
       ImportRecordMeta::empty(),
       None,
     );
     self.result.import_records[idx].asserted_module_type = Some(ModuleType::Asset);
-    self.result.new_url_references.insert(expr.span, idx);
+    self.result.new_url_references.insert(expr.node_id(), idx);
   }
 }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -3,8 +3,7 @@ use oxc::ast::ast::{
   IdentifierReference, UnaryOperator, VariableDeclarationKind,
 };
 use oxc::ast::match_member_expression;
-use oxc::semantic::SymbolId;
-use oxc_allocator::{Address, UnstableAddress};
+use oxc::semantic::{NodeId, SymbolId};
 use oxc_ecmascript::GlobalContext;
 use oxc_ecmascript::side_effects::{
   MayHaveSideEffects, MayHaveSideEffectsContext, PropertyReadSideEffects,
@@ -18,8 +17,8 @@ pub struct SideEffectDetector<'a> {
   scope: &'a AstScopes,
   options: &'a SharedNormalizedBundlerOptions,
   flat_options: FlatOptions,
-  /// Cross-module optimization: addresses of call expressions to known-pure functions.
-  side_effect_free_call_expr_addr: Option<&'a FxHashSet<Address>>,
+  /// Cross-module optimization: node IDs of call expressions to known-pure functions.
+  side_effect_free_call_expr_node_ids: Option<&'a FxHashSet<NodeId>>,
   /// Symbol IDs of namespace imports (`import * as ns from '...'`).
   /// Property reads on ES module namespace objects are guaranteed side-effect-free
   /// because namespace objects are frozen/sealed by spec with no getters.
@@ -31,21 +30,21 @@ impl<'a> SideEffectDetector<'a> {
     scope: &'a AstScopes,
     flat_options: FlatOptions,
     options: &'a SharedNormalizedBundlerOptions,
-    side_effect_free_call_expr_addr: Option<&'a FxHashSet<Address>>,
+    side_effect_free_call_expr_node_ids: Option<&'a FxHashSet<NodeId>>,
     namespace_object_symbol_ids: Option<&'a FxHashSet<SymbolId>>,
   ) -> Self {
     Self {
       scope,
       options,
       flat_options,
-      side_effect_free_call_expr_addr,
+      side_effect_free_call_expr_node_ids,
       namespace_object_symbol_ids,
     }
   }
 
   /// Check if a call expression has been marked pure by cross-module optimization.
   fn is_call_expr_marked_pure(&self, expr: &CallExpression) -> bool {
-    self.side_effect_free_call_expr_addr.is_some_and(|set| set.contains(&expr.unstable_address()))
+    self.side_effect_free_call_expr_node_ids.is_some_and(|set| set.contains(&expr.node_id()))
   }
 
   #[inline]

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -91,7 +91,7 @@ pub async fn create_ecma_view(
     dummy_record_set,
     constant_export_map,
     import_attribute_map,
-    cjs_reexport_require_spans: _,
+    cjs_reexport_require_node_ids: _,
     cjs_reexport_import_record_ids,
   } = scan_result;
   // If a export symbol in commonjs defined in multiple time, we just bailout treeshake it.

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -98,7 +98,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             // const import_foo = __rolldown_runtime__.loadExports('./foo.js');
             // console.log(import_foo.default, import_foo.bar);
             // ```
-            let rec_id = self.module.imports[&import_decl.span];
+            let rec_id = self.module.imports[&import_decl.node_id()];
             let rec = &self.module.import_records[rec_id];
             let Some(importee_idx) = rec.resolved_module else { return };
             let importee = &self.modules[importee_idx];
@@ -149,7 +149,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ast::ModuleDeclaration::ExportNamedDeclaration(decl) => {
             if let Some(_source) = &decl.source {
               // export {} from '...'
-              let rec_id = self.module.imports[&decl.span];
+              let rec_id = self.module.imports[&decl.node_id()];
               let rec = &self.module.import_records[rec_id];
               let Some(importee_idx) = rec.resolved_module else { return };
               let importee = &self.modules[importee_idx];
@@ -304,7 +304,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             }
           },
           ast::ModuleDeclaration::ExportAllDeclaration(export_all_decl) => {
-            let rec_id = self.module.imports[&export_all_decl.span];
+            let rec_id = self.module.imports[&export_all_decl.node_id()];
             let rec = &self.module.import_records[rec_id];
             let Some(importee_idx) = rec.resolved_module else { return };
             let importee = &self.modules[importee_idx];
@@ -562,7 +562,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       return;
     };
 
-    let Some(rec_idx) = self.module.imports.get(&import_expr.span) else {
+    let Some(rec_idx) = self.module.imports.get(&import_expr.node_id()) else {
       return;
     };
 
@@ -802,7 +802,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       return;
     }
 
-    let Some(rec_idx) = self.module.imports.get(&call_expr.span) else {
+    let Some(rec_idx) = self.module.imports.get(&call_expr.node_id()) else {
       return;
     };
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -453,6 +453,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
+          // Re-running semantic re-stamps every NodeId. The NodeId-keyed side-table lookups
+          // below still hit only because the clone is unmutated at this point: identical tree
+          // shape re-derives exactly the scan-time ids (see meta/design/ast-mutation.md).
           let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
 
           let mut finalizer = HmrAstFinalizer {
@@ -690,6 +693,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
+          // Re-running semantic re-stamps every NodeId. The NodeId-keyed side-table lookups
+          // below still hit only because the clone is unmutated at this point: identical tree
+          // shape re-derives exactly the scan-time ids (see meta/design/ast-mutation.md).
           let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
 
           let mut finalizer = HmrAstFinalizer {
@@ -880,6 +886,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         let modules = &self.module_table().modules;
 
         ast.program.with_mut(|fields| {
+          // Re-running semantic re-stamps every NodeId. The NodeId-keyed side-table lookups
+          // below still hit only because the clone is unmutated at this point: identical tree
+          // shape re-derives exactly the scan-time ids (see meta/design/ast-mutation.md).
           let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
 
           let mut finalizer = HmrAstFinalizer {

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -221,7 +221,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // Use `this_expr_replace_map` from scanning to avoid rewriting `this` inside classes
     if let ast::Expression::ThisExpression(this_expr) = node
       && self.module.exports_kind.is_commonjs()
-      && self.module.ecma_view.this_expr_replace_map.contains_key(&this_expr.span)
+      && self.module.ecma_view.this_expr_replace_map.contains_key(&this_expr.node_id())
     {
       *node = self.ast_factory.make_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF);
       return;

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -468,7 +468,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
       ast::Expression::ThisExpression(this_expr) => {
-        if let Some(kind) = self.ctx.module.ecma_view.this_expr_replace_map.get(&this_expr.span) {
+        if let Some(kind) =
+          self.ctx.module.ecma_view.this_expr_replace_map.get(&this_expr.node_id())
+        {
           match kind {
             ThisExprReplaceKind::Exports => {
               *expr = self.ast_factory.expression_identifier(SPAN, "exports");

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1041,7 +1041,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     &self,
     expr: &mut ast::NewExpression<'ast>,
   ) -> Option<()> {
-    let &rec_idx = self.ctx.module.new_url_references.get(&expr.span())?;
+    let &rec_idx = self.ctx.module.new_url_references.get(&expr.node_id())?;
     let rec = &self.ctx.module.import_records[rec_idx];
     let is_callee_global_url = matches!(expr.callee.as_identifier(), Some(ident) if ident.name == "URL" && self.is_global_identifier_reference(ident));
 
@@ -1090,7 +1090,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     member_expr: &ast::MemberExpression<'ast>,
   ) -> Option<Expression<'ast>> {
     let span = member_expr.span();
-    match self.ctx.linking_info.resolved_member_expr_refs.get(&span) {
+    match self.ctx.linking_info.resolved_member_expr_refs.get(&member_expr.node_id()) {
       Some(MemberExprRefResolution {
         resolved: object_ref,
         prop_and_related_span_list: props,
@@ -1170,9 +1170,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
 
-    // Build: ns_name.default
-    // IMPORTANT: Use SPAN (0-0) for the new member expression to avoid being matched
-    // by resolved_member_expr_refs lookup which uses span as key
+    // Build: ns_name.default. The resolved_member_expr_refs lookup is keyed by post-semantic
+    // NodeId, so this synthetic expression won't match scan-time records.
     let ns_name = self.canonical_name_for(ns_alias.namespace_ref);
     let ns_id_ref = self.ast_factory.make_id_ref_expr(SPAN, ns_name);
     let default_access =
@@ -1282,7 +1281,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if call_expr.is_global_require_call(self.scope) && !call_expr.span.is_unspanned() {
       //  `require` calls that can't be recognized by rolldown are ignored in scanning, so they were not stored in `NormalModule#imports`.
       //  we just keep these `require` calls as it is
-      if let Some(rec_idx) = self.ctx.module.imports.get(&call_expr.span).copied() {
+      if let Some(rec_idx) = self.ctx.module.imports.get(&call_expr.node_id()).copied() {
         let rec = &self.ctx.module.import_records[rec_idx];
         let module_idx = rec.resolved_module?;
         // use `__require` instead of `require`
@@ -1435,7 +1434,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     &self,
     import_expr: &oxc::allocator::Box<'ast, ImportExpression<'ast>>,
   ) -> Option<Expression<'ast>> {
-    let rec_idx = self.ctx.module.imports.get(&import_expr.span)?;
+    let rec_idx = self.ctx.module.imports.get(&import_expr.node_id())?;
     let rec = &self.ctx.module.import_records[*rec_idx];
     let importee_id = rec.resolved_module?;
 
@@ -1575,7 +1574,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
         if let Some(import_decl) = top_stmt.as_import_declaration() {
           let span = import_decl.span;
-          let rec_idx = self.ctx.module.imports[&import_decl.span];
+          let rec_idx = self.ctx.module.imports[&import_decl.node_id()];
           if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
             for comment in &mut program.comments {
               if comment.attached_to == span.start {
@@ -1588,7 +1587,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             return;
           }
         } else if let Some(export_all_decl) = top_stmt.as_export_all_declaration() {
-          let rec_idx = self.ctx.module.imports[&export_all_decl.span];
+          let rec_idx = self.ctx.module.imports[&export_all_decl.node_id()];
           // "export * as ns from 'path'"
           if let Some(_alias) = &export_all_decl.exported {
             if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
@@ -1867,7 +1866,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             }
           } else {
             // `export { foo } from 'path'`
-            let rec_idx = self.ctx.module.imports[&named_decl.span];
+            let rec_idx = self.ctx.module.imports[&named_decl.node_id()];
             if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
               return;
             }
@@ -2230,7 +2229,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
 
     let (Some(str), Some(rec_idx)) =
-      (expr.source.as_static_module_request(), self.ctx.module.imports.get(&expr.span))
+      (expr.source.as_static_module_request(), self.ctx.module.imports.get(&expr.node_id()))
     else {
       if matches!(self.ctx.options.format, OutputFormat::Cjs)
         && !self.ctx.options.dynamic_import_in_cjs

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -85,7 +85,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     ident_ref: &ast::IdentifierReference<'ast>,
     is_callee: bool,
   ) -> Option<Expression<'ast>> {
-    if self.ctx.module.dummy_record_set.contains(&ident_ref.span) {
+    if self.ctx.module.dummy_record_set.contains(&ident_ref.node_id()) {
       // use `__require` instead of `require`
       return Some(self.finalized_expr_for_runtime_symbol("__require"));
     }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use arcstr::ArcStr;
 use futures::future::join_all;
 use itertools::Itertools;
+use oxc::semantic::NodeId;
 use oxc::semantic::{ScopeId, Scoping};
 use oxc::span::Span;
 use oxc::transformer_plugins::ReplaceGlobalDefinesConfig;
-use oxc_allocator::Address;
 use oxc_index::IndexVec;
 use rolldown_common::dynamic_import_usage::DynamicImportExportsUsage;
 use rolldown_common::{
@@ -384,7 +384,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     let mut work_queue: VecDeque<(ModuleIdx, ImportedExports)> = VecDeque::new();
     let mut dynamic_import_entry_ids: FxHashMap<
       ModuleIdx,
-      Vec<(ModuleIdx, StmtInfoIdx, Address, ImportRecordIdx)>,
+      Vec<(ModuleIdx, StmtInfoIdx, NodeId, ImportRecordIdx)>,
     > = FxHashMap::default();
 
     let mut dynamic_import_exports_usage_pairs = vec![];
@@ -521,7 +521,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               match dynamic_import_entry_ids.entry(idx) {
                 Entry::Vacant(vac) => match raw_rec.dynamic_import_expr_info.as_ref() {
                   Some(info) => {
-                    vac.insert(vec![(module_idx, info.stmt_info_idx, info.address, rec_idx)]);
+                    vac.insert(vec![(module_idx, info.stmt_info_idx, info.node_id, rec_idx)]);
                   }
                   None => {
                     vac.insert(vec![]);
@@ -529,7 +529,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
                 },
                 Entry::Occupied(mut occ) => {
                   if let Some(info) = raw_rec.dynamic_import_expr_info.as_ref() {
-                    occ.get_mut().push((module_idx, info.stmt_info_idx, info.address, rec_idx));
+                    occ.get_mut().push((module_idx, info.stmt_info_idx, info.node_id, rec_idx));
                   }
                 }
               }

--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -296,7 +296,7 @@ impl GenerateStage<'_> {
       let dynamic_entry_bit: u32 =
         dynamic_entry_idx.try_into().expect("Too many entries, u32 overflowed.");
 
-      for (importer_idx, stmt_info_idx, _address, import_record_idx) in
+      for (importer_idx, stmt_info_idx, _node_id, import_record_idx) in
         &entry_point.related_stmt_infos
       {
         if !self.is_included_dynamic_import_record(

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -456,7 +456,7 @@ impl LinkStage<'_> {
                     // have any dynamic exports.
                     if !self.metas[canonical_ref_owner.idx].has_dynamic_exports {
                       resolved_map.insert(
-                        member_expr_ref.span,
+                        member_expr_ref.node_id,
                         MemberExprRefResolution {
                           resolved: if is_json_import_ns { Some(canonical_ref) } else { None },
                           prop_and_related_span_list: member_expr_ref.prop_and_span_list[cursor..]
@@ -485,7 +485,7 @@ impl LinkStage<'_> {
                   };
                   if !meta.sorted_and_non_ambiguous_resolved_exports.contains_key(name) {
                     resolved_map.insert(
-                      member_expr_ref.span,
+                      member_expr_ref.node_id,
                       MemberExprRefResolution {
                         resolved: None,
                         prop_and_related_span_list: member_expr_ref.prop_and_span_list[cursor..]
@@ -653,7 +653,7 @@ impl LinkStage<'_> {
 
                 if cursor > 0 || target_commonjs_exported_symbol.is_some() {
                   resolved_map.insert(
-                    member_expr_ref.span,
+                    member_expr_ref.node_id,
                     MemberExprRefResolution {
                       resolved: Some(canonical_ref),
                       prop_and_related_span_list: member_expr_ref.prop_and_span_list[cursor..]

--- a/crates/rolldown/src/stages/link_stage/compute_tla.rs
+++ b/crates/rolldown/src/stages/link_stage/compute_tla.rs
@@ -18,20 +18,8 @@ enum TlaVisitState {
   Visited(Option<ModuleIdx>),
 }
 
-/// Look up the source span of a given import record within a module. Linear
-/// in `imports.len()` but only called on error paths.
-///
-/// Every `Import`/`Require` record is registered in `module.imports` by the
-/// ast scanner, so this lookup must succeed for the kinds the TLA check
-/// traverses. A miss indicates a scanner invariant violation.
 fn import_span_for(module: &NormalModule, target: ImportRecordIdx) -> Span {
-  let span = module.imports.iter().find_map(|(span, &idx)| (idx == target).then_some(*span));
-  debug_assert!(
-    span.is_some(),
-    "import record {target:?} missing from imports map in module {:?}",
-    module.stable_id
-  );
-  span.unwrap_or(Span::empty(0))
+  module.import_records.get(target).map_or(Span::empty(0), |rec| rec.importer_span)
 }
 
 impl LinkStage<'_> {

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -1,5 +1,4 @@
 use oxc::{
-  allocator::{Address, GetAddress, UnstableAddress},
   ast::{
     AstBuilder, AstKind,
     ast::{
@@ -8,6 +7,7 @@ use oxc::{
     },
   },
   ast_visit::{Visit, walk},
+  semantic::NodeId,
 };
 use rolldown_common::{
   AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, IndexModules, ModuleIdx,
@@ -28,7 +28,7 @@ use super::LinkStage;
 type MutationResult = (
   Option<(ModuleIdx, FxHashMap<StmtInfoIdx, SideEffectDetail>)>,
   FxHashMap<SymbolRef, ConstExportMeta>,
-  FxHashSet<Address>,
+  FxHashSet<(ModuleIdx, NodeId)>,
 );
 
 #[derive(Default)]
@@ -49,8 +49,8 @@ struct CrossModuleOptimizationConfig {
   inline_const_optimization: bool,
 }
 
-type ModuleIdxAndStmtIdxToDynamicImportExprAddrMap =
-  FxHashMap<ModuleIdx, FxHashMap<StmtInfoIdx, FxHashSet<Address>>>;
+type ModuleIdxAndStmtIdxToDynamicImportExprNodeIdMap =
+  FxHashMap<ModuleIdx, FxHashMap<StmtInfoIdx, FxHashSet<NodeId>>>;
 
 impl LinkStage<'_> {
   fn prepare_cross_module_optimization(&self) -> CrossModuleOptimizationConfig {
@@ -69,7 +69,7 @@ impl LinkStage<'_> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  pub(super) fn cross_module_optimization(&mut self) -> FxHashSet<Address> {
+  pub(super) fn cross_module_optimization(&mut self) -> FxHashSet<(ModuleIdx, NodeId)> {
     let config = self.prepare_cross_module_optimization();
     if config.pass < 1 {
       return FxHashSet::default();
@@ -88,19 +88,19 @@ impl LinkStage<'_> {
     // The extra passes only run when user enable `inline_const` and set `pass` greater than 1.
     let mut ctx = CrossModuleOptimizationCtx::new(config);
     let mut constant_symbol_map = std::mem::take(&mut self.global_constant_symbol_map);
-    let mut unreachable_addresses = FxHashSet::default();
+    let mut unreachable_node_ids = FxHashSet::default();
     // collect all modules that has dynamic import record
-    // two dimension map module_idx -> stmt_idx -> dynamic_import_expression_address
-    let mut module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map = FxHashMap::default();
+    // two dimension map module_idx -> stmt_idx -> dynamic_import_expression_node_id
+    let mut module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map = FxHashMap::default();
     self.entries.values().flatten().for_each(|entry| {
       entry.related_stmt_infos.iter().for_each(
-        |(module_idx, stmt_idx, address, _import_record_idx)| {
-          module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map
+        |(module_idx, stmt_idx, node_id, _import_record_idx)| {
+          module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map
             .entry(*module_idx)
             .or_insert_with(FxHashMap::default)
             .entry(*stmt_idx)
             .or_insert_with(FxHashSet::default)
-            .insert(*address);
+            .insert(*node_id);
         },
       );
     });
@@ -112,8 +112,8 @@ impl LinkStage<'_> {
       let new_constant_refs = self.run(
         &mut ctx,
         &mut constant_symbol_map,
-        &module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map,
-        &mut unreachable_addresses,
+        &module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map,
+        &mut unreachable_node_ids,
         modules_to_process.as_ref(),
       );
       if !ctx.changed {
@@ -122,9 +122,9 @@ impl LinkStage<'_> {
       modules_to_process = Some(self.find_modules_referencing_constants(&new_constant_refs));
     }
     self.global_constant_symbol_map = constant_symbol_map;
-    // Return all unreachable import expression addresses instead of add it as a field of LinkStage,
+    // Return all unreachable import expression node IDs instead of add it as a field of LinkStage,
     // Because this set is only used include statement stage.
-    unreachable_addresses
+    unreachable_node_ids
   }
 
   /// Find all modules that have imports resolving to any of the given constant canonical refs.
@@ -155,8 +155,8 @@ impl LinkStage<'_> {
     &mut self,
     cross_module_inline_const_ctx: &mut CrossModuleOptimizationCtx,
     constant_symbol_map: &mut FxHashMap<SymbolRef, ConstExportMeta>,
-    module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map: &ModuleIdxAndStmtIdxToDynamicImportExprAddrMap,
-    all_unreachable_addresses: &mut FxHashSet<Address>,
+    module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map: &ModuleIdxAndStmtIdxToDynamicImportExprNodeIdMap,
+    all_unreachable_node_ids: &mut FxHashSet<(ModuleIdx, NodeId)>,
     modules_to_process: Option<&FxHashSet<ModuleIdx>>,
   ) -> FxHashSet<SymbolRef> {
     let mutation_result: Vec<MutationResult> = self
@@ -188,15 +188,15 @@ impl LinkStage<'_> {
             }),
             constant_map: &constant_map,
           };
-          let default_stmt_idx_to_dynamic_import_expr_addr = FxHashMap::default();
-          let stmt_idx_to_dynamic_import_expr_addr =
-            module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map
+          let default_stmt_idx_to_dynamic_import_expr_node_ids = FxHashMap::default();
+          let stmt_idx_to_dynamic_import_expr_node_ids =
+            module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map
               .get(&module_idx)
-              .unwrap_or(&default_stmt_idx_to_dynamic_import_expr_addr);
+              .unwrap_or(&default_stmt_idx_to_dynamic_import_expr_node_ids);
           let mut ctx = CrossModuleOptimizationRunnerContext {
             local_constant_symbol_map: FxHashMap::default(),
             side_effect_detail_mutations: FxHashMap::default(),
-            side_effect_free_call_expr_addr: FxHashSet::default(),
+            side_effect_free_call_expr_node_ids: FxHashSet::default(),
             immutable_ctx: CrossModuleOptimizationImmutableCtx {
               eval_ctx: &eval_ctx,
               export_default_symbol: module.default_export_ref,
@@ -207,13 +207,13 @@ impl LinkStage<'_> {
               flat_options: self.flat_options,
               options: self.options,
               ast_scope: &self.symbols.local_db(module_idx).ast_scopes,
-              stmt_idx_to_dynamic_import_expr_addr,
+              stmt_idx_to_dynamic_import_expr_node_ids,
             },
             // `0` is preserved for namespace stmt
             toplevel_stmt_idx: StmtInfoIdx::from_raw_unchecked(1),
             visit_path: vec![],
-            latest_side_effect_free_call_expr_addr: None,
-            unreachable_import_expression_addresses: FxHashSet::default(),
+            latest_side_effect_free_call_expr_node_id: None,
+            unreachable_import_expression_node_ids: FxHashSet::default(),
           };
           ctx.visit_program(&dep.program);
 
@@ -224,21 +224,25 @@ impl LinkStage<'_> {
           };
           if side_effect_mutations.is_none()
             && ctx.local_constant_symbol_map.is_empty()
-            && ctx.unreachable_import_expression_addresses.is_empty()
+            && ctx.unreachable_import_expression_node_ids.is_empty()
           {
             return None;
           }
           Some((
             side_effect_mutations,
             ctx.local_constant_symbol_map,
-            ctx.unreachable_import_expression_addresses,
+            ctx
+              .unreachable_import_expression_node_ids
+              .into_iter()
+              .map(|node_id| (module_idx, node_id))
+              .collect(),
           ))
         })
       })
       .collect();
 
     let mut new_constant_refs = FxHashSet::default();
-    for (side_effect_mutations, local_constants, unreachable_addresses) in mutation_result {
+    for (side_effect_mutations, local_constants, unreachable_node_ids) in mutation_result {
       if let Some((module_idx, mutations)) = side_effect_mutations
         && self.module_table[module_idx].as_normal().is_some()
       {
@@ -253,8 +257,8 @@ impl LinkStage<'_> {
         constant_symbol_map.extend(local_constants);
       }
 
-      // Collect all unreachable import expression addresses
-      all_unreachable_addresses.extend(unreachable_addresses);
+      // Collect all unreachable import expression node IDs
+      all_unreachable_node_ids.extend(unreachable_node_ids);
     }
     new_constant_refs
   }
@@ -270,20 +274,20 @@ struct CrossModuleOptimizationImmutableCtx<'a, 'ast: 'a> {
   flat_options: FlatOptions,
   options: &'a SharedNormalizedBundlerOptions,
   ast_scope: &'a AstScopes,
-  stmt_idx_to_dynamic_import_expr_addr: &'a FxHashMap<StmtInfoIdx, FxHashSet<Address>>,
+  stmt_idx_to_dynamic_import_expr_node_ids: &'a FxHashMap<StmtInfoIdx, FxHashSet<NodeId>>,
 }
 
 struct CrossModuleOptimizationRunnerContext<'a, 'ast: 'a> {
   local_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
   side_effect_detail_mutations: FxHashMap<StmtInfoIdx, SideEffectDetail>,
-  side_effect_free_call_expr_addr: FxHashSet<Address>,
+  side_effect_free_call_expr_node_ids: FxHashSet<NodeId>,
   immutable_ctx: CrossModuleOptimizationImmutableCtx<'a, 'ast>,
   toplevel_stmt_idx: StmtInfoIdx,
   visit_path: Vec<AstKind<'ast>>,
-  latest_side_effect_free_call_expr_addr: Option<Address>,
+  latest_side_effect_free_call_expr_node_id: Option<NodeId>,
   /// Import expressions that are inside lazy paths (e.g., inside a PURE-annotated function)
   /// and should be considered unreachable for chunk splitting purposes
-  unreachable_import_expression_addresses: FxHashSet<Address>,
+  unreachable_import_expression_node_ids: FxHashSet<NodeId>,
 }
 
 impl<'a, 'ast: 'a> std::ops::Deref for CrossModuleOptimizationRunnerContext<'a, 'ast> {
@@ -306,15 +310,15 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
   fn visit_program(&mut self, program: &oxc::ast::ast::Program<'ast>) {
     // Custom visit
     for (idx, stmt) in program.body.iter().enumerate() {
-      let pre_addr_len = self.side_effect_free_call_expr_addr.len();
+      let pre_node_id_len = self.side_effect_free_call_expr_node_ids.len();
       self.visit_statement(stmt);
-      if pre_addr_len != self.side_effect_free_call_expr_addr.len() {
+      if pre_node_id_len != self.side_effect_free_call_expr_node_ids.len() {
         let stmt_info_idx = StmtInfoIdx::new(idx + 1);
         let side_effect_detail = SideEffectDetector::new(
           self.immutable_ctx.ast_scope,
           self.immutable_ctx.flat_options,
           self.immutable_ctx.options,
-          Some(&self.side_effect_free_call_expr_addr),
+          Some(&self.side_effect_free_call_expr_node_ids),
           None,
         )
         .detect_side_effect_of_stmt(stmt);
@@ -325,19 +329,21 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
   }
 
   fn visit_import_expression(&mut self, it: &oxc::ast::ast::ImportExpression<'ast>) {
-    if let Some(addrs) = self.stmt_idx_to_dynamic_import_expr_addr.get(&self.toplevel_stmt_idx) {
-      if addrs.contains(&it.unstable_address()) {
+    if let Some(node_ids) =
+      self.stmt_idx_to_dynamic_import_expr_node_ids.get(&self.toplevel_stmt_idx)
+    {
+      if node_ids.contains(&it.node_id()) {
         // search the latest side effect free call expression parent
         let side_effect_free_call = self.visit_path.iter().rev().find_map(|ast| {
-          let addr = self.latest_side_effect_free_call_expr_addr.as_ref()?;
-          (&ast.address() == addr).then_some(ast)
+          let node_id = self.latest_side_effect_free_call_expr_node_id?;
+          (ast.node_id() == node_id).then_some(ast)
         });
         if let Some(kind) = side_effect_free_call {
           let is_lazy_path = is_lazy_path_from_first_lazy_node(&self.visit_path, kind);
           if is_lazy_path {
             // This import expression is inside a lazy path (e.g., inside a PURE-annotated
             // function callback), so it's unreachable and can be ignored for chunk splitting
-            self.unreachable_import_expression_addresses.insert(it.unstable_address());
+            self.unreachable_import_expression_node_ids.insert(it.node_id());
           }
         }
       }
@@ -346,7 +352,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
   }
 
   fn visit_call_expression(&mut self, it: &oxc::ast::ast::CallExpression<'ast>) {
-    let mut pre_addr = None;
+    let mut pre_node_id = None;
     let (is_side_effects_free_function, is_pure_annotation_only) = it
       .callee
       .as_identifier()
@@ -373,18 +379,18 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
       .unwrap_or((false, false));
 
     if is_side_effects_free_function {
-      self.side_effect_free_call_expr_addr.insert(it.unstable_address());
+      self.side_effect_free_call_expr_node_ids.insert(it.node_id());
       // Only track as latest side-effect-free call for unreachable import detection
       // when the function is truly empty (not just annotated with @__NO_SIDE_EFFECTS__).
       // Annotated functions may still use their arguments, so dynamic imports in
       // callback arguments should not be treated as unreachable.
       if !is_pure_annotation_only {
-        pre_addr = self.latest_side_effect_free_call_expr_addr.replace(it.unstable_address());
+        pre_node_id = self.latest_side_effect_free_call_expr_node_id.replace(it.node_id());
       }
     }
     walk::walk_call_expression(self, it);
-    if let Some(addr) = pre_addr {
-      self.latest_side_effect_free_call_expr_addr = Some(addr);
+    if let Some(node_id) = pre_node_id {
+      self.latest_side_effect_free_call_expr_node_id = Some(node_id);
     }
   }
 
@@ -425,10 +431,10 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
 
   fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'ast>) {
     // Only walk child nodes if we need to track import expressions (when
-    // `stmt_idx_to_dynamic_import_expr_addr` is not empty) or if `inline_const_optimization` is enabled.
+    // `stmt_idx_to_dynamic_import_expr_node_ids` is not empty) or if `inline_const_optimization` is enabled.
     // This placement ensures we skip walking when neither is needed.
     if !self.immutable_ctx.config.inline_const_optimization
-      && self.immutable_ctx.stmt_idx_to_dynamic_import_expr_addr.is_empty()
+      && self.immutable_ctx.stmt_idx_to_dynamic_import_expr_node_ids.is_empty()
     {
       return;
     }
@@ -471,7 +477,7 @@ fn is_lazy_path_from_first_lazy_node<'ast>(
   visit_path: &[AstKind<'ast>],
   target: &AstKind<'ast>,
 ) -> bool {
-  let target_addr = target.address();
+  let target_node_id = target.node_id();
 
   // Find the last lazy node after the target node
   let last_lazy_idx = visit_path.iter().rposition(|kind| {
@@ -487,9 +493,8 @@ fn is_lazy_path_from_first_lazy_node<'ast>(
   };
 
   for kind in visit_path[..=last_lazy_idx].iter().rev() {
-    let addr = kind.address();
     // All nodes from first lazy node to target must be lazy
-    if addr == target_addr {
+    if kind.node_id() == target_node_id {
       return true;
     }
     if !matches!(

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -236,8 +236,8 @@ impl<'a> LinkStage<'a> {
     self.bind_imports_and_exports();
     self.create_exports_for_ecma_modules();
     self.reference_needed_symbols();
-    let unreachable_import_expression_addrs = self.cross_module_optimization();
-    self.include_statements(&unreachable_import_expression_addrs);
+    let unreachable_import_expression_node_ids = self.cross_module_optimization();
+    self.include_statements(&unreachable_import_expression_node_ids);
     self.patch_module_dependencies();
 
     tracing::trace!("meta {:#?}", self.metas.iter_enumerated().collect::<Vec<_>>());

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -1,7 +1,7 @@
 use std::cmp::Reverse;
 
 use itertools::Itertools;
-use oxc_allocator::Address;
+use oxc::semantic::NodeId;
 use oxc_index::IndexVec;
 use petgraph::prelude::DiGraphMap;
 use rolldown_common::{
@@ -210,7 +210,10 @@ fn collect_depended_runtime_helpers(
 
 impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn include_statements(&mut self, unreachable_import_expression_addrs: &FxHashSet<Address>) {
+  pub fn include_statements(
+    &mut self,
+    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
+  ) {
     let mut is_stmt_info_included_vec: StmtInclusionVec = self
       .module_table
       .modules
@@ -303,7 +306,7 @@ impl LinkStage<'_> {
           &cycled_idx,
           context,
           &mut unused_record_idxs,
-          unreachable_import_expression_addrs,
+          unreachable_import_expression_node_ids,
         );
         if included {
           included_dynamic_entry.insert(entry.idx);
@@ -432,13 +435,13 @@ impl LinkStage<'_> {
     cycled_idx: &FxHashSet<ModuleIdx>,
     context: &mut IncludeContext,
     unused_record_idxs: &mut Vec<(ModuleIdx, ImportRecordIdx)>,
-    unreachable_import_expression_addr: &FxHashSet<Address>,
+    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
   ) -> bool {
     if !cycled_idx.contains(&entry.idx) {
       if let Some(item) = self.is_dynamic_entry_alive(
         entry,
         context.is_included_vec,
-        unreachable_import_expression_addr,
+        unreachable_import_expression_node_ids,
       ) {
         unused_record_idxs.extend(item);
         return false;
@@ -581,7 +584,7 @@ impl LinkStage<'_> {
     &self,
     entry_point: &EntryPoint,
     is_stmt_included_vec: &StmtInclusionVec,
-    unreachable_import_expression_addrs: &FxHashSet<Address>,
+    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
   ) -> Option<Vec<(ModuleIdx, ImportRecordIdx)>> {
     let mut ret = vec![];
     let is_lived = match entry_point.kind {
@@ -594,8 +597,8 @@ impl LinkStage<'_> {
 
         // Mark the dynamic entry as lived if at least one statement that create this entry is included
         entry_point.related_stmt_infos.iter().any(
-          |(module_idx, stmt_idx, address, import_record_idx)| {
-            if unreachable_import_expression_addrs.contains(address) {
+          |(module_idx, stmt_idx, node_id, import_record_idx)| {
+            if unreachable_import_expression_node_ids.contains(&(*module_idx, *node_id)) {
               return false;
             }
             let module =

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -171,7 +171,7 @@ impl ScanStageCache {
           .collect::<FxHashSet<_>>();
         _ = old_entry_point
           .related_stmt_infos
-          .extract_if(.., |(module_idx, _stmt_info_idx, _address, _)| {
+          .extract_if(.., |(module_idx, _stmt_info_idx, _node_id, _)| {
             removed_module_idxs.contains(module_idx)
           });
         old_entry_point.related_stmt_infos.extend(entry_point.related_stmt_infos);

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -1,7 +1,10 @@
 use crate::{ConstExportMeta, ImportAttribute, SourcemapChainElement};
 use arcstr::ArcStr;
 use bitflags::bitflags;
-use oxc::{semantic::SymbolId, span::Span};
+use oxc::{
+  semantic::{NodeId, SymbolId},
+  span::Span,
+};
 use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -38,10 +41,10 @@ pub enum ThisExprReplaceKind {
 #[inline]
 #[expect(clippy::implicit_hasher)]
 pub fn generate_replace_this_expr_map(
-  set: &FxHashSet<Span>,
+  set: &FxHashSet<NodeId>,
   kind: ThisExprReplaceKind,
-) -> FxHashMap<Span, ThisExprReplaceKind> {
-  set.iter().map(|span| (*span, kind)).collect()
+) -> FxHashMap<NodeId, ThisExprReplaceKind> {
+  set.iter().map(|node_id| (*node_id, kind)).collect()
 }
 
 impl EcmaViewMeta {
@@ -61,7 +64,7 @@ impl EcmaViewMeta {
 
 #[derive(Debug, Clone)]
 pub struct EcmaView {
-  pub dummy_record_set: FxHashSet<Span>,
+  pub dummy_record_set: FxHashSet<NodeId>,
   pub source: ArcStr,
   pub def_format: ModuleDefFormat,
   /// Represents [Module Namespace Object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
@@ -69,9 +72,11 @@ pub struct EcmaView {
   pub named_imports: FxIndexMap<SymbolRef, NamedImport>,
   pub named_exports: FxHashMap<CompactStr, LocalExport>,
   pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
-  /// The key is the `Span` of `ImportDeclaration`, `ImportExpression`, `ExportNamedDeclaration`, `ExportAllDeclaration`
+  /// Cross-pass AST-node side tables use post-semantic `NodeId`. See meta/design/ast-mutation.md.
+  ///
+  /// The key is the `NodeId` of `ImportDeclaration`, `ImportExpression`, `ExportNamedDeclaration`, `ExportAllDeclaration`
   /// and `CallExpression`(only when the callee is `require`).
-  pub imports: FxHashMap<Span, ImportRecordIdx>,
+  pub imports: FxHashMap<NodeId, ImportRecordIdx>,
   pub exports_kind: ExportsKind,
   pub default_export_ref: SymbolRef,
   pub sourcemap_chain: Vec<SourcemapChainElement>,
@@ -92,9 +97,9 @@ pub struct EcmaView {
   pub directive_range: Vec<Span>,
   pub meta: EcmaViewMeta,
   pub mutations: Vec<ArcSourceMutation>,
-  /// `Span` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
-  pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
-  pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
+  /// `NodeId` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
+  pub new_url_references: FxHashMap<NodeId, ImportRecordIdx>,
+  pub this_expr_replace_map: FxHashMap<NodeId, ThisExprReplaceKind>,
 
   pub hmr_hot_ref: Option<SymbolRef>,
   pub hmr_info: HmrInfo,

--- a/crates/rolldown_common/src/type_aliases.rs
+++ b/crates/rolldown_common/src/type_aliases.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arcstr::ArcStr;
-use oxc::span::Span;
+use oxc::semantic::NodeId;
 use oxc_index::IndexVec;
 use rolldown_utils::dashmap::FxDashMap;
 use rustc_hash::FxHashMap;
@@ -12,6 +12,6 @@ use crate::{
 
 pub type IndexChunks = IndexVec<ChunkIdx, Chunk>;
 
-pub type MemberExprRefResolutionMap = FxHashMap<Span, MemberExprRefResolution>;
+pub type MemberExprRefResolutionMap = FxHashMap<NodeId, MemberExprRefResolution>;
 
 pub type SharedModuleInfoDashMap = Arc<FxDashMap<ArcStr, Arc<ModuleInfo>>>;

--- a/crates/rolldown_common/src/types/entry_point.rs
+++ b/crates/rolldown_common/src/types/entry_point.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use arcstr::ArcStr;
-use oxc::allocator::Address;
+use oxc::semantic::NodeId;
 
 use crate::{ImportRecordIdx, ModuleIdx, StmtInfoIdx};
 
@@ -13,7 +13,7 @@ pub struct EntryPoint {
   /// emitted chunk specified filename, used to generate chunk filename
   pub file_name: Option<ArcStr>,
   /// which stmts create this entry point
-  pub related_stmt_infos: Vec<(ModuleIdx, StmtInfoIdx, Address, ImportRecordIdx)>,
+  pub related_stmt_infos: Vec<(ModuleIdx, StmtInfoIdx, NodeId, ImportRecordIdx)>,
 }
 
 #[derive(Debug, Eq, Clone, Copy, PartialOrd, Ord)]

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -3,7 +3,7 @@ use std::{
   ops::{Deref, DerefMut},
 };
 
-use oxc::{allocator::Address, span::Span};
+use oxc::{semantic::NodeId, span::Span};
 use oxc_str::CompactStr;
 
 use crate::{ImportKind, ModuleIdx, ModuleType, StmtInfoIdx, SymbolRef};
@@ -18,19 +18,24 @@ oxc_index::define_index_type! {
 pub struct DynamicImportExprInfo {
   /// Index of the top-level statement containing the dynamic import expression
   pub stmt_info_idx: StmtInfoIdx,
-  /// Address of the `ImportExpression` node in the AST
-  pub address: Address,
+  /// Node ID of the `ImportExpression` node in the AST
+  pub node_id: NodeId,
 }
 
 #[derive(Debug, Clone)]
 pub struct ImportRecordStateInit {
+  /// Span of the module request.
   pub span: Span,
+  /// Span of the import site that created this record.
+  pub importer_span: Span,
   /// The importee of this import record is asserted to be this specific module type.
   pub asserted_module_type: Option<ModuleType>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ImportRecordStateResolved {
+  /// Span of the import site that created this record.
+  pub importer_span: Span,
   pub resolved_module: Option<ModuleIdx>,
 }
 
@@ -89,7 +94,7 @@ pub struct ImportRecord<State: Debug + Clone> {
   pub namespace_ref: SymbolRef,
   pub meta: ImportRecordMeta,
   /// Information about the dynamic import expression, if this is a dynamic import.
-  /// Contains the statement index and AST address for tracking purposes.
+  /// Contains the statement index and AST node ID for tracking purposes.
   ///
   /// Wrapped in `Box` to reduce the size of `ImportRecord` since this field is only
   /// used for dynamic imports (a minority of import records), keeping the common case small.
@@ -124,6 +129,7 @@ impl RawImportRecord {
     kind: ImportKind,
     namespace_ref: SymbolRef,
     span: Span,
+    importer_span: Span,
     assert_module_type: Option<ModuleType>,
     dynamic_import_expr_info: Option<Box<DynamicImportExprInfo>>,
   ) -> RawImportRecord {
@@ -132,7 +138,11 @@ impl RawImportRecord {
       kind,
       namespace_ref,
       meta: ImportRecordMeta::empty(),
-      state: ImportRecordStateInit { span, asserted_module_type: assert_module_type },
+      state: ImportRecordStateInit {
+        span,
+        importer_span,
+        asserted_module_type: assert_module_type,
+      },
       dynamic_import_expr_info,
     }
   }
@@ -144,7 +154,7 @@ impl RawImportRecord {
 
   pub fn into_resolved(self, resolved_module: Option<ModuleIdx>) -> ResolvedImportRecord {
     ResolvedImportRecord {
-      state: ImportRecordStateResolved { resolved_module },
+      state: ImportRecordStateResolved { importer_span: self.state.importer_span, resolved_module },
       module_request: self.module_request,
       kind: self.kind,
       namespace_ref: self.namespace_ref,

--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -1,4 +1,7 @@
-use oxc::{semantic::ReferenceId, span::Span};
+use oxc::{
+  semantic::{NodeId, ReferenceId},
+  span::Span,
+};
 use oxc_str::CompactStr;
 
 use crate::{MemberExprRefResolution, SymbolRef, type_aliases::MemberExprRefResolutionMap};
@@ -19,9 +22,9 @@ pub struct MemberExprProp {
 pub struct MemberExprRef {
   pub object_ref: SymbolRef,
   pub prop_and_span_list: Vec<MemberExprProp>,
-  /// Span of the whole member expression
-  /// FIXME: use `AstNodeId` to identify the MemberExpr instead of `Span`
-  /// related discussion: https://github.com/rolldown/rolldown/pull/1818#discussion_r1699374441
+  /// Node ID of the whole member expression.
+  pub node_id: NodeId,
+  /// Span of the whole member expression, used for diagnostics and generated replacement spans.
   pub span: Span,
   pub object_ref_type: MemberExprObjectReferencedType,
   /// The semantic reference ID for the object identifier of this member expression.
@@ -43,6 +46,7 @@ impl MemberExprRef {
   pub fn new(
     object_ref: SymbolRef,
     prop_and_span_list: Vec<MemberExprProp>,
+    node_id: NodeId,
     span: Span,
     obj_ref_type: MemberExprObjectReferencedType,
     reference_id: Option<ReferenceId>,
@@ -51,6 +55,7 @@ impl MemberExprRef {
     Self {
       object_ref,
       prop_and_span_list,
+      node_id,
       span,
       object_ref_type: obj_ref_type,
       reference_id,
@@ -68,7 +73,7 @@ impl MemberExprRef {
     &self,
     resolved_map: &MemberExprRefResolutionMap,
   ) -> Option<SymbolRef> {
-    if let Some(resolution) = resolved_map.get(&self.span) {
+    if let Some(resolution) = resolved_map.get(&self.node_id) {
       // If the map does have the resolution, it either produces two results:
       // 1. The member expr points to a exist variable/export, which is `MemberExprRefResolution#resolved`
       // 2. The member expr points to a non-exist variable/export, which means `MemberExprRefResolution#resolved` is `None`.
@@ -83,6 +88,6 @@ impl MemberExprRef {
     &self,
     resolved_map: &'a MemberExprRefResolutionMap,
   ) -> Option<&'a MemberExprRefResolution> {
-    resolved_map.get(&self.span)
+    resolved_map.get(&self.node_id)
   }
 }

--- a/meta/design/ast-construction.md
+++ b/meta/design/ast-construction.md
@@ -28,7 +28,7 @@ Before this convention, the same kind of node could be built four different ways
 
 - **Parse-from-source-string.** Not all AST is built — some is authored as JS source and parsed via `EcmaCompiler::parse` (`crates/rolldown_ecmascript/src/ecma_compiler.rs`), which parses a source string into a standalone `EcmaAst` with its own allocator. On the output side this is essentially just the runtime module (`crates/rolldown/src/module_loader/runtime_module_task.rs:226`). The ~35 direct oxc `Parser::new` sites in plugins and scanner sub-analyzers parse _input_ source to analyze or transform it — a different activity from constructing rolldown's own AST.
 
-Two facts constrain every choice and are documented in [ast-mutation](./ast-mutation.md): synthesized nodes must carry a synthetic span (the reserved `SPAN`, `0..0`) so they don't false-match the span-keyed side tables (see `crates/rolldown/src/module_finalizers/mod.rs:1088`), and rolldown does not re-run semantic after finalize, so synthesized nodes keep a dummy `NodeId` for life rather than being backfilled.
+Two facts constrain every choice and are documented in [ast-mutation](./ast-mutation.md): synthesized nodes must carry the reserved synthetic span (`SPAN`, `0..0`) — the cross-pass side tables are `NodeId`-keyed now, so the span no longer prevents false matches, but `span.is_unspanned()` checks (such as the global-`require` rewrite guard in `crates/rolldown/src/module_finalizers/mod.rs`) still use it to tell synthesized nodes from scanned ones — and rolldown does not re-run semantic after finalize, so synthesized nodes keep a dummy `NodeId` for life; that dummy id is what keeps them from matching scan-time records.
 
 ## The convention
 

--- a/meta/design/ast-mutation.md
+++ b/meta/design/ast-mutation.md
@@ -2,115 +2,91 @@
 
 ## Summary
 
-Rolldown threads per-AST-node metadata between compiler passes via side tables keyed by the oxc `Span` of the node. Scan populates them, Link adds more, and the Finalizer mutates the AST in place by calling `node.span()` and looking the result up. This works today, but it rests on an implicit "spans are stable and unique within a module" contract that has no validation layer and is easy to break. This document describes the current behavior so that a future migration to oxc's upcoming `AstNodeId` has a baseline to compare against — it is not itself a proposal for that migration.
+Rolldown threads per-AST-node metadata between compiler passes via side tables. The cross-pass identity key is now oxc's post-semantic `NodeId`, while `Span` remains source-location metadata for diagnostics, comments, source maps, and generated replacement spans.
 
-## Pass overview
+The public oxc type is `oxc::semantic::NodeId`. It is the implementation behind the `node_id()` / `set_node_id()` accessors on AST nodes after semantic analysis; there is not a separate public `AstNodeId` type in the version Rolldown currently uses.
+
+## Pass Overview
 
 Rolldown's bundling pipeline has three stages that interact with the AST:
 
-- **Scan** — `ScanStage::scan` (`crates/rolldown/src/stages/scan_stage.rs:159`). Per module: parse, then walk the AST read-only via `AstScanner` to populate `EcmaView` side tables (imports, this-expressions, `new URL(...)` references, etc.). The AST itself is not mutated.
-- **Link** — `LinkStage::link` (`crates/rolldown/src/stages/link_stage/mod.rs:229`). Cross-module work — symbol binding, export resolution, tree shaking. Still no AST mutation. Computes additional side tables (most notably `resolved_member_expr_refs`) keyed by spans collected during scan.
-- **Generate / Finalize** — `ScopeHoistingFinalizer` (`crates/rolldown/src/module_finalizers/impl_visit_mut.rs:26`), driven from `GenerateStage::generate` (`crates/rolldown/src/stages/generate_stage/mod.rs:82`). The only stage that mutates the AST. Implemented as a `VisitMut` traversal; at each interesting node it calls `node.span()` and queries the side tables to decide what to rewrite.
+- **Scan** - `ScanStage::scan` parses each module, runs Rolldown's pre-scan AST tweaks, then rebuilds semantic/scoping information. This final rebuild is what assigns every node — including the nodes the tweaks created — its `NodeId`, so the subsequent read-only walk via `AstScanner` sees stable ids while populating `EcmaView` side tables.
+- **Link** - `LinkStage::link` performs cross-module work such as symbol binding, export resolution, tree shaking, and cross-module optimization. It still does not mutate the AST, but it can derive additional side tables from scan-time records.
+- **Generate / Finalize** - `ScopeHoistingFinalizer`, driven from `GenerateStage::generate`, is the main stage that mutates the AST in place. It visits interesting nodes, calls `node_id()`, and queries the side tables to decide what to rewrite.
 
-Between passes, rolldown does **not** hold direct references to AST nodes (lifetimes wouldn't allow it across the parallel + cross-module boundaries anyway). The only thing that survives across passes is the `Span`.
+Between passes, Rolldown does not hold direct references to AST nodes. Lifetimes and parallel cross-module work make that impractical. The durable identity for a node within one module AST is therefore its `NodeId`.
 
-## The Span-as-identity contract
+## NodeId Contract
 
-The shared invariant across all passes:
+The shared invariant across passes:
 
-- **Insertion**: scan/link write side-table entries using the `Span` of the AST node being recorded.
-- **Lookup**: the finalizer (or other AST walkers) read `node.span()` and query the table.
-- **Required guarantees**: each recorded node has a `Span` that is (a) unique within its module and (b) preserved unchanged from the time of insertion to the time of lookup.
+- **Insertion**: scan/link write side-table entries using the `NodeId` of the AST node being recorded.
+- **Lookup**: finalizer or another later AST walker reads `node_id()` from the current node and queries the table.
+- **Required guarantees**: the node comes from the same post-semantic AST, and the side table is scoped to the module unless the key also includes `ModuleIdx`.
 
-There is no `AstNodeId` or other stable identity. The span doubles as both source-position metadata and as a primary key.
+Important constraints:
 
-### Pre-scan span normalization
+- `NodeId` is only unique within a single AST. Any table that combines records from multiple modules must key by `(ModuleIdx, NodeId)`.
+- `NodeId` is meaningful only after semantic analysis has assigned ids. Rolldown's normal scan path is post-semantic, so scan-created records are valid.
+- Synthetic/default nodes use `NodeId::DUMMY` unless ids are assigned later. Do not insert cross-pass side-table records for synthetic `DUMMY` nodes.
+- `NodeId::DUMMY` equals `NodeId::ROOT` (both are `0`, the `Program` node's id). `DUMMY` probes from synthesized nodes only miss because no side table records a `Program`-level entry — never add a `Program`-keyed entry to a per-module `NodeId` table.
+- Cloned post-semantic nodes can preserve the original node id unless the clone is reset or semantic information is rebuilt. Treat cloned nodes as identity-sensitive.
 
-The contract above would be unsafe if held over the raw post-parse AST: oxc gives every node a span derived from source position, but identical-looking source can yield identical spans (most often empty / synthetic spans inside the parser's output). Rolldown therefore runs a pre-scan pass — `PreProcessor` in `crates/rolldown/src/utils/tweak_ast_for_scanning.rs` — that walks the AST and, for the node kinds it cares about, rewrites any duplicate span to a fresh empty span (`start == end`, allocated upward from `program.span.end + 1`).
+Two paths finalize a _clone_ of the scanned AST, produced by `EcmaAst::clone_with_another_arena` into a fresh allocator, and they satisfy the "same post-semantic AST" guarantee through different mechanisms:
 
-The deduplication is **a targeted subset, not an exhaustive list of all span-keyed node kinds**. `PreProcessor` visits the node kinds where the parser is known to produce duplicate or synthetic spans (e.g., empty spans from desugaring, or kinds that can legitimately overlap):
+- **Cache path — id preservation.** The incremental-build cache (`NormalizedScanStageOutput::make_copy`, `ScanStageCache::create_output`) hands its clones to the link stage and `ScopeHoistingFinalizer`, which reuse scan-time scoping and never re-run semantic. The clone itself must carry the scan-time ids — this is why `clone_with_another_arena` uses oxc's `clone_in_with_semantic_ids` rather than plain `clone_in`, which would reset every id to `NodeId::DUMMY` and silently break every lookup.
+- **HMR path — deterministic re-derivation.** The HMR renderers in `crates/rolldown/src/hmr/hmr_stage.rs` clone and then immediately run `EcmaAst::make_semantic` on the clone, which re-stamps every `NodeId`; the ids the clone preserved are overwritten before any lookup. Lookups still hit because `SemanticBuilder` numbers nodes purely by traversal order, so an unmutated clone of the same tree shape re-derives exactly the scan-time ids. Two invariants keep this true: nothing may mutate the clone before `make_semantic` runs, and oxc's numbering must remain a pure function of tree shape (true as of oxc 0.135 — builder options such as `with_cfg` / `with_enum_eval` do not affect numbering). Breaking either shifts ids silently: the indexing lookups (`module.imports[&…]`) panic, the `.get()` lookups silently skip rewrites.
 
-- `ModuleDeclaration` (import/export decls)
-- `ImportExpression` (dynamic `import()`)
-- `ThisExpression`
-- `CallExpression` whose callee is `require` (and `IdentifierReference`s named `require`)
-- `NewExpression`
+## Current NodeId-Keyed Tables
 
-See `tweak_ast_for_scanning.rs:208-240`. Other node kinds keep whatever span the parser gave them — including `StaticMemberExpression`, which `resolved_member_expr_refs` uses as a key. Member expressions are not deduplicated because their spans cover real source ranges and don't collide in practice. The synthetic `SPAN` (`0..0`) is pre-seeded into the visited set so the deduplicator never produces it as a "unique" replacement — synthetic spans remain reserved for finalizer-generated nodes.
+The main cross-pass side tables keyed by `NodeId` are:
 
-The practical guarantee is narrower than it might appear: **for the node kinds `PreProcessor` visits, spans are unique within a module by the time scan runs.** For any other side-table key — including the member-expression case — uniqueness relies on the parser's own behavior. Adding a new side table whose key is prone to collisions or synthetic spans would need either an entry added to `PreProcessor` or a different identity strategy.
+- `EcmaView::imports` - import declarations, export-from declarations, dynamic `import()` expressions, and recognized `require()` call expressions.
+- `EcmaView::dummy_record_set` - `require` identifier references that need the runtime helper rewrite.
+- `EcmaView::new_url_references` - `new URL('...', import.meta.url)` nodes mapped to asset import records.
+- `EcmaView::this_expr_replace_map` - top-level `this` expressions that should become `exports` or `undefined`.
+- `MemberExprRef::node_id` and `LinkingMetadata::resolved_member_expr_refs` - namespace/member-expression resolution from scan through link to finalization.
+- `DynamicImportExprInfo::node_id` records the dynamic `import()` node within its own module; `EntryPoint::related_stmt_infos` then carries `(ModuleIdx, …, NodeId, …)` tuples so a dynamic-import entry can be traced back across the module graph.
+- Cross-module optimization state, which comes in two shapes: a per-module set of side-effect-free call expressions (bare `NodeId`, only consumed within the same module's traversal) and a graph-wide set of unreachable dynamic imports keyed by `(ModuleIdx, NodeId)` because it aggregates records from every module.
 
-## Address-as-identity (alternative key)
+This means finalizer-generated nodes that keep the default `NodeId::DUMMY` do not accidentally match scan-time records. `Span` no longer needs to double as the key for these rewrite decisions.
 
-`Span` isn't the only node identity rolldown threads between passes. Some side tables key off oxc's `Address` (the arena pointer obtained via `GetAddress::address` / `UnstableAddress::unstable_address`). Unlike spans, an `Address` is **unique by construction within a live AST** — two distinct allocator-resident nodes can never share one, with no `PreProcessor` involvement needed — but it is only valid for the lifetime of the `Allocator` that owns the AST and is therefore unusable across reparses or after the AST is dropped.
+## Where Span Still Belongs
 
-Rolldown uses `Address` where the producer and consumer hold references into the same arena and the table doesn't need to survive the AST going away:
+`Span` remains the right representation for source positions. It is still used for:
 
-- **`DynamicImportExprInfo.address`** (`crates/rolldown_common/src/types/import_record.rs:22`) — scan records the `ImportExpression`'s address on each dynamic-import record (`ast_scanner/mod.rs:509-510`), and link looks it up during cross-module optimization (`stages/link_stage/cross_module_optimization.rs:328-329`).
-- **`side_effect_free_call_expr_addr`** (`stages/link_stage/cross_module_optimization.rs:376`) — link populates a `FxHashSet<Address>` of pure call expressions; `SideEffectDetector` consults it when re-evaluating side effects (`ast_scanner/side_effect_detector/mod.rs:48`).
-- **`unreachable_import_expression_addresses`** (`stages/link_stage/cross_module_optimization.rs:340`) — link flags dynamic imports inside lazy paths so the tree-shaker can skip them (`stages/link_stage/tree_shaking/include_statements.rs:213`).
-- **`EntryPoint.related_stmt_infos`** (`crates/rolldown_common/src/types/entry_point.rs:16`) — tuples carry an `Address` alongside `(ModuleIdx, StmtInfoIdx, ImportRecordIdx)` to point at the originating AST node.
-- **`PreProcessor`'s `statement_stack` / `statement_replace_map`** (`crates/rolldown/src/utils/tweak_ast_for_scanning.rs:17-18`) — scratch state used within a single traversal, where the AST is obviously still alive.
+- diagnostics and warnings that point at user source;
+- comments, source-map ranges, directive/hashbang ranges, and TLA keyword locations;
+- generated replacement spans where codegen should preserve a useful source location;
+- import-record source locations, including the raw module-request span for resolver diagnostics and resolved `importer_span` for diagnostics that need to point at the full import site.
 
-Why both mechanisms exist side by side: `Span` is what survives all the way into the finalizer, which re-derives identity by calling `node.span()` after the AST has been threaded through scan → link → finalize with no direct node references kept. `Address` is the natural choice when the consumer can keep a reference into the same arena and would otherwise have to extend `PreProcessor` (or fight synthetic-span collisions) just to make `Span` work. A future `AstNodeId` migration would in principle subsume both, but the fragilities listed below are specifically about the `Span` contract — `Address`-keyed sites aren't subject to them.
+For import records, the module-request span belongs to `ImportRecordStateInit`: dependency
+resolution diagnostics still need to underline the original specifier, but the span is not
+carried into `ImportRecordStateResolved`. Resolved records keep `importer_span` because later
+passes, such as TLA import-chain diagnostics, need a location for the resolved import edge.
 
-## Classical patterns
+For member expressions, `NodeId` is the cross-pass lookup key, but spans remain necessary as
+source locations: `MemberExprRef::span` points diagnostics at the original expression, and the
+finalizer applies the current member expression span to generated replacements so source-map and
+diagnostic locations stay tied to the rewritten source range.
 
-The side tables differ in detail, but they all instantiate one of two patterns. The pattern dictates which passes touch the entry, not the shape of the data.
+Do not add a cross-pass node side table keyed only by `Span`. If a later pass needs to identify the same AST node, prefer `NodeId`; if records from more than one module can share a table, include `ModuleIdx`.
 
-### Pattern A — Scan → Finalize
+## Address Use
 
-Scan records the span together with whatever rewriting decision it can make locally. The link stage doesn't modify the entry. The finalizer reads it back and mutates the AST.
+Oxc `Address` is still acceptable for scratch state inside one live AST traversal, where producer and consumer operate before the traversal returns and no data survives as cross-pass metadata. The current example is:
 
-Example: `EcmaView::new_url_references`.
+- `PreProcessor`'s `statement_stack` / `statement_replace_map` in `crates/rolldown/src/utils/tweak_ast_for_scanning.rs`.
 
-1. During scan, `ast_scanner/new_url.rs:69` sees a `new URL('./img.png', import.meta.url)`, resolves the path into an import record, and inserts `(NewExpression.span → ImportRecordIdx)` into the side table.
-2. During finalize, `module_finalizers/mod.rs:961` visits each `NewExpression`, looks up its span, and on a hit rewrites the expression to emit the resolved asset URL.
+`PreProcessor` specifically _cannot_ use `NodeId`: it runs before the final semantic rebuild (`recreate_scoping` in `crates/rolldown/src/utils/pre_process_ecma_ast.rs`), so node ids are not yet assigned to the nodes it creates or moves. `Address` is the only stable per-node identity available at that point, and it is safe because the table never outlives the traversal.
 
-The same shape recurs in:
+Do not store `Address` in module metadata, entry metadata, or link-stage tables that outlive the traversal that produced it. In the post-semantic scanner, prefer `NodeId` even for same-traversal node identity checks when the compared nodes already have semantic IDs.
 
-- `EcmaView::this_expr_replace_map` — scan picks the replacement (`exports` vs `undefined`), finalizer applies it at `impl_visit_mut.rs:460`.
-- `EcmaView::imports` — scan records the import-site span, finalizer rewrites the site.
-- `EcmaView::dummy_record_set` — scan flags `require` identifier references (`ast_scanner/impl_visit.rs:591`), finalizer at `module_finalizers/rename.rs:86` consults the set on each `IdentifierReference` and rewrites the call to use the runtime `__require` helper. Here the span functions as a per-node boolean rather than a key for richer data, but the round-trip is still scan→finalize.
+## Pre-Scan Span Normalization
 
-### Pattern B — Scan → Link → Finalize
+`PreProcessor` still rewrites duplicate spans for a targeted set of node kinds before semantic information is rebuilt. After the `NodeId` migration, pairwise span uniqueness no longer backs any identity table; the machinery's one remaining functional job is keeping the synthetic span out of scanned ASTs. `SPAN` (`0..0`) is pre-seeded into the visited set, so nodes `PreProcessor` itself creates with `SPAN` (e.g. the transposed `require(a ? 'x' : 'y')` calls) are rewritten to fresh non-zero empty spans. That upholds the `span.is_unspanned()` checks that mean "synthesized by the finalizer": the global-`require` rewrite guard in `crates/rolldown/src/module_finalizers/mod.rs` and the member-expression-chain guard in `crates/rolldown/src/ast_scanner/impl_visit.rs`. Shrinking the machinery down to that single job is a candidate follow-up cleanup.
 
-Scan collects the span with only the local information available to it; link uses those records to populate a resolution table keyed by the same spans once cross-module facts are known; the finalizer applies the final decision.
-
-Example: `LinkingMetadata::resolved_member_expr_refs`.
-
-1. **Scan** sees a chain like `ns.foo.bar` and records the `StaticMemberExpression.span` together with the local symbol reference.
-2. **Link**, in `link_stage/bind_imports_and_exports.rs:445-447, 477-479`, resolves each recorded span to the actual exported binding it points at across the module graph and writes the result into a `FxHashMap<Span, MemberExprRefResolution>` (committed to `LinkingMetadata` at `link_stage/bind_imports_and_exports.rs:700`).
-3. **Finalize**, in `module_finalizers/mod.rs:1006`, visits each `StaticMemberExpression`, calls `.span()`, and on a hit replaces the chain with a direct reference to the linked symbol.
-
-This is the fullest expression of the contract: three passes communicate about the same AST node entirely through its span.
-
-## Known fragilities
-
-- **Cloned nodes carry the original span.** If any pass clones an AST node without resetting its span, the clone falsely matches the side-table entry that belonged to the original. Future lookups can fire against the wrong node.
-- **Synthetic spans collide with each other.** When the finalizer constructs new AST nodes (helpers, member expressions, etc.) it must give them a span that won't accidentally match a recorded one. The convention is the synthetic `SPAN` (`0..0`) — see `module_finalizers/mod.rs:1088-1090`, where the comment explicitly notes the workaround:
-
-  ```rust
-  // IMPORTANT: Use SPAN (0-0) for the new member expression to avoid being
-  // matched by resolved_member_expr_refs lookup which uses span as key
-  let ns_id_ref = self.snippet.id_ref_expr(ns_name, SPAN);
-  ```
-
-  This is fragile in the other direction: every synthetic node shares the same key, so adding side tables that look up by `SPAN` itself would immediately collide.
-
-- **Uniqueness coverage is hand-maintained.** `PreProcessor` only deduplicates the node kinds it has been taught about (see "Pre-scan span normalization"). Other span-keyed kinds (e.g. `StaticMemberExpression`) rely on the parser to produce unique spans on its own. Adding a new side table on a kind prone to collisions or synthetic spans silently exits the safety net unless `PreProcessor` is extended — there's no compile-time check linking the two.
-- **No post-`PreProcessor` validation.** Nothing checks at runtime that the uniqueness invariant still holds once `PreProcessor` has finished — the contract is enforced by construction, not by assertion. (Plugin `transform` hooks operate on source code before parsing, so they're not a concern; the AST being keyed wasn't built yet when they ran.) When the invariant breaks anyway — a cloned span, a new side-table kind not covered by `PreProcessor`, etc. — the regression manifests as a silent miss in the finalizer (a rewrite that should have happened didn't) rather than as a crash.
-- **Existing FIXME.** `crates/rolldown_common/src/types/member_expr_ref.rs:23-24` already calls this out:
-
-  ```rust
-  /// FIXME: use `AstNodeId` to identify the MemberExpr instead of `Span`
-  /// related discussion: https://github.com/rolldown/rolldown/pull/1818#discussion_r1699374441
-  pub span: Span,
-  ```
-
-## Why this is on the radar
-
-Oxc is introducing an `AstNodeId` — a true per-tree node identity, independent of source position. Switching the side tables to be keyed by `AstNodeId` instead of `Span` would dissolve the structural problems above: no uniqueness assumption to maintain, no synthetic-span workaround for finalizer-generated nodes (synthesized nodes get fresh ids that can't collide with anything), and no need for `PreProcessor` to keep a hand-curated list of node kinds in sync with the side-table set. This document captures the current state so that migration can be evaluated and planned against a concrete description of what's there today.
+The practical rule is simple: treat `Span` as location, `NodeId` as same-AST node identity, and `(ModuleIdx, NodeId)` as cross-module node identity.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Replaces the two ad-hoc cross-pass AST-node identity keys — oxc `Span` (deduped by `PreProcessor`) and arena `Address` — with oxc's post-semantic `NodeId` for every side table threaded from scan → link → finalize:

- `EcmaView::imports`, `dummy_record_set`, `new_url_references`, `this_expr_replace_map`
- `MemberExprRef::node_id` / `LinkingMetadata::resolved_member_expr_refs`
- `DynamicImportExprInfo::node_id` / `EntryPoint::related_stmt_infos`
- cross-module-optimization state (side-effect-free calls, unreachable dynamic imports)

Cross-module tables are keyed by `(ModuleIdx, NodeId)` because node ids are unique only within a single AST. `Span` is retained purely as source-location metadata (diagnostics, source maps, generated replacement spans); import records now carry an explicit `importer_span` so the TLA import-chain diagnostic no longer needs a reverse lookup over the (formerly span-keyed) `imports` map.

This removes the implicit "spans are stable and unique within a module" contract: finalizer-generated nodes keep `NodeId::DUMMY` and can no longer collide with scan-time records. The `PreProcessor` span-dedup machinery itself is untouched — its one remaining functional job is keeping the synthetic `0..0` span out of scanned ASTs for `span.is_unspanned()` checks; shrinking it down to that job is left as a follow-up.

## Notes

- The incremental-cache (`make_copy`) and HMR paths finalize a *clone* of the scanned AST (`EcmaAst::clone_with_another_arena`). The cache path relies on `clone_in_with_semantic_ids` to preserve node ids, since link/finalize reuse scan-time scoping without re-running semantic (plain `clone_in` would reset them to `NodeId::DUMMY`). The HMR path re-runs `make_semantic` on the clone, which re-stamps every id — lookups still hit because deterministic numbering over the unmutated clone re-derives the scan-time ids. Both mechanisms are documented in `meta/design/ast-mutation.md`.
- `meta/design/ast-mutation.md` is rewritten to document the new `NodeId` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
