### PR TITLE
perf: use diagnostics-free semantic scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1612,7 +1612,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1764,8 +1764,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d804f86548486ce1b6c92bb5511214f44074ea1e5bc94eded8ee4de2f7ca98c7"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1827,8 +1826,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2303e54d087d40064154f2ec243fff0bf7641c078efae9bb14216a8869577ba7"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1841,8 +1839,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f628429436867a51e5d623b4b27c02807aec3ea241f01deadd21b0d1604c8ef"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1859,8 +1856,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b3190e5f69284b59a4876a3b42431c8e2309b4de3670553aab4888f15aa6f2"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1871,8 +1867,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe1897cf38bab83c998346184cba50db2849943b9d9e8634d09a2dc303ceaee"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1883,8 +1878,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee538c54f0efefd69029969fb274891cf3b7fa3f26d8aad338c753b57f619bf"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "itertools",
@@ -1897,8 +1891,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d690df0e909b1663c19a368cdfcf0cac94fd57ddf068230442ff82b27ad000"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1919,8 +1912,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae9249b8fc4604f787cbe39457565f21f7747a59cb94333bcc1ff85f9327323"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1932,8 +1924,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6aa082cf4bbc5b3c189e9331f31823e31a5452533da36dfa5b174f20e72c1c"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "ropey",
 ]
@@ -1941,8 +1932,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67daf165d8abff1577825a4303a5d0b61ae29c7b66c9e0e0e7f97f77705667ed"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1952,8 +1942,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e701220c14cc0d0733a6501f1837fe9d913e891e25647132389fdfd78dd7d3"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1968,8 +1957,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d42104865cba688a62c0cf5691592a890eef9de359bccb18a97b2be088478d"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1978,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
 dependencies = [
  "nonmax",
  "rayon",
@@ -1990,8 +1978,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9a8cdf9d9de031f83d3f26f4cfbc8373292fcc09cd2e5a895d49e5053b14f3"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -2008,8 +1995,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a83b68212db8f28b4a45c415d23255e94d19a7a654adb5a44de26a4aaa193c8"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2026,8 +2012,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133be4ee8743c487ef47bb8053e8c9bf3493b3c2fe338b99f18cf1c0e9482552"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2052,8 +2037,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b53d9f6e8f0b0d057c648df9bc9f60b9e1cd05868142512670859ff96d6292"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "napi",
  "napi-build",
@@ -2072,8 +2056,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d7a04a7cb15550f06c33036a88b42afd25b853693101cca83cd5b1261a95d9a"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "napi",
  "napi-build",
@@ -2088,8 +2071,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d671cb199fc83d8fc9764926c3c8f7979affbd2d916e3b2e22e403745305b6"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2112,8 +2094,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ef763dcadb41c6cdebdeffbc2b21cc38f9a943dcb9b30602867fc323aeb9ed"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "napi",
  "napi-build",
@@ -2129,8 +2110,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06eb61d28a8b83b0bda7dc75bf886f178155dead57746fab874312c81baa359"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -2187,8 +2167,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8573ff803b00bdacc550475aacc72305621d2992988e5f7886391fa9d9bfa611"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "itertools",
  "memchr",
@@ -2226,8 +2205,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ff77b2ca10d57dc7645c4af838b1aa455cac6569992fe544ed041a8021ae10"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2241,8 +2219,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcd6412fde266b6ffdbcdf118cba2c8dc0d6ddba6aa4e361842ebaf320a4eed"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -2254,8 +2231,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab19e002e05e4d107483ace848ca2d6ce5c714f238d70d591f91d17fef54be98"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2275,8 +2251,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c1a97a1b53417a703f0404b71179e3d74d4dda02704ecdc3535efc666a0693"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "napi",
  "napi-build",
@@ -2290,8 +2265,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c753c4eb41524071c4d13650642b5622b7b23fca6b4d92872dc43f6e71686e16"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "base64",
  "compact_str",
@@ -2320,8 +2294,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbd5a19932bc3aded01f5f2ff18f448cadbd921b26cffa2b90294fd1a44f4ce"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2343,8 +2316,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.134.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817fd3459ecb0c0ea37042e796954d8caff9a6c5e23bf60a41f002cacdd5c79"
+source = "git+https://github.com/oxc-project/oxc?branch=codex%2Fsemantic-errors-generic#0962a62a34a2999420cbd2818f81c7fc21c03d08"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3723,7 +3695,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3785,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4082,7 +4054,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4101,7 +4073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4581,7 +4553,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ napi-build = { version = "2.2.2" }
 napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { version = "0.134.0", features = [
+oxc = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -249,19 +249,21 @@ oxc = { version = "0.134.0", features = [
   "regular_expression",
   "cfg",
 ] }
-oxc_allocator = { version = "0.134.0", features = ["pool"] }
-oxc_ecmascript = { version = "0.134.0" }
-oxc_napi = { version = "0.134.0" }
-oxc_str = { version = "0.134.0" }
-oxc_minify_napi = { version = "0.134.0" }
-oxc_parser_napi = { version = "0.134.0" }
-oxc_transform_napi = { version = "0.134.0" }
-oxc_traverse = { version = "0.134.0" }
+oxc_allocator = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic", features = [
+  "pool",
+] }
+oxc_ecmascript = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_napi = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_str = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_minify_napi = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_parser_napi = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_transform_napi = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
+oxc_traverse = { version = "0.134.0", git = "https://github.com/oxc-project/oxc", branch = "codex/semantic-errors-generic" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.
 # Please update with `cargo update oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index oxc-browserslist`
-oxc_index = { version = "4", features = [
+oxc_index = { version = "5", features = [
   "rayon",
   "serde",
 ] } # https://github.com/oxc-project/oxc-index-vec

--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -260,7 +260,7 @@ mod tests {
     let source_type = SourceType::default();
     let ret = Parser::new(allocator, source, source_type).parse();
     let program = ret.program;
-    let semantic_ret = SemanticBuilder::new().build(&program);
+    let semantic_ret = SemanticBuilder::new_without_errors().build(&program);
     (AstScopes::new(semantic_ret.semantic.into_scoping()), program)
   }
 

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -236,7 +236,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   // recreate semantic data
   #[expect(clippy::cast_possible_truncation)]
   let scoping = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
-    SemanticBuilder::new().with_stats(Stats {
+    SemanticBuilder::new_without_errors().with_stats(Stats {
       nodes: declaration_binding_names.len().next_power_of_two() as u32,
       scopes: 1,
       symbols: declaration_binding_names.len() as u32,

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -16,7 +16,10 @@ use oxc::transformer_plugins::{
 use oxc_str::CompactStr;
 
 use rolldown_common::{ConstExportMeta, ConstantValue, NormalizedBundlerOptions};
-use rolldown_ecmascript::{EcmaAst, WithMutFields, semantic_builder_for_transform};
+use rolldown_ecmascript::{
+  EcmaAst, WithMutFields, semantic_builder_for_transform,
+  semantic_builder_for_transform_without_errors,
+};
 use rolldown_ecmascript_utils::contains_script_closing_tag;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, EventKind, Severity};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -271,7 +274,7 @@ impl PreProcessEcmaAst {
     if let Some(scoping) = scoping.take() {
       return scoping;
     }
-    let ret = semantic_builder_for_transform()
+    let ret = semantic_builder_for_transform_without_errors()
       // Preallocate memory for the underlying data structures.
       .with_stats(self.stats)
       .build(program)

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -14,7 +14,6 @@ use oxc::transformer::{Helper, HelperLoaderOptions};
 use oxc::{
   codegen::{Codegen, CodegenOptions, CodegenReturn},
   isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
-  semantic::SemanticBuilder,
   span::SourceType,
   transformer::Transformer,
   transformer_plugins::{
@@ -23,7 +22,9 @@ use oxc::{
   },
 };
 use oxc_resolver::TsConfig;
-use rolldown_ecmascript::semantic_builder_for_transform;
+use rolldown_ecmascript::{
+  semantic_builder_for_transform, semantic_builder_for_transform_without_errors,
+};
 use rolldown_error::{BuildDiagnostic, EventKind, Severity};
 use rolldown_sourcemap::{OwnedSourceMap, SourceMap, collapse_sourcemaps};
 use rustc_hash::FxHashMap;
@@ -386,9 +387,9 @@ pub fn enhanced_transform(
     }
   }
 
-  let scoping = scoping
-    .take()
-    .unwrap_or_else(|| semantic_builder_for_transform().build(&program).semantic.into_scoping());
+  let scoping = scoping.take().unwrap_or_else(|| {
+    semantic_builder_for_transform_without_errors().build(&program).semantic.into_scoping()
+  });
 
   let transform_ret = Transformer::new(&allocator, Path::new(filename), &oxc_transform_options)
     .build_with_scoping(scoping, &mut program);
@@ -403,7 +404,8 @@ pub fn enhanced_transform(
     && !inject.is_empty()
   {
     let config = build_inject_config(inject);
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping =
+      oxc::semantic::SemanticBuilder::new_without_errors().build(&program).semantic.into_scoping();
     let _ = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
   }
 

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -19,13 +19,19 @@ pub fn semantic_builder_for_transform<'a>() -> SemanticBuilder<'a> {
   SemanticBuilder::new().with_enum_eval(true)
 }
 
+/// Returns a diagnostics-free [`SemanticBuilder`] pre-configured for transform
+/// scoping rebuilds.
+pub fn semantic_builder_for_transform_without_errors<'a>() -> SemanticBuilder<'a, false> {
+  SemanticBuilder::new_without_errors().with_enum_eval(true)
+}
+
 impl EcmaAst {
   pub fn is_body_empty(&self) -> bool {
     self.program().is_empty()
   }
 
   pub fn make_semantic<'ast>(program: &'ast Program<'ast>, with_cfg: bool) -> Semantic<'ast> {
-    SemanticBuilder::new().with_cfg(with_cfg).build(program).semantic
+    SemanticBuilder::new_without_errors().with_cfg(with_cfg).build(program).semantic
   }
 
   pub fn make_scoping(&self) -> Scoping {
@@ -36,7 +42,7 @@ impl EcmaAst {
 
   pub fn make_symbol_table_and_scope_tree_with_semantic_builder<'a>(
     &'a self,
-    semantic_builder: SemanticBuilder<'a>,
+    semantic_builder: SemanticBuilder<'a, false>,
   ) -> Scoping {
     self.program.with_dependent::<'a, Scoping>(|_owner, dep| {
       semantic_builder.build(&dep.program).semantic.into_scoping()

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -15,7 +15,7 @@ mod r#gen;
 mod helpers;
 pub mod program_cell;
 pub use r#gen::ToSourceString;
-pub use helpers::semantic_builder_for_transform;
+pub use helpers::{semantic_builder_for_transform, semantic_builder_for_transform_without_errors};
 
 /// - To access `&mut ast::Program`, use `ast.program.with_mut(|fields| { fields.program; })`.
 pub struct EcmaAst {

--- a/crates/rolldown_ecmascript/src/lib.rs
+++ b/crates/rolldown_ecmascript/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::{
   },
   ecma_ast::{
     EcmaAst, ToSourceString, program_cell::WithMutFields, semantic_builder_for_transform,
+    semantic_builder_for_transform_without_errors,
   },
   ecma_compiler::{EcmaCompiler, PrintCommentsOptions, PrintOptions},
 };

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -7,7 +7,7 @@ use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
 use oxc::parser::Parser;
 use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
-use rolldown_ecmascript::semantic_builder_for_transform;
+use rolldown_ecmascript::semantic_builder_for_transform_without_errors;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, EventKind, Severity};
 use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
@@ -71,7 +71,8 @@ impl Plugin for ViteTransformPlugin {
     }
 
     let mut program = ret.program;
-    let scoping = semantic_builder_for_transform().build(&program).semantic.into_scoping();
+    let scoping =
+      semantic_builder_for_transform_without_errors().build(&program).semantic.into_scoping();
     let transformer = Transformer::new(&allocator, Path::new(args.id), &transform_options);
     let transformer_return = transformer.build_with_scoping(scoping, &mut program);
     if !transformer_return.errors.is_empty() {


### PR DESCRIPTION
# NOTE

This Pr isn't ready to be reviewed, it just needs to be non-draft so that cod speed CI job runs.



## Summary
- Points Rolldown's OXC workspace dependencies at `oxc-project/oxc` branch `codex/semantic-errors-generic`, which adds a diagnostics-free semantic builder mode.
- Uses the diagnostics-free semantic builder for scoping-only rebuilds after transforms, inject handling, lazy export generation, and test helpers.
- Keeps diagnostics-enabled semantic analysis in the paths that consume `semantic_ret.errors`.

## Notes for reviewers
- This depends on OXC commit `0962a62a34a2999420cbd2818f81c7fc21c03d08` until the semantic builder API lands upstream.
- `oxc_index` moves to v5 to match the OXC branch dependency graph.