### PR TITLE
fix(hmr): include missing synchronous dependencies in patches

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -22,6 +22,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::hmr::utils::{HmrAstBuilder, MODULE_EXPORTS_NAME_FOR_ESM};
 
+#[derive(Debug, Clone, Copy)]
+pub enum ModuleInitializerMode {
+  Always,
+  Deduplicate,
+}
+
 pub struct HmrAstFinalizer<'me, 'ast> {
   // Outside input
   pub alloc: &'ast Allocator,
@@ -32,18 +38,14 @@ pub struct HmrAstFinalizer<'me, 'ast> {
   pub affected_module_idx_to_init_fn_name: &'me FxHashMap<ModuleIdx, String>,
   pub use_pife_for_module_wrappers: bool,
 
-  /// Whether the runtime should short-circuit re-execution of the wrapped module body
-  /// when its stable id is already registered.
+  /// Controls whether the runtime should execute the wrapped module body.
   ///
-  /// `true` for lazy-compilation chunks: when a module appears in two lazy bundles served
-  /// concurrently, we want only the first one to actually execute the body.
-  ///
-  /// `false` for HMR patches: the patch's whole point is to re-execute the body and
-  /// replace the registered exports, so deduping would silently drop the update.
+  /// Lazy modules and HMR dependency backfills deduplicate already-loaded modules. Real HMR
+  /// updates always execute when invoked.
   ///
   /// Note: This works only as a **workaround**. In the future, HMR runtime should
   /// provide a runtime API to trigger module disposal and re-execution. @hana
-  pub dedup_module_initializer: bool,
+  pub module_initializer_mode: ModuleInitializerMode,
 
   // Each module has a unique index, which is used to generate something that needs to be unique.
   pub unique_index: usize,

--- a/crates/rolldown/src/hmr/hmr_render_plan.rs
+++ b/crates/rolldown/src/hmr/hmr_render_plan.rs
@@ -1,0 +1,127 @@
+use rolldown_common::{ClientHmrInput, ImportKind, IndexModules, Module, ModuleIdx};
+use rolldown_utils::indexmap::FxIndexSet;
+use rustc_hash::FxHashMap;
+
+use super::hmr_ast_finalizer::ModuleInitializerMode;
+
+#[derive(Debug)]
+pub(super) struct HmrRenderPlan {
+  pub(super) modules_to_render: FxIndexSet<ModuleIdx>,
+  modules_to_reexecute: FxIndexSet<ModuleIdx>,
+  modules_to_invoke_if_loaded: FxIndexSet<ModuleIdx>,
+}
+
+impl HmrRenderPlan {
+  pub(super) fn new(
+    mut modules_to_reexecute: FxIndexSet<ModuleIdx>,
+    modules_to_invoke_if_loaded: FxIndexSet<ModuleIdx>,
+  ) -> Self {
+    modules_to_reexecute.extend(modules_to_invoke_if_loaded.iter().copied());
+    let modules_to_render = modules_to_reexecute.clone();
+    Self { modules_to_render, modules_to_reexecute, modules_to_invoke_if_loaded }
+  }
+
+  pub(super) fn complete_for_client(
+    &mut self,
+    modules: &IndexModules,
+    actual_updates: &FxIndexSet<ModuleIdx>,
+    client: &ClientHmrInput<'_>,
+  ) {
+    let mut esm_importers_by_dependency = FxHashMap::<ModuleIdx, Vec<ModuleIdx>>::default();
+    let mut stack = self.modules_to_render.iter().copied().collect::<Vec<_>>();
+
+    for module_idx in actual_updates {
+      if self.modules_to_render.contains(module_idx) {
+        self.invoke_if_loaded(*module_idx);
+      }
+    }
+
+    // Complete the definition closure first. Static ESM imports, require calls, and dynamic
+    // imports need an initializer in the patch, but only a static ESM edge proves that the
+    // dependency executes with its importer.
+    while let Some(importer_idx) = stack.pop() {
+      let Module::Normal(importer) = &modules[importer_idx] else {
+        continue;
+      };
+
+      for rec in &importer.import_records {
+        if !matches!(rec.kind, ImportKind::Import | ImportKind::Require | ImportKind::DynamicImport)
+        {
+          continue;
+        }
+        let Some(dependency_idx) = rec.resolved_module else {
+          continue;
+        };
+        let Module::Normal(dependency) = &modules[dependency_idx] else {
+          continue;
+        };
+
+        if rec.kind == ImportKind::Import {
+          esm_importers_by_dependency.entry(dependency_idx).or_default().push(importer_idx);
+        }
+
+        let added = if actual_updates.contains(&dependency_idx) {
+          self.reexecute_and_invoke_if_loaded(dependency_idx)
+        } else if !client.is_module_executed(&dependency.stable_id) {
+          self.backfill(dependency_idx)
+        } else {
+          false
+        };
+
+        if added {
+          stack.push(dependency_idx);
+        }
+      }
+    }
+
+    // A deduplicated static ESM importer would skip its factory and never invoke a real update
+    // below it, so upgrade the rendered ESM path between each actual update and its HMR root.
+    // Do not upgrade require or dynamic-import paths: either call may be conditional.
+    let mut stack = actual_updates
+      .iter()
+      .copied()
+      .filter(|module_idx| self.modules_to_render.contains(module_idx))
+      .collect::<Vec<_>>();
+
+    while let Some(dependency_idx) = stack.pop() {
+      if let Some(importers) = esm_importers_by_dependency.get(&dependency_idx) {
+        for importer_idx in importers.iter().copied() {
+          if self.reexecute_and_invoke_if_loaded(importer_idx) {
+            stack.push(importer_idx);
+          }
+        }
+      }
+    }
+  }
+
+  pub(super) fn initializer_mode(&self, module_idx: ModuleIdx) -> ModuleInitializerMode {
+    if self.modules_to_reexecute.contains(&module_idx) {
+      ModuleInitializerMode::Always
+    } else {
+      ModuleInitializerMode::Deduplicate
+    }
+  }
+
+  pub(super) fn modules_to_invoke_if_loaded(&self) -> &FxIndexSet<ModuleIdx> {
+    &self.modules_to_invoke_if_loaded
+  }
+
+  fn backfill(&mut self, module_idx: ModuleIdx) -> bool {
+    self.modules_to_render.insert(module_idx)
+  }
+
+  fn reexecute(&mut self, module_idx: ModuleIdx) -> bool {
+    let upgraded = self.modules_to_reexecute.insert(module_idx);
+    self.modules_to_render.insert(module_idx);
+    upgraded
+  }
+
+  fn invoke_if_loaded(&mut self, module_idx: ModuleIdx) -> bool {
+    self.modules_to_invoke_if_loaded.insert(module_idx)
+  }
+
+  fn reexecute_and_invoke_if_loaded(&mut self, module_idx: ModuleIdx) -> bool {
+    self.invoke_if_loaded(module_idx);
+    self.reexecute(module_idx)
+  }
+}

--- a/crates/rolldown/src/hmr/hmr_renderer.rs
+++ b/crates/rolldown/src/hmr/hmr_renderer.rs
@@ -1,0 +1,159 @@
+use oxc_traverse::traverse_mut;
+use rolldown_common::{Module, ModuleIdx};
+use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
+use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_fs::FileSystem;
+use rolldown_sourcemap::{Source, SourceMapSource};
+#[cfg(not(target_family = "wasm"))]
+use rolldown_utils::rayon::IndexedParallelIterator;
+use rolldown_utils::{
+  concat_string,
+  indexmap::{FxIndexMap, FxIndexSet},
+  rayon::{IntoParallelIterator, ParallelIterator},
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use super::{
+  hmr_ast_finalizer::{HmrAstFinalizer, ModuleInitializerMode},
+  hmr_stage::HmrStage,
+};
+
+struct ModuleRenderInput {
+  idx: ModuleIdx,
+  ecma_ast: EcmaAst,
+}
+
+type RenderedModule = [Box<dyn Source + Send>; 3];
+
+pub(super) struct RenderedModules {
+  pub(super) init_fn_names: FxHashMap<ModuleIdx, String>,
+  pub(super) sources: Vec<Box<dyn Source + Send>>,
+}
+
+impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {
+  pub(super) fn render_modules(
+    &self,
+    modules_to_render: &FxIndexSet<ModuleIdx>,
+    initializer_mode: impl Fn(ModuleIdx) -> ModuleInitializerMode + Sync,
+  ) -> RenderedModules {
+    let module_idx_to_init_fn_name = modules_to_render
+      .iter()
+      .enumerate()
+      .map(|(index, module_idx)| {
+        let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
+          unreachable!(
+            "External modules should be removed before. But got {:?}",
+            self.module_table().modules[*module_idx].id().as_str()
+          );
+        };
+        let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };
+
+        // We use `index` as a part of the function name to avoid name collision without needing to deconflict.
+        (*module_idx, format!("{}_{}_{}", prefix, module.repr_name, index))
+      })
+      .collect::<FxHashMap<_, _>>();
+
+    let index_ecma_ast = self.index_ecma_ast();
+    let module_render_inputs = modules_to_render
+      .iter()
+      .copied()
+      .map(|module_idx| {
+        let Module::Normal(module) = &self.module_table().modules[module_idx] else {
+          unreachable!("Only normal modules should be rendered");
+        };
+
+        debug_assert_eq!(module_idx, module.idx);
+        let ecma_ast =
+          index_ecma_ast[module_idx].as_ref().expect("Normal module should have an AST");
+
+        ModuleRenderInput { idx: module.idx, ecma_ast: ecma_ast.clone_with_another_arena() }
+      })
+      .collect::<Vec<_>>();
+
+    let sources = module_render_inputs
+      .into_par_iter()
+      .enumerate()
+      .flat_map(|(index, render_input)| {
+        let module_initializer_mode = initializer_mode(render_input.idx);
+        self.render_module(
+          render_input,
+          index,
+          &module_idx_to_init_fn_name,
+          module_initializer_mode,
+        )
+      })
+      .collect::<Vec<_>>();
+
+    RenderedModules { init_fn_names: module_idx_to_init_fn_name, sources }
+  }
+
+  fn render_module(
+    &self,
+    render_input: ModuleRenderInput,
+    index: usize,
+    module_idx_to_init_fn_name: &FxHashMap<ModuleIdx, String>,
+    module_initializer_mode: ModuleInitializerMode,
+  ) -> RenderedModule {
+    let ModuleRenderInput { idx: module_idx, ecma_ast: mut ast } = render_input;
+
+    let Module::Normal(module) = &self.module_table().modules[module_idx] else {
+      unreachable!("Only normal modules should be rendered");
+    };
+
+    let enable_sourcemap = self.options.sourcemap.is_some() && !module.is_virtual();
+    let use_pife_for_module_wrappers =
+      self.options.optimization.is_pife_for_module_wrappers_enabled();
+    let modules = &self.module_table().modules;
+    ast.program.with_mut(|fields| {
+      let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+
+      let mut finalizer = HmrAstFinalizer {
+        modules,
+        alloc: fields.allocator,
+        snippet: AstSnippet::new(fields.allocator),
+        builder: &oxc::ast::AstBuilder::new(fields.allocator),
+        import_bindings: FxHashMap::default(),
+        module,
+        exports: oxc::allocator::Vec::new_in(fields.allocator),
+        affected_module_idx_to_init_fn_name: module_idx_to_init_fn_name,
+        use_pife_for_module_wrappers,
+        module_initializer_mode,
+        dependencies: FxIndexSet::default(),
+        imports: FxHashSet::default(),
+        generated_static_import_infos: FxHashMap::default(),
+        re_export_all_dependencies: FxIndexSet::default(),
+        generated_static_import_stmts_from_external: FxIndexMap::default(),
+        unique_index: index,
+        named_exports: FxHashMap::default(),
+      };
+
+      traverse_mut(&mut finalizer, fields.allocator, fields.program, scoping, ());
+    });
+
+    let codegen = EcmaCompiler::print_with(
+      &ast,
+      PrintOptions {
+        sourcemap: enable_sourcemap,
+        filename: module.id.to_string(),
+        comments: PrintCommentsOptions {
+          legal: false,
+          annotation: self.options.comments.annotation,
+          jsdoc: self.options.comments.jsdoc,
+        },
+        initial_indent: 0,
+      },
+    );
+
+    let intro_comment: Box<dyn Source + Send> =
+      Box::new(concat_string!("//#region ", module.debug_id));
+    let outro_comment: Box<dyn Source + Send> = Box::new(concat_string!("//#endregion"));
+
+    let code_source: Box<dyn Source + Send> = if let Some(map) = codegen.map {
+      Box::new(SourceMapSource::new(codegen.code, map.into_inner()))
+    } else {
+      Box::new(codegen.code)
+    };
+
+    [intro_comment, code_source, outro_comment]
+  }
+}

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -7,30 +7,27 @@ use std::{
 };
 
 use arcstr::ArcStr;
-use oxc_traverse::traverse_mut;
 use rolldown_common::{
   ClientHmrInput, ClientHmrUpdate, HmrBoundary, HmrBoundaryOutput, HmrPatch, HmrUpdate, ImportKind,
   Module, ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
 };
-use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
-use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_error::BuildResult;
 use rolldown_fs::FileSystem;
 use rolldown_plugin::SharedPluginDriver;
-use rolldown_sourcemap::{Source, SourceJoiner, SourceMapSource};
-#[cfg(not(target_family = "wasm"))]
-use rolldown_utils::rayon::IndexedParallelIterator;
-use rolldown_utils::{
-  concat_string,
-  indexmap::{FxIndexMap, FxIndexSet},
-  rayon::{IntoParallelIterator, ParallelIterator},
-};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rolldown_sourcemap::SourceJoiner;
+use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
+use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 
 use crate::{
-  SharedOptions, SharedResolver, hmr::hmr_ast_finalizer::HmrAstFinalizer,
-  module_loader::ModuleLoader, type_alias::IndexEcmaAst, types::scan_stage_cache::ScanStageCache,
+  SharedOptions, SharedResolver,
+  hmr::{
+    hmr_ast_finalizer::ModuleInitializerMode, hmr_render_plan::HmrRenderPlan,
+    hmr_renderer::RenderedModules,
+  },
+  module_loader::ModuleLoader,
+  type_alias::IndexEcmaAst,
+  types::scan_stage_cache::ScanStageCache,
   utils::process_code_and_sourcemap::process_code_and_sourcemap,
 };
 
@@ -233,7 +230,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
           .map(|boundary| self.module_table().modules[boundary.boundary].stable_id())
           .collect::<Vec<_>>(),
       );
-      clients_prerequisites.push((client.client_id.to_string(), prerequisites));
+      clients_prerequisites.push(prerequisites);
     }
 
     // 2. Do ONE module refetch and cache merge (if needed)
@@ -292,16 +289,23 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
     // 3. For each client, render their HMR patch or return full reload
     let mut client_updates = Vec::with_capacity(clients.len());
-    for (client_id, prerequisites) in clients_prerequisites {
+    for (client, prerequisites) in clients.iter().zip(clients_prerequisites) {
       let update = if prerequisites.require_full_reload {
         HmrUpdate::FullReload {
           reason: prerequisites.full_reload_reason.unwrap_or_else(|| "Unknown reason".to_string()),
         }
       } else {
-        self.render_hmr_patch_from_prerequisites(prerequisites, &new_added_modules).await?
+        self
+          .render_hmr_patch_from_prerequisites(
+            prerequisites,
+            changed_modules,
+            &new_added_modules,
+            client,
+          )
+          .await?
       };
 
-      client_updates.push(ClientHmrUpdate { client_id, update });
+      client_updates.push(ClientHmrUpdate { client_id: client.client_id.to_string(), update });
     }
 
     Ok(client_updates)
@@ -398,125 +402,17 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     modules_to_be_updated
       .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id());
 
-    // Generate init function names
-    let module_idx_to_init_fn_name = modules_to_be_updated
-      .iter()
-      .enumerate()
-      .map(|(index, module_idx)| {
-        let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
-          unreachable!(
-            "External modules should be removed before. But got {:?}",
-            self.module_table().modules[*module_idx].id()
-          );
-        };
-        let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };
-        (*module_idx, format!("{}_{}_{}", prefix, module.repr_name, index))
-      })
-      .collect::<FxHashMap<_, _>>();
+    let RenderedModules { init_fn_names, sources } =
+      self.render_modules(&modules_to_be_updated, |_| ModuleInitializerMode::Deduplicate);
 
-    // Prepare module render inputs
-    let index_ecma_ast = self.index_ecma_ast();
-    let module_render_inputs = modules_to_be_updated
-      .iter()
-      .copied()
-      .map(|affected_module_idx| {
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("Only normal modules should be rendered");
-        };
-
-        debug_assert_eq!(affected_module_idx, affected_module.idx);
-        let ecma_ast =
-          index_ecma_ast[affected_module_idx].as_ref().expect("Normal module should have an AST");
-
-        ModuleRenderInput {
-          idx: affected_module.idx,
-          ecma_ast: ecma_ast.clone_with_another_arena(),
-        }
-      })
-      .collect::<Vec<_>>();
-
-    // Render all modules
     let mut source_joiner = SourceJoiner::default();
-    let rendered_sources = module_render_inputs
-      .into_par_iter()
-      .enumerate()
-      .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
-
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("Only normal modules should be rendered");
-        };
-
-        let enable_sourcemap = self.options.sourcemap.is_some() && !affected_module.is_virtual();
-        let use_pife_for_module_wrappers =
-          self.options.optimization.is_pife_for_module_wrappers_enabled();
-        let modules = &self.module_table().modules;
-
-        ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
-
-          let mut finalizer = HmrAstFinalizer {
-            modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
-            import_bindings: FxHashMap::default(),
-            module: affected_module,
-            exports: oxc::allocator::Vec::new_in(fields.allocator),
-            affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
-            use_pife_for_module_wrappers,
-            // Lazy chunk: opt the runtime into deduping the module body so two
-            // concurrent lazy bundles for the same module don't double-execute it.
-            dedup_module_initializer: true,
-            dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
-            generated_static_import_infos: FxHashMap::default(),
-            re_export_all_dependencies: FxIndexSet::default(),
-            generated_static_import_stmts_from_external: FxIndexMap::default(),
-            unique_index: index,
-            named_exports: FxHashMap::default(),
-          };
-
-          traverse_mut(&mut finalizer, fields.allocator, fields.program, scoping, ());
-        });
-
-        let codegen = EcmaCompiler::print_with(
-          &ast,
-          PrintOptions {
-            sourcemap: enable_sourcemap,
-            filename: affected_module.id.to_string(),
-            comments: PrintCommentsOptions {
-              legal: false,
-              annotation: self.options.comments.annotation,
-              jsdoc: self.options.comments.jsdoc,
-            },
-            initial_indent: 0,
-          },
-        );
-
-        let intro_comment: Box<dyn Source + Send> =
-          Box::new(concat_string!("//#region ", affected_module.debug_id));
-        let outro_comment: Box<dyn Source + Send> = Box::new(concat_string!("//#endregion"));
-
-        let code_source: Box<dyn Source + Send> = if let Some(map) = codegen.map {
-          Box::new(SourceMapSource::new(codegen.code, map.into_inner()))
-        } else {
-          Box::new(codegen.code)
-        };
-
-        [intro_comment, code_source, outro_comment]
-      })
-      .collect::<Vec<_>>();
-
-    for source in rendered_sources {
+    for source in sources {
       source_joiner.append_source_dyn(source);
     }
 
     // Call the init function for the entry module automatically
     // This is NOT HMR boundary handling - just executing the lazy-loaded module
-    let entry_init_fn_name = &module_idx_to_init_fn_name[&entry_module_idx];
+    let entry_init_fn_name = &init_fn_names[&entry_module_idx];
     source_joiner.append_source(format!("{entry_init_fn_name}()"));
 
     let (mut code, mut map) = source_joiner.join();
@@ -542,411 +438,63 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     Ok(code)
   }
 
-  // Kept for backwards compatibility - this method is no longer used but kept in case
-  // it's needed for other use cases
-  #[expect(dead_code, clippy::too_many_lines)]
-  async fn compute_hmr_update_single(
-    &mut self,
-    stale_modules: &FxIndexSet<ModuleIdx>,
-    changed_modules: &FxIndexSet<ModuleIdx>,
-    first_invalidated_by: Option<String>,
-    client: &ClientHmrInput<'_>,
-  ) -> BuildResult<HmrUpdate> {
-    let hmr_prerequisites =
-      self.compute_out_hmr_prerequisites(stale_modules, first_invalidated_by.as_deref(), client);
-
-    tracing::debug!(
-      target: "hmr",
-      "computed out `hmr_boundaries` {:?}",
-      hmr_prerequisites.boundaries.iter()
-        .map(|boundary| self.module_table().modules[boundary.boundary].stable_id())
-        .collect::<Vec<_>>(),
-    );
-
-    tracing::debug!(
-      target: "hmr",
-      "computed out `stale_modules` {:?}",
-      hmr_prerequisites.modules_to_be_updated.iter()
-        .map(|module_idx| self.module_table().modules[*module_idx].stable_id())
-        .collect::<Vec<_>>(),
-    );
-
-    let mut modules_to_be_updated = hmr_prerequisites.modules_to_be_updated;
-
-    if !changed_modules.is_empty() {
-      let modules_to_be_refetched = changed_modules
-        .iter()
-        .filter_map(|module_idx| {
-          let module = &self.module_table().modules[*module_idx];
-          if let Module::Normal(module) = module {
-            Some(module.originative_resolved_id.clone())
-          } else {
-            // unreachable!("HMR only supports normal module. Got {:?}", module.id());
-            None
-          }
-        })
-        .collect::<Vec<_>>();
-
-      let fetch_mode = ScanMode::Partial(modules_to_be_refetched);
-
-      let mut module_loader = ModuleLoader::new(
-        self.fs.clone(),
-        Arc::clone(&self.options),
-        Arc::clone(&self.resolver),
-        Arc::clone(&self.plugin_driver),
-        self.cache,
-        fetch_mode.is_full(),
-        // TODO: support `background sourcemap generation` for hmr
-        None,
-      )?;
-
-      let module_loader_output = module_loader.fetch_modules(fetch_mode).await?;
-
-      // We manually impl `Drop` for `ModuleLoader` to avoid missing assign `importers` to
-      // `self.cache`, but rustc is not smart enough to infer actually we don't touch it in `drop`
-      // implementation, so we need to manually drop it.
-      drop(module_loader);
-
-      tracing::debug!(
-        target: "hmr",
-        "New added modules` {:?}",
-        module_loader_output
-          .new_added_modules_from_partial_scan
-          .iter()
-          .map(|module_idx| module_loader_output.module_table.get(*module_idx).stable_id())
-          .collect::<Vec<_>>(),
-      );
-      modules_to_be_updated
-        .extend(module_loader_output.new_added_modules_from_partial_scan.clone());
-      self.cache.merge(module_loader_output.into())?;
-      let options = Arc::clone(&self.options);
-      self.cache.update_defer_sync_data(&options).await?;
-
-      // Note: New added modules might include external modules. There's no way to "update" them, so we need to remove them.
-      modules_to_be_updated.retain(|idx| self.module_table().modules[*idx].is_normal());
-    }
-
-    if hmr_prerequisites.require_full_reload {
-      return Ok(HmrUpdate::FullReload {
-        reason: hmr_prerequisites
-          .full_reload_reason
-          .unwrap_or_else(|| "Unknown reason".to_string()),
-      });
-    }
-
-    // Sorting `modules_to_be_updated` is not strictly necessary, but it:
-    // - Makes the snapshot more stable when we change logic that affects the order of modules.
-    modules_to_be_updated
-      .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id().as_str());
-
-    let module_idx_to_init_fn_name = modules_to_be_updated
-      .iter()
-      .enumerate()
-      .map(|(index, module_idx)| {
-        let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
-          unreachable!(
-            "External modules should be removed before. But got {:?}",
-            self.module_table().modules[*module_idx].id().as_str()
-          );
-        };
-        let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };
-
-        // We use `index` as a part of the function name to avoid name collision without needing to deconflict.
-        (*module_idx, format!("{}_{}_{}", prefix, module.repr_name, index))
-      })
-      .collect::<FxHashMap<_, _>>();
-
-    let index_ecma_ast = self.index_ecma_ast();
-    let module_render_inputs = modules_to_be_updated
-      .iter()
-      .copied()
-      .map(|affected_module_idx| {
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("HMR only supports normal module");
-        };
-
-        debug_assert_eq!(affected_module_idx, affected_module.idx);
-        let ecma_ast =
-          index_ecma_ast[affected_module_idx].as_ref().expect("Normal module should have an AST");
-
-        ModuleRenderInput {
-          idx: affected_module.idx,
-          ecma_ast: ecma_ast.clone_with_another_arena(),
-        }
-      })
-      .collect::<Vec<_>>();
-
-    let mut source_joiner = SourceJoiner::default();
-    let rendered_sources = module_render_inputs
-      .into_par_iter()
-      .enumerate()
-      .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
-
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("HMR only supports normal module");
-        };
-
-        let enable_sourcemap = self.options.sourcemap.is_some() && !affected_module.is_virtual();
-        let use_pife_for_module_wrappers =
-          self.options.optimization.is_pife_for_module_wrappers_enabled();
-        let modules = &self.module_table().modules;
-
-        ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
-
-          let mut finalizer = HmrAstFinalizer {
-            modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
-            import_bindings: FxHashMap::default(),
-            module: affected_module,
-            exports: oxc::allocator::Vec::new_in(fields.allocator),
-            affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
-            use_pife_for_module_wrappers,
-            dedup_module_initializer: false,
-            dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
-            generated_static_import_infos: FxHashMap::default(),
-            re_export_all_dependencies: FxIndexSet::default(),
-            generated_static_import_stmts_from_external: FxIndexMap::default(),
-            unique_index: index,
-            named_exports: FxHashMap::default(),
-          };
-
-          traverse_mut(&mut finalizer, fields.allocator, fields.program, scoping, ());
-        });
-
-        let codegen = EcmaCompiler::print_with(
-          &ast,
-          PrintOptions {
-            sourcemap: enable_sourcemap,
-            filename: affected_module.id.to_string(),
-            comments: PrintCommentsOptions {
-              legal: false, // ignore hmr chunk comments
-              annotation: self.options.comments.annotation,
-              jsdoc: self.options.comments.jsdoc,
-            },
-            initial_indent: 0,
-          },
-        );
-
-        let intro_comment: Box<dyn Source + Send> =
-          Box::new(concat_string!("//#region ", affected_module.debug_id));
-        let outro_comment: Box<dyn Source + Send> = Box::new(concat_string!("//#endregion"));
-
-        let code_source: Box<dyn Source + Send> = if let Some(map) = codegen.map {
-          Box::new(SourceMapSource::new(codegen.code, map.into_inner()))
-        } else {
-          Box::new(codegen.code)
-        };
-
-        [intro_comment, code_source, outro_comment]
-      })
-      .collect::<Vec<_>>();
-
-    for source in rendered_sources {
-      source_joiner.append_source_dyn(source);
-    }
-
-    hmr_prerequisites.boundaries.iter().for_each(|boundary| {
-      let init_fn_name = &module_idx_to_init_fn_name[&boundary.accepted_via];
-      source_joiner.append_source(format!("{init_fn_name}()"));
-    });
-
-    // Use stable module IDs for consistent runtime lookup (in compute_hmr_update_single)
-    source_joiner.append_source(format!(
-      "__rolldown_runtime__.applyUpdates([{}]);",
-      hmr_prerequisites
-        .boundaries
-        .iter()
-        .map(|boundary| {
-          let boundary_mod = &self.module_table().modules[boundary.boundary];
-          let accepted_via = &self.module_table().modules[boundary.accepted_via];
-          format!("['{}', '{}']", boundary_mod.stable_id(), accepted_via.stable_id())
-        })
-        .collect::<Vec<_>>()
-        .join(",")
-    ));
-
-    let (mut code, mut map) = source_joiner.join();
-
-    let hmr_patch_id = self.next_hmr_patch_id.fetch_add(1, Ordering::Relaxed);
-    let filename = format!("hmr_patch_{hmr_patch_id}.js");
-
-    let file_dir = self.options.cwd.as_path().join(&self.options.out_dir);
-
-    let sourcemap_asset = if let Some(map) = map.as_mut() {
-      process_code_and_sourcemap(
-        &self.options,
-        &mut code,
-        map,
-        &file_dir,
-        filename.as_str(),
-        0,
-        /*is_css*/ false,
-      )
-      .await?
-    } else {
-      None
-    };
-
-    Ok(HmrUpdate::Patch(HmrPatch {
-      code,
-      filename,
-      sourcemap_filename: sourcemap_asset.as_ref().map(|asset| asset.filename.to_string()),
-      sourcemap: sourcemap_asset.map(|asset| asset.source.try_into_string()).transpose()?,
-      // Use stable module IDs for hmr_boundaries output
-      hmr_boundaries: hmr_prerequisites
-        .boundaries
-        .into_iter()
-        .map(|boundary| HmrBoundaryOutput {
-          boundary: self.module_table().modules[boundary.boundary].stable_id().as_arc_str().clone(),
-          accepted_via: self.module_table().modules[boundary.accepted_via]
-            .stable_id()
-            .as_arc_str()
-            .clone(),
-        })
-        .collect(),
-    }))
-  }
-
   async fn render_hmr_patch_from_prerequisites(
     &self,
     hmr_prerequisites: HmrPrerequisites,
+    changed_modules: &FxIndexSet<ModuleIdx>,
     new_added_modules: &FxIndexSet<ModuleIdx>,
+    client: &ClientHmrInput<'_>,
   ) -> BuildResult<HmrUpdate> {
-    let mut modules_to_be_updated = hmr_prerequisites.modules_to_be_updated;
+    let mut modules_to_reexecute = hmr_prerequisites.modules_to_be_updated;
 
-    // Extend with newly added modules from refetch
-    modules_to_be_updated.extend(new_added_modules.iter().copied());
+    // Newly discovered modules may be reached through dynamic imports, which the synchronous
+    // definition walk intentionally does not follow. Include their definitions so the rewritten
+    // dynamic import can initialize them when it executes.
+    modules_to_reexecute.extend(new_added_modules.iter().copied());
     // Note: New added modules might include external modules. There's no way to "update" them, so we need to remove them.
-    modules_to_be_updated.retain(|idx| self.module_table().modules[*idx].is_normal());
+    modules_to_reexecute.retain(|idx| self.module_table().modules[*idx].is_normal());
 
-    // Sorting `modules_to_be_updated` is not strictly necessary, but it:
+    let mut render_plan =
+      HmrRenderPlan::new(modules_to_reexecute, hmr_prerequisites.modules_to_invoke_if_loaded);
+    let mut actual_updates = changed_modules.clone();
+    actual_updates.extend(new_added_modules.iter().copied());
+    render_plan.complete_for_client(&self.module_table().modules, &actual_updates, client);
+
+    // Sorting `modules_to_render` is not strictly necessary, but it:
     // - Makes the snapshot more stable when we change logic that affects the order of modules.
-    modules_to_be_updated
+    render_plan
+      .modules_to_render
       .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id().as_str());
 
-    let module_idx_to_init_fn_name = modules_to_be_updated
-      .iter()
-      .enumerate()
-      .map(|(index, module_idx)| {
-        let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
-          unreachable!(
-            "External modules should be removed before. But got {:?}",
-            self.module_table().modules[*module_idx].id().as_str()
-          );
-        };
-        let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };
-
-        // We use `index` as a part of the function name to avoid name collision without needing to deconflict.
-        (*module_idx, format!("{}_{}_{}", prefix, module.repr_name, index))
-      })
-      .collect::<FxHashMap<_, _>>();
-
-    let index_ecma_ast = self.index_ecma_ast();
-    let module_render_inputs = modules_to_be_updated
-      .iter()
-      .copied()
-      .map(|affected_module_idx| {
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("HMR only supports normal module");
-        };
-
-        debug_assert_eq!(affected_module_idx, affected_module.idx);
-        let ecma_ast =
-          index_ecma_ast[affected_module_idx].as_ref().expect("Normal module should have an AST");
-
-        ModuleRenderInput {
-          idx: affected_module.idx,
-          ecma_ast: ecma_ast.clone_with_another_arena(),
-        }
-      })
-      .collect::<Vec<_>>();
+    let RenderedModules { init_fn_names, sources } = self
+      .render_modules(&render_plan.modules_to_render, |module_idx| {
+        render_plan.initializer_mode(module_idx)
+      });
 
     let mut source_joiner = SourceJoiner::default();
-    let rendered_sources = module_render_inputs
-      .into_par_iter()
-      .enumerate()
-      .flat_map(|(index, render_input)| {
-        let ModuleRenderInput { idx: affected_module_idx, ecma_ast: mut ast } = render_input;
-
-        let affected_module = &self.module_table().modules[affected_module_idx];
-        let Module::Normal(affected_module) = affected_module else {
-          unreachable!("HMR only supports normal module");
-        };
-
-        let enable_sourcemap = self.options.sourcemap.is_some() && !affected_module.is_virtual();
-        let use_pife_for_module_wrappers =
-          self.options.optimization.is_pife_for_module_wrappers_enabled();
-        let modules = &self.module_table().modules;
-
-        ast.program.with_mut(|fields| {
-          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
-
-          let mut finalizer = HmrAstFinalizer {
-            modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
-            import_bindings: FxHashMap::default(),
-            module: affected_module,
-            exports: oxc::allocator::Vec::new_in(fields.allocator),
-            affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
-            use_pife_for_module_wrappers,
-            dedup_module_initializer: false,
-            dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
-            generated_static_import_infos: FxHashMap::default(),
-            re_export_all_dependencies: FxIndexSet::default(),
-            generated_static_import_stmts_from_external: FxIndexMap::default(),
-            unique_index: index,
-            named_exports: FxHashMap::default(),
-          };
-
-          traverse_mut(&mut finalizer, fields.allocator, fields.program, scoping, ());
-        });
-
-        let codegen = EcmaCompiler::print_with(
-          &ast,
-          PrintOptions {
-            sourcemap: enable_sourcemap,
-            filename: affected_module.id.to_string(),
-            comments: PrintCommentsOptions {
-              legal: false, // ignore hmr chunk comments
-              annotation: self.options.comments.annotation,
-              jsdoc: self.options.comments.jsdoc,
-            },
-            initial_indent: 0,
-          },
-        );
-
-        let intro_comment: Box<dyn Source + Send> =
-          Box::new(concat_string!("//#region ", affected_module.debug_id));
-        let outro_comment: Box<dyn Source + Send> = Box::new(concat_string!("//#endregion"));
-
-        let code_source: Box<dyn Source + Send> = if let Some(map) = codegen.map {
-          Box::new(SourceMapSource::new(codegen.code, map.into_inner()))
-        } else {
-          Box::new(codegen.code)
-        };
-
-        [intro_comment, code_source, outro_comment]
-      })
-      .collect::<Vec<_>>();
-
-    for source in rendered_sources {
+    for source in sources {
       source_joiner.append_source_dyn(source);
     }
 
+    for module_idx in render_plan
+      .modules_to_render
+      .iter()
+      .filter(|module_idx| render_plan.modules_to_invoke_if_loaded().contains(*module_idx))
+    {
+      let stable_id =
+        serde_json::to_string(self.module_table().modules[*module_idx].stable_id().as_str())
+          .expect("stable module IDs should serialize");
+      let init_fn_name = &init_fn_names[module_idx];
+      source_joiner.append_source(format!(
+        "__rolldown_runtime__.runModuleInitializerIfLoaded({stable_id}, {init_fn_name});"
+      ));
+    }
+
     hmr_prerequisites.boundaries.iter().for_each(|boundary| {
-      let init_fn_name = &module_idx_to_init_fn_name[&boundary.accepted_via];
-      source_joiner.append_source(format!("{init_fn_name}()"));
+      if !render_plan.modules_to_invoke_if_loaded().contains(&boundary.accepted_via) {
+        let init_fn_name = &init_fn_names[&boundary.accepted_via];
+        source_joiner.append_source(format!("{init_fn_name}()"));
+      }
     });
 
     // Use stable module IDs for consistent runtime lookup (in render_hmr_patch_from_prerequisites)
@@ -1124,6 +672,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     let mut require_full_reload = false;
     let mut full_reload_reason = None;
     let mut modules_to_be_updated = FxIndexSet::default();
+    let mut modules_to_invoke_if_loaded = FxIndexSet::default();
 
     for stale_module in stale_modules.iter().copied() {
       if require_full_reload {
@@ -1132,6 +681,20 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       let mut boundaries = FxIndexSet::default();
 
       if !client.is_module_executed(self.module_table().modules[stale_module].stable_id()) {
+        let Module::Normal(module) = &self.module_table().modules[stale_module] else {
+          continue;
+        };
+        if module.is_hmr_self_accepting_module() {
+          tracing::trace!(
+            "[HmrStage] conditionally update self-accepting module {:?} for client {} because its registration may be in flight",
+            module.stable_id,
+            client.client_id,
+          );
+          modules_to_be_updated.insert(stale_module);
+          modules_to_invoke_if_loaded.insert(stale_module);
+          hmr_boundaries.insert(HmrBoundary { boundary: stale_module, accepted_via: stale_module });
+          continue;
+        }
         tracing::trace!(
           "[HmrStage] skip stale module {:?} for client {} since it's not executed",
           self.module_table().modules[stale_module].stable_id(),
@@ -1208,6 +771,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     HmrPrerequisites {
       boundaries: hmr_boundaries,
       modules_to_be_updated,
+      modules_to_invoke_if_loaded,
       require_full_reload,
       full_reload_reason,
     }
@@ -1218,6 +782,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 struct HmrPrerequisites {
   boundaries: FxIndexSet<HmrBoundary>,
   modules_to_be_updated: FxIndexSet<ModuleIdx>,
+  modules_to_invoke_if_loaded: FxIndexSet<ModuleIdx>,
   require_full_reload: bool,
   full_reload_reason: Option<String>,
 }
@@ -1232,11 +797,6 @@ impl PropagateUpdateStatus {
   pub fn is_reach_hmr_boundary(&self) -> bool {
     matches!(self, Self::ReachHmrBoundary)
   }
-}
-
-struct ModuleRenderInput {
-  pub idx: ModuleIdx,
-  pub ecma_ast: EcmaAst,
 }
 
 impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -10,7 +10,7 @@ use rolldown_ecmascript::{
 };
 
 use crate::hmr::{
-  hmr_ast_finalizer::HmrAstFinalizer,
+  hmr_ast_finalizer::{HmrAstFinalizer, ModuleInitializerMode},
   utils::{HmrAstBuilder, MODULE_ID_PARAM_FOR_HMR},
 };
 
@@ -144,10 +144,8 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
     user_code_wrapper.pife = self.use_pife_for_module_wrappers;
 
-    // Initializer call arguments: always (stable_id, factory). For lazy-compilation
-    // chunks we append a truthy dedup flag so the runtime short-circuits re-execution
-    // when another lazy blob has already registered this module. HMR patches omit the
-    // flag so the runtime always re-executes the body to publish new exports.
+    // Initializer call arguments: always (stable_id, factory). An optional numeric mode tells the
+    // runtime to deduplicate a definition.
     let mut initializer_args = self.snippet.builder.vec_with_capacity(3);
     initializer_args.push(ast::Argument::StringLiteral(self.snippet.builder.alloc_string_literal(
       SPAN,
@@ -156,10 +154,14 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     )));
     initializer_args
       .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
-    if self.dedup_module_initializer {
+    let mode = match self.module_initializer_mode {
+      ModuleInitializerMode::Always => None,
+      ModuleInitializerMode::Deduplicate => Some(1.0),
+    };
+    if let Some(mode) = mode {
       initializer_args.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
         SPAN,
-        1.0,
+        mode,
         None,
         ast::NumberBase::Decimal,
       )));

--- a/crates/rolldown/src/hmr/mod.rs
+++ b/crates/rolldown/src/hmr/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "experimental")]
 pub mod hmr_ast_finalizer;
 #[cfg(feature = "experimental")]
+mod hmr_render_plan;
+#[cfg(feature = "experimental")]
+mod hmr_renderer;
+#[cfg(feature = "experimental")]
 pub mod hmr_stage;
 #[cfg(feature = "experimental")]
 pub mod impl_traverse_for_hmr_ast_finalizer;

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -74,7 +74,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
-init_parent_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("parent.js", init_parent_0);
 __rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 ```
 
@@ -102,7 +102,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer("child.js", (functi
 }));
 
 //#endregion
-init_child_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("child.js", init_child_0);
 __rolldown_runtime__.applyUpdates([['parent.js', 'child.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_bridge_esm_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_bridge_esm_default/artifacts.snap
@@ -66,7 +66,7 @@ var require_bridge_0 = __rolldown_runtime__.createCjsInitializer("bridge.js", (f
 }));
 
 //#endregion
-require_bridge_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("bridge.js", require_bridge_0);
 __rolldown_runtime__.applyUpdates([['main.js', 'bridge.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_exports_lhs_rewrite/artifacts.snap
@@ -47,7 +47,7 @@ var require_a_0 = __rolldown_runtime__.createCjsInitializer("a.js", (function(__
 }));
 
 //#endregion
-require_a_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("a.js", require_a_0);
 __rolldown_runtime__.applyUpdates([['a.js', 'a.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_requires_esm_interop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_requires_esm_interop/artifacts.snap
@@ -94,7 +94,7 @@ var init_shim_0 = __rolldown_runtime__.createEsmInitializer("shim.js", (function
 }));
 
 //#endregion
-init_shim_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("shim.js", init_shim_0);
 __rolldown_runtime__.applyUpdates([['main.js', 'shim.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -62,7 +62,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
-init_parent_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("parent.js", init_parent_0);
 __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 ```
 
@@ -116,6 +116,7 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
+__rolldown_runtime__.runModuleInitializerIfLoaded("child.js", init_child_0);
 init_parent_1()
 __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 ```
@@ -150,7 +151,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
-init_parent_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("parent.js", init_parent_0);
 __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
@@ -60,7 +60,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
-init_parent_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("parent.js", init_parent_0);
 __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 ```
 
@@ -109,7 +109,8 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer("parent.js", (func
 }));
 
 //#endregion
-init_parent_1()
+__rolldown_runtime__.runModuleInitializerIfLoaded("child.js", init_child_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("parent.js", init_parent_1);
 __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/destructured_reexport/artifacts.snap
@@ -62,7 +62,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(_
 }));
 
 //#endregion
-init_hmr_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("hmr.js", init_hmr_0);
 __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -109,7 +109,9 @@ var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer("new-dep-esm.
 }));
 
 //#endregion
-init_hmr_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("hmr.js", init_hmr_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("new-dep-cjs.js", require_new_dep_cjs_1);
+__rolldown_runtime__.runModuleInitializerIfLoaded("new-dep-esm.js", init_new_dep_esm_2);
 __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -60,7 +60,7 @@ var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(_
 }));
 
 //#endregion
-init_dep_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("dep.js", init_dep_0);
 __rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -78,7 +78,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(_
 }));
 
 //#endregion
-init_hmr_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("hmr.js", init_hmr_0);
 __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -79,7 +79,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(_
 }));
 
 //#endregion
-init_hmr_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("hmr.js", init_hmr_0);
 __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -116,7 +116,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer("self_accept.
 }));
 
 //#endregion
-init_self_accept_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("self_accept.js", init_self_accept_0);
 __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 ```
 
@@ -148,7 +148,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer("self_accept.
 }));
 
 //#endregion
-init_self_accept_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("self_accept.js", init_self_accept_0);
 __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 ```
 
@@ -176,7 +176,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer("single_accept/chil
 }));
 
 //#endregion
-init_child_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("single_accept/child.js", init_child_0);
 __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
 ```
 
@@ -204,7 +204,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer("single_accept/chil
 }));
 
 //#endregion
-init_child_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("single_accept/child.js", init_child_0);
 __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
 ```
 
@@ -232,7 +232,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer("array_accept/child
 }));
 
 //#endregion
-init_child_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("array_accept/child.js", init_child_0);
 __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
 ```
 
@@ -260,7 +260,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer("array_accept/child
 }));
 
 //#endregion
-init_child_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("array_accept/child.js", init_child_0);
 __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
 ```
 
@@ -292,7 +292,7 @@ var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer("option
 }));
 
 //#endregion
-init_optional_chaining_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("optional_chaining.js", init_optional_chaining_0);
 __rolldown_runtime__.applyUpdates([['optional_chaining.js', 'optional_chaining.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -106,7 +106,8 @@ var init_messenger_1 = __rolldown_runtime__.createEsmInitializer("messenger.js",
 }));
 
 //#endregion
-init_messenger_1()
+__rolldown_runtime__.runModuleInitializerIfLoaded("foo.js", init_foo_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("messenger.js", init_messenger_1);
 __rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -133,7 +133,10 @@ var init_messenger_3 = __rolldown_runtime__.createEsmInitializer("messenger.js",
 }));
 
 //#endregion
-init_messenger_3()
+__rolldown_runtime__.runModuleInitializerIfLoaded("bar.js", init_bar_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("common.js", init_common_1);
+__rolldown_runtime__.runModuleInitializerIfLoaded("foo.js", init_foo_2);
+__rolldown_runtime__.runModuleInitializerIfLoaded("messenger.js", init_messenger_3);
 __rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_after_generate_bundle_error/artifacts.snap
@@ -41,7 +41,7 @@ var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(_
 }));
 
 //#endregion
-init_dep_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("dep.js", init_dep_0);
 __rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 
@@ -84,7 +84,7 @@ var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(_
 }));
 
 //#endregion
-init_dep_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("dep.js", init_dep_0);
 __rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -369,6 +369,17 @@ var init_trigger_dep_11 = __rolldown_runtime__.createEsmInitializer("trigger-dep
 }));
 
 //#endregion
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/deconflict_import_bindings/foo.mjs", init_foo_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/deconflict_import_bindings/foo/index.mjs", init_foo_1);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/deconflict_import_bindings/index.js", init_deconflict_import_bindings_2);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/manual_reexport/barrel.js", init_barrel_3);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/manual_reexport/index.js", init_manual_reexport_4);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/manual_reexport/lib.js", init_lib_5);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/require/cjs-lib-reassign-module-exports.js", require_cjs_lib_reassign_module_exports_6);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/require/cjs-lib.js", require_cjs_lib_7);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/require/index.js", init_require_8);
+__rolldown_runtime__.runModuleInitializerIfLoaded("cases/require/umd-lib.js", require_umd_lib_9);
+__rolldown_runtime__.runModuleInitializerIfLoaded("trigger-dep.js", init_trigger_dep_11);
 init_main_10()
 __rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -60,7 +60,7 @@ var init_c_0 = __rolldown_runtime__.createEsmInitializer("c.js", (function(__rol
 }));
 
 //#endregion
-init_c_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("c.js", init_c_0);
 __rolldown_runtime__.applyUpdates([['c.js', 'c.js']]);
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -135,7 +135,9 @@ var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer("modules/new-
 }));
 
 //#endregion
-init_hmr_0()
+__rolldown_runtime__.runModuleInitializerIfLoaded("hmr.js", init_hmr_0);
+__rolldown_runtime__.runModuleInitializerIfLoaded("modules/new-dep-cjs.js", require_new_dep_cjs_1);
+__rolldown_runtime__.runModuleInitializerIfLoaded("modules/new-dep-esm.js", init_new_dep_esm_2);
 __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -81,14 +81,21 @@ export class DevRuntime {
       return {};
     }
   }
+  /**
+   * Re-execute a real HMR update only if this client already loaded the module.
+   *
+   * @param {string} id
+   * @param {() => any} initializer
+   */
+  runModuleInitializerIfLoaded(id, initializer) {
+    if (this.modules[id]) initializer();
+  }
 
   /**
    * __esmMin
    *
    * When `dedup` is truthy and `id` is already registered on the runtime,
-   * skip the factory: another lazy blob got there first. HMR patches pass
-   * no `dedup` so they always re-run the factory and replace the registered
-   * exports.
+   * skip the factory.
    *
    * @type {<T>(id: string, fn: any, dedup: any, res: T) => () => T}
    * @internal
@@ -100,9 +107,7 @@ export class DevRuntime {
   /**
    * __commonJSMin
    *
-   * Same dedup gate as createEsmInitializer. With `dedup` truthy and `id`
-   * registered, reuse the registered exports object; otherwise run the
-   * factory.
+   * Same dedup gate as createEsmInitializer.
    *
    * @type {<T extends { exports: any }>(id: string, cb: any, dedup: any, mod: { exports: any }, registered: any) => () => T}
    * @internal

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -91,7 +91,14 @@
       "entry": ["dev.config.mjs", "src/*.js"], // no @rolldown/test-dev-server plugin
     },
     "packages/test-dev-server/tests/playground/hmr-full-bundle-mode": {
-      "entry": ["dev.config.mjs", "main.js", "hmr.js"], // Playwright test with dev config and source files
+      "entry": [
+        "dev.config.mjs",
+        "main.js",
+        "hmr.js",
+        "late-accept.js",
+        "dynamic-importer.js",
+        "unloaded-entry.js",
+      ], // Playwright test with dev config and source files
     },
     "packages/test-dev-server/tests/playground/lazy-compilation": {
       "entry": ["dev.config.mjs", "main.js", "lazy-module.js"], // Playwright test with dev config and source files

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -179,7 +179,10 @@ class DevServer {
             break;
           case 'hmr:module-registered': {
             console.log('Registering modules:', clientMessage.modules);
-            this.#devEngine?.registerModules(clientSession.id, clientMessage.modules);
+            await this.#devEngine?.registerModules(clientSession.id, clientMessage.modules);
+            for (const moduleId of clientMessage.modules) {
+              clientSession.registeredModules.add(moduleId);
+            }
             this.#moduleRegistrationSeq++;
             break;
           }
@@ -239,6 +242,12 @@ class DevServer {
             buildSeq: this.#buildSeq,
             connectedClients: this.#clients.size,
             moduleRegistrationSeq: this.#moduleRegistrationSeq,
+            registeredModulesByClient: Object.fromEntries(
+              Array.from(this.#clients, ([clientId, client]) => [
+                clientId,
+                Array.from(client.registeredModules),
+              ]),
+            ),
           }),
         );
         return;

--- a/packages/test-dev-server/src/types/client-session.ts
+++ b/packages/test-dev-server/src/types/client-session.ts
@@ -3,6 +3,7 @@ import type { WebSocket } from 'ws';
 export class ClientSession {
   id: string;
   ws: WebSocket;
+  registeredModules = new Set<string>();
 
   constructor(ws: WebSocket, id: string) {
     this.id = id;

--- a/packages/test-dev-server/tests/browser.spec.ts
+++ b/packages/test-dev-server/tests/browser.spec.ts
@@ -1,21 +1,154 @@
 import { setTimeout } from 'node:timers/promises';
+import type { Page, Request } from 'playwright';
 import { describe, expect, test } from 'vitest';
 import { CONFIG } from './src/config';
 import {
   editFile,
   editLazySharedModuleFile,
+  getClientRegisteredModules,
   getLazyAliasedImportPage,
   getLazyPage,
   getLazySharedModulePage,
   getNestedLazyPage,
   getPage,
   waitForBuildStable,
+  waitForClientModuleRegistration,
 } from './test-utils';
 
+const HMR_URL = `http://localhost:${CONFIG.ports.hmrFullBundleMode}`;
 const LAZY_URL = `http://localhost:${CONFIG.ports.lazyCompilation}`;
 const LAZY_SHARED_MODULE_URL = `http://localhost:${CONFIG.ports.lazySharedModule}`;
 const NESTED_LAZY_URL = `http://localhost:${CONFIG.ports.lazyNestedDynamicImport}`;
 const LAZY_ALIASED_IMPORT_URL = `http://localhost:${CONFIG.ports.lazyAliasedImport}`;
+
+const IDENTITY_RENDER = 'export const render = (value) => value;';
+const FACADE_RENDER = "import { decorate } from './facade.js';\nexport const render = decorate;";
+const CJS_FACADE_RENDER =
+  "import cjsFacade from './cjs-facade.cjs';\nexport const render = cjsFacade.decorate;";
+const CONDITIONAL_CJS_FACADE_RENDER =
+  "import conditionalCjsFacade from './conditional-cjs-facade.cjs';\n" +
+  'export const render = conditionalCjsFacade.decorate;';
+const CONDITIONAL_CHANGED_RENDER =
+  "if (globalThis.__runConditionalChanged) require('./conditional-changed.cjs');\n" +
+  IDENTITY_RENDER;
+
+async function getHmrClientId(page: Page) {
+  return page.evaluate(() => (globalThis as any).__rolldown_runtime__.clientId as string);
+}
+
+async function waitForHmrClientModules(page: Page, modules: string[]) {
+  const clientId = await getHmrClientId(page);
+  await waitForClientModuleRegistration(CONFIG.ports.hmrFullBundleMode, clientId, modules);
+  return clientId;
+}
+
+async function openHmrPage(page: Page) {
+  await page.goto(HMR_URL, { waitUntil: 'networkidle' });
+  await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+  await waitForHmrClientModules(page, ['hmr.js']);
+}
+
+async function reloadHmrPage(page: Page) {
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+  await waitForHmrClientModules(page, ['hmr.js']);
+}
+
+async function holdModuleRegistrationMessages(page: Page) {
+  await page.evaluate(() => {
+    const runtime = (globalThis as any).__rolldown_runtime__;
+    const messenger = runtime.messenger;
+    const originalSend = messenger.send;
+    const heldMessages: unknown[] = [];
+
+    messenger.send = (message: unknown) => {
+      heldMessages.push(message);
+    };
+    (globalThis as any).__rolldownRegistrationHold = {
+      heldMessages,
+      release() {
+        messenger.send = originalSend;
+        for (const message of heldMessages) {
+          originalSend.call(messenger, message);
+        }
+        delete (globalThis as any).__rolldownRegistrationHold;
+      },
+    };
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => (globalThis as any).__rolldownRegistrationHold?.heldMessages.length ?? 0),
+    )
+    .toBe(0);
+
+  return async () => {
+    await page.evaluate(() => (globalThis as any).__rolldownRegistrationHold?.release());
+  };
+}
+
+async function loadFacadeWithoutAcknowledging(page: Page) {
+  const clientId = await getHmrClientId(page);
+  const release = await holdModuleRegistrationMessages(page);
+
+  try {
+    await page.addScriptTag({ type: 'module', url: '/unloaded.js' });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (globalThis as any).__rolldownRegistrationHold?.heldMessages.length ?? 0,
+        ),
+      )
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() => page.evaluate(() => (globalThis as any).__implementationExecutions))
+      .toBe(1);
+
+    const registeredModules = await getClientRegisteredModules(
+      CONFIG.ports.hmrFullBundleMode,
+      clientId,
+    );
+    expect(registeredModules).not.toContain('facade.js');
+    expect(registeredModules).not.toContain('implementation.js');
+
+    return release;
+  } catch (error) {
+    await release().catch(() => {});
+    throw error;
+  }
+}
+
+function trackHmrPatchRequests(page: Page) {
+  const urls: string[] = [];
+  const onRequest = (request: Request) => {
+    const url = new URL(request.url());
+    if (/\/\d+\.js$/.test(url.pathname)) {
+      urls.push(request.url());
+    }
+  };
+  page.on('request', onRequest);
+  return {
+    urls,
+    stop: () => page.off('request', onRequest),
+  };
+}
+
+async function readHmrPatch(urls: string[]) {
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+  const response = await fetch(urls.at(-1)!);
+  expect(response.ok).toBe(true);
+  return response.text();
+}
+
+async function markPageInstance(page: Page) {
+  const marker = `hmr-page-${Date.now()}-${Math.random()}`;
+  await page.evaluate((value) => ((globalThis as any).__hmrPageInstance = value), marker);
+  return async () => {
+    await expect
+      .poll(() => page.evaluate(() => (globalThis as any).__hmrPageInstance))
+      .toBe(marker);
+  };
+}
 
 describe('hmr-full-bundle-mode', () => {
   test.sequential('should render initial content', async () => {
@@ -51,6 +184,314 @@ describe('hmr-full-bundle-mode', () => {
     await editFile('hmr.js', (code) => code.replace("const foo = 'hello2'", "const foo = 'hello'"));
     await expect.poll(() => page.textContent('.hmr')).toBe('hello');
   });
+
+  test.sequential('backfills missing static ESM dependencies', async () => {
+    const page = getPage();
+    const assertNoReload = await markPageInstance(page);
+
+    try {
+      await editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, FACADE_RENDER));
+      await expect.poll(() => page.textContent('.hmr')).toBe('[hello]');
+      await assertNoReload();
+    } finally {
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('hmr.js', (code) => code.replace(FACADE_RENDER, IDENTITY_RENDER));
+    }
+
+    await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
+
+  test.sequential('backfills missing CommonJS require dependencies', async () => {
+    const page = getPage();
+    const assertNoReload = await markPageInstance(page);
+
+    try {
+      await editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, CJS_FACADE_RENDER));
+      await expect.poll(() => page.textContent('.hmr')).toBe('[cjs:hello]');
+      await assertNoReload();
+    } finally {
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('hmr.js', (code) => code.replace(CJS_FACADE_RENDER, IDENTITY_RENDER));
+    }
+
+    await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
+
+  test.sequential('does not eagerly execute conditional CommonJS require dependencies', async () => {
+    const page = getPage();
+    const patches = trackHmrPatchRequests(page);
+    const assertNoReload = await markPageInstance(page);
+
+    try {
+      await editFile('hmr.js', (code) =>
+        code.replace(IDENTITY_RENDER, CONDITIONAL_CJS_FACADE_RENDER),
+      );
+      await expect.poll(() => page.textContent('.hmr')).toBe('[conditional:hello]');
+      await expect
+        .poll(() => page.evaluate(() => (globalThis as any).__conditionalCjsExecutions))
+        .toBeUndefined();
+      await assertNoReload();
+
+      const patch = await readHmrPatch(patches.urls);
+      expect(patch).toContain('conditional-cjs-facade.cjs');
+      expect(patch).toContain('conditional-cjs-side-effect.cjs');
+    } finally {
+      patches.stop();
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('hmr.js', (code) =>
+        code.replace(CONDITIONAL_CJS_FACADE_RENDER, IDENTITY_RENDER),
+      );
+    }
+
+    await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
+
+  test.sequential('updates a loaded changed dependency behind a false conditional require', async () => {
+    const loadedPage = getPage();
+    const browser = loadedPage.context().browser();
+    expect(browser).not.toBeNull();
+    const unloadedContext = await browser!.newContext();
+    const unloadedPage = await unloadedContext.newPage();
+
+    try {
+      await openHmrPage(unloadedPage);
+      await loadedPage.evaluate(() => {
+        (globalThis as any).__rolldown_runtime__.registerModule('conditional-changed.cjs', {
+          exports: {},
+        });
+        (globalThis as any).__conditionalChangedValue = 'stale';
+        (globalThis as any).__runConditionalChanged = false;
+      });
+      await waitForHmrClientModules(loadedPage, ['conditional-changed.cjs']);
+
+      await editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, CONDITIONAL_CHANGED_RENDER));
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('conditional-changed.cjs', (code) => code.replace("'initial'", "'updated'"));
+
+      await expect
+        .poll(() => loadedPage.evaluate(() => (globalThis as any).__conditionalChangedValue))
+        .toBe('updated');
+      await expect
+        .poll(() => unloadedPage.evaluate(() => (globalThis as any).__conditionalChangedValue))
+        .toBeUndefined();
+    } finally {
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('conditional-changed.cjs', (code) => code.replace("'updated'", "'initial'"));
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('hmr.js', (code) => code.replace(CONDITIONAL_CHANGED_RENDER, IDENTITY_RENDER));
+      await unloadedContext.close();
+    }
+
+    await expect.poll(() => loadedPage.textContent('.hmr')).toBe('hello');
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
+
+  test.sequential('backfills an existing unloaded dynamic import target', async () => {
+    const page = getPage();
+    const assertNoReload = await markPageInstance(page);
+
+    try {
+      await page.addScriptTag({ type: 'module', url: '/dynamicImporter.js' });
+      await page.evaluate(() => {
+        (globalThis as any).__loadDynamicExisting = true;
+      });
+      await editFile('dynamic-importer.js', (code) => code.replace("'initial'", "'updated'"));
+      await expect
+        .poll(() => page.evaluate(() => (globalThis as any).__dynamicExistingValue))
+        .toBe('dynamic-existing');
+      await assertNoReload();
+    } finally {
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+      await editFile('dynamic-importer.js', (code) => code.replace("'updated'", "'initial'"));
+    }
+
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
+
+  test.sequential(
+    'deduplicates a backfill before its real registration acknowledgement arrives',
+    { retry: 0 },
+    async () => {
+      const page = getPage();
+      const browser = page.context().browser();
+      expect(browser).not.toBeNull();
+      const context = await browser!.newContext();
+      const racePage = await context.newPage();
+      let release: (() => Promise<void>) | undefined;
+
+      try {
+        await openHmrPage(racePage);
+        release = await loadFacadeWithoutAcknowledging(racePage);
+        await editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, FACADE_RENDER));
+        await expect.poll(() => racePage.textContent('.hmr')).toBe('[hello]');
+        await expect
+          .poll(() => racePage.evaluate(() => (globalThis as any).__implementationExecutions))
+          .toBe(1);
+      } finally {
+        await release?.();
+        await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+        await editFile('hmr.js', (code) => code.replace(FACADE_RENDER, IDENTITY_RENDER));
+        await context.close();
+      }
+
+      await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+    },
+  );
+
+  test.sequential(
+    'updates a self-accepting module before its registration acknowledgement arrives',
+    { retry: 0 },
+    async () => {
+      const page = getPage();
+      const browser = page.context().browser();
+      expect(browser).not.toBeNull();
+      const context = await browser!.newContext();
+      const racePage = await context.newPage();
+      await openHmrPage(racePage);
+      const clientId = await getHmrClientId(racePage);
+      const release = await holdModuleRegistrationMessages(racePage);
+
+      await racePage.addScriptTag({ type: 'module', url: '/lateAccept.js' });
+      await expect
+        .poll(() => racePage.evaluate(() => (globalThis as any).__lateAcceptValue))
+        .toBe('late');
+      await expect
+        .poll(() =>
+          racePage.evaluate(
+            () => (globalThis as any).__rolldownRegistrationHold?.heldMessages.length ?? 0,
+          ),
+        )
+        .toBeGreaterThan(0);
+      expect(
+        await getClientRegisteredModules(CONFIG.ports.hmrFullBundleMode, clientId),
+      ).not.toContain('late-accept.js');
+
+      try {
+        await editFile('late-accept.js', (code) =>
+          code.replace("export const value = 'late';", "export const value = 'late2';"),
+        );
+        await expect
+          .poll(() => racePage.evaluate(() => (globalThis as any).__lateAcceptValue))
+          .toBe('late2');
+        await expect
+          .poll(() => page.evaluate(() => (globalThis as any).__lateAcceptValue))
+          .toBeUndefined();
+      } finally {
+        await release();
+        await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+        await editFile('late-accept.js', (code) =>
+          code.replace("export const value = 'late2';", "export const value = 'late';"),
+        );
+        await context.close();
+      }
+
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+    },
+  );
+
+  test.sequential(
+    'reexecutes a backfilled ESM path when its dependency changed',
+    { retry: 0 },
+    async () => {
+      const page = getPage();
+      const browser = page.context().browser();
+      expect(browser).not.toBeNull();
+      const context = await browser!.newContext();
+      const racePage = await context.newPage();
+      let release: (() => Promise<void>) | undefined;
+
+      const patches = trackHmrPatchRequests(racePage);
+      try {
+        await openHmrPage(racePage);
+        release = await loadFacadeWithoutAcknowledging(racePage);
+        await Promise.all([
+          editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, FACADE_RENDER)),
+          editFile('implementation.js', (code) =>
+            code.replace('return `[${value}]`;', 'return `<${value}>`;'),
+          ),
+        ]);
+        await expect.poll(() => racePage.textContent('.hmr')).toBe('<hello>');
+        await expect
+          .poll(() => racePage.evaluate(() => (globalThis as any).__implementationExecutions))
+          .toBe(2);
+        await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+
+        const patch = await readHmrPatch(patches.urls);
+        expect(patch).toContain('facade.js');
+        expect(patch).toContain('implementation.js');
+      } finally {
+        patches.stop();
+        await release?.();
+        await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+        await Promise.all([
+          editFile('hmr.js', (code) => code.replace(FACADE_RENDER, IDENTITY_RENDER)),
+          editFile('implementation.js', (code) =>
+            code.replace('return `<${value}>`;', 'return `[${value}]`;'),
+          ),
+        ]);
+        await context.close();
+      }
+
+      await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+    },
+  );
+
+  test.sequential(
+    'renders different patches for clients with different registered modules',
+    { retry: 0 },
+    async () => {
+      const loadedPage = getPage();
+      await reloadHmrPage(loadedPage);
+
+      const browser = loadedPage.context().browser();
+      expect(browser).not.toBeNull();
+      const missingContext = await browser!.newContext();
+      const missingPage = await missingContext.newPage();
+      try {
+        await openHmrPage(missingPage);
+
+        await loadedPage.addScriptTag({ type: 'module', url: '/unloaded.js' });
+        await waitForHmrClientModules(loadedPage, ['facade.js', 'implementation.js']);
+
+        const loadedPagePatches = trackHmrPatchRequests(loadedPage);
+        const missingPagePatches = trackHmrPatchRequests(missingPage);
+        try {
+          await editFile('hmr.js', (code) => code.replace(IDENTITY_RENDER, FACADE_RENDER));
+          await Promise.all([
+            expect.poll(() => loadedPage.textContent('.hmr')).toBe('[hello]'),
+            expect.poll(() => missingPage.textContent('.hmr')).toBe('[hello]'),
+          ]);
+
+          const [loadedPatch, missingPatch] = await Promise.all([
+            readHmrPatch(loadedPagePatches.urls),
+            readHmrPatch(missingPagePatches.urls),
+          ]);
+          expect(loadedPatch).not.toContain('//#region facade.js');
+          expect(missingPatch).toContain('//#region facade.js');
+          expect(missingPatch).toContain('//#region implementation.js');
+        } finally {
+          loadedPagePatches.stop();
+          missingPagePatches.stop();
+          await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+          await editFile('hmr.js', (code) => code.replace(FACADE_RENDER, IDENTITY_RENDER));
+        }
+
+        await Promise.all([
+          expect.poll(() => loadedPage.textContent('.hmr')).toBe('hello'),
+          expect.poll(() => missingPage.textContent('.hmr')).toBe('hello'),
+        ]);
+      } finally {
+        await missingContext.close();
+      }
+
+      await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+    },
+  );
 
   // https://github.com/vitejs/rolldown-vite/blob/942cb2b51b59fd6aefe886ec78eb34fff56ead34/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts#L49-L70
   test.sequential('debounce bundle', async () => {

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/cjs-facade.cjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/cjs-facade.cjs
@@ -1,0 +1,5 @@
+const implementation = require('./cjs-implementation.cjs');
+
+module.exports = {
+  decorate: implementation.decorate,
+};

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/cjs-implementation.cjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/cjs-implementation.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  decorate: (value) => `[cjs:${value}]`,
+};

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-changed.cjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-changed.cjs
@@ -1,0 +1,2 @@
+module.exports = {};
+globalThis.__conditionalChangedValue = 'initial';

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-cjs-facade.cjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-cjs-facade.cjs
@@ -1,0 +1,7 @@
+if (globalThis.__loadConditionalCjs) {
+  require('./conditional-cjs-side-effect.cjs');
+}
+
+module.exports = {
+  decorate: (value) => `[conditional:${value}]`,
+};

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-cjs-side-effect.cjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/conditional-cjs-side-effect.cjs
@@ -1,0 +1,1 @@
+globalThis.__conditionalCjsExecutions = (globalThis.__conditionalCjsExecutions ?? 0) + 1;

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dev.config.mjs
@@ -8,6 +8,10 @@ export default defineDevConfig({
   build: {
     input: {
       main: 'main.js',
+      lateAccept: 'late-accept.js',
+      dynamicImporter: 'dynamic-importer.js',
+      // Keep the facade in Rolldown's graph without loading it in the browser.
+      unloaded: 'unloaded-entry.js',
     },
     platform: 'browser',
     treeshake: false,

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dynamic-existing.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dynamic-existing.js
@@ -1,0 +1,1 @@
+export const value = 'dynamic-existing';

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dynamic-importer.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/dynamic-importer.js
@@ -1,0 +1,11 @@
+if (globalThis.__loadDynamicExisting) {
+  import('./dynamic-existing.js').then((mod) => {
+    globalThis.__dynamicExistingValue = mod.value;
+  });
+}
+
+export const version = 'initial';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/facade.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/facade.js
@@ -1,0 +1,1 @@
+export { decorate } from './implementation.js';

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/hmr.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/hmr.js
@@ -1,6 +1,8 @@
 export const foo = 'hello';
 
-text('.hmr', foo);
+export const render = (value) => value;
+
+text('.hmr', render(foo));
 
 function text(el, text) {
   document.querySelector(el).textContent = text;
@@ -8,6 +10,6 @@ function text(el, text) {
 
 import.meta.hot?.accept((mod) => {
   if (mod) {
-    text('.hmr', mod.foo);
+    text('.hmr', mod.render(mod.foo));
   }
 });

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/implementation.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/implementation.js
@@ -1,0 +1,5 @@
+globalThis.__implementationExecutions = (globalThis.__implementationExecutions ?? 0) + 1;
+
+export function decorate(value) {
+  return `[${value}]`;
+}

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/late-accept.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/late-accept.js
@@ -1,0 +1,9 @@
+export const value = 'late';
+
+globalThis.__lateAcceptValue = value;
+
+import.meta.hot?.accept((mod) => {
+  if (mod) {
+    globalThis.__lateAcceptValue = mod.value;
+  }
+});

--- a/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/unloaded-entry.js
+++ b/packages/test-dev-server/tests/playground/hmr-full-bundle-mode/unloaded-entry.js
@@ -1,0 +1,9 @@
+import { decorate } from './facade.js';
+import cjsFacade from './cjs-facade.cjs';
+import conditionalCjsFacade from './conditional-cjs-facade.cjs';
+import conditionalChanged from './conditional-changed.cjs';
+
+console.log(decorate('unloaded entry'));
+console.log(cjsFacade.decorate('unloaded CJS entry'));
+console.log(conditionalCjsFacade.decorate('unloaded conditional CJS entry'));
+console.log(conditionalChanged);

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import nodeFs from 'node:fs';
 import { resolve } from 'node:path';
 import { vi } from 'vitest';
@@ -118,6 +120,7 @@ interface DevStatus {
   buildSeq: number;
   connectedClients: number;
   moduleRegistrationSeq: number;
+  registeredModulesByClient: Record<string, string[]>;
 }
 
 async function fetchDevStatus(port: number): Promise<DevStatus> {
@@ -202,6 +205,37 @@ export async function waitForModuleRegistration(
 export async function getModuleRegistrationSeq(port: number): Promise<number> {
   const status = await fetchDevStatus(port);
   return status.moduleRegistrationSeq;
+}
+
+/** Poll until the given client has registered every requested module. */
+export async function waitForClientModuleRegistration(
+  port: number,
+  clientId: string,
+  modules: string[],
+  timeoutMs = 30_000,
+): Promise<DevStatus> {
+  return vi.waitFor(
+    async () => {
+      const status = await fetchDevStatus(port);
+      const registeredModules = status.registeredModulesByClient[clientId] ?? [];
+      const missingModules = modules.filter((moduleId) => !registeredModules.includes(moduleId));
+      if (missingModules.length === 0) return status;
+      throw new Error(
+        `Client ${clientId} has not registered: ${missingModules.join(', ')}. ` +
+          `Registered: ${registeredModules.join(', ')}`,
+      );
+    },
+    { timeout: timeoutMs, interval: 50 },
+  );
+}
+
+/** Get the modules the dev server has observed for one client. */
+export async function getClientRegisteredModules(
+  port: number,
+  clientId: string,
+): Promise<string[]> {
+  const status = await fetchDevStatus(port);
+  return status.registeredModulesByClient[clientId] ?? [];
 }
 
 /** Get current build sequence number. */

--- a/packages/test-dev-server/tests/vitest-setup-browser.ts
+++ b/packages/test-dev-server/tests/vitest-setup-browser.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 // Per-file setup that runs in the SAME PROCESS as tests (setupFiles).
 // Each test file gets its own servers, browser, and pages.
 // Servers are killed in afterAll so the worker can exit cleanly.
@@ -31,7 +33,14 @@ async function killPort(port: number): Promise<void> {
   }
 }
 
-const TEST_FILES_TO_RESET = ['hmr.js', 'main.js'];
+const TEST_FILES_TO_RESET = [
+  'conditional-changed.cjs',
+  'dynamic-importer.js',
+  'hmr.js',
+  'implementation.js',
+  'late-accept.js',
+  'main.js',
+];
 
 async function resetTestFiles() {
   for (const filename of TEST_FILES_TO_RESET) {


### PR DESCRIPTION
## Summary

Make full-bundle HMR patches self-contained for each connected browser.

This was surfaced by React Router Framework Mode on Vite 8 bundled dev, but the
underlying bug is framework-independent: an edited module can reference a
module that already exists in Rolldown's graph but has never executed in a
particular browser.

## What was broken

Rolldown rewrites bundled imports, `require()` calls, and dynamic imports to
runtime-registry lookups. A referenced module must therefore either:

1. already be registered in that browser's runtime, or
2. have an initializer definition included in that browser's HMR patch.

Previously, a patch rendered the modules selected by HMR propagation and newly
added modules. It did not complete the patch over existing dependencies missing
from the target browser's runtime registry.

For example:

```js
// edited-module.js
import { decorate } from "./facade.js";
```

If `facade.js` and its implementation were already in Rolldown's graph but had
never executed in that browser, the generated patch could call
`loadExports("facade.js")` without defining `facade.js`.

The same problem applies to an existing unloaded dynamic-import target: the
rewritten dynamic import calls `loadExports()`, so its definition must be in
the patch before the import executes.

## How this fixes it

Each client's patch now builds an explicit render plan after the changed graph
has been refetched and merged:

- start from modules selected by normal HMR propagation and newly added modules
- walk static `import`, `require()`, and dynamic-import edges
- add normal-module definitions missing from that client's executed-module set
- render the completed set once through a shared module renderer

The plan distinguishes **definition availability** from **execution**:

- unchanged missing dependencies are rendered with deduplicated initializers
- real updates use normal non-deduplicated initializers
- real updates are invoked through
  `runModuleInitializerIfLoaded(id, initializer)`, so they run only in browsers
  that had actually loaded them
- static ESM importer paths to real updates are also invoked only when loaded,
  allowing facades to relink without executing them in unrelated browsers

This preserves control-flow semantics:

- an unchanged conditional or function-local `require()` target is defined but
  runs only if the original `require()` expression executes
- a previously loaded changed target behind a currently-false conditional
  `require()` still receives its real update
- a dynamic-import target is defined up front but remains lazy; its initializer
  runs only when the dynamic import executes

Initializers remain one-shot within a patch, so deterministic loaded-only
invocation order cannot execute a module twice.

## Multi-client behavior

Bundled dev tracks registered modules per connected client and asks Rolldown to
render a personalized patch for each client. This change keeps that
architecture and makes each patch complete:

- a browser that already registered an unchanged dependency does not need a
  backfill
- a browser missing it receives a deduplicated definition
- a real update executes only in browsers that previously loaded that module

The browser regressions cover divergent client state directly, including a
changed conditional dependency that updates one browser without affecting a
second browser that never loaded it.

## Scope and limitations

This does not change server-side HMR boundary selection or full-reload
decisions. It makes the patch selected by the existing propagation algorithm
self-contained and client-correct.

The patch deliberately does not infer that a discovered `require()` or dynamic
import edge executed. Safely relinking an unacknowledged non-self-accepting
importer on those edges would require runtime parent/child execution tracking
and is outside this focused fix.

The change also removes duplicate rendering logic by sharing one focused module
renderer between lazy compilation and HMR patch generation.

## Tests

Added browser regressions covering:

- transitive ESM facade backfills
- transitive CommonJS facade backfills
- existing unloaded dynamic-import target backfills
- conditional `require()` definitions without eager execution
- a loaded changed dependency behind a false conditional `require()`
- changed but unacknowledged dependencies and ESM facades
- registration-acknowledgement races without duplicate execution
- two browsers with divergent registered-module sets
- page sentinels proving HMR occurred without reload

Validation run on the final commit:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- --deny warnings --allow clippy::allow_attributes`
- `cargo check --workspace --all-features --all-targets --locked`
- `CI=1 cargo test -p rolldown --test integration hmr --features experimental --locked`
  - 31 passed
- `pnpm --filter @rolldown/test-dev-server-tests run test:fixtures`
  - 9 passed
- `pnpm --filter @rolldown/test-dev-server-tests run test:browser`
  - 18 passed
- `pnpm --filter @rolldown/test-dev-server-tests run typecheck`
