### PR TITLE
fix: explicit `moduleSideEffects` from a hook must take priority over the `package.json#sideEffects`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -175,7 +175,9 @@ pub async fn normalize_side_effects(
 ) -> BuildResult<DeterminedSideEffects> {
   let side_effects = match hook_side_effects {
     Some(side_effects) => match side_effects {
-      HookSideEffects::True => lazy_check_side_effects(resolved_id, stmt_infos),
+      // The hook explicitly asserted side effects, so it takes priority over the
+      // `package.json#sideEffects`.
+      HookSideEffects::True => lazy_check_side_effects(resolved_id, stmt_infos, false),
       HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
       HookSideEffects::NoTreeshake => DeterminedSideEffects::NoTreeshake,
     },
@@ -191,7 +193,7 @@ pub async fn normalize_side_effects(
             .await?
           {
             Some(value) => DeterminedSideEffects::UserDefined(value),
-            None => lazy_check_side_effects(resolved_id, stmt_infos),
+            None => lazy_check_side_effects(resolved_id, stmt_infos, true),
           }
         } else {
           match opt
@@ -199,7 +201,7 @@ pub async fn normalize_side_effects(
             .native_resolve(&resolved_id.id, resolved_id.external.is_external())
           {
             Some(value) => DeterminedSideEffects::UserDefined(value),
-            None => lazy_check_side_effects(resolved_id, stmt_infos),
+            None => lazy_check_side_effects(resolved_id, stmt_infos, true),
           }
         }
       }
@@ -211,6 +213,7 @@ pub async fn normalize_side_effects(
 pub fn lazy_check_side_effects(
   resolved_id: &ResolvedId,
   stmt_infos: Option<&rolldown_common::StmtInfos>,
+  check_package_json_side_effects: bool,
 ) -> DeterminedSideEffects {
   if resolved_id.external.is_external() {
     return if resolved_id.is_external_without_side_effects {
@@ -220,10 +223,8 @@ pub fn lazy_check_side_effects(
     };
   }
   let stmt_infos = stmt_infos.expect("Normal module should have stmt_infos");
-  resolved_id
-    .package_json
-    .as_ref()
-    .and_then(|p| {
+  if check_package_json_side_effects
+    && let Some(side_effects) = resolved_id.package_json.as_ref().and_then(|p| {
       // the glob expr is based on parent path of package.json, which is package path
       // so we should use the relative path of the module to package path
       let module_path_relative_to_package =
@@ -231,12 +232,13 @@ pub fn lazy_check_side_effects(
       p.check_side_effects_for(&module_path_relative_to_package.to_string_lossy())
         .map(DeterminedSideEffects::UserDefined)
     })
-    .unwrap_or_else(|| {
-      // when determining cjs module side effects:
-      // we don't considered `exports.a` has side effects
-      let analyzed_side_effects = stmt_infos
-        .iter()
-        .any(|stmt_info| stmt_info.side_effect.contains(SideEffectDetail::Unknown));
-      DeterminedSideEffects::Analyzed(analyzed_side_effects)
-    })
+  {
+    return side_effects;
+  }
+
+  // when determining cjs module side effects:
+  // we don't considered `exports.a` has side effects
+  let analyzed_side_effects =
+    stmt_infos.iter().any(|stmt_info| stmt_info.side_effect.contains(SideEffectDetail::Unknown));
+  DeterminedSideEffects::Analyzed(analyzed_side_effects)
 }

--- a/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/_config.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const packageJsonPath = path.join(import.meta.dirname, 'package.json');
+
+// An explicit `moduleSideEffects` from a hook must take priority over the
+// `package.json#sideEffects`, so the inline module's side effect must be kept.
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'inline-side-effects-repro',
+        resolveId(id) {
+          if (id === 'virtual:dep') return { id: '\0dep', packageJsonPath };
+          return null;
+        },
+        load(id) {
+          if (id === '\0dep') {
+            return { code: 'console.log("sideeffects")', moduleSideEffects: true };
+          }
+          return null;
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const code = output.output[0].code;
+    expect(code).toContain('sideeffects');
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/main.js
@@ -1,0 +1,1 @@
+import 'virtual:dep';

--- a/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/package.json
+++ b/packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hook-side-effects-overrides-package-json",
+  "private": true,
+  "sideEffects": false,
+  "dependencies": {
+    "rolldown-tests": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json:
+    dependencies:
+      rolldown-tests:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/rollup-tests:
     dependencies:
       acorn-import-assertions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - packages/test-dev-server/tests/fixtures/*
   - packages/rolldown/tests/fixtures/resolve/issue-5846
   - packages/rolldown/tests/fixtures/resolve/issue-5846-2
+  - packages/rolldown/tests/fixtures/tree-shake/hook-side-effects-overrides-package-json
   - docs
   - examples/*
   - scripts


### PR DESCRIPTION
An explicit `moduleSideEffects` from a hook had lower priority than `package.json#sideEffects`. This was not the priority order described in the docs:

> The precedence of this option is as follows (highest to lowest):
> 1. [`transform`](https://rolldown.rs/reference/Interface.Plugin#transform) hook's returned moduleSideEffects option
> 1. [`load`](https://rolldown.rs/reference/Interface.Plugin#load) hook's returned moduleSideEffects option
> 1. [`resolveId`](https://rolldown.rs/reference/Interface.Plugin#resolveid) hook's returned moduleSideEffects option
> 1. [`treeshake.moduleSideEffects`](https://rolldown.rs/reference/TypeAlias.TreeshakingOptions#modulesideeffects) option
> 1. `sideEffects` field in the `package.json` file
> 1. true (default)
> https://rolldown.rs/reference/Interface.SourceDescription#modulesideeffects

This PR will fix, https://github.com/vitejs/vite/issues/22620
