### PR TITLE
chore: ban importing from `assert` and recommend `assert/strict`

### DIFF
--- a/packages/rolldown/tests/cli/fixtures/cli-environment-option/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-environment-option/rolldown.config.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { defineConfig } from 'rolldown';
 
 export default defineConfig(() => {

--- a/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/rolldown.config.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { defineConfig } from 'rolldown';
 
 export default defineConfig((args) => {

--- a/packages/rolldown/tests/cli/fixtures/ext-mts/nest/index.js
+++ b/packages/rolldown/tests/cli/fixtures/ext-mts/nest/index.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 
 assert(import.meta.dirname.includes('nest'));
 assert(import.meta.filename.includes('nest'));

--- a/scripts/meta/utils.js
+++ b/scripts/meta/utils.js
@@ -1,4 +1,4 @@
-import * as nodeAssert from 'node:assert';
+import * as nodeAssert from 'node:assert/strict';
 import * as nodePath from 'node:path';
 import { REPO_ROOT } from './constants.js';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,21 @@ export default defineConfig({
           argsIgnorePattern: '^_',
         },
       ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'assert',
+              message: "Use 'assert/strict' instead of 'assert'.",
+            },
+            {
+              name: 'node:assert',
+              message: "Use 'node:assert/strict' instead of 'node:assert'.",
+            },
+          ],
+        },
+      ],
       'unicorn/prefer-node-protocol': 'error',
       'typescript/no-base-to-string': 'allow',
       'typescript/no-floating-promises': 'allow',


### PR DESCRIPTION
Added a rule to ban importing from `assert` and recommend `assert/strict`. It currently only applies to some files.