### PR TITLE
perf(renamer): dedup before allocating the owned name in add_symbol_in_root_scope

### DIFF
--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -168,6 +168,14 @@ impl<'name> Renamer<'name> {
     let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
     let canonical_name = canonical_ref.name(self.symbol_db);
 
+    // Dedup-before-alloc: in the deconflict path, a re-add of an already-present
+    // canonical_ref is a no-op, so check it BEFORE building the owned name and
+    // skip the wasted CompactStr allocation on that path. The `!needs_deconflict`
+    // path still inserts and therefore still needs the built name.
+    if needs_deconflict && self.canonical_names.contains_key(&canonical_ref) {
+      return;
+    }
+
     let original_name = if self.symbol_db.has_module_preserve_jsx()
       && canonical_name.as_bytes()[0].is_ascii_lowercase()
       && canonical_ref
@@ -184,10 +192,6 @@ impl<'name> Renamer<'name> {
 
     if !needs_deconflict {
       self.canonical_names.insert(canonical_ref, original_name);
-      return;
-    }
-
-    if self.canonical_names.contains_key(&canonical_ref) {
       return;
     }
 


### PR DESCRIPTION
## Summary

In the `Renamer::add_symbol_in_root_scope` deconflict path, an owned `original_name` (`CompactStr`) was built *before* the `canonical_names.contains_key(&canonical_ref)` dedup check. On apps/10000, ~19,870 of ~59,943 calls are re-adds of an already-present `canonical_ref` (31.7%) — every one of those built and then discarded the owned name.

This hoists the dedup check above the name construction so an already-present `canonical_ref` returns before the `CompactStr` allocation. It's guarded by `needs_deconflict` to preserve the original control flow exactly: the old unguarded check was only reachable on the `needs_deconflict` path (the `!needs_deconflict` branch returns earlier, and still needs the built name to insert).

## Correctness

Behavior-preserving and **byte-identical** (`main.js` + `main.js.map` sha256 match baseline on apps/10000). Verified by cases:
- `!needs_deconflict` → unchanged: builds the name and inserts (the new guard is skipped).
- `needs_deconflict` + already present → returns without state change (only difference vs before: the wasted name-build is skipped).
- `needs_deconflict` + not present → falls through to the same fast/slow path.

## Performance

Removes ~19,870 wasted `CompactStr` builds per build. (Note: the deconflict path's remaining cost is genuine — ~66.7% of symbols on this workload really do collide and need renaming; this PR only removes the pre-dedup waste, nothing structural.) Local wall is within ambient noise; relying on **CodSpeed** for the clean number.

`+8 / -4`, one file. fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving reorder of an existing early return; only affects performance on the chunk symbol deconflict hot path, not naming semantics.
> 
> **Overview**
> **`Renamer::add_symbol_in_root_scope`** now returns early on duplicate `canonical_ref` entries *before* constructing the owned `original_name` (`CompactStr`), but only when `needs_deconflict` is true.
> 
> The `!needs_deconflict` path is unchanged: it still builds the name and inserts. On large bundles, many deconflict calls are no-op re-adds; skipping the JSX-capitalization and `CompactStr` work on those calls removes redundant allocations without changing rename results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08280d51ca1d7fecad3857c5ff7848a582e878a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->