### PR TITLE
fix(hmr): report the full-reload reason for the invalidate-loop case

### DIFF
--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -1188,7 +1188,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
             == *first_invalidated_by
         }) {
           require_full_reload = true;
-          // full_reload_reason = Some("circular import invalidate".to_string());
+          full_reload_reason = Some(format!(
+            "update propagated back to `{first_invalidated_by}`, which already called `import.meta.hot.invalidate()`"
+          ));
           continue;
         }
       }


### PR DESCRIPTION
Re-enables the missing full-reload reason for the invalidate-loop case.

### Problem

- When an HMR update propagates back to the module that already called `import.meta.hot.invalidate()` for the same update, rolldown falls back to a full reload.
- Unlike the other two full-reload branches (`circular import chain: ...`, ``no hmr boundary found for module `...` ``), this one reports **"Unknown reason"**.

### History

- #4339 introduced the branch with the reason assignment **live**.
- #5400 extracted the logic into a helper and rewrote the sibling branches onto the new `reason: &mut Option<String>` out-param — this one assignment was commented out instead of rewritten.
- The comment then survived two further refactors (#5748, #6442) even after `full_reload_reason` came back into scope.

### Fix

- Re-enable the assignment, upgrading the message to carry the invalidating module's id (matching the sibling branches' detail level):

  ```
  update propagated back to `<module id>`, which already called `import.meta.hot.invalidate()`
  ```

### Blast radius

- Exactly one string — no consumer parses the reason text, and nothing in-repo asserts on it.
- The branch is only reachable when an integrator passes `firstInvalidatedBy` to `devEngine.invalidate()` (e.g. rolldown-vite), so there is zero in-repo test/snapshot impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
