### PR TITLE
fix(dev): force rebuild after HMR errors

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::binding_dev_options::BindingDevOptions;
 use crate::types::binding_bundler_options::BindingBundlerOptions;
 use crate::types::binding_client_hmr_update::BindingClientHmrUpdate;
+use crate::types::binding_error_stage::BindingErrorStage;
 use crate::types::binding_outputs::{BindingOutputs, to_binding_error};
 use crate::types::error::{BindingErrors, BindingResult};
 use crate::utils::create_bundler_config_from_binding_options::create_bundler_config_from_binding_options;
@@ -274,11 +275,22 @@ impl ScheduledBuild {
 #[napi(object)]
 pub struct BindingBundleState {
   pub last_build_errored: bool,
+  /// The stage of the last incremental failure, when `last_build_errored`
+  /// is true and the engine is in an incremental-failure state. Absent on
+  /// success and for an initial full-build failure (use
+  /// `last_build_errored` to detect that). The consumer can force a full
+  /// rebuild on the next page load when this is `Hmr`. See
+  /// `meta/design/dev-engine.md` §12.
+  pub last_error_stage: Option<BindingErrorStage>,
   pub has_stale_output: bool,
 }
 
 impl From<BundleState> for BindingBundleState {
   fn from(state: BundleState) -> Self {
-    Self { last_build_errored: state.last_build_errored, has_stale_output: state.has_stale_output }
+    Self {
+      last_build_errored: state.last_build_errored,
+      last_error_stage: state.last_error_stage.map(Into::into),
+      has_stale_output: state.has_stale_output,
+    }
   }
 }

--- a/crates/rolldown_binding/src/types/binding_error_stage.rs
+++ b/crates/rolldown_binding/src/types/binding_error_stage.rs
@@ -1,0 +1,25 @@
+use napi_derive::napi;
+use rolldown_dev::ErrorStage;
+
+/// Which stage of an incremental dev build produced the last error.
+///
+/// Mirrors `rolldown_dev::ErrorStage`. Surfaced on
+/// [`crate::binding_dev_engine::BindingBundleState`] so the consumer can
+/// treat an `Hmr`-stage failure as recoverable by forcing a full rebuild
+/// on the next page load (HMR generation may itself be buggy). See
+/// `meta/design/dev-engine.md` §12.
+#[derive(Debug, Clone, Copy)]
+#[napi(string_enum)]
+pub enum BindingErrorStage {
+  Hmr,
+  Rebuild,
+}
+
+impl From<ErrorStage> for BindingErrorStage {
+  fn from(value: ErrorStage) -> Self {
+    match value {
+      ErrorStage::Hmr => Self::Hmr,
+      ErrorStage::Rebuild => Self::Rebuild,
+    }
+  }
+}

--- a/crates/rolldown_binding/src/types/mod.rs
+++ b/crates/rolldown_binding/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod binding_bundler_options;
 pub mod binding_client_hmr_update;
+pub mod binding_error_stage;
 pub mod binding_generate_hmr_patch_return;
 pub mod binding_hmr_boundary_output;
 pub mod binding_hmr_update;

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -464,9 +464,14 @@ impl BundleCoordinator {
   fn create_state_snapshot(&self) -> CoordinatorStateSnapshot {
     let last_build_errored =
       matches!(self.state, CoordinatorState::Failed { .. } | CoordinatorState::FullBuildFailed);
+    let last_error_stage = match self.state {
+      CoordinatorState::Failed { last_error_stage } => Some(last_error_stage),
+      _ => None,
+    };
     CoordinatorStateSnapshot {
       running_future: self.current_bundling_future.clone(),
       last_build_errored,
+      last_error_stage,
       has_stale_output: self.has_stale_bundle_output,
     }
   }

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -22,7 +22,10 @@ use crate::{
   dev_context::{DevContext, PinBoxSendStaticFuture},
   normalize_dev_options,
   type_aliases::CoordinatorSender,
-  types::{coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot},
+  types::{
+    coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot,
+    error_stage::ErrorStage,
+  },
 };
 
 #[cfg(feature = "testing")]
@@ -455,6 +458,11 @@ impl DevEngine {
 pub struct BundleState {
   /// True for any error state (initial or incremental).
   pub last_build_errored: bool,
+  /// The stage of the last incremental failure (`Some` only in
+  /// `Failed { .. }`; `None` on success and on `FullBuildFailed`). Lets
+  /// the consumer force a full rebuild on access after an `Hmr`-stage
+  /// failure — see `meta/design/dev-engine.md` §12.
+  pub last_error_stage: Option<ErrorStage>,
   pub has_stale_output: bool,
 }
 
@@ -462,6 +470,7 @@ impl From<CoordinatorStateSnapshot> for BundleState {
   fn from(snapshot: CoordinatorStateSnapshot) -> Self {
     Self {
       last_build_errored: snapshot.last_build_errored,
+      last_error_stage: snapshot.last_error_stage,
       has_stale_output: snapshot.has_stale_output,
     }
   }

--- a/crates/rolldown_dev/src/lib.rs
+++ b/crates/rolldown_dev/src/lib.rs
@@ -14,6 +14,7 @@ pub use {
   crate::{
     dev_context::BundlingFuture,
     dev_engine::{BundleState, DevEngine},
+    types::error_stage::ErrorStage,
   },
   rolldown::BundlerConfig,
   rolldown_dev_common::types::{

--- a/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
+++ b/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
@@ -1,4 +1,4 @@
-use crate::dev_context::BundlingFuture;
+use crate::{dev_context::BundlingFuture, types::error_stage::ErrorStage};
 
 /// Response containing current coordinator status
 #[derive(Debug, Clone)]
@@ -12,5 +12,16 @@ pub struct CoordinatorStateSnapshot {
   /// access-triggered rebuilds (Design principles §1) so a stale + errored bundle doesn't keep retriggering work
   /// that the engine will no-op anyway. See `meta/design/dev-engine.md`.
   pub last_build_errored: bool,
+  /// The stage that produced the last incremental failure, when the
+  /// coordinator is in `Failed { .. }`. `None` for the success path and
+  /// for `FullBuildFailed` (a full build covers every stage, so there is
+  /// no single originating stage to report; use `last_build_errored` to
+  /// detect that case).
+  ///
+  /// Consumers use this as an escape hatch: an `Hmr`-stage failure may be
+  /// a bug in HMR generation, so a page reload can force a full rebuild
+  /// (via `trigger_full_build`) rather than replaying the cached HMR
+  /// error. See `meta/design/dev-engine.md` §12.
+  pub last_error_stage: Option<ErrorStage>,
   pub has_stale_output: bool,
 }

--- a/meta/design/dev-engine.md
+++ b/meta/design/dev-engine.md
@@ -62,8 +62,22 @@ to each connected client individually and is not logged to the terminal.
 
 After a failed build, the engine waits for a file change before
 rebuilding. Both Vite config edits and user-land source edits are
-valid triggers. Nothing else — not page refresh, not elapsed time, not
-manual UI dismissal — counts as recovery.
+valid triggers. Inside rolldown_dev nothing else counts as recovery —
+not page refresh, not elapsed time, not manual UI dismissal:
+`ensure_latest_bundle_output` no-ops in every failed state (§13b), so
+access never rebuilds on its own.
+
+**One consumer-side exception — page refresh after an HMR-stage
+failure.** When the last failure originated in HMR generation
+(`last_error_stage == Hmr`), the consumer is permitted to treat a page
+refresh as a recovery trigger: on access it calls `triggerFullBuild`
+(§13e) to force a full rebuild that bypasses the possibly-buggy HMR
+path, instead of replaying the cached error. This stays scoped to the
+consumer — rolldown_dev itself does not change behavior; the escalation
+is the consumer's decision, keyed on the `last_error_stage` it reads
+from `BundleState` (§12). A `Rebuild`-stage or full-build failure gets
+no such exception — only a file change recovers those. (Not yet wired
+up in the in-repo reference consumer; the plumbing exists.)
 
 Realized in: `handle_file_changes` (§7) is the sole producer of
 post-failure rebuild tasks. `triggerFullBuild` (§13e) is an explicit
@@ -704,6 +718,35 @@ naive "promise resolved ⇒ build fresh" interpretation in the consumer
 leads to a spurious reload loop. It covers both initial-build failure
 (`FullBuildFailed`) and incremental failure (`Failed { .. }`) — the
 narrower initial-only predicate was removed as redundant.
+
+### Companion: `last_error_stage`
+
+The snapshot also exposes `last_error_stage: Option<ErrorStage>` — `Some`
+only in `Failed { last_error_stage }`, carrying the stage of the last
+incremental failure (§10). It is `None` on the success path and for
+`FullBuildFailed` (a full build covers every stage, so there is no single
+originating stage — detect that case with `last_build_errored` instead).
+It flows through `BundleState.last_error_stage` and
+`BindingBundleState.last_error_stage` (a `'Hmr' | 'Rebuild'` string union
+on the JS side).
+
+`Some(Hmr)` enables a deliberate **exception** to Design principles §3
+("file changes are the only recovery trigger"), scoped to the consumer
+rather than rolldown_dev: because HMR generation can itself be buggy, a
+consumer may, on a page load where `last_build_errored && last_error_stage
+== Hmr`, call `trigger_full_build` (§13e) before
+`ensure_latest_bundle_output` to force a full rebuild that bypasses the
+HMR path. FIFO channel ordering guarantees the `FullBuild` is scheduled
+before the ensure message is processed, so the access still waits for the
+fresh build. rolldown_dev itself stays conservative —
+`ensure_latest_bundle_output` still no-ops in every `Failed` /
+`FullBuildFailed` state (§13b). A `Rebuild`-stage or full-build failure is
+left alone; only a file change recovers those.
+
+This consumer-side escape hatch is **not yet wired up in-repo** — the
+plumbing (`last_error_stage` through the binding) exists, but the
+reference dev server in `packages/test-dev-server/src/dev-server.ts` does
+not yet escalate on it.
 
 ---
 

--- a/packages/rolldown/src/binding.cjs
+++ b/packages/rolldown/src/binding.cjs
@@ -639,6 +639,7 @@ module.exports.TsconfigCache = nativeBinding.TsconfigCache
 module.exports.BindingAttachDebugInfo = nativeBinding.BindingAttachDebugInfo
 module.exports.BindingBuiltinPluginName = nativeBinding.BindingBuiltinPluginName
 module.exports.BindingChunkModuleOrderBy = nativeBinding.BindingChunkModuleOrderBy
+module.exports.BindingErrorStage = nativeBinding.BindingErrorStage
 module.exports.BindingLogLevel = nativeBinding.BindingLogLevel
 module.exports.BindingPluginOrder = nativeBinding.BindingPluginOrder
 module.exports.BindingPropertyReadSideEffects = nativeBinding.BindingPropertyReadSideEffects

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1999,6 +1999,15 @@ export interface BindingBundlerOptions {
 
 export interface BindingBundleState {
   lastBuildErrored: boolean
+  /**
+   * The stage of the last incremental failure, when `last_build_errored`
+   * is true and the engine is in an incremental-failure state. Absent on
+   * success and for an initial full-build failure (use
+   * `last_build_errored` to detect that). The consumer can force a full
+   * rebuild on the next page load when this is `Hmr`. See
+   * `meta/design/dev-engine.md` §12.
+   */
+  lastErrorStage?: BindingErrorStage
   hasStaleOutput: boolean
 }
 
@@ -2264,6 +2273,18 @@ export interface BindingErrors {
   errors: Array<BindingError>
   isBindingErrors: boolean
 }
+
+/**
+ * Which stage of an incremental dev build produced the last error.
+ *
+ * Mirrors `rolldown_dev::ErrorStage`. Surfaced on
+ * [`crate::binding_dev_engine::BindingBundleState`] so the consumer can
+ * treat an `Hmr`-stage failure as recoverable by forcing a full rebuild
+ * on the next page load (HMR generation may itself be buggy). See
+ * `meta/design/dev-engine.md` §12.
+ */
+export type BindingErrorStage =  'Hmr'|
+'Rebuild';
 
 export interface BindingEsmExternalRequirePluginConfig {
   external: Array<BindingStringOrRegex>

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -122,6 +122,7 @@ export const TsconfigCache = __napiModule.exports.TsconfigCache
 export const BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 export const BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModuleOrderBy
+export const BindingErrorStage = __napiModule.exports.BindingErrorStage
 export const BindingLogLevel = __napiModule.exports.BindingLogLevel
 export const BindingPluginOrder = __napiModule.exports.BindingPluginOrder
 export const BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -161,6 +161,7 @@ module.exports.TsconfigCache = __napiModule.exports.TsconfigCache
 module.exports.BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 module.exports.BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModuleOrderBy
+module.exports.BindingErrorStage = __napiModule.exports.BindingErrorStage
 module.exports.BindingLogLevel = __napiModule.exports.BindingLogLevel
 module.exports.BindingPluginOrder = __napiModule.exports.BindingPluginOrder
 module.exports.BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects


### PR DESCRIPTION
This PR adds one exception for the case described here: https://github.com/rolldown/rolldown/pull/9652#discussion_r3378689222.

HMR errors will now trigger full build after page refreshes. 
This is to make it easier to recover if the HMR generation is broken for some reason.

Corresponding code in Vite has been updated: https://github.com/vitejs/vite/pull/22617/changes#diff-fa8a3ccea3d0248153b01e43e694f0c778ece12ea7887cde413299f79b697c4bR289-R304

Tests will be added once the alignment completes.