### PR TITLE
fix: report TSCONFIG_ERROR instead of UNHANDLEABLE_ERROR for a missing tsconfig file

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -338,9 +338,9 @@ pub fn prepare_build_context(
     match tsconfig {
       ref v @ TsConfig::Manual(ref path) => {
         // Manual mode: Resolve tsconfig now and create Normal mode
-        let resolved_tsconfig = resolver.resolve_tsconfig(&path).map_err(|err| {
-          anyhow::anyhow!("Failed to resolve `tsconfig` option: {}", path.display()).context(err)
-        })?;
+        let resolved_tsconfig = resolver
+          .resolve_tsconfig(&path)
+          .map_err(|err| BuildDiagnostic::tsconfig_error(path.display().to_string(), err))?;
         Box::new(if resolved_tsconfig.references_resolved.is_empty() {
           TransformOptions::new(
             merge_transform_options_with_tsconfig(

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "tsconfig": "./foo.json"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/artifacts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## TSCONFIG_ERROR
+
+```text
+[TSCONFIG_ERROR] Failed to load tsconfig for 'foo.json': Tsconfig not found
+
+```

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/main.js
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/option_not_found/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
Fixes #9618.

When the `tsconfig` option points to a file that does not exist, rolldown reported a generic `UNHANDLEABLE_ERROR` ("Something went wrong inside rolldown, please report this problem...") instead of a meaningful diagnostic.

### Cause

The bug lives in `prepare_build_context`. For `TsConfig::Manual` (an explicit tsconfig path), the error returned by `resolver.resolve_tsconfig` was wrapped in an `anyhow::Error`:

```rust
let resolved_tsconfig = resolver.resolve_tsconfig(&path).map_err(|err| {
  anyhow::anyhow!("Failed to resolve `tsconfig` option: {}", path.display()).context(err)
})?;
```

`From<anyhow::Error> for BuildDiagnostic` falls back to `unhandleable_error()`, so the missing file surfaced as `UNHANDLEABLE_ERROR`. The `TsConfig::Auto` path already maps this same `ResolveError` to `BuildDiagnostic::tsconfig_error`; only the manual path was missing the conversion.

### Fix

Map the failure to the existing `TSCONFIG_ERROR` diagnostic, consistent with the auto path and the binding layer:

```rust
let resolved_tsconfig = resolver
  .resolve_tsconfig(&path)
  .map_err(|err| BuildDiagnostic::tsconfig_error(path.display().to_string(), err))?;
```

A missing tsconfig now reports:

```text
[TSCONFIG_ERROR] Failed to load tsconfig for 'foo.json': Tsconfig not found
```