### PR TITLE
fix(finalizer): skip init_*() for tree-shaken wrapped ESM owners

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -234,6 +234,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let canonical_ref = self.ctx.symbol_db.canonical_ref_resolving_namespace(symbol_ref);
     let meta = &self.ctx.linking_infos[canonical_ref.owner];
     if matches!(meta.wrap_kind(), WrapKind::Esm)
+      // Only emit `init_*()` for wrapped owners that tree-shaking actually kept.
+      // A non-wrapped barrel can forward a binding (e.g. via `export { ns }` or
+      // `export *`) from a wrapped ESM module that ends up tree-shaken because the
+      // binding is never read. In that case the owner's `init_*` wrapper statement
+      // was never included, so it has no chunk assignment and emitting a call to it
+      // would reference a function that doesn't exist in the output. This mirrors
+      // the `is_included` guard in `generate_transitive_esm_init`.
+      && meta.is_included
       && meta.wrapper_ref.is_some()
       && !matches!(meta.concatenated_wrapped_module_kind, ConcatenateWrappedModuleKind::Inner)
     {

--- a/crates/rolldown/tests/rolldown/issues/9651/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9651/_config.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Reproduces #9651: the module finalizer panicked with `\"init_external\" is not in any chunk` when a side-effect-free (`sideEffects: false`) barrel module is reached both statically (via `import * as z from './zod'`) and via a dynamic import() chain, under cjs + inlineDynamicImports + tree-shaking. The static `import * as` lowering walked every resolved export of the barrel and emitted `init_external()` for `external.js` even though tree-shaking had dropped it. The fixture now bundles and runs successfully.",
+  "config": {
+    "platform": "node",
+    "format": "cjs",
+    "codeSplitting": false,
+    "shimMissingExports": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+//#endregion
+//#region src/zod/locales.js
+function en() {
+	return "en";
+}
+//#endregion
+//#region main.js
+__esmMin((() => {}))();
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+if (en() !== "en") throw new Error("expected z.locales.en() to be 'en'");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9651/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/main.js
@@ -1,0 +1,19 @@
+// Repro for https://github.com/rolldown/rolldown/issues/9651
+//
+// `src/zod/external.js` is reached two ways: statically through
+// `import * as z from './src/zod/index.js'` (path 1), and through a dynamic
+// `import()` chain `main -> src/dyn/a.js -> src/dyn/b.js -> src/zod/external.js`
+// (path 2). The dynamic import forces zod's side-effect-free barrel modules to
+// be wrapped (lazy-init). With tree-shaking on, `external.js` itself is dropped
+// (its namespace is never read — only `z.locales`, which resolves through to
+// `locales.js`), yet the finalizer used to still emit an `init_external()` call
+// for it while lowering the static `import * as z` barrel, hitting a wrapper
+// symbol with no chunk assignment and panicking:
+//
+//   "init_external" is not in any chunk, which is unexpected
+import * as z from './src/zod/index.js';
+import('./src/dyn/a.js');
+
+if (z.locales.en() !== 'en') {
+  throw new Error("expected z.locales.en() to be 'en'");
+}

--- a/crates/rolldown/tests/rolldown/issues/9651/src/dyn/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/dyn/a.js
@@ -1,0 +1,3 @@
+// dynamic-import target; must be a separate module from the one that imports
+// `../zod/external.js` (b.js) — merging them does not reproduce.
+import './b.js';

--- a/crates/rolldown/tests/rolldown/issues/9651/src/dyn/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/dyn/b.js
@@ -1,0 +1,1 @@
+import { z } from '../zod/external.js';

--- a/crates/rolldown/tests/rolldown/issues/9651/src/zod/external.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/zod/external.js
@@ -1,0 +1,1 @@
+export * as locales from './locales.js';

--- a/crates/rolldown/tests/rolldown/issues/9651/src/zod/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/zod/index.js
@@ -1,0 +1,3 @@
+import * as z from './external.js';
+export * from './external.js';
+export { z };

--- a/crates/rolldown/tests/rolldown/issues/9651/src/zod/locales.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/zod/locales.js
@@ -1,0 +1,3 @@
+export function en() {
+  return 'en';
+}

--- a/crates/rolldown/tests/rolldown/issues/9651/src/zod/package.json
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/zod/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}


### PR DESCRIPTION
Fixes #9651.

## Problem

Under `cjs` + `inlineDynamicImports` + tree-shaking, the module finalizer panicked with:

```
"init_external" is not in any chunk, which is unexpected
```

This happened when a side-effect-free (`sideEffects: false`) barrel forwards a binding from a wrapped ESM module that is reached **both** statically (`import * as z from './zod'`) **and** through a dynamic `import()` chain. The dynamic import forces the barrel modules to be wrapped as lazy-init ESM, but tree-shaking then drops `external.js` because its namespace is never actually read (only `z.locales` is used, and that resolves straight through to `locales.js`).

When lowering the static `import * as z` from the non-wrapped barrel, `collect_wrapped_esm_init_modules_for_import_record` walked **every** resolved export of the barrel and emitted an `init_*()` call for each wrapped owner — including `external.js`, which tree-shaking had eliminated. Its `init_*` wrapper statement was never included, so the wrapper symbol had no chunk assignment and the finalizer panicked.

## Fix

`add_wrapped_esm_init_module_for_symbol` now only emits `init_*()` for wrapped owners that tree-shaking actually kept, by guarding on `meta.is_included`. This mirrors the existing `is_included` guard in the sibling `generate_transitive_esm_init`. A non-included module produces no `init_*` function in the output, so skipping its init call is required for correctness — there is no case where calling it would be valid.

## Test

Adds a runnable regression fixture under `crates/rolldown/tests/rolldown/issues/9651` that reproduces the panic without the fix and bundles **and executes** successfully with it.
