### PR TITLE
chore(hmr): delete commented-out dead code left from old register-module codegen

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -370,62 +370,6 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     }
     ret.push(self.create_register_module_stmt());
 
-    // let module_exports =
-    //   match self.module.exports_kind {
-    //     rolldown_common::ExportsKind::Esm => {
-    //       ret.extend(self.generate_declaration_of_module_namespace_object(
-    //         &binding_name_for_namespace_object_ref,
-    //       ));
-
-    //       // { exports: namespace }
-    //       ast::Argument::ObjectExpression(self.ast_factory.alloc_object_expression(
-    //         SPAN,
-    //         self.ast_factory.vec1(self.ast_factory.object_property_kind_object_property(
-    //           SPAN,
-    //           PropertyKind::Init,
-    //           self.ast_factory.property_key_static_identifier(SPAN, "exports"),
-    //           self.ast_factory.make_id_ref_expr(SPAN, &binding_name_for_namespace_object_ref),
-    //           true,
-    //           false,
-    //           false,
-    //         )),
-    //       ))
-    //     }
-    //     rolldown_common::ExportsKind::CommonJs => {
-    //       // `module`
-    //       ast::Argument::Identifier(self.ast_factory.alloc_identifier_reference(SPAN, "module"))
-    //     }
-    //     rolldown_common::ExportsKind::None => ast::Argument::ObjectExpression(
-    //       // `{}`
-    //       self.ast_factory.alloc_object_expression(SPAN, self.ast_factory.vec()),
-    //     ),
-    //   };
-
-    // // __rolldown_runtime__.registerModule(moduleId, module)
-    // let arguments = self.ast_factory.vec_from_array([
-    //   ast::Argument::StringLiteral(self.ast_factory.alloc_string_literal(
-    //     SPAN,
-    //     self.ast_factory.str(&self.module.stable_id),
-    //     None,
-    //   )),
-    //   module_exports,
-    // ]);
-
-    // let register_call = self.ast_factory.alloc_call_expression(
-    //   SPAN,
-    //   self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.registerModule"),
-    //   NONE,
-    //   arguments,
-    //   false,
-    // );
-
-    // ret.push(ast::Statement::ExpressionStatement(
-    //   self
-    //     .snippet
-    //     .builder
-    //     .alloc_expression_statement(SPAN, ast::Expression::CallExpression(register_call)),
-    // ));
-
     ret
   }
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -147,7 +147,6 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .await?;
 
     // Extract the single result
-    // ret.is_self_accepting = true; // (hyf0) TODO: what's this for?
     Ok(results.pop().unwrap().update)
   }
 
@@ -247,7 +246,6 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
           if let Module::Normal(module) = module {
             Some(module.originative_resolved_id.clone())
           } else {
-            // unreachable!("HMR only supports normal module. Got {:?}", module.id());
             None
           }
         })
@@ -579,7 +577,6 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
           if let Module::Normal(module) = module {
             Some(module.originative_resolved_id.clone())
           } else {
-            // unreachable!("HMR only supports normal module. Got {:?}", module.id());
             None
           }
         })


### PR DESCRIPTION
Deletes commented-out dead code (not explanatory comments) left in the areas touched by the AstFactory migration stack. Every removed line is a comment or blank — zero behavior change.

### `hmr_ast_finalizer.rs` — 55-line commented block in `generate_runtime_module_register_for_hmr`

- The old hand-rolled `__rolldown_runtime__.registerModule` codegen.
- #5310 replaced it with `HmrAstBuilder::create_register_module_stmt()` (the live call sits right above the block) and pasted the old body in as a comment.
- Cannot be revived: it references the since-deleted `snippet` field and a never-imported `PropertyKind`.
- Its two semantic deltas vs. the live path are intentional evolutions, documented in surviving code:
  - stable-id string literal → `__rolldown_module_id__` parameter (#9179)
  - bare `module` → `__rolldown_module__` (#4511)

### `hmr_stage.rs` — 3 single lines

- 2× `// unreachable!("HMR only supports normal module. ...")` inside `else { None }` branches — the silent-skip semantics were decided long ago; the four live `unreachable!` calls elsewhere in the file are untouched.
- 1× `// ret.is_self_accepting = true; // (hyf0) TODO: what's this for?` — both the `ret` binding and the `is_self_accepting` field no longer exist anywhere in the workspace (pre-#5488 residue), so the question is unanswerable.

### Deliberately kept

- `// full_reload_reason = Some("circular import invalidate")` in `hmr_stage.rs` — marks real missing behavior, re-enabled separately in #9708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
