### PR TITLE
perf: avoid CompactStr allocation in sorted-exports membership check

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -483,10 +483,7 @@ impl LinkStage<'_> {
                     }
                     break;
                   };
-                  if !meta
-                    .sorted_and_non_ambiguous_resolved_exports
-                    .contains_key(&CompactStr::new(name))
-                  {
+                  if !meta.sorted_and_non_ambiguous_resolved_exports.contains_key(name) {
                     resolved_map.insert(
                       member_expr_ref.span,
                       MemberExprRefResolution {


### PR DESCRIPTION
In `match_imports_with_exports`, the membership check did `contains_key(&CompactStr::new(name))`, allocating a fresh `CompactStr` even though `name` is already a `&CompactStr` and the map only borrows the key for the lookup. (The sibling `resolved_exports.get(name)` a few lines above already passes it directly.)

Pass `name` straight to `contains_key`, removing one allocation per property in the namespace-resolution loop.

Behavior-preserving; covered by existing tests.