### PR TITLE
fix(resolver): honor package.json#type for .jsx/.tsx extensions (#9690)

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/9690/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9690/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      { "name": "from-ts", "import": "./src/from-ts.ts" },
+      { "name": "from-tsx", "import": "./src/from-tsx.tsx" }
+    ],
+    "external": ["mock-cjs"],
+    "format": "cjs"
+  },
+  "extendedTests": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9690/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9690/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+// https://github.com/rolldown/rolldown/issues/9690
+// `.ts` and `.tsx` entries with identical content (importing a default from an
+// external CJS module under `"type": "module"`) must get identical node-mode
+// CJS interop. Previously the `.tsx` entry lost the node-mode flag
+// (`__toESM(mod)` instead of `__toESM(mod, 1)`) because `oxc_resolver` only
+// resolves `package.json#type` for `.js`/`.ts`, so its default import resolved
+// to `exports.default` instead of `module.exports` and `fn.div` blew up at
+// runtime. Executing both bundles asserts the runtime behavior directly.
+const require = createRequire(import.meta.url);
+
+const fromTs = require('./dist/from-ts.js');
+const fromTsx = require('./dist/from-tsx.js');
+
+assert.strictEqual(fromTs.result, 'div-tag-result');
+assert.strictEqual(fromTsx.result, 'div-tag-result');

--- a/crates/rolldown/tests/rolldown/issues/9690/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9690/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## from-ts.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+let mock_cjs = require("mock-cjs");
+mock_cjs = require_rolldown_runtime.__toESM(mock_cjs, 1);
+//#region src/from-ts.ts
+const result = mock_cjs.default.div``;
+//#endregion
+exports.result = result;
+
+```
+
+## from-tsx.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+let mock_cjs = require("mock-cjs");
+mock_cjs = require_rolldown_runtime.__toESM(mock_cjs, 1);
+//#region src/from-tsx.tsx
+const result = mock_cjs.default.div``;
+//#endregion
+exports.result = result;
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9690/node_modules/mock-cjs/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9690/node_modules/mock-cjs/index.js
@@ -1,0 +1,11 @@
+'use strict';
+// Mimics a transpiled CJS package (the styled-components shape from the issue)
+// that marks itself `__esModule` and ships a `default` differing from
+// `module.exports`. Node's real ESM semantics — and the node-mode
+// `__toESM(mod, 1)` interop that emulates them — resolve a default import to
+// `module.exports` itself, so `fn.div` works. The buggy classic `__toESM(mod)`
+// honors `__esModule` and resolves it to `exports.default`, where `div` is
+// missing, so `fn.div` blows up at runtime.
+exports.__esModule = true;
+exports.default = {};
+exports.div = () => 'div-tag-result';

--- a/crates/rolldown/tests/rolldown/issues/9690/node_modules/mock-cjs/package.json
+++ b/crates/rolldown/tests/rolldown/issues/9690/node_modules/mock-cjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-cjs",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/crates/rolldown/tests/rolldown/issues/9690/src/from-ts.ts
+++ b/crates/rolldown/tests/rolldown/issues/9690/src/from-ts.ts
@@ -1,0 +1,3 @@
+import fn from 'mock-cjs';
+
+export const result = fn.div``;

--- a/crates/rolldown/tests/rolldown/issues/9690/src/from-tsx.tsx
+++ b/crates/rolldown/tests/rolldown/issues/9690/src/from-tsx.tsx
@@ -1,0 +1,3 @@
+import fn from 'mock-cjs';
+
+export const result = fn.div``;

--- a/crates/rolldown/tests/rolldown/issues/9690/src/package.json
+++ b/crates/rolldown/tests/rolldown/issues/9690/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -7,8 +7,8 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use dashmap::DashMap;
 use oxc_resolver::{
-  ModuleType, PackageJson as OxcPackageJson, Resolution, ResolveError, ResolverGeneric,
-  TsConfig as OxcTsConfig,
+  ModuleType, PackageJson as OxcPackageJson, PackageType, Resolution, ResolveError,
+  ResolverGeneric, TsConfig as OxcTsConfig,
 };
 use rolldown_common::{
   ImportKind, ModuleDefFormat, ModuleId, PackageJson, Platform, ResolveOptions, ResolvedId,
@@ -243,6 +243,17 @@ fn infer_module_def_format(info: &Resolution) -> ModuleDefFormat {
         ModuleType::CommonJs => ModuleDefFormat::CjsPackageJson,
         ModuleType::Module => ModuleDefFormat::EsmPackageJson,
         ModuleType::Json | ModuleType::Wasm | ModuleType::Addon => ModuleDefFormat::Unknown,
+      };
+    }
+    // `oxc_resolver` only resolves `module_type` from `package.json#type` for `.js`/`.ts`
+    // extensions, following the Node.js ESM spec which has no native `.jsx`/`.tsx`. As a bundler,
+    // rolldown also treats `.jsx`/`.tsx` according to the nearest `package.json#type`, so fall back
+    // to reading it directly here to keep all js-like extensions consistent.
+    // See https://github.com/rolldown/rolldown/issues/9690
+    if let Some(ty) = info.package_json().and_then(|pkg_json| pkg_json.r#type()) {
+      return match ty {
+        PackageType::CommonJs => ModuleDefFormat::CjsPackageJson,
+        PackageType::Module => ModuleDefFormat::EsmPackageJson,
       };
     }
   }


### PR DESCRIPTION
`oxc_resolver` only resolves `module_type` from `package.json#type` for `.js`/`.ts` extensions, following the Node.js ESM spec which has no native `.jsx`/`.tsx`. rolldown relied on that `module_type`, so a `.tsx` entry under `"type": "module"` fell back to `Unknown` instead of `EsmPackageJson`.

This made identical `.ts` and `.tsx` sources emit different CJS interop for a default import of an external CJS module: the `.ts` file got node-mode `__toESM(mod, 1)` while the `.tsx` file got `__toESM(mod)`, breaking `mod.default` at runtime.

As a bundler, rolldown already treats `.jsx`/`.tsx` as js-like extensions, so fall back to reading the nearest `package.json#type` directly when oxc reports no `module_type`, keeping all js-like extensions consistent (and matching esbuild, which emits `__toESM(require(...), 1)` for both).

closed https://github.com/rolldown/rolldown/issues/9690