### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,81 @@
 
+## [1.1.1] - 2026-06-11
+
+### 🚀 Features
+
+- ecmascript_utils: introduce AstFactory for AST construction (#9682) by @hyf0
+- drop no-op init calls for empty wrapped-ESM modules (#9678) by @IWANABETHATGUY
+
+### 🐛 Bug Fixes
+
+- resolver: honor package.json#type for .jsx/.tsx extensions (#9690) (#9699) by @IWANABETHATGUY
+- hmr: report the full-reload reason for the invalidate-loop case (#9708) by @hyf0
+- explicit `moduleSideEffects` from a hook must take priority over the `package.json#sideEffects` (#9688) by @sapphi-red
+- keep the `rolldown-runtime` name for the standalone runtime chunk (#9685) by @shulaoda
+- lazy-barrel: request all exports for entry barrels on first encounter (#9672) by @shulaoda
+- finalizer: skip init_*() for tree-shaken wrapped ESM owners (#9669) by @IWANABETHATGUY
+- order `chunk.imports` by execution order (#9654) by @chuganzy
+- vite-resolve: preserve slash separators for Sass partial exports (#9546) by @cjc0013
+- cross-chunk CJS wrapper shadowed by author-local binding (#9648) by @IWANABETHATGUY
+
+### 🚜 Refactor
+
+- precompute wrapped-ESM init metadata in generate stage (#9712) by @IWANABETHATGUY
+- ecmascript_utils: fold construction ext traits onto AstFactory and delete AstSnippet (#9702) by @hyf0
+- finalizer: finish ScopeHoistingFinalizer migration to AstFactory (#9701) by @hyf0
+- finalizer: migrate module_finalizers/mod.rs to AstFactory (#9700) by @hyf0
+- hmr: migrate hmr finalizer to AstFactory (#9695) by @hyf0
+- plugin: migrate vite_build_import_analysis to AstFactory (#9693) by @hyf0
+- scanner: migrate tweak_ast_for_scanning to AstFactory (#9683) by @hyf0
+- always split runtime module first (#9419) by @IWANABETHATGUY
+
+### 📚 Documentation
+
+- tsconfig: correct auto-discovery resolution to match TypeScript (#9714) by @shulaoda
+- design: plan to unify all internal AST construction (#9673) by @hyf0
+- tsconfig: align reference resolution docs with TypeScript behavior (#9641) by @shulaoda
+
+### ⚡ Performance
+
+- avoid per-module join Strings in scope-hoisting concatenation (#9645) by @Boshen
+- avoid intermediate Strings in the ESM export clause (#9644) by @Boshen
+- reuse a scratch buffer for facade namespace names in the scanner (#9642) by @Boshen
+- reuse the import-matching tracker stack across named imports (#9643) by @Boshen
+- avoid cloning the per-chunk export-items map in render_chunk_exports (#9639) by @Boshen
+- avoid CompactStr allocation in sorted-exports membership check (#9640) by @Boshen
+
+### 🧪 Testing
+
+- add more `moduleSideEffects` precedence tests (#9689) by @sapphi-red
+- 9651: drop shimMissingExports from regression fixture (#9674) by @IWANABETHATGUY
+
+### ⚙️ Miscellaneous Tasks
+
+- update react repo links (#9711) by @iiio2
+- remove outdated pnpm configurations (#9666) by @btea
+- deps: update github actions to v2.81.5 (#9665) by @renovate[bot]
+- testing: migrate test harness off deprecated inlineDynamicImports (#9710) by @IWANABETHATGUY
+- hmr: delete commented-out dead code left from old register-module codegen (#9707) by @hyf0
+- deps: update napi-rs toolchain (#9706) by @shulaoda
+- deps: update rollup submodule for tests to v4.61.1 (#9676) by @rolldown-guard[bot]
+- deps: update test262 submodule for tests (#9677) by @rolldown-guard[bot]
+- deps: update oxc to 0.135.0 (#9670) by @Boshen
+- pass ALGOLIA_APP_ID and ALGOLIA_API_KEY to void deploy (#9667) by @Boshen
+- deps: update github actions (#9662) by @renovate[bot]
+- deps: update rust crates (#9663) by @renovate[bot]
+- deps: update rolldown-plugin-dts to v0.25.2 (#9661) by @renovate[bot]
+- deps: update typos to v1.47.2 (#9660) by @renovate[bot]
+- deps: update docs dependencies (#9657) by @bddjr
+- deps: update typos to v1.47.1 (#9655) by @renovate[bot]
+- deploy website in its own workflow, only on docs output change (#9650) by @Boshen
+- publish to pkg.pr.new add pm and `commentWithDev` option (#9638) by @btea
+
+### ❤️ New Contributors
+
+* @chuganzy made their first contribution in [#9654](https://github.com/rolldown/rolldown/pull/9654)
+* @cjc0013 made their first contribution in [#9546](https://github.com/rolldown/rolldown/pull/9546)
+
+
 ## [1.1.0] - 2026-06-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,7 +2952,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rolldown"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "ts-rs",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "oxc",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "memchr",
  "oxc",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "memchr",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "oxc",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arcstr",
  "phf",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "oxc",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "criterion2",
  "memchr",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "regex",
 ]
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "ropey"
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "insta",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,30 +98,30 @@ trivial_regex = "allow"
 
 [workspace.dependencies]
 # publish = true
-rolldown = { version = "1.1.0", path = "crates/rolldown" }
-rolldown_common = { version = "1.1.0", path = "crates/rolldown_common" }
-rolldown_dev = { version = "1.1.0", path = "crates/rolldown_dev" }
-rolldown_dev_common = { version = "1.1.0", path = "crates/rolldown_dev_common" }
-rolldown_devtools = { version = "1.1.0", path = "crates/rolldown_devtools" }
-rolldown_devtools_action = { version = "1.1.0", path = "crates/rolldown_devtools_action" }
-rolldown_ecmascript = { version = "1.1.0", path = "crates/rolldown_ecmascript" }
-rolldown_ecmascript_utils = { version = "1.1.0", path = "crates/rolldown_ecmascript_utils" }
-rolldown_error = { version = "1.1.0", path = "crates/rolldown_error" }
-rolldown_fs = { version = "1.1.0", path = "crates/rolldown_fs" }
-rolldown_fs_watcher = { version = "1.1.0", path = "crates/rolldown_fs_watcher" }
-rolldown_plugin = { version = "1.1.0", path = "crates/rolldown_plugin" }
-rolldown_plugin_chunk_import_map = { version = "1.1.0", path = "crates/rolldown_plugin_chunk_import_map" }
-rolldown_plugin_asset_module = { version = "1.1.0", path = "crates/rolldown_plugin_asset_module" }
-rolldown_plugin_copy_module = { version = "1.1.0", path = "crates/rolldown_plugin_copy_module" }
-rolldown_plugin_bundle_analyzer = { version = "1.1.0", path = "crates/rolldown_plugin_bundle_analyzer" }
-rolldown_plugin_data_url = { version = "1.1.0", path = "crates/rolldown_plugin_data_url" }
-rolldown_plugin_esm_external_require = { version = "1.1.0", path = "crates/rolldown_plugin_esm_external_require" }
-rolldown_plugin_hmr = { version = "1.1.0", path = "crates/rolldown_plugin_hmr" }
-rolldown_plugin_isolated_declaration = { version = "1.1.0", path = "crates/rolldown_plugin_isolated_declaration" }
-rolldown_plugin_lazy_compilation = { version = "1.1.0", path = "crates/rolldown_plugin_lazy_compilation" }
-rolldown_plugin_oxc_runtime = { version = "1.1.0", path = "crates/rolldown_plugin_oxc_runtime" }
-rolldown_plugin_replace = { version = "1.1.0", path = "crates/rolldown_plugin_replace" }
-rolldown_plugin_utils = { version = "1.1.0", path = "crates/rolldown_plugin_utils" }
+rolldown = { version = "1.1.1", path = "crates/rolldown" }
+rolldown_common = { version = "1.1.1", path = "crates/rolldown_common" }
+rolldown_dev = { version = "1.1.1", path = "crates/rolldown_dev" }
+rolldown_dev_common = { version = "1.1.1", path = "crates/rolldown_dev_common" }
+rolldown_devtools = { version = "1.1.1", path = "crates/rolldown_devtools" }
+rolldown_devtools_action = { version = "1.1.1", path = "crates/rolldown_devtools_action" }
+rolldown_ecmascript = { version = "1.1.1", path = "crates/rolldown_ecmascript" }
+rolldown_ecmascript_utils = { version = "1.1.1", path = "crates/rolldown_ecmascript_utils" }
+rolldown_error = { version = "1.1.1", path = "crates/rolldown_error" }
+rolldown_fs = { version = "1.1.1", path = "crates/rolldown_fs" }
+rolldown_fs_watcher = { version = "1.1.1", path = "crates/rolldown_fs_watcher" }
+rolldown_plugin = { version = "1.1.1", path = "crates/rolldown_plugin" }
+rolldown_plugin_chunk_import_map = { version = "1.1.1", path = "crates/rolldown_plugin_chunk_import_map" }
+rolldown_plugin_asset_module = { version = "1.1.1", path = "crates/rolldown_plugin_asset_module" }
+rolldown_plugin_copy_module = { version = "1.1.1", path = "crates/rolldown_plugin_copy_module" }
+rolldown_plugin_bundle_analyzer = { version = "1.1.1", path = "crates/rolldown_plugin_bundle_analyzer" }
+rolldown_plugin_data_url = { version = "1.1.1", path = "crates/rolldown_plugin_data_url" }
+rolldown_plugin_esm_external_require = { version = "1.1.1", path = "crates/rolldown_plugin_esm_external_require" }
+rolldown_plugin_hmr = { version = "1.1.1", path = "crates/rolldown_plugin_hmr" }
+rolldown_plugin_isolated_declaration = { version = "1.1.1", path = "crates/rolldown_plugin_isolated_declaration" }
+rolldown_plugin_lazy_compilation = { version = "1.1.1", path = "crates/rolldown_plugin_lazy_compilation" }
+rolldown_plugin_oxc_runtime = { version = "1.1.1", path = "crates/rolldown_plugin_oxc_runtime" }
+rolldown_plugin_replace = { version = "1.1.1", path = "crates/rolldown_plugin_replace" }
+rolldown_plugin_utils = { version = "1.1.1", path = "crates/rolldown_plugin_utils" }
 rolldown_plugin_vite_alias = { version = "0.1.0", path = "crates/rolldown_plugin_vite_alias" }
 rolldown_plugin_vite_build_import_analysis = { version = "0.1.0", path = "crates/rolldown_plugin_vite_build_import_analysis" }
 rolldown_plugin_vite_dynamic_import_vars = { version = "0.1.0", path = "crates/rolldown_plugin_vite_dynamic_import_vars" }
@@ -132,20 +132,20 @@ rolldown_plugin_vite_manifest = { version = "0.1.0", path = "crates/rolldown_plu
 rolldown_plugin_vite_module_preload_polyfill = { version = "0.1.0", path = "crates/rolldown_plugin_vite_module_preload_polyfill" }
 rolldown_plugin_vite_react_refresh_wrapper = { version = "0.1.0", path = "crates/rolldown_plugin_vite_react_refresh_wrapper" }
 rolldown_plugin_vite_reporter = { version = "0.1.0", path = "crates/rolldown_plugin_vite_reporter" }
-rolldown_plugin_vite_resolve = { version = "1.1.0", path = "crates/rolldown_plugin_vite_resolve" }
+rolldown_plugin_vite_resolve = { version = "1.1.1", path = "crates/rolldown_plugin_vite_resolve" }
 rolldown_plugin_vite_transform = { version = "0.1.0", path = "crates/rolldown_plugin_vite_transform" }
 rolldown_plugin_vite_wasm_fallback = { version = "0.1.0", path = "crates/rolldown_plugin_vite_wasm_fallback" }
 rolldown_plugin_vite_web_worker_post = { version = "0.1.0", path = "crates/rolldown_plugin_vite_web_worker_post" }
-rolldown_resolver = { version = "1.1.0", path = "crates/rolldown_resolver" }
-rolldown_sourcemap = { version = "1.1.0", path = "crates/rolldown_sourcemap" }
-rolldown_std_utils = { version = "1.1.0", path = "crates/rolldown_std_utils" }
+rolldown_resolver = { version = "1.1.1", path = "crates/rolldown_resolver" }
+rolldown_sourcemap = { version = "1.1.1", path = "crates/rolldown_sourcemap" }
+rolldown_std_utils = { version = "1.1.1", path = "crates/rolldown_std_utils" }
 rolldown_testing = { version = "0.1.0", path = "crates/rolldown_testing" }
 rolldown_testing_config = { version = "0.1.0", path = "crates/rolldown_testing_config" }
-rolldown_tracing = { version = "1.1.0", path = "crates/rolldown_tracing" }
-rolldown_utils = { version = "1.1.0", path = "crates/rolldown_utils" }
-rolldown_watcher = { version = "1.1.0", path = "crates/rolldown_watcher" }
-rolldown_workspace = { version = "1.1.0", path = "crates/rolldown_workspace" }
-string_wizard = { version = "1.1.0", path = "crates/string_wizard", features = ["serde"] }
+rolldown_tracing = { version = "1.1.1", path = "crates/rolldown_tracing" }
+rolldown_utils = { version = "1.1.1", path = "crates/rolldown_utils" }
+rolldown_watcher = { version = "1.1.1", path = "crates/rolldown_watcher" }
+rolldown_workspace = { version = "1.1.1", path = "crates/rolldown_workspace" }
+string_wizard = { version = "1.1.1", path = "crates/string_wizard", features = ["serde"] }
 
 #
 anyhow = "1.0.98"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_common"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "This crate is mostly for sharing code between rolldwon crates."
 readme = "../../README.md"

--- a/crates/rolldown_dev/Cargo.toml
+++ b/crates/rolldown_dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_dev"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_dev_common/Cargo.toml
+++ b/crates/rolldown_dev_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_dev_common"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "Common types for rolldown dev mode"
 readme = "../../README.md"

--- a/crates/rolldown_devtools/Cargo.toml
+++ b/crates/rolldown_devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_devtools"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_devtools_action/Cargo.toml
+++ b/crates/rolldown_devtools_action/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_devtools_action"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_ecmascript"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "ECMAScript AST and parsing utilities for Rolldown"
 readme = "../../README.md"

--- a/crates/rolldown_ecmascript_utils/Cargo.toml
+++ b/crates/rolldown_ecmascript_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_ecmascript_utils"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_error"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "rolldown_error"
 readme = "../../README.md"

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_fs"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_fs_watcher/Cargo.toml
+++ b/crates/rolldown_fs_watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_fs_watcher"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_asset_module/Cargo.toml
+++ b/crates/rolldown_plugin_asset_module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_asset_module"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
+++ b/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_plugin_chunk_import_map/Cargo.toml
+++ b/crates/rolldown_plugin_chunk_import_map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_plugin_copy_module/Cargo.toml
+++ b/crates/rolldown_plugin_copy_module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_copy_module"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_data_url"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_plugin_esm_external_require/Cargo.toml
+++ b/crates/rolldown_plugin_esm_external_require/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_esm_external_require"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_hmr"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_isolated_declaration/Cargo.toml
+++ b/crates/rolldown_plugin_isolated_declaration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_lazy_compilation/Cargo.toml
+++ b/crates/rolldown_plugin_lazy_compilation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_oxc_runtime/Cargo.toml
+++ b/crates/rolldown_plugin_oxc_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_replace"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_utils"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_plugin_vite_resolve"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_resolver"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "rolldown_resolver"
 readme = "../../README.md"

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_sourcemap"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "Source map generation and manipulation for Rolldown"
 readme = "../../README.md"

--- a/crates/rolldown_std_utils/Cargo.toml
+++ b/crates/rolldown_std_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_std_utils"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_tracing"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "rolldown_tracing"
 readme = "../../README.md"

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_utils"
-version = "1.1.0"
+version = "1.1.1"
 publish = true
 description = "General-purpose utilities for Rolldown"
 readme = "../../README.md"

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_watcher"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/rolldown_workspace/Cargo.toml
+++ b/crates/rolldown_workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolldown_workspace"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_wizard"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license = "MIT"
 publish = true

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/browser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "keywords": [
     "bundler",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/debug",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://rolldown.rs/",
   "license": "MIT",
   "repository": {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolldown",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "keywords": [
     "bundler",

--- a/packages/rolldown/src/binding.cjs
+++ b/packages/rolldown/src/binding.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-android-arm64')
         const bindingPackageVersion = require('@rolldown/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-android-arm-eabi')
         const bindingPackageVersion = require('@rolldown/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@rolldown/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@rolldown/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@rolldown/binding-darwin-universal')
       const bindingPackageVersion = require('@rolldown/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-darwin-x64')
         const bindingPackageVersion = require('@rolldown/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-darwin-arm64')
         const bindingPackageVersion = require('@rolldown/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-freebsd-x64')
         const bindingPackageVersion = require('@rolldown/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-freebsd-arm64')
         const bindingPackageVersion = require('@rolldown/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-x64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@rolldown/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@rolldown/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@rolldown/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@rolldown/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@rolldown/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@rolldown/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-arm64')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-x64')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@rolldown/binding-openharmony-arm')
         const bindingPackageVersion = require('@rolldown/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {


### PR DESCRIPTION

## [1.1.1] - 2026-06-11

### 🚀 Features

- ecmascript_utils: introduce AstFactory for AST construction (#9682) by @hyf0
- drop no-op init calls for empty wrapped-ESM modules (#9678) by @IWANABETHATGUY

### 🐛 Bug Fixes

- resolver: honor package.json#type for .jsx/.tsx extensions (#9690) (#9699) by @IWANABETHATGUY
- hmr: report the full-reload reason for the invalidate-loop case (#9708) by @hyf0
- explicit `moduleSideEffects` from a hook must take priority over the `package.json#sideEffects` (#9688) by @sapphi-red
- keep the `rolldown-runtime` name for the standalone runtime chunk (#9685) by @shulaoda
- lazy-barrel: request all exports for entry barrels on first encounter (#9672) by @shulaoda
- finalizer: skip init_*() for tree-shaken wrapped ESM owners (#9669) by @IWANABETHATGUY
- order `chunk.imports` by execution order (#9654) by @chuganzy
- vite-resolve: preserve slash separators for Sass partial exports (#9546) by @cjc0013
- cross-chunk CJS wrapper shadowed by author-local binding (#9648) by @IWANABETHATGUY

### 🚜 Refactor

- precompute wrapped-ESM init metadata in generate stage (#9712) by @IWANABETHATGUY
- ecmascript_utils: fold construction ext traits onto AstFactory and delete AstSnippet (#9702) by @hyf0
- finalizer: finish ScopeHoistingFinalizer migration to AstFactory (#9701) by @hyf0
- finalizer: migrate module_finalizers/mod.rs to AstFactory (#9700) by @hyf0
- hmr: migrate hmr finalizer to AstFactory (#9695) by @hyf0
- plugin: migrate vite_build_import_analysis to AstFactory (#9693) by @hyf0
- scanner: migrate tweak_ast_for_scanning to AstFactory (#9683) by @hyf0
- always split runtime module first (#9419) by @IWANABETHATGUY

### 📚 Documentation

- tsconfig: correct auto-discovery resolution to match TypeScript (#9714) by @shulaoda
- design: plan to unify all internal AST construction (#9673) by @hyf0
- tsconfig: align reference resolution docs with TypeScript behavior (#9641) by @shulaoda

### ⚡ Performance

- avoid per-module join Strings in scope-hoisting concatenation (#9645) by @Boshen
- avoid intermediate Strings in the ESM export clause (#9644) by @Boshen
- reuse a scratch buffer for facade namespace names in the scanner (#9642) by @Boshen
- reuse the import-matching tracker stack across named imports (#9643) by @Boshen
- avoid cloning the per-chunk export-items map in render_chunk_exports (#9639) by @Boshen
- avoid CompactStr allocation in sorted-exports membership check (#9640) by @Boshen

### 🧪 Testing

- add more `moduleSideEffects` precedence tests (#9689) by @sapphi-red
- 9651: drop shimMissingExports from regression fixture (#9674) by @IWANABETHATGUY

### ⚙️ Miscellaneous Tasks

- update react repo links (#9711) by @iiio2
- remove outdated pnpm configurations (#9666) by @btea
- deps: update github actions to v2.81.5 (#9665) by @renovate[bot]
- testing: migrate test harness off deprecated inlineDynamicImports (#9710) by @IWANABETHATGUY
- hmr: delete commented-out dead code left from old register-module codegen (#9707) by @hyf0
- deps: update napi-rs toolchain (#9706) by @shulaoda
- deps: update rollup submodule for tests to v4.61.1 (#9676) by @rolldown-guard[bot]
- deps: update test262 submodule for tests (#9677) by @rolldown-guard[bot]
- deps: update oxc to 0.135.0 (#9670) by @Boshen
- pass ALGOLIA_APP_ID and ALGOLIA_API_KEY to void deploy (#9667) by @Boshen
- deps: update github actions (#9662) by @renovate[bot]
- deps: update rust crates (#9663) by @renovate[bot]
- deps: update rolldown-plugin-dts to v0.25.2 (#9661) by @renovate[bot]
- deps: update typos to v1.47.2 (#9660) by @renovate[bot]
- deps: update docs dependencies (#9657) by @bddjr
- deps: update typos to v1.47.1 (#9655) by @renovate[bot]
- deploy website in its own workflow, only on docs output change (#9650) by @Boshen
- publish to pkg.pr.new add pm and `commentWithDev` option (#9638) by @btea

### ❤️ New Contributors

* @chuganzy made their first contribution in [#9654](https://github.com/rolldown/rolldown/pull/9654)
* @cjc0013 made their first contribution in [#9546](https://github.com/rolldown/rolldown/pull/9546)

