### PR TITLE
refactor(finalizer): finish ScopeHoistingFinalizer migration to AstFactory

### DIFF
--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -182,7 +182,7 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
 
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for ScopeHoistingFinalizer<'any, 'ast> {
   fn builder(&self) -> oxc::ast::AstBuilder<'ast> {
-    self.snippet.builder
+    *self.ast_factory
   }
 
   fn module(&self) -> &NormalModule {

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -11,7 +11,7 @@ pub type FinalizerMutableFields = (
 
 use oxc::ast_visit::VisitMut as _;
 use rolldown_ecmascript::EcmaAst;
-use rolldown_ecmascript_utils::{AstFactory, AstSnippet};
+use rolldown_ecmascript_utils::AstFactory;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -78,7 +78,6 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         alloc,
         ctx: self,
         scope: ast_scope,
-        snippet: AstSnippet::new(alloc),
         ast_factory: AstFactory::new(alloc),
         generated_init_esm_importee_ids: FxHashSet::default(),
         scope_stack: vec![],

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -27,7 +27,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if expr.is_import_meta_hot() {
       if let Some(hmr_hot_ref) = self.ctx.module.ecma_view.hmr_hot_ref {
         let hot_name = self.canonical_name_for(hmr_hot_ref);
-        *expr = self.snippet.id_ref_expr(hot_name, SPAN);
+        *expr = self.ast_factory.make_id_ref_expr(SPAN, hot_name);
       }
     }
   }
@@ -56,10 +56,8 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           .hmr_info
           .module_request_to_import_record_idx[string_literal.value.as_str()]];
         // Use stable module ID for consistent runtime lookup
-        string_literal.value = self
-          .snippet
-          .builder
-          .str(self.ctx.modules[import_record.into_resolved_module()].stable_id());
+        string_literal.value =
+          self.ast_factory.str(self.ctx.modules[import_record.into_resolved_module()].stable_id());
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -72,8 +70,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
               .module_request_to_import_record_idx[string_literal.value.as_str()]];
             // Use stable module ID for consistent runtime lookup
             string_literal.value = self
-              .snippet
-              .builder
+              .ast_factory
               .str(self.ctx.modules[import_record.into_resolved_module()].stable_id());
           }
         });

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools;
-use oxc::allocator::FromIn;
 use oxc::ast::AstType;
-use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression, Str};
+use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::{
   allocator::{self, IntoIn, TakeIn},
   ast::{
@@ -18,7 +17,6 @@ use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKi
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{ExpressionExt, JsxExt, JsxMemberExpressionObjectExt};
 
-use crate::hmr::utils::HmrAstBuilder;
 use crate::module_finalizers::{KeepNameId, TraverseState};
 
 use super::ScopeHoistingFinalizer;
@@ -137,7 +135,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         .any(|id| self.ctx.linking_info.stmt_info_included.has_bit(*id));
       if is_included {
         let canonical_name = self.canonical_name_for(*symbol_ref);
-        program.body.push(self.snippet.var_decl_stmt(canonical_name, self.snippet.void_zero()));
+        program
+          .body
+          .push(self.ast_factory.make_var_decl(canonical_name, self.ast_factory.void_0(SPAN)));
       }
     });
 
@@ -172,7 +172,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         let mut stmts_inside_closure = allocator::Vec::new_in(self.alloc);
         stmts_inside_closure.append(&mut program.body);
 
-        program.body.push(self.snippet.commonjs_wrapper_stmt(
+        program.body.push(self.ast_factory.make_commonjs_wrapper_stmt(
           wrap_ref_name,
           commonjs_ref_expr,
           stmts_inside_closure,
@@ -239,23 +239,25 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
 
         if !is_concatenated_wrapped_module && !self.top_level_var_bindings.is_empty() {
-          let builder = self.builder();
+          let ast_factory = self.ast_factory;
           let decorations = self.top_level_var_bindings.iter().map(|var_name| {
-            builder.variable_declarator(
+            ast_factory.variable_declarator(
               SPAN,
               ast::VariableDeclarationKind::Var,
-              builder.binding_pattern_binding_identifier(SPAN, *var_name),
+              ast_factory.binding_pattern_binding_identifier(SPAN, *var_name),
               NONE,
               None,
               false,
             )
           });
-          program.body.push(Statement::VariableDeclaration(builder.alloc_variable_declaration(
-            SPAN,
-            ast::VariableDeclarationKind::Var,
-            builder.vec_from_iter(decorations),
-            false,
-          )));
+          program.body.push(Statement::VariableDeclaration(
+            ast_factory.alloc_variable_declaration(
+              SPAN,
+              ast::VariableDeclarationKind::Var,
+              ast_factory.vec_from_iter(decorations),
+              false,
+            ),
+          ));
         }
 
         // The wrapping would happen during the chunk codegen phase
@@ -280,14 +282,14 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           ConcatenateWrappedModuleKind::Root
         ) {
           self.rendered_concatenated_wrapped_module_parts.rendered_esm_runtime_expr =
-            Some(self.builder().expression_statement(SPAN, esm_ref_expr).to_source_string());
+            Some(self.ast_factory.expression_statement(SPAN, esm_ref_expr).to_source_string());
           self.rendered_concatenated_wrapped_module_parts.wrap_ref_name =
             Some(CompactStr::new(wrap_ref_name));
           program.body.extend(stmts_inside_closure);
           return;
         }
 
-        program.body.push(self.snippet.esm_wrapper_stmt(
+        program.body.push(self.ast_factory.make_esm_wrapper_stmt(
           wrap_ref_name,
           esm_ref_expr,
           stmts_inside_closure,
@@ -317,7 +319,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       assert!(symbol.namespace_alias.is_none());
       let canonical_name = self.canonical_name_for(symbol_ref);
       if ident.name != canonical_name {
-        ident.name = self.snippet.atom(canonical_name).into();
+        ident.name = self.ast_factory.str(canonical_name).into();
       }
       ident.symbol_id.get_mut().take();
     } else {
@@ -341,7 +343,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       {
         self.top_level_var_bindings.extend(bindings);
         *it = ast::Statement::ExpressionStatement(
-          self.builder().alloc_expression_statement(SPAN, expr),
+          self.ast_factory.alloc_expression_statement(SPAN, expr),
         );
       }
     }
@@ -396,7 +398,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let symbol_ref: SymbolRef = (self.ctx.idx, symbol_id).into();
                 let canonical_name = self.canonical_name_for(symbol_ref);
                 if id.name != canonical_name {
-                  id.name = self.snippet.atom(canonical_name).into();
+                  id.name = self.ast_factory.str(canonical_name).into();
                 }
                 // Clear symbol_id to prevent double processing:
                 // - visit_expression won't re-wrap when walker visits inner fn
@@ -407,8 +409,12 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let name_ref = self.canonical_ref_for_runtime("__name");
                 let (finalized_callee, _) =
                   self.finalized_expr_for_symbol_ref(name_ref, false, false);
-                *expr =
-                  self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_callee, true);
+                *expr = self.ast_factory.make_keep_name_call(
+                  &original_name,
+                  fn_expr,
+                  finalized_callee,
+                  true,
+                );
               }
             }
           }
@@ -464,16 +470,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         if let Some(kind) = self.ctx.module.ecma_view.this_expr_replace_map.get(&this_expr.span) {
           match kind {
             ThisExprReplaceKind::Exports => {
-              *expr = self.snippet.builder.expression_identifier(SPAN, "exports");
+              *expr = self.ast_factory.expression_identifier(SPAN, "exports");
             }
             ThisExprReplaceKind::Context if self.ctx.options.context.is_empty() => {
-              *expr = self.snippet.void_zero();
+              *expr = self.ast_factory.void_0(SPAN);
             }
             ThisExprReplaceKind::Context => {
-              *expr = self.snippet.builder.expression_identifier(
-                SPAN,
-                Str::from_in(self.ctx.options.context.as_str(), self.alloc),
-              );
+              *expr = self.ast_factory.make_id_ref_expr(SPAN, self.ctx.options.context.as_str());
             }
           }
         }
@@ -483,7 +486,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           && meta.meta.name == "import"
           && meta.property.name == "meta"
         {
-          *expr = self.snippet.builder.expression_object(SPAN, self.snippet.builder.vec());
+          *expr = self.ast_factory.expression_object(SPAN, self.ast_factory.vec());
         }
       }
       ast::Expression::ChainExpression(_) => {
@@ -512,12 +515,11 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             match new_expr {
               ast::Expression::StaticMemberExpression(member) => {
                 *expr = self
-                  .snippet
-                  .builder
+                  .ast_factory
                   .expression_chain(chain_span, ast::ChainElement::StaticMemberExpression(member));
               }
               ast::Expression::ComputedMemberExpression(member) => {
-                *expr = self.snippet.builder.expression_chain(
+                *expr = self.ast_factory.expression_chain(
                   chain_span,
                   ast::ChainElement::ComputedMemberExpression(member),
                 );
@@ -684,7 +686,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       {
         let binding = if let Some(init) = prop.init.take() {
           ast::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
-            self.snippet.builder.alloc_assignment_target_with_default(
+            self.ast_factory.alloc_assignment_target_with_default(
               Span::default(),
               ast::AssignmentTarget::from(target),
               init,
@@ -694,10 +696,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           ast::AssignmentTargetMaybeDefault::from(target)
         };
         *property = ast::AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-          self.snippet.builder.alloc_assignment_target_property_property(
+          self.ast_factory.alloc_assignment_target_property_property(
             Span::default(),
             ast::PropertyKey::StaticIdentifier(
-              self.snippet.id_name(&prop.binding.name, prop.span).into_in(self.alloc),
+              self.ast_factory.make_id_name(prop.span, &prop.binding.name).into_in(self.alloc),
             ),
             binding,
             false,

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -20,7 +20,7 @@ use rolldown_common::{
 };
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{
-  AstFactory, AstSnippet, BindingPatternExt, CallExpressionExt, ExpressionExt, StatementExt,
+  AstFactory, BindingPatternExt, CallExpressionExt, ExpressionExt, StatementExt,
 };
 
 mod finalizer_context;
@@ -80,7 +80,6 @@ pub struct ScopeHoistingFinalizer<'me, 'ast: 'me> {
   pub ctx: ScopeHoistingFinalizerContext<'me>,
   pub scope: &'me AstScopes,
   pub alloc: &'ast Allocator,
-  pub snippet: AstSnippet<'ast>,
   pub ast_factory: AstFactory<'ast>,
   pub generated_init_esm_importee_ids: FxHashSet<ModuleIdx>,
   pub scope_stack: Vec<ScopeFlags>,

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -63,7 +63,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if let Some(ns_alias) = &symbol.namespace_alias {
       let canonical_ns_name = self.canonical_name_for(ns_alias.namespace_ref);
       let prop_name = &ns_alias.property_name;
-      let access_expr = self.snippet.literal_prop_access_member_expr(canonical_ns_name, prop_name);
+      let access_expr = self.ast_factory.make_member_access(canonical_ns_name, prop_name);
 
       return Some(ast::SimpleAssignmentTarget::from(access_expr));
     }
@@ -71,7 +71,9 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     let canonical_name = self.canonical_name_for(canonical_ref);
     if id_ref.name != canonical_name {
       return Some(ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(
-        self.snippet.alloc_id_ref(canonical_name, id_ref.span),
+        self
+          .ast_factory
+          .alloc_identifier_reference(id_ref.span, self.ast_factory.str(canonical_name)),
       ));
     }
 
@@ -112,15 +114,14 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
         let symbol = self.ctx.symbol_db.get(canonical_ref);
 
         if let Some(ns_alias) = &symbol.namespace_alias {
-          *target =
-            ast::SimpleAssignmentTarget::from(self.snippet.literal_prop_access_member_expr(
-              self.canonical_name_for(ns_alias.namespace_ref),
-              &ns_alias.property_name,
-            ));
+          *target = ast::SimpleAssignmentTarget::from(self.ast_factory.make_member_access(
+            self.canonical_name_for(ns_alias.namespace_ref),
+            &ns_alias.property_name,
+          ));
         } else {
           let canonical_name = self.canonical_name_for(canonical_ref);
           if target_id_ref.name != canonical_name {
-            target_id_ref.name = self.snippet.atom(canonical_name).into();
+            target_id_ref.name = self.ast_factory.str(canonical_name).into();
           }
           target_id_ref.reference_id.take();
         }
@@ -149,7 +150,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name = self.snippet.atom(canonical_name).into();
+              ident.name = self.ast_factory.str(canonical_name).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();
@@ -164,7 +165,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name = self.snippet.atom(canonical_name).into();
+              ident.name = self.ast_factory.str(canonical_name).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -14,7 +14,7 @@ use oxc::{
   },
   span::{GetSpanMut, SPAN, Span},
 };
-use rolldown_common::{Interop, MemberExprProp};
+use rolldown_common::{EcmaModuleAstUsage, Interop, MemberExprProp};
 use rolldown_utils::ecmascript::is_validate_identifier_name;
 
 /// Rolldown's newtype wrapper around oxc's [`AstBuilder`].
@@ -392,6 +392,116 @@ impl<'ast> AstFactory<'ast> {
       false,
       true,
     ))
+  }
+
+  /// `var <binding_name> = __commonJS(... (exports, module) => { <statements> } ...)`
+  #[expect(clippy::too_many_arguments)]
+  pub fn make_commonjs_wrapper_stmt(
+    &self,
+    binding_name: &str,
+    commonjs_expr: Expression<'ast>,
+    statements: allocator::Vec<'ast, Statement<'ast>>,
+    ast_usage: EcmaModuleAstUsage,
+    profiler_names: bool,
+    stable_id: &str,
+    is_async: bool,
+  ) -> Statement<'ast> {
+    let mut params =
+      self.formal_parameters(SPAN, FormalParameterKind::Signature, self.vec_with_capacity(1), NONE);
+    let body = self.function_body(SPAN, self.vec(), statements);
+    if ast_usage.intersects(EcmaModuleAstUsage::ModuleOrExports) {
+      params.items.push(self.formal_parameter(
+        SPAN,
+        self.vec(),
+        self.binding_pattern_binding_identifier(SPAN, "exports"),
+        NONE,
+        NONE,
+        false,
+        None,
+        false,
+        false,
+      ));
+    }
+    if ast_usage.contains(EcmaModuleAstUsage::ModuleRef) {
+      params.items.push(self.formal_parameter(
+        SPAN,
+        self.vec(),
+        self.binding_pattern_binding_identifier(SPAN, "module"),
+        NONE,
+        NONE,
+        false,
+        None,
+        false,
+        false,
+      ));
+    }
+    let mut commonjs_call_expr =
+      self.call_expression_with_pure(SPAN, commonjs_expr, NONE, self.vec(), false, true);
+    let mut arrow_expr =
+      self.alloc_arrow_function_expression(SPAN, false, is_async, NONE, params, NONE, body);
+    arrow_expr.pife = true;
+    if profiler_names {
+      let obj_expr = self.alloc_object_expression(
+        SPAN,
+        self.vec1(self.object_property_kind_object_property(
+          SPAN,
+          PropertyKind::Init,
+          PropertyKey::from(self.expression_string_literal(SPAN, self.str(stable_id), None)),
+          Expression::ArrowFunctionExpression(arrow_expr),
+          true,
+          false,
+          false,
+        )),
+      );
+      commonjs_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
+    } else {
+      commonjs_call_expr.arguments.push(Argument::ArrowFunctionExpression(arrow_expr));
+    }
+    self.make_var_decl(
+      binding_name,
+      Expression::CallExpression(commonjs_call_expr.into_in(self.allocator)),
+    )
+  }
+
+  /// `var <binding_name> = __esm(... () => { <statements> } ...)`
+  #[expect(clippy::too_many_arguments)]
+  pub fn make_esm_wrapper_stmt(
+    &self,
+    binding_name: &str,
+    esm_fn_expr: Expression<'ast>,
+    statements: allocator::Vec<'ast, Statement<'ast>>,
+    profiler_names: bool,
+    use_pife: bool,
+    stable_id: &str,
+    is_async: bool,
+  ) -> Statement<'ast> {
+    let params = self.formal_parameters(SPAN, FormalParameterKind::Signature, self.vec(), NONE);
+    let body = self.function_body(SPAN, self.vec(), statements);
+    let mut esm_call_expr = self.call_expression(SPAN, esm_fn_expr, NONE, self.vec(), false);
+    let mut arrow_expr =
+      self.alloc_arrow_function_expression(SPAN, false, is_async, NONE, params, NONE, body);
+    arrow_expr.pife = use_pife;
+    if profiler_names {
+      let obj_expr = self.alloc_object_expression(
+        SPAN,
+        self.vec1(self.object_property_kind_object_property(
+          SPAN,
+          PropertyKind::Init,
+          PropertyKey::from(self.expression_string_literal(SPAN, self.str(stable_id), None)),
+          Expression::ArrowFunctionExpression(arrow_expr),
+          false,
+          false,
+          false,
+        )),
+      );
+      esm_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
+    } else {
+      esm_call_expr.arguments.push(Argument::ArrowFunctionExpression(arrow_expr));
+    }
+    self.make_var_decl(
+      binding_name,
+      Expression::CallExpression(esm_call_expr.into_in(self.allocator)),
+    )
   }
 
   /// `n => n.<property_name>`


### PR DESCRIPTION
Finishes the `ScopeHoistingFinalizer` migration: the remaining `impl_visit_mut.rs` (16 sites) / `rename.rs` (6) / `hmr.rs` (3) call sites move off `AstSnippet`, **adding the `make_commonjs_wrapper_stmt` / `make_esm_wrapper_stmt` ports alongside their first callers**. The transitional `snippet` field from #9700 is removed (struct + construction + imports), and the `HmrAstBuilder::builder()` impl for `ScopeHoistingFinalizer` now returns `*self.ast_factory`. `literal_prop_access_member_expr` (the `MemberExpression`-returning variant) and other thin wrappers are inlined.

Behavior-preserving: full-fixture snapshot suite byte-identical + 2 adversarial reviews + 1 CodeX review + Copilot, all clean.

### AstFactory migration progress (`meta/design/ast-construction.md`)

- [x] Design doc + conventions — #9673 (merged)
- [x] Introduce `AstFactory` + `vite_web_worker_post` + `generate_lazy_export` — #9682 (merged)
- [x] `tweak_ast_for_scanning` — #9683
- [x] `vite_build_import_analysis` — #9693
- [x] hmr finalizer + `hmr_stage` (+ 6 shared `make_*`, `builder()` by-value) — #9695
- [x] `module_finalizers/mod.rs` (+ the `make_*` ports it consumes; transitional dual field) — #9700
- [x] rest of `ScopeHoistingFinalizer` (+ wrapper `make_*` ports; `snippet` field removed) — **#9701 ← this PR**
- [x] fold construction ext traits onto `AstFactory`; delete `AstSnippet` — #9702

🤖 Generated with [Claude Code](https://claude.com/claude-code)