### PR TITLE
test: remove unnecessary module namespace object JSON serializations in tests

### DIFF
--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -37,11 +37,11 @@ assert.strictEqual(share_default$1, "shared");
 assert.deepStrictEqual(share_default, {});
 console.log(share_default$1, share_default);
 Promise.resolve().then(() => share_exports$1).then((mod) => {
-	assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: "shared" });
+	assert.deepEqual(mod, Object.defineProperty({ default: "shared" }, Symbol.toStringTag, { value: "Module" }));
 	console.log(mod);
 });
 Promise.resolve().then(() => share_exports).then((mod) => {
-	assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: {} });
+	assert.deepEqual(mod, Object.defineProperty({ default: {} }, Symbol.toStringTag, { value: "Module" }));
 	console.log(mod);
 });
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
@@ -7,12 +7,28 @@ assert.deepStrictEqual(sharedJson, {});
 console.log(shared, sharedJson);
 
 import('./share').then((mod) => {
-  // workaround for the String tag `Module`
-  assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: 'shared' });
+  assert.deepEqual(
+    mod,
+    Object.defineProperty(
+      {
+        default: 'shared',
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  );
   console.log(mod);
 });
 import('./share.json').then((mod) => {
-  // workaround for the String tag `Module`
-  assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: {} });
+  assert.deepEqual(
+    mod,
+    Object.defineProperty(
+      {
+        default: {},
+      },
+      Symbol.toStringTag,
+      { value: 'Module' },
+    ),
+  );
   console.log(mod);
 });

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -39,10 +39,11 @@ const load = async () => {
 		assert.strictEqual(m.imp2, 2);
 	});
 	import("./imp.js").then((n) => n.t).then((m) => {
-		assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
+		assert.deepEqual(Object.setPrototypeOf(m, null), Object.defineProperty({
+			__proto__: null,
 			imp3: 3,
 			imp33: 33
-		});
+		}, Symbol.toStringTag, { value: "Module" }));
 	});
 };
 load();
@@ -108,10 +109,11 @@ const load = async () => {
 		assert.strictEqual(m.imp2, 2);
 	});
 	import("./imp3.js").then((m) => {
-		assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
+		assert.deepEqual(Object.setPrototypeOf(m, null), Object.defineProperty({
+			__proto__: null,
 			imp3: 3,
 			imp33: 33
-		});
+		}, Symbol.toStringTag, { value: "Module" }));
 	});
 };
 load();
@@ -179,10 +181,11 @@ const load = async () => {
 		node_assert_strict.default.strictEqual(m.imp2, 2);
 	});
 	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp3_exports).then((m) => {
-		node_assert_strict.default.deepStrictEqual(JSON.parse(JSON.stringify(m)), {
+		node_assert_strict.default.deepEqual(Object.setPrototypeOf(m, null), Object.defineProperty({
+			__proto__: null,
 			imp3: 3,
 			imp33: 33
-		});
+		}, Symbol.toStringTag, { value: "Module" }));
 	});
 };
 load();

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/main.js
@@ -8,9 +8,19 @@ const load = async () => {
     assert.strictEqual(m.imp2, 2);
   });
   import('./imp3').then((m) => {
-    // When m is imported from a facade chunk, plain object assertion would fail since it has StringTag `Module`
-    // use JSON serialization as a workaround
-    assert.deepStrictEqual(JSON.parse(JSON.stringify(m)), { imp3: 3, imp33: 33 });
+    assert.deepEqual(
+      // Workaround: When m is imported from a facade chunk, it has a null prototype
+      Object.setPrototypeOf(m, null),
+      Object.defineProperty(
+        {
+          __proto__: null,
+          imp3: 3,
+          imp33: 33,
+        },
+        Symbol.toStringTag,
+        { value: 'Module' },
+      ),
+    );
   });
 };
 


### PR DESCRIPTION
Removed `JSON.parse(JSON.stringify(mod))` by improving the expected value.