### PR TITLE
ci: pass ALGOLIA_APP_ID and ALGOLIA_API_KEY to void deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -92,6 +92,8 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
           VOID_PROJECT: rolldown
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
       # Mark this fingerprint as deployed so the next identical-content run skips. The marker
       # file's contents are unused (the cache key is the fingerprint); an evicted marker only


### PR DESCRIPTION
## Summary

The VitePress Algolia search provider reads `ALGOLIA_APP_ID` and `ALGOLIA_API_KEY` at build time (`docs/.vitepress/config.ts`). The docs build runs inside the `deploy-void` job (`vp run docs:void`), but that job never passed these variables, so search shipped unconfigured.

This wires both keys into the deploy job's `env` from the `void` environment secrets.

## Follow-up (manual, in repo settings)

Add the secrets to the `void` GitHub Actions environment:
- `ALGOLIA_APP_ID`
- `ALGOLIA_API_KEY` (Algolia **Search-Only** API key)

Until set, `secrets.ALGOLIA_*` resolve to empty strings and `config.ts` falls back to `''`, so the deploy won't break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)