### PR TITLE
fix: keep the `rolldown-runtime` name for the standalone runtime chunk

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -994,8 +994,15 @@ impl GenerateStage<'_> {
 
     // See meta/design/code-splitting.md#runtime-module-placement.
     let bits = &index_splitting_info[runtime_module_idx].bits;
-    let mut runtime_chunk =
-      Chunk::new(None, None, bits.clone(), vec![], ChunkKind::Common, input_base.clone(), None);
+    let mut runtime_chunk = Chunk::new(
+      Some("rolldown-runtime".into()),
+      None,
+      bits.clone(),
+      vec![],
+      ChunkKind::Common,
+      input_base.clone(),
+      None,
+    );
     runtime_chunk.add_creation_reason(
       ChunkCreationReason::CommonChunk { bits, link_output: self.link_output },
       self.options,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -994,6 +994,9 @@ impl GenerateStage<'_> {
 
     // See meta/design/code-splitting.md#runtime-module-placement.
     let bits = &index_splitting_info[runtime_module_idx].bits;
+    // Keep the `rolldown-runtime` name: downstream tooling (Vite / @vitejs/plugin-rsc)
+    // identifies the runtime chunk by it. `None` emits a generic `chunk-[hash].js`
+    // and silently breaks them. See rolldown/rolldown#9685.
     let mut runtime_chunk = Chunk::new(
       Some("rolldown-runtime".into()),
       None,

--- a/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region a.js
 var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { bar: 123 };
@@ -19,7 +19,7 @@ export default require_a();
 ## b.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region b.js
 var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { bar: 123 };
@@ -32,7 +32,7 @@ export default require_b();
 ## c.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region c.js
 var require_c = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = { bar: 123 };
@@ -42,7 +42,7 @@ export default require_c();
 
 ```
 
-## chunk.js
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]

--- a/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+import { n as __toESM } from "./rolldown-runtime.js";
 //#region a.js
 x ? import("a") : y ? import("./import.js").then((m) => /* @__PURE__ */ __toESM(m.default)) : import("c");
 //#endregion
@@ -16,30 +16,30 @@ x ? import("a") : y ? import("./import.js").then((m) => /* @__PURE__ */ __toESM(
 ## b.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+import { n as __toESM } from "./rolldown-runtime.js";
 //#region b.js
 x ? y ? import("a") : import("./import.js").then((m) => /* @__PURE__ */ __toESM(m.default)) : import(c);
 //#endregion
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as n, __commonJSMin as t };
-
-```
-
 ## import.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region import.js
 var require_import = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 213;
 }));
 //#endregion
 export default require_import();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/esbuild/default/import_namespace_this_value/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_namespace_this_value/artifacts.snap
@@ -47,9 +47,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 let external = require("external");
-external = require_chunk.__toESM(external);
+external = require_rolldown_runtime.__toESM(external);
 //#region a.js
 console.log(external[foo](), new external[foo]());
 //#endregion
@@ -59,9 +59,9 @@ console.log(external[foo](), new external[foo]());
 ## b.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 let external = require("external");
-external = require_chunk.__toESM(external);
+external = require_rolldown_runtime.__toESM(external);
 //#region b.js
 console.log(external.foo(), new external.foo());
 //#endregion
@@ -71,9 +71,9 @@ console.log(external.foo(), new external.foo());
 ## c.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 let external = require("external");
-external = require_chunk.__toESM(external);
+external = require_rolldown_runtime.__toESM(external);
 //#region c.js
 console.log((0, external.default)(), (0, external.foo)());
 console.log(new external.default(), new external.foo());
@@ -81,7 +81,7 @@ console.log(new external.default(), new external.foo());
 
 ```
 
-## chunk.js
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]

--- a/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## array.js
 
 ```js
-import "./chunk.js";
+import "./rolldown-runtime.js";
 //#endregion
 
 ```
@@ -14,25 +14,17 @@ import "./chunk.js";
 ## assign.js
 
 ```js
-import "./chunk.js";
+import "./rolldown-runtime.js";
 //#region assign.js
 require = x;
 //#endregion
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __require as t };
-
-```
-
 ## dot.js
 
 ```js
-import { t as __require } from "./chunk.js";
+import { t as __require } from "./rolldown-runtime.js";
 //#region dot.js
 __require.cache;
 //#endregion
@@ -42,7 +34,7 @@ __require.cache;
 ## ident.js
 
 ```js
-import "./chunk.js";
+import "./rolldown-runtime.js";
 //#endregion
 
 ```
@@ -50,9 +42,17 @@ import "./chunk.js";
 ## index.js
 
 ```js
-import { t as __require } from "./chunk.js";
+import { t as __require } from "./rolldown-runtime.js";
 //#region index.js
 __require[cache];
 //#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __require as t };
 
 ```

--- a/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/artifacts.snap
@@ -51,14 +51,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __commonJSMin as t };
-
-```
-
 ## cjs-in-esm.js
 
 ```js
@@ -74,7 +66,7 @@ export { foo };
 ## import-in-cjs.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 import { foo } from "bar";
 //#region import-in-cjs.js
 var require_import_in_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -89,12 +81,20 @@ export default require_import_in_cjs();
 ## no-warnings-here.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region no-warnings-here.js
 var require_no_warnings_here = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log(module, exports);
 }));
 //#endregion
 export default require_no_warnings_here();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/diff.md
+++ b/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/diff.md
@@ -37,7 +37,7 @@ module.exports = foo;
 ```
 ### rolldown
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 import { foo } from "bar";
 //#region import-in-cjs.js
 var require_import_in_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -54,7 +54,7 @@ export default require_import_in_cjs();
 --- esbuild	/out/import-in-cjs.js
 +++ rolldown	import-in-cjs.js
 @@ -1,3 +1,7 @@
-+import {t as __commonJSMin} from "./chunk.js";
++import {t as __commonJSMin} from "./rolldown-runtime.js";
  import {foo} from "bar";
 -exports.foo = foo;
 -module.exports = foo;
@@ -72,7 +72,7 @@ console.log(module, exports);
 ```
 ### rolldown
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region no-warnings-here.js
 var require_no_warnings_here = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log(module, exports);
@@ -88,7 +88,7 @@ export default require_no_warnings_here();
 +++ rolldown	no-warnings-here.js
 @@ -1,1 +1,5 @@
 -console.log(module, exports);
-+import {t as __commonJSMin} from "./chunk.js";
++import {t as __commonJSMin} from "./rolldown-runtime.js";
 +var require_no_warnings_here = __commonJSMin((exports, module) => {
 +    console.log(module, exports);
 +});

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./chunk.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
@@ -20,7 +20,7 @@ export { foo, init_a as n, a_exports as t };
 ## b.js
 
 ```js
-import { r as __toCommonJS } from "./chunk.js";
+import { r as __toCommonJS } from "./rolldown-runtime.js";
 import { n as init_a, t as a_exports } from "./a.js";
 //#region b.js
 let bar = (init_a(), __toCommonJS(a_exports));
@@ -29,7 +29,7 @@ export { bar };
 
 ```
 
-## chunk.js
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as n, __commonJSMin as t };
-
-```
-
 ## cjs.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "cjs";
@@ -27,10 +19,18 @@ export default require_cjs();
 ## main.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+import { n as __toESM } from "./rolldown-runtime.js";
 //#region main.js
 var main_default = import("./cjs.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 //#endregion
 export { main_default as default };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __commonJSMin as t };
-
-```
-
 ## i18n-ar.js
 
 ```js
-import { n as __exportAll, t as __commonJSMin } from "./chunk.js";
+import { n as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
 //#region vendor/rc-picker/locale/common.js
 var require_common = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.commonLocale = {
@@ -44,7 +36,7 @@ export { require_common as n, ar_EG_exports as t };
 ## i18n-en-US.js
 
 ```js
-import { n as __exportAll } from "./chunk.js";
+import { n as __exportAll } from "./rolldown-runtime.js";
 import { n as require_common } from "./i18n-ar.js";
 //#region vendor/rc-picker/locale/en_US.js
 var import_common = require_common();
@@ -87,9 +79,17 @@ main();
 
 ```
 
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __commonJSMin as t };
+
+```
+
 # Output Stats
 
-- chunk.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
 - i18n-ar.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
 - i18n-en-US.js, is_entry false, is_dynamic_entry false, exports ["t"]
 - main.js, is_entry true, is_dynamic_entry false, exports []
+- rolldown-runtime.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -3,7 +3,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
+## main1.js
+
+```js
+require("./rolldown-runtime.js");
+
+```
+
+## main2.js
+
+```js
+require("./rolldown-runtime.js").__esmMin((() => {}));
+//#endregion
+
+```
+
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -25,20 +40,5 @@ Object.defineProperty(exports, "__toESM", {
 		return __toESM;
 	}
 });
-
-```
-
-## main1.js
-
-```js
-require("./chunk.js");
-
-```
-
-## main2.js
-
-```js
-require("./chunk.js").__esmMin((() => {}));
-//#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/artifacts.snap
@@ -40,30 +40,11 @@ load();
 
 ## Assets
 
-### chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__exportAll", {
-	enumerable: true,
-	get: function() {
-		return __exportAll;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ### imp.js
 
 ```js
 //#region imp.js
-var imp_exports = /* @__PURE__ */ require("./chunk.js").__exportAll({
+var imp_exports = /* @__PURE__ */ require("./rolldown-runtime.js").__exportAll({
 	imp2: () => 2,
 	imp22: () => 22
 });
@@ -87,10 +68,10 @@ Object.defineProperty(exports, "imp_exports", {
 ### main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 require("./imp.js");
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#region main.js
 node_assert.default.strictEqual(2, 2);
 node_assert.default.strictEqual(22, 22);
@@ -101,5 +82,24 @@ const load = async () => {
 };
 load();
 //#endregion
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__exportAll", {
+	enumerable: true,
+	get: function() {
+		return __exportAll;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 ## main.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import { n as init_foo, t as foo } from "./vendor.js";
 import nodeAssert from "node:assert";
 //#endregion
@@ -25,10 +17,18 @@ __esmMin((() => {
 
 ```
 
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
 ## vendor.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 //#region bar.js
 var init_bar = __esmMin((() => {}));
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -3,7 +3,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
+## main.js
+
+```js
+import { t as lib_ui_exports } from "./ui.js";
+import { n as lib_npm_a_exports, t as lib_npm_b_exports } from "./other-libs.js";
+export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as ui };
+
+```
+
+## other-libs.js
+
+```js
+import { t as __exportAll } from "./rolldown-runtime.js";
+//#region node_modules/lib-npm-a/index.js
+var lib_npm_a_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_a_default });
+var lib_npm_a_default = "npm-a";
+//#endregion
+//#region node_modules/lib-npm-b/index.js
+var lib_npm_b_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_b_default });
+var lib_npm_b_default = "npm-b";
+//#endregion
+export { lib_npm_a_exports as n, lib_npm_b_exports as t };
+
+```
+
+## rolldown-runtime.js
 
 ```js
 //#region \0rolldown/runtime.js
@@ -22,35 +47,10 @@ export { __exportAll as t };
 
 ```
 
-## main.js
-
-```js
-import { t as lib_ui_exports } from "./ui.js";
-import { n as lib_npm_a_exports, t as lib_npm_b_exports } from "./other-libs.js";
-export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as ui };
-
-```
-
-## other-libs.js
-
-```js
-import { t as __exportAll } from "./chunk.js";
-//#region node_modules/lib-npm-a/index.js
-var lib_npm_a_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_a_default });
-var lib_npm_a_default = "npm-a";
-//#endregion
-//#region node_modules/lib-npm-b/index.js
-var lib_npm_b_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_b_default });
-var lib_npm_b_default = "npm-b";
-//#endregion
-export { lib_npm_a_exports as n, lib_npm_b_exports as t };
-
-```
-
 ## ui.js
 
 ```js
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./rolldown-runtime.js";
 //#region node_modules/lib-ui/index.js
 var lib_ui_exports = /* @__PURE__ */ __exportAll({ default: () => "ui" });
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 ## main.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import { t as init_foo } from "./test.js";
 __esmMin((() => {
 	//#region setup.js
@@ -27,10 +19,18 @@ __esmMin((() => {
 
 ```
 
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
 ## test.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region foo_inner.js
 var foo_inner_default;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __exportAll as r, __commonJSMin as t };
-
-```
-
 ## node0.js
 
 ```js
-import { n as __esmMin } from "./chunk.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
 //#region node0.js
 var node_0;
 //#endregion
@@ -30,7 +22,7 @@ __esmMin((() => {
 ## node1.js
 
 ```js
-import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./chunk.js";
+import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
 //#region node2.js
 var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
 var node_2;
@@ -50,5 +42,13 @@ var require_node1 = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#endregion
 export default require_node1();
 export { node2_exports as n, init_node2 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 ## common.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 //#region common.js
 function foo() {
 	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
@@ -32,7 +24,7 @@ export { common as n, init_common as r, _ as t };
 ## main.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 //#endregion
 await __esmMin((async () => {
 	await import("./page-a.js").then(console.log);
@@ -44,7 +36,7 @@ await __esmMin((async () => {
 ## page-a.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import { n as common, r as init_common, t as _ } from "./common.js";
 import nodeAssert from "node:assert";
 //#region page-a.js
@@ -63,7 +55,7 @@ export { render };
 ## page-b.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
 //#region page-b.js
 function render() {}
@@ -72,5 +64,13 @@ __esmMin((() => {
 	nodeAssert.strictEqual(globalThis.value, 0);
 }))();
 export { render };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
@@ -3,25 +3,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## main.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_path = require("node:path");
-node_path = require_chunk.__toESM(node_path);
+node_path = require_rolldown_runtime.__toESM(node_path);
 //#region main.js
 var main_default = node_path.default.join;
 //#endregion
@@ -32,12 +19,25 @@ module.exports = main_default;
 ## main2.js
 
 ```js
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_fs = require("node:fs");
-node_fs = require_chunk.__toESM(node_fs);
+node_fs = require_rolldown_runtime.__toESM(node_fs);
 //#region main2.js
 var main2_default = node_fs.default.existsSync;
 //#endregion
 module.exports = main2_default;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
@@ -3,23 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-
-```
-
 ## main.js
 
 ```js
-(/* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
+(/* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports, module) => {
 	module.exports = console.log("cjs-dep");
 })))();
 //#endregion
@@ -29,9 +16,22 @@ Object.defineProperty(exports, "__commonJSMin", {
 ## main2.js
 
 ```js
-(/* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
+(/* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports, module) => {
 	module.exports = console.log("cjs-dep2");
 })))();
 //#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -18,18 +18,10 @@ To fix:
 
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
-
-```
-
 ## first.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./chunk.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { r as value$1, t as init_second } from "./second.js";
 //#region first.js
 var first_exports = /* @__PURE__ */ __exportAll({ value: () => value });
@@ -46,7 +38,7 @@ export { init_first as n, value as r, first_exports as t };
 ## main.js
 
 ```js
-import { t as __esmMin } from "./chunk.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
 import { n as second_exports, t as init_second } from "./second.js";
 import { n as init_first, t as first_exports } from "./first.js";
 //#endregion
@@ -58,10 +50,18 @@ __esmMin((() => {
 
 ```
 
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
 ## second.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./chunk.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { n as init_first, r as value$1 } from "./first.js";
 //#region second.js
 var second_exports = /* @__PURE__ */ __exportAll({ value: () => value });

--- a/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toESM as n, __commonJSMin as t };
-
-```
-
 ## lib.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region plugin.js
 var require_plugin = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
@@ -37,11 +29,19 @@ export default require_lib();
 ## main.js
 
 ```js
-import { n as __toESM } from "./chunk.js";
+import { n as __toESM } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region entry.js
 const mod = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 assert.strictEqual(mod.default().name, "plugin");
 //#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7150/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __name as t };
-
-```
-
 ## main.js
 
 ```js
-import { t as __name } from "./chunk.js";
+import { t as __name } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region dep.js
 function dep_default() {
@@ -50,7 +42,7 @@ export { main_default as default };
 ## main2.js
 
 ```js
-import { t as __name } from "./chunk.js";
+import { t as __name } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region main2.js
 var count = 100;
@@ -59,5 +51,13 @@ __name(main2_default, "default");
 assert.strictEqual(count, 100);
 //#endregion
 export { main2_default as default };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __name as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
@@ -15,7 +15,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## b.js
 
 ```js
-import { n as __exportAll, r as __toESM } from "./chunk.js";
+import { n as __exportAll, r as __toESM } from "./rolldown-runtime.js";
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ foo2: () => foo2 });
 function foo2() {
@@ -27,18 +27,10 @@ import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
 
 ```
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __toESM as r, __commonJSMin as t };
-
-```
-
 ## cjs.js
 
 ```js
-import { t as __commonJSMin } from "./chunk.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 42;
@@ -51,7 +43,7 @@ export { require_cjs as t };
 ## main.js
 
 ```js
-import { n as __exportAll } from "./chunk.js";
+import { n as __exportAll } from "./rolldown-runtime.js";
 import { t as require_cjs } from "./cjs.js";
 import "./b.js";
 //#region a.js
@@ -59,5 +51,13 @@ var a_exports = /* @__PURE__ */ __exportAll({});
 require_cjs();
 //#endregion
 export { a_exports as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __toESM as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/common_cjs_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_cjs_named_default/artifacts.snap
@@ -3,7 +3,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
+## main.js
+
+```js
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_shared$1 = require("./shared.js");
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+//#region main.js
+var import_shared = /* @__PURE__ */ require_rolldown_runtime.__toESM(require_shared$1.require_shared());
+node_assert.default.strictEqual(import_shared.default.value, 42);
+//#endregion
+
+```
+
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -22,25 +36,11 @@ Object.defineProperty(exports, "__toESM", {
 
 ```
 
-## main.js
-
-```js
-const require_chunk = require("./chunk.js");
-const require_shared$1 = require("./shared.js");
-let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
-//#region main.js
-var import_shared = /* @__PURE__ */ require_chunk.__toESM(require_shared$1.require_shared());
-node_assert.default.strictEqual(import_shared.default.value, 42);
-//#endregion
-
-```
-
 ## shared.js
 
 ```js
 //#region shared.js
-var require_shared = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
+var require_shared = /* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports, module) => {
 	module.exports = { value: 42 };
 }));
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
@@ -3,7 +3,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
+## main.js
+
+```js
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_shared = require("./shared.js");
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+//#endregion
+require_rolldown_runtime.__esmMin((() => {
+	require_shared.init_shared();
+	node_assert.default.strictEqual(42, 42);
+}))();
+
+```
+
+## rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -22,26 +37,11 @@ Object.defineProperty(exports, "__toESM", {
 
 ```
 
-## main.js
-
-```js
-const require_chunk = require("./chunk.js");
-const require_shared = require("./shared.js");
-let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
-//#endregion
-require_chunk.__esmMin((() => {
-	require_shared.init_shared();
-	node_assert.default.strictEqual(42, 42);
-}))();
-
-```
-
 ## shared.js
 
 ```js
 //#region shared.js
-var init_shared = require("./chunk.js").__esmMin((() => {}));
+var init_shared = require("./rolldown-runtime.js").__esmMin((() => {}));
 //#endregion
 Object.defineProperty(exports, "init_shared", {
 	enumerable: true,

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_named/artifacts.snap
@@ -3,30 +3,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__commonJSMin", {
-	enumerable: true,
-	get: function() {
-		return __commonJSMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## lib.js
 
 ```js
 //#region lib.js
-var require_lib = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports) => {
+var require_lib = /* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports) => {
 	exports.foo = "foo_value";
 	exports.bar = 42;
 }));
@@ -44,10 +25,10 @@ Object.defineProperty(exports, "default", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib$1 = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#region main.js
 var import_lib = require_lib$1.default;
 node_assert.default.strictEqual(import_lib.foo, "foo_value");
@@ -55,5 +36,24 @@ node_assert.default.strictEqual(import_lib.bar, 42);
 //#endregion
 exports.bar = import_lib.bar;
 exports.foo = import_lib.foo;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
@@ -3,25 +3,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__esmMin", {
-	enumerable: true,
-	get: function() {
-		return __esmMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## lib.js
 
 ```js
@@ -29,10 +10,10 @@ Object.defineProperties(exports, {
 	__esModule: { value: true },
 	[Symbol.toStringTag]: { value: "Module" }
 });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
 var lib_default, named;
-var init_lib = require_chunk.__esmMin((() => {
+var init_lib = require_rolldown_runtime.__esmMin((() => {
 	lib_default = { value: 42 };
 	named = "named_value";
 }));
@@ -53,15 +34,34 @@ exports.named = named;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#endregion
-require_chunk.__esmMin((() => {
+require_rolldown_runtime.__esmMin((() => {
 	require_lib.init_lib();
 	node_assert.default.strictEqual(require_lib.default.value, 42);
 }))();
 exports.lib = require_lib.default;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
@@ -3,33 +3,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__esmMin", {
-	enumerable: true,
-	get: function() {
-		return __esmMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## lib.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
 var foo, bar;
-var init_lib = require_chunk.__esmMin((() => {
+var init_lib = require_rolldown_runtime.__esmMin((() => {
 	foo = "foo_value";
 	bar = 42;
 }));
@@ -50,17 +31,36 @@ Object.defineProperty(exports, "init_lib", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#endregion
-require_chunk.__esmMin((() => {
+require_rolldown_runtime.__esmMin((() => {
 	require_lib.init_lib();
 	node_assert.default.strictEqual(require_lib.foo, "foo_value");
 	node_assert.default.strictEqual(42, 42);
 }))();
 exports.bar = require_lib.bar;
 exports.foo = require_lib.foo;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -3,17 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-
-```
-
 ## entry.js
 
 ```js
-import "./chunk.js";
+import "./rolldown-runtime.js";
 __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", {});
 console.log("entry");
@@ -24,10 +17,17 @@ console.log("entry");
 ## index.js
 
 ```js
-import "./chunk.js";
+import "./rolldown-runtime.js";
 __rolldown_runtime__.createModuleHotContext("index.js");
 __rolldown_runtime__.registerModule("index.js", {});
 console.log("index");
 //#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
@@ -3,33 +3,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__esmMin", {
-	enumerable: true,
-	get: function() {
-		return __esmMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
-
-```
-
 ## lib.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
 var foo, bar;
-var init_lib = require_chunk.__esmMin((() => {
+var init_lib = require_rolldown_runtime.__esmMin((() => {
 	foo = "foo_value";
 	bar = 42;
 }));
@@ -50,18 +31,37 @@ Object.defineProperty(exports, "init_lib", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_chunk = require("./chunk.js");
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = require_chunk.__toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#endregion
-require_chunk.__esmMin((() => {
+require_rolldown_runtime.__esmMin((() => {
 	require_lib.init_lib();
 	node_assert.default.strictEqual(require_lib.foo, "foo_value");
 	node_assert.default.strictEqual(42, 42);
 }))();
 exports.bar = require_lib.bar;
 exports.foo = require_lib.foo;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
@@ -1,4 +1,4 @@
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./rolldown-runtime.js";
 import { t as a_exports$1 } from "./a.js";
 import { t as b_exports$1 } from "./b.js";
 //#region ../fixtures/a/modules/index.ts

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -1,4 +1,4 @@
-import { t as __exportAll } from "./chunk.js";
+import { t as __exportAll } from "./rolldown-runtime.js";
 import { t as a_exports$1 } from "./a.js";
 import { t as b_exports$1 } from "./b.js";
 //#region ../fixtures/a/modules/index.ts


### PR DESCRIPTION
### Summary

Restore the `rolldown-runtime` name for the standalone runtime chunk, which was accidentally dropped in #9419.

### Background

#9419 ("refactor: always split runtime module first") reworked how the runtime module is placed: it is now always extracted into its own chunk first and merged back into a safe host when possible. When it stays standalone, the chunk is created in `extract_standalone_runtime_chunk` (`crates/rolldown/src/stages/generate_stage/code_splitting.rs`) via `Chunk::new(None, …)`. The old code path passed `Some("rolldown-runtime".into())` as the name, so that name was lost in the rewrite.

Consequently the standalone runtime chunk is now emitted as a generic `chunk-[hash].js` rather than `rolldown-runtime-[hash].js`. The content, hash and placement are identical — only the name changed.

### Why it matters

The `rolldown-runtime` name is the documented, recognizable name for the runtime chunk ("why there's always a runtime.js chunk"), and downstream tooling relies on it. It surfaced as a `@vitejs/plugin-rsc` ecosystem-ci failure: a test that excludes the runtime chunk by name (`imports.filter((f) => !f.includes('rolldown-runtime'))`) no longer matched, so a vendor chunk wrongly looked like it had a non-runtime import.

### Fix

Pass `Some("rolldown-runtime".into())` as the chunk name in `extract_standalone_runtime_chunk`, restoring the pre-#9419 name. The runtime placement logic from #9419 is otherwise unchanged.
