### PR TITLE
test: use `assert.deepStrictEqual` instead of `assert.deepEqual` by using `assert/strict` instead of `assert`

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## src_entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/src/entry.js
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/src/entry.js
@@ -1,4 +1,4 @@
-import assert from "node:assert"
+import assert from "node:assert/strict"
 import * as ns from "demo-pkg"
 assert.deepEqual(ns, {
   default: {

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -6,17 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## src_entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/demo-pkg/index.js
 var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 console.log("hello");
 //#endregion
 //#region src/entry.js
-assert.deepEqual(demo_pkg_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 123
-});
+assert.deepEqual(demo_pkg_exports, Object.defineProperty({ foo: 123 }, Symbol.toStringTag, { value: "Module" }));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/src/entry.js
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/src/entry.js
@@ -1,6 +1,12 @@
-import assert from "node:assert"
+import assert from "node:assert/strict"
 import * as ns from "demo-pkg"
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: "Module",
-  foo: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      foo: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var keep1, keep2;

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/entry.js
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/entry.js
@@ -1,6 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import {keep1} from './lib'
 assert.equal(keep1(), "keep1")
 assert.deepEqual(require('./cjs'), {default:"keep2"})
-
-

--- a/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region types.mjs
 var types_exports = /* @__PURE__ */ __exportAll({});

--- a/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/entry.js
+++ b/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 assert.deepEqual(require('./types.mjs'), {
 
 })

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+let node_assert_strict = require("node:assert/strict");
+node_assert_strict = __toESM(node_assert_strict);
 //#region foo/test.js
 var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#endregion
@@ -17,8 +17,8 @@ var test_exports = /* @__PURE__ */ __exportAll({ bar: () => 123 });
 //#endregion
 //#region entry.js
 console.log(exports, module.exports);
-node_assert.default.deepEqual(test_exports$1, { foo: 123 });
-node_assert.default.deepEqual(test_exports, { bar: 123 });
+node_assert_strict.default.deepEqual(test_exports$1, { foo: 123 });
+node_assert_strict.default.deepEqual(test_exports, { bar: 123 });
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/entry.js
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/entry.js
@@ -1,6 +1,6 @@
 import * as foo from './foo/test'
 import * as bar from './bar/test'
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 console.log(exports, module.exports)
 assert.deepEqual(foo, { foo: 123 })
 assert.deepEqual(bar, { bar: 123 })

--- a/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dir_entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region index.js
 var require_require_parent_dir_common_js = /* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/dir/entry.js
+++ b/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/dir/entry.js
@@ -1,2 +1,2 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 assert.deepEqual(require('..'), 123)

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## MISSING_GLOBAL_NAME
 
 ```text
-[MISSING_GLOBAL_NAME] No name was provided for external module "node:assert" in "output.globals" – guessing "node_assert".
+[MISSING_GLOBAL_NAME] No name was provided for external module "node:assert/strict" in "output.globals" – guessing "node_assert_strict".
 
 ```
 
@@ -22,10 +22,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-(function(process, node_assert) {
+(function(process, node_assert_strict) {
 	// HIDDEN [\0rolldown/runtime.js]
 	process = __toESM(process);
-	node_assert = __toESM(node_assert);
+	node_assert_strict = __toESM(node_assert_strict);
 	//#region shims.js
 	var init_shims = __esmMin((() => {}));
 	//#endregion
@@ -37,8 +37,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 	//#endregion
 	//#region entry.js
 	init_shims();
-	node_assert.default.deepEqual(require_cjs(), { foo: process.default });
+	node_assert_strict.default.deepEqual(require_cjs(), { foo: process.default });
 	//#endregion
-})(process, node_assert);
+})(process, node_assert_strict);
 
 ```

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/entry.js
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 assert.deepEqual(require('./cjs'), {
   foo: process
 })

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -6,17 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 123
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ foo: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(123, 123);
 assert.equal(foo, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/entry.js
@@ -1,9 +1,15 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
 let foo = 234
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  foo: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      foo: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, 123)
 assert.equal(foo, 234)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
 let foo = 234
 assert.deepEqual(ns, {

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -6,17 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 123
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ foo: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(123, 123);
 assert.equal(foo, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/entry.js
@@ -1,9 +1,15 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import {ns} from './bar'
 let foo = 234
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  foo: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      foo: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, 123)
 assert.equal(foo, 234)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -6,17 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 123
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ foo: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(123, 123);
 assert.equal(foo, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/entry.js
@@ -1,9 +1,15 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import {ns} from './bar'
 let foo = 234
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  foo: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      foo: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, 123)
 assert.equal(foo, 234)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -6,17 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(bar_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 123
-});
+assert.deepEqual(bar_exports, Object.defineProperty({ foo: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(123, 123);
 assert.equal(foo, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/entry.js
@@ -1,9 +1,15 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './bar'
 let foo = 234
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  foo: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      foo: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, 123)
 assert.equal(foo, 234)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region common.js
 var common_exports = /* @__PURE__ */ __exportAll({
@@ -15,11 +15,10 @@ var common_exports = /* @__PURE__ */ __exportAll({
 });
 //#endregion
 //#region entry.js
-assert.deepEqual(common_exports, {
-	[Symbol.toStringTag]: "Module",
+assert.deepEqual(common_exports, Object.defineProperty({
 	x: 1,
 	z: 4
-});
+}, Symbol.toStringTag, { value: "Module" }));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/entry.js
@@ -1,7 +1,13 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './common'
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  x: 1,
-  z: 4
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      x: 1,
+      z: 4,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => 123 });
@@ -16,13 +16,7 @@ var foo_exports = /* @__PURE__ */ __exportAll({ bar_ns: () => bar_exports });
 //#endregion
 //#region entry.js
 console.log(foo_exports);
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	bar_ns: {
-		[Symbol.toStringTag]: "Module",
-		bar: 123
-	}
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ bar_ns: Object.defineProperty({ bar: 123 }, Symbol.toStringTag, { value: "Module" }) }, Symbol.toStringTag, { value: "Module" }));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/entry.js
@@ -1,10 +1,17 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as foo_ns from './foo'
 console.log(foo_ns)
-assert.deepEqual(foo_ns, {
-  [Symbol.toStringTag]: 'Module',
-  bar_ns: {
-    [Symbol.toStringTag]: 'Module',
-    bar: 123
-  }
-})
+assert.deepEqual(
+  foo_ns,
+  Object.defineProperty(
+    {
+      bar_ns: Object.defineProperty(
+        { bar: 123 },
+        Symbol.toStringTag,
+        { value: "Module" },
+      )
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/entry.js
@@ -1,9 +1,9 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
 assert.deepEqual(ns, {
   default: {
-    x: 123
+    x: 123,
   },
-  x: 123
+  x: 123,
 })
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -7,12 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Import `foo` will always be undefined because there is no matching export in 'foo.js'
-   ╭─[ entry.js:7:14 ]
-   │
- 7 │ assert.equal(ns.foo, undefined)
-   │              ───┬──  
-   │                 ╰──── 
-───╯
+    ╭─[ entry.js:13:14 ]
+    │
+ 13 │ assert.equal(ns.foo, undefined)
+    │              ───┬──  
+    │                 ╰──── 
+────╯
 
 ```
 
@@ -21,16 +21,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ x: () => 123 });
 //#endregion
 //#region entry.js
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	x: 123
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ x: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(void 0, void 0);
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/entry.js
@@ -1,7 +1,13 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  x: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      x: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -7,12 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Import `foo` will always be undefined because there is no matching export in 'foo.js'
-   ╭─[ entry.js:7:14 ]
-   │
- 7 │ assert.equal(ns.foo, undefined)
-   │              ───┬──  
-   │                 ╰──── 
-───╯
+    ╭─[ entry.js:13:14 ]
+    │
+ 13 │ assert.equal(ns.foo, undefined)
+    │              ───┬──  
+    │                 ╰──── 
+────╯
 
 ```
 
@@ -21,16 +21,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ x: () => 123 });
 //#endregion
 //#region entry.js
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	x: 123
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ x: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(void 0, void 0);
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/entry.js
@@ -1,7 +1,13 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  x: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      x: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/artifacts.snap
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region entry.js
 assert.deepEqual(void 0, void 0);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/entry.js
@@ -1,3 +1,3 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import * as ns from './foo'
 assert.deepEqual(ns.foo, void 0)

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -7,12 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Import `foo` will always be undefined because there is no matching export in 'bar.js'
-   ╭─[ entry.js:7:14 ]
-   │
- 7 │ assert.equal(ns.foo, undefined)
-   │              ───┬──  
-   │                 ╰──── 
-───╯
+    ╭─[ entry.js:13:14 ]
+    │
+ 13 │ assert.equal(ns.foo, undefined)
+    │              ───┬──  
+    │                 ╰──── 
+────╯
 
 ```
 
@@ -21,16 +21,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ x: () => 123 });
 //#endregion
 //#region entry.js
-assert.deepEqual(bar_exports, {
-	[Symbol.toStringTag]: "Module",
-	x: 123
-});
+assert.deepEqual(bar_exports, Object.defineProperty({ x: 123 }, Symbol.toStringTag, { value: "Module" }));
 assert.equal(void 0, void 0);
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/entry.js
@@ -1,7 +1,13 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import {ns} from './foo'
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  x: 123
-})
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      x: 123,
+    },
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/artifacts.snap
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region entry.js
 assert.deepEqual(void 0, void 0);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/entry.js
@@ -1,3 +1,3 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import {ns} from './foo'
 assert.deepEqual(ns.foo, void 0)

--- a/crates/rolldown/tests/esbuild/loader/empty_loader_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/empty_loader_js/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region b.empty
 var b_exports = /* @__PURE__ */ __exportAll({});
@@ -18,7 +18,7 @@ var default$1 = void 0;
 var named = void 0;
 //#endregion
 //#region entry.js
-assert.deepEqual(b_exports, { [Symbol.toStringTag]: "Module" });
+assert.deepEqual(b_exports, Object.defineProperty({}, Symbol.toStringTag, { value: "Module" }));
 assert.deepEqual(default$1, void 0);
 assert.equal(named, void 0);
 //#endregion

--- a/crates/rolldown/tests/esbuild/loader/empty_loader_js/entry.js
+++ b/crates/rolldown/tests/esbuild/loader/empty_loader_js/entry.js
@@ -1,9 +1,16 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import './a.empty'
 import * as ns from './b.empty'
 import def from './c.empty'
 import { named } from './d.empty'
 
-assert.deepEqual(ns, { [Symbol.toStringTag]: 'Module' })
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {},
+    Symbol.toStringTag,
+    { value: "Module" },
+  ),
+)
 assert.deepEqual(def, undefined)
 assert.equal(named, undefined)

--- a/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region y.b64
 var y_default = "eQ==";

--- a/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/entry.js
@@ -1,5 +1,5 @@
 const x_b64 = require('./x.b64')
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import y_b64 from './y.b64'
 assert.deepEqual(x_b64, 'eA==')
 assert.equal(y_b64, 'eQ==')

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region (ignored) node_modules/demo-pkg/util-node.js
 var require_util_node = /* @__PURE__ */ __commonJSMin((() => {}));

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/src/entry.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/src/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import fn from 'demo-pkg'
 
 assert.deepEqual(fn(), {})

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/util-browser/index.js
 var require_util_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/src/entry.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/src/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import fn from 'demo-pkg'
 
 assert.deepEqual(fn(), ['main', 'util-browser'])

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/demo-pkg/lib/util-browser.js
 var require_util_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/src/entry.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/src/entry.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import fn from 'demo-pkg'
 
 assert.deepEqual(fn(), ['main-browser', 'util-browser'])

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -6,7 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
+import assert$1 from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/demo-pkg/module.browser.js
 var module_browser_exports = /* @__PURE__ */ __exportAll({ default: () => module_browser_default });
@@ -20,7 +21,7 @@ assert.deepEqual((init_module_browser(), __toCommonJS(module_browser_exports)), 
 //#endregion
 //#region src/test-module.js
 init_module_browser();
-assert.equal(module_browser_default, "browser module");
+assert$1.equal(module_browser_default, "browser module");
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/src/test-main.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/src/test-main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 
 assert.deepEqual(require('demo-pkg'), {
   default: 'browser main'

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -6,7 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
+import assert$1 from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/demo-pkg/module.js
 var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
@@ -20,7 +21,7 @@ assert.deepEqual((init_module(), __toCommonJS(module_exports)), { default: "modu
 //#endregion
 //#region src/test-module.js
 init_module();
-assert.equal(module_default, "module");
+assert$1.equal(module_default, "module");
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/src/test-main.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/src/test-main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 
 assert.deepEqual(require('demo-pkg'), {
   default: 'module'

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -6,7 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
+import assert$1 from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region node_modules/demo-pkg/module.js
 var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
@@ -20,7 +21,7 @@ assert.deepEqual((init_module(), __toCommonJS(module_exports)), { default: "modu
 //#endregion
 //#region src/test-module.js
 init_module();
-assert.equal(module_default, "module");
+assert$1.equal(module_default, "module");
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/src/test-index.js
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/src/test-index.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 
 assert.deepEqual(require('demo-pkg'), {
   default: 'module'

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import * as ns from './commonjs.js';
 assert.deepEqual(ns, {
   default: {

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region json.js
 var json_exports = /* @__PURE__ */ __exportAll({ default: () => json_default });

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/main.js
@@ -1,5 +1,5 @@
 import mod from './commonjs.js';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 
 assert.deepEqual(mod.slice(1), [2, 3], 'should import JSON file as expected');
 

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -15,16 +15,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => 1 });
 //#endregion
 //#region main.js
-assert.deepEqual(foo_exports, {
-	[Symbol.toStringTag]: "Module",
-	foo: 1
-});
+assert.deepEqual(foo_exports, Object.defineProperty({ foo: 1 }, Symbol.toStringTag, { value: "Module" }));
 Promise.resolve().then(() => foo_exports).then((mod) => {
 	assert.deepEqual(mod, foo_exports);
 });

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
@@ -1,10 +1,16 @@
 import * as fooNamespace from './foo.js';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 
-assert.deepEqual(fooNamespace, {
-  [Symbol.toStringTag]: 'Module',
-  foo: 1,
-});
+assert.deepEqual(
+  fooNamespace,
+  Object.defineProperty(
+    {
+      foo: 1,
+    },
+    Symbol.toStringTag,
+    { value: 'Module' },
+  ),
+);
 
 import('./foo.js').then((mod) => {
   assert.deepEqual(mod, fooNamespace);

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -22,7 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region share.js
 var share_exports$1 = /* @__PURE__ */ __exportAll({ default: () => share_default$1 });

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
@@ -1,6 +1,6 @@
 import shared from './share';
 import sharedJson from './share.json';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 
 assert.strictEqual(shared, 'shared');
 assert.deepStrictEqual(sharedJson, {});

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -29,7 +29,7 @@ export { imp2_exports as n, imp1_exports as r, imp3_exports as t };
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region main.js
 const load = async () => {
 	import("./imp.js").then((n) => n.r).then((m) => {
@@ -39,7 +39,7 @@ const load = async () => {
 		assert.strictEqual(m.imp2, 2);
 	});
 	import("./imp.js").then((n) => n.t).then((m) => {
-		assert.deepEqual(JSON.parse(JSON.stringify(m)), {
+		assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
 			imp3: 3,
 			imp33: 33
 		});
@@ -98,7 +98,7 @@ export { imp3, imp33 };
 ### main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region main.js
 const load = async () => {
 	import("./imp1.js").then((m) => {
@@ -108,7 +108,7 @@ const load = async () => {
 		assert.strictEqual(m.imp2, 2);
 	});
 	import("./imp3.js").then((m) => {
-		assert.deepEqual(JSON.parse(JSON.stringify(m)), {
+		assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
 			imp3: 3,
 			imp33: 33
 		});
@@ -168,18 +168,18 @@ Object.defineProperty(exports, "imp3_exports", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+let node_assert_strict = require("node:assert/strict");
+node_assert_strict = __toESM(node_assert_strict);
 //#region main.js
 const load = async () => {
 	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp1_exports).then((m) => {
-		node_assert.default.strictEqual(m.imp1, 1);
+		node_assert_strict.default.strictEqual(m.imp1, 1);
 	});
 	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp2_exports).then((m) => {
-		node_assert.default.strictEqual(m.imp2, 2);
+		node_assert_strict.default.strictEqual(m.imp2, 2);
 	});
 	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp3_exports).then((m) => {
-		node_assert.default.deepEqual(JSON.parse(JSON.stringify(m)), {
+		node_assert_strict.default.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
 			imp3: 3,
 			imp33: 33
 		});

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 
 const load = async () => {
   import('./imp1').then((m) => {
@@ -10,7 +10,7 @@ const load = async () => {
   import('./imp3').then((m) => {
     // When m is imported from a facade chunk, plain object assertion would fail since it has StringTag `Module`
     // use JSON serialization as a workaround
-    assert.deepEqual(JSON.parse(JSON.stringify(m)), { imp3: 3, imp33: 33 });
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), { imp3: 3, imp33: 33 });
   });
 };
 

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -22,7 +22,8 @@ export {};
 
 ```js
 import { createRequire } from "node:module";
-import nodeAssert from "node:assert";
+import nodeAssert from "node:assert/strict";
+import nodeAssert$1 from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region non-node-mode.js
 async function main$1() {
@@ -36,18 +37,18 @@ main$1();
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
 	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default, 1));
-	nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
-	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
-	nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	nodeAssert$1.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
+	nodeAssert$1.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+	nodeAssert$1.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const nodeAssert$1 = __require("node:assert");
+	const nodeAssert$2 = __require("node:assert");
 	async function main() {
 		const exports$1 = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default, 1));
-		nodeAssert$1.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
-		nodeAssert$1.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
-		nodeAssert$1.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+		nodeAssert$2.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
+		nodeAssert$2.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
+		nodeAssert$2.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 	}
 	main();
 	module.exports = {};
@@ -84,24 +85,25 @@ Object.defineProperty(exports, "default", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+let node_assert_strict = require("node:assert/strict");
+node_assert_strict = __toESM(node_assert_strict);
 let node_assert = require("node:assert");
-let node_assert$1 = __toESM(node_assert, 1);
-node_assert = __toESM(node_assert);
+node_assert = __toESM(node_assert, 1);
 //#region non-node-mode.js
 async function main$1() {
 	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default));
-	node_assert.default.deepEqual(Object.keys(exports).sort(), ["parse"]);
-	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
-	node_assert.default.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
+	node_assert_strict.default.deepEqual(Object.keys(exports).sort(), ["parse"]);
+	node_assert_strict.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+	node_assert_strict.default.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
 }
 main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
 	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
-	node_assert$1.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
-	node_assert$1.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
-	node_assert$1.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	node_assert.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
+	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+	node_assert.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -128,7 +130,8 @@ exports.__commonJSMin = __commonJSMin;
 
 ```js
 import { createRequire } from "node:module";
-import nodeAssert from "node:assert";
+import nodeAssert from "node:assert/strict";
+import nodeAssert$1 from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
@@ -148,18 +151,18 @@ main$1();
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
 	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_lib(), 1));
-	nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
-	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
-	nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	nodeAssert$1.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
+	nodeAssert$1.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+	nodeAssert$1.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const nodeAssert$1 = __require("node:assert");
+	const nodeAssert$2 = __require("node:assert");
 	async function main() {
 		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_lib(), 1));
-		nodeAssert$1.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
-		nodeAssert$1.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
-		nodeAssert$1.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+		nodeAssert$2.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
+		nodeAssert$2.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
+		nodeAssert$2.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 	}
 	main();
 	module.exports = {};

--- a/crates/rolldown/tests/rolldown/issues/4289/non-node-mode.js
+++ b/crates/rolldown/tests/rolldown/issues/4289/non-node-mode.js
@@ -1,4 +1,4 @@
-import nodeAssert from 'node:assert';
+import nodeAssert from 'node:assert/strict';
 
 async function main() {
   const exports = await import('./lib.js');

--- a/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.json
 var lib_exports = /* @__PURE__ */ __exportAll({

--- a/crates/rolldown/tests/rolldown/issues/6651/main.js
+++ b/crates/rolldown/tests/rolldown/issues/6651/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import * as foo from './lib.json';
 
 assert.deepEqual(JSON.parse(JSON.stringify(foo)).default, {

--- a/crates/rolldown/tests/rolldown/issues/6881/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6881/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region main.js
 const testJson = await import("./test.js").then((r) => {
 	assert.deepEqual(r.default, { hello: "Hola" });

--- a/crates/rolldown/tests/rolldown/issues/6881/main.js
+++ b/crates/rolldown/tests/rolldown/issues/6881/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 const testJson = await import('./test.json').then((r) => {
   assert.deepEqual(r.default, { hello: 'Hola' });
 });

--- a/crates/rolldown/tests/rolldown/issues/7146/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7146/artifacts.snap
@@ -33,7 +33,7 @@ Object.defineProperty(exports, "default", {
 ```js
 const require_config$1 = require("./config.js");
 //#region main.js
-const assert = require("assert");
+const assert = require("assert/strict");
 const config = require_config$1.default;
 assert.deepEqual(config, { foo: 1 });
 //#endregion
@@ -73,7 +73,7 @@ export { require_config };
 import { __require } from "./_virtual/_rolldown/runtime.js";
 import { require_config } from "./config.js";
 //#region main.js
-const assert = __require("assert");
+const assert = __require("assert/strict");
 const config = require_config();
 assert.deepEqual(config, { foo: 1 });
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/7146/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7146/main.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert/strict');
 const config = require('./config.json');
 
 assert.deepEqual(config, { foo: 1 });

--- a/crates/rolldown/tests/rolldown/issues/7597/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7597/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
+import assert$1 from "node:assert";
 //#region lib.js
-assert.strictEqual("b", "b", "CloseButton should be \"b\"");
-assert.strictEqual("a", "a", "Transition should be \"a\"");
+assert$1.strictEqual("b", "b", "CloseButton should be \"b\"");
+assert$1.strictEqual("a", "a", "Transition should be \"a\"");
 //#endregion
 //#region main.js
 assert.deepEqual({}, {}, "Modal should be an object");

--- a/crates/rolldown/tests/rolldown/issues/7597/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7597/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { Modal } from './lib.js';
 
 assert.deepEqual(Modal, {}, 'Modal should be an object');

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
@@ -7,15 +7,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+let node_assert_strict = require("node:assert/strict");
+node_assert_strict = __toESM(node_assert_strict);
 //#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("This chunk should not have \"use strict\" at the top.");
 	module.exports = {};
 })))());
-node_assert.default.deepEqual(import_cjs.default, { default: {} });
+node_assert_strict.default.deepEqual(import_cjs.default, { default: {} });
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/main.js
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import foo from './cjs';
 assert.deepEqual(foo, {
   default: {},

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/artifacts.snap
@@ -6,16 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => "bar" });
 //#endregion
 //#region main.js
-assert.deepEqual(bar_exports, {
-	[Symbol.toStringTag]: "Module",
-	bar: "bar"
-});
+assert.deepEqual(bar_exports, Object.defineProperty({ bar: "bar" }, Symbol.toStringTag, { value: "Module" }));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/main.js
@@ -1,7 +1,13 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import * as ns from './bar';
 
-assert.deepEqual(ns, {
-  [Symbol.toStringTag]: 'Module',
-  bar: 'bar',
-});
+assert.deepEqual(
+  ns,
+  Object.defineProperty(
+    {
+      bar: 'bar',
+    },
+    Symbol.toStringTag,
+    { value: 'Module' },
+  ),
+);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
@@ -1,12 +1,27 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Could not resolve 'assert/strict' in main.js
+   ╭─[ main.js:1:20 ]
+   │
+ 1 │ import assert from 'assert/strict';
+   │                    ───────┬───────  
+   │                           ╰───────── Module not found, treating it as an external dependency
+───╯
+
+```
+
 # Assets
 
 ## main.js
 
 ```js
-import assert from "assert";
+import assert from "assert/strict";
 //#region a.js
 const a$1 = "a.js";
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/main.js
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/main.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'assert/strict';
 import { a as aJs } from './a';
 const a = 'main.js';
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -53,10 +53,7 @@ assert.deepStrictEqual(import_dep_cjs_namespace, {
 	value: "cjs-namespace",
 	default: { value: "cjs-namespace" }
 });
-assert.deepEqual(dep_esm_namespace_exports, {
-	[Symbol.toStringTag]: "Module",
-	value: "esm-namespace"
-});
+assert.deepEqual(dep_esm_namespace_exports, Object.defineProperty({ value: "esm-namespace" }, Symbol.toStringTag, { value: "Module" }));
 hmr_hot.accept((mod) => {
 	if (mod) console.log(".hmr", mod.foo);
 });
@@ -75,7 +72,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ```js
 //#region hmr.js
-import * as import_node_assert_00 from "node:assert";
+import * as import_node_assert_strict_00 from "node:assert/strict";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
@@ -93,18 +90,15 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer("hmr.js", (function(_
 		var import_dep_esm_namespace_08 = __rolldown_runtime__.loadExports("modules/dep-esm-namespace.js");
 		var import_new_dep_cjs_09 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/new-dep-cjs.js"));
 		var import_new_dep_esm_010 = __rolldown_runtime__.loadExports("modules/new-dep-esm.js");
-		import_node_assert_00.default.strictEqual(import_dep_cjs_default_03.default, "cjs-default");
-		import_node_assert_00.default.strictEqual(import_dep_esm_default_04.default, "esm-default");
-		import_node_assert_00.default.strictEqual(import_dep_cjs_named_05.named, "cjs-named");
-		import_node_assert_00.default.strictEqual(import_dep_esm_named_06.named, "esm-named");
-		import_node_assert_00.default.deepStrictEqual(import_dep_cjs_namespace_07, {
+		import_node_assert_strict_00.default.strictEqual(import_dep_cjs_default_03.default, "cjs-default");
+		import_node_assert_strict_00.default.strictEqual(import_dep_esm_default_04.default, "esm-default");
+		import_node_assert_strict_00.default.strictEqual(import_dep_cjs_named_05.named, "cjs-named");
+		import_node_assert_strict_00.default.strictEqual(import_dep_esm_named_06.named, "esm-named");
+		import_node_assert_strict_00.default.deepStrictEqual(import_dep_cjs_namespace_07, {
 			value: "cjs-namespace",
 			default: { value: "cjs-namespace" }
 		});
-		import_node_assert_00.default.deepEqual(import_dep_esm_namespace_08, {
-			[Symbol.toStringTag]: "Module",
-			value: "esm-namespace"
-		});
+		import_node_assert_strict_00.default.deepEqual(import_dep_esm_namespace_08, Object.defineProperty({ value: "esm-namespace" }, Symbol.toStringTag, { value: "Module" }));
 		hot_hmr.accept((mod) => {
 			if (mod) {
 				console.log(".hmr", mod.foo);

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.hmr-0.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import './modules/dep-cjs';
 import './modules/dep-esm';
 import cjsDefault from './modules/dep-cjs-default';
@@ -18,10 +18,10 @@ assert.deepStrictEqual(cjsNamespace, {
   value: 'cjs-namespace',
   default: { value: 'cjs-namespace' },
 });
-assert.deepEqual(esmNamespace, {
-  [Symbol.toStringTag]: 'Module',
-  value: 'esm-namespace',
-});
+assert.deepEqual(
+  esmNamespace,
+  Object.defineProperty({ value: 'esm-namespace' }, Symbol.toStringTag, { value: 'Module' }),
+);
 
 import.meta.hot.accept((mod) => {
   if (mod) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import './modules/dep-cjs';
 import './modules/dep-esm';
 import cjsDefault from './modules/dep-cjs-default';
@@ -16,10 +16,10 @@ assert.deepStrictEqual(cjsNamespace, {
   value: 'cjs-namespace',
   default: { value: 'cjs-namespace' },
 });
-assert.deepEqual(esmNamespace, {
-  [Symbol.toStringTag]: 'Module',
-  value: 'esm-namespace',
-});
+assert.deepEqual(
+  esmNamespace,
+  Object.defineProperty({ value: 'esm-namespace' }, Symbol.toStringTag, { value: 'Module' }),
+);
 
 import.meta.hot.accept((mod) => {
   if (mod) {

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_default_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_default_import/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#region foo.json
 var a$1 = "used";
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_default_import/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_default_import/main.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import mod from './foo.json';
 import mod2 from './bailout.json';
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import assert from "node:assert";
+import assert from "node:assert/strict";
 //#endregion
 //#region main.js
 assert.deepEqual([[1, 2]].flat(), [1, 2]);

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/main.js
@@ -1,3 +1,3 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import foo from './foo.json';
 assert.deepEqual(foo.flat(), [1, 2]);

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -533,7 +533,8 @@ impl IntegrationTest {
     }
 
     if options.external.is_none() {
-      options.external = Some(IsExternal::from(vec!["node:assert".to_string()]));
+      options.external =
+        Some(IsExternal::from(vec!["node:assert".to_string(), "node:assert/strict".to_string()]));
     }
 
     if options.input.is_none() {

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { SourceMapConsumer } from 'source-map-js';
 import { RolldownMagicString as MagicString } from 'rolldown';
 import { describe, it } from 'vitest';

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/packages/rollup-tests/test/hooks/index.js
+++ b/packages/rollup-tests/test/hooks/index.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const path = require('node:path');
 const { outputFile, readdir, remove } = require('fs-extra');
 const rollup = require('../../dist/rollup.js');

--- a/packages/rollup-tests/test/incremental/index.js
+++ b/packages/rollup-tests/test/incremental/index.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const acorn = require('acorn');
 const rollup = require('../../dist/rollup');
 const { executeBundle, getObject } = require('../utils.js');

--- a/packages/rollup-tests/test/misc/bundle-information.js
+++ b/packages/rollup-tests/test/misc/bundle-information.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const rollup = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/packages/rollup-tests/test/misc/iife.js
+++ b/packages/rollup-tests/test/misc/iife.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const { rollup } = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 const { compareError } = require('../utils.js');

--- a/packages/rollup-tests/test/misc/misc.js
+++ b/packages/rollup-tests/test/misc/misc.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const rollup = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/packages/rollup-tests/test/misc/umd.js
+++ b/packages/rollup-tests/test/misc/umd.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const { rollup } = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/packages/rollup-tests/test/utils.js
+++ b/packages/rollup-tests/test/utils.js
@@ -6,7 +6,7 @@
  * @typedef {import('./types').TestConfigBase} TestConfigBase
  */
 
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const {
 	closeSync,
 	fsyncSync,

--- a/packages/test-dev-server/tests/fixtures/multiple-edits/src/main.js
+++ b/packages/test-dev-server/tests/fixtures/multiple-edits/src/main.js
@@ -1,15 +1,21 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import nodeFs from 'node:fs';
 export { value as barValue } from './bar';
 export { value as fooValue } from './foo';
 
 if (import.meta.hot) {
   import.meta.hot.accept((newExports) => {
-    assert.deepEqual(newExports, {
-      [Symbol.toStringTag]: 'Module',
-      fooValue: 'edited-foo',
-      barValue: 'edited-bar',
-    });
+    assert.deepEqual(
+      newExports,
+      Object.defineProperty(
+        {
+          fooValue: 'edited-foo',
+          barValue: 'edited-bar',
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    );
     nodeFs.writeFileSync('./ok-0', '');
   });
 }

--- a/scripts/src/esbuild-tests/snap-diff/rewrite.ts
+++ b/scripts/src/esbuild-tests/snap-diff/rewrite.ts
@@ -42,7 +42,7 @@ export function rewriteRolldown(code: string, config: RewriteConfig) {
       },
     },
     ImportDeclaration(path) {
-      let sourceList = ['assert', 'node:assert'];
+      let sourceList = ['assert', 'assert/strict', 'node:assert', 'node:assert/strict'];
       let node = path.node as acorn.ImportDeclaration;
       if (node.source.value && sourceList.includes(node.source.value.toString())) {
         path.remove();


### PR DESCRIPTION
Replaced imports from `assert` to `assert/strict` instead so that `assert.deepEqual` means the same as `assert.deepStrictEqual`. This would make the assertions more strict.