### PR TITLE
refactor(hmr): migrate hmr finalizer to AstFactory

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -1,8 +1,8 @@
 use oxc::ast::ast::Str;
 use oxc::{
-  allocator::{Allocator, Box as ArenaBox, IntoIn, TakeIn},
+  allocator::{Box as ArenaBox, IntoIn, TakeIn},
   ast::{
-    AstBuilder, NONE,
+    NONE,
     ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind, Statement},
   },
   semantic::{IsGlobalReference, Scoping, SymbolId},
@@ -13,7 +13,7 @@ use rolldown_common::{
   ExternalModule, ImportRecordIdx, ImportRecordMeta, IndexModules, Module, ModuleIdx, NormalModule,
 };
 use rolldown_ecmascript::CJS_REQUIRE_REF_STR;
-use rolldown_ecmascript_utils::{AstSnippet, ExpressionExt};
+use rolldown_ecmascript_utils::{AstFactory, ExpressionExt};
 use rolldown_utils::{
   ecmascript::is_validate_identifier_name,
   indexmap::{FxIndexMap, FxIndexSet},
@@ -24,9 +24,7 @@ use crate::hmr::utils::{HmrAstBuilder, MODULE_EXPORTS_NAME_FOR_ESM};
 
 pub struct HmrAstFinalizer<'me, 'ast> {
   // Outside input
-  pub alloc: &'ast Allocator,
-  pub snippet: AstSnippet<'ast>,
-  pub builder: &'me AstBuilder<'ast>,
+  pub ast_factory: AstFactory<'ast>,
   pub modules: &'me IndexModules,
   pub module: &'me NormalModule,
   pub affected_module_idx_to_init_fn_name: &'me FxHashMap<ModuleIdx, String>,
@@ -158,25 +156,25 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               self.dependencies.insert(importee_idx);
               let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
               self.exports.extend(decl.specifiers.iter().map(|specifier| {
-                        self.snippet.object_property_kind_object_property(
+                        self.ast_factory.make_lazy_export_property(
                           &specifier.exported.name(),
                           match &specifier.local {
                             ast::ModuleExportName::IdentifierName(ident) => {
                               Expression::StaticMemberExpression(
-                                self.snippet.builder.alloc_static_member_expression(
+                                self.ast_factory.alloc_static_member_expression(
                                   SPAN,
-                                  self.snippet.id_ref_expr(&binding_name, SPAN),
-                                  self.snippet.builder.identifier_name(SPAN, ident.name.as_str()),
+                                  self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
+                                  self.ast_factory.identifier_name(SPAN, ident.name.as_str()),
                                   false,
                                 ),
                               )
                             }
                             ast::ModuleExportName::StringLiteral(str) => {
                               Expression::ComputedMemberExpression(
-                                self.snippet.builder.alloc_computed_member_expression(
+                                self.ast_factory.alloc_computed_member_expression(
                                   SPAN,
-                                  self.snippet.id_ref_expr(&binding_name, SPAN),
-                                  self.snippet.builder.expression_string_literal(
+                                  self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
+                                  self.ast_factory.expression_string_literal(
                                     SPAN, str.value.as_str(), None
                                   ),
                                   false,
@@ -204,9 +202,9 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                   // export var { foo, bar } = { foo: 1, bar: 2 }
                   self.exports.extend(var_decl.declarations.iter().flat_map(|decl| {
                     decl.id.get_binding_identifiers().into_iter().map(|ident| {
-                      self.snippet.object_property_kind_object_property(
+                      self.ast_factory.make_lazy_export_property(
                         ident.name.as_str(),
-                        self.snippet.id_ref_expr(ident.name.as_str(), SPAN),
+                        self.ast_factory.make_id_ref_expr(SPAN, ident.name.as_str()),
                         false,
                       )
                     })
@@ -215,24 +213,24 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                 ast::Declaration::FunctionDeclaration(fn_decl) => {
                   // export function foo() {}
                   let id = fn_decl.id.as_ref().unwrap().name.as_str();
-                  self.exports.push(self.snippet.object_property_kind_object_property(
+                  self.exports.push(self.ast_factory.make_lazy_export_property(
                     id,
-                    self.snippet.id_ref_expr(id, SPAN),
+                    self.ast_factory.make_id_ref_expr(SPAN, id),
                     false,
                   ));
                 }
                 ast::Declaration::ClassDeclaration(cls_decl) => {
                   // export class Foo {}
                   let id = cls_decl.id.as_ref().unwrap().name.as_str();
-                  self.exports.push(self.snippet.object_property_kind_object_property(
+                  self.exports.push(self.ast_factory.make_lazy_export_property(
                     id,
-                    self.snippet.id_ref_expr(id, SPAN),
+                    self.ast_factory.make_id_ref_expr(SPAN, id),
                     false,
                   ));
                 }
                 _ => unreachable!("doesn't support ts now"),
               }
-              program_body.push(ast::Statement::from(decl.take_in(self.alloc)));
+              program_body.push(ast::Statement::from(decl.take_in(self.ast_factory.allocator)));
             } else {
               // export { foo, bar as bar2 }
               decl.specifiers.iter().for_each(|specifier| {
@@ -249,52 +247,55 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ast::ModuleDeclaration::ExportDefaultDeclaration(decl) => match &mut decl.declaration {
             ast::ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
               if let Some(id) = &function.id {
-                self.exports.push(self.snippet.object_property_kind_object_property(
+                self.exports.push(self.ast_factory.make_lazy_export_property(
                   "default",
-                  self.snippet.id_ref_expr(&id.name, SPAN),
+                  self.ast_factory.make_id_ref_expr(SPAN, &id.name),
                   false,
                 ));
               } else {
-                function.id = Some(self.snippet.id("__rolldown_default__", SPAN));
-                self.exports.push(self.snippet.object_property_kind_object_property(
+                function.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
+                self.exports.push(self.ast_factory.make_lazy_export_property(
                   "default",
-                  self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+                  self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
                   false,
                 ));
               }
               program_body.push(ast::Statement::FunctionDeclaration(ArenaBox::new_in(
-                function.as_mut().take_in(self.alloc),
-                self.alloc,
+                function.as_mut().take_in(self.ast_factory.allocator),
+                self.ast_factory.allocator,
               )));
             }
             ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
               if let Some(id) = &class.id {
-                self.exports.push(self.snippet.object_property_kind_object_property(
+                self.exports.push(self.ast_factory.make_lazy_export_property(
                   "default",
-                  self.snippet.id_ref_expr(&id.name, SPAN),
+                  self.ast_factory.make_id_ref_expr(SPAN, &id.name),
                   false,
                 ));
               } else {
-                class.id = Some(self.snippet.id("__rolldown_default__", SPAN));
-                self.exports.push(self.snippet.object_property_kind_object_property(
+                class.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
+                self.exports.push(self.ast_factory.make_lazy_export_property(
                   "default",
-                  self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+                  self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
                   false,
                 ));
               }
               program_body.push(ast::Statement::ClassDeclaration(ArenaBox::new_in(
-                class.as_mut().take_in(self.alloc),
-                self.alloc,
+                class.as_mut().take_in(self.ast_factory.allocator),
+                self.ast_factory.allocator,
               )));
             }
             expr @ ast::match_expression!(ExportDefaultDeclarationKind) => {
               let expr = expr.to_expression_mut();
               // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
-              program_body
-                .push(self.snippet.var_decl_stmt("__rolldown_default__", expr.take_in(self.alloc)));
-              self.exports.push(self.snippet.object_property_kind_object_property(
+              program_body.push(
+                self
+                  .ast_factory
+                  .make_var_decl("__rolldown_default__", expr.take_in(self.ast_factory.allocator)),
+              );
+              self.exports.push(self.ast_factory.make_lazy_export_property(
                 "default",
-                self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+                self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
                 false,
               ));
             }
@@ -377,13 +378,13 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     //       ));
 
     //       // { exports: namespace }
-    //       ast::Argument::ObjectExpression(self.snippet.builder.alloc_object_expression(
+    //       ast::Argument::ObjectExpression(self.ast_factory.alloc_object_expression(
     //         SPAN,
-    //         self.snippet.builder.vec1(self.snippet.builder.object_property_kind_object_property(
+    //         self.ast_factory.vec1(self.ast_factory.object_property_kind_object_property(
     //           SPAN,
     //           PropertyKind::Init,
-    //           self.snippet.builder.property_key_static_identifier(SPAN, "exports"),
-    //           self.snippet.id_ref_expr(&binding_name_for_namespace_object_ref, SPAN),
+    //           self.ast_factory.property_key_static_identifier(SPAN, "exports"),
+    //           self.ast_factory.make_id_ref_expr(SPAN, &binding_name_for_namespace_object_ref),
     //           true,
     //           false,
     //           false,
@@ -392,27 +393,27 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     //     }
     //     rolldown_common::ExportsKind::CommonJs => {
     //       // `module`
-    //       ast::Argument::Identifier(self.snippet.builder.alloc_identifier_reference(SPAN, "module"))
+    //       ast::Argument::Identifier(self.ast_factory.alloc_identifier_reference(SPAN, "module"))
     //     }
     //     rolldown_common::ExportsKind::None => ast::Argument::ObjectExpression(
     //       // `{}`
-    //       self.snippet.builder.alloc_object_expression(SPAN, self.snippet.builder.vec()),
+    //       self.ast_factory.alloc_object_expression(SPAN, self.ast_factory.vec()),
     //     ),
     //   };
 
     // // __rolldown_runtime__.registerModule(moduleId, module)
-    // let arguments = self.snippet.builder.vec_from_array([
-    //   ast::Argument::StringLiteral(self.snippet.builder.alloc_string_literal(
+    // let arguments = self.ast_factory.vec_from_array([
+    //   ast::Argument::StringLiteral(self.ast_factory.alloc_string_literal(
     //     SPAN,
-    //     self.snippet.builder.str(&self.module.stable_id),
+    //     self.ast_factory.str(&self.module.stable_id),
     //     None,
     //   )),
     //   module_exports,
     // ]);
 
-    // let register_call = self.snippet.builder.alloc_call_expression(
+    // let register_call = self.ast_factory.alloc_call_expression(
     //   SPAN,
-    //   self.snippet.id_ref_expr("__rolldown_runtime__.registerModule", SPAN),
+    //   self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.registerModule"),
     //   NONE,
     //   arguments,
     //   false,
@@ -446,7 +447,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           [self.module.hmr_info.module_request_to_import_record_idx[string_literal.value.as_str()]];
         let Some(module_idx) = import_record.resolved_module else { return };
         // Use stable module ID for consistent runtime lookup
-        string_literal.value = self.snippet.builder.str(self.modules[module_idx].stable_id());
+        string_literal.value = self.ast_factory.str(self.modules[module_idx].stable_id());
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -457,7 +458,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                 [string_literal.value.as_str()]];
             let Some(module_idx) = import_record.resolved_module else { return };
             // Use stable module ID for consistent runtime lookup
-            string_literal.value = self.snippet.builder.str(self.modules[module_idx].stable_id());
+            string_literal.value = self.ast_factory.str(self.modules[module_idx].stable_id());
           }
         });
       }
@@ -468,7 +469,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
   pub fn rewrite_import_meta_hot(&self, expr: &mut ast::Expression<'ast>) {
     if expr.is_import_meta_hot() {
       let hot_name = format!("hot_{}", self.module.repr_name);
-      *expr = self.snippet.id_ref_expr(&hot_name, SPAN);
+      *expr = self.ast_factory.make_id_ref_expr(SPAN, &hot_name);
     }
   }
 
@@ -489,16 +490,35 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       Module::Normal(importee) => self.module.interop(importee),
       Module::External(_) => None,
     };
-    let call_expr = self.snippet.call_expr_with_arg_expr(
-      self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "loadExports"),
-      self.snippet.string_literal_expr(id, SPAN),
+    let call_expr = self.ast_factory.make_call_with_arg(
+      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports"),
+      self.ast_factory.expression_string_literal(SPAN, self.ast_factory.str(id), None),
       false,
     );
 
-    let stmt = self.snippet.variable_declarator_require_call_stmt(
-      binding_name,
-      self.snippet.to_esm_call_with_interop("__rolldown_runtime__.__toESM", call_expr, interop),
-      span,
+    // var [binding_name] = [__toESM-wrapped loadExports call];
+    let stmt = Statement::from(
+      self.ast_factory.declaration_variable(
+        span,
+        ast::VariableDeclarationKind::Var,
+        self.ast_factory.vec1(
+          self.ast_factory.variable_declarator(
+            SPAN,
+            ast::VariableDeclarationKind::Var,
+            self
+              .ast_factory
+              .binding_pattern_binding_identifier(SPAN, self.ast_factory.str(binding_name)),
+            NONE,
+            Some(self.ast_factory.make_to_esm_call_with_interop(
+              "__rolldown_runtime__.__toESM",
+              call_expr,
+              interop,
+            )),
+            false,
+          ),
+        ),
+        false,
+      ),
     );
     Some(stmt)
   }
@@ -516,7 +536,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let module_request = &importee.id;
 
     // import * as [binding_name] from 'external';
-    let stmt = self.snippet.import_star_stmt(module_request, binding_name);
+    let stmt = self.ast_factory.make_import_star_stmt(module_request, binding_name);
 
     self.generated_static_import_stmts_from_external.insert(importee.idx, stmt);
   }
@@ -534,14 +554,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     let self_exports = self.module_exports_name();
 
-    let call_expr = self.snippet.call_expr_with_2arg_expr(
-      self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "__reExport"),
-      self.snippet.id_ref_expr(self_exports, SPAN),
-      self.snippet.id_ref_expr(binding_name, SPAN),
+    let call_expr = self.ast_factory.expression_call(
+      SPAN,
+      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__reExport"),
+      NONE,
+      self.ast_factory.vec_from_iter([
+        ast::Argument::from(self.ast_factory.make_id_ref_expr(SPAN, self_exports)),
+        ast::Argument::from(self.ast_factory.make_id_ref_expr(SPAN, binding_name)),
+      ]),
+      false,
     );
 
     Some(ast::Statement::ExpressionStatement(
-      self.snippet.builder.alloc_expression_statement(span, call_expr),
+      self.ast_factory.alloc_expression_statement(span, call_expr),
     ))
   }
 
@@ -554,38 +579,36 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     // construct `{ prop_name: () => returned, ... }`
     let mut arg_obj_expr = self
-      .snippet
-      .builder
-      .alloc_object_expression(SPAN, self.snippet.builder.vec_with_capacity(self.exports.len()));
+      .ast_factory
+      .alloc_object_expression(SPAN, self.ast_factory.vec_with_capacity(self.exports.len()));
     arg_obj_expr.properties.extend(self.exports.drain(..));
     arg_obj_expr.properties.extend(self.named_exports.iter().map(|(exported, named_export)| {
       let expr = if let Some(local_binding) = self.import_bindings.get(&named_export.local_binding)
       {
-        self.snippet.id_ref_expr(local_binding, SPAN)
+        self.ast_factory.make_id_ref_expr(SPAN, local_binding)
       } else {
         let name = scoping.symbol_name(named_export.local_binding);
-        self.snippet.id_ref_expr(name, SPAN)
+        self.ast_factory.make_id_ref_expr(SPAN, name)
       };
       // Use computed property syntax for non-identifier export names (e.g., 'rolldown:exports')
       let computed = !is_validate_identifier_name(exported.as_str());
-      self.snippet.object_property_kind_object_property(exported, expr, computed)
+      self.ast_factory.make_lazy_export_property(exported, expr, computed)
     }));
 
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
-    let export_call_expr = self.snippet.builder.expression_call(
+    let export_call_expr = self.ast_factory.expression_call(
       SPAN,
-      self.snippet.id_ref_expr("__rolldown_runtime__.__exportAll", SPAN),
+      self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.__exportAll"),
       NONE,
-      self
-        .snippet
-        .builder
-        .vec_from_array([ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc))]),
+      self.ast_factory.vec_from_array([ast::Argument::ObjectExpression(
+        arg_obj_expr.into_in(self.ast_factory.allocator),
+      )]),
       false,
     );
 
     // construct `var [binding_name_for_namespace_object_ref] = __exportAll({ prop_name: () => returned, ... })`
     let decl_stmt =
-      self.snippet.var_decl_stmt(binding_name_for_namespace_object_ref, export_call_expr);
+      self.ast_factory.make_var_decl(binding_name_for_namespace_object_ref, export_call_expr);
     vec![decl_stmt]
   }
 
@@ -630,96 +653,101 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // TODO: hyf0 should switch to a more robust way to identify lazy proxy modules
     if importee.id.contains("?rolldown-lazy=1") {
       // Build: encodeURIComponent(importee.id)
-      let encode_call = ast::Expression::CallExpression(self.builder.alloc_call_expression(
-        SPAN,
-        self.snippet.id_ref_expr("encodeURIComponent", SPAN),
-        NONE,
-        self.builder.vec1(ast::Argument::StringLiteral(self.builder.alloc_string_literal(
+      let encode_call =
+        ast::Expression::CallExpression(self.ast_factory.alloc_call_expression(
           SPAN,
-          self.builder.str(&importee.id),
-          None,
-        ))),
-        false,
-      ));
+          self.ast_factory.make_id_ref_expr(SPAN, "encodeURIComponent"),
+          NONE,
+          self.ast_factory.vec1(ast::Argument::StringLiteral(
+            self.ast_factory.alloc_string_literal(SPAN, self.ast_factory.str(&importee.id), None),
+          )),
+          false,
+        ));
 
       // Build template literal: `/@vite/lazy?id=${encodeURIComponent(importee.id)}&clientId=${__rolldown_runtime__.clientId}`
       let url_expr = {
-        let quasis = self.builder.vec_from_iter([
-          self.builder.template_element(
+        let quasis = self.ast_factory.vec_from_iter([
+          self.ast_factory.template_element(
             SPAN,
-            ast::TemplateElementValue { raw: self.builder.str("/@vite/lazy?id="), cooked: None },
+            ast::TemplateElementValue {
+              raw: self.ast_factory.str("/@vite/lazy?id="),
+              cooked: None,
+            },
             false,
           ),
-          self.builder.template_element(
+          self.ast_factory.template_element(
             SPAN,
-            ast::TemplateElementValue { raw: self.builder.str("&clientId="), cooked: None },
+            ast::TemplateElementValue { raw: self.ast_factory.str("&clientId="), cooked: None },
             false,
           ),
-          self.builder.template_element(
+          self.ast_factory.template_element(
             SPAN,
-            ast::TemplateElementValue { raw: self.builder.str(""), cooked: None },
+            ast::TemplateElementValue { raw: self.ast_factory.str(""), cooked: None },
             true,
           ),
         ]);
-        let expressions = self.builder.vec_from_iter([
+        let expressions = self.ast_factory.vec_from_iter([
           encode_call,
-          self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "clientId"),
+          self.ast_factory.make_member_access_expr("__rolldown_runtime__", "clientId"),
         ]);
-        self.builder.expression_template_literal(SPAN, quasis, expressions)
+        self.ast_factory.expression_template_literal(SPAN, quasis, expressions)
       };
 
       // Build: import(`/@vite/lazy?id=...&clientId=...`)
-      let import_expr = self.builder.expression_import(SPAN, url_expr, None, None);
+      let import_expr = self.ast_factory.expression_import(SPAN, url_expr, None, None);
 
       // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
-      let load_exports_call = ast::Expression::CallExpression(self.builder.alloc_call_expression(
-        SPAN,
-        self.snippet.id_ref_expr("__rolldown_runtime__.loadExports", SPAN),
-        NONE,
-        self.builder.vec1(ast::Argument::StringLiteral(self.builder.alloc_string_literal(
+      let load_exports_call =
+        ast::Expression::CallExpression(self.ast_factory.alloc_call_expression(
           SPAN,
-          self.builder.str(&importee.stable_id),
-          None,
-        ))),
-        false,
-      ));
+          self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports"),
+          NONE,
+          self.ast_factory.vec1(ast::Argument::StringLiteral(
+            self.ast_factory.alloc_string_literal(
+              SPAN,
+              self.ast_factory.str(&importee.stable_id),
+              None,
+            ),
+          )),
+          false,
+        ));
 
       // Build: () => __rolldown_runtime__.loadExports("<stable_proxy_id>")
-      let arrow_fn = self.builder.expression_arrow_function(
+      let arrow_fn = self.ast_factory.expression_arrow_function(
         SPAN,
         /* expression */ true,
         /* async */ false,
         NONE,
-        self.builder.formal_parameters(
+        self.ast_factory.formal_parameters(
           SPAN,
           ast::FormalParameterKind::ArrowFormalParameters,
-          self.builder.vec(),
+          self.ast_factory.vec(),
           NONE,
         ),
         NONE,
-        self.builder.function_body(
+        self.ast_factory.function_body(
           SPAN,
-          self.builder.vec(),
-          self.builder.vec1(ast::Statement::ExpressionStatement(
-            self.builder.alloc_expression_statement(SPAN, load_exports_call),
+          self.ast_factory.vec(),
+          self.ast_factory.vec1(ast::Statement::ExpressionStatement(
+            self.ast_factory.alloc_expression_statement(SPAN, load_exports_call),
           )),
         ),
       );
 
       // Build: import(...).then(() => __rolldown_runtime__.loadExports("..."))
       let then_callee =
-        Expression::StaticMemberExpression(self.builder.alloc_static_member_expression(
+        Expression::StaticMemberExpression(self.ast_factory.alloc_static_member_expression(
           SPAN,
           import_expr,
-          self.builder.identifier_name(SPAN, "then"),
+          self.ast_factory.identifier_name(SPAN, "then"),
           false,
         ));
 
-      *it = self.builder.expression_call(
+      *it = self.ast_factory.expression_call(
         SPAN,
         then_callee,
         NONE,
-        self.builder.vec1(ast::Argument::from(arrow_fn)),
+        self.ast_factory.vec1(ast::Argument::from(arrow_fn)),
         false,
       );
       return;
@@ -731,26 +759,24 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // __rolldown_runtime__.loadExports('./foo.js')
     // Use stable module ID for consistent runtime lookup
     let mut load_exports_call_expr =
-      ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression(
+      ast::Expression::CallExpression(self.ast_factory.alloc_call_expression(
         SPAN,
-        self.snippet.id_ref_expr("__rolldown_runtime__.loadExports", SPAN),
+        self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports"),
         NONE,
-        self.snippet.builder.vec1(ast::Argument::StringLiteral(
-          self.snippet.builder.alloc_string_literal(
-            SPAN,
-            self.snippet.builder.str(&importee.stable_id),
-            None,
-          ),
-        )),
+        self.ast_factory.vec1(ast::Argument::StringLiteral(self.ast_factory.alloc_string_literal(
+          SPAN,
+          self.ast_factory.str(&importee.stable_id),
+          None,
+        ))),
         false,
       ));
 
     if is_importee_cjs {
       let is_node_cjs = importee.def_format.is_commonjs();
 
-      let mut args = self.snippet.builder.vec1(ast::Argument::from(load_exports_call_expr));
+      let mut args = self.ast_factory.vec1(ast::Argument::from(load_exports_call_expr));
       if is_node_cjs {
-        args.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
+        args.push(ast::Argument::from(self.ast_factory.expression_numeric_literal(
           SPAN,
           1.0,
           None,
@@ -759,9 +785,9 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       }
 
       // __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports('./foo.js'), node_mode)
-      load_exports_call_expr = self.snippet.builder.expression_call(
+      load_exports_call_expr = self.ast_factory.expression_call(
         SPAN,
-        self.snippet.id_ref_expr("__rolldown_runtime__.__toDynamicImportESM", SPAN),
+        self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.__toDynamicImportESM"),
         NONE,
         args,
         false,
@@ -773,23 +799,23 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Turn `import('./foo.js')` into `(init_foo(), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))`
 
       // init_foo()
-      let init_fn_call = self.snippet.builder.alloc_call_expression(
+      let init_fn_call = self.ast_factory.alloc_call_expression(
         SPAN,
-        self.snippet.id_ref_expr(init_fn_name, SPAN),
+        self.ast_factory.make_id_ref_expr(SPAN, init_fn_name),
         NONE,
-        self.snippet.builder.vec(),
+        self.ast_factory.vec(),
         false,
       );
 
       // Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js'))
       let promise_resolve_then_load_exports =
-        self.snippet.promise_resolve_then_call_expr(load_exports_call_expr);
+        self.ast_factory.make_promise_resolve_then(load_exports_call_expr);
 
       // (init_foo(), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))
       let ret_expr =
-        ast::Expression::SequenceExpression(self.snippet.builder.alloc_sequence_expression(
+        ast::Expression::SequenceExpression(self.ast_factory.alloc_sequence_expression(
           SPAN,
-          self.snippet.builder.vec_from_array([
+          self.ast_factory.vec_from_array([
             ast::Expression::CallExpression(init_fn_call),
             promise_resolve_then_load_exports,
           ]),
@@ -799,7 +825,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Turn `import('./foo.js')` into `Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js'))`
 
       // `Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js'))`
-      *it = self.snippet.promise_resolve_then_call_expr(load_exports_call_expr);
+      *it = self.ast_factory.make_promise_resolve_then(load_exports_call_expr);
     }
   }
 
@@ -816,8 +842,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       && id_ref.is_global_reference(scoping)
       && !ctx.parent().is_call_expression()
     {
-      *it =
-        self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "loadExports");
+      *it = self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports");
     }
 
     // Rewrite `require(...)` to `(require_xxx(), __rolldown_runtime__.loadExports())` or keep it as is for external module importee.
@@ -850,9 +875,13 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let is_importee_cjs = importee.exports_kind == rolldown_common::ExportsKind::CommonJs;
 
     // Use stable module ID for consistent runtime lookup
-    let load_exports_call = self.snippet.call_expr_with_arg_expr(
-      self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "loadExports"),
-      self.snippet.string_literal_expr(&importee.stable_id, SPAN),
+    let load_exports_call = self.ast_factory.make_call_with_arg(
+      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports"),
+      self.ast_factory.expression_string_literal(
+        SPAN,
+        self.ast_factory.str(&importee.stable_id),
+        None,
+      ),
       false,
     );
 
@@ -883,20 +912,20 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       load_exports_call
     } else if rec.meta.contains(ImportRecordMeta::JsonModule) {
       // Vite-mode JSON: ESM-wrapped at runtime, unwrap to the JSON value.
-      let to_commonjs_call = self.snippet.call_expr_with_arg_expr(
-        self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "__toCommonJS"),
+      let to_commonjs_call = self.ast_factory.make_call_with_arg(
+        self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__toCommonJS"),
         load_exports_call,
         false,
       );
-      Expression::from(self.snippet.builder.member_expression_static(
+      Expression::from(self.ast_factory.member_expression_static(
         SPAN,
         to_commonjs_call,
-        self.snippet.id_name("default", SPAN),
+        self.ast_factory.make_id_name(SPAN, "default"),
         false,
       ))
     } else {
-      self.snippet.call_expr_with_arg_expr(
-        self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "__toCommonJS"),
+      self.ast_factory.make_call_with_arg(
+        self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__toCommonJS"),
         load_exports_call,
         false,
       )
@@ -905,9 +934,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     if let Some(init_fn_name) = self.affected_module_idx_to_init_fn_name.get(&importee_idx) {
       // If the importee is in the current patch, call init before loading exports
       // Turn `require('./foo.js')` into `(init_foo(), __rolldown_runtime__.loadExports('./foo.js'))`
-      *it = self
-        .snippet
-        .seq2_in_paren_expr(self.snippet.call_expr_expr(init_fn_name), load_exports_expr);
+      *it = self.ast_factory.make_seq_in_parens(
+        self.ast_factory.expression_call(
+          SPAN,
+          self.ast_factory.make_id_ref_expr(SPAN, init_fn_name),
+          NONE,
+          self.ast_factory.vec(),
+          false,
+        ),
+        load_exports_expr,
+      );
     } else {
       // Importee is not in current patch (already executed by client), just load its exports
       // Turn `require('./foo.js')` into `__rolldown_runtime__.loadExports('./foo.js')`

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -13,7 +13,7 @@ use rolldown_common::{
   Module, ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
-use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_error::BuildResult;
 use rolldown_fs::FileSystem;
 use rolldown_plugin::SharedPluginDriver;
@@ -459,9 +459,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
           let mut finalizer = HmrAstFinalizer {
             modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
+            ast_factory: AstFactory::new(fields.allocator),
             import_bindings: FxHashMap::default(),
             module: affected_module,
             exports: oxc::allocator::Vec::new_in(fields.allocator),
@@ -699,9 +697,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
           let mut finalizer = HmrAstFinalizer {
             modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
+            ast_factory: AstFactory::new(fields.allocator),
             import_bindings: FxHashMap::default(),
             module: affected_module,
             exports: oxc::allocator::Vec::new_in(fields.allocator),
@@ -891,9 +887,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
           let mut finalizer = HmrAstFinalizer {
             modules,
-            alloc: fields.allocator,
-            snippet: AstSnippet::new(fields.allocator),
-            builder: &oxc::ast::AstBuilder::new(fields.allocator),
+            ast_factory: AstFactory::new(fields.allocator),
             import_bindings: FxHashMap::default(),
             module: affected_module,
             exports: oxc::allocator::Vec::new_in(fields.allocator),

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -20,7 +20,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let taken_body = node.body.take_in(self.alloc);
+    let taken_body = node.body.take_in(self.ast_factory.allocator);
     node.body.reserve_exact(taken_body.len());
     taken_body.into_iter().for_each(|top_level_stmt| {
       self.handle_top_level_stmt(&mut node.body, top_level_stmt, ctx.scoping());
@@ -32,16 +32,21 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let mut try_block =
-      self.snippet.builder.alloc_block_statement(SPAN, self.snippet.builder.vec());
+    let mut try_block = self.ast_factory.alloc_block_statement(SPAN, self.ast_factory.vec());
 
     let dependencies_init_fn_stmts: Vec<_> = self
       .dependencies
       .iter()
       .filter_map(|dep| self.affected_module_idx_to_init_fn_name.get(dep))
       .map(|fn_name| {
-        let call_expr = self.snippet.call_expr_expr(fn_name);
-        self.snippet.builder.statement_expression(SPAN, call_expr)
+        let call_expr = self.ast_factory.expression_call(
+          SPAN,
+          self.ast_factory.make_id_ref_expr(SPAN, fn_name),
+          NONE,
+          self.ast_factory.vec(),
+          false,
+        );
+        self.ast_factory.statement_expression(SPAN, call_expr)
       })
       .collect();
 
@@ -53,16 +58,15 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     try_block.body.extend(runtime_module_register);
     try_block.body.extend(dependencies_init_fn_stmts);
     try_block.body.push(self.create_module_hot_context_initializer_stmt());
-    try_block.body.extend(node.body.take_in(self.alloc));
+    try_block.body.extend(node.body.take_in(self.ast_factory.allocator));
 
     node
       .body
       .extend(std::mem::take(&mut self.generated_static_import_stmts_from_external).into_values());
 
-    let final_block = self.snippet.builder.alloc_block_statement(SPAN, self.snippet.builder.vec());
+    let final_block = self.ast_factory.alloc_block_statement(SPAN, self.ast_factory.vec());
 
-    let try_stmt =
-      self.snippet.builder.alloc_try_statement(SPAN, try_block, NONE, Some(final_block));
+    let try_stmt = self.ast_factory.alloc_try_statement(SPAN, try_block, NONE, Some(final_block));
 
     let init_fn_name = &self.affected_module_idx_to_init_fn_name[&self.module.idx];
 
@@ -70,10 +74,10 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // with the module's stable id as an extra argument, so it's available inside the body
     // as `__rolldown_module_id__`. This lets registerModule / createModuleHotContext reference
     // the id by identifier instead of duplicating the string literal.
-    let module_id_param = self.snippet.builder.formal_parameter(
+    let module_id_param = self.ast_factory.formal_parameter(
       SPAN,
-      self.builder.vec(),
-      self.snippet.builder.binding_pattern_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR),
+      self.ast_factory.vec(),
+      self.ast_factory.binding_pattern_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR),
       NONE,
       NONE,
       false,
@@ -81,18 +85,17 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       false,
       false,
     );
-    let params = self.snippet.builder.formal_parameters(
+    let params = self.ast_factory.formal_parameters(
       SPAN,
       ast::FormalParameterKind::Signature,
       {
         if self.module.exports_kind.is_commonjs() {
-          self.snippet.builder.vec_from_array([
-            self.snippet.builder.formal_parameter(
+          self.ast_factory.vec_from_array([
+            self.ast_factory.formal_parameter(
               SPAN,
-              self.builder.vec(),
+              self.ast_factory.vec(),
               self
-                .snippet
-                .builder
+                .ast_factory
                 .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_EXPORTS_REF_IDENT),
               NONE,
               NONE,
@@ -101,12 +104,11 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
               false,
               false,
             ),
-            self.snippet.builder.formal_parameter(
+            self.ast_factory.formal_parameter(
               SPAN,
-              self.builder.vec(),
+              self.ast_factory.vec(),
               self
-                .snippet
-                .builder
+                .ast_factory
                 .binding_pattern_binding_identifier(SPAN, CJS_ROLLDOWN_MODULE_REF_IDENT),
               NONE,
               NONE,
@@ -118,13 +120,13 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
             module_id_param,
           ])
         } else {
-          self.snippet.builder.vec1(module_id_param)
+          self.ast_factory.vec1(module_id_param)
         }
       },
       NONE,
     );
     // function () { [user code] }
-    let mut user_code_wrapper = self.snippet.builder.alloc_function(
+    let mut user_code_wrapper = self.ast_factory.alloc_function(
       SPAN,
       ast::FunctionType::FunctionExpression,
       None,
@@ -135,10 +137,10 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       NONE,
       params,
       NONE,
-      Some(self.snippet.builder.function_body(
+      Some(self.ast_factory.function_body(
         SPAN,
-        self.snippet.builder.vec(),
-        self.snippet.builder.vec1(ast::Statement::TryStatement(try_stmt)),
+        self.ast_factory.vec(),
+        self.ast_factory.vec1(ast::Statement::TryStatement(try_stmt)),
       )),
     );
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
@@ -148,16 +150,16 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // chunks we append a truthy dedup flag so the runtime short-circuits re-execution
     // when another lazy blob has already registered this module. HMR patches omit the
     // flag so the runtime always re-executes the body to publish new exports.
-    let mut initializer_args = self.snippet.builder.vec_with_capacity(3);
-    initializer_args.push(ast::Argument::StringLiteral(self.snippet.builder.alloc_string_literal(
+    let mut initializer_args = self.ast_factory.vec_with_capacity(3);
+    initializer_args.push(ast::Argument::StringLiteral(self.ast_factory.alloc_string_literal(
       SPAN,
-      self.snippet.builder.str(&self.module.stable_id),
+      self.ast_factory.str(&self.module.stable_id),
       None,
     )));
     initializer_args
       .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
     if self.dedup_module_initializer {
-      initializer_args.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
+      initializer_args.push(ast::Argument::from(self.ast_factory.expression_numeric_literal(
         SPAN,
         1.0,
         None,
@@ -172,26 +174,25 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       // __rolldown__runtime.createEsmInitializer(stable_id, (function () { [user code] })[, 1])
       "__rolldown_runtime__.createEsmInitializer"
     };
-    let initializer_call = self.snippet.builder.alloc_call_expression(
+    let initializer_call = self.ast_factory.alloc_call_expression(
       SPAN,
-      self.snippet.id_ref_expr(initializer_callee, SPAN),
+      self.ast_factory.make_id_ref_expr(SPAN, initializer_callee),
       NONE,
       initializer_args,
       false,
     );
 
     // var init_foo = __rolldown__runtime.createEsmInitializer((function () { [user code] }))
-    let var_decl = self.snippet.builder.alloc_variable_declaration(
+    let var_decl = self.ast_factory.alloc_variable_declaration(
       SPAN,
       ast::VariableDeclarationKind::Var,
-      self.snippet.builder.vec1(
-        self.snippet.builder.variable_declarator(
+      self.ast_factory.vec1(
+        self.ast_factory.variable_declarator(
           SPAN,
           ast::VariableDeclarationKind::Var,
           self
-            .snippet
-            .builder
-            .binding_pattern_binding_identifier(SPAN, self.snippet.builder.str(init_fn_name)),
+            .ast_factory
+            .binding_pattern_binding_identifier(SPAN, self.ast_factory.str(init_fn_name)),
           NONE,
           Some(ast::Expression::CallExpression(initializer_call)),
           false,
@@ -222,7 +223,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       && self.module.exports_kind.is_commonjs()
       && self.module.ecma_view.this_expr_replace_map.contains_key(&this_expr.span)
     {
-      *node = self.snippet.id_ref_expr(CJS_ROLLDOWN_EXPORTS_REF, SPAN);
+      *node = self.ast_factory.make_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF);
       return;
     }
 
@@ -255,7 +256,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let reference = ctx.scoping().get_reference(reference_id);
     if let Some(symbol_id) = reference.symbol_id() {
       if let Some(binding_name) = self.import_bindings.get(&symbol_id) {
-        ident.name = self.snippet.atom(binding_name.as_str()).into();
+        ident.name = self.ast_factory.str(binding_name.as_str()).into();
       }
     } else if ident.name == CJS_EXPORTS_REF_STR {
       ident.name = CJS_ROLLDOWN_EXPORTS_REF_IDENT;

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -17,7 +17,7 @@ pub static MODULE_EXPORTS_NAME_FOR_ESM: &str = "__rolldown_exports__";
 pub static MODULE_ID_PARAM_FOR_HMR: &str = "__rolldown_module_id__";
 
 pub trait HmrAstBuilder<'any, 'ast> {
-  fn builder(&self) -> &oxc::ast::AstBuilder<'ast>;
+  fn builder(&self) -> oxc::ast::AstBuilder<'ast>;
 
   fn module(&self) -> &NormalModule;
 
@@ -149,8 +149,8 @@ pub trait HmrAstBuilder<'any, 'ast> {
 
 #[cfg(feature = "experimental")]
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
-  fn builder(&self) -> &oxc::ast::AstBuilder<'ast> {
-    self.builder
+  fn builder(&self) -> oxc::ast::AstBuilder<'ast> {
+    *self.ast_factory
   }
 
   fn module(&self) -> &NormalModule {
@@ -181,8 +181,8 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
 }
 
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for ScopeHoistingFinalizer<'any, 'ast> {
-  fn builder(&self) -> &oxc::ast::AstBuilder<'ast> {
-    &self.snippet.builder
+  fn builder(&self) -> oxc::ast::AstBuilder<'ast> {
+    self.snippet.builder
   }
 
   fn module(&self) -> &NormalModule {

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -1,17 +1,20 @@
 use std::ops::Deref;
 
 use oxc::{
-  allocator::Allocator,
+  allocator::{Allocator, IntoIn},
   ast::{
     AstBuilder, NONE,
     ast::{
-      AssignmentOperator, AssignmentTarget, BindingIdentifier, Declaration,
+      Argument, AssignmentOperator, AssignmentTarget, BindingIdentifier, Declaration,
       ExportDefaultDeclarationKind, Expression, FormalParameterKind, IdentifierName,
-      ImportOrExportKind, SimpleAssignmentTarget, Statement, VariableDeclarationKind,
+      ImportDeclarationSpecifier, ImportOrExportKind, MemberExpression, NumberBase,
+      ObjectPropertyKind, PropertyKey, PropertyKind, SimpleAssignmentTarget, Statement,
+      VariableDeclarationKind,
     },
   },
   span::{SPAN, Span},
 };
+use rolldown_common::Interop;
 
 /// Rolldown's newtype wrapper around oxc's [`AstBuilder`].
 ///
@@ -131,6 +134,134 @@ impl<'ast> AstFactory<'ast> {
       self.formal_parameters(SPAN, FormalParameterKind::Signature, self.vec(), NONE),
       NONE,
       self.function_body(SPAN, self.vec(), statements),
+    ))
+  }
+
+  /// `<object>.<property>` as a `MemberExpression`.
+  pub fn make_member_access(&self, object: &str, property: &str) -> MemberExpression<'ast> {
+    MemberExpression::StaticMemberExpression(self.alloc_static_member_expression(
+      SPAN,
+      self.make_id_ref_expr(SPAN, object),
+      self.make_id_name(SPAN, property),
+      false,
+    ))
+  }
+
+  /// `<object>.<property>` as an `Expression`.
+  pub fn make_member_access_expr(&self, object: &str, property: &str) -> Expression<'ast> {
+    Expression::from(self.make_member_access(object, property))
+  }
+
+  /// `<callee>(<arg>)`, optionally annotated `@__PURE__`.
+  pub fn make_call_with_arg(
+    &self,
+    callee: Expression<'ast>,
+    arg: Expression<'ast>,
+    pure: bool,
+  ) -> Expression<'ast> {
+    let mut call_expr = self.call_expression(SPAN, callee, NONE, self.vec(), false);
+    call_expr.pure = pure;
+    call_expr.arguments.push(arg.into());
+    Expression::CallExpression(call_expr.into_in(self.allocator))
+  }
+
+  /// `Promise.resolve().then(() => <expr>)`
+  pub fn make_promise_resolve_then(&self, expr: Expression<'ast>) -> Expression<'ast> {
+    Expression::CallExpression(self.alloc_call_expression(
+      SPAN,
+      Expression::StaticMemberExpression(self.alloc_static_member_expression(
+        SPAN,
+        Expression::CallExpression(self.alloc_call_expression(
+          SPAN,
+          Expression::StaticMemberExpression(self.alloc_static_member_expression(
+            SPAN,
+            self.expression_identifier(SPAN, self.str("Promise")),
+            self.identifier_name(SPAN, self.str("resolve")),
+            false,
+          )),
+          NONE,
+          self.vec(),
+          false,
+        )),
+        self.identifier_name(SPAN, self.str("then")),
+        false,
+      )),
+      NONE,
+      self.vec1(Argument::from(self.make_arrow_returning(expr))),
+      false,
+    ))
+  }
+
+  /// `<key>: () => <expr>` — a lazy-export object property.
+  pub fn make_lazy_export_property(
+    &self,
+    key: &str,
+    expr: Expression<'ast>,
+    computed: bool,
+  ) -> ObjectPropertyKind<'ast> {
+    self.object_property_kind_object_property(
+      SPAN,
+      PropertyKind::Init,
+      if computed {
+        PropertyKey::from(self.expression_string_literal(SPAN, self.str(key), None))
+      } else {
+        self.property_key_static_identifier(SPAN, self.str(key))
+      },
+      self.make_arrow_returning(expr),
+      true,
+      false,
+      computed,
+    )
+  }
+
+  /// `import * as <as_name> from "<source>";`
+  pub fn make_import_star_stmt(&self, source: &str, as_name: &str) -> Statement<'ast> {
+    let specifiers = self.vec1(ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+      self.alloc_import_namespace_specifier(SPAN, self.binding_identifier(SPAN, self.str(as_name))),
+    ));
+    Statement::ImportDeclaration(self.alloc_import_declaration(
+      SPAN,
+      Some(specifiers),
+      self.string_literal(SPAN, self.str(source), None),
+      None,
+      NONE,
+      ImportOrExportKind::Value,
+    ))
+  }
+
+  /// `None` → `<call_expr>`; `Babel` → `__toESM(<call_expr>)`; `Node` → `__toESM(<call_expr>, 1)`.
+  #[expect(clippy::needless_pass_by_value)]
+  pub fn make_to_esm_call_with_interop(
+    &self,
+    to_esm_fn_name: &str,
+    call_expr: Expression<'ast>,
+    interop: Option<Interop>,
+  ) -> Expression<'ast> {
+    let arguments = match interop {
+      None => return call_expr,
+      Some(Interop::Babel) => self.vec1(Argument::from(call_expr)),
+      Some(Interop::Node) => self.vec_from_iter([
+        Argument::from(call_expr),
+        Argument::from(self.expression_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal)),
+      ]),
+    };
+    self.expression_call(
+      SPAN,
+      self.expression_identifier(SPAN, self.str(to_esm_fn_name)),
+      NONE,
+      arguments,
+      false,
+    )
+  }
+
+  /// `(<a>, <b>)` — a parenthesized two-element sequence expression.
+  pub fn make_seq_in_parens(&self, a: Expression<'ast>, b: Expression<'ast>) -> Expression<'ast> {
+    let mut expressions = self.vec_with_capacity(2);
+    expressions.push(a);
+    expressions.push(b);
+    Expression::ParenthesizedExpression(self.alloc_parenthesized_expression(
+      SPAN,
+      Expression::SequenceExpression(self.alloc_sequence_expression(SPAN, expressions)),
     ))
   }
 }


### PR DESCRIPTION
Migrates the HMR finalizer area (`crates/rolldown/src/hmr/`) off the legacy `AstSnippet` facade onto the `AstFactory` newtype. Behavior-preserving.

- **Consolidates 3 redundant construction fields** on `HmrAstFinalizer` (`alloc: &Allocator`, `snippet: AstSnippet`, `builder: &AstBuilder`) into a single `ast_factory: AstFactory`. The 3 construction sites in `hmr_stage.rs` build `AstFactory::new(allocator)`.
- **`HmrAstBuilder::builder()`** (shared trait, also impl'd for the not-yet-migrated `ScopeHoistingFinalizer`) now returns `AstBuilder` **by value** (it is `Copy`) instead of `&AstBuilder` — the one non-mechanical fix the design doc flagged. `HmrAstFinalizer` returns `*self.ast_factory`; `ScopeHoistingFinalizer` returns `self.snippet.builder` and keeps compiling unchanged.
- **Shared `make_*` additions on `AstFactory`** (incl. `make_member_access` -> `MemberExpression`, which `make_member_access_expr` delegates to) (faithful ports of `AstSnippet` patterns, reused later by `module_finalizers`): `make_member_access_expr`, `make_call_with_arg`, `make_promise_resolve_then`, `make_lazy_export_property` (renamed from `object_property_kind_object_property` to avoid shadowing the oxc builder method reached via `Deref`), `make_import_star_stmt`, `make_to_esm_call_with_interop`, `make_seq_in_parens`.
- Thin wrappers inlined (`id`/`id_ref_expr`/`id_name`/`atom`/`string_literal_expr`/`call_expr_expr`/…); `var_decl_stmt` → existing `make_var_decl`; `.builder.*` → deref'd `ast_factory.*`; `.alloc()` → `.allocator`.

### AstFactory migration progress (`meta/design/ast-construction.md`)

- [x] Design doc + conventions — #9673 (merged)
- [x] Introduce `AstFactory` + `vite_web_worker_post` + `generate_lazy_export` — #9682 (merged)
- [x] `tweak_ast_for_scanning` — #9683
- [x] `vite_build_import_analysis` — #9693
- [x] hmr finalizer + `hmr_stage` (+ 6 shared `make_*`, `builder()` by-value) — **#9695 ← this PR**
- [x] `module_finalizers/mod.rs` (+ the `make_*` ports it consumes; transitional dual field) — #9700
- [x] rest of `ScopeHoistingFinalizer` (+ wrapper `make_*` ports; `snippet` field removed) — #9701
- [x] fold construction ext traits onto `AstFactory`; delete `AstSnippet` — #9702

🤖 Generated with [Claude Code](https://claude.com/claude-code)