### PR TITLE
refactor(binding): remove infer-able `napi(ts_type)`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_inject_import.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_inject_import.rs
@@ -1,6 +1,7 @@
 use napi::Either;
 use rolldown::InjectImport;
 
+#[napi_derive::napi]
 pub type BindingInjectImport = Either<BindingInjectImportNamed, BindingInjectImportNamespace>;
 
 #[napi_derive::napi(object, object_to_js = false)]

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
@@ -11,7 +11,6 @@ pub struct BindingInlineConstConfig {
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug, Default)]
 pub struct BindingOptimization {
-  #[napi(ts_type = "boolean | BindingInlineConstConfig")]
   pub inline_const: Option<Either<bool, BindingInlineConstConfig>>,
   pub pife_for_module_wrappers: Option<bool>,
 }

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -57,7 +57,6 @@ pub struct BindingModuleSideEffectsRule {
   #[napi(ts_type = "RegExp | undefined")]
   pub test: Option<JsRegExp>,
   pub side_effects: bool,
-  #[napi(ts_type = "boolean | undefined")]
   pub external: Option<bool>,
 }
 

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -86,7 +86,6 @@ pub struct BindingInputOptions<'env> {
   pub module_types: Option<HashMap<String, String, FxBuildHasher>>,
   pub define: Option<Vec<(/* Target to be replaced */ String, /* Replacement */ String)>>,
   pub drop_labels: Option<Vec<String>>,
-  #[napi(ts_type = "Array<BindingInjectImportNamed | BindingInjectImportNamespace>")]
   pub inject: Option<Vec<BindingInjectImport>>,
   pub experimental: Option<binding_experimental_options::BindingExperimentalOptions>,
   pub profiler_names: Option<bool>,
@@ -106,6 +105,5 @@ pub struct BindingInputOptions<'env> {
   pub preserve_entry_signatures: Option<BindingPreserveEntrySignatures>,
   pub optimization: Option<BindingOptimization>,
   pub context: Option<String>,
-  #[napi(ts_type = "boolean | string")]
   pub tsconfig: Option<Either<bool, String>>,
 }

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -88,7 +88,6 @@ pub struct BindingOutputOptions<'env> {
   #[napi(ts_type = "'es' | 'cjs' | 'iife' | 'umd'")]
   pub format: Option<String>,
   // freeze: boolean;
-  #[napi(ts_type = "BindingGeneratedCodeOptions")]
   pub generated_code: Option<BindingGeneratedCodeOptions>,
   #[debug(skip)]
   #[napi(ts_type = "Record<string, string> | ((name: string) => string)")]

--- a/crates/rolldown_binding/src/options/binding_transform_options.rs
+++ b/crates/rolldown_binding/src/options/binding_transform_options.rs
@@ -165,7 +165,6 @@ pub struct BindingEnhancedTransformOptions {
   /// Configure tsconfig handling.
   /// - true: Auto-discover and load the nearest tsconfig.json
   /// - TsconfigRawOptions: Use the provided inline tsconfig options
-  #[napi(ts_type = "boolean | BindingTsconfigRawOptions")]
   pub tsconfig: Option<Either<bool, BindingTsconfigRawOptions>>,
   /// An input source map to collapse with the output source map.
   pub input_map: Option<SourceMap>,

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2419,6 +2419,9 @@ export interface BindingIndentOptions {
   exclude?: Array<Array<number>> | Array<number>
 }
 
+export type BindingInjectImport =
+  BindingInjectImportNamed | BindingInjectImportNamespace
+
 export interface BindingInjectImportNamed {
   tagNamed: true
   imported: string
@@ -2456,7 +2459,7 @@ export interface BindingInputOptions {
   moduleTypes?: Record<string, string>
   define?: Array<[string, string]>
   dropLabels?: Array<string>
-  inject?: Array<BindingInjectImportNamed | BindingInjectImportNamespace>
+  inject?: Array<BindingInjectImport>
   experimental?: BindingExperimentalOptions
   profilerNames?: boolean
   transform?: TransformOptions
@@ -2570,7 +2573,7 @@ export interface BindingModules {
 export interface BindingModuleSideEffectsRule {
   test?: RegExp | undefined
   sideEffects: boolean
-  external?: boolean | undefined
+  external?: boolean
 }
 
 export interface BindingOptimization {


### PR DESCRIPTION
To simplify the code a bit.