### PR TITLE
perf: reuse the import-matching tracker stack across named imports

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -822,6 +822,11 @@ impl BindImportsAndExportsContext<'_> {
       return;
     };
     let is_esm = matches!(self.options.format, OutputFormat::Esm);
+    // Reused across all named imports of this module. `match_import_with_export` always starts
+    // from an empty stack (and the ambiguous-reexport recursion gets its own cloned stack), so
+    // clearing before each call preserves behavior while reusing this allocation instead of
+    // allocating a fresh `Vec` per import.
+    let mut matching_ctx = MatchingContext { tracker_stack: Vec::new() };
     for (imported_as_ref, named_import) in &module.named_imports {
       let match_import_span = tracing::trace_span!(
         "MATCH_IMPORT",
@@ -860,9 +865,10 @@ impl BindImportsAndExportsContext<'_> {
           Specifier::Literal(_) => {}
         }
       }
+      matching_ctx.tracker_stack.clear();
       let ret = self.match_import_with_export(
         self.index_modules,
-        &mut MatchingContext { tracker_stack: Vec::default() },
+        &mut matching_ctx,
         ImportTracker {
           importer: module_idx,
           importee: resolved_module_idx,


### PR DESCRIPTION
`match_imports_with_exports` allocated a fresh `Vec<ImportTracker>` (`MatchingContext { tracker_stack: Vec::default() }`) for every named import. Each match always starts from an empty stack, and the ambiguous-reexport recursion gets its own cloned stack, so the top-level stack is safe to reuse.

Hoist one `MatchingContext` outside the per-import loop and `clear()` it before each match — reusing the allocation instead of allocating one `Vec` per import. dhat flagged this as the ~1,370-alloc site on three.js.

Behavior-preserving (each match still sees an empty stack). Covered by the existing snapshot suite.