### PR TITLE
fix(treeshake): drop dead star re-export sources of wrapped barrels

### DIFF
--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -174,8 +174,28 @@ impl LinkStage<'_> {
                       }
                       WrapKind::Esm => {
                         // Turn `import ... from 'bar_esm'` into `init_bar_esm()`
-                        stmt_info.side_effect =
-                          (is_reexport_all || importee.side_effects.has_side_effects()).into();
+                        //
+                        // `export * from 'bar_esm'` is treated like a named re-export and only
+                        // forced to be side-effectful when the eager `init_bar_esm()` call is
+                        // really needed (#9691). If the statement gets tree-shaken while the
+                        // importee is still included, the finalizer re-creates the init call for
+                        // excluded re-export statements of ESM-wrapped importers
+                        // (`generate_transitive_esm_init`), so initialization order is preserved
+                        // while a side-effect-free star source whose exports are all unused can
+                        // be dropped entirely. The eager call is still required when:
+                        // - the importee has dynamic exports: the `__reExport(...)` namespace
+                        //   copy must run eagerly;
+                        // - the importer is not ESM-wrapped (e.g. an entry module): the finalizer
+                        //   fallback only applies to wrapped importers;
+                        // - the importee is TLA-tainted: the fallback emits a plain call without
+                        //   `await`.
+                        let reexport_all_init_is_lazy = is_reexport_all
+                          && !importee_linking_info.has_dynamic_exports
+                          && !importee_linking_info.is_tla_or_contains_tla_dependency
+                          && matches!(self.metas[importer_idx].wrap_kind(), WrapKind::Esm);
+                        stmt_info.side_effect = ((is_reexport_all && !reexport_all_init_is_lazy)
+                          || importee.side_effects.has_side_effects())
+                        .into();
                         // Reference to `init_foo`
                         stmt_info
                           .referenced_symbols

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -6,10 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
-var init_a = __esmMin((() => {})), init_b = __esmMin((() => {}));
+var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res), init_b = __esmMin((() => {}));
 var init_commonjs = __esmMin((() => {
-	init_a();
 	init_b();
 }));
 var init_c = __esmMin((() => {}));

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -30,11 +30,9 @@ var init_Foo$1 = __esmMin((() => {
 var init_Foo = __esmMin((() => {
 	init_Foo$1();
 	init_fooClasses();
-	init_fooClasses();
 }));
 //#endregion
 __esmMin((() => {
-	init_Foo();
 	init_Foo();
 }))();
 export { Foo, fooClasses, getFooUtilityClass };

--- a/crates/rolldown/tests/rolldown/issues/9691/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9691/_config.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Regression test for #9691 (ReferenceError in @aws-sdk/client-s3 with lazyBarrel + codeSplitting:false). main.js dynamically imports ./trigger.js; under `codeSplitting: false` the dynamic import cannot become its own chunk, so rolldown inlines it and *wraps* the imported module (determine_module_exports_kind.rs). The wrap propagates through the barrel's `export *` records (wrapping.rs `wrap_module_recursively`), and reference_needed_symbols.rs used to force-mark `export *` statements of wrapped importees as side-effectful, force-including the dead `sideEffects: false` star source lib/handler-b.js even though its only export (HandlerB) is never used. handler-b's retained body reads `dep_b` at the top level, but lazyBarrel drops the `./dep-b.js` import it needs (handler-b's exports are never requested) => `ReferenceError: dep_b is not defined` at runtime. Now the `export *` statement is tree-shaken like a named re-export (the finalizer's `generate_transitive_esm_init` re-creates the `init_*()` call if the star source ends up included), so handler-b.js must appear in NEITHER snapshot and the bundle must execute cleanly, matching the `code-splitting-on` variant.",
+  "config": {
+    "platform": "node",
+    "codeSplitting": false,
+    "experimental": {
+      "lazyBarrel": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "code-splitting-on",
+      "inlineDynamicImports": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/9691/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9691/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import dep_a from "node:https";
+var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+//#endregion
+//#region lib/dep-a.js
+var init_dep_a = __esmMin((() => {}));
+//#endregion
+//#region lib/handler-a.js
+var HandlerA;
+var init_handler_a = __esmMin((() => {
+	init_dep_a();
+	HandlerA = class {
+		constants = dep_a.constants;
+	};
+}));
+//#endregion
+//#region main.js
+__esmMin((() => {
+	init_handler_a();
+}))();
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+console.log(HandlerA);
+//#endregion
+export {};
+
+```
+
+# Variant: code-splitting-on: [inline_dynamic_imports: false]
+
+## Assets
+
+### main.js
+
+```js
+import dep_a from "node:https";
+//#region lib/handler-a.js
+var HandlerA = class {
+	constants = dep_a.constants;
+};
+//#endregion
+//#region main.js
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+console.log(HandlerA);
+//#endregion
+export {};
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/dep-a.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/dep-a.js
@@ -1,3 +1,3 @@
 // Mirrors @smithy node-https.js: import a builtin's default and re-export it.
-import dep_a from "node:https";
+import dep_a from 'node:https';
 export { dep_a };

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/dep-a.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/dep-a.js
@@ -1,0 +1,3 @@
+// Mirrors @smithy node-https.js: import a builtin's default and re-export it.
+import dep_a from "node:https";
+export { dep_a };

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/dep-b.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/dep-b.js
@@ -1,3 +1,3 @@
 // Mirrors @smithy node-http2.js: import a builtin's default and re-export it.
-import dep_b from "node:http2";
+import dep_b from 'node:http2';
 export { dep_b };

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/dep-b.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/dep-b.js
@@ -1,0 +1,3 @@
+// Mirrors @smithy node-http2.js: import a builtin's default and re-export it.
+import dep_b from "node:http2";
+export { dep_b };

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/handler-a.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/handler-a.js
@@ -1,6 +1,6 @@
 // Mirrors @smithy node-http-handler.js: a re-export-shaped dep that IS used by
 // the consumer's requested export, so its import (node:https) is loaded.
-import { dep_a } from "./dep-a.js";
+import { dep_a } from './dep-a.js';
 
 export class HandlerA {
   constants = dep_a.constants;

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/handler-a.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/handler-a.js
@@ -1,0 +1,7 @@
+// Mirrors @smithy node-http-handler.js: a re-export-shaped dep that IS used by
+// the consumer's requested export, so its import (node:https) is loaded.
+import { dep_a } from "./dep-a.js";
+
+export class HandlerA {
+  constants = dep_a.constants;
+}

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/handler-b.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/handler-b.js
@@ -1,0 +1,13 @@
+// Mirrors @smithy/node-http-handler's node-http2-handler.js. Its only export
+// (HandlerB) is unused, but a top-level destructuring read of an imported binding
+// is classified as a side effect and kept once the module is force-included.
+import { dep_b } from "./dep-b.js";
+
+// Top-level read of the imported binding. lazyBarrel drops the `dep-b.js` import
+// (handler-b's exports are never requested), but this statement survives — so at
+// runtime `dep_b` is undefined.
+const { constants } = dep_b;
+
+export class HandlerB {
+  constants = constants;
+}

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/handler-b.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/handler-b.js
@@ -1,7 +1,7 @@
 // Mirrors @smithy/node-http-handler's node-http2-handler.js. Its only export
 // (HandlerB) is unused, but a top-level destructuring read of an imported binding
 // is classified as a side effect and kept once the module is force-included.
-import { dep_b } from "./dep-b.js";
+import { dep_b } from './dep-b.js';
 
 // Top-level read of the imported binding. lazyBarrel drops the `dep-b.js` import
 // (handler-b's exports are never requested), but this statement survives — so at

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/index.js
@@ -1,0 +1,7 @@
+// Barrel with two `export *`. Resolving a name not directly exported here forces
+// a star-search across every source (handler-a AND handler-b).
+export * from "./handler-a.js";
+export * from "./handler-b.js";
+
+// A local export used by the dynamic-import trigger.
+export const TAG = "lib";

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/index.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/index.js
@@ -1,7 +1,7 @@
 // Barrel with two `export *`. Resolving a name not directly exported here forces
 // a star-search across every source (handler-a AND handler-b).
-export * from "./handler-a.js";
-export * from "./handler-b.js";
+export * from './handler-a.js';
+export * from './handler-b.js';
 
 // A local export used by the dynamic-import trigger.
-export const TAG = "lib";
+export const TAG = 'lib';

--- a/crates/rolldown/tests/rolldown/issues/9691/lib/package.json
+++ b/crates/rolldown/tests/rolldown/issues/9691/lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib",
+  "type": "module",
+  "sideEffects": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9691/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/main.js
@@ -1,0 +1,13 @@
+// Consumer imports ONLY HandlerA from the barrel. Because lib/index.js is an
+// `export *` barrel, resolving `HandlerA` makes rolldown search every star
+// source — including the dead handler-b.js. handler-b's own export (HandlerB) is
+// never used.
+import { HandlerA } from "./lib/index.js";
+
+// A dynamic import. With `codeSplitting: false` rolldown inlines it and WRAPS the
+// imported module; the wrap propagates through the barrel's `export *` and
+// force-includes handler-b.js's body (Problem 1). With lazyBarrel enabled the
+// import that body needs is then dropped (Problem 2) -> ReferenceError.
+import("./trigger.js");
+
+console.log(HandlerA);

--- a/crates/rolldown/tests/rolldown/issues/9691/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/main.js
@@ -2,12 +2,12 @@
 // `export *` barrel, resolving `HandlerA` makes rolldown search every star
 // source — including the dead handler-b.js. handler-b's own export (HandlerB) is
 // never used.
-import { HandlerA } from "./lib/index.js";
+import { HandlerA } from './lib/index.js';
 
 // A dynamic import. With `codeSplitting: false` rolldown inlines it and WRAPS the
 // imported module; the wrap propagates through the barrel's `export *` and
 // force-includes handler-b.js's body (Problem 1). With lazyBarrel enabled the
 // import that body needs is then dropped (Problem 2) -> ReferenceError.
-import("./trigger.js");
+import('./trigger.js');
 
 console.log(HandlerA);

--- a/crates/rolldown/tests/rolldown/issues/9691/trigger.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/trigger.js
@@ -1,0 +1,4 @@
+// Dynamically imported by main.js. Imports the barrel's local export so the wrap
+// (under codeSplitting:false) propagates down into the barrel.
+import { TAG } from "./lib/index.js";
+export const tag = TAG;

--- a/crates/rolldown/tests/rolldown/issues/9691/trigger.js
+++ b/crates/rolldown/tests/rolldown/issues/9691/trigger.js
@@ -1,4 +1,4 @@
 // Dynamically imported by main.js. Imports the barrel's local export so the wrap
 // (under codeSplitting:false) propagates down into the barrel.
-import { TAG } from "./lib/index.js";
+import { TAG } from './lib/index.js';
 export const tag = TAG;


### PR DESCRIPTION
### Description

Fixes #9691.

With `codeSplitting: false`, a dynamic `import()` wraps its target, and the wrap propagates through `export *` barrels into every star source. `reference_needed_symbols.rs` then force-marked the barrel's `export *` statements as side-effectful, so a `sideEffects: false` star source whose exports are all unused was force-included anyway:

- the retained dead module bloats the bundle, and
- combined with `lazyBarrel` (which drops the imports the dead body needs, since its exports are never requested), the retained body reads an undefined binding at top level — the `ReferenceError: dep_b is not defined` crash reported with `@aws-sdk/client-s3`.

### Fix

Treat `export *` from an ESM-wrapped importee like a named re-export: let tree-shaking drop the statement, and rely on the finalizer's existing fallback for excluded re-export statements (`generate_transitive_esm_init`), which re-creates the `init_*()` call at the statement's position only when the star source is actually included. Initialization order is preserved, while a fully-unused, side-effect-free star source disappears from the bundle.

The statement is still forced eager when the lazy fallback can't substitute for it:

- the importee has dynamic exports — the eager `__reExport(...)` namespace copy must run;
- the importer is not ESM-wrapped (e.g. an entry module) — the fallback only fires for wrapped importers;
- the importee is TLA-tainted — the fallback emits the call without `await`.

### Tests

- New regression fixture `tests/rolldown/issues/9691` mirrors the `@aws-sdk/client-s3` shape. Without the fix, its node-execution step fails with the original `ReferenceError: dep_b is not defined`; with the fix, the dead handler module is fully dropped in both the `codeSplitting: false` build and the `code-splitting-on` variant, and both execute cleanly.
- Two existing snapshots improve: `export_forms_common_js` drops a no-op `init_a` wrapper, and `strict_execution_order/issue_8777` no longer emits duplicate `init_*()` calls (the force-included `export *` path used to bypass the `generated_init_esm_importee_ids` dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
