### PR TITLE
perf: avoid cloning the per-chunk export-items map in render_chunk_exports

### DIFF
--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -88,9 +88,11 @@ pub fn render_chunk_exports(
   let GenerateContext { chunk, link_output, options, .. } = ctx;
   let mut export_items: Vec<(CompactStr, SymbolRef)> = ctx.render_export_items_index_vec
     [ctx.chunk_idx]
-    .clone()
-    .into_iter()
-    .flat_map(|(symbol_ref, names)| names.into_iter().map(move |name| (name, symbol_ref)))
+    .iter()
+    .flat_map(|(symbol_ref, names)| {
+      let symbol_ref = *symbol_ref;
+      names.iter().map(move |name| (name.clone(), symbol_ref))
+    })
     .collect();
 
   match options.format {


### PR DESCRIPTION
`render_chunk_exports` cloned the entire `render_export_items_index_vec[chunk_idx]` map — an `FxIndexMap<SymbolRef, Vec<CompactStr>>`, including every value `Vec` — only to consume it into a flat `Vec<(CompactStr, SymbolRef)>`.

This iterates the map by reference and clones only the individual export-name strings that actually go into `export_items`, avoiding the deep clone of the map spine, the `SymbolRef` keys, and the per-symbol name `Vec`s on every chunk.

Behavior-preserving — no logic change, only how the items are collected. Covered by the existing chunk-rendering snapshot tests.