### PR TITLE
docs(tsconfig): correct auto-discovery resolution to match TypeScript

### DIFF
--- a/packages/rolldown/src/options/docs/tsconfig.md
+++ b/packages/rolldown/src/options/docs/tsconfig.md
@@ -2,23 +2,15 @@
 
 ##### Auto-discovery mode (`true`)
 
-When set to `true`, Rolldown enables auto-discovery mode. For each module, both the resolver and transformer search upward from the module's directory for a `tsconfig.json` that **owns the file**, the way TypeScript selects a project. A `tsconfig.json` whose `files`/`include`/`exclude` (or one of its `references`) does not cover the file is skipped, and the search continues in the parent directory. If nothing up the tree owns the file, Rolldown falls back to the **outermost (topmost)** `tsconfig.json` found, not the nearest one.
+When set to `true`, Rolldown enables auto-discovery mode. For each module, both the resolver and transformer search **upward** from the module's directory, starting at the nearest `tsconfig.json`. If it has `references`, Rolldown checks each referenced project's `files`/`include`/`exclude` and uses the first one that matches the file. If no reference matches, it checks the `tsconfig.json`'s own `files`/`include`/`exclude`. If the file matches neither, Rolldown continues upward to the next `tsconfig.json` and repeats. If no `tsconfig.json` matches the file, it falls back to the **outermost (topmost)** one found, not the nearest one.
 
-If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: a referenced project that includes the file **takes precedence over the root**, and the first matching reference wins. Each referenced project uses its own `allowJs`, so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included by projects that enable it. If no referenced project includes the file, Rolldown falls back to the root's own `files`/`include`/`exclude`. A solution-style root (only `references` with an explicit empty `files`/`include`, as Vite scaffolds) includes nothing on its own, so once none of its references match either, it does **not** claim the file, and discovery continues in the parent directories as described above.
+If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: a referenced project that includes the file **takes precedence over the root**, and the first matching reference wins. Each referenced project uses its own `allowJs`, so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included by projects that enable it. If no referenced project includes the file, Rolldown falls back to the root's own `files`/`include`/`exclude`. A solution-style root (only `references` with an explicit empty `files`/`include`, as Vite scaffolds) has no file patterns of its own, so once none of its references match either, it does **not** own the file, and discovery continues in the parent directories as described above.
 
 ```js
 export default {
   tsconfig: true,
 };
 ```
-
-::: warning Behavior change in v1.1.0
-
-Rolldown 1.1.0 realigned tsconfig resolution with TypeScript. Discovery now walks **up** through ancestor directories and uses the `tsconfig.json` that actually owns the file, instead of stopping at the nearest one and falling back to the topmost when nothing owns it. For a tsconfig with `references`, a referenced project that includes the file takes precedence over the root, and each referenced project's own `allowJs` decides whether `.js`/`.jsx`/`.mjs`/`.cjs` files are included.
-
-For most projects this is a fix, but it is a breaking change if you relied on the old "nearest tsconfig / root wins" behavior. See the [v1.1.0 release notes](https://github.com/rolldown/rolldown/releases/tag/v1.1.0) for migration guidance.
-
-:::
 
 ##### Explicit path (`string`)
 

--- a/packages/rolldown/src/options/docs/tsconfig.md
+++ b/packages/rolldown/src/options/docs/tsconfig.md
@@ -2,15 +2,23 @@
 
 ##### Auto-discovery mode (`true`)
 
-When set to `true`, Rolldown enables auto-discovery mode (similar to Vite). For each module, both the resolver and transformer will find the nearest `tsconfig.json`.
+When set to `true`, Rolldown enables auto-discovery mode. For each module, both the resolver and transformer search upward from the module's directory for a `tsconfig.json` that **owns the file**, the way TypeScript selects a project. A `tsconfig.json` whose `files`/`include`/`exclude` (or one of its `references`) does not cover the file is skipped, and the search continues in the parent directory. If nothing up the tree owns the file, Rolldown falls back to the **outermost (topmost)** `tsconfig.json` found, not the nearest one.
 
-If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: a referenced project that includes the file **takes precedence over the root**. Each referenced project uses its own `allowJs`, so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included by projects that enable it. If no referenced project includes the file, Rolldown falls back to the root tsconfig.
+If the tsconfig has `references`, Rolldown resolves them the way TypeScript does: a referenced project that includes the file **takes precedence over the root**, and the first matching reference wins. Each referenced project uses its own `allowJs`, so a `.js`/`.jsx`/`.mjs`/`.cjs` file is only included by projects that enable it. If no referenced project includes the file, Rolldown falls back to the root's own `files`/`include`/`exclude`. A solution-style root (only `references` with an explicit empty `files`/`include`, as Vite scaffolds) includes nothing on its own, so once none of its references match either, it does **not** claim the file, and discovery continues in the parent directories as described above.
 
 ```js
 export default {
   tsconfig: true,
 };
 ```
+
+::: warning Behavior change in v1.1.0
+
+Rolldown 1.1.0 realigned tsconfig resolution with TypeScript. Discovery now walks **up** through ancestor directories and uses the `tsconfig.json` that actually owns the file, instead of stopping at the nearest one and falling back to the topmost when nothing owns it. For a tsconfig with `references`, a referenced project that includes the file takes precedence over the root, and each referenced project's own `allowJs` decides whether `.js`/`.jsx`/`.mjs`/`.cjs` files are included.
+
+For most projects this is a fix, but it is a breaking change if you relied on the old "nearest tsconfig / root wins" behavior. See the [v1.1.0 release notes](https://github.com/rolldown/rolldown/releases/tag/v1.1.0) for migration guidance.
+
+:::
 
 ##### Explicit path (`string`)
 


### PR DESCRIPTION
## What

Corrects the `tsconfig` auto-discovery documentation to match how Rolldown actually resolves `tsconfig.json` since v1.1.0.

## Why

The v1.1.0 release notes covered the in-config reference changes (oxc-resolver #1151 reference priority, #1198 allowJs) but omitted [oxc-resolver #1154](https://github.com/oxc-project/oxc-resolver/pull/1154) ("walk past a tsconfig that doesn't claim the file"), which shipped in oxc_resolver v11.19.2 and is part of the 11.19.1 -> 11.21.0 upgrade.

As a result the docs still described the old behavior:

- "find the nearest tsconfig.json"
- "if no referenced project includes the file, fall back to the root tsconfig"

Both are inaccurate now. `find_tsconfig_auto` walks up ancestor directories, uses the first tsconfig that owns the file (its `files`/`include`/`exclude`, or a matching `references` entry), and falls back to the outermost (topmost) tsconfig when nothing claims it. This matches TypeScript 6.0 tsserver. A solution-style root (`files: []` plus only `references`) never claims files on its own, so resolution continues upward unless one of its references matches.

## Changes

- Rewrite the auto-discovery paragraph: upward, ownership-based search with topmost fallback instead of "nearest".
- Fix the references paragraph: root's own `include` vs. a solution-style root, first matching reference wins, per-project `allowJs`.
- Drop the "(similar to Vite)" qualifier; the semantics follow TypeScript, not Vite.
- Add a `::: warning` callout flagging the v1.1.0 behavior change.
