### PR TITLE
fix(dev): detect same-second rewrites in CI poll watcher

### DIFF
--- a/packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts
+++ b/packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts
@@ -4,7 +4,13 @@ export function getDevWatchOptionsForCi() {
   return {
     usePolling: true,
     pollInterval: 50,
-    compareContentsForPolling: false,
+    // The poll watcher stores mtime at whole-second granularity and only
+    // emits an mtime-based change when the second advances; with content
+    // comparison off, two writes to the same file within the same second are
+    // invisible. On loaded CI runners that blind spot drops the recovery edit
+    // in the dev-server specs and the build never re-fires. Comparing content
+    // hashes adds a second detection path for same-second rewrites.
+    compareContentsForPolling: true,
     useDebounce: true,
     debounceDuration: 310,
     debounceTickRate: 300,


### PR DESCRIPTION
## Problem

The CI dev-server specs intermittently hang on ubuntu node-20 until the 15-min job ceiling, then get canceled.

## Cause

The CI dev-watch options use the **poll watcher**, which stores mtime at **whole-second** granularity and only emits a change when that second advances. With content comparison off, two writes to the same file **within the same second** are invisible. On a loaded CI runner the recovery edit in the dev-server specs lands in the same second as the prior write, the watcher misses it, and the build never re-fires — so the spec polls until the job times out.

## Fix

Enable `compareContentsForPolling`. The watcher then also compares a content hash, which gives a second detection path for same-second rewrites. It is purely additive — it never suppresses an event that mtime alone would have caught.

```ts
// packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts
compareContentsForPolling: true,
```

## Verification

Repeated the previously-flaky recovery scenario 40× per run with retries disabled — green on node 20 / 22 / 24, each well within the 15-min budget.

https://claude.ai/code/session_01PRs5hSHmbjySb2RXG36twX