### PR TITLE
fix: cross-chunk CJS wrapper shadowed by author-local binding

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -121,6 +121,25 @@ pub fn deconflict_chunk_symbols(
         .insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
     }
   }
+  if matches!(format, OutputFormat::Esm) {
+    // A CJS wrapper whose module lives in *another* chunk is hoisted here as a real root-scope
+    // import binding (`import { ... as require_foo } from "./other.js"`) and is likewise captured
+    // by every CJS-wrapped closure in this chunk. The in-chunk loop above can't see it because its
+    // owner module isn't in `chunk.modules`, so we recover it from the cross-chunk import list.
+    // Without this, an author-local of the same name inside a CJS closure shadows the imported
+    // wrapper, emitting the self-referential `var require_foo = require_foo()` (issue #9630).
+    for item in chunk.imports_from_other_chunks.values().flatten() {
+      let canonical_ref = link_output.symbol_db.canonical_ref_for(item.import_ref);
+      let is_cjs_wrapper =
+        link_output.metas[canonical_ref.owner].wrapper_ref.is_some_and(|wrapper_ref| {
+          link_output.symbol_db.canonical_ref_for(wrapper_ref) == canonical_ref
+        });
+      if is_cjs_wrapper {
+        chunk_scope_captured_names
+          .insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
+      }
+    }
+  }
 
   chunk
     .modules

--- a/crates/rolldown/tests/rolldown/issues/9630/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9630/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {},
+  "configVariants": [
+    {
+      "_configName": "cjs",
+      "format": "cjs",
+      "treeshake": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/9630/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9630/_test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+// The bug (#9630): a CJS wrapper hoisted across a chunk boundary was imported
+// under its un-deconflicted base name (`require_isArrayLike`), which an author's
+// local binding of the same name then shadowed, emitting the self-shadowing
+// `var require_isArrayLike = require_isArrayLike()`. The CJS variant covers the
+// same cross-chunk wrapper reference without treating CJS's generated
+// `const require_<chunk> = require(...)` binding as an ESM import binding.
+const require = createRequire(import.meta.url);
+const mod =
+  globalThis.__configName === 'cjs' ? require('./dist/main.js') : await import('./dist/main.js');
+
+assert.strictEqual(mod.eager, true);
+assert.strictEqual(await mod.lazy(), 3);

--- a/crates/rolldown/tests/rolldown/issues/9630/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9630/artifacts.snap
@@ -1,0 +1,142 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## isArrayLike.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region isArrayLike.cjs
+var require_isArrayLike = /* @__PURE__ */ __commonJSMin(((exports) => {
+	function isArrayLike(value) {
+		return value != null && typeof value.length === "number";
+	}
+	exports.isArrayLike = isArrayLike;
+}));
+//#endregion
+export { __commonJSMin as n, __toESM as r, require_isArrayLike as t };
+
+```
+
+## last.js
+
+```js
+import { n as __commonJSMin, t as require_isArrayLike$1 } from "./isArrayLike.js";
+//#region last.cjs
+var require_last = /* @__PURE__ */ __commonJSMin(((exports) => {
+	var require_isArrayLike = require_isArrayLike$1();
+	function last(array) {
+		if (!require_isArrayLike.isArrayLike(array)) return;
+		return array[array.length - 1];
+	}
+	var require_isArrayLike$2 = {};
+	exports.shadow = function() {
+		return require_isArrayLike$2;
+	};
+	exports.last = last;
+}));
+//#endregion
+export default require_last();
+
+```
+
+## main.js
+
+```js
+import { r as __toESM, t as require_isArrayLike } from "./isArrayLike.js";
+const eager = (0, require_isArrayLike().isArrayLike)([1]);
+async function lazy() {
+	return (await import("./last.js").then((m) => /* @__PURE__ */ __toESM(m.default))).default.last([
+		1,
+		2,
+		3
+	]);
+}
+//#endregion
+export { eager, lazy };
+
+```
+
+# Variant: cjs: [format: Cjs] [treeshake: Boolean(false)]
+
+## Assets
+
+### isArrayLike.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region isArrayLike.cjs
+var require_isArrayLike = /* @__PURE__ */ __commonJSMin(((exports) => {
+	function isArrayLike(value) {
+		return value != null && typeof value.length === "number";
+	}
+	exports.isArrayLike = isArrayLike;
+}));
+//#endregion
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+Object.defineProperty(exports, "require_isArrayLike", {
+	enumerable: true,
+	get: function() {
+		return require_isArrayLike;
+	}
+});
+
+```
+
+### last.js
+
+```js
+const require_isArrayLike$1 = require("./isArrayLike.js");
+//#region last.cjs
+var require_last = /* @__PURE__ */ require_isArrayLike$1.__commonJSMin(((exports) => {
+	var require_isArrayLike = require_isArrayLike$1.require_isArrayLike();
+	function last(array) {
+		if (!require_isArrayLike.isArrayLike(array)) return;
+		return array[array.length - 1];
+	}
+	var require_isArrayLike$2 = {};
+	exports.shadow = function() {
+		return require_isArrayLike$2;
+	};
+	exports.last = last;
+}));
+//#endregion
+Object.defineProperty(exports, "default", {
+	enumerable: true,
+	get: function() {
+		return require_last();
+	}
+});
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_isArrayLike$1 = require("./isArrayLike.js");
+const eager = (0, require_isArrayLike$1.require_isArrayLike().isArrayLike)([1]);
+async function lazy() {
+	return (await Promise.resolve().then(() => /* @__PURE__ */ require_isArrayLike$1.__toESM(require("./last.js").default))).default.last([
+		1,
+		2,
+		3
+	]);
+}
+//#endregion
+exports.eager = eager;
+exports.lazy = lazy;
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9630/isArrayLike.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9630/isArrayLike.cjs
@@ -1,0 +1,7 @@
+// CommonJS leaf. Rolldown derives its wrapper-function name from the filename:
+// `require_isArrayLike`. `main.js` imports it eagerly, so its wrapper is hoisted
+// into the entry chunk — a *different* chunk than `last.cjs`'s wrapper.
+function isArrayLike(value) {
+  return value != null && typeof value.length === 'number';
+}
+exports.isArrayLike = isArrayLike;

--- a/crates/rolldown/tests/rolldown/issues/9630/last.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9630/last.cjs
@@ -1,0 +1,24 @@
+// CommonJS module that requires the leaf. The critical detail (copied from
+// es-toolkit's compiled `dist/compat/array/last.js`): the author's OWN local
+// binding is literally named `require_isArrayLike` — the SAME name rolldown
+// derives for the leaf's wrapper function. When both wrappers land in the same
+// chunk, rolldown deconflicts (wrapper -> `require_isArrayLike$1`). When the
+// leaf's wrapper lives in another chunk it is imported under its base name and
+// the local binding then shadows it, emitting the self-shadowing
+// `var require_isArrayLike = require_isArrayLike()`.
+var require_isArrayLike = require('./isArrayLike.cjs');
+
+function last(array) {
+  if (!require_isArrayLike.isArrayLike(array)) return;
+  return array[array.length - 1];
+}
+
+// CJS-format output derives a cross-chunk `require_<chunk>` binding from the
+// imported wrapper's chunk. This source local catches regressions where ESM-only
+// cross-chunk wrapper reservations push that generated binding to the same name.
+var require_isArrayLike$2 = {};
+
+exports.shadow = function () {
+  return require_isArrayLike$2;
+};
+exports.last = last;

--- a/crates/rolldown/tests/rolldown/issues/9630/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9630/main.js
@@ -1,0 +1,14 @@
+// Entry chunk. Two things force the repro:
+//   1. eagerly import `isArrayLike` -> its wrapper is hoisted into the ENTRY chunk.
+//   2. lazily import `last`        -> it lands in a SEPARATE (lazy) chunk that must
+//      reach back across the boundary for the leaf's wrapper.
+import { isArrayLike } from './isArrayLike.cjs';
+
+export const eager = isArrayLike([1]);
+
+// Evaluating the lazy chunk runs `require_last()`, which is where the bug bit:
+// `TypeError: require_isArrayLike is not a function`.
+export async function lazy() {
+  const last = await import('./last.cjs');
+  return last.default.last([1, 2, 3]);
+}


### PR DESCRIPTION
Fixes #9630.

## Problem

When code-splitting hoists a CommonJS `require_*` wrapper into a different chunk than the module that `require()`s it, an author's local binding of the same name shadowed the imported wrapper. This happens in real code — es-toolkit's compiled output literally writes `var require_isArrayLike = require("./isArrayLike.cjs")`, whose local matches the wrapper name rolldown derives from the filename.

The lazy chunk then emitted the self-referential:

```js
import { n as __commonJSMin, t as require_isArrayLike } from "./isArrayLike.js";
var require_last = __commonJSMin(((exports) => {
  var require_isArrayLike = require_isArrayLike(); // local shadows the import
  ...
```

The hoisted `var` resolves to itself (`undefined`), throwing `TypeError: require_isArrayLike is not a function` at runtime. (A subsequent DCE pass also drops the now-"unused" import, so the import disappears entirely — but the crash is the same either way.)

## Root cause

`deconflict_chunk_symbols` already guards against an author-local inside a CJS `__commonJS((exports, module) => { ... })` closure shadowing a name captured at the chunk's root scope (issues #9055 / #9375). It does this via `chunk_scope_captured_names` — but that set was only seeded from wrappers of modules **in the current chunk**.

A wrapper hoisted into another chunk is imported here as a real root-scope binding (`import { ... as require_foo } from "./other.js"`) and is *equally* captured by every CJS closure in this chunk, yet it was invisible to that loop. So the colliding author-local was not deconflicted.

## Fix

Seed `chunk_scope_captured_names` from cross-chunk CJS wrapper imports too (`chunk.imports_from_other_chunks`), the symmetric counterpart to the existing in-chunk wrapper loop. The colliding local is now renamed, matching the same-chunk output:

```js
import { n as __commonJSMin, t as require_isArrayLike$1 } from "./isArrayLike.js";
var require_last = __commonJSMin(((exports) => {
  var require_isArrayLike = require_isArrayLike$1();
  ...
```

## Test

Adds `tests/rolldown/issues/9630`, a minimal reproduction (eager import of the leaf + dynamic import of the requirer to force the cross-chunk split). The fixture executes the bundled output, so it fails on the runtime `TypeError` without the fix and passes with it.

Verified regression-free: full rolldown fixture, esbuild, and rollup snapshot suites pass with zero existing-snapshot changes.
