### PR TITLE
fix: avoid dangling wrapped-ESM init call across chunks (#9502)

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -221,11 +221,28 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // would reference a function that doesn't exist in the output. This mirrors
       // the `is_included` guard in `collect_transitive_esm_init_targets`.
       && meta.is_included
-      && meta.wrapper_ref.is_some()
+      && meta.wrapper_ref.is_some_and(|wrapper_ref| self.wrapper_is_reachable_in_chunk(wrapper_ref))
       && !matches!(meta.concatenated_wrapped_module_kind, ConcatenateWrappedModuleKind::Inner)
     {
       init_modules.insert(canonical_ref.owner);
     }
+  }
+
+  /// Whether a wrapper symbol can be referenced from the chunk being finalized: it is either
+  /// declared in this chunk or registered as a cross-chunk import — exactly the symbols
+  /// deconfliction assigned a canonical name for. Finalizers run after cross-chunk imports are
+  /// computed, so a synthesized call to any other wrapper would render as a bare identifier
+  /// with no backing import (`ReferenceError` at runtime).
+  ///
+  /// Skipping the init call in that case is sound: cross-chunk wrapper imports are registered
+  /// whenever a chunk depends on a symbol *owned by* the wrapped module
+  /// (`add_depended_symbol_with_wrapped_esm_init`), so an unreachable wrapper means every
+  /// access flows through the forwarding barrel's namespace object instead. That namespace
+  /// dependency imports the barrel's chunk, which executes first and performs the init via the
+  /// barrel's own lowered statements.
+  fn wrapper_is_reachable_in_chunk(&self, wrapper_ref: SymbolRef) -> bool {
+    let canonical_ref = self.ctx.symbol_db.canonical_ref_for(wrapper_ref);
+    self.ctx.chunk.canonical_names.contains_key(&canonical_ref)
   }
 
   fn wrapped_esm_init_stmt_for_import_record(

--- a/crates/rolldown/tests/rolldown/issues/9502/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9502/_config.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "tu",
+        "import": "./test-utils.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "shared",
+          "test": "shared\\.js$"
+        },
+        {
+          "name": "vue",
+          "test": "vue\\.js$"
+        }
+      ]
+    }
+  },
+  "_comment": "Regression test for rolldown/rolldown#9502: when a wrapped ESM module is re-exported through a namespace barrel in another chunk, the finalizer must not synthesize an init_*() call for the wrapper unless it is reachable in this chunk; otherwise the call renders as a dangling identifier (ReferenceError). Initialization instead flows through the barrel's own chunk."
+}

--- a/crates/rolldown/tests/rolldown/issues/9502/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9502/_test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+
+// The bug (#9502) manifests as an eagerly-executed `init_*()` call in a chunk
+// that fails to import it, so simply importing the entry throws a ReferenceError
+// on broken output.
+const { slot } = await import('./dist/tu.js');
+assert.equal(slot(), Object.assign);

--- a/crates/rolldown/tests/rolldown/issues/9502/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9502/artifacts.snap
@@ -1,0 +1,57 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## shared.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ extend: () => extend });
+var extend;
+var init_shared = __esmMin((() => {
+	extend = Object.assign;
+}));
+//#endregion
+export { init_shared as n, shared_exports as r, extend as t };
+
+```
+
+## tu.js
+
+```js
+import { t as vue_exports } from "./vue.js";
+//#region test-utils.js
+const slot = (V = vue_exports) => V.extend;
+//#endregion
+export { slot };
+
+```
+
+## vue.js
+
+```js
+import { r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_shared, t as extend } from "./shared.js";
+//#region compiler-core.cjs
+var require_compiler_core = /* @__PURE__ */ __commonJSMin((() => {
+	init_shared();
+}));
+//#endregion
+//#region vue.js
+var vue_exports = /* @__PURE__ */ __exportAll({ extend: () => extend });
+require_compiler_core();
+init_shared();
+//#endregion
+export { vue_exports as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9502/compiler-core.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9502/compiler-core.cjs
@@ -1,0 +1,1 @@
+require('./shared.js');

--- a/crates/rolldown/tests/rolldown/issues/9502/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9502/shared.js
@@ -1,0 +1,1 @@
+export const extend = Object.assign;

--- a/crates/rolldown/tests/rolldown/issues/9502/test-utils.js
+++ b/crates/rolldown/tests/rolldown/issues/9502/test-utils.js
@@ -1,0 +1,3 @@
+import * as Vue from './vue.js';
+
+export const slot = (V = Vue) => V.extend;

--- a/crates/rolldown/tests/rolldown/issues/9502/vue.js
+++ b/crates/rolldown/tests/rolldown/issues/9502/vue.js
@@ -1,0 +1,2 @@
+import './compiler-core.cjs';
+export { extend } from './shared.js';

--- a/meta/design/linking/reference-needed-symbols.md
+++ b/meta/design/linking/reference-needed-symbols.md
@@ -33,7 +33,7 @@ For each `(importer, stmt_info, rec)` triple this pass dispatches on `rec.kind`,
 
 ### `Module::Normal` importees
 
-- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call. Later stages still must check the canonical owner of live imported symbols: a non-wrapped barrel can forward a binding from a wrapped ESM module, and that owner still needs its `init_*()` call before the binding is read when the barrel does not execute in the same chunk.
+- **`Import`, `WrapKind::None`, not reexport** — nothing recorded; flat ESM on both sides has no wrapper to call. Later stages still must check the canonical owner of live imported symbols: a non-wrapped barrel can forward a binding from a wrapped ESM module, and that owner still needs its `init_*()` call before the binding is read when the barrel does not execute in the same chunk — but only when the wrapper is reachable from the importer's chunk (declared there or registered as a cross-chunk import); otherwise the access flows through the barrel's namespace and the barrel's chunk performs the init itself.
 
   ```js
   // foo.js: export const x = 1;


### PR DESCRIPTION
When a wrapped ESM module is re-exported through a namespace barrel across chunks, only synthesize its init_*() call when the wrapper symbol is reachable from the current chunk (declared there or registered as a cross-chunk import).

Previously an unreachable wrapper rendered as a bare identifier with no backing import, causing a ReferenceError at runtime. Now such accesses correctly flow through the barrel's namespace object, whose chunk imports and performs the init itself.

Adds a regression test for #9502 and updates the reference-needed-symbols design doc.

Fixed #9502 