### PR TITLE
test(9651): drop shimMissingExports from regression fixture

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/9651/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9651/_config.json
@@ -3,7 +3,6 @@
   "config": {
     "platform": "node",
     "format": "cjs",
-    "codeSplitting": false,
-    "shimMissingExports": true
+    "codeSplitting": false
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/9651/src/dyn/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9651/src/dyn/b.js
@@ -1,1 +1,3 @@
-import { z } from '../zod/external.js';
+// Statically pulls the wrapped `external.js` into the dynamic-import chain.
+// The binding itself is unused — only the import edge matters for the repro.
+import '../zod/external.js';


### PR DESCRIPTION
Follow-up to #9669 addressing the Copilot review feedback on the regression fixture: https://github.com/rolldown/rolldown/pull/9669#pullrequestreview-4451531768

## What

The `#9651` regression fixture had `src/dyn/b.js` import a named `z` from `../zod/external.js`, but `external.js` never exports `z`. That import was only valid because the fixture enabled `shimMissingExports`, which is unrelated to the bug under test. The binding is never used — only the `b.js → external.js` import **edge** matters (it pulls the wrapped `external.js` into the dynamic-import chain).

This PR:
- switches `b.js` to a bare side-effect import (`import '../zod/external.js';`), so the fixture is semantically valid without missing-export shimming, and
- drops the now-unnecessary `"shimMissingExports": true` from `_config.json`.

## Why it's safe

- The bundled output is **unchanged** — `artifacts.snap` does not move.
- The fixture still reproduces the original panic on the pre-fix commit: I checked out `5cfff49` (the commit right before #9669 landed), dropped in this updated fixture, and it still panics with `"init_external" is not in any chunk`.

Test-only change; keeps the regression focused on #9651.
