### PR TITLE
feat: enable `experimental.lazyBarrel` by default

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -123,6 +123,6 @@ impl ExperimentalOptions {
   }
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
-    self.lazy_barrel.unwrap_or(false)
+    self.lazy_barrel.unwrap_or(true)
   }
 }

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -244,7 +244,7 @@ If the loaded modules (`a.js`, `b.js`, etc.) are also barrel modules, lazy barre
 
 ## Configuration
 
-Lazy barrel optimization is enabled by default. You can disable it in your Rolldown configuration:
+Lazy barrel optimization is enabled by default. You can temporarily disable it in your Rolldown configuration:
 
 ```js
 // rolldown.config.js
@@ -254,6 +254,10 @@ export default {
   },
 };
 ```
+
+::: warning
+This option is planned to be removed in the future. If you need to opt out, please [open an issue](https://github.com/rolldown/rolldown/issues) describing your use case so we can address it before the option is gone.
+:::
 
 ## Requirements
 

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -244,13 +244,13 @@ If the loaded modules (`a.js`, `b.js`, etc.) are also barrel modules, lazy barre
 
 ## Configuration
 
-Enable lazy barrel optimization in your Rolldown configuration:
+Lazy barrel optimization is enabled by default. You can disable it in your Rolldown configuration:
 
 ```js
 // rolldown.config.js
 export default {
   experimental: {
-    lazyBarrel: true,
+    lazyBarrel: false,
   },
 };
 ```

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -711,6 +711,9 @@ export interface InputOptions {
      * Lazy barrel optimization avoids compiling unused re-export modules in side-effect-free barrel modules,
      * significantly improving build performance for large codebases with many barrel modules.
      *
+     * This option is planned to be removed in the future. If you need to opt out, please open an issue
+     * describing your use case so we can address it before the option is gone.
+     *
      * @see {@link https://rolldown.rs/in-depth/lazy-barrel-optimization | Lazy Barrel Documentation}
      * @default true
      */

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -712,7 +712,7 @@ export interface InputOptions {
      * significantly improving build performance for large codebases with many barrel modules.
      *
      * @see {@link https://rolldown.rs/in-depth/lazy-barrel-optimization | Lazy Barrel Documentation}
-     * @default false
+     * @default true
      */
     lazyBarrel?: boolean;
   };


### PR DESCRIPTION
### Description

Related to #8936

This PR makes `experimental.lazyBarrel` enabled by default.

Lazy barrel optimization avoids compiling unused re-export modules in side-effect-free barrel modules, which significantly improves build performance for large codebases with many barrel modules (e.g. component libraries like Ant Design or `@mui/icons-material`). The feature has been available behind the experimental flag for a while and is stable enough to become the default.

Users who need the previous behavior can temporarily opt out:

```js
export default {
  experimental: {
    lazyBarrel: false,
  },
};
```

Note that this option is planned to be removed in the future. If you need to opt out, please open an issue describing your use case so we can address it before the option is gone.

### Changes

- Default `experimental.lazyBarrel` to `true` in `is_lazy_barrel_enabled`.
- Update the `@default` JSDoc tag on the `lazyBarrel` option to `true`.
- Update the lazy barrel docs to reflect that it is now on by default and document how to opt out.
