### PR TITLE
perf: defer link-stage-output drop to rayon workers after output is produced

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -277,7 +277,13 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     // performance; reinstate it here, before the fallible steps below, so the
     // cache stays whole on their `Err` paths.
     // See meta/design/bundler-data-lifecycle.md ("Cache integrity on a failed build").
-    self.merge_immutable_fields_for_cache(link_stage_output.symbol_db);
+    self.merge_immutable_fields_for_cache(std::mem::take(&mut link_stage_output.symbol_db));
+
+    // `link_stage_output` is dead from here on (its `symbol_db` was just taken
+    // for the cache merge); ship the remaining heavy fields (module_table,
+    // metas, stmt_infos, ...) to a rayon worker so their free() happens off
+    // the critical path.
+    crate::utils::defer_drop::spawn_drop(link_stage_output);
 
     if let Err(errors) = &bundle_output {
       debug_assert!(errors.iter().all(|e| e.severity() == Severity::Error));

--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -152,6 +152,12 @@ impl BundleFactory {
     resolver: SharedResolver<Fs>,
     cache: ScanStageCache,
   ) -> Bundle<Fs> {
+    // Every build passes through here exactly once before any scan/link work
+    // starts. Wait for the previous build's deferred drops to retire so they
+    // can never overlap this build's rayon work; a no-op in steady state.
+    // See `utils::defer_drop` for the full invariant.
+    crate::utils::defer_drop::drain();
+
     let bundle_span = self.generate_unique_bundle_span();
     let module_infos = Arc::clone(&self.module_infos_for_incremental_build);
     let transform_dependencies = Arc::clone(&self.transform_dependencies_for_incremental_build);

--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -24,6 +24,10 @@ impl Bundler {
     clients: &[ClientHmrInput<'_>],
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
+    // HMR partial scans use the shared rayon pool without passing through
+    // `BundleFactory::build_bundle`; wait for any deferred drops here too.
+    crate::utils::defer_drop::drain();
+
     let Some(plugin_driver) = self.last_bundle_handle.as_ref().map(|ctx| &ctx.plugin_driver) else {
       return Err(anyhow::format_err!(
         "HMR requires to run at least one bundle before invalidation"
@@ -48,6 +52,10 @@ impl Bundler {
     executed_modules: &FxHashSet<String>,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<HmrUpdate> {
+    // HMR partial scans use the shared rayon pool without passing through
+    // `BundleFactory::build_bundle`; wait for any deferred drops here too.
+    crate::utils::defer_drop::drain();
+
     let Some(plugin_driver) = self.last_bundle_handle.as_ref().map(|ctx| &ctx.plugin_driver) else {
       return Err(anyhow::format_err!(
         "HMR requires to run at least one bundle before invalidation"
@@ -83,6 +91,10 @@ impl Bundler {
     executed_modules: &FxHashSet<String>,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<String> {
+    // HMR partial scans use the shared rayon pool without passing through
+    // `BundleFactory::build_bundle`; wait for any deferred drops here too.
+    crate::utils::defer_drop::drain();
+
     let Some(plugin_driver) = self.last_bundle_handle.as_ref().map(|ctx| &ctx.plugin_driver) else {
       panic!("Lazy compilation requires at least one bundle to be built first");
     };

--- a/crates/rolldown/src/utils/defer_drop.rs
+++ b/crates/rolldown/src/utils/defer_drop.rs
@@ -1,0 +1,88 @@
+//! Drop heavy values on rayon worker threads instead of the caller's thread.
+//!
+//! Freeing the link stage output (module_table, metas, stmt_infos, ...)
+//! takes ~15ms of hot-thread time on a 20k-module build, after the output is
+//! already produced. The rayon workers are idle by then, so shipping the
+//! drop to one of them takes the free() off the critical path.
+//!
+//! Deferred drops cannot pile up across builds: this is ENFORCED, not
+//! assumed. Every pending drop is counted, and [`drain`] blocks until the
+//! count is zero. It is called at every entry point that starts scan/link/
+//! render work on the shared rayon pool: `BundleFactory::build_bundle` (full
+//! and incremental builds) and the three HMR partial-scan entries in
+//! `impl_bundler_hmr.rs`, which bypass `build_bundle`. In steady state it is
+//! a no-op (a single uncontended lock check): the frees take ~20ms while any
+//! build that could produce the next pair takes hundreds of ms. Even in the
+//! worst case, drain blocks for no longer than main spent doing the same
+//! frees inline on the same thread.
+//!
+//! Within a single build the count stays bounded by construction: exactly one
+//! object is enqueued, once per build, at the build boundary (right after
+//! `generate()` returns). There is no per-item or per-iteration use.
+//!
+//! Within the SAME build, the free intentionally overlaps the
+//! `render_error`/`generateBundle` hooks and the write tail — that overlap IS
+//! the optimization. This never extends a memory window relative to main:
+//! main held `link_stage_output` alive until `bundle_up` scope end, i.e.
+//! through those same hooks; here it is freed concurrently DURING them
+//! (measured peak RSS is flat). Only values main itself kept alive through
+//! the overlapped region are eligible — that is why the non-incremental
+//! `symbol_db`, which main frees inline BEFORE the hooks, is NOT deferred.
+//! The dropped value is exclusively owned, so overlap can only cost bounded
+//! background CPU, never correctness.
+//!
+//! The counter is process-global rather than per-bundler on purpose: with
+//! concurrent bundler instances, the worst case is one instance waiting (at
+//! most the ~20ms free time) for another instance's drops, or a few ms of
+//! background free work overlapping a concurrent build — accepted as far
+//! cheaper than per-instance plumbing for a non-correctness concern.
+//!
+//! Do NOT use [`spawn_drop`] for values that are still live before the output
+//! exists (e.g. the per-module AST arenas, which main intentionally frees
+//! before chunk instantiation/minify allocate — deferring them would extend
+//! their memory window and spike peak RSS), or for anything enqueued in a
+//! loop.
+
+use std::sync::{Condvar, Mutex, PoisonError};
+
+/// Number of `spawn_drop` closures that have been enqueued but not yet
+/// finished dropping their value.
+static PENDING: Mutex<usize> = Mutex::new(0);
+static PENDING_IS_ZERO: Condvar = Condvar::new();
+
+/// Decrements `PENDING` on drop, so the count goes down even if the deferred
+/// value's `Drop` impl panics — a panic must not wedge `drain()` forever.
+struct PendingGuard;
+
+impl Drop for PendingGuard {
+  fn drop(&mut self) {
+    let mut pending = PENDING.lock().unwrap_or_else(PoisonError::into_inner);
+    *pending -= 1;
+    if *pending == 0 {
+      PENDING_IS_ZERO.notify_all();
+    }
+  }
+}
+
+/// Drop `value` on a rayon worker thread instead of the caller's thread.
+///
+/// See the module docs for the invariants call sites must uphold.
+pub fn spawn_drop<T: Send + 'static>(value: T) {
+  *PENDING.lock().unwrap_or_else(PoisonError::into_inner) += 1;
+  rayon::spawn(move || {
+    let _guard = PendingGuard;
+    drop(value);
+  });
+}
+
+/// Block until every pending deferred drop has finished.
+///
+/// Called once at build entry (`BundleFactory::build_bundle`) so a queued
+/// watch rebuild can never overlap the previous build's frees on the shared
+/// rayon pool. Expected to be a no-op in steady state; see the module docs.
+pub fn drain() {
+  let mut pending = PENDING.lock().unwrap_or_else(PoisonError::into_inner);
+  while *pending > 0 {
+    pending = PENDING_IS_ZERO.wait(pending).unwrap_or_else(PoisonError::into_inner);
+  }
+}

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod apply_inner_plugins;
 pub mod augment_chunk_hash;
 pub mod chunk;
+pub mod defer_drop;
 pub mod external_import_interop;
 pub mod fs_utils;
 pub mod load_entry_module;


### PR DESCRIPTION
## Summary

Once the bundle output exists, the hot thread still spends ~15ms (on a 20k-module build) inside `free()` tearing down the link stage output (`module_table`, `metas`, `stmt_infos`, ...). The rayon workers are idle at that point, so this PR ships that drop to one of them (`utils/defer_drop.rs`):

- `symbol_db` is `mem::take`'n out for the cache merge **exactly as main consumes it** (inline, unchanged on both incremental and non-incremental paths).
- The remaining `link_stage_output` is `spawn_drop`'d right after `generate()` returns instead of being freed at `bundle_up` scope end.

Only this one object is deferred, governed by one rule (documented in the module): **only values main itself kept alive through the overlapped region are eligible.** main held `link_stage_output` through the `render_error`/`generateBundle` hooks and the write tail anyway — here it is freed concurrently *during* them, so no memory window ever extends (peak RSS measured flat).

Deferred drops cannot pile up — this is enforced, not assumed: every pending drop is counted, and `defer_drop::drain()` blocks until the count is zero at every entry point that starts rayon work (`BundleFactory::build_bundle` plus the three HMR partial-scan entries). In steady state it is a single uncontended lock check.

## Numbers

apps/10000 (20,014 modules), full build incl. minify + sourcemap, binary A/B vs main, order-balanced ABAB pairs, first run per binary discarded, 1.3x-median scan filter:

| pair | base build_ms | this PR | delta |
|---|---|---|---|
| 1 | 203.1 | 194.7 | −8.4 |
| 2 | 199.4 | 195.6 | −3.8 |
| 3 | 209.0 | 194.0 | −15.1 |
| 4 | 193.4 | 183.4 | −9.9 |
| 5 | 200.3 | 184.4 | −15.9 |
| 6 | 205.2 | 190.7 | −14.5 |
| 7 | 193.6 | 185.1 | −8.5 |
| 8 | 215.7 | 188.5 | −27.2 |

**Median pair delta −12.2 ms (~−6% of build), 8/8 pairs negative.** Output is byte-identical (`main.js` / `main.js.map` sha256 match the unmodified baseline). Peak RSS flat (`/usr/bin/time -l`, interleaved runs).

## What was deliberately NOT deferred

Adversarial review (4 rounds) shrank this change to what's provably safe:

- **`ast_table` (per-module AST arenas):** main frees these *before* chunk instantiation/minify allocate; deferring them would overlap the full arena graph with allocation-heavy phases and risk a peak-RSS spike. Kept inline.
- **non-incremental `symbol_db`:** main frees it inline *before* the output hooks; deferring it would extend its lifetime across unbounded plugin hooks. Kept inline (this costs ~5ms of the potential win and is the right trade).

## Notes

- The free still happens — on otherwise-idle workers, overlapping the hook/write tail. Real work is moved off the critical path, not eliminated; in-process memory is released a few ms later within the same build span.
- The pending counter is process-global on purpose: the dropped value is exclusively owned, so the worst cross-instance effect is a bounded (~15ms) wait or background CPU, never correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build lifecycle and the shared rayon pool with global synchronization; correctness relies on documented invariants (one deferred object per build, drain at entry), though output is intended to stay byte-identical.
> 
> **Overview**
> Moves teardown of heavy **link stage output** (`module_table`, metas, stmt infos, etc.) off the main thread after `GenerateStage::generate()` returns, so ~15ms of `free()` can overlap plugin hooks and the write tail on idle rayon workers.
> 
> Adds **`utils/defer_drop`**: `spawn_drop` enqueues exclusive drops on `rayon::spawn`, with a process-global pending counter and **`drain()`** so deferred work cannot pile up across builds. **`symbol_db`** is still taken with `mem::take` and merged into the cache inline before deferral (unchanged lifecycle for cache integrity).
> 
> **`defer_drop::drain()`** runs at every rayon-work entry: **`BundleFactory::build_bundle`** and the three HMR/lazy-compile paths in **`impl_bundler_hmr.rs`** that skip `build_bundle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f95690a8459952aca2809620338f25036502a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->