### PR TITLE
refactor(plugin): migrate vite_build_import_analysis to AstFactory

### DIFF
--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -5,11 +5,12 @@ use oxc::{
   ast::{
     AstBuilder, NONE,
     ast::{
-      AssignmentOperator, AssignmentTarget, Declaration, ExportDefaultDeclarationKind, Expression,
+      AssignmentOperator, AssignmentTarget, BindingIdentifier, Declaration,
+      ExportDefaultDeclarationKind, Expression, FormalParameterKind, IdentifierName,
       ImportOrExportKind, SimpleAssignmentTarget, Statement, VariableDeclarationKind,
     },
   },
-  span::SPAN,
+  span::{SPAN, Span},
 };
 
 /// Rolldown's newtype wrapper around oxc's [`AstBuilder`].
@@ -26,6 +27,21 @@ pub struct AstFactory<'ast>(AstBuilder<'ast>);
 impl<'ast> AstFactory<'ast> {
   pub fn new(allocator: &'ast Allocator) -> Self {
     Self(AstBuilder::new(allocator))
+  }
+
+  /// `<name>` as a `BindingIdentifier`, with the name copied into the arena.
+  pub fn make_id(&self, span: Span, name: &str) -> BindingIdentifier<'ast> {
+    self.binding_identifier(span, self.str(name))
+  }
+
+  /// A reference to `<name>` as an `Expression`, with the name copied into the arena.
+  pub fn make_id_ref_expr(&self, span: Span, name: &str) -> Expression<'ast> {
+    self.expression_identifier(span, self.str(name))
+  }
+
+  /// `<name>` as an `IdentifierName`, with the name copied into the arena.
+  pub fn make_id_name(&self, span: Span, name: &str) -> IdentifierName<'ast> {
+    self.identifier_name(span, self.str(name))
   }
 
   /// `var <name> = <init>;`
@@ -100,6 +116,21 @@ impl<'ast> AstFactory<'ast> {
       None,
       ImportOrExportKind::Value,
       NONE,
+    ))
+  }
+
+  /// `() => <expr>`
+  pub fn make_arrow_returning(&self, expr: Expression<'ast>) -> Expression<'ast> {
+    let statements =
+      self.vec1(Statement::ExpressionStatement(self.alloc_expression_statement(SPAN, expr)));
+    Expression::ArrowFunctionExpression(self.alloc_arrow_function_expression(
+      SPAN,
+      true,
+      false,
+      NONE,
+      self.formal_parameters(SPAN, FormalParameterKind::Signature, self.vec(), NONE),
+      NONE,
+      self.function_body(SPAN, self.vec(), statements),
     ))
   }
 }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -10,14 +10,14 @@ use oxc::{
   span::SPAN,
 };
 
-use crate::AstSnippet;
+use crate::{AstFactory, AstSnippet};
 
 use super::binding_property_ext::BindingPropertyExt as _;
 
 pub trait BindingPatternExt<'ast> {
   fn into_assignment_target(self, alloc: &'ast Allocator) -> AssignmentTarget<'ast>;
 
-  fn into_expression(self, snippet: &AstSnippet<'ast>) -> Expression<'ast>;
+  fn into_expression(self, ast_factory: &AstFactory<'ast>) -> Expression<'ast>;
 }
 
 impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
@@ -81,50 +81,46 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
     }
   }
 
-  fn into_expression(self, snippet: &AstSnippet<'ast>) -> Expression<'ast> {
+  fn into_expression(self, ast_factory: &AstFactory<'ast>) -> Expression<'ast> {
     match self {
-      BindingPattern::BindingIdentifier(id) => snippet.builder.expression_identifier(SPAN, id.name),
+      BindingPattern::BindingIdentifier(id) => ast_factory.expression_identifier(SPAN, id.name),
       BindingPattern::ObjectPattern(mut obj_pat) => {
         let capacity = obj_pat.properties.len() + usize::from(obj_pat.rest.is_some());
-        let mut properties = snippet.builder.vec_with_capacity(capacity);
-        obj_pat.properties.take_in(snippet.alloc()).into_iter().for_each(|binding_prop| {
-          properties.push(ObjectPropertyKind::ObjectProperty(
-            snippet.builder.alloc_object_property(
-              SPAN,
-              PropertyKind::Init,
-              binding_prop.key,
-              binding_prop.value.into_expression(snippet),
-              false,
-              binding_prop.shorthand,
-              binding_prop.computed,
-            ),
-          ));
+        let mut properties = ast_factory.vec_with_capacity(capacity);
+        obj_pat.properties.take_in(ast_factory.allocator).into_iter().for_each(|binding_prop| {
+          properties.push(ObjectPropertyKind::ObjectProperty(ast_factory.alloc_object_property(
+            SPAN,
+            PropertyKind::Init,
+            binding_prop.key,
+            binding_prop.value.into_expression(ast_factory),
+            false,
+            binding_prop.shorthand,
+            binding_prop.computed,
+          )));
         });
         if let Some(rest) = obj_pat.rest.take() {
           let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
             unreachable!("The rest element should be `BindingIdentifier`")
           };
-          properties.push(ObjectPropertyKind::ObjectProperty(
-            snippet.builder.alloc_object_property(
-              SPAN,
-              PropertyKind::Init,
-              snippet.builder.property_key_static_identifier(SPAN, id.name),
-              snippet.builder.expression_identifier(SPAN, id.name),
-              false,
-              true,
-              false,
-            ),
-          ));
+          properties.push(ObjectPropertyKind::ObjectProperty(ast_factory.alloc_object_property(
+            SPAN,
+            PropertyKind::Init,
+            ast_factory.property_key_static_identifier(SPAN, id.name),
+            ast_factory.expression_identifier(SPAN, id.name),
+            false,
+            true,
+            false,
+          )));
         }
-        Expression::ObjectExpression(snippet.builder.alloc_object_expression(SPAN, properties))
+        Expression::ObjectExpression(ast_factory.alloc_object_expression(SPAN, properties))
       }
       BindingPattern::ArrayPattern(mut arg_pat) => {
         let capacity = arg_pat.elements.len() + usize::from(arg_pat.rest.is_some());
-        let mut elements = snippet.builder.vec_with_capacity(capacity);
-        arg_pat.elements.take_in(snippet.alloc()).into_iter().for_each(|binding_pat| {
+        let mut elements = ast_factory.vec_with_capacity(capacity);
+        arg_pat.elements.take_in(ast_factory.allocator).into_iter().for_each(|binding_pat| {
           elements.push(binding_pat.map_or(
-            ArrayExpressionElement::Elision(snippet.builder.alloc_elision(SPAN)),
-            |binding_pat| ArrayExpressionElement::from(binding_pat.into_expression(snippet)),
+            ArrayExpressionElement::Elision(ast_factory.alloc_elision(SPAN)),
+            |binding_pat| ArrayExpressionElement::from(binding_pat.into_expression(ast_factory)),
           ));
         });
         if let Some(rest) = arg_pat.rest.take() {
@@ -132,13 +128,13 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
             unreachable!("The rest element should be `BindingIdentifier`")
           };
           elements.push(ArrayExpressionElement::Identifier(
-            snippet.builder.alloc_identifier_reference(SPAN, id.name),
+            ast_factory.alloc_identifier_reference(SPAN, id.name),
           ));
         }
-        Expression::ArrayExpression(snippet.builder.alloc_array_expression(SPAN, elements))
+        Expression::ArrayExpression(ast_factory.alloc_array_expression(SPAN, elements))
       }
       BindingPattern::AssignmentPattern(mut assign_pat) => {
-        assign_pat.left.take_in(snippet.alloc()).into_expression(snippet)
+        assign_pat.left.take_in(ast_factory.allocator).into_expression(ast_factory)
       }
     }
   }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -11,21 +11,21 @@ use oxc::{
   semantic::ScopeFlags,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::{AstSnippet, BindingPatternExt as _};
+use rolldown_ecmascript_utils::{AstFactory, BindingPatternExt as _};
 
 use super::ast_visit::BuildImportAnalysisVisitor;
 
 impl<'a> BuildImportAnalysisVisitor<'a> {
   #[expect(clippy::fn_params_excessive_bools)]
   pub fn new(
-    snippet: AstSnippet<'a>,
+    ast_factory: AstFactory<'a>,
     insert_preload: bool,
     render_built_url: bool,
     is_relative_base: bool,
     is_modern: bool,
   ) -> Self {
     Self {
-      snippet,
+      ast_factory,
       is_modern,
       insert_preload,
       render_built_url,
@@ -55,21 +55,21 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         key @ "default" => (key, "__vite_default__"),
         _ => (member_expr.property.name.as_str(), member_expr.property.name.as_str()),
       };
-      *await_expr = Expression::AwaitExpression(self.snippet.builder.alloc_await_expression(
+      *await_expr = Expression::AwaitExpression(self.ast_factory.alloc_await_expression(
         SPAN,
         self.construct_vite_preload_call(
-          BindingPattern::ObjectPattern(self.snippet.builder.alloc_object_pattern(
+          BindingPattern::ObjectPattern(self.ast_factory.alloc_object_pattern(
             SPAN,
-            self.snippet.builder.vec1(self.snippet.builder.binding_property(
+            self.ast_factory.vec1(self.ast_factory.binding_property(
               SPAN,
-              self.snippet.builder.property_key_static_identifier(SPAN, key),
-              self.snippet.builder.binding_pattern_binding_identifier(SPAN, value),
+              self.ast_factory.property_key_static_identifier(SPAN, key),
+              self.ast_factory.binding_pattern_binding_identifier(SPAN, value),
               true,
               false,
             )),
             NONE,
           )),
-          await_expr.take_in(self.snippet.alloc()),
+          await_expr.take_in(self.ast_factory.allocator),
         ),
       ));
       return true;
@@ -103,7 +103,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       };
       let first_param = params.items.first()?;
       if matches!(&first_param.pattern, BindingPattern::ObjectPattern(_)) {
-        Some(first_param.pattern.clone_in(self.snippet.alloc()))
+        Some(first_param.pattern.clone_in(self.ast_factory.allocator))
       } else {
         None
       }
@@ -116,7 +116,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       };
       callee.object = self.construct_vite_preload_call(
         binding_pat,
-        self.snippet.builder.expression_await(SPAN, callee.object.take_in(self.snippet.alloc())),
+        self.ast_factory.expression_await(SPAN, callee.object.take_in(self.ast_factory.allocator)),
       );
       walk_arguments(self, &mut call_expr.arguments);
       return true;
@@ -124,9 +124,9 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
     // For non-destructuring: wrap the entire import().then() expression
     walk_arguments(self, &mut call_expr.arguments);
-    let import_then_expr = expr.take_in(self.snippet.alloc());
-    *expr =
-      self.vite_preload_call(Argument::from(self.snippet.only_return_arrow_expr(import_then_expr)));
+    let import_then_expr = expr.take_in(self.ast_factory.allocator);
+    *expr = self
+      .vite_preload_call(Argument::from(self.ast_factory.make_arrow_returning(import_then_expr)));
     true
   }
 
@@ -135,7 +135,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   pub fn rewrite_import_expr(&self, expr: &mut Expression<'a>) -> bool {
     let Expression::ImportExpression(_) = expr else { return false };
     *expr = self.vite_preload_call(Argument::from(
-      self.snippet.only_return_arrow_expr(expr.take_in(self.snippet.alloc())),
+      self.ast_factory.make_arrow_returning(expr.take_in(self.ast_factory.allocator)),
     ));
     true
   }
@@ -149,30 +149,30 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       let Expression::AwaitExpression(expr) = await_expr else {
         unreachable!("The `await_expr` must be `Expression::AwaitExpression`.")
       };
-      self.snippet.only_return_arrow_expr(expr.unbox().argument)
+      self.ast_factory.make_arrow_returning(expr.unbox().argument)
     } else {
-      Expression::ArrowFunctionExpression(self.snippet.builder.alloc_arrow_function_expression(
+      Expression::ArrowFunctionExpression(self.ast_factory.alloc_arrow_function_expression(
         SPAN,
         false,
         true,
         NONE,
-        self.snippet.builder.formal_parameters(
+        self.ast_factory.formal_parameters(
           SPAN,
           FormalParameterKind::Signature,
-          self.snippet.builder.vec(),
+          self.ast_factory.vec(),
           NONE,
         ),
         NONE,
-        self.snippet.builder.function_body(SPAN, self.snippet.builder.vec(), {
-          let mut statements = self.snippet.builder.vec_with_capacity(2);
+        self.ast_factory.function_body(SPAN, self.ast_factory.vec(), {
+          let mut statements = self.ast_factory.vec_with_capacity(2);
           statements.push(Statement::from(Declaration::VariableDeclaration(
-            self.snippet.builder.alloc_variable_declaration(
+            self.ast_factory.alloc_variable_declaration(
               SPAN,
               VariableDeclarationKind::Const,
-              self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
+              self.ast_factory.vec1(self.ast_factory.variable_declarator(
                 SPAN,
                 VariableDeclarationKind::Const,
-                binding_pat.clone_in(self.snippet.alloc()),
+                binding_pat.clone_in(self.ast_factory.allocator),
                 NONE,
                 Some(await_expr),
                 false,
@@ -182,9 +182,8 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           )));
           statements.push(Statement::ReturnStatement(
             self
-              .snippet
-              .builder
-              .alloc_return_statement(SPAN, Some(binding_pat.into_expression(&self.snippet))),
+              .ast_factory
+              .alloc_return_statement(SPAN, Some(binding_pat.into_expression(&self.ast_factory))),
           ));
           statements
         }),
@@ -194,34 +193,32 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   }
 
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
-    self.snippet.builder.expression_call(
+    self.ast_factory.expression_call(
       SPAN,
-      self.snippet.id_ref_expr("__vitePreload", SPAN),
+      self.ast_factory.make_id_ref_expr(SPAN, "__vitePreload"),
       NONE,
       {
         let append_import_meta_url = self.render_built_url || self.is_relative_base;
         let capacity = if append_import_meta_url { 3 } else { 2 };
-        let mut items = self.snippet.builder.vec_with_capacity(capacity);
+        let mut items = self.ast_factory.vec_with_capacity(capacity);
 
         items.push(argument);
         items.push(Argument::from(if self.is_modern {
-          self.snippet.id_ref_expr("__VITE_PRELOAD__", SPAN)
+          self.ast_factory.make_id_ref_expr(SPAN, "__VITE_PRELOAD__")
         } else {
-          self.snippet.void_zero()
+          self.ast_factory.void_0(SPAN)
         }));
         if append_import_meta_url {
-          items.push(Argument::from(Expression::from(
-            self.snippet.builder.member_expression_static(
+          items.push(Argument::from(Expression::from(self.ast_factory.member_expression_static(
+            SPAN,
+            self.ast_factory.expression_meta_property(
               SPAN,
-              self.snippet.builder.expression_meta_property(
-                SPAN,
-                self.snippet.id_name("import", SPAN),
-                self.snippet.id_name("meta", SPAN),
-              ),
-              self.snippet.id_name("url", SPAN),
-              false,
+              self.ast_factory.make_id_name(SPAN, "import"),
+              self.ast_factory.make_id_name(SPAN, "meta"),
             ),
-          )));
+            self.ast_factory.make_id_name(SPAN, "url"),
+            false,
+          ))));
         }
         items
       },

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -10,7 +10,7 @@ use oxc::{
   semantic::ScopeFlags,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_plugin_utils::constants::RemovedPureCSSFilesCache;
 use sugar_path::SugarPath;
 
@@ -20,7 +20,7 @@ const PRELOAD_METHOD: &str = "__vitePreload";
 
 #[expect(clippy::struct_excessive_bools)]
 pub struct BuildImportAnalysisVisitor<'a> {
-  pub snippet: AstSnippet<'a>,
+  pub ast_factory: AstFactory<'a>,
   pub scope_stack: Vec<ScopeFlags>,
   pub insert_preload: bool,
   pub has_inserted_helper: bool,
@@ -34,17 +34,17 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_program(&mut self, it: &mut oxc::ast::ast::Program<'a>) {
     walk_mut::walk_program(self, it);
     if self.need_prepend_helper && self.insert_preload && !self.has_inserted_helper {
-      it.body.push(Statement::from(self.snippet.builder.module_declaration_import_declaration(
+      it.body.push(Statement::from(self.ast_factory.module_declaration_import_declaration(
         SPAN,
-        Some(self.snippet.builder.vec1(
-          self.snippet.builder.import_declaration_specifier_import_specifier(
+        Some(self.ast_factory.vec1(
+          self.ast_factory.import_declaration_specifier_import_specifier(
             SPAN,
-            self.snippet.builder.module_export_name_identifier_name(SPAN, PRELOAD_METHOD),
-            self.snippet.id(PRELOAD_METHOD, SPAN),
+            self.ast_factory.module_export_name_identifier_name(SPAN, PRELOAD_METHOD),
+            self.ast_factory.make_id(SPAN, PRELOAD_METHOD),
             ImportOrExportKind::Value,
           ),
         )),
-        self.snippet.builder.string_literal(SPAN, PRELOAD_HELPER_ID, None),
+        self.ast_factory.string_literal(SPAN, PRELOAD_HELPER_ID, None),
         None,
         NONE,
         ImportOrExportKind::Value,
@@ -82,10 +82,10 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
             Some(Expression::AwaitExpression(expr)) if matches!(expr.argument, Expression::ImportExpression(_))
           )
         {
-          decl.init = Some(self.snippet.builder.expression_await(
+          decl.init = Some(self.ast_factory.expression_await(
             SPAN,
             self.construct_vite_preload_call(
-              decl.id.clone_in(self.snippet.alloc()),
+              decl.id.clone_in(self.ast_factory.allocator),
               decl.init.take().unwrap(),
             ),
           ));

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -12,7 +12,7 @@ use arcstr::ArcStr;
 use itertools::Itertools as _;
 use oxc::ast_visit::VisitMut;
 use rolldown_common::{Output, side_effects::HookSideEffects};
-use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookRenderChunkOutput, HookResolveIdArgs,
   HookResolveIdOutput, HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn,
@@ -97,9 +97,9 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
   ) -> HookTransformAstReturn {
     let mut ast = args.ast;
     ast.program.with_mut(|fields| {
-      let builder = AstSnippet::new(fields.allocator);
+      let ast_factory = AstFactory::new(fields.allocator);
       let mut visitor = BuildImportAnalysisVisitor::new(
-        builder,
+        ast_factory,
         self.insert_preload,
         self.render_built_url,
         self.is_relative_base,


### PR DESCRIPTION
Migrates `vite_build_import_analysis` off `AstSnippet` onto `AstFactory`. Adds `AstFactory::make_arrow_returning` **and the identifier shortcuts `make_id` / `make_id_ref_expr` / `make_id_name`** (high-frequency one-liners that read poorly when inlined — per review feedback); migrates `BindingPatternExt::into_expression` to `&AstFactory` (its only external caller is here; `into_assignment_target` deferred). Remaining thin wrappers inlined. Behavior-preserving; 2 adversarial + 1 CodeX review, all clean.

### AstFactory migration progress (`meta/design/ast-construction.md`)

- [x] Design doc + conventions — #9673 (merged)
- [x] Introduce `AstFactory` + `vite_web_worker_post` + `generate_lazy_export` — #9682 (merged)
- [x] `tweak_ast_for_scanning` — #9683
- [x] `vite_build_import_analysis` — **#9693 ← this PR**
- [x] hmr finalizer + `hmr_stage` (+ 6 shared `make_*`, `builder()` by-value) — #9695
- [x] `module_finalizers/mod.rs` (+ the `make_*` ports it consumes; transitional dual field) — #9700
- [x] rest of `ScopeHoistingFinalizer` (+ wrapper `make_*` ports; `snippet` field removed) — #9701
- [x] fold construction ext traits onto `AstFactory`; delete `AstSnippet` — #9702

🤖 Generated with [Claude Code](https://claude.com/claude-code)