### PR TITLE
docs(tsconfig): align reference resolution docs with TypeScript behavior

### DIFF
--- a/packages/rolldown/src/options/docs/tsconfig.md
+++ b/packages/rolldown/src/options/docs/tsconfig.md
@@ -4,11 +4,7 @@
 
 When set to `true`, Rolldown enables auto-discovery mode (similar to Vite). For each module, both the resolver and transformer will find the nearest `tsconfig.json`.
 
-If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: each referenced project is checked in order, and the **first one that includes the file takes precedence over the root**. A referenced project includes the file when the file's extension is allowed by that project's own `allowJs` and the file matches its `files`/`include` patterns (and is not excluded). Only when no referenced project includes the file does Rolldown fall back to the root tsconfig.
-
-:::info Changed in v1.1.0
-Project references are now resolved like TypeScript: they are checked before the root tsconfig, so the `paths` / `allowJs` that apply to a file may differ from earlier versions.
-:::
+If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: a referenced project that includes the file **takes precedence over the root**. Each referenced project uses its own `allowJs`, so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included by projects that enable it. If no referenced project includes the file, Rolldown falls back to the root tsconfig.
 
 ```js
 export default {

--- a/packages/rolldown/src/options/docs/tsconfig.md
+++ b/packages/rolldown/src/options/docs/tsconfig.md
@@ -4,7 +4,11 @@
 
 When set to `true`, Rolldown enables auto-discovery mode (similar to Vite). For each module, both the resolver and transformer will find the nearest `tsconfig.json`.
 
-If the tsconfig has `references` and certain conditions are met (the file extension is allowed and the tsconfig's `include`/`exclude` patterns don't match the file), then the referenced tsconfigs will be searched for a match. If no match is found, it falls back to the original tsconfig.
+If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: each referenced project is checked in order, and the **first one that includes the file takes precedence over the root**. A referenced project includes the file when the file's extension is allowed by that project's own `allowJs` and the file matches its `files`/`include` patterns (and is not excluded). Only when no referenced project includes the file does Rolldown fall back to the root tsconfig.
+
+:::info Changed in v1.1.0
+Project references are now resolved like TypeScript: they are checked before the root tsconfig, so the `paths` / `allowJs` that apply to a file may differ from earlier versions.
+:::
 
 ```js
 export default {


### PR DESCRIPTION
## What

Updates `packages/rolldown/src/options/docs/tsconfig.md` to describe how a tsconfig's `references` are resolved as of **v1.1.0**. Docs-only, no behavior or code change.

## Why

The reference resolution behavior changed in v1.1.0 through the `oxc_resolver` upgrades:

- **#9549** (`oxc_resolver` → `11.20.0`) brought in oxc-resolver [#1151](https://github.com/oxc-project/oxc-resolver/pull/1151): a referenced project that includes the file takes precedence over the root, instead of the root claiming it first.
- **#9634** (`oxc_resolver` → `11.21.0`) brought in oxc-resolver [#1198](https://github.com/oxc-project/oxc-resolver/pull/1198): whether a `.js`/`.jsx`/`.mjs`/`.cjs` file is included is decided by each referenced project's own `allowJs`, not the root's.

The existing docs still described the previous model (root matches first, references consulted only as a fallback), which no longer holds. A solution-style `tsconfig.json` (only `references`, as Vite scaffolds) now resolves the way TypeScript does, which is also what made the standard Vite `paths` aliases resolve correctly again (rolldown/rolldown#8468).

## Changes

- Rewrote the `references` resolution paragraph: a referenced project that includes the file takes precedence over the root, each referenced project uses its own `allowJs` (so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included where that project enables it), and the root is used only when no referenced project includes the file.