### PR TITLE
fix: Make external_import_binding_merger deterministic

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -187,10 +187,20 @@ impl LinkStage<'_> {
     self.external_import_namespace_merger = binding_ctx.external_import_namespace_merger;
 
     for (module_idx, map) in &binding_ctx.external_import_binding_merger {
-      for (key, symbol_set) in map {
+      let mut imported_binding_merger = map.iter().collect::<Vec<_>>();
+      imported_binding_merger.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
+
+      for (key, symbol_set) in imported_binding_merger {
         let name = if key.as_str() == "default" {
           let key = symbol_set
-            .first()
+            .iter()
+            .min_by_key(|symbol_ref| {
+              let symbol_ref = **symbol_ref;
+              (
+                self.module_table.modules[symbol_ref.owner].stable_id().as_str(),
+                symbol_ref.name(&self.symbols),
+              )
+            })
             .map_or_else(|| key.clone(), |sym_ref| sym_ref.name(&self.symbols).into());
           Cow::Owned(key)
         } else if is_validate_identifier_name(key.as_str()) {

--- a/crates/rolldown/tests/rolldown/issues/9754/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9754/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "platform": "node",
+    "input": [
+      { "name": "entry0", "import": "entry0.js" },
+      { "name": "entry1", "import": "entry1.js" }
+    ],
+    "external": ["node:process"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9754/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9754/artifacts.snap
@@ -1,0 +1,26 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry0.js
+
+```js
+import process from "node:process";
+//#region mod0.js
+console.log(0, process.pid);
+//#endregion
+export {};
+
+```
+
+## entry1.js
+
+```js
+import process from "node:process";
+//#region mod1.js
+console.log(1, process.pid);
+//#endregion
+export {};
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9754/entry0.js
+++ b/crates/rolldown/tests/rolldown/issues/9754/entry0.js
@@ -1,0 +1,1 @@
+import './mod0.js';

--- a/crates/rolldown/tests/rolldown/issues/9754/entry1.js
+++ b/crates/rolldown/tests/rolldown/issues/9754/entry1.js
@@ -1,0 +1,1 @@
+import './mod1.js';

--- a/crates/rolldown/tests/rolldown/issues/9754/mod0.js
+++ b/crates/rolldown/tests/rolldown/issues/9754/mod0.js
@@ -1,0 +1,3 @@
+import process from 'node:process';
+const process2 = 0;
+console.log(process2, process.pid);

--- a/crates/rolldown/tests/rolldown/issues/9754/mod1.js
+++ b/crates/rolldown/tests/rolldown/issues/9754/mod1.js
@@ -1,0 +1,3 @@
+import process2 from 'node:process';
+const process = 1;
+console.log(process, process2.pid);


### PR DESCRIPTION
Fixes #9754.

## Root cause

When naming an external **default** import, the name was derived from `IndexSet::first()` on the merged symbol set in `external_import_binding_merger`. `first()` reflects raw insertion (module load) order, so the chosen name — and therefore the generated output — could vary between builds, producing nondeterministic output.

## Fix

- Pick the default import name deterministically via `min_by_key((stable_id, name))` instead of `first()`.
- Iterate the binding-merger entries in sorted key order.

Adds the `issues/9754` regression fixture.

---

I verified that this patch stabilizes the output for the build in the repro: https://github.com/naruaway-sandbox/20260615-rolldown-nondeterministic-build-repro

However, I am not sure this fix is the right fix so feel free to close this PR and fix the issue in a different way if it's preferred
