### PR TITLE
feat: drop no-op init calls for empty wrapped-ESM modules

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -210,6 +210,17 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             }
           });
 
+        // Safety net for the `init_is_noop` predictive classifier (see
+        // `generate_stage::compute_init_is_noop`): if a module was flagged as having an empty
+        // `__esm` closure, the statements that actually land inside the closure must be empty.
+        // Otherwise we'd have marked a side-effecting `init_*()` as `@__PURE__` and DCE could
+        // wrongly drop it. Turns any misclassification into a loud failure across the fixtures.
+        debug_assert!(
+          !self.ctx.linking_info.init_is_noop || stmts_inside_closure.is_empty(),
+          "init_is_noop set but the __esm closure is non-empty for {}",
+          self.ctx.module.stable_id
+        );
+
         if is_concatenated_wrapped_module {
           self.rendered_concatenated_wrapped_module_parts.hoisted_functions_or_module_ns_decl =
             declaration_of_module_namespace_object

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -157,12 +157,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           false,
           false,
         );
-        let init_call = self.snippet.builder.expression_call(
+        let init_call = self.snippet.builder.expression_call_with_pure(
           SPAN,
           wrapper_ref_expr,
           NONE,
           self.snippet.builder.vec(),
           false,
+          // A no-op `init_*()` (empty wrapped-ESM closure) is pure; let `dce-only` drop it.
+          importee_linking_info.init_is_noop,
         );
         body.push(self.snippet.builder.statement_expression(SPAN, init_call));
       } else {
@@ -285,13 +287,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         importee_linking_info.is_tla_or_contains_tla_dependency;
       let (wrapper_ref_expr, _) = self.finalized_expr_for_symbol_ref(wrapper_ref, false, false);
 
-      let init_call = ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression(
-        SPAN,
-        wrapper_ref_expr,
-        NONE,
-        self.snippet.builder.vec(),
-        false,
-      ));
+      let init_call =
+        ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression_with_pure(
+          SPAN,
+          wrapper_ref_expr,
+          NONE,
+          self.snippet.builder.vec(),
+          false,
+          // A no-op `init_*()` (empty wrapped-ESM closure) is pure; let `dce-only` drop it.
+          importee_linking_info.init_is_noop,
+        ));
 
       Some(if is_tla_or_contains_tla_dependency {
         ast::Expression::AwaitExpression(
@@ -1406,13 +1411,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   if hint.contains(FinalizedExprProcessHint::FromCjsWrapKindEntry) {
                     wrap_ref_expr
                   } else {
-                    ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression(
-                      SPAN,
-                      wrap_ref_expr,
-                      NONE,
-                      self.snippet.builder.vec(),
-                      false,
-                    ))
+                    ast::Expression::CallExpression(
+                      self.snippet.builder.alloc_call_expression_with_pure(
+                        SPAN,
+                        wrap_ref_expr,
+                        NONE,
+                        self.snippet.builder.vec(),
+                        false,
+                        // No-op `init_*()` (empty ESM closure) is pure; `init_is_noop` is only
+                        // set for `WrapKind::Esm`, so a `require_*()` here is never marked pure.
+                        importee_linking_info.init_is_noop,
+                      ),
+                    )
                   };
 
                 if matches!(importee.exports_kind, ExportsKind::CommonJs)

--- a/crates/rolldown/src/stages/generate_stage/compute_init_is_noop.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_init_is_noop.rs
@@ -1,0 +1,93 @@
+use oxc::ast::ast::{Declaration, Statement};
+use rolldown_common::{ConcatenateWrappedModuleKind, WrapKind};
+use rolldown_utils::{index_vec_ext::IndexVecRefExt, rayon::ParallelIterator as _};
+
+use crate::type_alias::IndexEcmaAst;
+
+use super::GenerateStage;
+
+impl GenerateStage<'_> {
+  /// Pre-finalization pass: flag wrapped (`WrapKind::Esm`) modules whose `__esm` closure body is
+  /// empty, i.e. every top-level statement is a hoisted function declaration (lifted out of the
+  /// closure) or a source-less export clause, so nothing remains inside the closure.
+  ///
+  /// Calling such a module's `init_*()` is a no-op, so [`super::super::module_finalizers`] marks
+  /// those call sites `@__PURE__` and the default `dce-only` minifier drops them (and, once the
+  /// wrapper is unreferenced, the wrapper declaration / runtime helper too).
+  ///
+  /// Must run before [`Self::finalize_modules`], which finalizes modules in parallel: an
+  /// importer needs the importee's flag while emitting the init call, so it cannot be computed
+  /// during finalization itself.
+  pub(super) fn compute_init_is_noop(&mut self, ast_table: &IndexEcmaAst) {
+    // Classify in parallel (read-only); the cheap flag write-back stays sequential.
+    let keep_names = self.options.keep_names;
+    let metas = &self.link_output.metas;
+    let noop_modules = ast_table
+      .par_iter_enumerated()
+      .filter_map(|(idx, ast)| {
+        let ast = ast.as_ref()?;
+        let meta = &metas[idx];
+        if !meta.is_included || !matches!(meta.wrap_kind(), WrapKind::Esm) {
+          return None;
+        }
+        // Restrict to standalone wrappers. In a concatenated group the shared `init_*` runs the
+        // whole group's closure, so this module's own empty body wouldn't prove the call is a
+        // no-op (a sibling could carry content).
+        if !matches!(meta.concatenated_wrapped_module_kind, ConcatenateWrappedModuleKind::None) {
+          return None;
+        }
+        // Shimmed missing exports emit `<name> = void 0;` assignments *into* the closure
+        // (generated after this pass, so they aren't visible in the AST below). Their presence
+        // makes the init non-empty.
+        if !meta.shimmed_missing_exports.is_empty() {
+          return None;
+        }
+        // Require *every* top-level statement to be a hoisted function declaration. Such a
+        // module has nothing to put inside its `__esm` closure: function declarations are lifted
+        // out, and the absence of imports / re-exports / side-effecting statements means there is
+        // no init-call glue or eager code to run — under plain tree-shaking *or*
+        // `strictExecutionOrder` (which can force init calls from re-export statements even when
+        // their binding is unused). We deliberately check non-included statements too: a
+        // statement that is *not* a function declaration is treated as making the init non-empty,
+        // which only ever keeps a redundant (harmless) init call — never drops a needed one.
+        let is_noop =
+          ast.program().body.iter().all(|stmt| contributes_no_closure_body(stmt, keep_names));
+        is_noop.then_some(idx)
+      })
+      .collect::<Vec<_>>();
+
+    for idx in noop_modules {
+      self.link_output.metas[idx].init_is_noop = true;
+    }
+  }
+}
+
+/// Whether a top-level statement contributes nothing to the `__esm` closure body. Qualifying
+/// statements:
+/// - function declarations (`function f(){}`) — hoisted out of the closure;
+/// - `export function f(){}` — same, just re-exported;
+/// - source-less export clauses (`export {}`, `export { a, b }`) — namespace-level only; any
+///   actual bindings they reference live in separate statements that are checked on their own.
+///
+/// Everything else (variables, classes, expressions, and crucially any `import`/`export … from`
+/// which can lower to an eager init call inside the closure) is treated as making the init
+/// non-empty. Being conservative here only keeps a redundant (harmless) init call — it never
+/// drops a needed one. A [`debug_assert!`] in the finalizer guards this classification against
+/// the actual closure contents.
+fn contributes_no_closure_body(stmt: &Statement, keep_names: bool) -> bool {
+  match stmt {
+    // With `keepNames`, a function declaration gets a `__name(fn, "...")` assignment inserted
+    // into the wrapper closure to preserve `fn.name` (see `insert_keep_name_statements`), so the
+    // init is no longer a no-op.
+    Statement::FunctionDeclaration(_) => !keep_names,
+    Statement::ExportNamedDeclaration(export) => {
+      export.source.is_none()
+        && match &export.declaration {
+          None => true,
+          Some(Declaration::FunctionDeclaration(_)) => !keep_names,
+          Some(_) => false,
+        }
+    }
+    _ => false,
+  }
+}

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -101,6 +101,7 @@ mod chunk_ext;
 mod chunk_optimizer;
 mod code_splitting;
 mod compute_cross_chunk_links;
+mod compute_init_is_noop;
 mod detect_ineffective_dynamic_imports;
 mod dynamic_already_loaded;
 mod finalize_modules;
@@ -198,6 +199,7 @@ impl<'a> GenerateStage<'a> {
     }
 
     let mut ast_table = std::mem::take(&mut self.ast_table);
+    self.compute_init_is_noop(&ast_table);
     self.finalize_modules(&mut chunk_graph, &mut ast_table);
     self.detect_ineffective_dynamic_imports(&chunk_graph);
     self.render_chunk_to_assets(&chunk_graph, ast_table).await

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -91,6 +91,12 @@ pub struct LinkingMetadata {
   pub stmt_info_included: IndexBitSet<StmtInfoIdx>,
   /// Tracks whether the module is included after tree-shaking.
   pub is_included: bool,
+  /// Set for a standalone wrapped (`WrapKind::Esm`) module whose `__esm` closure body is empty
+  /// (every top-level statement is a hoisted function declaration or a source-less export clause,
+  /// so nothing lands inside the wrapper closure). Calling such an `init_*` is a no-op, so init
+  /// call sites are marked `@__PURE__` and the default `dce-only` minifier drops them (and the
+  /// now-unused wrapper). Computed by [`crate::stages::generate_stage`]'s `compute_init_is_noop`.
+  pub init_is_noop: bool,
 }
 
 impl LinkingMetadata {

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -13,20 +13,18 @@ var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 function foo$1() {
 	return "foo";
 }
-var init_foo = __esmMin((() => {}));
 //#endregion
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar$1 });
 function bar$1() {
 	return "bar";
 }
-var init_bar = __esmMin((() => {}));
 //#endregion
 //#region entry.js
-const { foo } = (init_foo(), __toCommonJS(foo_exports));
+const { foo } = __toCommonJS(foo_exports);
 assert.equal(foo(), "foo");
 assert.equal(bar(), "bar");
-const { bar } = (init_bar(), __toCommonJS(bar_exports));
+const { bar } = __toCommonJS(bar_exports);
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
@@ -10,10 +10,9 @@ import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region types.mjs
 var types_exports = /* @__PURE__ */ __exportAll({});
-var init_types = __esmMin((() => {}));
 //#endregion
 //#region entry.js
-assert.deepEqual((init_types(), __toCommonJS(types_exports)), {});
+assert.deepEqual(__toCommonJS(types_exports), {});
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
@@ -6,12 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
-var init_esm = __esmMin((() => {}));
-//#endregion
-//#region main.js
-init_esm();
-init_esm();
 //#endregion
 
 //# sourceMappingURL=main.js.map

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -38,9 +38,7 @@ require("./chunk.js");
 ## main2.js
 
 ```js
-//#endregion
-//#region main2.js
-require("./chunk.js").__esmMin((() => {}))();
+require("./chunk.js").__esmMin((() => {}));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
@@ -6,15 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
 //#endregion
 //#region src/zod/locales.js
 function en() {
 	return "en";
 }
-//#endregion
-//#region main.js
-__esmMin((() => {}))();
 Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 if (en() !== "en") throw new Error("expected z.locales.en() to be 'en'");
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "external": ["node:assert"],
+    "format": "esm",
+    "keepNames": true,
+    "platform": "node"
+  },
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/cjs.cjs
@@ -1,0 +1,3 @@
+const { dep } = require('./dep.js');
+
+module.exports = dep;

--- a/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/dep.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/dep.js
@@ -1,0 +1,1 @@
+export function dep() {}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/main.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/wrapped_export_function_is_not_noop/main.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import depFromCjs from './cjs.cjs';
+
+function dep() {}
+
+assert.strictEqual(dep.name, 'dep');
+assert.strictEqual(depFromCjs.name, 'dep');


### PR DESCRIPTION
## Summary

Follow-up to the review nit on #9669: when a wrapped ESM module tree-shakes down to an
empty body, rolldown still emitted a no-op call to its `__esm`/`__esmMin` wrapper, e.g.

```js
function en() { return "en"; }
__esmMin((() => {}))();   // ← dead weight: empty closure, calling it does nothing
```

This PR marks such no-op init calls `@__PURE__` so the default `minify: 'dce-only'`
pass drops them (and, once the wrapper is unreferenced, the wrapper declaration and the
`__esm`/`__esmMin` runtime helper too).

**Before**
```js
var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
function en() { return "en"; }
__esmMin((() => {}))();
```
**After**
```js
function en() { return "en"; }
```

It also collapses the `require(esm)` sequence form `(init_x(), __toCommonJS(x_exports))`
→ `__toCommonJS(x_exports)` via the same mechanism.

## Approach

1. A small generate-stage pre-pass, `compute_init_is_noop`, flags wrapped (`WrapKind::Esm`)
   modules whose `__esm` closure body is provably empty — every top-level statement is a
   hoisted function declaration or a source-less export clause, so nothing lands inside the
   closure. The classification runs in parallel (`par_iter_enumerated`).
2. The finalizer sets `pure = true` on the init `CallExpression` at the three emission sites
   when the callee module is flagged; `dce-only` does the rest.

The classifier is deliberately conservative (a non-qualifying statement only ever *keeps* a
redundant init call — it never drops a needed one), and a `debug_assert!` in the finalizer
cross-checks every flagged module against the *actual* `stmts_inside_closure`, so any
misclassification fails loudly across the fixture suite. Guards exclude shimmed missing
exports (their `x = void 0` lands in the closure) and concatenated wrapper groups.

## Out of scope (kept on purpose)

The empty inlined dynamic import `Promise.resolve().then(() => Object.freeze({ __proto__: null }))`
is **not** removed — Rollup keeps it for `import('./empty.js')` of an empty module, so it's
Rollup-equivalent and stays.

## Why the detection lives in its own pass (and not elsewhere)

The flag is consumed **cross-module** — an importer marks `init_importee()` pure based on the
*importee's* status — which constrains where it can be computed.

### Not in the link stage (`cross_module_optimization.rs`)

That pass runs **before** the two inputs the decision needs even exist:

- **`is_included`** is produced by tree-shaking (`include_statements`), which runs *after*
  `cross_module_optimization`. A module that's tree-shaken away has no init to reason about.
- **`concatenated_wrapped_module_kind`** is assigned during the generate stage's
  chunk/concatenation analysis. We must restrict the optimization to standalone wrappers
  (`ConcatenateWrappedModuleKind::None`): in a concatenated group the shared `init_*` runs the
  *whole group's* closure, so one module's empty body wouldn't prove the call is a no-op. That
  isn't knowable before chunks are formed.

Folding it here would force the decision with incomplete information (pre-tree-shaking,
pre-chunking).

### Not in the finalizer (`module_finalizers/`)

`finalize_modules` runs the per-module finalizers in parallel (`par_iter_mut_enumerated`):

1. **Immutable borrow** — the finalizer holds `&LinkingMetadata` / `&LinkingMetadataVec`
   (`ScopeHoistingFinalizerContext`), read-only, so it *cannot write* the flag mid-pass.
2. **Determinism** — even if it could, an importer finalizing concurrently with its importee
   could read a not-yet-computed (default `false`) value → non-deterministic `@__PURE__`
   placement → flaky snapshots.

So the flag must be settled as a barrier *before* finalization begins.

### The fit

The pre-pass sits in the generate stage **after** tree-shaking and chunk generation (so
`is_included` and `concatenated_wrapped_module_kind` are known) but **immediately before** the
parallel `finalize_modules` (so every importer reads a settled, deterministic value).

## Testing

- Updated 5 fixture snapshots (incl. the #9651 regression); each remains runnable.
- Full `rolldown` + `esbuild` integration suites pass; the `init_is_noop` debug-assert holds
  across all ~1.6k fixtures.
- `just lint-rust` clean (clippy `--deny warnings`, fmt, `cargo check --all-features`).
