### PR TITLE
refactor: remove preprocessor span dedup

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1278,7 +1278,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     &self,
     call_expr: &mut ast::CallExpression<'ast>,
   ) -> Option<Expression<'ast>> {
-    if call_expr.is_global_require_call(self.scope) && !call_expr.span.is_unspanned() {
+    if call_expr.is_global_require_call(self.scope) {
       //  `require` calls that can't be recognized by rolldown are ignored in scanning, so they were not stored in `NormalModule#imports`.
       //  we just keep these `require` calls as it is
       if let Some(rec_idx) = self.ctx.module.imports.get(&call_expr.node_id()).copied() {

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -3,12 +3,11 @@ use oxc::allocator::{Address, Allocator, GetAddress, TakeIn};
 use oxc::ast::NONE;
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
 use oxc::ast_visit::{VisitMut, walk_mut};
-use oxc::span::{GetSpanMut, SPAN, Span};
+use oxc::span::{SPAN, Span};
 use rolldown_ecmascript_utils::{AstFactory, StatementExt};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Pre-process is a essential step to make rolldown generate correct and efficient code.
-/// This also ensures span uniqueness in the AST.
 pub struct PreProcessor<'ast, 'a> {
   ast_factory: AstFactory<'ast>,
   /// used to store none_hoisted statements.
@@ -21,9 +20,6 @@ pub struct PreProcessor<'ast, 'a> {
   drop_labels: Option<&'a FxHashSet<String>>,
   statement_stack: Vec<Address>,
   statement_replace_map: FxHashMap<Address, Vec<Statement<'ast>>>,
-  // Fields for span uniqueness
-  visited_spans: FxHashSet<Span>,
-  next_unique_span_start: u32,
   /// Spans of `import defer ...` statements / expressions whose `defer` phase
   /// was lowered to a regular import. Read after `visit_program` to emit the
   /// `UNSUPPORTED_FEATURE` warning.
@@ -43,8 +39,6 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
       drop_labels: drop_labels.filter(|set| !set.is_empty()),
       statement_stack: vec![],
       statement_replace_map: FxHashMap::default(),
-      visited_spans: FxHashSet::from_iter([SPAN]),
-      next_unique_span_start: 1,
       defer_spans: vec![],
     }
   }
@@ -65,23 +59,6 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
       return true;
     }
     false
-  }
-
-  fn ensure_uniqueness(&mut self, span: &mut Span) {
-    if self.visited_spans.contains(span) {
-      *span = self.generate_unique_span();
-    }
-    self.visited_spans.insert(*span);
-  }
-
-  fn generate_unique_span(&mut self) -> Span {
-    let mut span_candidate = Span::new(self.next_unique_span_start, self.next_unique_span_start);
-    while self.visited_spans.contains(&span_candidate) {
-      self.next_unique_span_start += 1;
-      span_candidate = Span::new(self.next_unique_span_start, self.next_unique_span_start);
-    }
-    debug_assert!(span_candidate.is_empty());
-    span_candidate
   }
 
   /// split `var a = 1, b = 2;` into `var a = 1; var b = 2;`
@@ -130,9 +107,6 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
-    // Initialize next_unique_span_start for span uniqueness
-    self.next_unique_span_start = program.span.end + 1;
-
     let original_body = program.body.take_in(self.ast_factory.allocator);
     program.body.reserve_exact(original_body.len());
     self.top_level_stmt_temp_storage = Vec::with_capacity(
@@ -254,42 +228,12 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
     }
   }
 
-  // Span uniqueness visitor methods
-  fn visit_module_declaration(&mut self, it: &mut ast::ModuleDeclaration<'ast>) {
-    self.ensure_uniqueness(it.span_mut());
-    walk_mut::walk_module_declaration(self, it);
-  }
-
   fn visit_import_expression(&mut self, it: &mut ast::ImportExpression<'ast>) {
     if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
       self.defer_spans.push(it.span);
       it.phase = None;
     }
-    self.ensure_uniqueness(it.span_mut());
     walk_mut::walk_import_expression(self, it);
-  }
-
-  fn visit_this_expression(&mut self, it: &mut ast::ThisExpression) {
-    self.ensure_uniqueness(it.span_mut());
-    walk_mut::walk_this_expression(self, it);
-  }
-
-  fn visit_call_expression(&mut self, it: &mut ast::CallExpression<'ast>) {
-    if it.callee.is_specific_id("require") && it.arguments.len() == 1 {
-      self.ensure_uniqueness(it.span_mut());
-    }
-    walk_mut::walk_call_expression(self, it);
-  }
-
-  fn visit_new_expression(&mut self, it: &mut ast::NewExpression<'ast>) {
-    self.ensure_uniqueness(it.span_mut());
-    walk_mut::walk_new_expression(self, it);
-  }
-
-  fn visit_identifier_reference(&mut self, it: &mut ast::IdentifierReference<'ast>) {
-    if it.name == "require" {
-      self.ensure_uniqueness(it.span_mut());
-    }
   }
 
   fn visit_expression(&mut self, it: &mut ast::Expression<'ast>) {

--- a/meta/design/ast-mutation.md
+++ b/meta/design/ast-mutation.md
@@ -82,9 +82,11 @@ Oxc `Address` is still acceptable for scratch state inside one live AST traversa
 
 Do not store `Address` in module metadata, entry metadata, or link-stage tables that outlive the traversal that produced it. In the post-semantic scanner, prefer `NodeId` even for same-traversal node identity checks when the compared nodes already have semantic IDs.
 
-## Pre-Scan Span Normalization
+## Pre-Scan Span Handling
 
-`PreProcessor` still rewrites duplicate spans for a targeted set of node kinds before semantic information is rebuilt. After the `NodeId` migration, pairwise span uniqueness no longer backs any identity table; the machinery's one remaining functional job is keeping the synthetic span out of scanned ASTs. `SPAN` (`0..0`) is pre-seeded into the visited set, so nodes `PreProcessor` itself creates with `SPAN` (e.g. the transposed `require(a ? 'x' : 'y')` calls) are rewritten to fresh non-zero empty spans. That upholds the `span.is_unspanned()` checks that mean "synthesized by the finalizer": the global-`require` rewrite guard in `crates/rolldown/src/module_finalizers/mod.rs` and the member-expression-chain guard in `crates/rolldown/src/ast_scanner/impl_visit.rs`. Shrinking the machinery down to that single job is a candidate follow-up cleanup.
+`PreProcessor` does not rewrite spans for identity anymore. Pairwise span uniqueness does not back any identity table after the `NodeId` migration, so ordinary duplicate spans are left alone, and nodes created during pre-scan rewrites can keep the reserved synthetic span (`SPAN`, `0..0`).
+
+Later passes must not use `span.is_unspanned()` to decide whether a scanner-visible node has a cross-pass record. For example, finalizing a `require()` call now relies on `EcmaView::imports.get(call_expr.node_id())`: pre-scan-created calls have semantic `NodeId`s and can hit, while finalizer-created calls keep `NodeId::DUMMY` and miss.
 
 The practical rule is simple: treat `Span` as location, `NodeId` as same-AST node identity, and `(ModuleIdx, NodeId)` as cross-module node identity.
 


### PR DESCRIPTION
## Summary

Follow-up to #9609.

- Remove the old `PreProcessor` span uniqueness machinery entirely: no visited-span set, no duplicate-span rewrite, and no synthetic-span rewrite for pre-scan-created nodes.
- Let pre-scan-created `require(...)` / `import(...)` nodes keep `SPAN` (`0..0`); their cross-pass identity is their post-semantic `NodeId`.
- Remove the finalizer's `require()` `span.is_unspanned()` guard so recognized pre-scan-created `require()` calls are still finalized via `EcmaView::imports.get(call_expr.node_id())`.
- Update `meta/design/ast-mutation.md` to document the post-NodeId contract.

## Why

After cross-pass AST identity moved from `Span`/`Address` to post-semantic `NodeId`, PreProcessor does not need to maintain source-span uniqueness or keep its own generated nodes out of `SPAN`. Scanner-visible pre-scan nodes get semantic `NodeId`s and can hit side tables; finalizer-created nodes keep `NodeId::DUMMY` and miss.

## Validation

- `cargo fmt --all -- --emit=files`
- `cargo fmt --all -- --check`
- `just t-run crates/rolldown/tests/esbuild/default/conditional_require/_config.json`
- `just t-run crates/rolldown/tests/esbuild/default/conditional_import/_config.json`
- `cargo check -p rolldown --all-targets --all-features --locked`
