### PR TITLE
perf: avoid intermediate Strings in the ESM export clause

### DIFF
--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -123,15 +123,13 @@ pub fn render_chunk_exports(
               .symbol_db
               .canonical_name_for_or_original(ns_alias.namespace_ref, &chunk.canonical_names);
             let property_name = &ns_alias.property_name;
-            s.push_str(&concat_string!(
-              "var ",
-              canonical_name,
-              " = ",
-              canonical_ns_name,
-              ".",
-              property_name,
-              ";\n"
-            ));
+            s.push_str("var ");
+            s.push_str(canonical_name);
+            s.push_str(" = ");
+            s.push_str(canonical_ns_name);
+            s.push('.');
+            s.push_str(property_name);
+            s.push_str(";\n");
           }
 
           if canonical_name == exported_name {
@@ -145,7 +143,14 @@ pub fn render_chunk_exports(
           }
         })
         .collect::<Vec<_>>();
-      s.push_str(&concat_string!("export { ", rendered_items.join(", "), " };"));
+      s.push_str("export { ");
+      for (i, item) in rendered_items.iter().enumerate() {
+        if i > 0 {
+          s.push_str(", ");
+        }
+        s.push_str(item);
+      }
+      s.push_str(" };");
       Some(s)
     }
     OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {


### PR DESCRIPTION
Rendering the ESM `export { ... }` clause collected items into a `Vec`, `join`ed them into a temporary `String`, wrapped that in another `concat_string!` `String`, and built a per-item `concat_string!` for each namespace-alias `var` declaration — all just to `push_str` into the output buffer.

Write the var declarations and the export clause directly into the output `String`. Output bytes are identical.

Behavior-preserving. Covered by the existing snapshot suite. Scope: the ESM branch; the CJS/IIFE/UMD `join("\n")` paths are left as-is.