### PR TITLE
fix(browser): add missing exports and ensure consistency with `rolldown` package

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,14 +39,19 @@
       "browser": "./dist/experimental-index.browser.mjs",
       "default": "./dist/experimental-index.mjs"
     },
+    "./experimental/runtime-types": {
+      "types": "./dist/experimental-runtime-types.d.ts"
+    },
     "./plugins": {
       "browser": "./dist/plugins-index.browser.mjs",
       "default": "./dist/plugins-index.mjs"
     },
     "./filter": "./dist/filter-index.mjs",
+    "./getLogFilter": "./dist/get-log-filter.mjs",
     "./parallelPlugin": "./dist/parallel-plugin.mjs",
     "./parseAst": "./dist/parse-ast-index.mjs",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./utils": "./dist/utils-index.mjs"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/rolldown/tests/exports-consistency.test.ts
+++ b/packages/rolldown/tests/exports-consistency.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from 'vitest';
 import pkg from '../package.json';
+import browserPkg from '../../browser/package.json';
 
 describe('package.json exports consistency', () => {
   test('publishConfig.exports keys match exports keys', () => {
     const exportsKeys = Object.keys(pkg.exports).sort();
+    const publishExportsKeys = Object.keys(pkg.publishConfig.exports).sort();
+
+    expect(exportsKeys).toStrictEqual(publishExportsKeys);
+  });
+
+  test('browser package.json exports keys match normal package exports keys', () => {
+    const exportsKeys = Object.keys(browserPkg.exports).sort();
     const publishExportsKeys = Object.keys(pkg.publishConfig.exports).sort();
 
     expect(exportsKeys).toStrictEqual(publishExportsKeys);


### PR DESCRIPTION
Some exports were missing in `@rolldown/browser`