### PR TITLE
fix(lazy-barrel): request all exports for entry barrels on first encounter

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -217,6 +217,29 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     })
   }
 
+  /// Lazy barrel must not skip any of an entry's re-exports — an entry has to
+  /// preserve all of its exports. Request `All` from it: if it has already been
+  /// loaded as a barrel, load its remaining (deferred) records now; otherwise
+  /// record the request so they get loaded once it finishes loading.
+  #[expect(clippy::rc_buffer)]
+  fn request_all_exports_for_entry(
+    &mut self,
+    idx: ModuleIdx,
+    user_defined_entries: &Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  ) {
+    if let Some(barrel_module_state) = self.cache.barrel_state.barrel_infos.get(&idx) {
+      // If the module is already a barrel module, we need to load its remaining re-export import records
+      if barrel_module_state.is_some() {
+        self.process_barrel_import_record(
+          &mut VecDeque::from_iter([(idx, ImportedExports::All)]),
+          user_defined_entries,
+        );
+      }
+    } else {
+      self.cache.barrel_state.requested_exports.insert(idx, ImportedExports::All);
+    }
+  }
+
   #[expect(clippy::rc_buffer)]
   fn try_spawn_new_task(
     &mut self,
@@ -229,17 +252,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     let idx = match self.cache.module_id_to_idx.get(&resolved_id.id).copied() {
       Some(VisitState::Seen(idx)) => {
         if self.flat_options.is_lazy_barrel_enabled() && owner.is_none() {
-          if let Some(barrel_module_state) = self.cache.barrel_state.barrel_infos.get(&idx) {
-            // If the module is already a barrel module, we need to load its remaining re-export import records
-            if barrel_module_state.is_some() {
-              self.process_barrel_import_record(
-                &mut VecDeque::from_iter([(idx, ImportedExports::All)]),
-                user_defined_entries,
-              );
-            }
-          } else {
-            self.cache.barrel_state.requested_exports.insert(idx, ImportedExports::All);
-          }
+          self.request_all_exports_for_entry(idx, user_defined_entries);
         }
         return idx;
       }
@@ -263,6 +276,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
         idx
       }
     };
+    if self.flat_options.is_lazy_barrel_enabled() && owner.is_none() {
+      self.request_all_exports_for_entry(idx, user_defined_entries);
+    }
     let ctx = Arc::clone(&self.shared_context);
     if resolved_id.external.is_external() {
       let task = ExternalModuleTask::new(ctx, idx, resolved_id, Arc::clone(user_defined_entries));

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/_config.ts
@@ -1,0 +1,39 @@
+import { defineTest } from 'rolldown-tests';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Regression test for the lazy-barrel "dropped local import" bug.
+//
+// `barrel.js` is a side-effect-free barrel that is also an entry: it imports `x`
+// from `m.js` for local use (in `useX`) and re-exports `y` from `m.js`.
+// `consumer.js` imports ONLY the re-export `y` (a partial request on `barrel`),
+// and `splitter.js` makes `m.js` a shared chunk. Lazy barrel used to leave
+// `barrel`'s plain import record for `x` unresolved, dropping `x` from the
+// output, so `useX()` threw `ReferenceError: x is not defined` at runtime.
+//
+// The bug is order-sensitive; delaying `barrel.js`'s transform pins the module
+// load order so it reproduces deterministically without the fix.
+export default defineTest({
+  config: {
+    input: {
+      barrel: './barrel.js',
+      splitter: './splitter.js',
+      consumer: './consumer.js',
+    },
+    experimental: { lazyBarrel: true },
+    plugins: [
+      {
+        name: 'side-effect-free-and-delay-barrel',
+        async transform(_code, id) {
+          if (id.replace(/\\/g, '/').endsWith('/barrel.js')) {
+            await sleep(100);
+          }
+          return { moduleSideEffects: false };
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/_test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { useX } from './dist/barrel.js';
+
+// Without the fix, lazy barrel drops barrel.js's `import { x }`, so the emitted
+// `useX` references an unbound `x` and calling it throws `ReferenceError`.
+assert.strictEqual(useX(), 'x-value');

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/barrel.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/barrel.js
@@ -1,0 +1,5 @@
+import { x } from './m.js'; // record#0: imported for local use (in useX)
+export { y } from './m.js'; // re-export of a different symbol
+export function useX() {
+  return x();
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/consumer.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/consumer.js
@@ -1,0 +1,2 @@
+// imports ONLY the re-export `y` -> a partial request on `barrel`
+export { y } from './barrel.js';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/m.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/m.js
@@ -1,0 +1,6 @@
+export function x() {
+  return 'x-value';
+}
+export function y() {
+  return 'y-value';
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/splitter.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/entry-local-import-and-reexport/splitter.js
@@ -1,0 +1,2 @@
+// second consumer of m.js -> m.js becomes its own chunk
+export { y } from './m.js';


### PR DESCRIPTION
### Background

Surfaced downstream as vitejs/vite#22593 — `@emotion/react` breaks under Vite's dependency pre-bundling once `experimental.lazyBarrel` is the default: `@emotion/react` imports `withEmotionCache` for local use and also re-exports it, and `@emotion/styled` imports only the re-export, producing `ReferenceError: withEmotionCache$1 is not defined`. The minimal repro below is that pattern reduced.

### Repro

```
m.js        export function x(){...}  export function y(){...}
barrel.js   import { x } from './m'   // record#0: local use, in useX()
            export { y } from './m'   // a re-export
            export function useX(){ return x() }
consumer.js export { y } from './barrel'   // requests ONLY the re-export y
splitter.js export { y } from './m'        // makes m its own chunk
```

`useX()` → `ReferenceError: x is not defined`.

### Problem

`barrel` is a barrel and a user entry. `consumer` requests only its re-export `y`, so `barrel` is processed with `Partial({ y })` → `has_local_export` is false → lazy barrel **defers `barrel`'s own `import { x }` record** (`resolved_module = None`). But `barrel` is an entry, so its body is still emitted and uses `x` — which was never imported → dangling reference.

An entry must keep all its exports, so it should request `All` and load every record. That recovery existed but only in the `Some(VisitState::Seen)` branch; a first-time entry registration goes through the `None` branch and skips it. (Order-sensitive, hence intermittent — if an importer registered the module first, the entry add hit `Seen` and it worked.)

### Flow

1. `barrel` registered as entry (first encounter, `None` arm) → recovery skipped.
2. `consumer` imports `y` → records `Partial({ y })` on `barrel`.
3. `barrel` initializes → `take_needed_records(Partial({ y }))`, `has_local_export = false` → `import { x }` record deferred, never resolved.
4. binder skips the unresolved record → `useX`'s `x` unbound → emitted barrel references an undefined `x`.