### PR TITLE
fix(dev): print build errors on browser refresh after a failed build

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -273,15 +273,12 @@ impl ScheduledBuild {
 
 #[napi(object)]
 pub struct BindingBundleState {
-  pub last_full_build_failed: bool,
+  pub last_build_errored: bool,
   pub has_stale_output: bool,
 }
 
 impl From<BundleState> for BindingBundleState {
   fn from(state: BundleState) -> Self {
-    Self {
-      last_full_build_failed: state.last_full_build_failed,
-      has_stale_output: state.has_stale_output,
-    }
+    Self { last_build_errored: state.last_build_errored, has_stale_output: state.has_stale_output }
   }
 }

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -24,7 +24,7 @@ use crate::{
   types::{
     coordinator_msg::CoordinatorMsg, coordinator_state::CoordinatorState,
     coordinator_state_snapshot::CoordinatorStateSnapshot,
-    ensure_latest_bundle_output_return::EnsureLatestBundleOutputReturn,
+    ensure_latest_bundle_output_return::EnsureLatestBundleOutputReturn, error_stage::ErrorStage,
     schedule_build_return::ScheduleBuildReturn, task_input::TaskInput,
   },
   watcher_event_handler::WatcherEventHandler,
@@ -101,8 +101,8 @@ impl BundleCoordinator {
         CoordinatorMsg::WatchEvent(watch_event) => {
           self.handle_watch_event(watch_event).await;
         }
-        CoordinatorMsg::BundleCompleted { has_encountered_error, has_generated_bundle_output } => {
-          self.handle_bundle_completed(has_encountered_error, has_generated_bundle_output).await;
+        CoordinatorMsg::BundleCompleted { error_stage, has_generated_bundle_output } => {
+          self.handle_bundle_completed(error_stage, has_generated_bundle_output).await;
         }
         #[cfg(feature = "testing")]
         CoordinatorMsg::ScheduleBuildIfStale { reply } => {
@@ -209,11 +209,27 @@ impl BundleCoordinator {
       CoordinatorState::FullBuildInProgress => {
         self.queued_file_changes_waited_for_full_build.extend(changed_files);
       }
-      CoordinatorState::Idle | CoordinatorState::InProgress | CoordinatorState::Failed => {
-        // The metal model for being `CoordinatorState::Failed` and receiving file changes is a bit of non-intuitive.
-        // Like the file is edited 2 times, the first edit is invalid and the second edit fixes the error.
-        // We just think the file is changed to second edit directly, ignoring the first invalid edit and follow the usual flow.
+      CoordinatorState::Idle | CoordinatorState::InProgress => {
         let task_input = if self.ctx.options.rebuild_strategy.is_always() {
+          TaskInput::HmrRebuild { changed_files }
+        } else {
+          TaskInput::Hmr { changed_files }
+        };
+
+        self.queued_tasks.push_back(task_input);
+
+        let _ = self.schedule_build_if_stale().await;
+      }
+      CoordinatorState::Failed { last_error_stage } => {
+        // Mental model: if the file is edited twice and the first edit was invalid,
+        // we treat the second edit as the only edit and follow the usual flow.
+        //
+        // Recovery choice (per Design principles §3 corollary): a Rebuild-stage
+        // failure left the bundle output stale w.r.t. source, so the recovery
+        // task must include a rebuild. An Hmr-stage failure (incl. watch_change
+        // hook) is recoverable by re-running the Hmr task alone.
+        let force_rebuild = matches!(last_error_stage, ErrorStage::Rebuild);
+        let task_input = if force_rebuild || self.ctx.options.rebuild_strategy.is_always() {
           TaskInput::HmrRebuild { changed_files }
         } else {
           TaskInput::Hmr { changed_files }
@@ -244,12 +260,12 @@ impl BundleCoordinator {
   /// Handle build completion notification
   async fn handle_bundle_completed(
     &mut self,
-    has_encountered_error: bool,
+    error_stage: Option<ErrorStage>,
     has_generated_bundle_output: bool,
   ) {
     match self.state {
       CoordinatorState::Initialized
-      | CoordinatorState::Failed
+      | CoordinatorState::Failed { .. }
       | CoordinatorState::FullBuildFailed
       | CoordinatorState::Idle => {
         tracing::error!(
@@ -264,7 +280,9 @@ impl BundleCoordinator {
         // so that a new full build is triggered by the change for those files
         let _ = self.update_watch_paths().await;
 
-        if has_encountered_error {
+        if error_stage.is_some() {
+          // FullBuildFailed always recovers via FullBuild on next file change,
+          // so the originating stage is not tracked.
           self.set_initial_build_state(CoordinatorState::FullBuildFailed);
           self.has_stale_bundle_output = true;
         } else {
@@ -289,8 +307,8 @@ impl BundleCoordinator {
         // (e.g. an edit that introduced a new transitive import).
         let _ = self.update_watch_paths().await;
 
-        if has_encountered_error {
-          self.set_initial_build_state(CoordinatorState::Failed);
+        if let Some(stage) = error_stage {
+          self.set_initial_build_state(CoordinatorState::Failed { last_error_stage: stage });
           self.has_stale_bundle_output = true;
         } else {
           self.has_stale_bundle_output = !has_generated_bundle_output;
@@ -325,7 +343,9 @@ impl BundleCoordinator {
         // So, we only need to wait for the latest build to finish.
         Some(ScheduleBuildReturn { future: self.current_bundling_future.clone().unwrap() })
       }
-      CoordinatorState::Idle | CoordinatorState::FullBuildFailed | CoordinatorState::Failed => {
+      CoordinatorState::Idle
+      | CoordinatorState::FullBuildFailed
+      | CoordinatorState::Failed { .. } => {
         if let Some(mut task_input) = self.queued_tasks.pop_front() {
           tracing::trace!(
             "[BundleCoordinator] scheduling new build task\n - state: {:?}\n - task_input: {task_input:#?}",
@@ -424,7 +444,7 @@ impl BundleCoordinator {
           is_ensure_latest_bundle_output_future: false,
         })
       }
-      CoordinatorState::FullBuildFailed | CoordinatorState::Failed => {
+      CoordinatorState::FullBuildFailed | CoordinatorState::Failed { .. } => {
         // Don't auto-retry — without file changes the same error would recur.
         // Recovery is driven by file change events from the watcher (see handle_file_changes).
         None
@@ -442,14 +462,15 @@ impl BundleCoordinator {
 
   /// Get current build status - atomic operation that doesn't block
   fn create_state_snapshot(&self) -> CoordinatorStateSnapshot {
+    let last_build_errored =
+      matches!(self.state, CoordinatorState::Failed { .. } | CoordinatorState::FullBuildFailed);
     CoordinatorStateSnapshot {
       running_future: self.current_bundling_future.clone(),
-      last_full_build_failed: self.state == CoordinatorState::FullBuildFailed,
+      last_build_errored,
       has_stale_output: self.has_stale_bundle_output,
     }
   }
 
-  /// Set initial build state with logging
   fn set_initial_build_state(&mut self, new_state: CoordinatorState) {
     self.state = new_state;
   }

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -11,7 +11,7 @@ use rolldown::Bundler;
 
 use crate::{
   dev_context::SharedDevContext,
-  types::{coordinator_msg::CoordinatorMsg, task_input::TaskInput},
+  types::{coordinator_msg::CoordinatorMsg, error_stage::ErrorStage, task_input::TaskInput},
 };
 
 pub struct BundlingTask {
@@ -19,7 +19,11 @@ pub struct BundlingTask {
   pub bundler: Arc<Mutex<Bundler>>,
   pub dev_context: SharedDevContext,
   pub next_hmr_patch_id: Arc<AtomicU32>,
-  has_encountered_error: bool,
+  /// Set when `watch_change` hook or `generate_hmr_updates` errored.
+  hmr_errored: bool,
+  /// Set when `rebuild()` errored. Takes precedence over `hmr_errored`
+  /// when deriving the final stage — see `final_error_stage`.
+  rebuild_errored: bool,
   has_rebuild_happen: bool,
 }
 
@@ -50,7 +54,21 @@ impl BundlingTask {
       dev_context,
       next_hmr_patch_id,
       has_rebuild_happen: false,
-      has_encountered_error: false,
+      hmr_errored: false,
+      rebuild_errored: false,
+    }
+  }
+
+  /// Rebuild precedes Hmr: if both stages errored in the same task (only
+  /// possible after the auto-upgrade rewrite), `Rebuild` is reported so
+  /// recovery forces a fresh rebuild on the next file change.
+  fn final_error_stage(&self) -> Option<ErrorStage> {
+    if self.rebuild_errored {
+      Some(ErrorStage::Rebuild)
+    } else if self.hmr_errored {
+      Some(ErrorStage::Hmr)
+    } else {
+      None
     }
   }
 
@@ -59,14 +77,14 @@ impl BundlingTask {
     self.run_inner().await;
 
     let has_generated_bundle_output = self.has_rebuild_happen;
-    let has_encountered_error = self.has_encountered_error;
+    let error_stage = self.final_error_stage();
 
     tracing::trace!(
       "[BundlingTask] completed\n - has_generated_bundle_output: {has_generated_bundle_output:?}",
     );
 
     self.dev_context.coordinator_tx.send(CoordinatorMsg::BundleCompleted {
-      has_encountered_error,
+      error_stage,
       has_generated_bundle_output,
     }).expect(
       "Coordinator channel closed while sending BundleCompleted - coordinator terminated unexpectedly"
@@ -83,7 +101,9 @@ impl BundlingTask {
           if let Err(err) = plugin_driver.watch_change(changed_file.to_str().unwrap(), *event).await
           {
             tracing::error!("[BundlingTask] watchChange hook failed: {err:?}");
-            self.has_encountered_error = true;
+            // Classified as Hmr stage: the next Hmr task re-runs watch_change,
+            // which is sufficient to retry the hook.
+            self.hmr_errored = true;
             if let Some(on_output) = self.dev_context.options.on_output.as_ref() {
               on_output(Err(err.into()));
             }
@@ -169,7 +189,7 @@ impl BundlingTask {
     let has_callback = self.dev_context.options.on_hmr_updates.is_some();
     if let Err(err) = &hmr_result {
       tracing::error!("[BundlingTask] failed to generate HMR updates: {:?}", err);
-      self.has_encountered_error = true;
+      self.hmr_errored = true;
     }
 
     // Call on_hmr_updates callback if provided
@@ -210,7 +230,7 @@ impl BundlingTask {
 
     if let Err(err) = &build_result {
       tracing::error!("[BundlingTask] rebuild failed: {:?}", err);
-      self.has_encountered_error = true;
+      self.rebuild_errored = true;
     }
 
     // Call on_output callback if provided

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -453,14 +453,15 @@ impl DevEngine {
 
 #[derive(Debug, Clone)]
 pub struct BundleState {
-  pub last_full_build_failed: bool,
+  /// True for any error state (initial or incremental).
+  pub last_build_errored: bool,
   pub has_stale_output: bool,
 }
 
 impl From<CoordinatorStateSnapshot> for BundleState {
   fn from(snapshot: CoordinatorStateSnapshot) -> Self {
     Self {
-      last_full_build_failed: snapshot.last_full_build_failed,
+      last_build_errored: snapshot.last_build_errored,
       has_stale_output: snapshot.has_stale_output,
     }
   }

--- a/crates/rolldown_dev/src/types/coordinator_msg.rs
+++ b/crates/rolldown_dev/src/types/coordinator_msg.rs
@@ -3,13 +3,17 @@ use rolldown_fs_watcher::FsEventResult;
 use crate::type_aliases::{EnsureLatestBundleOutputSender, GetStateSender};
 #[cfg(feature = "testing")]
 use crate::type_aliases::{GetWatchedFilesSender, ScheduleBuildIfStaleSender};
+use crate::types::error_stage::ErrorStage;
 
 /// Messages sent to the BundleCoordinator
 #[derive(Debug)]
 pub enum CoordinatorMsg {
   WatchEvent(FsEventResult),
   BundleCompleted {
-    has_encountered_error: bool,
+    /// `None` on success; on error, identifies which stage produced it
+    /// so the coordinator can pick the right recovery task variant on
+    /// the next file change. See `meta/design/dev-engine.md` §7.
+    error_stage: Option<ErrorStage>,
     has_generated_bundle_output: bool,
   },
   #[cfg(feature = "testing")]

--- a/crates/rolldown_dev/src/types/coordinator_state.rs
+++ b/crates/rolldown_dev/src/types/coordinator_state.rs
@@ -1,3 +1,5 @@
+use crate::types::error_stage::ErrorStage;
+
 /// State of the initial build process
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoordinatorState {
@@ -6,5 +8,10 @@ pub enum CoordinatorState {
   FullBuildInProgress,
   FullBuildFailed,
   InProgress,
-  Failed,
+  /// Incremental task errored. The carried stage drives the recovery
+  /// choice in `handle_file_changes` — see `meta/design/dev-engine.md`
+  /// §7 and the Design principles section.
+  Failed {
+    last_error_stage: ErrorStage,
+  },
 }

--- a/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
+++ b/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
@@ -5,6 +5,12 @@ use crate::dev_context::BundlingFuture;
 pub struct CoordinatorStateSnapshot {
   // `None` if no build is running
   pub running_future: Option<BundlingFuture>,
-  pub last_full_build_failed: bool,
+  /// True when the coordinator is in any error state — `FullBuildFailed`
+  /// OR `Failed { .. }`.
+  ///
+  /// Consumers should use this to gate
+  /// access-triggered rebuilds (Design principles §1) so a stale + errored bundle doesn't keep retriggering work
+  /// that the engine will no-op anyway. See `meta/design/dev-engine.md`.
+  pub last_build_errored: bool,
   pub has_stale_output: bool,
 }

--- a/crates/rolldown_dev/src/types/error_stage.rs
+++ b/crates/rolldown_dev/src/types/error_stage.rs
@@ -1,0 +1,19 @@
+/// Which stage of `BundlingTask::run_inner` produced a build error.
+///
+/// Carried on `CoordinatorState::Failed` and used by `handle_file_changes`
+/// to pick the right `TaskInput` on recovery: an `Hmr`-stage failure
+/// recovers with an `Hmr` task (re-runs `watch_change` + HMR computation);
+/// a `Rebuild`-stage failure requires `HmrRebuild` so the link/codegen
+/// stage runs again.
+///
+/// See `meta/design/dev-engine.md` — Design principles §3, §4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorStage {
+  /// Failed in `plugin_driver.watch_change` or `generate_hmr_updates`.
+  /// `watch_change` is grouped here because the next `Hmr` task re-runs
+  /// the hook, which is sufficient to retry it.
+  Hmr,
+  /// Failed in `rebuild()` (incremental link/codegen). The bundle output
+  /// is now stale w.r.t. the source; only a fresh rebuild can recover.
+  Rebuild,
+}

--- a/crates/rolldown_dev/src/types/mod.rs
+++ b/crates/rolldown_dev/src/types/mod.rs
@@ -3,5 +3,6 @@ pub mod coordinator_msg;
 pub mod coordinator_state;
 pub mod coordinator_state_snapshot;
 pub mod ensure_latest_bundle_output_return;
+pub mod error_stage;
 pub mod schedule_build_return;
 pub mod task_input;

--- a/meta/design/dev-engine.md
+++ b/meta/design/dev-engine.md
@@ -17,6 +17,75 @@ implementation, not the narrative of any particular change.
 
 ---
 
+## Design principles
+
+Four principles govern when the dev engine rebuilds and how its errors
+flow out to the binding consumer. They define rolldown_dev's contract
+with its consumer (typically Vite) and constrain the implementation in
+§7, §13, and §16.
+
+### 1. Conservative rebuilds
+
+Rebuilds happen only when the bundle is **stale** — when input has
+changed since the last build attempt. Page access and browser
+reconnect on their own never trigger a rebuild. In particular: if the
+previous build failed, an access request does not retry — without new
+input the same error would recur.
+
+Realized in: `BundleCoordinator::ensure_latest_bundle_output` returning
+`None` for `Failed` / `FullBuildFailed` (§13b, §13e).
+
+### 2. Errors are emitted on every build
+
+rolldown_dev surfaces build errors to the binding consumer on every
+build via the `on_output` / `on_hmr_updates` callbacks (§16b). It never
+silently retries past an error, never silently swallows one, and never
+caches one across requests — rolldown_dev is stateless across HTTP
+requests. The binding consumer (Vite) is responsible for retaining the
+most recent error and replaying it on each client reconnect, so the
+error overlay appears even after a browser refresh.
+
+Vite-side realization (in `fullBundleEnvironment.ts`): a single
+`lastBuildError: Error | null` field caches the most recent error from
+**either** channel — it is set in both `onOutput` (full-build errors)
+and `onHmrUpdates` (HMR errors), and cleared back to `null` only on a
+successful `onOutput`. It is replayed on the **`vite:client:connect`**
+event for every freshly connected client (including a post-refresh
+reconnect), so the error overlay reappears after a browser refresh.
+The two channels differ only in their _live_
+delivery: an `onOutput` error is additionally logged to the terminal
+(`logger.error`) so a build break is visible without a browser, and is
+broadcast to all clients via `hot.send`; an `onHmrUpdates` error is sent
+to each connected client individually and is not logged to the terminal.
+
+### 3. File changes are the only recovery trigger
+
+After a failed build, the engine waits for a file change before
+rebuilding. Both Vite config edits and user-land source edits are
+valid triggers. Nothing else — not page refresh, not elapsed time, not
+manual UI dismissal — counts as recovery.
+
+Realized in: `handle_file_changes` (§7) is the sole producer of
+post-failure rebuild tasks. `triggerFullBuild` (§13e) is an explicit
+escape hatch for cases the watcher cannot observe (e.g. missing-import
+resolution; see Unresolved Questions).
+
+Corollary: a file change after a failed build must schedule work that
+can undo the failure. In practice this means tracking where the
+failure originated (HMR computation vs incremental rebuild) so the
+next task covers the stage that broke (§7).
+
+### 4. Build errors are recoverable; panics are bugs
+
+Every error reaching the consumer via `on_output` / `on_hmr_updates`
+is treated as a **user error** — caused by source code or plugin
+behavior, recoverable by editing source. Rolldown and Vite themselves
+are assumed bug-free in this model. The only state not recoverable
+through a file-change cycle is a panic, which signals an invariant
+violation in rolldown_dev itself (§16g).
+
+---
+
 ## 1. Components and layering
 
 The dev engine is built from four cooperating pieces, all in
@@ -102,7 +171,7 @@ coordinator is one of these messages:
 pub enum CoordinatorMsg {
   WatchEvent(FsEventResult),                 // raw fs-watcher event batch
   BundleCompleted {                          // a BundlingTask finished
-    has_encountered_error: bool,
+    error_stage: Option<ErrorStage>,         // None on success; see §10
     has_generated_bundle_output: bool,
   },
   ScheduleBuildIfStale { reply: … },         // ask coordinator to drain its queue
@@ -154,7 +223,7 @@ pub enum CoordinatorState {
   FullBuildInProgress,
   FullBuildFailed,
   InProgress,
-  Failed,
+  Failed { last_error_stage: ErrorStage },
 }
 ```
 
@@ -169,63 +238,84 @@ two halves joined by `Idle`:
 
 ### State meanings
 
-| State                 | Meaning                                                            |
-| --------------------- | ------------------------------------------------------------------ |
-| `Initialized`         | Constructed but `run()` not yet entered. Transient.                |
-| `FullBuildInProgress` | The initial `TaskInput::FullBuild` is running.                     |
-| `FullBuildFailed`     | The initial full build errored. No usable output exists at all.    |
-| `Idle`                | No build running; last build (if any) succeeded.                   |
-| `InProgress`          | An incremental task (`Hmr` / `HmrRebuild` / `Rebuild`) is running. |
-| `Failed`              | The last incremental task errored.                                 |
+| State                         | Meaning                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `Initialized`                 | Constructed but `run()` not yet entered. Transient.                                         |
+| `FullBuildInProgress`         | The initial `TaskInput::FullBuild` is running.                                              |
+| `FullBuildFailed`             | The initial full build errored. No usable output exists at all.                             |
+| `Idle`                        | No build running; last build (if any) succeeded.                                            |
+| `InProgress`                  | An incremental task (`Hmr` / `HmrRebuild` / `Rebuild`) is running.                          |
+| `Failed { last_error_stage }` | The last incremental task errored; `last_error_stage` records which stage produced it (§7). |
 
 ### Transition map
 
-```
-            ┌──────────────┐
-            │ Initialized  │  (constructor: BundleCoordinator::new)
-            └──────┬───────┘
-                   │ run() entry: push TaskInput::FullBuild,
-                   │ set state=Idle, schedule_build_if_stale()
-                   ▼
-        ┌────────────────────┐
-        │        Idle        │ ◄──────────────────────────────┐
-        └─────────┬──────────┘                                │
-                  │ schedule_build_if_stale pops a task:      │
-                  │   FullBuild → FullBuildInProgress         │
-                  │   else      → InProgress                  │
-        ┌─────────┴──────────┐                                │
-        ▼                    ▼                                │
-┌───────────────────┐  ┌───────────────────┐                  │
-│FullBuildInProgress│  │    InProgress     │                  │
-└─────────┬─────────┘  └─────────┬─────────┘                  │
-          │ BundleCompleted      │ BundleCompleted            │
-          │  err → FullBuildFailed│  err → Failed             │
-          │  ok  → Idle ─────────┼──ok──→ Idle ───────────────┤
-          ▼                      ▼  (then schedule_build_if_  │
-┌───────────────────┐  ┌───────────────────┐    stale always)│
-│  FullBuildFailed  │  │      Failed       │                  │
-└─────────┬─────────┘  └─────────┬─────────┘                  │
-          │ next file change:    │ next file change:          │
-          │  queue FullBuild,    │  queue Hmr/HmrRebuild,     │
-          │  schedule →          │  schedule →                │
-          │  FullBuildInProgress │  InProgress ───────────────┘
-          ▼                      ▼
-       (loop)                 (loop)
+Edges are grouped by what drives them: **scheduling** (a queued task
+starts), **completion** (`BundleCompleted`), **file-change recovery**, and
+the **rebuild triggers** that enqueue work without a file change
+(access-driven `EnsureLatestBundleOutput`, programmatic `ModuleChanged`,
+manual `TriggerFullBuild`). Every rebuild trigger enqueues a task and then
+calls `schedule_build_if_stale`, which is the actual state-mutation site
+(§8) — so while a build is already running, a trigger only appends to the
+queue and the transition happens when the current task completes and the
+queue drains.
+
+```mermaid
+stateDiagram-v2
+    state "Failed { stage }" as Failed
+
+    [*] --> Initialized : new()
+    Initialized --> Idle : run() startup<br/>queue FullBuild + schedule
+
+    %% scheduling: schedule_build_if_stale pops a queued task and starts it
+    Idle --> FullBuildInProgress : schedule pops FullBuild
+    Idle --> InProgress : schedule pops Rebuild / Hmr / HmrRebuild
+
+    %% completion: BundleCompleted
+    FullBuildInProgress --> Idle : completed ok
+    FullBuildInProgress --> FullBuildFailed : completed err
+    InProgress --> Idle : completed ok → schedule
+    InProgress --> Failed : completed err<br/>(records stage)
+
+    %% file-change recovery from a failed build
+    FullBuildFailed --> FullBuildInProgress : file change<br/>queue FullBuild
+    Failed --> InProgress : file change<br/>queue Hmr / HmrRebuild
+
+    %% rebuild triggers (no file change)
+    Idle --> InProgress : EnsureLatestBundleOutput when stale<br/>queue empty Rebuild
+    Idle --> InProgress : ModuleChanged<br/>queue Rebuild
+    Idle --> FullBuildInProgress : TriggerFullBuild<br/>clear queue + FullBuild
+    Failed --> FullBuildInProgress : TriggerFullBuild
+    FullBuildFailed --> FullBuildInProgress : TriggerFullBuild
 ```
 
 ### Where each transition lives
 
+These are the `set_initial_build_state` call sites — the single mutation
+point, a convenient place to observe every transition.
+
 | Transition                                                         | Site                                           |
 | ------------------------------------------------------------------ | ---------------------------------------------- |
 | `Initialized → Idle`                                               | `run()` startup, `bundle_coordinator.rs:84-87` |
-| `Idle/Failed/FullBuildFailed → FullBuildInProgress` / `InProgress` | `schedule_build_if_stale`, `:352-356`          |
-| `FullBuildInProgress → FullBuildFailed`                            | `handle_bundle_completed`, `:263`              |
-| `FullBuildInProgress → Idle`                                       | `handle_bundle_completed`, `:268`              |
-| `InProgress → Failed`                                              | `handle_bundle_completed`, `:288`              |
-| `InProgress → Idle`                                                | `handle_bundle_completed`, `:293`              |
+| `Idle/Failed/FullBuildFailed → FullBuildInProgress` / `InProgress` | `schedule_build_if_stale`, `:378-380`          |
+| `FullBuildInProgress → FullBuildFailed`                            | `handle_bundle_completed`, `:286`              |
+| `FullBuildInProgress → Idle`                                       | `handle_bundle_completed`, `:291`              |
+| `InProgress → Failed { last_error_stage }`                         | `handle_bundle_completed`, `:311`              |
+| `InProgress → Idle`                                                | `handle_bundle_completed`, `:316`              |
 
-`set_initial_build_state` is the single mutation point — a convenient
-place to observe all transitions.
+### What enqueues a rebuild
+
+Each of these enqueues a `TaskInput` and calls `schedule_build_if_stale`;
+the state mutation itself is the `schedule_build_if_stale` row above. They
+are the distinct ways a build gets initiated — a file change is only one
+of them.
+
+| Trigger                                                      | Enqueues                       | Resulting state       | Site                                                |
+| ------------------------------------------------------------ | ------------------------------ | --------------------- | --------------------------------------------------- |
+| File change, steady state (`Idle` / `InProgress` / `Failed`) | `Hmr` or `HmrRebuild`          | `InProgress`          | `handle_file_changes`, `:202`                       |
+| File change, `FullBuildFailed`                               | `FullBuild` (clears the stash) | `FullBuildInProgress` | `handle_file_changes`, `:248`                       |
+| Browser access while stale (`EnsureLatestBundleOutput`)      | empty-files `Rebuild`          | `InProgress`          | `ensure_latest_bundle_output`, `:401` (push `:419`) |
+| Programmatic module change (`ModuleChanged`)                 | `Rebuild`                      | `InProgress`          | run loop, `:128-145`                                |
+| Manual full build (`TriggerFullBuild`)                       | clears queue, `FullBuild`      | `FullBuildInProgress` | `trigger_full_build`, `:457`                        |
 
 ---
 
@@ -323,8 +413,15 @@ state                                 → action
 FullBuildInProgress                   → stash files into
                                         queued_file_changes_waited_
                                         for_full_build (no task queued)
-Idle | InProgress | Failed            → queue Hmr (or HmrRebuild if
+Idle | InProgress                     → queue Hmr (or HmrRebuild if
                                         rebuild_strategy == Always),
+                                        then schedule_build_if_stale()
+Failed { last_error_stage: Hmr }      → queue Hmr (or HmrRebuild if
+                                        rebuild_strategy == Always),
+                                        then schedule_build_if_stale()
+Failed { last_error_stage: Rebuild }  → queue HmrRebuild
+                                        (unconditional — Rebuild-stage
+                                        failure must rebuild),
                                         then schedule_build_if_stale()
 FullBuildFailed                       → clear queued_file_changes,
                                         queue TaskInput::FullBuild,
@@ -338,12 +435,20 @@ Notes:
   they are stashed and replayed when the full build succeeds
   (`handle_bundle_completed` `:269-273` calls `handle_file_changes` with
   the drained set).
-- `Idle`, `InProgress`, and `Failed` are treated **identically** here —
-  all three queue an `Hmr`/`HmrRebuild`.
+- `Idle` and `InProgress` behave identically — both queue `Hmr`
+  (or `HmrRebuild` under `Always`).
+- `Failed` discriminates on `last_error_stage`. An `Hmr`-stage failure
+  recovers by re-running the same Hmr task (the `watch_change` hook and
+  HMR computation get a second chance). A `Rebuild`-stage failure left
+  the bundle output stale w.r.t. source, so the recovery task must
+  include a rebuild — `HmrRebuild` regardless of `rebuild_strategy`.
+  This realizes the Design principles §3 corollary.
 - The `Always` vs non-`Always` choice for `Hmr` vs `HmrRebuild` is the
-  `rebuild_strategy` option (see §9).
+  `rebuild_strategy` option (see §9). Only the `Idle`, `InProgress`, and
+  `Failed { Hmr }` arms honor it; `Failed { Rebuild }` overrides it.
 - `FullBuildFailed` is the one state whose file-change handling queues a
-  `FullBuild`.
+  `FullBuild`. Stage tracking is unnecessary because a full rebuild
+  covers every stage by construction.
 
 ---
 
@@ -431,12 +536,41 @@ a `HmrRebuild` mid-task.
 ## 10. `BundlingTask` — executing one unit of work
 
 `BundlingTask::run` (`bundling_task.rs:58-81`) calls `run_inner`, then
-sends `BundleCompleted` back to the coordinator with two booleans:
+sends `BundleCompleted` back to the coordinator with two fields:
 
-- `has_encountered_error` — `has_encountered_error` flag OR `run_inner`
-  returned `Err`.
-- `has_generated_bundle_output` — equals `has_rebuild_happen`, i.e.
-  whether the task actually performed a rebuild.
+- `error_stage: Option<ErrorStage>` — `None` on success; on error,
+  identifies which stage produced it.
+- `has_generated_bundle_output: bool` — equals `has_rebuild_happen`,
+  i.e. whether the task actually performed a rebuild.
+
+### Stage classification
+
+`BundlingTask` tracks two independent flags during `run_inner`
+(`hmr_errored`, `rebuild_errored`) and derives the reported
+`Option<ErrorStage>` via the precedence **`Rebuild > Hmr`**:
+
+| `rebuild_errored` | `hmr_errored` | reported `error_stage` |
+| ----------------- | ------------- | ---------------------- |
+| `true`            | any           | `Some(Rebuild)`        |
+| `false`           | `true`        | `Some(Hmr)`            |
+| `false`           | `false`       | `None`                 |
+
+`Rebuild` wins because of the auto-upgrade path (§9b): an `Hmr` task can
+be rewritten to `HmrRebuild` mid-task, then fail in rebuild. In that
+case both flags are set; reporting `Rebuild` is conservative — the next
+file change forces a rebuild, which is what's needed to confirm the fix.
+
+Set sites:
+
+| `run_inner` site                          | flag set          |
+| ----------------------------------------- | ----------------- |
+| `plugin_driver.watch_change` hook failure | `hmr_errored`     |
+| `generate_hmr_updates` failure            | `hmr_errored`     |
+| `rebuild()` (`incremental_*`) failure     | `rebuild_errored` |
+
+`watch_change` failures classify as `Hmr` because the next `Hmr` task
+re-runs the hook against the new changed files — sufficient retry
+without forcing a rebuild.
 
 `run_inner` (`bundling_task.rs:83-122`) does, in order:
 
@@ -456,7 +590,7 @@ true` and calls `rebuild()`.
 - Calls `bundler.compute_hmr_update_for_file_changes(...)`.
 - Scans the resulting updates; if any `is_full_reload()`, sets
   `has_full_reload_update = true`.
-- On error, sets `self.has_encountered_error = true`.
+- On error, sets `self.hmr_errored = true`.
 - Invokes the `on_hmr_updates` callback if configured.
 
 ### `rebuild` (`bundling_task.rs:189-223`)
@@ -472,7 +606,7 @@ true` and calls `rebuild()`.
   ```
 - Calls `bundler.incremental_write(scan_mode)` if `skip_write` is
   false, else `bundler.incremental_generate(scan_mode)`.
-- On error, sets `self.has_encountered_error = true`.
+- On error, sets `self.rebuild_errored = true`.
 - Invokes the `on_output` callback if configured.
 
 Only `TaskInput::FullBuild` produces `ScanMode::Full`. Every other
@@ -490,7 +624,9 @@ rebuilding task (`Rebuild`, `HmrRebuild`) produces `ScanMode::Partial`.
 ```rust
 current_bundling_future = None;
 update_watch_paths();                       // even on failure
-if has_encountered_error {
+if error_stage.is_some() {
+  // FullBuildFailed always recovers via FullBuild on next file change,
+  // so the originating stage is discarded here.
   state = FullBuildFailed;
   has_stale_bundle_output = true;
 } else {
@@ -510,8 +646,8 @@ if has_encountered_error {
 ```rust
 current_bundling_future = None;
 update_watch_paths();                       // register newly-pulled-in files
-if has_encountered_error {
-  state = Failed;
+if let Some(stage) = error_stage {
+  state = Failed { last_error_stage: stage };
   has_stale_bundle_output = true;
 } else {
   has_stale_bundle_output = !has_generated_bundle_output;
@@ -519,6 +655,10 @@ if has_encountered_error {
 }
 schedule_build_if_stale();                  // ALWAYS — drain the queue
 ```
+
+The stage carried into `Failed` is the one reported by `BundleCompleted`
+(§10 precedence). It's read on the next file change by §7 to choose
+between `Hmr` and `HmrRebuild`.
 
 Key facts:
 
@@ -551,6 +691,19 @@ It is consumed by `ensure_latest_bundle_output` (§13) to decide whether
 a lazy rebuild is needed before serving the full bundle. It is also
 surfaced in `CoordinatorStateSnapshot.has_stale_output` and thence
 `BundleState.has_stale_output`.
+
+### Companion: `last_build_errored`
+
+The snapshot also exposes `last_build_errored: bool` — `true` when the
+coordinator is in any error state (`FullBuildFailed` OR `Failed { .. }`).
+This is the predicate the binding consumer should pair with
+`has_stale_output` when deciding whether to kick an access-triggered
+regen: a stale-and-errored bundle must NOT be regenerated on access
+(Design principles §1), since the engine no-ops the request and the
+naive "promise resolved ⇒ build fresh" interpretation in the consumer
+leads to a spurious reload loop. It covers both initial-build failure
+(`FullBuildFailed`) and incremental failure (`Failed { .. }`) — the
+narrower initial-only predicate was removed as redundant.
 
 ---
 
@@ -782,7 +935,7 @@ Beyond `ensure_latest_bundle_output`, the public methods on `DevEngine`
 | `trigger_full_build()`                           | sends `TriggerFullBuild` (fire-and-forget, compose with `ensure_latest_bundle_output` to wait) |
 | `wait_for_close()`                               | awaits the coordinator's join handle                                                           |
 | `wait_for_ongoing_bundle()`                      | `GetState`, awaits any running future                                                          |
-| `get_bundle_state()`                             | `GetState` → `BundleState { last_full_build_failed, has_stale_output }`                        |
+| `get_bundle_state()`                             | `GetState` → `BundleState { last_build_errored, has_stale_output }`                            |
 | `invalidate(caller, first_invalidated_by)`       | locks the bundler, calls `compute_update_for_calling_invalidate` per client                    |
 | `compile_lazy_entry(proxy_module_id, client_id)` | compiles a lazy entry; on success sends `ModuleChanged`                                        |
 | `close()`                                        | sends `Close`, runs `closeBundle`, awaits coordinator shutdown                                 |
@@ -919,10 +1072,13 @@ error handler.
 | `generate_hmr_updates` | `on_hmr_updates` | deliver, then may continue | log only, may stop     |
 | `rebuild`              | `on_output`      | deliver                    | log only               |
 
-A failure in any phase sets `self.has_encountered_error = true`, reported to
-the coordinator via `BundleCompleted { has_encountered_error, ... }`. The
-coordinator uses this to transition into `FullBuildFailed` / `Failed` (§11)
-regardless of whether a callback was registered to receive the error itself.
+A failure in a phase sets the matching per-stage flag (`hmr_errored` for
+`watch_change` / `generate_hmr_updates`, `rebuild_errored` for `rebuild`).
+At task end these collapse to `error_stage: Option<ErrorStage>` (precedence
+`Rebuild > Hmr`, §10), reported to the coordinator via `BundleCompleted {
+error_stage, .. }`. The coordinator uses it to transition into
+`FullBuildFailed` / `Failed { last_error_stage }` (§11) regardless of
+whether a callback was registered to receive the error itself.
 
 `generate_hmr_updates` returns `bool` — "may subsequent stages continue?" —
 preserving the pre-`BuildResult` short-circuit: rebuild is skipped only when
@@ -1000,9 +1156,9 @@ Three stops:
 - **Each phase owns its delivery.** Inside `BundlingTask`, each phase
   function handles its own error delivery; `run_inner` is not a centralized
   error handler.
-- **`has_encountered_error` is the coordinator signal, callbacks are the
-  consumer signal.** Both are set on every error; one drives the state
-  machine, the other notifies the user.
+- **`error_stage` is the coordinator signal, callbacks are the consumer
+  signal.** Both are produced on every error; the stage drives the state
+  machine, the callback notifies the user.
 
 ### 16g. When to panic
 
@@ -1063,6 +1219,7 @@ reconstruct it.
 | `CoordinatorState` enum                        | `crates/rolldown_dev/src/types/coordinator_state.rs`            |
 | `TaskInput` enum, merge rules                  | `crates/rolldown_dev/src/types/task_input.rs`                   |
 | `CoordinatorMsg` enum                          | `crates/rolldown_dev/src/types/coordinator_msg.rs`              |
+| `ErrorStage` enum                              | `crates/rolldown_dev/src/types/error_stage.rs`                  |
 | `RebuildStrategy` enum                         | `crates/rolldown_dev_common/src/types/rebuild_strategy.rs`      |
 | Incremental entry points, `with_cached_bundle` | `crates/rolldown/src/bundler/impl_bundler_incremental_build.rs` |
 | HMR entry points                               | `crates/rolldown/src/bundler/impl_bundler_hmr.rs`               |

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1998,7 +1998,7 @@ export interface BindingBundlerOptions {
 }
 
 export interface BindingBundleState {
-  lastFullBuildFailed: boolean
+  lastBuildErrored: boolean
   hasStaleOutput: boolean
 }
 

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -235,7 +235,7 @@ class DevServer {
         res.end(
           JSON.stringify({
             hasStaleOutput: bundleState.hasStaleOutput,
-            lastFullBuildFailed: bundleState.lastFullBuildFailed,
+            lastBuildErrored: bundleState.lastBuildErrored,
             buildSeq: this.#buildSeq,
             connectedClients: this.#clients.size,
             moduleRegistrationSeq: this.#moduleRegistrationSeq,

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -114,7 +114,7 @@ export function getLazyAliasedImportPage() {
 
 interface DevStatus {
   hasStaleOutput: boolean;
-  lastFullBuildFailed: boolean;
+  lastBuildErrored: boolean;
   buildSeq: number;
   connectedClients: number;
   moduleRegistrationSeq: number;


### PR DESCRIPTION
## Design Principles

This PR mainly clarifies a few principles that we hold while implementing Rolldown's dev engine and Vite's full-bundle mode dev server. Mostly are written in `meta/design/dev-engine.md`. Just to give you a briefing, here're these things:

1. **Be conservative** — rebuild only when the bundle is stale, and defer it until the full bundle is actually requested (e.g. a page refresh). By default we ship HMR-only output.
2. **Replay errors when needed** — the dev *engine* is stateless across HTTP requests and never caches results from `onHmrUpdates`/`onOutput`; caching and replay are the dev *server*'s job, so errors survive a refresh.
3. **File changes are the only recovery trigger** — after a failed build the engine waits for a file edit (Vite config or source). Not a page refresh, elapsed time, or UI dismissal.
4. **Build errors are always recoverable** — every error via `on_output`/`on_hmr_updates` is treated as a user error (source/plugin), fixable by editing source. Only a panic is unrecoverable.

### Problem

  #9552 made `ensure_latest_bundle_output` return `None` in `FullBuildFailed` /
  `Failed` instead of retrying a build. That fixed a double-`onOutput` and an
  infinite loop — but the retry it removed had been doing double duty: on a
  browser refresh, the dev-server middleware calls `ensureLatestBuildOutput`,
  the retry reran the build, and `onOutput` re-fired the error to the client.

  With the retry gone, a refresh no longer reruns the build, so **a project whose
  build output contains an error stops re-emitting that error on refresh** — the
  error overlay disappears even though the build is still broken.

  The right fix is *not* to rerun the build on access (that brings back the loop
  and the double-emit). It's to make `Failed` / `FullBuildFailed` work as the
  genuine resting states they now are:

  - the error must survive a refresh **without** a rebuild, and
  - recovery must be driven entirely by file changes, re-running the stage that
    actually broke.


### Changes

  **1. Expose errored-and-stale state to the consumer.**
  Snapshot field `last_full_build_failed` → `last_build_errored`, now true for
  *both* `FullBuildFailed` and `Failed { .. }`. This is the predicate the
  consumer pairs with `has_stale_output` to (a) replay its cached build error on
  client reconnect instead of triggering a doomed regen, and (b) avoid the
  access-triggered reload loop against a bundle the engine won't regenerate.

  **2. File-change-driven, stage-aware recovery.**
  Because access no longer retries, the next file change is the only recovery
  trigger — and it must re-run the broken stage:

  - New `ErrorStage` enum (`Hmr` | `Rebuild`); `BundlingTask` tracks
    `hmr_errored` / `rebuild_errored` and collapses them with precedence
    `Rebuild > Hmr` (covers the `Hmr → HmrRebuild` auto-upgrade that then fails
    in rebuild).
  - `CoordinatorState::Failed { last_error_stage }` carries the stage;
    `handle_file_changes` forces `HmrRebuild` on a `Rebuild`-stage failure
    (regardless of `rebuild_strategy`) so the rebuild re-runs, and uses an `Hmr`
    task for an `Hmr`-stage failure.

### Tests

Tests will be added when Rolldown's test-dev-server is fully aligned with Vite's full-bundle mode server.

This PR is meant to be released along with https://github.com/vitejs/vite/pull/22617.