### PR TITLE
perf: reserve capacity for the resolve dedup map

### DIFF
--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -66,7 +66,9 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
   let mut dedup_map: FxHashMap<(&str, ImportKind), ImportRecordIdx> =
     FxHashMap::with_capacity_and_hasher(dependencies.len(), Default::default());
   dedup_map.extend(
-    dependencies.iter_enumerated().map(|(idx, item)| ((item.module_request.as_str(), item.kind), idx)),
+    dependencies
+      .iter_enumerated()
+      .map(|(idx, item)| ((item.module_request.as_str(), item.kind), idx)),
   );
 
   let jobs = dedup_map.values().map(|&idx| async move {

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -63,10 +63,11 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
   module_type: &ModuleType,
 ) -> BuildResult<IndexVec<ImportRecordIdx, ResolvedId>> {
   // NOTE: this dedupes the identical (specifier, kind) resolve calls
-  let dedup_map: FxHashMap<(&str, ImportKind), ImportRecordIdx> = dependencies
-    .iter_enumerated()
-    .map(|(idx, item)| ((item.module_request.as_str(), item.kind), idx))
-    .collect();
+  let mut dedup_map: FxHashMap<(&str, ImportKind), ImportRecordIdx> =
+    FxHashMap::with_capacity_and_hasher(dependencies.len(), Default::default());
+  dedup_map.extend(
+    dependencies.iter_enumerated().map(|(idx, item)| ((item.module_request.as_str(), item.kind), idx)),
+  );
 
   let jobs = dedup_map.values().map(|&idx| async move {
     let item = &dependencies[idx];


### PR DESCRIPTION
`resolve_dependencies` builds `dedup_map` with `.collect()` and no capacity hint, so it rehashes/reallocates its bucket array as it fills, even though the final size is bounded by `dependencies.len()`.

Reserve `dependencies.len()` up front (the keys borrow `&str`, so no string allocation is involved). Behavior-preserving.