### PR TITLE
Draft: collapse dynamic manual group facades

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -952,10 +952,22 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
     module_is_assigned: &mut IndexBitSet<ModuleIdx>,
     temp_chunk_opt_graph: &ChunkOptimizationGraph,
+    allow_common_chunk_merges: bool,
   ) {
-    // Find empty dynamic entry chunks that should be merged with their target common chunks
-    let (mut facade_eliminations, common_chunk_merges, emitted_chunk_groups) =
+    // Find empty dynamic entry chunks that should be merged with their target chunks.
+    let (mut facade_eliminations, mut common_chunk_merges, mut emitted_chunk_groups) =
       self.find_facade_chunk_merge_ops(chunk_graph, temp_chunk_opt_graph);
+
+    if !allow_common_chunk_merges {
+      common_chunk_merges.clear();
+      emitted_chunk_groups.clear();
+      facade_eliminations.retain(|elimination| {
+        matches!(
+          elimination.reason,
+          FacadeChunkEliminationReason::DynamicEntryMergedIntoManualGroup
+        )
+      });
+    }
 
     if facade_eliminations.is_empty()
       && common_chunk_merges.is_empty()

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -957,15 +957,16 @@ impl GenerateStage<'_> {
         input_base,
         &mut temp_chunk_graph,
       );
-
-      self.optimize_facade_entry_chunks(
-        chunk_graph,
-        index_splitting_info,
-        input_base,
-        &mut module_is_assigned,
-        &temp_chunk_graph,
-      );
     }
+
+    self.optimize_facade_entry_chunks(
+      chunk_graph,
+      index_splitting_info,
+      input_base,
+      &mut module_is_assigned,
+      &temp_chunk_graph,
+      allow_merge_common_chunks,
+    );
 
     self.try_merge_runtime_chunk(chunk_graph, None);
 

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "shared-abc",
+          "test": "/[abc]\\.js$"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const files = readdirSync(distDir).filter((file) => file.endsWith('.js'));
+
+assert.deepStrictEqual(files.sort(), ['main.js', 'shared-abc.js']);
+
+const main = readFileSync(path.join(distDir, 'main.js'), 'utf8');
+assert.match(main, /import\("\.\/shared-abc\.js"\)\.then/);
+assert.doesNotMatch(main, /import\("\.\/[abc]\.js"\)/);
+
+const distMain = path.join(distDir, 'main.js');
+execFileSync('node', [distMain], { encoding: 'utf-8' });

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/a.js
@@ -1,0 +1,1 @@
+export const A = 'A';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+const [a, b, c] = await Promise.all([
+	import("./shared-abc.js").then((n) => n.r),
+	import("./shared-abc.js").then((n) => n.n),
+	import("./shared-abc.js").then((n) => n.t)
+]);
+if (`${a.A}${b.B}${c.C}` !== "ABC") throw new Error("unexpected dynamic namespace result");
+//#endregion
+
+```
+
+## shared-abc.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ A: () => "A" });
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ B: () => "B" });
+//#endregion
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ C: () => "C" });
+//#endregion
+export { b_exports as n, a_exports as r, c_exports as t };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/b.js
@@ -1,0 +1,1 @@
+export const B = 'B';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/c.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/c.js
@@ -1,0 +1,1 @@
+export const C = 'C';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/main.js
@@ -1,0 +1,5 @@
+const [a, b, c] = await Promise.all([import('./a.js'), import('./b.js'), import('./c.js')]);
+
+if (`${a.A}${b.B}${c.C}` !== 'ABC') {
+  throw new Error('unexpected dynamic namespace result');
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/_config.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "main2",
+        "import": "./main2.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "shared-abc",
+          "test": "/[abc]\\.js$",
+          "entriesAware": true
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/_test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const files = readdirSync(distDir)
+  .filter((file) => file.endsWith('.js'))
+  .sort();
+
+assert.deepStrictEqual(files, [
+  'main.js',
+  'main2.js',
+  'rolldown-runtime.js',
+  'shared-abc~a.js',
+  'shared-abc~b.js',
+  'shared-abc~c.js',
+]);
+
+const main = readFileSync(path.join(distDir, 'main.js'), 'utf8');
+assert.match(main, /import\("\.\/shared-abc~a\.js"\)\.then/);
+assert.match(main, /import\("\.\/shared-abc~b\.js"\)\.then/);
+assert.match(main, /import\("\.\/shared-abc~c\.js"\)\.then/);
+assert.doesNotMatch(main, /import\("\.\/[abc]\.js"\)/);
+
+const main2 = readFileSync(path.join(distDir, 'main2.js'), 'utf8');
+assert.match(main2, /import\("\.\/shared-abc~a\.js"\)\.then/);
+assert.match(main2, /import\("\.\/shared-abc~b\.js"\)\.then/);
+assert.doesNotMatch(main2, /import\("\.\/shared-abc~c\.js"\)/);
+assert.doesNotMatch(main2, /import\("\.\/[abc]\.js"\)/);
+
+execFileSync('node', [path.join(distDir, 'main.js')], { encoding: 'utf-8' });
+execFileSync('node', [path.join(distDir, 'main2.js')], { encoding: 'utf-8' });

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/a.js
@@ -1,0 +1,1 @@
+export const A = 'A';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/artifacts.snap
@@ -1,0 +1,69 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+const [a, b, c] = await Promise.all([
+	import("./shared-abc~a.js").then((n) => n.t),
+	import("./shared-abc~b.js").then((n) => n.t),
+	import("./shared-abc~c.js").then((n) => n.t)
+]);
+if (`${a.A}${b.B}${c.C}` !== "ABC") throw new Error("unexpected dynamic namespace result");
+//#endregion
+
+```
+
+## main2.js
+
+```js
+//#region main2.js
+const [a, b] = await Promise.all([import("./shared-abc~a.js").then((n) => n.t), import("./shared-abc~b.js").then((n) => n.t)]);
+if (`${a.A}${b.B}` !== "AB") throw new Error("unexpected dynamic namespace result");
+//#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
+
+```
+
+## shared-abc~a.js
+
+```js
+import { t as __exportAll } from "./rolldown-runtime.js";
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ A: () => "A" });
+//#endregion
+export { a_exports as t };
+
+```
+
+## shared-abc~b.js
+
+```js
+import { t as __exportAll } from "./rolldown-runtime.js";
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ B: () => "B" });
+//#endregion
+export { b_exports as t };
+
+```
+
+## shared-abc~c.js
+
+```js
+import { t as __exportAll } from "./rolldown-runtime.js";
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ C: () => "C" });
+//#endregion
+export { c_exports as t };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/b.js
@@ -1,0 +1,1 @@
+export const B = 'B';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/c.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/c.js
@@ -1,0 +1,1 @@
+export const C = 'C';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/main.js
@@ -1,0 +1,5 @@
+const [a, b, c] = await Promise.all([import('./a.js'), import('./b.js'), import('./c.js')]);
+
+if (`${a.A}${b.B}${c.C}` !== 'ABC') {
+  throw new Error('unexpected dynamic namespace result');
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/main2.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/main2.js
@@ -1,0 +1,5 @@
+const [a, b] = await Promise.all([import('./a.js'), import('./b.js')]);
+
+if (`${a.A}${b.B}` !== 'AB') {
+  throw new Error('unexpected dynamic namespace result');
+}

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -153,10 +153,16 @@ For chunks shared only by dynamic entries, the optimizer does not infer a merge 
 
 ### Facade Elimination (`optimize_facade_entry_chunks`)
 
-Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks by the optimizer. The optimizer identifies these and either:
+Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks by the optimizer or by manual code splitting. The optimizer identifies these and either:
 
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
+
+Manual code splitting can also create this shape without common-chunk merging: a dynamic entry module may be assigned directly to a manual group while its original dynamic-entry chunk would otherwise only proxy to that group. In that case, facade elimination may remove the proxy and rewrite `import("./entry")` to the manual chunk with namespace extraction, as long as the dynamic import still resolves to the original entry module namespace rather than the whole manual chunk namespace.
+
+Facade elimination does not split flat manual groups. If a flat manual group contains `a`, `b`, and `c`, every dynamic import rewritten to that group loads the whole group. Use `entriesAware: true` when the manual group should split by entry reachability; dynamic-entry facades can then collapse to the corresponding entries-aware subgroup chunks instead of one monolithic group chunk.
+
+The first implementation deliberately keeps this narrow. It reuses the same absorbed-facade namespace machinery as other dynamic-entry facade eliminations, and it does not introduce a manual-code-splitting-specific rewrite path. Top-level-await and import-attribute refinements are not modeled here; those cases should keep the facade until a dedicated design proves they are safe.
 
 ### Runtime Module Placement
 
@@ -206,6 +212,7 @@ Runtime used to be placed by normal bitset grouping and later peeled out when a 
 - `crates/rolldown/tests/rolldown/issues/8989/` — facade elimination introduces helper consumers; runtime may merge only into a downstream dominator.
 - `crates/rolldown/tests/rolldown/issues/8920_2/` — fuzz-discovered shape where consumer-count heuristics produced a cycle.
 - `crates/rolldown/tests/rolldown/issues/9597/` — a static + dynamic import cycle that previously placed the runtime chunk inside the cycle, throwing `__exportAll is not a function`; standalone-first keeps the runtime out of the cycle.
+- `crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/` — manual grouping can remove dynamic-entry proxy chunks while preserving each original dynamic import namespace.
 
 These fixtures assert structural invariants in `_test.mjs`, so runtime-placement regressions fail immediately rather than only showing up as snapshot drift.
 

--- a/meta/design/manual-code-splitting.md
+++ b/meta/design/manual-code-splitting.md
@@ -45,6 +45,8 @@ Step 3: Each subgroup → chunk
 
 Entry A loads all three vendor chunks. Entry B loads the first two. Entry C loads only the first. Each entry only downloads what it actually needs.
 
+Dynamic imports participate in the same reachability model. If one entry dynamically imports `a`, `b`, and `c`, while another dynamically imports only `a` and `b`, an entries-aware manual group can keep the `c` subgroup out of the second entry's dynamic load path. Facade elimination may still remove the dynamic-entry proxy chunks, but the rewritten imports target the relevant entries-aware subgroup chunks instead of one flat group chunk.
+
 #### Why flat-then-split matters
 
 The split must happen **after** collecting all modules into a flat group. If subgroups are created during the build phase (per module's own bits), `includeDependenciesRecursively` adds shared dependencies to each subgroup independently:

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -899,6 +899,8 @@ export type CodeSplittingGroup = {
    *
    * With `entriesAware: false` → one `vendor.js` chunk with both modules; C loads `moduleY` unnecessarily.
    * With `entriesAware: true`  → `vendor.js` (moduleX, loaded by all) + `vendor2.js` (moduleY, loaded by A and B only).
+   * Dynamic imports use the same reachability model: if one entry imports `a`, `b`, and `c` dynamically,
+   * while another imports only `a` and `b`, an entries-aware group can keep `c` out of the second entry's load path.
    *
    * @default false
    */


### PR DESCRIPTION
## What

Draft prototype for issue #9729 that removes dynamic-entry proxy chunks when manual code splitting has already moved the entry module into a manual group.

## Why

Issue #9729 shows Rolldown preserving import/re-export proxy chunks for manually grouped dynamic imports, while Rollup rewrites the dynamic import to the shared manual chunk with namespace extraction. This draft demonstrates the implementation shape before asking maintainers to confirm the desired semantics.

Flat manual groups still load the full group. When entries should avoid loading modules they do not reach, use `entriesAware: true`; the draft includes a multi-entry fixture showing `main2` dynamically imports `a/b` without loading the `c` subgroup.

Relates to https://github.com/rolldown/rolldown/issues/9729

## Tophat

Run the fixtures and inspect that dynamic-entry proxy chunks are removed while namespace values remain correct:

```sh
cargo run -q -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_facade/_config.json
cargo run -q -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_manual_group_multi_entry/_config.json
```
