### PR TITLE
feat(ecmascript_utils): introduce AstFactory for AST construction

### DIFF
--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -1,6 +1,6 @@
 use indexmap::map::Entry;
 use oxc::{
-  allocator::TakeIn,
+  allocator::{Allocator, TakeIn},
   ast::ast::{self, Expression},
   semantic::{SemanticBuilder, Stats},
   span::SPAN,
@@ -12,7 +12,7 @@ use rolldown_common::{
   SymbolRefDbForModule, TaggedSymbolRef, WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_utils::ecmascript::legitimize_json_local_binding_name;
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
@@ -105,17 +105,30 @@ enum LazyExportWrap {
 /// and replaces the statement with either `module.exports = expr` or `export default expr`.
 fn replace_first_expr_stmt(ecma_ast: &mut EcmaAst, kind: LazyExportWrap) {
   ecma_ast.program.with_mut(|fields| {
-    let snippet = AstSnippet::new(fields.allocator);
+    let ast_factory = AstFactory::new(fields.allocator);
     let Some(stmt) = fields.program.body.first_mut() else { unreachable!() };
     let expr = match stmt {
-      ast::Statement::ExpressionStatement(stmt) => stmt.expression.take_in(snippet.alloc()),
+      ast::Statement::ExpressionStatement(stmt) => stmt.expression.take_in(ast_factory.allocator),
       _ => unreachable!(),
     };
     *stmt = match kind {
-      LazyExportWrap::CjsExport => snippet.module_exports_expr_stmt(expr),
-      LazyExportWrap::EsmDefault => snippet.export_default_expr_stmt(expr),
+      LazyExportWrap::CjsExport => ast_factory.make_module_exports_stmt(expr),
+      LazyExportWrap::EsmDefault => ast_factory.make_export_default_stmt(expr),
     };
   });
+}
+
+/// Takes `expr` (leaving a dummy in its place) and returns the owned inner
+/// expression with any wrapping `(...)` parentheses removed.
+fn take_without_parentheses<'ast>(
+  expr: &mut Expression<'ast>,
+  allocator: &'ast Allocator,
+) -> Expression<'ast> {
+  let mut inner_expr = expr.take_in(allocator);
+  while let Expression::ParenthesizedExpression(mut paren_expr) = inner_expr {
+    inner_expr = paren_expr.expression.take_in(allocator);
+  }
+  inner_expr
 }
 
 fn update_module_default_export_info(
@@ -144,7 +157,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     FxIndexMap::default();
   let transformed = ecma_ast.program.with_mut(|fields| {
     let mut index_map = FxIndexMap::default();
-    let snippet = AstSnippet::new(fields.allocator);
+    let ast_factory = AstFactory::new(fields.allocator);
     let program = fields.program;
     let Some(stmts) = program.body.first_mut() else { unreachable!() };
     let expr = match stmts {
@@ -157,7 +170,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
       return false;
     }
     let Expression::ObjectExpression(mut obj_expr) =
-      snippet.expr_without_parentheses(expr.take_in(snippet.alloc()))
+      take_without_parentheses(expr, ast_factory.allocator)
     else {
       unreachable!();
     };
@@ -184,9 +197,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
 
           let value = std::mem::replace(
             &mut property.value,
-            snippet
-              .builder
-              .expression_identifier(SPAN, snippet.builder.str(legitimized_ident.as_str())),
+            ast_factory.expression_identifier(SPAN, ast_factory.str(legitimized_ident.as_str())),
           );
           // TODO(shulaoda): Waiting for oxc transform to support the ES feature `ShorthandProperties`.
           if key == "__proto__" {
@@ -194,9 +205,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
           } else if is_legal_ident {
             property.shorthand = is_legal_ident;
             property.key = ast::PropertyKey::StaticIdentifier(
-              snippet
-                .builder
-                .alloc_identifier_name(SPAN, snippet.builder.str(legitimized_ident.as_ref())),
+              ast_factory.alloc_identifier_name(SPAN, ast_factory.str(legitimized_ident.as_ref())),
             );
           }
           match index_map.entry(legitimized_ident) {
@@ -215,16 +224,15 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     let stmts = index_map
       .into_iter()
       // declaration
-      .map(|(local, v)| snippet.var_decl_stmt(local.as_str(), v))
+      .map(|(local, v)| ast_factory.make_var_decl(local.as_str(), v))
       // export default json module
       .chain(std::iter::once(
-        snippet.export_default_expr_stmt(Expression::ObjectExpression(obj_expr)),
+        ast_factory.make_export_default_stmt(Expression::ObjectExpression(obj_expr)),
       ))
       // export all declaration
-      .chain(std::iter::once(snippet.statement_module_declaration_export_named_declaration(
-        None,
-        declaration_binding_names.iter(),
-      )));
+      .chain(std::iter::once(
+        ast_factory.make_export_named_stmt(None, declaration_binding_names.iter()),
+      ));
     program.body.extend(stmts);
     true
   });

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -1,0 +1,114 @@
+use std::ops::Deref;
+
+use oxc::{
+  allocator::Allocator,
+  ast::{
+    AstBuilder, NONE,
+    ast::{
+      AssignmentOperator, AssignmentTarget, Declaration, ExportDefaultDeclarationKind, Expression,
+      ImportOrExportKind, SimpleAssignmentTarget, Statement, VariableDeclarationKind,
+    },
+  },
+  span::SPAN,
+};
+
+/// Rolldown's newtype wrapper around oxc's [`AstBuilder`].
+///
+/// Generic oxc node constructors are reached through [`Deref`]; rolldown's own
+/// recurring constructions are added as inherent `make_*` methods. Routing all
+/// construction through this single type lets rolldown absorb future oxc
+/// construction-API changes at one point.
+///
+/// See `meta/design/ast-construction.md`.
+#[derive(Clone, Copy)]
+pub struct AstFactory<'ast>(AstBuilder<'ast>);
+
+impl<'ast> AstFactory<'ast> {
+  pub fn new(allocator: &'ast Allocator) -> Self {
+    Self(AstBuilder::new(allocator))
+  }
+
+  /// `var <name> = <init>;`
+  pub fn make_var_decl(&self, name: &str, init: Expression<'ast>) -> Statement<'ast> {
+    let declarations = self.vec1(self.variable_declarator(
+      SPAN,
+      VariableDeclarationKind::Var,
+      self.binding_pattern_binding_identifier(SPAN, self.str(name)),
+      NONE,
+      Some(init),
+      false,
+    ));
+
+    Statement::from(Declaration::VariableDeclaration(self.alloc_variable_declaration(
+      SPAN,
+      VariableDeclarationKind::Var,
+      declarations,
+      false,
+    )))
+  }
+
+  /// `export default <expr>`
+  pub fn make_export_default_stmt(&self, expr: Expression<'ast>) -> Statement<'ast> {
+    Statement::from(self.module_declaration_export_default_declaration(
+      SPAN,
+      ExportDefaultDeclarationKind::from(expr),
+    ))
+  }
+
+  /// `module.exports = <expr>`
+  pub fn make_module_exports_stmt(&self, expr: Expression<'ast>) -> Statement<'ast> {
+    self.statement_expression(
+      SPAN,
+      self.expression_assignment(
+        SPAN,
+        AssignmentOperator::Assign,
+        AssignmentTarget::from(SimpleAssignmentTarget::from(self.member_expression_static(
+          SPAN,
+          self.expression_identifier(SPAN, "module"),
+          self.identifier_name(SPAN, "exports"),
+          false,
+        ))),
+        expr,
+      ),
+    )
+  }
+
+  /// `export { <local> as <exported>, ... };`, optionally with a `declaration`.
+  pub fn make_export_named_stmt<'a, T: AsRef<str> + 'a, I>(
+    &self,
+    declaration: Option<Declaration<'ast>>,
+    specifiers: I,
+  ) -> Statement<'ast>
+  where
+    I: Iterator<Item = (&'a T, &'a (T, bool))>,
+  {
+    Statement::from(self.module_declaration_export_named_declaration(
+      SPAN,
+      declaration,
+      self.vec_from_iter(specifiers.into_iter().map(|(local, (exported, legal_ident))| {
+        self.export_specifier(
+          SPAN,
+          self.module_export_name_identifier_reference(SPAN, self.str(local.as_ref())),
+          if *legal_ident {
+            self.module_export_name_identifier_name(SPAN, self.str(exported.as_ref()))
+          } else {
+            self.module_export_name_string_literal(SPAN, self.str(exported.as_ref()), None)
+          },
+          ImportOrExportKind::Value,
+        )
+      })),
+      None,
+      ImportOrExportKind::Value,
+      NONE,
+    ))
+  }
+}
+
+impl<'ast> Deref for AstFactory<'ast> {
+  type Target = AstBuilder<'ast>;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}

--- a/crates/rolldown_ecmascript_utils/src/lib.rs
+++ b/crates/rolldown_ecmascript_utils/src/lib.rs
@@ -1,9 +1,11 @@
+mod ast_factory;
 mod ast_snippet;
 mod extensions;
 mod scope;
 mod source_utils;
 
 pub use crate::{
+  ast_factory::AstFactory,
   ast_snippet::AstSnippet,
   extensions::ast_ext::{
     binding_pattern_ext::BindingPatternExt,

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -1,56 +1,49 @@
 use oxc::{ast::ast::Expression, ast_visit::VisitMut, span::SPAN};
-use rolldown_ecmascript_utils::{AstSnippet, ExpressionExt as _};
+use rolldown_ecmascript_utils::{AstFactory, ExpressionExt as _};
 
 pub struct WebWorkerPostVisitor<'ast> {
-  pub ast_snippet: AstSnippet<'ast>,
+  pub ast_factory: AstFactory<'ast>,
   pub should_inject_import_meta_object: bool,
 }
 
 impl<'ast> WebWorkerPostVisitor<'ast> {
-  pub fn new(ast_snippet: AstSnippet<'ast>) -> Self {
-    Self { ast_snippet, should_inject_import_meta_object: false }
+  pub fn new(ast_factory: AstFactory<'ast>) -> Self {
+    Self { ast_factory, should_inject_import_meta_object: false }
   }
 
   #[inline]
   fn create_self_location_href_expr(&self) -> Expression<'ast> {
-    Expression::StaticMemberExpression(self.ast_snippet.builder.alloc_static_member_expression(
+    Expression::StaticMemberExpression(self.ast_factory.alloc_static_member_expression(
       SPAN,
-      Expression::StaticMemberExpression(self.ast_snippet.builder.alloc_static_member_expression(
+      Expression::StaticMemberExpression(self.ast_factory.alloc_static_member_expression(
         SPAN,
-        self.ast_snippet.id_ref_expr("self", SPAN),
-        self.ast_snippet.id_name("location", SPAN),
+        self.ast_factory.expression_identifier(SPAN, self.ast_factory.str("self")),
+        self.ast_factory.identifier_name(SPAN, self.ast_factory.str("location")),
         false,
       )),
-      self.ast_snippet.id_name("href", SPAN),
+      self.ast_factory.identifier_name(SPAN, self.ast_factory.str("href")),
       false,
     ))
   }
 
   #[inline]
   fn create_import_meta_object_decl(&self) -> oxc::ast::ast::Statement<'ast> {
-    self.ast_snippet.var_decl_stmt(
+    self.ast_factory.make_var_decl(
       "_vite_importMeta",
-      Expression::ObjectExpression(
-        self.ast_snippet.builder.alloc_object_expression(
+      Expression::ObjectExpression(self.ast_factory.alloc_object_expression(
+        SPAN,
+        self.ast_factory.vec1(self.ast_factory.object_property_kind_object_property(
           SPAN,
-          self.ast_snippet.builder.vec1(
-            self.ast_snippet.builder.object_property_kind_object_property(
-              SPAN,
-              oxc::ast::ast::PropertyKind::Init,
-              oxc::ast::ast::PropertyKey::StaticIdentifier(
-                self
-                  .ast_snippet
-                  .builder
-                  .alloc_identifier_name(SPAN, self.ast_snippet.builder.str("url")),
-              ),
-              self.create_self_location_href_expr(),
-              false,
-              false,
-              false,
-            ),
+          oxc::ast::ast::PropertyKind::Init,
+          oxc::ast::ast::PropertyKey::StaticIdentifier(
+            self.ast_factory.alloc_identifier_name(SPAN, self.ast_factory.str("url")),
           ),
-        ),
-      ),
+          self.create_self_location_href_expr(),
+          false,
+          false,
+          false,
+        )),
+      )),
     )
   }
 }
@@ -74,7 +67,8 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
         if meta.meta.name == "import" && meta.property.name == "meta" =>
       {
         self.should_inject_import_meta_object = true;
-        *it = self.ast_snippet.id_ref_expr("_vite_importMeta", SPAN);
+        *it =
+          self.ast_factory.expression_identifier(SPAN, self.ast_factory.str("_vite_importMeta"));
       }
       _ => oxc::ast_visit::walk_mut::walk_expression(self, it),
     }

--- a/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
@@ -3,7 +3,7 @@ mod ast_visitor;
 use std::borrow::Cow;
 
 use oxc::ast_visit::VisitMut;
-use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_plugin::{HookUsage, Plugin, PluginHookMeta, PluginOrder};
 
 use crate::ast_visitor::WebWorkerPostVisitor;
@@ -26,8 +26,8 @@ impl Plugin for ViteWebWorkerPostPlugin {
     mut args: rolldown_plugin::HookTransformAstArgs<'_>,
   ) -> rolldown_plugin::HookTransformAstReturn {
     args.ast.program.with_mut(|fields| {
-      let ast_snippet = AstSnippet::new(fields.allocator);
-      let mut visitor = WebWorkerPostVisitor::new(ast_snippet);
+      let ast_factory = AstFactory::new(fields.allocator);
+      let mut visitor = WebWorkerPostVisitor::new(ast_factory);
       visitor.visit_program(fields.program);
     });
     Ok(args.ast)

--- a/meta/design/ast-construction.md
+++ b/meta/design/ast-construction.md
@@ -32,21 +32,21 @@ Two facts constrain every choice and are documented in [ast-mutation](./ast-muta
 
 ## The convention
 
-Everything goes through one handle, `ast: AstFactory<'a>` — rolldown's newtype over `oxc::ast::AstBuilder`. Pick the tool by what you are building:
+Everything goes through one handle, `ast_factory: AstFactory<'a>` — rolldown's newtype over `oxc::ast::AstBuilder`. Pick the tool by what you are building:
 
-### Generic nodes → the `ast` handle (oxc's builder, via `Deref`)
+### Generic nodes → the `ast_factory` handle (oxc's builder, via `Deref`)
 
-`AstFactory` derefs to the wrapped builder, so every oxc constructor is callable directly on `ast`. The thin `AstSnippet` renames collapse to those oxc calls:
+`AstFactory` derefs to the wrapped builder, so every oxc constructor is callable directly on `ast_factory`. The thin `AstSnippet` renames collapse to those oxc calls:
 
 ```rust
 // before: an AstSnippet wrapper method
 let member = self.snippet.builder.alloc_static_member_expression(SPAN, object, property, false);
 
-// after: the same oxc constructor, on the `ast` handle (resolved through Deref)
-let member = ast.alloc_static_member_expression(SPAN, object, property, false);
+// after: the same oxc constructor, on the `ast_factory` handle (resolved through Deref)
+let member = ast_factory.alloc_static_member_expression(SPAN, object, property, false);
 ```
 
-Don't construct an `AstFactory` / `AstBuilder` ad hoc when a handle is already in scope, and don't reach for raw `oxc::allocator::Vec` / `Box` when the builder already offers `ast.vec*` / `ast.alloc_*`. oxc's constructors are positional; preface a verbose chunk with a comment showing the JS it produces, as oxc itself recommends.
+Don't construct an `AstFactory` / `AstBuilder` ad hoc when a handle is already in scope, and don't reach for raw `oxc::allocator::Vec` / `Box` when the builder already offers `ast_factory.vec*` / `ast_factory.alloc_*`. oxc's constructors are positional; preface a verbose chunk with a comment showing the JS it produces, as oxc itself recommends.
 
 ### Rolldown-specific patterns → inherent `make_*` methods on `AstFactory`
 
@@ -62,21 +62,21 @@ impl<'a> Deref for AstFactory<'a> {          // generic oxc constructors, no boi
 }
 
 impl<'a> AstFactory<'a> {                     // rolldown's own patterns
-  pub fn make_to_esm_wrapper(self, namespace: Expression<'a>) -> Expression<'a> { /* ... */ }
-  pub fn make_commonjs_wrapper(self, /* ... */) -> Statement<'a> { /* ... */ }
+  pub fn make_to_esm_wrapper(&self, namespace: Expression<'a>) -> Expression<'a> { /* ... */ }
+  pub fn make_commonjs_wrapper(&self, /* ... */) -> Statement<'a> { /* ... */ }
 }
 ```
 
 These methods:
 
 - are prefixed **`make_`** and named after the **operation** (`make_to_esm_wrapper`), never after a bare AST node;
-- mirror oxc's builder signature style: positional args, `make_<x>` returns a value and `make_alloc_<x>` returns a boxed node. A caller-provided `span` comes first as in oxc, but most `make_*` patterns synthesize nodes with the reserved `SPAN` internally and take no span. `AstFactory` is `Copy` (like the builder it wraps), so taking `self` by value does not consume the caller's handle.
+- mirror oxc's builder signature style: positional args, `make_<x>` returns a value and `make_alloc_<x>` returns a boxed node. A caller-provided `span` comes first as in oxc, but most `make_*` patterns synthesize nodes with the reserved `SPAN` internally and take no span. They take **`&self`** and reach the wrapped builder through `Deref` (`self.foo()`, never `self.0.foo()`). `&self` keeps the **call sites** independent of `Copy` — the handle is borrowed, never moved, so reusing it after a `make_*` call always compiles. The method **bodies** still lean on today's `Copy` builder (Deref yields `&AstBuilder` and oxc's value-taking constructors copy it back out); when oxc#23043 lands — per-type constructors taking the generator by reference, `AstFactory` impl `AstGenerator`, the `Deref` dropped — the bodies move onto that API while the `&self` call sites stay unchanged.
 
 A method earns a place here only if it encodes a multi-step rolldown convention that is wrong-by-default when open-coded — not merely to shorten one oxc call.
 
 ### Build programmatically by default; parsing source is an exception
 
-Construct nodes through the `ast` handle (oxc constructors via `Deref`, rolldown patterns via `make_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
+Construct nodes through the `ast_factory` handle (oxc constructors via `Deref`, rolldown patterns via `make_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
 
 Authoring code as JS source and parsing it (`EcmaCompiler::parse`) is reserved for a large, fixed body of code where maintaining it as real JS clearly outweighs the one-time parse cost. In practice that is the **runtime module** (`crates/rolldown/src/module_loader/runtime_module_task.rs:226`) and essentially nothing else on the output side — treat it as a special case, not a tool to reach for. Never parse for nodes that splice into an existing AST and need a synthetic `SPAN` + dummy `NodeId` — build those programmatically, per the constraint above.
 
@@ -88,10 +88,10 @@ Keep read-only inspection helpers separate from construction; they are not metho
 
 The prefix is not decoration — it does two jobs:
 
-- **Every call site self-identifies.** A bare node name (`ast.call_expression(..)`) reaches oxc's builder through `Deref`; a `make_*` name (`ast.make_to_esm_wrapper(..)`) is a rolldown method on `AstFactory`. Rust doesn't mark the two differently at the call site, so the distinction is carried by naming: oxc methods are named after the node they produce (nouns), rolldown's after the operation they perform (verbs).
+- **Every call site self-identifies.** A bare node name (`ast_factory.call_expression(..)`) reaches oxc's builder through `Deref`; a `make_*` name (`ast_factory.make_to_esm_wrapper(..)`) is a rolldown method on `AstFactory`. Rust doesn't mark the two differently at the call site, so the distinction is carried by naming: oxc methods are named after the node they produce (nouns), rolldown's after the operation they perform (verbs).
 - **It prevents accidental shadowing.** Inherent methods on `AstFactory` take priority over the oxc methods reached through `Deref`. Naming a rolldown method after a bare node (e.g. `call_expression`) would silently override oxc's — occasionally that is the deliberate way to absorb an upstream change, but as an accident it's a trap. The `make_` prefix keeps rolldown's additions in their own namespace, so any override is intentional.
 
-Naming the handle `ast` matches oxc's own code, so oxc calls and rolldown calls read uniformly when interleaved.
+The handle is spelled out as `ast_factory` rather than a bare `ast`: it reads unambiguously as an instance of `AstFactory`, and isn't visually confused with oxc's `ast` module that some files import.
 
 ## Forward compatibility: one chokepoint for oxc's construction API
 
@@ -122,9 +122,19 @@ First, what this does **not** touch, to head off a likely assumption:
 
 The rollout shape — **create `AstFactory` as a brand-new type alongside `AstSnippet`, migrate consumers area-by-area smallest-first, then delete `AstSnippet`.** No bridging alias and no temporary `pub builder` on `AstFactory`: it is born in final form (`AstFactory(AstBuilder)` + `Deref` + `make_*`). The only transitional thing is the old `AstSnippet`, deleted once empty.
 
+### Conventions every step must follow (locked from #9682 review)
+
+Settled while reviewing #9682 (the introduce-`AstFactory` PR). They describe the **target** for every area — including the first two PRs (#9682 / #9683), whose own code is being brought into compliance — not what every file already shows, so the same review comments don't recur:
+
+- **Handle name `ast_factory`** (not `ast`). Spelled out it reads as an instance of `AstFactory` and isn't confused with oxc's `ast` module ([#9682](https://github.com/rolldown/rolldown/pull/9682)). Use it for every migrated handle, the ext-trait fold, and any new code — including the already-merged-style sites in `vite_web_worker_post` / `generate_lazy_export` / `tweak_ast_for_scanning`, which are renamed to match.
+- **`make_*` take `&self`**, reaching the builder through `Deref` (`self.foo()`, never `self.0.foo()`) — so the **call sites** never depend on `AstFactory: Copy` (the handle is borrowed, not moved) and survive oxc#23043 making `AstBuilder` non-`Copy` unchanged; the method bodies migrate onto oxc's new by-reference constructors when that lands ([#9682](https://github.com/rolldown/rolldown/pull/9682)). Applies to every `make_*` added in any step.
+- **Extract a reused, non-trivial snippet into a function** rather than inlining it at several sites (e.g. the `expr_without_parentheses` paren-unwrap loop in `generate_lazy_export`) ([#9682](https://github.com/rolldown/rolldown/pull/9682)). The guidance to inline old `AstSnippet` wrappers is only for _trivial one-liners_: when collapsing a wrapper yields a multi-line body that recurs, keep it as a named helper instead of copy-pasting it.
+
+One-off, not a per-step concern (recorded only so it isn't lost): the `AstFactory` struct doc comment in `ast_factory.rs` will be reworded for grammar ([#9682](https://github.com/rolldown/rolldown/pull/9682)).
+
 1. **Create `AstFactory`** — new file `crates/rolldown_ecmascript_utils/src/ast_factory.rs`: `struct AstFactory<'a>(AstBuilder<'a>)`, `Copy`, `Deref<Target = AstBuilder>`, `new(alloc)`; exported from `lib.rs`. `AstSnippet` is left untouched, so there are zero call-site changes.
-2. **Migrate consumers area-by-area, smallest blast radius first.** Per area: switch the handle to `AstFactory`; `.builder.*` reach-throughs become deref'd `ast.*` calls; genuine patterns become `make_*` methods added to `AstFactory` on first use; thin wrappers are inlined to their deref'd oxc equivalent. Delete each `AstSnippet` method once it has no callers left (e.g. when a lint flags it). Approximate order (touch counts): `vite_web_worker_post` (~13) → `generate_lazy_export` (~12) → `tweak_ast_for_scanning` (~26) → `vite_build_import_analysis` (~45) → hmr finalizer + `hmr_stage` → `module_finalizers` (~211). The one non-mechanical fix is the hmr `utils.rs:185` `Deref` blocker — change `HmrAstBuilder::builder` to return `AstBuilder` by value (it is `Copy`).
-3. **Fold the construction ext traits** (`binding_pattern_ext` etc.) onto the shared `ast: AstFactory` handle, removing their internal `AstBuilder::new(alloc)`. Read-only `as_*` / `is_*` traits stay.
+2. **Migrate consumers area-by-area, smallest blast radius first.** Per area: switch the handle to `AstFactory` (named `ast_factory`); `.builder.*` reach-throughs become deref'd `ast_factory.*` calls; genuine patterns become `make_*` methods added to `AstFactory` on first use; thin wrappers are inlined to their deref'd oxc equivalent (unless the body is non-trivial and recurs — then keep it a named helper). Delete each `AstSnippet` method once it has no callers left (e.g. when a lint flags it). Approximate order (touch counts): `vite_web_worker_post` (~13) → `generate_lazy_export` (~12) → `tweak_ast_for_scanning` (~26) → `vite_build_import_analysis` (~45) → hmr finalizer + `hmr_stage` → `module_finalizers` (~211). The one non-mechanical fix is the hmr `utils.rs:185` `Deref` blocker — change `HmrAstBuilder::builder` to return `AstBuilder` by value (it is `Copy`).
+3. **Fold the construction ext traits** (`binding_pattern_ext` etc.) onto the shared `ast_factory: AstFactory` handle, removing their internal `AstBuilder::new(alloc)`. Read-only `as_*` / `is_*` traits stay.
 4. **Delete `AstSnippet`** once empty — the file, the `lib.rs` export, any residual methods — and delete this Plan section.
 
 Two `make_*` names must avoid shadowing oxc builder methods reached via `Deref`: `object_property_kind_object_property` → `make_lazy_export_property`, `statement_module_declaration_export_named_declaration` → `make_export_named_stmt`.


### PR DESCRIPTION
Introduces `AstFactory<'a>(AstBuilder<'a>)` — a rolldown-owned newtype over oxc's `AstBuilder` that `Deref`s to it, with rolldown-specific constructions added as inherent `make_*` methods. Each `make_*` takes `&self` and reaches the builder through `Deref`, so call sites don't depend on `AstFactory: Copy` and stay stable when oxc#23043 makes `AstBuilder` non-`Copy`. This is the AST-construction baseline; consumers migrate off `AstSnippet` area-by-area, and `AstSnippet` is deleted once empty. Design doc: `meta/design/ast-construction.md` (#9673), refined here to lock the conventions below.

Migrates the first two areas to `AstFactory` (handle named `ast_factory`):

- **vite-web-worker-post** — `.builder` reach-throughs → deref'd calls; `id_ref_expr`/`id_name` inlined to their oxc equivalents; `var_decl_stmt` → `make_var_decl`.
- **generate_lazy_export** — same pattern; `module_exports_expr_stmt` / `export_default_expr_stmt` / `statement_module_declaration_export_named_declaration` → `make_module_exports_stmt` / `make_export_default_stmt` / `make_export_named_stmt` (the last avoids shadowing oxc's builder method); the reused paren-unwrap loop is extracted into a `take_without_parentheses` helper.

**Locked conventions** (applied here, followed by every later step; recorded in the design doc's Plan section): handle named `ast_factory`; `make_*` take `&self`; reused non-trivial snippets become named helpers.

The now-unused `AstSnippet` helpers are left in place — they're removed wholesale when `AstSnippet` is deleted at the end of the migration. Behavior-preserving.

### AstFactory migration progress (`meta/design/ast-construction.md`)

- [x] Design doc + conventions — #9673 (merged)
- [x] Introduce `AstFactory` + migrate `vite_web_worker_post` + `generate_lazy_export` — **#9682 ← this PR**
- [x] Migrate `tweak_ast_for_scanning` — #9683
- [ ] `vite_build_import_analysis` (~45 sites)
- [ ] hmr finalizer + `hmr_stage` (incl. the `utils.rs` `Deref` blocker)
- [ ] `module_finalizers` (~211 sites)
- [ ] fold construction ext traits; delete `AstSnippet`

Verified: `cargo clippy --deny warnings` + `cargo fmt --check` clean; adversarial sub-agent reviews (behavior-equivalence, Rust soundness, convention/completeness) found no real issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
