### PR TITLE
fix: avoid O(N^2) rendering of high-volume diagnostics (#9748)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,7 +3224,6 @@ dependencies = [
  "oxc",
  "oxc_resolver",
  "rolldown-ariadne",
- "ropey",
  "rustc-hash",
  "sugar_path",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,6 @@ regex = "1.12.4"
 regress = "0.11.0"
 rolldown-notify = "10.2.0"
 rolldown-notify-debouncer-full = "0.7.5"
-ropey = "1.6.1"
 rustc-hash = { version = "2.1.1" }
 schemars = "1.0.0"
 self_cell = "1.2.0"

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -8,6 +8,7 @@ pub mod normalize_binding_options;
 
 use std::any::Any;
 
+use futures::stream::{StreamExt, TryStreamExt};
 use napi_derive::napi;
 use rolldown::{LogLevel, NormalizedBundlerOptions};
 use rolldown_error::{BuildDiagnostic, DiagnosticOptions, filter_out_disabled_diagnostics};
@@ -46,11 +47,24 @@ pub async fn handle_warnings(
   warnings: Vec<BuildDiagnostic>,
   options: &NormalizedBundlerOptions,
 ) -> anyhow::Result<()> {
+  // Emitting warnings one at a time forces a Rust -> JS -> Rust round-trip per
+  // warning. With tens of thousands of warnings (e.g. a large app whose deps are
+  // littered with `"use client"` directives or `eval`) awaiting each call
+  // sequentially degenerates into a pathological ping-pong across the napi bridge
+  // that can appear to hang the build entirely (#9748). Pipelining the calls with
+  // bounded concurrency lets the JS event loop drain many queued calls per tick
+  // while capping the number of in-flight calls (and therefore memory).
+  const MAX_IN_FLIGHT_WARNINGS: usize = 256;
+
   if options.log_level == Some(LogLevel::Silent) {
     return Ok(());
   }
-  if let Some(on_log) = options.on_log.as_ref() {
-    for warning in filter_out_disabled_diagnostics(warnings, &options.checks) {
+  let Some(on_log) = options.on_log.as_ref() else {
+    return Ok(());
+  };
+
+  futures::stream::iter(filter_out_disabled_diagnostics(warnings, &options.checks).map(
+    |warning| {
       let diag = warning.to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() });
       let code = warning.kind().to_string();
 
@@ -76,22 +90,26 @@ pub async fn handle_warnings(
         (None, None)
       };
 
-      on_log
-        .call(
-          LogLevel::Warn,
-          rolldown::Log {
-            id: warning.id(),
-            exporter: warning.exporter(),
-            code: Some(code),
-            message: diag.to_color_string(),
-            plugin: warning.plugin(),
-            loc,
-            pos,
-            ids: warning.ids(),
-          },
-        )
-        .await?;
-    }
-  }
+      on_log.call(
+        LogLevel::Warn,
+        rolldown::Log {
+          id: warning.id(),
+          exporter: warning.exporter(),
+          code: Some(code),
+          message: diag.to_color_string(),
+          plugin: warning.plugin(),
+          loc,
+          pos,
+          ids: warning.ids(),
+        },
+      )
+    },
+  ))
+  // `buffer_unordered` is fine here: warnings are collected from parallel module
+  // tasks in completion order, so there is no cross-module ordering to preserve.
+  .buffer_unordered(MAX_IN_FLIGHT_WARNINGS)
+  .try_collect::<Vec<()>>()
+  .await?;
+
   Ok(())
 }

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -8,7 +8,6 @@ pub mod normalize_binding_options;
 
 use std::any::Any;
 
-use futures::stream::{StreamExt, TryStreamExt};
 use napi_derive::napi;
 use rolldown::{LogLevel, NormalizedBundlerOptions};
 use rolldown_error::{
@@ -49,12 +48,6 @@ pub async fn handle_warnings(
   warnings: Vec<BuildDiagnostic>,
   options: &NormalizedBundlerOptions,
 ) -> anyhow::Result<()> {
-  // Emitting warnings one at a time forces a Rust -> JS -> Rust round-trip per
-  // warning; pipelining the calls with bounded concurrency lets the JS event loop
-  // drain many queued calls per tick while capping the number of in-flight calls
-  // (and therefore memory). See #9748.
-  const MAX_IN_FLIGHT_WARNINGS: usize = 256;
-
   if options.log_level == Some(LogLevel::Silent) {
     return Ok(());
   }
@@ -77,47 +70,47 @@ pub async fn handle_warnings(
     warnings.iter().map(|warning| warning.to_diagnostic_with(&diagnostic_options)).collect();
   let rendered = Diagnostic::render_batch(&diagnostics, true);
 
-  let logs: Vec<rolldown::Log> = warnings
-    .into_iter()
-    .zip(rendered)
-    .map(|(warning, rendered)| {
-      // Only include loc/pos for warning types that report specific source locations.
-      // Use warning.id() for the file path since the diagnostic may only store the filename.
-      #[expect(
-        clippy::cast_possible_truncation,
-        reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
-      )]
-      let (loc, pos) = match rendered.primary_location {
-        Some(location) => (
-          Some(rolldown::LogLocation {
-            line: location.line as u32,
-            column: location.column as u32,
-            file: warning.id(),
-          }),
-          Some(location.utf16_position as u32),
-        ),
-        None => (None, None),
-      };
+  // Dispatch the callbacks sequentially, awaiting each before invoking the next.
+  // A warning handler is allowed to `throw` to abort the build, so we must stop at
+  // the first failure without invoking any later handler (and without leaving
+  // concurrent in-flight calls racing the returned error). The expensive part of
+  // #9748 was the per-warning re-render above, not the JS round-trip, so awaiting
+  // one call at a time does not reintroduce the hang.
+  for (warning, rendered) in warnings.into_iter().zip(rendered) {
+    // Only include loc/pos for warning types that report specific source locations.
+    // Use warning.id() for the file path since the diagnostic may only store the filename.
+    #[expect(
+      clippy::cast_possible_truncation,
+      reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
+    )]
+    let (loc, pos) = match rendered.primary_location {
+      Some(location) => (
+        Some(rolldown::LogLocation {
+          line: location.line as u32,
+          column: location.column as u32,
+          file: warning.id(),
+        }),
+        Some(location.utf16_position as u32),
+      ),
+      None => (None, None),
+    };
 
-      rolldown::Log {
-        id: warning.id(),
-        exporter: warning.exporter(),
-        code: Some(warning.kind().to_string()),
-        message: rendered.message,
-        plugin: warning.plugin(),
-        loc,
-        pos,
-        ids: warning.ids(),
-      }
-    })
-    .collect();
-
-  // `buffer_unordered` is fine here: warnings are collected from parallel module
-  // tasks in completion order, so there is no cross-module ordering to preserve.
-  futures::stream::iter(logs.into_iter().map(|log| on_log.call(LogLevel::Warn, log)))
-    .buffer_unordered(MAX_IN_FLIGHT_WARNINGS)
-    .try_collect::<Vec<()>>()
-    .await?;
+    on_log
+      .call(
+        LogLevel::Warn,
+        rolldown::Log {
+          id: warning.id(),
+          exporter: warning.exporter(),
+          code: Some(warning.kind().to_string()),
+          message: rendered.message,
+          plugin: warning.plugin(),
+          loc,
+          pos,
+          ids: warning.ids(),
+        },
+      )
+      .await?;
+  }
 
   Ok(())
 }

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -11,7 +11,9 @@ use std::any::Any;
 use futures::stream::{StreamExt, TryStreamExt};
 use napi_derive::napi;
 use rolldown::{LogLevel, NormalizedBundlerOptions};
-use rolldown_error::{BuildDiagnostic, DiagnosticOptions, filter_out_disabled_diagnostics};
+use rolldown_error::{
+  BuildDiagnostic, Diagnostic, DiagnosticOptions, filter_out_disabled_diagnostics,
+};
 use rolldown_tracing::try_init_tracing;
 
 pub use normalize_binding_transform_options::normalize_binding_transform_options;
@@ -48,12 +50,9 @@ pub async fn handle_warnings(
   options: &NormalizedBundlerOptions,
 ) -> anyhow::Result<()> {
   // Emitting warnings one at a time forces a Rust -> JS -> Rust round-trip per
-  // warning. With tens of thousands of warnings (e.g. a large app whose deps are
-  // littered with `"use client"` directives or `eval`) awaiting each call
-  // sequentially degenerates into a pathological ping-pong across the napi bridge
-  // that can appear to hang the build entirely (#9748). Pipelining the calls with
-  // bounded concurrency lets the JS event loop drain many queued calls per tick
-  // while capping the number of in-flight calls (and therefore memory).
+  // warning; pipelining the calls with bounded concurrency lets the JS event loop
+  // drain many queued calls per tick while capping the number of in-flight calls
+  // (and therefore memory). See #9748.
   const MAX_IN_FLIGHT_WARNINGS: usize = 256;
 
   if options.log_level == Some(LogLevel::Silent) {
@@ -63,53 +62,62 @@ pub async fn handle_warnings(
     return Ok(());
   };
 
-  futures::stream::iter(filter_out_disabled_diagnostics(warnings, &options.checks).map(
-    |warning| {
-      let diag = warning.to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() });
-      let code = warning.kind().to_string();
+  let warnings: Vec<BuildDiagnostic> =
+    filter_out_disabled_diagnostics(warnings, &options.checks).collect();
+  if warnings.is_empty() {
+    return Ok(());
+  }
 
-      // Extract location information from the diagnostic if available
+  // Render every warning up front through the batch API. Rendering per-warning
+  // rebuilds the line index / ariadne `Source` for the whole file each time,
+  // which is O(N^2) for many warnings in one large file and is what actually
+  // makes a high-volume build appear to hang (#9748).
+  let diagnostic_options = DiagnosticOptions { cwd: options.cwd.clone() };
+  let diagnostics: Vec<Diagnostic> =
+    warnings.iter().map(|warning| warning.to_diagnostic_with(&diagnostic_options)).collect();
+  let rendered = Diagnostic::render_batch(&diagnostics, true);
+
+  let logs: Vec<rolldown::Log> = warnings
+    .into_iter()
+    .zip(rendered)
+    .map(|(warning, rendered)| {
       // Only include loc/pos for warning types that report specific source locations.
-      // Note: Line numbers, columns, and byte positions are cast to u32.
-      // This is safe for practical use cases as files with >4 billion lines or bytes are extremely rare.
       // Use warning.id() for the file path since the diagnostic may only store the filename.
       #[expect(
         clippy::cast_possible_truncation,
         reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
       )]
-      let (loc, pos) = if let Some((_file, line, column, position)) = diag.get_primary_location() {
-        (
+      let (loc, pos) = match rendered.primary_location {
+        Some(location) => (
           Some(rolldown::LogLocation {
-            line: line as u32,
-            column: column as u32,
+            line: location.line as u32,
+            column: location.column as u32,
             file: warning.id(),
           }),
-          Some(position as u32),
-        )
-      } else {
-        (None, None)
+          Some(location.utf16_position as u32),
+        ),
+        None => (None, None),
       };
 
-      on_log.call(
-        LogLevel::Warn,
-        rolldown::Log {
-          id: warning.id(),
-          exporter: warning.exporter(),
-          code: Some(code),
-          message: diag.to_color_string(),
-          plugin: warning.plugin(),
-          loc,
-          pos,
-          ids: warning.ids(),
-        },
-      )
-    },
-  ))
+      rolldown::Log {
+        id: warning.id(),
+        exporter: warning.exporter(),
+        code: Some(warning.kind().to_string()),
+        message: rendered.message,
+        plugin: warning.plugin(),
+        loc,
+        pos,
+        ids: warning.ids(),
+      }
+    })
+    .collect();
+
   // `buffer_unordered` is fine here: warnings are collected from parallel module
   // tasks in completion order, so there is no cross-module ordering to preserve.
-  .buffer_unordered(MAX_IN_FLIGHT_WARNINGS)
-  .try_collect::<Vec<()>>()
-  .await?;
+  futures::stream::iter(logs.into_iter().map(|log| on_log.call(LogLevel::Warn, log)))
+    .buffer_unordered(MAX_IN_FLIGHT_WARNINGS)
+    .try_collect::<Vec<()>>()
+    .await?;
 
   Ok(())
 }

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -28,6 +28,5 @@ heck = { workspace = true }
 napi = { workspace = true, optional = true }
 oxc = { workspace = true }
 oxc_resolver = { workspace = true }
-ropey = { workspace = true }
 rustc-hash = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -229,11 +229,20 @@ impl Diagnostic {
 
   /// Render many diagnostics at once, sharing per-source work across all of them.
   ///
-  /// Rendering diagnostics one by one re-derives line offsets and rebuilds the
-  /// ariadne `Source` for the whole file on every diagnostic, so emitting N
+  /// Rendering diagnostics one by one rebuilds the ariadne `Source` (its rope and
+  /// full line index) for the whole file on every diagnostic, so emitting N
   /// diagnostics that point into the same large file is O(N^2) and can appear to
-  /// hang the build (#9748). Sharing the per-source line table and source cache
-  /// makes it O(N log N).
+  /// hang the build (#9748). Sharing the `Source` cache and a per-source line table
+  /// removes that quadratic factor — the line containing an offset is found in
+  /// O(log lines) per diagnostic, then its UTF-16 column is read by scanning only
+  /// that one line (see [`LineTable`]).
+  ///
+  /// One residual cost is outside this batching: ariadne prints the entire labelled
+  /// line for every diagnostic, so a pathological input where N diagnostics all land
+  /// on one very long line (e.g. a minified bundle) still costs O(N * line_len)
+  /// inside ariadne itself — the within-line column scan is bounded by that same
+  /// line and is not the deciding factor. The cross-diagnostic O(N^2) blow-up that
+  /// actually caused the reported hang is what this removes.
   pub fn render_batch(diagnostics: &[Diagnostic], color: bool) -> Vec<RenderedDiagnostic> {
     // Collect every source referenced by any diagnostic, deduplicated, so the
     // ariadne cache builds each `Source` exactly once.
@@ -291,8 +300,10 @@ pub struct RenderedDiagnostic {
   pub primary_location: Option<DiagnosticPrimaryLocation>,
 }
 
-/// Precomputed line-start offsets for one source, mapping a byte offset to a
-/// (line, column) in O(log n) instead of scanning from the start of the file.
+/// Precomputed line-start offsets for one source. Finding the line that contains a
+/// byte offset is O(log lines) instead of scanning from the start of the file; the
+/// UTF-16 column within that line is then read by scanning the line's prefix (see
+/// [`Self::locate`]).
 struct LineTable {
   /// Byte offset of the start of each line.
   line_byte_starts: Vec<usize>,
@@ -317,7 +328,7 @@ impl LineTable {
   }
 
   /// Returns `(1-based line, 0-based utf16 column, utf16 offset from file start)`
-  /// for `byte_offset`. Mirrors the semantics of the previous linear scan.
+  /// for `byte_offset`.
   fn locate(&self, source: &str, byte_offset: usize) -> (usize, usize, usize) {
     // Index of the last line whose start is <= byte_offset. `line_byte_starts`
     // always begins with 0, so `partition_point` is >= 1 and the `- 1` is safe.
@@ -327,6 +338,9 @@ impl LineTable {
     // Clamp to the source length so a (malformed) out-of-range offset degrades to
     // the end-of-file position instead of yielding column 0.
     let end = byte_offset.min(source.len());
+    // UTF-16 column within the line. Linear in the line's length, which is short in
+    // practice; the pathological single-very-long-line case is bounded by ariadne
+    // re-rendering that whole line per diagnostic anyway (see `render_batch`).
     let column: usize = source
       .get(line_byte_start..end)
       .map(|within_line| within_line.chars().map(char::len_utf16).sum())
@@ -338,5 +352,58 @@ impl LineTable {
 impl Display for Diagnostic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.convert_to_string(false).fmt(f)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::LineTable;
+
+  /// Straightforward, independent reference for [`LineTable::locate`] used to
+  /// validate it. `byte_offset` must fall on a char boundary.
+  fn reference_locate(source: &str, byte_offset: usize) -> (usize, usize, usize) {
+    let end = byte_offset.min(source.len());
+    let prefix = &source[..end];
+    let utf16_position: usize = prefix.chars().map(char::len_utf16).sum();
+    let line0 = prefix.matches('\n').count();
+    let line_byte_start = prefix.rfind('\n').map_or(0, |i| i + 1);
+    let column: usize = source[line_byte_start..end].chars().map(char::len_utf16).sum();
+    (line0 + 1, column, utf16_position)
+  }
+
+  fn assert_matches_reference(source: &str) {
+    let table = LineTable::new(source);
+    for byte_offset in 0..=source.len() {
+      if !source.is_char_boundary(byte_offset) {
+        continue;
+      }
+      assert_eq!(
+        table.locate(source, byte_offset),
+        reference_locate(source, byte_offset),
+        "mismatch at byte offset {byte_offset} of {source:?}"
+      );
+    }
+    // An out-of-range offset clamps to the end-of-file position.
+    let past_end = source.len() + 5;
+    assert_eq!(
+      table.locate(source, past_end),
+      reference_locate(source, past_end),
+      "mismatch at out-of-range offset {past_end} of {source:?}"
+    );
+  }
+
+  #[test]
+  fn line_table_matches_linear_reference() {
+    for source in [
+      "",
+      "abc",
+      "a\nbc\n\ndef",
+      "trailing\n",
+      "héllo\nwörld",  // 2-byte chars
+      "a𝐀b\n𝐁cd",      // astral (4-byte) chars
+      "café\n😀xy\nz", // emoji astral + accent across lines
+    ] {
+      assert_matches_reference(source);
+    }
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -395,13 +395,9 @@ mod tests {
   #[test]
   fn line_table_matches_linear_reference() {
     for source in [
-      "",
-      "abc",
-      "a\nbc\n\ndef",
-      "trailing\n",
-      "héllo\nwörld",  // 2-byte chars
-      "a𝐀b\n𝐁cd",      // astral (4-byte) chars
-      "café\n😀xy\nz", // emoji astral + accent across lines
+      "",              // empty source / single-entry table + out-of-range clamp
+      "a\nbc\n\ndef",  // multiple lines incl. an empty one: binary-search line lookup
+      "café\n😀xy\nz", // 2-byte accent + astral emoji across lines: cumulative utf16 table
     ] {
       assert_matches_reference(source);
     }

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -153,6 +153,18 @@ impl Diagnostic {
   }
 
   pub fn convert_to_string(&self, color: bool) -> String {
+    let mut cache = sources(self.files.clone());
+    self.convert_to_string_with_cache(color, &mut cache)
+  }
+
+  /// Like [`Self::convert_to_string`], but renders against a caller-owned ariadne
+  /// source cache so the line-indexed `Source` for each file is built once and
+  /// reused across many diagnostics instead of rebuilt per render (see #9748).
+  fn convert_to_string_with_cache(
+    &self,
+    color: bool,
+    cache: &mut impl ariadne::Cache<DiagnosticFileId>,
+  ) -> String {
     let builder = self.init_report_builder();
     let mut output = Vec::new();
     let result = builder
@@ -163,7 +175,7 @@ impl Diagnostic {
           .with_severity_prefix(false),
       )
       .finish()
-      .write_for_stdout(sources(self.files.clone()), &mut output);
+      .write_for_stdout(&mut *cache, &mut output);
     match result {
       Ok(()) => String::from_utf8_lossy(&output).into_owned(),
       Err(_) => format!("[{}] {}", self.kind, self.title),
@@ -174,6 +186,7 @@ impl Diagnostic {
     self.convert_to_string(true)
   }
 
+  #[must_use]
   pub fn with_kind(mut self, kind: String) -> Self {
     self.kind = kind;
     self
@@ -212,6 +225,113 @@ impl Diagnostic {
 
   pub fn kind(&self) -> String {
     self.kind.clone()
+  }
+
+  /// Render many diagnostics at once, sharing per-source work across all of them.
+  ///
+  /// Rendering diagnostics one by one re-derives line offsets and rebuilds the
+  /// ariadne `Source` for the whole file on every diagnostic, so emitting N
+  /// diagnostics that point into the same large file is O(N^2) and can appear to
+  /// hang the build (#9748). Sharing the per-source line table and source cache
+  /// makes it O(N log N).
+  pub fn render_batch(diagnostics: &[Diagnostic], color: bool) -> Vec<RenderedDiagnostic> {
+    // Collect every source referenced by any diagnostic, deduplicated, so the
+    // ariadne cache builds each `Source` exactly once.
+    let mut files: FxHashMap<DiagnosticFileId, ArcStr> = FxHashMap::default();
+    for diagnostic in diagnostics {
+      for (id, content) in &diagnostic.files {
+        files.entry(id.clone()).or_insert_with(|| content.clone());
+      }
+    }
+    let mut cache = sources(files.iter().map(|(id, content)| (id.clone(), content.clone())));
+    let mut line_tables: FxHashMap<DiagnosticFileId, LineTable> = FxHashMap::default();
+
+    diagnostics
+      .iter()
+      .map(|diagnostic| {
+        let primary_location = diagnostic.primary_location_with(&files, &mut line_tables);
+        let message = diagnostic.convert_to_string_with_cache(color, &mut cache);
+        RenderedDiagnostic { message, primary_location }
+      })
+      .collect()
+  }
+
+  /// Compute the primary location using a caller-owned per-source line-table
+  /// cache, so the line index for each file is built once across many lookups.
+  fn primary_location_with(
+    &self,
+    files: &FxHashMap<DiagnosticFileId, ArcStr>,
+    line_tables: &mut FxHashMap<DiagnosticFileId, LineTable>,
+  ) -> Option<DiagnosticPrimaryLocation> {
+    let first_label = self.labels.first()?;
+    let span = first_label.span();
+    let source_id = span.source();
+    let source = files.get(source_id)?;
+    let table = line_tables.entry(source_id.clone()).or_insert_with(|| LineTable::new(source));
+    let (line, column, utf16_position) = table.locate(source, span.start());
+    Some(DiagnosticPrimaryLocation { line, column, utf16_position })
+  }
+}
+
+/// Primary source location of a diagnostic's first label.
+#[derive(Debug, Clone)]
+pub struct DiagnosticPrimaryLocation {
+  /// 1-based line number.
+  pub line: usize,
+  /// 0-based UTF-16 column within the line.
+  pub column: usize,
+  /// UTF-16 code-unit offset from the start of the file.
+  pub utf16_position: usize,
+}
+
+/// A diagnostic rendered to its display string together with its primary location.
+#[derive(Debug, Clone)]
+pub struct RenderedDiagnostic {
+  pub message: String,
+  pub primary_location: Option<DiagnosticPrimaryLocation>,
+}
+
+/// Precomputed line-start offsets for one source, mapping a byte offset to a
+/// (line, column) in O(log n) instead of scanning from the start of the file.
+struct LineTable {
+  /// Byte offset of the start of each line.
+  line_byte_starts: Vec<usize>,
+  /// UTF-16 offset (from file start) of the start of each line, parallel to
+  /// `line_byte_starts`.
+  line_utf16_starts: Vec<usize>,
+}
+
+impl LineTable {
+  fn new(source: &str) -> Self {
+    let mut line_byte_starts = vec![0usize];
+    let mut line_utf16_starts = vec![0usize];
+    let mut utf16 = 0usize;
+    for (byte_idx, ch) in source.char_indices() {
+      utf16 += ch.len_utf16();
+      if ch == '\n' {
+        line_byte_starts.push(byte_idx + ch.len_utf8());
+        line_utf16_starts.push(utf16);
+      }
+    }
+    Self { line_byte_starts, line_utf16_starts }
+  }
+
+  /// Returns `(1-based line, 0-based utf16 column, utf16 offset from file start)`
+  /// for `byte_offset`. Mirrors the semantics of the previous linear scan.
+  fn locate(&self, source: &str, byte_offset: usize) -> (usize, usize, usize) {
+    // Index of the last line whose start is <= byte_offset. `line_byte_starts`
+    // always begins with 0, so `partition_point` is >= 1 and the `- 1` is safe.
+    let line_idx = self.line_byte_starts.partition_point(|&start| start <= byte_offset) - 1;
+    let line_byte_start = self.line_byte_starts[line_idx];
+    let line_utf16_start = self.line_utf16_starts[line_idx];
+    // Clamp to the source length so a (malformed) out-of-range offset degrades to
+    // the end-of-file position instead of yielding column 0.
+    let end = byte_offset.min(source.len());
+    let column: usize = source
+      .get(line_byte_start..end)
+      .map(|within_line| within_line.chars().map(char::len_utf16).sum())
+      .unwrap_or(0);
+    (line_idx + 1, column, line_utf16_start + column)
   }
 }
 

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -8,6 +8,7 @@ pub type SingleBuildResult<T> = std::result::Result<T, BuildDiagnostic>;
 
 pub use crate::{
   build_diagnostic::consolidate_diagnostics,
+  build_diagnostic::diagnostic::{Diagnostic, DiagnosticPrimaryLocation, RenderedDiagnostic},
   build_diagnostic::events::DiagnosableArcstr,
   build_diagnostic::events::ambiguous_external_namespace::AmbiguousExternalNamespaceModule,
   build_diagnostic::events::bundler_initialize_error::BundlerInitializeError,

--- a/crates/rolldown_error/src/utils/is_context_too_long.rs
+++ b/crates/rolldown_error/src/utils/is_context_too_long.rs
@@ -18,25 +18,27 @@ pub fn is_context_too_long(
   if source.len() < 600 {
     return false;
   }
-  let rope = ropey::Rope::from_str(source);
 
-  if span.start() > rope.len_bytes() || span.end() > rope.len_bytes() {
+  // Only the ~300 chars on either side of the span matter, so slice the source
+  // string directly instead of building a whole-file rope. Building a rope here
+  // is O(file length) per call, which turns rendering N diagnostics in one large
+  // file into O(N^2) (see #9748).
+  let (Some(prefix), Some(postfix)) = (source.get(..span.start()), source.get(span.end()..)) else {
     eprintln!(
       "Internal error: Diagnostic span is out of range. \
-       Span: {}..{}, Rope length: {} bytes, Source ID: {:?}, Label message: {:?}. \
+       Span: {}..{}, source length: {} bytes, Source ID: {:?}, Label message: {:?}. \
        Please report this bug with the source file that triggered this error.",
       span.start(),
       span.end(),
-      rope.len_bytes(),
+      source.len(),
       source_id,
       label.display_info().msg()
     );
     return true;
-  }
+  };
 
   // 1. If start to beginning of the file is less than 300 characters, treated as it has line feed before.
   // 2. If end to end of the file is less than 300 characters, treated as it has line feed after.
-  let postfix = rope.byte_slice(span.end()..);
   let mut has_line_feed_after = false;
   let mut cnt = 0;
   for ch in postfix.chars() {
@@ -54,11 +56,9 @@ pub fn is_context_too_long(
     has_line_feed_after = true;
   }
 
-  let prefix = rope.byte_slice(..span.start());
-
   let mut has_line_feed_before = false;
   let mut cnt = 0;
-  for ch in prefix.chars().reversed() {
+  for ch in prefix.chars().rev() {
     if ch == '\n' {
       has_line_feed_before = true;
       break;

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -207,6 +207,9 @@ impl WatchTask {
       warnings.iter().map(|warning| warning.to_diagnostic_with(&diagnostic_options)).collect();
     let rendered = Diagnostic::render_batch(&diagnostics, true);
 
+    // Dispatch sequentially, awaiting each callback before the next, so a handler
+    // that throws to abort the build stops at the first failure without invoking
+    // later handlers. Mirrors `handle_warnings` in the binding. See #9748.
     for (warning, rendered) in warnings.into_iter().zip(rendered) {
       #[expect(
         clippy::cast_possible_truncation,

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -4,7 +4,7 @@ use rolldown_common::{
   BundleMode, LogLevel, NormalizedBundlerOptions, ScanMode, WatcherChangeKind,
 };
 use rolldown_error::{
-  BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, DiagnosticOptions, ResultExt,
+  BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, Diagnostic, DiagnosticOptions, ResultExt,
   filter_out_disabled_diagnostics,
 };
 use rolldown_fs_watcher::{DynFsWatcher, RecursiveMode};
@@ -189,43 +189,55 @@ impl WatchTask {
     if warnings.is_empty() || options.log_level == Some(LogLevel::Silent) {
       return Ok(());
     }
-    if let Some(on_log) = options.on_log.as_ref() {
-      for warning in filter_out_disabled_diagnostics(warnings, &options.checks) {
-        let diag = warning.to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() });
-        let code = warning.kind().to_string();
-        #[expect(
-          clippy::cast_possible_truncation,
-          reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
-        )]
-        let (loc, pos) = if let Some((_file, line, column, position)) = diag.get_primary_location()
-        {
-          (
-            Some(rolldown_common::LogLocation {
-              line: line as u32,
-              column: column as u32,
-              file: warning.id(),
-            }),
-            Some(position as u32),
-          )
-        } else {
-          (None, None)
-        };
-        on_log
-          .call(
-            LogLevel::Warn,
-            rolldown_common::Log {
-              id: warning.id(),
-              exporter: warning.exporter(),
-              code: Some(code),
-              message: diag.to_color_string(),
-              plugin: None,
-              loc,
-              pos,
-              ids: warning.ids(),
-            },
-          )
-          .await?;
-      }
+    let Some(on_log) = options.on_log.as_ref() else {
+      return Ok(());
+    };
+
+    let warnings: Vec<BuildDiagnostic> =
+      filter_out_disabled_diagnostics(warnings, &options.checks).collect();
+    if warnings.is_empty() {
+      return Ok(());
+    }
+
+    // Render all warnings through the batch API so the per-source line index /
+    // ariadne `Source` is built once and shared, rather than rebuilt for every
+    // warning (O(N^2) for many warnings in one large file, see #9748).
+    let diagnostic_options = DiagnosticOptions { cwd: options.cwd.clone() };
+    let diagnostics: Vec<Diagnostic> =
+      warnings.iter().map(|warning| warning.to_diagnostic_with(&diagnostic_options)).collect();
+    let rendered = Diagnostic::render_batch(&diagnostics, true);
+
+    for (warning, rendered) in warnings.into_iter().zip(rendered) {
+      #[expect(
+        clippy::cast_possible_truncation,
+        reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
+      )]
+      let (loc, pos) = match rendered.primary_location {
+        Some(location) => (
+          Some(rolldown_common::LogLocation {
+            line: location.line as u32,
+            column: location.column as u32,
+            file: warning.id(),
+          }),
+          Some(location.utf16_position as u32),
+        ),
+        None => (None, None),
+      };
+      on_log
+        .call(
+          LogLevel::Warn,
+          rolldown_common::Log {
+            id: warning.id(),
+            exporter: warning.exporter(),
+            code: Some(warning.kind().to_string()),
+            message: rendered.message,
+            plugin: None,
+            loc,
+            pos,
+            ids: warning.ids(),
+          },
+        )
+        .await?;
     }
     Ok(())
   }

--- a/packages/rolldown/tests/behaviors/many-warnings.test.ts
+++ b/packages/rolldown/tests/behaviors/many-warnings.test.ts
@@ -7,10 +7,11 @@ import { expect, test } from 'vitest';
 // rolldown re-scanned the source from offset 0 to locate the span and rebuilt
 // the ariadne `Source` (line index) for the whole file. With tens of thousands
 // of warnings in one large module that made the build appear to hang. The
-// per-source work is now shared across all diagnostics (O(N log N)), so even 20k
-// warnings finish in well under a second. This asserts both that the build
-// completes and that every warning is delivered exactly once (none dropped or
-// duplicated).
+// per-source `Source` / line index is now built once and shared across all
+// diagnostics instead of rebuilt per warning, removing that quadratic blow-up,
+// so even 20k warnings finish in well under a second. This asserts both that the
+// build completes and that every warning is delivered exactly once (none dropped
+// or duplicated).
 test('delivers every warning when a build emits a high volume of them', async () => {
   const WARNING_COUNT = 20000;
   const virtualId = '\0many-eval-warnings';
@@ -42,4 +43,46 @@ test('delivers every warning when a build emits a high volume of them', async ()
   await bundle.close();
 
   expect(evalWarnings).toBe(WARNING_COUNT);
+});
+
+// A warning handler is allowed to `throw` to abort the build. Warnings are
+// dispatched sequentially (awaiting each callback before the next), so when many
+// warnings are emitted the handler that throws must stop the build at the first
+// call without invoking any later handler. This guards against pipelining the
+// callbacks, which would fire many handlers concurrently before the throw is
+// observed.
+test('throwing from a warning handler aborts before invoking later handlers', async () => {
+  const WARNING_COUNT = 50;
+  const virtualId = '\0throwing-eval-warnings';
+
+  let calls = 0;
+  await expect(
+    (async () => {
+      const bundle = await rolldown({
+        input: virtualId,
+        plugins: [
+          {
+            name: 'virtual-eval',
+            resolveId(id) {
+              if (id === virtualId) return id;
+            },
+            load(id) {
+              if (id === virtualId) {
+                let src = '';
+                for (let i = 0; i < WARNING_COUNT; i++) src += `eval("${i}");\n`;
+                return src;
+              }
+            },
+          },
+        ],
+        onwarn() {
+          calls++;
+          throw new Error('abort from warning handler');
+        },
+      });
+      await bundle.generate({});
+    })(),
+  ).rejects.toThrow('abort from warning handler');
+
+  expect(calls).toBe(1);
 });

--- a/packages/rolldown/tests/behaviors/many-warnings.test.ts
+++ b/packages/rolldown/tests/behaviors/many-warnings.test.ts
@@ -58,29 +58,34 @@ test('throwing from a warning handler aborts before invoking later handlers', as
   let calls = 0;
   await expect(
     (async () => {
-      const bundle = await rolldown({
-        input: virtualId,
-        plugins: [
-          {
-            name: 'virtual-eval',
-            resolveId(id) {
-              if (id === virtualId) return id;
+      let bundle;
+      try {
+        bundle = await rolldown({
+          input: virtualId,
+          plugins: [
+            {
+              name: 'virtual-eval',
+              resolveId(id) {
+                if (id === virtualId) return id;
+              },
+              load(id) {
+                if (id === virtualId) {
+                  let src = '';
+                  for (let i = 0; i < WARNING_COUNT; i++) src += `eval("${i}");\n`;
+                  return src;
+                }
+              },
             },
-            load(id) {
-              if (id === virtualId) {
-                let src = '';
-                for (let i = 0; i < WARNING_COUNT; i++) src += `eval("${i}");\n`;
-                return src;
-              }
-            },
+          ],
+          onwarn() {
+            calls++;
+            throw new Error('abort from warning handler');
           },
-        ],
-        onwarn() {
-          calls++;
-          throw new Error('abort from warning handler');
-        },
-      });
-      await bundle.generate({});
+        });
+        await bundle.generate({});
+      } finally {
+        await bundle?.close();
+      }
     })(),
   ).rejects.toThrow('abort from warning handler');
 

--- a/packages/rolldown/tests/behaviors/many-warnings.test.ts
+++ b/packages/rolldown/tests/behaviors/many-warnings.test.ts
@@ -3,14 +3,16 @@ import { expect, test } from 'vitest';
 
 // Regression test for https://github.com/rolldown/rolldown/issues/9748.
 //
-// Replaying warnings used to do one Rust -> JS -> Rust round-trip per warning,
-// awaited sequentially. With tens of thousands of warnings that degenerated into
-// a pathological ping-pong across the napi bridge that could appear to hang the
-// build. Warnings are now emitted with bounded concurrency; this asserts that the
-// pipelining still delivers every warning exactly once (none dropped/duplicated)
-// and that a high-volume build completes.
+// Emitting a high volume of warnings used to be O(N^2): for every warning,
+// rolldown re-scanned the source from offset 0 to locate the span and rebuilt
+// the ariadne `Source` (line index) for the whole file. With tens of thousands
+// of warnings in one large module that made the build appear to hang. The
+// per-source work is now shared across all diagnostics (O(N log N)), so even 20k
+// warnings finish in well under a second. This asserts both that the build
+// completes and that every warning is delivered exactly once (none dropped or
+// duplicated).
 test('delivers every warning when a build emits a high volume of them', async () => {
-  const WARNING_COUNT = 5000;
+  const WARNING_COUNT = 20000;
   const virtualId = '\0many-eval-warnings';
 
   let evalWarnings = 0;

--- a/packages/rolldown/tests/behaviors/many-warnings.test.ts
+++ b/packages/rolldown/tests/behaviors/many-warnings.test.ts
@@ -1,0 +1,43 @@
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+// Regression test for https://github.com/rolldown/rolldown/issues/9748.
+//
+// Replaying warnings used to do one Rust -> JS -> Rust round-trip per warning,
+// awaited sequentially. With tens of thousands of warnings that degenerated into
+// a pathological ping-pong across the napi bridge that could appear to hang the
+// build. Warnings are now emitted with bounded concurrency; this asserts that the
+// pipelining still delivers every warning exactly once (none dropped/duplicated)
+// and that a high-volume build completes.
+test('delivers every warning when a build emits a high volume of them', async () => {
+  const WARNING_COUNT = 5000;
+  const virtualId = '\0many-eval-warnings';
+
+  let evalWarnings = 0;
+  const bundle = await rolldown({
+    input: virtualId,
+    plugins: [
+      {
+        name: 'virtual-eval',
+        resolveId(id) {
+          if (id === virtualId) return id;
+        },
+        load(id) {
+          if (id === virtualId) {
+            // Each direct `eval(...)` call emits one EVAL warning during scan.
+            let src = '';
+            for (let i = 0; i < WARNING_COUNT; i++) src += `eval("${i}");\n`;
+            return src;
+          }
+        },
+      },
+    ],
+    onwarn(warning) {
+      if (warning.code === 'EVAL') evalWarnings++;
+    },
+  });
+  await bundle.generate({});
+  await bundle.close();
+
+  expect(evalWarnings).toBe(WARNING_COUNT);
+});


### PR DESCRIPTION
Fixes #9748.

## Problem

Emitting a high volume of warnings in one large module made the build appear to hang. Rendering was `O(N^2)` for two independent reasons, both paid once **per diagnostic**:

1. The ariadne `Source` (its rope + full line index) was rebuilt for the whole file on every diagnostic.
2. `is_context_too_long` built a whole-file `ropey::Rope` on every call, even though only the ~300 chars around the span matter.

With tens of thousands of warnings pointing into the same file, this quadratic work is what actually stalled the build.

## Fix

- Add `Diagnostic::render_batch`, which builds the per-source ariadne `Source` cache and a per-source `LineTable` once and shares them across all diagnostics. Line lookup is `O(log lines)` per diagnostic; the UTF-16 column is read by scanning only the matched line.
- Replace the per-call `ropey::Rope` in `is_context_too_long` with direct string slicing of the prefix/postfix around the span, removing the `ropey` dependency entirely.
- Dispatch warning callbacks **sequentially** in both the binding (`handle_warnings`) and the watcher (`emit_warnings`), awaiting each before the next. A handler may `throw` from `onwarn`/`onLog` to abort the build, so calls must stop at the first failure without racing later in-flight callbacks. The expensive part of #9748 was the per-warning re-render, not the JS round-trip, so this does not reintroduce the hang.

## Residual cost (documented, not a regression)

ariadne still prints the entire labelled line for every diagnostic, so N diagnostics all landing on one very long line (e.g. a minified bundle) cost `O(N * line_len)` inside ariadne itself. That is bounded by the same per-line cost and is unrelated to the cross-diagnostic `O(N^2)` blow-up this PR removes.

## Tests

- `delivers every warning when a build emits a high volume of them` — 20k EVAL warnings complete quickly and every warning is delivered exactly once.
- `throwing from a warning handler aborts before invoking later handlers` — guards the sequential-dispatch / throw-to-abort contract.
- A `LineTable` unit test validates line/column/UTF-16 offset math against an independent linear reference across multi-byte, astral, and trailing-newline edge cases.

> [!note]
> Will consolidate the existing byte locator in https://github.com/rolldown/rolldown/pull/9762