### PR TITLE
feat: enable oxc react compiler and point oxc to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -846,9 +846,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forked_react_compiler"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34495a9926779b57310fd72e031fafdabc90f7c62e188aa5317ca08a115cce21"
+checksum = "f6970d9da2347af882a10b88480d6b2f44caca55567d85c2b1fa35420b53c1cc"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -861,16 +861,15 @@ dependencies = [
  "forked_react_compiler_typeinference",
  "forked_react_compiler_validation",
  "indexmap",
- "regex-lite",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "forked_react_compiler_ast"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ed273c27b68afe5b5f3bec2cd0215d6507f93921bf93a63b77f4362699c67e"
+checksum = "46f9465a3f9934ef1c1e76bdbab8e70c86b41016a8e7ca1b51fede63e47a6036"
 dependencies = [
  "indexmap",
  "serde",
@@ -879,18 +878,18 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_diagnostics"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0c5c845634ca8381a4dba94fc53f757c85de2e1e29711ef8fd7b5a4ca1fe9f"
+checksum = "3e282f5f7b9506e5055758e4ec9857cdc4873e530d3d381d3ecd0d0321e139ec"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "forked_react_compiler_hir"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bbec4ac046d8eac451b16c75d51d7709b10cbfdc8a52e7c580e1e45239491b"
+checksum = "9df1312f02a4e7a90686a0fc301fb0dfb58a99cdf53a375922e65b8678dc9df7"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "indexmap",
@@ -900,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_inference"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c910dd22822ab23c29d2e969f3e3ca9302fb10c065fcf48b83344dab715e798"
+checksum = "dd9a5bd84db67b0958c414da69f38184fb60e7a55a63ce9f95b367497939b892"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -915,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_lowering"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d891d2ea5d43aa948c56a036960059f405489c60089e57c261be4f35f05d815"
+checksum = "036e4fb36420ed59df1f20a5bb4ae08b095e8e3e1e1c047b7ca4cb0abebd04d9"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -928,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_optimization"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8611f21629cf6333c1b634e1bca816c863d4cba48d4ac1f42d61203835797de9"
+checksum = "a1ec9f8dfb36bcfab25f3f476ccdada95f55f1071e45d25f4549c7c3395aaffc"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -941,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_reactive_scopes"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294a00391f2051dec90669fdff54397a464b16bb568117b48a959bed56d2798b"
+checksum = "1cc54d3b97369ae60549db1d7f792f585920ee451b09946a247cc25087eb384d"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -956,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_ssa"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4782ac57df264c71abaabf68e90b9e3a96f3d607e772bc9ee6e9d26654614aa"
+checksum = "8edcb5fac346f6ad59478ca4b373a930bdc41fd073dccbb10ff69461bdc94423"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -968,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_typeinference"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d9379f0f48a565d82ed03de02946571af209057cfdc81fe09355518e587a54"
+checksum = "b3191b89198d502e11f624a15086ba54ce2828ede7d56eb2b78650da7aef06c1"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -979,18 +978,18 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_utils"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531d2adbbfa861f9669f70e49eb1cc27e8817a7f1d000bee3e2c71a2d82217ec"
+checksum = "005055ef8bfe84dd5f766302bb39fc2d4a361c30abb8a49384d6aff9cc479028"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "forked_react_compiler_validation"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f8b2c12e00b41dc87bc2c63656b473047dcdf75b1f5dc545ca93a308d53a89"
+checksum = "2699f361db2993828d9194af7f6942a8ae746a3688eb5847c70d28da672f4269"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -1468,7 +1467,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1823,7 +1822,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1975,8 +1974,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126fa21513275eca9dd1e9a7d21602e33d3b9449bde2a55d4c3090970c4d1f78"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1988,7 +1986,6 @@ dependencies = [
  "oxc_mangler",
  "oxc_minifier",
  "oxc_parser",
- "oxc_react_compiler",
  "oxc_regular_expression",
  "oxc_semantic",
  "oxc_span",
@@ -1999,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-browserslist"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939b33dabf9f7f1cf6c7cebd977b95fe8f6ecae0ef00cfc8f25b8da89d52983d"
+checksum = "ed057e45c57a87f33e7942215417089e3c038ba6c5dd5e4a6b3ecaa09bbd58d8"
 dependencies = [
  "flate2",
  "postcard",
@@ -2012,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+checksum = "b776084bf11ad750806cb63f9ed2606a12ab374cf458f36a7731eba1f5d753fc"
 dependencies = [
  "cfg-if",
  "owo-colors",
@@ -2027,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.7.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2039,8 +2036,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d732c2d8df8067a8d7417be81a8a4631e3201ad420ae70aa2426aebf7bc0326"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -2053,8 +2049,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29512a9acf168a734cbead68ae798c07102b9ecb897cdbe17a40d327b5fff2ec"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -2071,8 +2066,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06186227ab1f27f214d824030ef8d7abd604fb24cd647d2acfebfe6bbe378dc6"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -2083,8 +2077,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8a8771bbedc5904b6536822fb719f76291d00ab2bccbf5f98950d666f0154f"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -2095,8 +2088,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc39341500115d569f18920da32f89bbecd1719fcc03d532c5508d062c5b764"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "itertools",
@@ -2109,8 +2101,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a375edc284941656da7e436e44ca223426994b98f9035ed99f57b5f36df327a5"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2131,8 +2122,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4134154f80f0b95fe891f3cfbf4936fc8f22817f4649977ef6d6f14518e7ecd2"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -2144,8 +2134,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46270ed833a7d2e5f5fbf0c51f970c2d7e1ef09356d40798cf4702f7d2dae30d"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "ropey",
 ]
@@ -2153,8 +2142,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ebb338486583af9e603f4d20be123ad3ae52a5415265454995020386d8afe"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -2164,8 +2152,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef5f3e346539b48dbda9d0b618021ba6bb781f7a192476e4bf9b18df7ccaab4"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -2180,8 +2167,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816dfd17df8b02a45b122a1f7bb3c1486d4392e0163aea0e6334ad3894a7ea6b"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -2202,8 +2188,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bb2e933b29b70abb2cd48ba72c63a9bf91d2eef5073e3b899e63153724b4ca"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -2220,8 +2205,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af362ebcb00395e4eaf2c5a158a65f76c3962d2f50d4af7d9d0c763426335803"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2238,8 +2222,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8873a4b6bac638cd818eb8a81ca06352d8217cdad1ef561b6eedcf7b83bf88"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2264,8 +2247,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f85e64a6fe1402af1d24978cbab11df26088b8e40e46f3185c321f8d207cfd8"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "napi",
  "napi-build",
@@ -2284,8 +2266,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ff5e5e576a2df1de09a2ec9e1745985414d29d2602261196a5b4cc6ec91573"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "napi",
  "napi-build",
@@ -2300,8 +2281,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cb9af99a1d02989ed53780e3b2b67757226d4501365e65781ae4519be150b6"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2324,8 +2304,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c269884f7d312ce9ed4842d81731396bd468ee1774971fc7b0a7bd05ffc9e9db"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "napi",
  "napi-build",
@@ -2341,8 +2320,7 @@ dependencies = [
 [[package]]
 name = "oxc_react_compiler"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631c0d06a24d6976fbc67267d42460e20b6c9e46fe680dc0761e45805aa77641"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "forked_react_compiler",
  "forked_react_compiler_ast",
@@ -2364,8 +2342,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfe28ec0ffa88784155900d5b7ea1f8383f69d80659ed86f1c4a18a6f117488"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -2422,8 +2399,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6735efd98d54e0f5e8c30a6b17df921085373d54b2b1e10e42d7f4ec8d2597bc"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "itertools",
  "memchr",
@@ -2431,6 +2407,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_cfg",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
@@ -2461,8 +2438,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fbd1667674fd9c25e079a0ab84a87b26e2946d1ce86ad6c5827afa0518c493"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2476,8 +2452,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887823468316c2b4798275976857edeb0574201a944810f2f94f3d79aaf6187e"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -2489,8 +2464,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad8963ea5ad880d3185db2f8a50809e3a10772c2762500518229bca5347be04"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2510,8 +2484,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b98b08b6df56d7a8422d9801a4ba2901967646173a53131346538a537f54eea"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "napi",
  "napi-build",
@@ -2526,8 +2499,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8addbc29d06bbb4249cc1b6c0102b9fdcc783a6f4eaca44a9b6e896778d98296"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "base64",
  "compact_str",
@@ -2541,6 +2513,7 @@ dependencies = [
  "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
+ "oxc_react_compiler",
  "oxc_regular_expression",
  "oxc_semantic",
  "oxc_span",
@@ -2556,8 +2529,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad78b49c571eee9d3821547d2fd703eced54fbdaec6e4ec58a78e874f75cd31b"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2579,8 +2551,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e03d0cb61b3c0d0094a328e47d14649c8d00559544cd16ee0861b1771af7d01"
+source = "git+https://github.com/oxc-project/oxc?rev=94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b#94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -2923,12 +2894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3120,7 @@ dependencies = [
  "oxc",
  "oxc_ecmascript",
  "oxc_index",
+ "oxc_react_compiler",
  "oxc_resolver",
  "oxc_str",
  "rolldown_ecmascript",
@@ -3965,7 +3931,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4027,7 +3993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4341,7 +4307,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4360,7 +4326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4840,7 +4806,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,9 +237,10 @@ napi-build = { version = "2.2.2" }
 napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { version = "0.135.0", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b", features = [
   "ast_visit",
   "transformer",
+  "react_compiler",
   "minifier",
   "mangler",
   "semantic",
@@ -249,14 +250,17 @@ oxc = { version = "0.135.0", features = [
   "regular_expression",
   "cfg",
 ] }
-oxc_allocator = { version = "0.135.0", features = ["pool"] }
-oxc_ecmascript = { version = "0.135.0" }
-oxc_napi = { version = "0.135.0" }
-oxc_str = { version = "0.135.0" }
-oxc_minify_napi = { version = "0.135.0" }
-oxc_parser_napi = { version = "0.135.0" }
-oxc_transform_napi = { version = "0.135.0" }
-oxc_traverse = { version = "0.135.0" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b", features = [
+  "pool",
+] }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_react_compiler = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -70,7 +70,7 @@ impl PreProcessEcmaAst {
     });
 
     let (errors, warnings): (Vec<_>, Vec<_>) =
-      semantic_ret.errors.into_iter().partition(|w| w.severity == OxcSeverity::Error);
+      semantic_ret.diagnostics.into_iter().partition(|w| w.severity == OxcSeverity::Error);
 
     let mut warnings = if errors.is_empty() {
       BuildDiagnostic::from_oxc_diagnostics(
@@ -179,7 +179,7 @@ impl PreProcessEcmaAst {
           .build_with_scoping(scoping, program);
 
         let (errors, transformer_warnings): (Vec<_>, Vec<_>) =
-          ret.errors.into_iter().partition(|error| error.severity == OxcSeverity::Error);
+          ret.diagnostics.into_iter().partition(|error| error.severity == OxcSeverity::Error);
         if !errors.is_empty() {
           return Err(BatchedBuildDiagnostic::from(BuildDiagnostic::from_oxc_diagnostics(
             errors,
@@ -249,7 +249,7 @@ impl PreProcessEcmaAst {
         String::new(),
         "`import defer` is currently lowered to a normal import. This changes execution timing because side effects run immediately instead of when the deferred import is first used.".to_string(),
         vec![LabeledSpan::at(
-          span.start as usize..span.end as usize,
+          span.start..span.end,
           "The deferred phase is removed here.",
         )],
         EventKind::UnsupportedFeatureError,

--- a/crates/rolldown/tests/esbuild/default/jsx_automatic_syntax_in_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_automatic_syntax_in_js/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
    ╭─[ entry.js:1:13 ]
    │
  1 │ console.log(<div/>)
-   │             ───┬──  
-   │                ╰──── 
+   │             ┬  
+   │             ╰── 
    │ 
    │ Help: JSX syntax is disabled and should be enabled via the parser options
 ───╯

--- a/crates/rolldown_binding/src/options/binding_transform_options.rs
+++ b/crates/rolldown_binding/src/options/binding_transform_options.rs
@@ -6,7 +6,8 @@ use napi_derive::napi;
 use oxc_napi::get_source_type;
 use oxc_sourcemap::napi::SourceMap;
 use oxc_transform_napi::{
-  CompilerAssumptions, DecoratorOptions, Helpers, JsxOptions, PluginsOptions, TypeScriptOptions,
+  CompilerAssumptions, DecoratorOptions, Helpers, JsxOptions, PluginsOptions, ReactCompilerOptions,
+  TypeScriptOptions,
 };
 use rolldown_common::{EnhancedTransformOptions, TsconfigOption};
 use rustc_hash::FxHashMap;
@@ -160,6 +161,10 @@ pub struct BindingEnhancedTransformOptions {
   /// Third-party plugins to use.
   /// @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
   pub plugins: Option<PluginsOptions>,
+  /// Experimental [React Compiler](https://github.com/facebook/react/tree/main/compiler).
+  /// `true` enables it with default options; pass an object to configure it.
+  #[napi(ts_type = "boolean | ReactCompilerOptions")]
+  pub react_compiler: Option<Either<bool, ReactCompilerOptions>>,
 
   // --- Enhanced options ---
   /// Configure tsconfig handling.
@@ -187,7 +192,7 @@ impl BindingEnhancedTransformOptions {
       inject: self.inject,
       decorator: self.decorator,
       plugins: self.plugins,
-      react_compiler: None,
+      react_compiler: self.react_compiler,
     }
   }
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
@@ -98,5 +98,16 @@ pub fn normalize_binding_transform_options(options: TransformOptions) -> Bundler
     module_name: HelperLoaderOptions::default().module_name,
   });
 
-  BundlerTransformOptions { jsx, target, decorator, typescript, assumptions, plugins, helpers }
+  let react_compiler = oxc_transform_napi::resolve(options.react_compiler);
+
+  BundlerTransformOptions {
+    jsx,
+    target,
+    decorator,
+    typescript,
+    assumptions,
+    plugins,
+    helpers,
+    react_compiler,
+  }
 }

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -24,6 +24,7 @@ itertools = { workspace = true }
 oxc = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
+oxc_react_compiler = { workspace = true }
 oxc_str = { workspace = true }
 oxc_resolver = { workspace = true }
 rolldown_ecmascript = { workspace = true }

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -467,6 +467,13 @@ where
               .ok_or_else(|| serde::de::Error::custom("transform.target should be a string"))?;
             transform_options.target = Some(Either::Left(target.to_string()));
           }
+          "reactCompiler" => {
+            let enabled = v.as_bool().ok_or_else(|| {
+              serde::de::Error::custom("transform.reactCompiler should be a boolean")
+            })?;
+            transform_options.react_compiler =
+              enabled.then(oxc_react_compiler::default_plugin_options);
+          }
           "jsx" => {
             transform_options.jsx = match v {
               Value::String(str) if str == "preserve" => Some(Either::Left(str)),

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_option/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_option/mod.rs
@@ -48,6 +48,10 @@ pub struct TransformOptions {
 
   /// Behaviour for runtime helpers.
   pub helpers: Option<HelperLoaderOptions>,
+
+  /// Experimental [React Compiler](https://github.com/facebook/react/tree/main/compiler).
+  /// Runs in a separate pass before all other transforms.
+  pub react_compiler: Option<oxc_react_compiler::PluginOptions>,
 }
 
 impl From<crate::utils::enhanced_transform::EnhancedTransformOptions> for TransformOptions {
@@ -60,6 +64,7 @@ impl From<crate::utils::enhanced_transform::EnhancedTransformOptions> for Transf
       typescript: options.typescript,
       plugins: options.plugins,
       helpers: options.helpers,
+      react_compiler: options.react_compiler,
     }
   }
 }
@@ -74,6 +79,7 @@ impl From<TransformOptions> for crate::utils::enhanced_transform::EnhancedTransf
       typescript: options.typescript,
       plugins: options.plugins,
       helpers: options.helpers,
+      react_compiler: options.react_compiler,
       // These fields are not present in TransformOptions
       cwd: None,
       source_type: None,
@@ -123,6 +129,7 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
         .helpers
         .map_or_else(HelperLoaderOptions::default, HelperLoaderOptions::from),
       plugins: oxc::transformer::PluginsOptions::from(options.plugins.unwrap_or_default()),
+      react_compiler: options.react_compiler,
       ..Default::default()
     })
   }

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 use oxc::allocator::Allocator;
-use oxc::diagnostics::{OxcDiagnostic, Severity as OxcSeverity};
+use oxc::diagnostics::Severity as OxcSeverity;
 use oxc::parser::{ParseOptions, Parser};
 use oxc::transformer::{Helper, HelperLoaderOptions};
 use oxc::{
@@ -114,6 +114,10 @@ pub struct EnhancedTransformOptions {
   /// Behaviour for runtime helpers.
   pub helpers: Option<HelperLoaderOptions>,
 
+  /// Experimental [React Compiler](https://github.com/facebook/react/tree/main/compiler).
+  /// Runs in a separate pass before all other transforms.
+  pub react_compiler: Option<oxc_react_compiler::PluginOptions>,
+
   /// The current working directory. Used to resolve relative paths in other
   /// options.
   pub cwd: Option<String>,
@@ -161,6 +165,7 @@ impl EnhancedTransformOptions {
       typescript: options.typescript,
       plugins: options.plugins,
       helpers: options.helpers,
+      react_compiler: options.react_compiler,
       cwd,
       source_type,
       tsconfig,
@@ -186,8 +191,8 @@ fn generate_declarations(
     IsolatedDeclarationsOptions { strip_internal: options.strip_internal.unwrap_or(false) };
 
   let ret = IsolatedDeclarations::new(allocator, isolated_decl_options).build(program);
-  if !ret.errors.is_empty() {
-    append_oxc_diagnostics(ret.errors, source, filename, warnings, errors);
+  if !ret.diagnostics.is_empty() {
+    append_oxc_diagnostics(ret.diagnostics, source, filename, warnings, errors);
     if !errors.is_empty() {
       return (None, None);
     }
@@ -208,7 +213,7 @@ fn generate_declarations(
 }
 
 fn append_oxc_diagnostics(
-  diagnostics: Vec<OxcDiagnostic>,
+  diagnostics: oxc::diagnostics::Diagnostics,
   source: &ArcStr,
   filename: &str,
   warnings: &mut Vec<BuildDiagnostic>,
@@ -326,8 +331,8 @@ pub fn enhanced_transform(
   let parse_ret = Parser::new(&allocator, &source, source_type)
     .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
     .parse();
-  if parse_ret.panicked || !parse_ret.errors.is_empty() {
-    append_oxc_diagnostics(parse_ret.errors, &source, filename, &mut warnings, &mut errors);
+  if parse_ret.panicked || !parse_ret.diagnostics.is_empty() {
+    append_oxc_diagnostics(parse_ret.diagnostics, &source, filename, &mut warnings, &mut errors);
     return EnhancedTransformResult::new_for_error(errors, warnings, tsconfig_file_paths);
   }
 
@@ -335,8 +340,8 @@ pub fn enhanced_transform(
 
   let semantic_ret = semantic_builder_for_transform().build(&program);
   let mut scoping = Some(semantic_ret.semantic.into_scoping());
-  if !semantic_ret.errors.is_empty() {
-    append_oxc_diagnostics(semantic_ret.errors, &source, filename, &mut warnings, &mut errors);
+  if !semantic_ret.diagnostics.is_empty() {
+    append_oxc_diagnostics(semantic_ret.diagnostics, &source, filename, &mut warnings, &mut errors);
     if !errors.is_empty() {
       return EnhancedTransformResult::new_for_error(errors, warnings, tsconfig_file_paths);
     }
@@ -392,8 +397,14 @@ pub fn enhanced_transform(
 
   let transform_ret = Transformer::new(&allocator, Path::new(filename), &oxc_transform_options)
     .build_with_scoping(scoping, &mut program);
-  if !transform_ret.errors.is_empty() {
-    append_oxc_diagnostics(transform_ret.errors, &source, filename, &mut warnings, &mut errors);
+  if !transform_ret.diagnostics.is_empty() {
+    append_oxc_diagnostics(
+      transform_ret.diagnostics,
+      &source,
+      filename,
+      &mut warnings,
+      &mut errors,
+    );
     if !errors.is_empty() {
       return EnhancedTransformResult::new_for_error(errors, warnings, tsconfig_file_paths);
     }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -29,9 +29,9 @@ impl EcmaCompiler {
           ..ParseOptions::default()
         });
         let ret = parser.parse();
-        if ret.panicked || !ret.errors.is_empty() {
+        if ret.panicked || !ret.diagnostics.is_empty() {
           Err(BuildDiagnostic::from_oxc_diagnostics(
-            ret.errors,
+            ret.diagnostics,
             &source.clone(),
             id,
             Severity::Error,

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -285,7 +285,7 @@ impl BuildDiagnostic {
           id.to_string(),
           error.help.take().unwrap_or_default().into(),
           error.message.to_string(),
-          error.labels.take().unwrap_or_default(),
+          std::mem::take(&mut error.labels).as_slice().to_vec(),
           event_kind,
         );
         if matches!(severity, Severity::Warning) {

--- a/crates/rolldown_error/src/build_diagnostic/events/oxc_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/oxc_error.rs
@@ -38,15 +38,10 @@ impl BuildEvent for OxcError {
     let file_id = diagnostic.add_file(opts.stabilize_path(&self.id), self.source.clone());
 
     self.error_labels.iter().for_each(|label| {
-      // Skip labels with spans that don't fit in u32 or would overflow,
-      // rather than panicking or attaching a bogus span.
-      let Ok(offset) = u32::try_from(label.offset()) else {
-        return;
-      };
-      let Ok(len) = u32::try_from(label.len()) else {
-        return;
-      };
-      let Some(end) = offset.checked_add(len) else {
+      // Skip labels whose spans would overflow, rather than panicking or
+      // attaching a bogus span.
+      let offset = label.offset();
+      let Some(end) = offset.checked_add(label.len()) else {
         return;
       };
 

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -52,9 +52,9 @@ impl Plugin for IsolatedDeclarationPlugin {
         .build(fields.program)
       });
 
-      if !ret.errors.is_empty() {
+      if !ret.diagnostics.is_empty() {
         return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
-          ret.errors,
+          ret.diagnostics,
           &ArcStr::from(ret.program.source_text),
           args.id,
           Severity::Error,

--- a/crates/rolldown_plugin_vite_asset_import_meta_url/src/lib.rs
+++ b/crates/rolldown_plugin_vite_asset_import_meta_url/src/lib.rs
@@ -62,7 +62,7 @@ impl Plugin for ViteAssetImportMetaUrlPlugin {
         oxc::parser::Parser::new(&allocator, args.code, oxc::span::SourceType::default()).parse();
       if parser_ret.panicked
         && let Some(err) =
-          parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+          parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
       {
         return Err(anyhow::anyhow!(format!(
           "Failed to parse code in '{}': {:?}",

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -171,8 +171,10 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
             )
             .parse();
             if parser_ret.panicked
-              && let Some(err) =
-                parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+              && let Some(err) = parser_ret
+                .diagnostics
+                .iter()
+                .find(|e| e.severity == oxc::diagnostics::Severity::Error)
             {
               return Err(anyhow::anyhow!(format!(
                 "Failed to parse code in '{}': {:?}",
@@ -228,8 +230,10 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
           )
           .parse();
           if parser_ret.panicked
-            && let Some(err) =
-              parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+            && let Some(err) = parser_ret
+              .diagnostics
+              .iter()
+              .find(|e| e.severity == oxc::diagnostics::Severity::Error)
           {
             return Err(anyhow::anyhow!(format!(
               "Failed to parse code in '{}': {:?}",

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -83,7 +83,7 @@ impl Plugin for ViteDynamicImportVarsPlugin {
       let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
       if parser_ret.panicked
         && let Some(err) =
-          parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+          parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
       {
         return Err(anyhow::anyhow!(format!(
           "Failed to parse code in '{}': {:?}",

--- a/crates/rolldown_plugin_vite_html/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html/src/lib.rs
@@ -223,7 +223,7 @@ impl Plugin for ViteHtmlPlugin {
                   .parse();
                   if parser_ret.panicked
                     && let Some(err) = parser_ret
-                      .errors
+                      .diagnostics
                       .iter()
                       .find(|e| e.severity == oxc::diagnostics::Severity::Error)
                   {

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -44,7 +44,7 @@ impl Plugin for ViteImportGlobPlugin {
       let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
       if parser_ret.panicked
         && let Some(err) =
-          parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+          parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
       {
         return Err(anyhow::anyhow!(format!(
           "Failed to parse code in '{}': {:?}",

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -60,9 +60,9 @@ impl Plugin for ViteTransformPlugin {
 
     let allocator = oxc::allocator::Allocator::default();
     let ret = Parser::new(&allocator, args.code, source_type).parse();
-    if ret.panicked || !ret.errors.is_empty() {
+    if ret.panicked || !ret.diagnostics.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
-        ret.errors,
+        ret.diagnostics,
         args.code,
         args.id,
         Severity::Error,
@@ -74,9 +74,9 @@ impl Plugin for ViteTransformPlugin {
     let scoping = semantic_builder_for_transform().build(&program).semantic.into_scoping();
     let transformer = Transformer::new(&allocator, Path::new(args.id), &transform_options);
     let transformer_return = transformer.build_with_scoping(scoping, &mut program);
-    if !transformer_return.errors.is_empty() {
+    if !transformer_return.diagnostics.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
-        transformer_return.errors,
+        transformer_return.diagnostics,
         args.code,
         args.id,
         Severity::Error,

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -78,12 +78,12 @@ impl IntegrationTest {
   }
 
   pub async fn run_with_plugins(&self, options: BundlerOptions, plugins: Vec<SharedPluginable>) {
-    self
-      .run_multiple(
-        vec![NamedBundlerOptions { options, description: None, snapshot: None, config_name: None }],
-        plugins,
-      )
-      .await;
+    // Boxed so callers' futures stay under clippy's `large_futures` threshold.
+    Box::pin(self.run_multiple(
+      vec![NamedBundlerOptions { options, description: None, snapshot: None, config_name: None }],
+      plugins,
+    ))
+    .await;
   }
 
   /// Determine if output should be executed based on test meta
@@ -118,9 +118,9 @@ impl IntegrationTest {
           .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
           .parse();
 
-        if ret.panicked || !ret.errors.is_empty() {
+        if ret.panicked || !ret.diagnostics.is_empty() {
           let errors_str = ret
-            .errors
+            .diagnostics
             .iter()
             .map(|e| e.clone().with_source_code(chunk.code.clone()).to_string())
             .collect::<Vec<_>>()

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1148,7 +1148,7 @@ export interface ReactCompilerGating {
 }
 
 /**
- * Options for the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+ * Options for the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
  *
  * Mirrors the compiler's `PluginOptions`. The deep `environment` configuration
  * (inference / validation flags) is not surfaced here.
@@ -1271,7 +1271,10 @@ export interface StyledComponentsOptions {
    * Transpiles styled-components tagged template literals to a smaller representation
    * than what Babel normally creates, helping to reduce bundle size.
    *
-   * @default true
+   * Disabled by default because Oxc does not down-level template literals, so this
+   * transform only increases output size.
+   *
+   * @default false
    */
   transpileTemplateLiterals?: boolean
   /**
@@ -1338,6 +1341,13 @@ export declare function transform(filename: string, sourceText: string, options?
 /**
  * Options for transforming a JavaScript or TypeScript file.
  *
+ * Options are listed in evaluation order: the source is parsed (`lang`,
+ * `sourceType`), declarations are emitted (`typescript.declaration`), then
+ * transforms run (`reactCompiler`, `typescript`, `decorator`, `plugins`,
+ * `jsx`, `target`), followed by the `inject` and `define` plugins, and
+ * finally codegen (`sourcemap`). `helpers` configures the runtime helpers
+ * the transforms emit.
+ *
  * @see {@link transform}
  */
 export interface TransformOptions {
@@ -1350,23 +1360,31 @@ export interface TransformOptions {
    * options.
    */
   cwd?: string
-  /**
-   * Enable source map generation.
-   *
-   * When `true`, the `sourceMap` field of transform result objects will be populated.
-   *
-   * @default false
-   *
-   * @see {@link SourceMap}
-   */
-  sourcemap?: boolean
   /** Set assumptions in order to produce smaller output. */
   assumptions?: CompilerAssumptions
   /**
+   * Enable the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+   *
+   * `true` enables it with default options; an object enables it with the
+   * given options; `false` or omitted disables it. When enabled, the compiler
+   * runs as the first transform and memoizes React components and hooks.
+   */
+  reactCompiler?: boolean | ReactCompilerOptions
+  /**
    * Configure how TypeScript is transformed.
+   *
+   * `typescript.declaration` is evaluated before all transforms.
+   *
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/typescript}
    */
   typescript?: TypeScriptOptions
+  /** Decorator plugin */
+  decorator?: DecoratorOptions
+  /**
+   * Third-party plugins to use.
+   * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
+   */
+  plugins?: PluginsOptions
   /**
    * Configure how TSX and JSX are transformed.
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/jsx}
@@ -1390,30 +1408,31 @@ export interface TransformOptions {
   /** Behaviour for runtime helpers. */
   helpers?: Helpers
   /**
+   * Inject Plugin
+   *
+   * Runs after all transforms.
+   *
+   * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#inject}
+   */
+  inject?: Record<string, string | [string, string]>
+  /**
    * Define Plugin
+   *
+   * Runs after the inject plugin.
+   *
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#define}
    */
   define?: Record<string, string>
   /**
-   * Inject Plugin
-   * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#inject}
-   */
-  inject?: Record<string, string | [string, string]>
-  /** Decorator plugin */
-  decorator?: DecoratorOptions
-  /**
-   * Enable the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+   * Enable source map generation.
    *
-   * `true` enables it with default options; an object enables it with the
-   * given options; `false` or omitted disables it. When enabled, the compiler
-   * runs as the first transform and memoizes React components and hooks.
+   * When `true`, the `sourceMap` field of transform result objects will be populated.
+   *
+   * @default false
+   *
+   * @see {@link SourceMap}
    */
-  reactCompiler?: boolean | ReactCompilerOptions
-  /**
-   * Third-party plugins to use.
-   * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
-   */
-  plugins?: PluginsOptions
+  sourcemap?: boolean
 }
 
 export interface TransformResult {
@@ -2204,6 +2223,11 @@ export interface BindingEnhancedTransformOptions {
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
    */
   plugins?: PluginsOptions
+  /**
+   * Experimental [React Compiler](https://github.com/facebook/react/tree/main/compiler).
+   * `true` enables it with default options; pass an object to configure it.
+   */
+  reactCompiler?: boolean | ReactCompilerOptions
   /**
    * Configure tsconfig handling.
    * - true: Auto-discover and load the nearest tsconfig.json


### PR DESCRIPTION
## Summary

- Point all oxc monorepo crates to git rev [`94bfbd83`](https://github.com/oxc-project/oxc/commit/94bfbd83f5fbb8d50e5e92777fc0e88cc9e86b7b) (latest main) and enable the experimental `react_compiler` feature.
- Expose `transform.reactCompiler: boolean | ReactCompilerOptions` on both the bundler input options and the experimental `transform()` API. The compiler runs as a separate pass before all other transforms.
- The serde config path (`deserialize_bundler_options`) accepts `"reactCompiler": true`.

## Breaking changes fixed from the oxc bump

- `ParserReturn`/`SemanticBuilderReturn`/`TransformerReturn`/`IsolatedDeclarationsReturn` renamed `.errors` → `.diagnostics` (new `Diagnostics` type)
- oxc-miette 3.0: `OxcDiagnostic.labels` is now a `Labels` enum with u32-based spans
- Boxed the future inside `rolldown_testing::run_with_plugins` (grew past clippy's `large_futures` threshold with the new compiler pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)