### PR TITLE
chore(testing): migrate test harness off deprecated inlineDynamicImports

### DIFF
--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -181,7 +181,7 @@ impl<'a> LinkStage<'a> {
             .iter()
             .filter_map(|rec| match rec.kind {
               // Dynamically imported modules are included automatically by `include_statements`
-              // when `inlineDynamicImports` is enabled.
+              // when code splitting is disabled (`codeSplitting: false`).
               ImportKind::DynamicImport | ImportKind::Require => None,
               _ => rec.resolved_module,
             })

--- a/crates/rolldown/tests/rolldown/issues/4289/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4289/_config.json
@@ -8,7 +8,7 @@
       "format": "cjs"
     },
     {
-      "inlineDynamicImports": true
+      "codeSplitting": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -120,7 +120,7 @@ exports.__commonJSMin = __commonJSMin;
 
 ```
 
-# Variant: [inline_dynamic_imports: true]
+# Variant: [code_splitting: disabled]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/9651/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9651/_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Reproduces #9651: the module finalizer panicked with `\"init_external\" is not in any chunk` when a side-effect-free (`sideEffects: false`) barrel module is reached both statically (via `import * as z from './zod'`) and via a dynamic import() chain, under cjs + inlineDynamicImports + tree-shaking. The static `import * as` lowering walked every resolved export of the barrel and emitted `init_external()` for `external.js` even though tree-shaking had dropped it. The fixture now bundles and runs successfully.",
+  "_comment": "Reproduces #9651: the module finalizer panicked with `\"init_external\" is not in any chunk` when a side-effect-free (`sideEffects: false`) barrel module is reached both statically (via `import * as z from './zod'`) and via a dynamic import() chain, under cjs + codeSplitting: false + tree-shaking. The static `import * as` lowering walked every resolved export of the barrel and emitted `init_external()` for `external.js` even though tree-shaking had dropped it. The fixture now bundles and runs successfully.",
   "config": {
     "platform": "node",
     "format": "cjs",

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1839,10 +1839,14 @@
             "null"
           ]
         },
-        "inlineDynamicImports": {
-          "type": [
-            "boolean",
-            "null"
+        "codeSplitting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CodeSplittingMode"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "dynamicImportInCjs": {

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -18,7 +18,7 @@ pub struct ConfigVariant {
   pub strict_execution_order: Option<bool>,
   pub strict: Option<StrictMode>,
   pub entry_filenames: Option<String>,
-  pub inline_dynamic_imports: Option<bool>,
+  pub code_splitting: Option<CodeSplittingMode>,
   pub dynamic_import_in_cjs: Option<bool>,
   pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
   pub treeshake: Option<TreeshakeOptions>,
@@ -69,8 +69,8 @@ impl ConfigVariant {
     if let Some(entry_filenames) = &self.entry_filenames {
       config.entry_filenames = Some(entry_filenames.clone().into());
     }
-    if let Some(inline_dynamic_imports) = &self.inline_dynamic_imports {
-      config.code_splitting = Some(CodeSplittingMode::Bool(!*inline_dynamic_imports));
+    if let Some(code_splitting) = &self.code_splitting {
+      config.code_splitting = Some(*code_splitting);
     }
     if let Some(dynamic_import_in_cjs) = &self.dynamic_import_in_cjs {
       config.dynamic_import_in_cjs = Some(*dynamic_import_in_cjs);
@@ -160,8 +160,8 @@ impl ConfigVariant {
     if let Some(strict) = &self.strict {
       fields.push(format!("strict: {strict:?}"));
     }
-    if let Some(inline_dynamic_imports) = &self.inline_dynamic_imports {
-      fields.push(format!("inline_dynamic_imports: {inline_dynamic_imports:?}"));
+    if let Some(code_splitting) = &self.code_splitting {
+      fields.push(format!("code_splitting: {code_splitting}"));
     }
     if let Some(dynamic_import_in_cjs) = &self.dynamic_import_in_cjs {
       fields.push(format!("dynamic_import_in_cjs: {dynamic_import_in_cjs:?}"));


### PR DESCRIPTION
## Summary

The public JS API keeps `inlineDynamicImports` only as a deprecated Rollup-compat alias for `codeSplitting: false` (`output-options.ts` marks it `@deprecated`, the binding inverts it into the core `code_splitting` option). The Rust core has no `inline_dynamic_imports` anymore — but the test harness still exposed the old name on `ConfigVariant` and performed the bool inversion itself.

## Changes

- `rolldown_testing_config`: replace `ConfigVariant.inline_dynamic_imports: Option<bool>` with `code_splitting: Option<CodeSplittingMode>`, passed through directly (no inversion); the variant description uses the mode's `Display` (`enabled`/`disabled`).
- `issues/4289/_config.json`: variant `{"inlineDynamicImports": true}` → `{"codeSplitting": false}`. The variant's bundled output is byte-identical — only the snapshot header changes to `[code_splitting: disabled]`.
- `issues/9651/_config.json`: update `_comment` prose to match its own config (already `codeSplitting: false`).
- `link_stage/mod.rs`: fix a stale comment referencing the deprecated option name.
- `_config.schema.json`: regenerated by `build.rs`; editors validating `_config.json` now suggest `codeSplitting` instead of the removed field.

Since `ConfigVariant` uses `deny_unknown_fields`, any fixture still using the old name would fail loudly — none remain. No public API change: the deprecated JS alias is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)