### PR TITLE
chore: add npm bugs metadata for rolldown

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/rolldown/rolldown.git",
     "directory": "packages/rolldown"
   },
+  "bugs": {
+    "url": "https://github.com/rolldown/rolldown/issues"
+  },
   "bin": {
     "rolldown": "./bin/cli.mjs"
   },

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -11,14 +11,14 @@
     "webpack"
   ],
   "homepage": "https://rolldown.rs/",
+  "bugs": {
+    "url": "https://github.com/rolldown/rolldown/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rolldown/rolldown.git",
     "directory": "packages/rolldown"
-  },
-  "bugs": {
-    "url": "https://github.com/rolldown/rolldown/issues"
   },
   "bin": {
     "rolldown": "./bin/cli.mjs"


### PR DESCRIPTION
Adds the standard npm `bugs.url` metadata to the published `rolldown` package, pointing to the Rolldown GitHub issue tracker.