### PR TITLE
feat(dev): align test-dev-server with Vite dev server

### DIFF
--- a/meta/design/dev-engine.md
+++ b/meta/design/dev-engine.md
@@ -48,8 +48,10 @@ error overlay appears even after a browser refresh.
 Vite-side realization (in `fullBundleEnvironment.ts`): a single
 `lastBuildError: Error | null` field caches the most recent error from
 **either** channel — it is set in both `onOutput` (full-build errors)
-and `onHmrUpdates` (HMR errors), and cleared back to `null` only on a
-successful `onOutput`. It is replayed on the **`vite:client:connect`**
+and `onHmrUpdates` (HMR errors), and cleared back to `null` on a
+successful build from **either** channel (a successful `onOutput` _or_
+a successful `onHmrUpdates`, since an HMR patch that computes cleanly
+supersedes a previously cached error). It is replayed on the **`vite:client:connect`**
 event for every freshly connected client (including a post-refresh
 reconnect), so the error overlay reappears after a browser refresh.
 The two channels differ only in their _live_

--- a/packages/test-dev-server/src/clients.ts
+++ b/packages/test-dev-server/src/clients.ts
@@ -1,0 +1,42 @@
+import type { ClientSession } from './types/client-session.js';
+
+/**
+ * Registry of connected HMR clients, mirroring the `Clients` class in Vite
+ * full-bundle mode (`fullBundleEnvironment.ts`). A "client" here is a
+ * {@link ClientSession} (its own id + websocket) rather than a Vite hot-channel
+ * client, but the surface (`setupIfNeeded` / `get` / `getAll` / `delete`) is the
+ * same.
+ */
+export class Clients {
+  #byId = new Map<string, ClientSession>();
+
+  get size(): number {
+    return this.#byId.size;
+  }
+
+  /** Register a client, replacing a stale session that reconnected with the same id. */
+  setupIfNeeded(client: ClientSession): void {
+    const existing = this.#byId.get(client.id);
+    if (existing && existing.ws !== client.ws) {
+      console.warn(`Client ${client.id} reconnecting, replacing existing session`);
+      existing.ws.close(1000, 'Replaced by new connection');
+    }
+    this.#byId.set(client.id, client);
+  }
+
+  get(id: string): ClientSession | undefined {
+    return this.#byId.get(id);
+  }
+
+  getAll(): ClientSession[] {
+    return Array.from(this.#byId.values());
+  }
+
+  has(id: string): boolean {
+    return this.#byId.has(id);
+  }
+
+  delete(id: string): void {
+    this.#byId.delete(id);
+  }
+}

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -1,27 +1,17 @@
 import connect from 'connect';
-import nodeFs from 'node:fs';
 import http from 'node:http';
 import nodePath from 'node:path';
-import nodeUrl from 'node:url';
-import type { BindingClientHmrUpdate, DevEngine } from 'rolldown/experimental';
-import { dev } from 'rolldown/experimental';
 import serveStatic from 'serve-static';
-import { WebSocket, WebSocketServer } from 'ws';
-import type { HmrInvalidateMessage } from './types/client-message.js';
-import { ClientSession } from './types/client-session.js';
-import type { NormalizedDevOptions } from './types/normalized-dev-options.js';
-import type {
-  ConnectedMessage,
-  HmrReloadMessage,
-  HmrUpdateMessage,
-} from './types/server-message.js';
+import { WebSocketServer } from 'ws';
+import { FullBundleDevEnvironment } from './environments/full-bundle-dev-environment.js';
+import { indexHtmlMiddleware } from './middlewares/index-html.js';
+import { memoryFilesMiddleware } from './middlewares/memory-files.js';
+import { statusMiddleware } from './middlewares/status.js';
+import { triggerLazyBundlingMiddleware } from './middlewares/trigger-lazy-bundling.js';
 import { createDevServerPlugin } from './utils/create-dev-server-plugin.js';
 import { decodeClientMessage } from './utils/decode-client-message.js';
-import { getDevWatchOptionsForCi } from './utils/get-dev-watch-options-for-ci.js';
 import { loadDevConfig } from './utils/load-dev-config.js';
 import { normalizeDevOptions } from './utils/normalize-dev-options.js';
-
-let seed = 0;
 
 // Node20 does not support `Promise.withResolvers`
 const withResolvers = <T>() => {
@@ -34,45 +24,43 @@ const withResolvers = <T>() => {
   return { promise, resolve: resolve!, reject: reject! };
 };
 
+/**
+ * The http/websocket transport and middleware wiring around a
+ * {@link FullBundleDevEnvironment} — the test-dev-server equivalent of Vite's
+ * `server/index.ts`. All full-bundle behavior lives in the environment; this
+ * class only owns the connect/http/ws plumbing and registers the same
+ * middleware chain Vite does.
+ */
 class DevServer {
-  connectServer = connect();
-  server = http.createServer(this.connectServer);
-  serverStatus = {
-    allowRequest: false,
-    allowRequestPromiseResolvers: withResolvers<void>(),
-  };
-  wsServer = new WebSocketServer({ server: this.server });
-  #clients = new Map<string, ClientSession>();
-  #devOptions?: NormalizedDevOptions;
-  #devEngine?: DevEngine;
+  #connectServer = connect();
+  #server = http.createServer(this.#connectServer);
+  #wsServer = new WebSocketServer({ server: this.#server });
   #port = 3000;
-  #buildSeq = 0;
-  #moduleRegistrationSeq = 0;
 
-  constructor() {}
-
-  #sendMessage(
-    socket: WebSocket,
-    message: HmrUpdateMessage | HmrReloadMessage | ConnectedMessage,
-  ): void {
-    if (socket.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify(message));
-    }
-  }
+  // node platform gates requests until the initial build is on disk (browser
+  // serves a spinner instead, so it never blocks). Mirrors nothing in Vite —
+  // Vite is browser-only.
+  #serverStatus = {
+    allowRequest: false,
+    resolvers: withResolvers<void>(),
+  };
 
   async serve(): Promise<void> {
     const devConfig = await loadDevConfig();
     const devOptions = normalizeDevOptions(devConfig.dev ?? {});
-    this.#devOptions = devOptions;
     this.#port = process.env.DEV_SERVER_PORT
       ? parseInt(process.env.DEV_SERVER_PORT, 10)
       : devOptions.port;
 
-    this.#prepareServer();
-
     const buildOptions = devConfig.build ?? {};
 
-    // Inject port into devMode options for HMR runtime
+    // Serve from memory (Vite full-bundle parity) only for a browser build
+    // target; node builds keep disk serving (the fixture harness execs the
+    // artifact from disk). `build.platform` is the only platform signal set
+    // consistently across every fixture/playground config.
+    const serveFromMemory = buildOptions.platform === 'browser';
+
+    // Inject port into devMode options for the HMR runtime.
     buildOptions.experimental = buildOptions.experimental ?? {};
     buildOptions.experimental.devMode = buildOptions.experimental.devMode ?? {};
     if (typeof buildOptions.experimental.devMode === 'object') {
@@ -86,34 +74,80 @@ class DevServer {
     }
 
     const { output: outputOptions, ...inputOptions } = buildOptions;
-    let devEngine = await dev(inputOptions, outputOptions ?? {}, {
-      onHmrUpdates: (errOrUpdates) => {
-        if (errOrUpdates instanceof Error) {
-          console.error('HMR update error:', errOrUpdates);
-          this.#buildSeq++;
-        } else {
-          this.handleHmrUpdates(errOrUpdates.updates);
-          // Only increment if no FullReload — a FullReload triggers a rebuild
-          // which will call onOutput, so we let onOutput do the increment to
-          // avoid double-counting a single build cycle.
-          const hasFullReload = errOrUpdates.updates.some((u) => u.update.type === 'FullReload');
-          if (!hasFullReload) {
-            this.#buildSeq++;
+
+    // Gate + websocket transport must be wired before the engine starts so a
+    // client can connect while the initial build runs.
+    this.#prepareGate(serveFromMemory);
+    this.#server.listen(this.#port, () => {
+      console.log(`Server listening on http://localhost:${this.#port}`);
+    });
+
+    const env = await FullBundleDevEnvironment.create({
+      inputOptions,
+      outputOptions: outputOptions ?? {},
+      serveFromMemory,
+    });
+    this.#prepareWebSocket(env);
+    this.#prepareStdin(env);
+    this.#registerMiddlewares(env, serveFromMemory);
+
+    await env.run();
+    this.#readyHttpServer();
+  }
+
+  /** First middleware: block node requests until the initial build is ready. */
+  #prepareGate(serveFromMemory: boolean): void {
+    this.#connectServer.use(async (_req, _res, next) => {
+      // Browser never blocks: a not-ready request is answered with the
+      // "Bundling in progress" spinner by the index-html middleware.
+      if (serveFromMemory || this.#serverStatus.allowRequest) {
+        next();
+      } else {
+        await this.#serverStatus.resolvers.promise;
+        next();
+      }
+    });
+  }
+
+  #prepareWebSocket(env: FullBundleDevEnvironment): void {
+    this.#wsServer.on('connection', (ws, req) => {
+      const url = new URL(req.url ?? '', `http://localhost:${this.#port}`);
+      const clientId = url.searchParams.get('clientId');
+      if (!clientId) {
+        console.warn('WebSocket connection without clientId, closing');
+        ws.close(1008, 'Missing clientId');
+        return;
+      }
+
+      const client = env.connectClient(ws, clientId);
+
+      ws.on('error', console.error);
+      ws.on('close', () => {
+        env.disconnectClient(client.id);
+        console.log(`Client ${client.id} disconnected`);
+      });
+      ws.on('message', async (rawData) => {
+        const clientMessage = decodeClientMessage(rawData);
+        switch (clientMessage.type) {
+          case 'hmr:invalidate':
+            await env.invalidate(clientMessage.moduleId, client);
+            break;
+          case 'hmr:module-registered':
+            await env.registerModules(client.id, clientMessage.modules);
+            break;
+          default: {
+            const _never: never = clientMessage;
+            void _never;
           }
         }
-      },
-      onOutput: (errOrOutputs) => {
-        if (errOrOutputs instanceof Error) {
-          console.error('Build error:', errOrOutputs);
-        }
-        this.#buildSeq++;
-      },
-      watch: getDevWatchOptionsForCi(),
+      });
     });
-    this.#devEngine = devEngine;
+  }
+
+  #prepareStdin(env: FullBundleDevEnvironment): void {
     process.stdin.on('data', (data) => {
       if (data.toString() === 'r') {
-        devEngine.triggerFullBuild();
+        env.triggerFullBuild();
       }
     });
     // Unref stdin to prevent it from keeping the process alive.
@@ -121,221 +155,31 @@ class DevServer {
     if (typeof process.stdin.unref === 'function') {
       process.stdin.unref();
     }
-    this.#prepareHttpServerAfterCreateDevEngine(devEngine);
-    const initialBuildStart = Date.now();
-    console.log('Starting initial build...');
-    await devEngine.run();
-    const initialBuildEnd = Date.now();
-    console.log(`Initial build completed in ${initialBuildEnd - initialBuildStart}ms`);
-    this.#readyHttpServer();
   }
 
-  #prepareServer(): void {
-    this.connectServer.use(async (_req, _res, next) => {
-      if (this.serverStatus.allowRequest) {
-        next();
-      } else {
-        await this.serverStatus.allowRequestPromiseResolvers.promise;
-        next();
-      }
-    });
+  /** Register the full-bundle middleware chain (Vite's `server/index.ts` order). */
+  #registerMiddlewares(env: FullBundleDevEnvironment, serveFromMemory: boolean): void {
+    this.#connectServer.use(triggerLazyBundlingMiddleware(env));
+    this.#connectServer.use(statusMiddleware(env));
 
-    this.wsServer.on('connection', (ws, req) => {
-      // Parse client ID from WebSocket URL query parameter
-      const url = new URL(req.url ?? '', `http://localhost:${this.#port}`);
-      const clientId = url.searchParams.get('clientId');
-
-      if (!clientId) {
-        console.warn('WebSocket connection without clientId, closing');
-        ws.close(1008, 'Missing clientId');
-        return;
-      }
-
-      // Handle duplicate client ID (could be a reconnect)
-      if (this.#clients.has(clientId)) {
-        console.warn(`Client ${clientId} reconnecting, replacing existing session`);
-        const oldSession = this.#clients.get(clientId)!;
-        oldSession.ws.close(1000, 'Replaced by new connection');
-        this.#clients.delete(clientId);
-      }
-
-      const clientSession = new ClientSession(ws, clientId);
-      this.#clients.set(clientSession.id, clientSession);
-
-      // Acknowledge the connection
-      this.#sendMessage(ws, { type: 'connected' });
-
-      ws.on('error', console.error);
-      ws.on('close', () => {
-        this.#clients.delete(clientSession.id);
-        this.#devEngine?.removeClient(clientSession.id);
-        console.log(`Client ${clientSession.id} disconnected`);
-      });
-      ws.on('message', async (rawData) => {
-        const clientMessage = decodeClientMessage(rawData);
-        switch (clientMessage.type) {
-          case 'hmr:invalidate':
-            await this.#handleHmrInvalidate(clientMessage);
-            break;
-          case 'hmr:module-registered': {
-            console.log('Registering modules:', clientMessage.modules);
-            this.#devEngine?.registerModules(clientSession.id, clientMessage.modules);
-            this.#moduleRegistrationSeq++;
-            break;
-          }
-          default: {
-            const _never: never = clientMessage;
-          }
-        }
-      });
-    });
-
-    this.server.listen(this.#port, () => {
-      console.log(`Server listening on http://localhost:${this.#port}`);
-    });
-  }
-
-  #prepareHttpServerAfterCreateDevEngine(devEngine: DevEngine): void {
-    this.connectServer.use(async (req, _res, next) => {
-      if (req.url === '/' || req.url === '/index.html') {
-        await devEngine.ensureLatestBuildOutput();
-        next();
-      } else {
-        next();
-      }
-    });
-    this.connectServer.use(async (req, res, next) => {
-      if (req.url?.startsWith('/@vite/lazy?')) {
-        try {
-          const url = new URL(req.url, `http://localhost:${this.#port}`);
-          const moduleId = url.searchParams.get('id');
-          const clientId = url.searchParams.get('clientId');
-          console.log(`Lazy compile request for module ${moduleId} from client ${clientId}`);
-
-          if (moduleId && clientId) {
-            const moduleCode = await devEngine.compileEntry(moduleId, clientId);
-            res!.setHeader('Content-Type', 'application/javascript');
-            res!.end(moduleCode);
-            return;
-          }
-        } catch (err) {
-          // Return server error response
-          res!.statusCode = 500;
-          res!.end('Internal Server Error during lazy compilation');
-          console.error('Error handling lazy compile request:', err);
-          return;
-        }
-      }
-      next();
-    });
-    this.connectServer.use(async (req, res, next) => {
-      if (req.url === '/_dev/status') {
-        const bundleState = await devEngine.getBundleState();
-        res.setHeader('Content-Type', 'application/json');
-        res.end(
-          JSON.stringify({
-            hasStaleOutput: bundleState.hasStaleOutput,
-            lastBuildErrored: bundleState.lastBuildErrored,
-            buildSeq: this.#buildSeq,
-            connectedClients: this.#clients.size,
-            moduleRegistrationSeq: this.#moduleRegistrationSeq,
-          }),
-        );
-        return;
-      }
-      next();
-    });
-    this.connectServer.use(
-      serveStatic(nodePath.join(process.cwd(), 'dist'), {
-        index: ['index.html'],
-        extensions: ['html'],
-      }),
-    );
-  }
-
-  #readyHttpServer() {
-    this.serverStatus.allowRequest = true;
-    this.serverStatus.allowRequestPromiseResolvers.resolve();
-  }
-
-  handleHmrUpdates(updates: BindingClientHmrUpdate[]): void {
-    for (const clientUpdate of updates) {
-      const update = clientUpdate.update;
-      switch (update.type) {
-        case 'Patch': {
-          const client = this.#clients.get(clientUpdate.clientId);
-          if (!client) {
-            console.warn(`Client ${clientUpdate.clientId} not found`);
-            continue;
-          }
-          this.sendUpdateToClient(client.ws, update);
-          break;
-        }
-        case 'FullReload':
-          if (this.#devOptions?.platform === 'browser') {
-            const client = this.#clients.get(clientUpdate.clientId);
-            if (!client) {
-              console.warn(`Client ${clientUpdate.clientId} not found`);
-              break;
-            }
-            console.log(`[hmr]: Sending reload message to client ${clientUpdate.clientId}`);
-            this.#sendMessage(client.ws, { type: 'hmr:reload' });
-          }
-          this.#devEngine?.ensureLatestBuildOutput();
-          break;
-        case 'Noop':
-          console.warn(`Client ${clientUpdate.clientId} received noop update`);
-          break;
-        default:
-          throw new Error(`Unknown update type: ${update}`);
-      }
-    }
-  }
-
-  sendUpdateToClient(socket: WebSocket, output: BindingClientHmrUpdate['update']): void {
-    if (output.type !== 'Patch') {
-      return;
-    }
-    if (output.code) {
-      console.log('Patching...');
-      const path = `${seed}.js`;
-      seed++;
-      nodeFs.writeFileSync(nodePath.join(process.cwd(), 'dist', path), output.code);
-      const patchUriForBrowser = `/${path}`;
-      const patchUriForFile = nodeUrl
-        .pathToFileURL(nodePath.join(process.cwd(), 'dist', path))
-        .toString();
-      console.log(
-        'Patch:',
-        JSON.stringify({
-          type: 'update',
-          url: patchUriForBrowser,
-          path: patchUriForFile,
+    if (serveFromMemory) {
+      this.#connectServer.use(memoryFilesMiddleware(env));
+      this.#connectServer.use(indexHtmlMiddleware(env));
+    } else {
+      // node: the artifact (and HMR patches) are written to disk and read
+      // directly by the fixture harness, so serve `dist/` statically.
+      this.#connectServer.use(
+        serveStatic(nodePath.join(process.cwd(), 'dist'), {
+          index: ['index.html'],
+          extensions: ['html'],
         }),
       );
-      this.#sendMessage(socket, {
-        type: 'hmr:update',
-        url: patchUriForBrowser,
-        path: patchUriForFile,
-      });
-    } else {
-      console.debug(
-        `Failed to send update to client due to ${JSON.stringify(
-          {
-            hasCode: output.code != null,
-          },
-          null,
-          2,
-        )}`,
-      );
     }
   }
 
-  async #handleHmrInvalidate(msg: HmrInvalidateMessage): Promise<void> {
-    console.log('Invalidating...');
-    // Always invalidate - sendMessage will handle empty client lists
-    const updates = await this.#devEngine!.invalidate(msg.moduleId);
-    this.handleHmrUpdates(updates);
+  #readyHttpServer(): void {
+    this.#serverStatus.allowRequest = true;
+    this.#serverStatus.resolvers.resolve();
   }
 }
 

--- a/packages/test-dev-server/src/environments/full-bundle-dev-environment.ts
+++ b/packages/test-dev-server/src/environments/full-bundle-dev-environment.ts
@@ -1,0 +1,416 @@
+import nodeFs from 'node:fs';
+import nodePath from 'node:path';
+import nodeUrl from 'node:url';
+import type { BindingClientHmrUpdate, DevEngine } from 'rolldown/experimental';
+import { dev } from 'rolldown/experimental';
+import type { WebSocket } from 'ws';
+import { Clients } from '../clients.js';
+import { MemoryFiles, weakEtag } from '../memory-files.js';
+import { ClientSession } from '../types/client-session.js';
+import type {
+  BuildOkMessage,
+  ConnectedMessage,
+  ErrorMessage,
+  HmrReloadMessage,
+  HmrUpdateMessage,
+} from '../types/server-message.js';
+import { debounce } from '../utils/debounce.js';
+import { getDevWatchOptionsForCi } from '../utils/get-dev-watch-options-for-ci.js';
+import { prepareError } from '../utils/prepare-error.js';
+
+type ServerMessage =
+  | HmrUpdateMessage
+  | HmrReloadMessage
+  | ConnectedMessage
+  | ErrorMessage
+  | BuildOkMessage;
+
+let seed = 0;
+
+export interface FullBundleDevEnvironmentOptions {
+  inputOptions: Parameters<typeof dev>[0];
+  outputOptions: Parameters<typeof dev>[1];
+  /**
+   * Serve from memory (Vite full-bundle parity) vs. disk. Derived from the
+   * rolldown build target — see `DevServer`.
+   */
+  serveFromMemory: boolean;
+}
+
+/**
+ * Port of Vite's `FullBundleDevEnvironment`
+ * (`packages/vite/src/node/server/environments/fullBundleEnvironment.ts`).
+ *
+ * Owns the dev engine, the in-memory output store, the connected clients, and
+ * the build-error / reload bookkeeping. The surrounding `DevServer` owns the
+ * http/ws transport and wires connections + middlewares into this environment —
+ * the same split Vite has between `server/index.ts` and this class. The only
+ * intentional divergences are documented inline: a `node` build target serves
+ * from disk (the fixture harness execs the artifact), and the client transport
+ * is the rolldown default HMR runtime over a plain websocket rather than Vite's
+ * hot channel.
+ */
+export class FullBundleDevEnvironment {
+  /**
+   * In-memory output store (Vite parity). On a browser target the engine runs
+   * with `watch.skipWrite: true` so the full bundle and HMR patches live here
+   * and are served by the memory-files / index-html middlewares. Empty on a
+   * node target, which serves the on-disk `dist/`.
+   */
+  readonly memoryFiles = new MemoryFiles();
+  readonly serveFromMemory: boolean;
+
+  #devEngine!: DevEngine;
+  #clients = new Clients();
+
+  /**
+   * Most recent build error from *either* callback channel. Set in both
+   * `onOutput` and `onHmrUpdates` on failure, cleared on a success from either
+   * channel, and replayed to freshly-connected clients so the error survives a
+   * refresh. See `meta/design/dev-engine.md` §2.
+   */
+  #lastBuildError: Error | null = null;
+  /**
+   * A FullReload HMR update defers its page reload until the auto-upgraded
+   * rebuild lands in `onOutput`, avoiding an error-overlay flash on a build
+   * that turns out to break.
+   */
+  #fullReloadPending = false;
+  /** Gate for access-triggered regeneration (see `triggerBundleRegenerationIfStale`). */
+  #initialBuildCompleted = false;
+
+  // Test-only instrumentation (no Vite equivalent); surfaced via the status
+  // middleware so the e2e harness can await builds / module registrations.
+  #buildSeq = 0;
+  #moduleRegistrationSeq = 0;
+
+  // Debounced broadcast reload, mirroring Vite's `debouncedFullReload`.
+  // Only browser clients act on a reload; node artifact processes are restarted
+  // by the test harness instead, so we skip them.
+  #debouncedFullReload = debounce(20, () => {
+    if (!this.serveFromMemory) return;
+    for (const client of this.#clients.getAll()) {
+      this.#send(client.ws, { type: 'hmr:reload' });
+    }
+    console.log('[hmr]: page reload');
+  });
+
+  private constructor(serveFromMemory: boolean) {
+    this.serveFromMemory = serveFromMemory;
+  }
+
+  /** Create the environment and its dev engine (Vite's `listen()`). */
+  static async create(options: FullBundleDevEnvironmentOptions): Promise<FullBundleDevEnvironment> {
+    const env = new FullBundleDevEnvironment(options.serveFromMemory);
+    env.#devEngine = await dev(options.inputOptions, options.outputOptions, {
+      onHmrUpdates: (result) => env.#onHmrUpdates(result),
+      onOutput: (result) => env.#onOutput(result),
+      watch: { ...getDevWatchOptionsForCi(), skipWrite: options.serveFromMemory },
+    });
+    return env;
+  }
+
+  /** Run the initial build, then reload any spinner clients (Vite parity). */
+  async run(): Promise<void> {
+    const start = Date.now();
+    console.log('Starting initial build...');
+    await this.#devEngine.run();
+    console.log(`Initial build completed in ${Date.now() - start}ms`);
+    // `run()` resolves once the initial build settles (success OR failure), so
+    // the engine is now in its steady state and access-triggered regeneration
+    // may begin.
+    this.#initialBuildCompleted = true;
+    // Reload any "Bundling in progress" spinner clients that connected during
+    // the initial build (Vite broadcasts a full-reload after the first build).
+    this.#debouncedFullReload();
+  }
+
+  async close(): Promise<void> {
+    this.memoryFiles.clear();
+    await this.#devEngine.close();
+  }
+
+  triggerFullBuild(): void {
+    this.#devEngine.triggerFullBuild();
+  }
+
+  async getStatus(): Promise<{
+    hasStaleOutput: boolean;
+    lastBuildErrored: boolean;
+    buildSeq: number;
+    connectedClients: number;
+    moduleRegistrationSeq: number;
+  }> {
+    const bundleState = await this.#devEngine.getBundleState();
+    return {
+      hasStaleOutput: bundleState.hasStaleOutput,
+      lastBuildErrored: bundleState.lastBuildErrored,
+      buildSeq: this.#buildSeq,
+      connectedClients: this.#clients.size,
+      moduleRegistrationSeq: this.#moduleRegistrationSeq,
+    };
+  }
+
+  // --- Client lifecycle (driven by the DevServer's websocket transport) ------
+
+  /** Register a freshly-connected client; ack it and replay any cached error. */
+  connectClient(ws: WebSocket, clientId: string): ClientSession {
+    const client = new ClientSession(ws, clientId);
+    this.#clients.setupIfNeeded(client);
+
+    this.#send(ws, { type: 'connected' });
+    // Replay the cached build error so it survives a browser refresh (Vite
+    // `vite:client:connect` parity).
+    if (this.#lastBuildError) {
+      this.#sendError(ws, this.#lastBuildError);
+    }
+    return client;
+  }
+
+  async disconnectClient(clientId: string): Promise<void> {
+    this.#clients.delete(clientId);
+    await this.#devEngine.removeClient(clientId);
+  }
+
+  async registerModules(clientId: string, modules: string[]): Promise<void> {
+    console.log('Registering modules:', modules);
+    await this.#devEngine.registerModules(clientId, modules);
+    this.#moduleRegistrationSeq++;
+  }
+
+  /**
+   * Programmatic `import.meta.hot.invalidate()` (Vite's `invalidateModule`).
+   * Surfaces an invalidate-time build error to the calling client instead of
+   * crashing the connection handler.
+   */
+  async invalidate(moduleId: string, client: ClientSession): Promise<void> {
+    console.log('Invalidating...');
+    let updates: BindingClientHmrUpdate[];
+    try {
+      updates = await this.#devEngine.invalidate(moduleId);
+    } catch (e) {
+      const error = e as Error;
+      this.#lastBuildError = error;
+      this.#sendError(client.ws, error);
+      return;
+    }
+    // `invalidate()` never auto-upgrades to a rebuild, so onOutput won't fire;
+    // FullReload updates must trigger regeneration + reload inline.
+    this.#handleHmrUpdates(updates, true);
+  }
+
+  // --- Access-triggered regeneration / lazy bundling (Vite parity) -----------
+
+  /**
+   * Vite's `triggerBundleRegenerationIfStale` with the conservative-rebuild
+   * guard (dev-engine §1/§12): regenerate only when output is stale, the last
+   * build did NOT error, and the initial build has completed. Fire-and-forget —
+   * kick the rebuild, reload when it lands, and return whether a regeneration
+   * was triggered so the caller can serve the spinner meanwhile.
+   *
+   * Exception (dev-engine §3/§12): after an HMR-stage failure a page access
+   * forces a full rebuild instead, so a buggy HMR generation can be recovered
+   * by reloading. A Rebuild-stage or full-build failure is left alone.
+   */
+  async triggerBundleRegenerationIfStale(): Promise<boolean> {
+    const state = await this.#devEngine.getBundleState();
+
+    // Trigger full build if the HMR errors,
+    // this is to make it easier to recover if the HMR generation is broken for some reason.
+    if (this.#initialBuildCompleted && state.lastBuildErrored && state.lastErrorStage === 'Hmr') {
+      this.#devEngine.triggerFullBuild();
+      this.#devEngine.ensureLatestBuildOutput().then(() => this.#debouncedFullReload());
+      return true;
+    }
+
+    const shouldTrigger =
+      state.hasStaleOutput && !state.lastBuildErrored && this.#initialBuildCompleted;
+    if (shouldTrigger) {
+      this.#devEngine.ensureLatestBuildOutput().then(() => this.#debouncedFullReload());
+    }
+    return shouldTrigger;
+  }
+
+  /** Compile a lazy entry on demand (Vite's `triggerLazyBundling`). */
+  async triggerLazyBundling(
+    moduleId: string | null,
+    clientId: string | null,
+  ): Promise<string | undefined> {
+    if (!moduleId || !clientId) {
+      return undefined;
+    }
+    return this.#devEngine.compileEntry(moduleId, clientId);
+  }
+
+  // --- Dev engine callbacks --------------------------------------------------
+
+  #onHmrUpdates(
+    result: Error | { updates: BindingClientHmrUpdate[]; changedFiles: string[] },
+  ): void {
+    if (result instanceof Error) {
+      console.error('HMR update error:', result);
+      this.#lastBuildError = result;
+      this.#broadcastError(result);
+      this.#buildSeq++;
+      return;
+    }
+    // A successful HMR computation supersedes any cached error.
+    const wasErrored = this.#lastBuildError !== null;
+    this.#lastBuildError = null;
+    if (wasErrored) {
+      // Recovered from a build error via HMR. The recovery patch reaches only
+      // the module's own client; broadcast `build:ok` so the error overlay
+      // clears on every client (incl. the separate overlay client).
+      this.#broadcast({ type: 'build:ok' });
+    }
+    const { updates, changedFiles } = result;
+    const hasFullReload = updates.some((u) => u.update.type === 'FullReload');
+    // Mirror Vite: skip client-facing work for empty / all-noop batches.
+    if (changedFiles.length > 0 && !updates.every((u) => u.update.type === 'Noop')) {
+      this.#handleHmrUpdates(updates);
+    }
+    // Only increment if no FullReload — a FullReload triggers a rebuild which
+    // will call onOutput, so we let onOutput do the increment to avoid
+    // double-counting a single build cycle.
+    if (!hasFullReload) {
+      this.#buildSeq++;
+    }
+  }
+
+  #onOutput(result: Error | { output: readonly unknown[] }): void {
+    if (result instanceof Error) {
+      console.error('Build error:', result);
+      this.#lastBuildError = result;
+      this.#broadcastError(result);
+      this.#buildSeq++;
+      return;
+    }
+    // A fresh full bundle clears any cached error. Remember whether we are
+    // recovering from one: a plain recovery rebuild emits no client-facing HMR
+    // message, so we must reload to clear the error overlay / spinner and show
+    // the now-working page.
+    const wasErrored = this.#lastBuildError !== null;
+    this.#lastBuildError = null;
+    if (this.serveFromMemory) {
+      // Mirror Vite: populate the in-memory output. Don't clear first —
+      // incremental builds reuse files. Lazily materialize per request.
+      for (const outputFile of result.output as Array<
+        | { type: 'chunk'; fileName: string; code: string }
+        | { type: 'asset'; fileName: string; source: string | Uint8Array }
+      >) {
+        const fileName = outputFile.fileName;
+        this.memoryFiles.set(fileName, () => {
+          const source = outputFile.type === 'chunk' ? outputFile.code : outputFile.source;
+          return { source, etag: weakEtag(source) };
+        });
+      }
+    }
+    // Fire a deferred full reload (queued by a FullReload HMR update), or a
+    // recovery reload (a build that just went from errored → ok), now that
+    // fresh output exists — so we never reload onto a broken bundle.
+    if (this.#fullReloadPending || wasErrored) {
+      this.#fullReloadPending = false;
+      this.#debouncedFullReload();
+    }
+    this.#buildSeq++;
+  }
+
+  // --- HMR fan-out -----------------------------------------------------------
+
+  #handleHmrUpdates(updates: BindingClientHmrUpdate[], fromInvalidate = false): void {
+    for (const clientUpdate of updates) {
+      const update = clientUpdate.update;
+      switch (update.type) {
+        case 'Patch': {
+          const client = this.#clients.get(clientUpdate.clientId);
+          if (!client) {
+            console.warn(`Client ${clientUpdate.clientId} not found`);
+            continue;
+          }
+          this.#sendPatch(client.ws, update);
+          break;
+        }
+        case 'FullReload':
+          if (fromInvalidate) {
+            // An invalidate-driven FullReload does not auto-upgrade to a
+            // rebuild, so onOutput won't fire — regenerate then reload here.
+            this.#devEngine.ensureLatestBuildOutput().then(() => {
+              this.#debouncedFullReload();
+            });
+          } else {
+            // Defer the reload until the auto-upgraded rebuild lands in
+            // onOutput (avoids flashing onto a possibly-broken bundle).
+            this.#fullReloadPending = true;
+          }
+          break;
+        case 'Noop':
+          console.warn(`Client ${clientUpdate.clientId} received noop update`);
+          break;
+        default:
+          throw new Error(`Unknown update type: ${JSON.stringify(update)}`);
+      }
+    }
+  }
+
+  #sendPatch(socket: WebSocket, output: BindingClientHmrUpdate['update']): void {
+    if (output.type !== 'Patch') {
+      return;
+    }
+    if (!output.code) {
+      console.debug('Failed to send update to client: patch has no code');
+      return;
+    }
+    console.log('Patching...');
+
+    if (this.serveFromMemory) {
+      // Store the patch (and its sourcemap) in memory; the client loads it by
+      // URL via the memory-files middleware. The `\n; export {}` guard mirrors
+      // Vite — it forces the patch to be treated as an ES module to mitigate
+      // XSSI-style attacks (see fullBundleEnvironment.ts).
+      this.memoryFiles.set(output.filename, { source: output.code + '\n; export {}' });
+      if (output.sourcemapFilename && output.sourcemap) {
+        this.memoryFiles.set(output.sourcemapFilename, { source: output.sourcemap });
+      }
+      const url = `/${output.filename}`;
+      this.#send(socket, { type: 'hmr:update', url, path: url });
+      return;
+    }
+
+    // node: write the patch to disk; the artifact imports it via a file:// URL.
+    const path = `${seed}.js`;
+    seed++;
+    nodeFs.writeFileSync(nodePath.join(process.cwd(), 'dist', path), output.code);
+    const patchUriForBrowser = `/${path}`;
+    const patchUriForFile = nodeUrl
+      .pathToFileURL(nodePath.join(process.cwd(), 'dist', path))
+      .toString();
+    this.#send(socket, {
+      type: 'hmr:update',
+      url: patchUriForBrowser,
+      path: patchUriForFile,
+    });
+  }
+
+  // --- Messaging -------------------------------------------------------------
+
+  #broadcast(message: ServerMessage): void {
+    for (const client of this.#clients.getAll()) {
+      this.#send(client.ws, message);
+    }
+  }
+
+  /** Push a build error to every connected client (Vite's `prepareError` broadcast). */
+  #broadcastError(error: Error): void {
+    this.#broadcast({ type: 'error', err: prepareError(error) });
+  }
+
+  #sendError(socket: WebSocket, error: Error): void {
+    this.#send(socket, { type: 'error', err: prepareError(error) });
+  }
+
+  #send(socket: WebSocket, message: ServerMessage): void {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(JSON.stringify(message));
+    }
+  }
+}

--- a/packages/test-dev-server/src/error-overlay.ts
+++ b/packages/test-dev-server/src/error-overlay.ts
@@ -1,0 +1,66 @@
+/**
+ * Client-side build-error overlay, served by the dev server.
+ *
+ * This is the test-dev-server's stand-in for Vite's client error overlay. The
+ * shared rolldown HMR runtime (`crates/rolldown_plugin_hmr/.../runtime-extra-dev-default.js`)
+ * is intentionally NOT modified — instead this snippet is injected into the
+ * served HTML (the generated index.html AND the "Bundling in progress"
+ * fallback). It runs as its own lightweight websocket client alongside the
+ * rolldown HMR runtime: it renders `{ type: 'error' }` messages (broadcast on
+ * every build break and replayed on reconnect, so the overlay survives a
+ * refresh), clears on a successful `hmr:update`, and reloads on `hmr:reload`
+ * (which doubles as the spinner's reload mechanism).
+ */
+export function overlayClientScript(): string {
+  return /* js */ `
+const OVERLAY_ID = 'rolldown-error-overlay';
+function clearOverlay() {
+  const el = document.getElementById(OVERLAY_ID);
+  if (el) el.remove();
+}
+function showOverlay(err) {
+  clearOverlay();
+  const overlay = document.createElement('div');
+  overlay.id = OVERLAY_ID;
+  overlay.setAttribute(
+    'style',
+    'position:fixed;inset:0;z-index:99999;margin:0;background:rgba(0,0,0,0.85);'
+      + 'color:#ff5555;font-family:monospace;font-size:14px;line-height:1.5;'
+      + 'padding:24px;white-space:pre-wrap;overflow:auto;',
+  );
+  // Build a readable report from the \`prepareError\` payload, keeping the
+  // message visible even when the cleaned stack only holds internal frames.
+  const parts = [err.message];
+  if (err.plugin) parts.push('Plugin: ' + err.plugin);
+  if (err.id) {
+    const loc = err.loc ? ':' + err.loc.line + ':' + err.loc.column : '';
+    parts.push('File: ' + err.id + loc);
+  }
+  if (err.frame) parts.push(err.frame);
+  if (err.stack) parts.push(err.stack);
+  overlay.textContent = parts.join('\\n');
+  document.body.appendChild(overlay);
+}
+const clientId = crypto.randomUUID();
+const socket = new WebSocket('ws://' + location.host + '?clientId=' + clientId);
+socket.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  if (data.type === 'error') {
+    showOverlay(data.err);
+  } else if (data.type === 'hmr:update' || data.type === 'build:ok') {
+    clearOverlay();
+  } else if (data.type === 'hmr:reload') {
+    location.reload();
+  }
+};
+`;
+}
+
+/** Inject the overlay client script before `</body>` (or append it). */
+export function injectOverlayScript(html: string): string {
+  const tag = `<script type="module">${overlayClientScript()}</script>`;
+  if (html.includes('</body>')) {
+    return html.replace('</body>', `${tag}\n</body>`);
+  }
+  return html + tag;
+}

--- a/packages/test-dev-server/src/fallback-html.ts
+++ b/packages/test-dev-server/src/fallback-html.ts
@@ -1,0 +1,75 @@
+import { overlayClientScript } from './error-overlay.js';
+
+/**
+ * The "Bundling in progress" page, ported from Vite full-bundle mode
+ * (`indexHtml.ts::generateFallbackHtml`). Served by the index-html middleware
+ * when the bundle output is not ready yet or a stale regeneration was just
+ * triggered.
+ *
+ * Vite inlines its full HMR runtime here (via `getHmrImplementation`) so the
+ * spinner holds a live connection and reloads when output is ready. We inline
+ * the shared overlay client instead: it reloads on `hmr:reload` (sent on
+ * initial-build completion, stale regeneration, and error recovery) AND renders
+ * the build error if the initial build failed — so a broken initial build is
+ * explained rather than spinning forever.
+ */
+export function generateFallbackHtml(): string {
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bundling in progress</title>
+  <script type="module">${overlayClientScript()}</script>
+  <style>
+    :root {
+      --page-bg: #ffffff;
+      --text-color: #1d1d1f;
+      --spinner-track: #f5f5f7;
+      --spinner-accent: #0071e3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --page-bg: #1e1e1e;
+        --text-color: #f5f5f5;
+        --spinner-track: #424242;
+      }
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      background-color: var(--page-bg);
+      color: var(--text-color);
+    }
+
+    .container {
+      margin: auto;
+      padding: 2rem;
+      text-align: center;
+      border-radius: 1rem;
+    }
+
+    .spinner {
+      width: 3rem;
+      height: 3rem;
+      margin: 2rem auto;
+      border: 3px solid var(--spinner-track);
+      border-top-color: var(--spinner-accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg) } }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Bundling in progress</h1>
+    <p>The page will automatically reload when ready.</p>
+    <div class="spinner"></div>
+  </div>
+</body>
+</html>
+`;
+}

--- a/packages/test-dev-server/src/memory-files.ts
+++ b/packages/test-dev-server/src/memory-files.ts
@@ -1,0 +1,81 @@
+import nodeCrypto from 'node:crypto';
+
+/**
+ * In-memory output store, ported from Vite full-bundle mode
+ * (`packages/vite/src/node/server/environments/fullBundleEnvironment.ts`).
+ *
+ * In browser platform the dev engine runs with `watch.skipWrite: true`, so the
+ * full bundle and HMR patches never hit disk — they live here and are served by
+ * the memory-files / index-html middlewares (mirroring Vite's
+ * `memoryFilesMiddleware` + `indexHtmlMiddleware`).
+ */
+export type MemoryFile = {
+  source: string | Uint8Array;
+  etag?: string;
+};
+
+export class MemoryFiles {
+  #files = new Map<string, MemoryFile | (() => MemoryFile)>();
+
+  get size(): number {
+    return this.#files.size;
+  }
+
+  get(file: string): MemoryFile | undefined {
+    const result = this.#files.get(file);
+    if (result === undefined) {
+      return undefined;
+    }
+    // Lazily materialize (and memoize) so etag/source are only computed for
+    // files that are actually requested.
+    if (typeof result === 'function') {
+      const content = result();
+      this.#files.set(file, content);
+      return content;
+    }
+    return result;
+  }
+
+  set(file: string, content: MemoryFile | (() => MemoryFile)): void {
+    this.#files.set(file, content);
+  }
+
+  has(file: string): boolean {
+    return this.#files.has(file);
+  }
+
+  clear(): void {
+    this.#files.clear();
+  }
+}
+
+/** Weak etag over the content, matching Vite's `etag` weak-mode usage. */
+export function weakEtag(source: string | Uint8Array): string {
+  const hash = nodeCrypto.createHash('sha1').update(source).digest('base64');
+  const len = typeof source === 'string' ? Buffer.byteLength(source) : source.length;
+  return `W/"${len.toString(16)}-${hash.slice(0, 27)}"`;
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.cjs': 'application/javascript',
+  '.json': 'application/json',
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.map': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.wasm': 'application/wasm',
+  '.txt': 'text/plain',
+};
+
+export function contentTypeFor(filePath: string): string | undefined {
+  const dot = filePath.lastIndexOf('.');
+  if (dot < 0) return undefined;
+  return MIME_BY_EXT[filePath.slice(dot).toLowerCase()];
+}

--- a/packages/test-dev-server/src/middlewares/index-html.ts
+++ b/packages/test-dev-server/src/middlewares/index-html.ts
@@ -1,0 +1,45 @@
+import type http from 'node:http';
+import type { FullBundleDevEnvironment } from '../environments/full-bundle-dev-environment.js';
+import { generateFallbackHtml } from '../fallback-html.js';
+import type { MemoryFile } from '../memory-files.js';
+
+type Next = (err?: unknown) => void;
+
+/**
+ * Serve index.html from the in-memory store, or the "Bundling in progress"
+ * spinner when output is not ready / a stale regeneration was just triggered.
+ * Ported from Vite's `indexHtmlMiddleware` + `generateFallbackHtml`.
+ */
+export function indexHtmlMiddleware(env: FullBundleDevEnvironment) {
+  return async function indexHtmlMiddleware(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    next: Next,
+  ): Promise<void> {
+    const cleanedUrl = (req.url ?? '').split('?', 1)[0];
+    if (cleanedUrl !== '/' && !cleanedUrl.endsWith('.html')) {
+      next();
+      return;
+    }
+    const filePath = cleanedUrl === '/' ? 'index.html' : decodeURIComponent(cleanedUrl).slice(1);
+
+    let file: MemoryFile | undefined = env.memoryFiles.get(filePath);
+    // The html isn't in memory but other output is → it genuinely doesn't exist.
+    if (!file && env.memoryFiles.size !== 0) {
+      next();
+      return;
+    }
+    // Serve the spinner while a stale regeneration runs, or before any output
+    // exists. It auto-reloads when the server broadcasts `hmr:reload`.
+    if ((await env.triggerBundleRegenerationIfStale()) || file === undefined) {
+      file = { source: generateFallbackHtml() };
+    }
+
+    const html = typeof file.source === 'string' ? file.source : Buffer.from(file.source);
+    res.setHeader('Content-Type', 'text/html');
+    if (file.etag) {
+      res.setHeader('Etag', file.etag);
+    }
+    res.end(html);
+  };
+}

--- a/packages/test-dev-server/src/middlewares/memory-files.ts
+++ b/packages/test-dev-server/src/middlewares/memory-files.ts
@@ -1,0 +1,42 @@
+import type http from 'node:http';
+import type { FullBundleDevEnvironment } from '../environments/full-bundle-dev-environment.js';
+import { contentTypeFor } from '../memory-files.js';
+
+type Next = (err?: unknown) => void;
+
+/**
+ * Serve a built asset / HMR patch from the in-memory store, ported from Vite's
+ * `memoryFilesMiddleware`. `.html` is left to the index-html middleware.
+ */
+export function memoryFilesMiddleware(env: FullBundleDevEnvironment) {
+  return function memoryFilesMiddleware(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    next: Next,
+  ): void {
+    const cleanedUrl = (req.url ?? '').split('?', 1)[0];
+    if (cleanedUrl.endsWith('.html')) {
+      next();
+      return;
+    }
+    const filePath = decodeURIComponent(cleanedUrl).slice(1); // remove leading /
+    const file = env.memoryFiles.get(filePath);
+    if (!file) {
+      next();
+      return;
+    }
+    if (file.etag) {
+      if (req.headers['if-none-match'] === file.etag) {
+        res.statusCode = 304;
+        res.end();
+        return;
+      }
+      res.setHeader('Etag', file.etag);
+    }
+    const mime = contentTypeFor(filePath);
+    if (mime) {
+      res.setHeader('Content-Type', mime);
+    }
+    res.end(file.source);
+  };
+}

--- a/packages/test-dev-server/src/middlewares/status.ts
+++ b/packages/test-dev-server/src/middlewares/status.ts
@@ -1,0 +1,25 @@
+import type http from 'node:http';
+import type { FullBundleDevEnvironment } from '../environments/full-bundle-dev-environment.js';
+
+type Next = (err?: unknown) => void;
+
+/**
+ * Test-only `/_dev/status` endpoint (no Vite equivalent). The e2e harness polls
+ * it to await builds (`buildSeq`) and module registrations
+ * (`moduleRegistrationSeq`), and to read bundle freshness.
+ */
+export function statusMiddleware(env: FullBundleDevEnvironment) {
+  return async function statusMiddleware(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    next: Next,
+  ): Promise<void> {
+    if (req.url !== '/_dev/status') {
+      next();
+      return;
+    }
+    const status = await env.getStatus();
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(status));
+  };
+}

--- a/packages/test-dev-server/src/middlewares/trigger-lazy-bundling.ts
+++ b/packages/test-dev-server/src/middlewares/trigger-lazy-bundling.ts
@@ -1,0 +1,50 @@
+import type http from 'node:http';
+import type { FullBundleDevEnvironment } from '../environments/full-bundle-dev-environment.js';
+
+type Next = (err?: unknown) => void;
+
+/**
+ * Lazy-bundling endpoint, ported from Vite's `triggerLazyBundlingMiddleware`.
+ * `/@vite/lazy?id=...&clientId=...` compiles a lazy entry on demand.
+ */
+export function triggerLazyBundlingMiddleware(env: FullBundleDevEnvironment) {
+  return async function lazyBundlingMiddleware(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    next: Next,
+  ): Promise<void> {
+    if (!req.url?.startsWith('/@vite/lazy?')) {
+      next();
+      return;
+    }
+
+    let params: URLSearchParams;
+    try {
+      params = new URL(`http://localhost${req.url}`).searchParams;
+    } catch {
+      next();
+      return;
+    }
+
+    const moduleId = params.get('id');
+    const clientId = params.get('clientId');
+    console.log(`Lazy compile request for module ${moduleId} from client ${clientId}`);
+
+    let code: string | undefined;
+    try {
+      code = await env.triggerLazyBundling(moduleId, clientId);
+    } catch (err) {
+      res.statusCode = 500;
+      res.end('Internal Server Error during lazy compilation');
+      console.error('Error handling lazy compile request:', err);
+      return;
+    }
+
+    if (code == null) {
+      next();
+      return;
+    }
+    res.setHeader('Content-Type', 'application/javascript');
+    res.end(code);
+  };
+}

--- a/packages/test-dev-server/src/types/client-message.ts
+++ b/packages/test-dev-server/src/types/client-message.ts
@@ -1,6 +1,6 @@
 // (hyf0) TODO: These types should be exported from `rolldown/hmr`
 
-export interface HmrInvalidateMessage {
+interface HmrInvalidateMessage {
   type: 'hmr:invalidate';
   moduleId: string;
 }

--- a/packages/test-dev-server/src/types/dev-options.ts
+++ b/packages/test-dev-server/src/types/dev-options.ts
@@ -1,4 +1,8 @@
-export type Platform = 'browser';
+// `browser` mirrors Vite full-bundle mode (in-memory serving + spinner).
+// `node` is a rolldown-only scenario: the artifact is executed from disk by the
+// fixture harness, so it keeps disk serving. Several fixtures set `'node'` in
+// their (untypechecked) dev.config.mjs.
+export type Platform = 'browser' | 'node';
 
 export interface DevOptions {
   platform?: Platform;

--- a/packages/test-dev-server/src/types/server-message.ts
+++ b/packages/test-dev-server/src/types/server-message.ts
@@ -1,3 +1,5 @@
+import type { PreparedError } from '../utils/prepare-error.js';
+
 export interface HmrUpdateMessage {
   type: 'hmr:update';
   url: string;
@@ -10,4 +12,28 @@ export interface HmrReloadMessage {
 
 export interface ConnectedMessage {
   type: 'connected';
+}
+
+/**
+ * Mirrors Vite full-bundle mode: a build error is pushed to every connected
+ * client and replayed to freshly-connected ones, so the error survives a
+ * browser refresh. See `fullBundleEnvironment.ts` (`prepareError` + the
+ * `vite:client:connect` replay) and `meta/design/dev-engine.md` §2.
+ *
+ * `err` is the ANSI-stripped, serializable payload produced by `prepareError`,
+ * mirroring the `err` field of Vite's `ErrorPayload`.
+ */
+export interface ErrorMessage {
+  type: 'error';
+  err: PreparedError;
+}
+
+/**
+ * Broadcast when a build recovers (errored → ok). HMR patches are delivered
+ * per-client (only to the client that registered the changed module), so they
+ * can't clear the error overlay on the separate overlay client — this broadcast
+ * does. See `error-overlay.ts` and `FullBundleDevEnvironment`.
+ */
+export interface BuildOkMessage {
+  type: 'build:ok';
 }

--- a/packages/test-dev-server/src/utils/create-dev-server-plugin.ts
+++ b/packages/test-dev-server/src/utils/create-dev-server-plugin.ts
@@ -1,6 +1,7 @@
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
 import type { NormalizedInputOptions, Plugin } from 'rolldown';
+import { injectOverlayScript } from '../error-overlay.js';
 import type { NormalizedDevOptions } from '../types/normalized-dev-options';
 
 export function createDevServerPlugin(devOptions: NormalizedDevOptions): Plugin {
@@ -37,7 +38,9 @@ export function createDevServerPlugin(devOptions: NormalizedDevOptions): Plugin 
         this.emitFile({
           type: 'asset',
           fileName: 'index.html',
-          source: htmlSource,
+          // Inject the dev-server error overlay client (kept out of the shared
+          // rolldown HMR runtime — see error-overlay.ts).
+          source: injectOverlayScript(htmlSource),
         });
       }
     },

--- a/packages/test-dev-server/src/utils/debounce.ts
+++ b/packages/test-dev-server/src/utils/debounce.ts
@@ -1,0 +1,14 @@
+/**
+ * Collapse a burst of calls into a single trailing invocation, mirroring the
+ * `debounce` helper in Vite's `fullBundleEnvironment.ts`.
+ */
+export function debounce(time: number, cb: () => void): () => void {
+  let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  return () => {
+    if (timer) {
+      globalThis.clearTimeout(timer);
+      timer = null;
+    }
+    timer = globalThis.setTimeout(cb, time);
+  };
+}

--- a/packages/test-dev-server/src/utils/prepare-error.ts
+++ b/packages/test-dev-server/src/utils/prepare-error.ts
@@ -1,0 +1,46 @@
+import { stripVTControlCharacters as strip } from 'node:util';
+import type { RollupError } from 'rolldown';
+
+/**
+ * Serializable build-error payload sent to the browser, mirroring the `err`
+ * field of Vite's `ErrorPayload` (`packages/vite/types/hmrPayload.d.ts`).
+ */
+export interface PreparedError {
+  message: string;
+  stack: string;
+  id?: string;
+  frame?: string;
+  plugin?: string;
+  pluginCode?: string;
+  loc?: {
+    file?: string;
+    line: number;
+    column: number;
+  };
+}
+
+/**
+ * Port of Vite's `prepareError` (`server/middlewares/error.ts`): copy only the
+ * fields the client overlay needs and strip ANSI control characters so they
+ * don't leak into the browser. Avoids serializing the whole error object, since
+ * some errors attach large objects (e.g. PostCSS).
+ */
+export function prepareError(err: Error | RollupError): PreparedError {
+  const rollupErr = err as RollupError;
+  return {
+    message: strip(err.message),
+    stack: strip(cleanStack(err.stack || '')),
+    id: rollupErr.id,
+    frame: strip(rollupErr.frame || ''),
+    plugin: rollupErr.plugin,
+    pluginCode: rollupErr.pluginCode?.toString(),
+    loc: rollupErr.loc,
+  };
+}
+
+function cleanStack(stack: string): string {
+  return stack
+    .split(/\n/)
+    .filter((l) => /^\s*at/.test(l))
+    .join('\n');
+}

--- a/packages/test-dev-server/tests/browser.spec.ts
+++ b/packages/test-dev-server/tests/browser.spec.ts
@@ -86,6 +86,29 @@ describe('hmr-full-bundle-mode', () => {
     );
     await expect.poll(() => page.textContent('.hmr')).toBe('hello');
   });
+
+  // The dev server injects its own build-error overlay (`#rolldown-error-overlay`)
+  // into the served HTML — the shared rolldown HMR runtime is deliberately not
+  // touched. This asserts the overlay appears on a build break and clears on
+  // recovery (exercising the dev engine's error-recovery path end-to-end).
+  test.sequential('shows build-error overlay and recovers on fix', async () => {
+    const page = getPage();
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+
+    // Introduce a syntax error (unterminated string).
+    await editFile('hmr.js', (code) => code.replace("const foo = 'hello'", "const foo = 'hello"));
+
+    const overlay = page.locator('#rolldown-error-overlay');
+    await expect.poll(() => overlay.count(), { timeout: 15_000 }).toBe(1);
+    expect(await overlay.textContent()).toMatch(/Unterminated|PARSE_ERROR|error/i);
+
+    // Fix it: overlay clears (via recovery reload) and the app renders again.
+    await editFile('hmr.js', (code) => code.replace("const foo = 'hello", "const foo = 'hello'"));
+    await expect.poll(() => overlay.count(), { timeout: 15_000 }).toBe(0);
+    await expect.poll(() => page.textContent('.hmr')).toBe('hello');
+
+    await waitForBuildStable(CONFIG.ports.hmrFullBundleMode);
+  });
 });
 
 describe('lazy-compilation', () => {

--- a/packages/test-dev-server/tests/vitest-setup-browser.ts
+++ b/packages/test-dev-server/tests/vitest-setup-browser.ts
@@ -43,11 +43,19 @@ async function resetTestFiles() {
 }
 
 async function waitForDevServerReady(port: number) {
-  const maxAttempts = 60;
+  // Browser platform no longer blocks requests until the build is ready (it
+  // serves a "Bundling in progress" spinner instead, mirroring Vite), so a bare
+  // `/` returns 200 immediately. Poll the status endpoint until the initial
+  // build has completed (buildSeq >= 1) so navigations land on the real page,
+  // not the spinner.
+  const maxAttempts = 100;
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      const response = await fetch(`http://localhost:${port}`);
-      if (response.ok) return;
+      const response = await fetch(`http://localhost:${port}/_dev/status`);
+      if (response.ok) {
+        const status = await response.json();
+        if (status.buildSeq >= 1) return;
+      }
     } catch {}
     await new Promise((r) => setTimeout(r, 100));
   }


### PR DESCRIPTION
## Summary

Stacked on #9652.

Restructures `packages/test-dev-server` so it tracks Vite's full-bundle-mode dev
server (`packages/vite/src/node/server/environments/fullBundleEnvironment.ts`),
rather than carrying its own ad-hoc shape. The goal is to let dev-engine work be
exercised inside the rolldown repo against a server whose error handling,
middleware, and reload behavior match Vite's — so behavioral regressions in the
`dev()` engine surface here before they reach Vite.

A literal 1:1 port isn't possible: the test harness depends on pieces Vite
doesn't have. Those are **kept** intentionally:

- the standalone connect + `ws` server (Vite reuses its own HTTP/HMR transport),
- the **disk**-serving path for the node target,
- the `/_dev/status` endpoint plus `buildSeq` / `moduleRegistrationSeq` test
  instrumentation.

**Constraint:** the shared rolldown HMR runtime
(`crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js`) is **not**
touched — every change lives in `packages/test-dev-server`.

## Structure

The flat `dev-server.ts` is split to mirror Vite's layout:

| test-dev-server | Vite equivalent |
| --- | --- |
| `src/environments/full-bundle-dev-environment.ts` (`FullBundleDevEnvironment`) | `environments/fullBundleEnvironment.ts` |
| `src/middlewares/{memory-files,index-html,trigger-lazy-bundling,status}.ts` | `server/middlewares/*` |
| `src/{clients,memory-files,fallback-html}.ts`, `src/utils/{debounce,prepare-error}.ts` | Vite helpers |
| `src/dev-server.ts` | `server/index.ts` (connect/http/ws transport + middleware wiring only) |

`FullBundleDevEnvironment` now owns the dev engine, the in-memory output, the
client registry, and the `lastBuildError` / `fullReloadPending` state.

## Behavior ported from Vite

- **Error replay:** `lastBuildError` is cached from either callback channel
  (`onOutput` / `onHmrUpdates`), broadcast on break, and replayed on client
  connect so the overlay survives a refresh; it's cleared on a successful build
  from **either** channel.
- **Build-error overlay** (`error-overlay.ts`): stand-in for Vite's client
  overlay, injected into the generated `index.html` and the "Bundling in
  progress" spinner. Runs as its own ws client alongside the rolldown HMR
  runtime; because HMR patches are delivered per-client, recovery is signalled
  by a broadcast `build:ok` (HMR recovery) and a reload (full-build recovery).
- **`prepareError`** (`utils/prepare-error.ts`): port of Vite's helper — strips
  ANSI via `node:util`'s `stripVTControlCharacters` and copies only the fields
  the overlay needs (`message`/`stack`/`id`/`frame`/`plugin`/`pluginCode`/`loc`).
- **Reload handling:** deferred full reload (`fullReloadPending`), debounced
  reload, conservative stale-output regen guard
  (`hasStaleOutput && !lastBuildErrored && initialBuildCompleted`), and
  noop/empty HMR-batch filtering.
- **Serving targets:** browser target serves from memory with the spinner +
  `skipWrite`; node target serves from disk behind a request gate.

## Docs

Reconciles `meta/design/dev-engine.md` §2: it claimed `lastBuildError` clears
only on a successful `onOutput`, but Vite (and now this port) also clears it on a
successful `onHmrUpdates`.

## Testing

`pnpm test:fixtures` (9) and `pnpm test:browser` (10) pass, including a new
`browser.spec.ts` case asserting the build-error overlay appears on a break and
clears on recovery.
