### PR TITLE
fix(lazy-barrel): load locally-used imports on a re-exported record

### DIFF
--- a/crates/rolldown_common/src/types/lazy_barrel.rs
+++ b/crates/rolldown_common/src/types/lazy_barrel.rs
@@ -233,7 +233,14 @@ impl BarrelInfo {
             .extend(self.named.values().filter(|v| v.is_direct_reexport).map(|v| v.record_idx));
           reexports.extend(self.star.iter().copied());
           imported_exports_per_record.retain(|rec_idx, rec| match needs_records.entry(*rec_idx) {
-            Entry::Occupied(_) => true,
+            Entry::Occupied(mut occ) => {
+              if reexports.contains(rec_idx) {
+                true
+              } else {
+                occ.get_mut().merge(rec);
+                false
+              }
+            }
             Entry::Vacant(vac) => {
               if reexports.contains(rec_idx) {
                 vac.insert(ImportedExports::Partial(FxHashSet::default()));

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/_config.ts
@@ -1,0 +1,35 @@
+import { defineTest } from 'rolldown-tests';
+
+// Regression test for https://github.com/rolldown/rolldown/issues/9713
+//
+// `outer.js` is a side-effect-free barrel whose SINGLE import record from
+// `inner.js` is BOTH used locally (`setup`, called by the local export `build`)
+// and re-exported (`helper`) -- a "mixed" record. The entry requests the local
+// export `build` and the re-export `helper` together.
+//
+// Lazy barrel resolved `helper` first (marking that record "occupied"), then the
+// `has_local_export` branch skipped merging the locally-used `setup` into the
+// request. So `outer.js` asked `inner.js` only for `helper`; `inner.js`'s own
+// `store` import (used only by `setup`) was deferred, never re-resolved, and
+// `store.js` was dropped from the bundle. The emitted `setup` then referenced an
+// undefined `store`, throwing `ReferenceError: store is not defined` at runtime.
+export default defineTest({
+  config: {
+    input: './entry.js',
+    experimental: { lazyBarrel: true },
+    plugins: [
+      {
+        name: 'side-effect-free-barrel',
+        transform(_code, id) {
+          // The entry keeps its side effects; everything else is a
+          // side-effect-free barrel so it becomes a lazy-barrel candidate.
+          if (id.replace(/\\/g, '/').endsWith('/entry.js')) return null;
+          return { moduleSideEffects: false };
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/_test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+// Without the fix, lazy barrel drops `store.js`, so the emitted `setup`
+// references an unbound `store` and importing the bundle throws `ReferenceError`.
+import { result } from './dist/entry.js';
+
+assert.deepStrictEqual(result, ['setup-ran', 'helper']);

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/entry.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/entry.js
@@ -1,0 +1,5 @@
+import { build, helper } from './outer.js'; // requests a local export + a re-export together
+
+// `build()` runs at module-eval time. With the bug, `store` is dropped from the
+// bundle, so importing this entry throws `ReferenceError: store is not defined`.
+export const result = [build(), helper()];

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/inner.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/inner.js
@@ -1,0 +1,11 @@
+// Inner barrel. `setup` (local export) uses `store` from a SEPARATE record;
+// `helper` is re-exported. When `outer.js` only requests `helper`, `setup` looks
+// unused here, so the `./store.js` record is deferred and `store.js` is dropped.
+import { store } from './store.js';
+
+export { helper } from './reexported.js';
+
+export function setup() {
+  store.value = 'setup-ran';
+  return store.value;
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/outer.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/outer.js
@@ -1,0 +1,9 @@
+// Outer barrel. One import record carries BOTH `setup` (used by the local
+// `build` export) and `helper` (re-exported below) -- a "mixed" record.
+import { setup, helper } from './inner.js';
+
+export function build() {
+  return setup();
+}
+
+export { helper };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/reexported.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/reexported.js
@@ -1,0 +1,5 @@
+// Requesting this re-export is what makes the shared `inner.js` record
+// "occupied" and triggers the skip of the locally-used `setup`.
+export function helper() {
+  return 'helper';
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/store.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport/store.js
@@ -1,0 +1,2 @@
+// Wrongly dropped from the bundle when lazy barrel skips the deferred record.
+export const store = {};


### PR DESCRIPTION
## Summary

Fixes [#9713](https://github.com/rolldown/rolldown/issues/9713): with `experimental.lazyBarrel` enabled (the default), bundling `@elastic/apm-rum` produces code that throws `ReferenceError: serviceCreators is not defined` as soon as it is loaded. More generally, lazy barrel can drop a module that is still referenced, producing a dangling reference at runtime.

## Repro

```js
// index.js
import '@elastic/apm-rum';
```

Minimal, self-contained version (also added as a regression fixture):

```js
// entry.js  (has side effects; requests a local export + a re-export together)
import { build, helper } from './outer.js';
export const result = [build(), helper()];

// outer.js  (barrel B) — ONE record carries both `setup` (local use) and `helper` (re-export)
import { setup, helper } from './inner.js';
export function build() { return setup(); }
export { helper };

// inner.js  (barrel M) — local `setup` uses `store` from a SEPARATE record
import { store } from './store.js';
export { helper } from './reexported.js';
export function setup() { store.value = 'setup-ran'; return store.value; }

// store.js
export const store = {};        // <-- wrongly dropped
// reexported.js
export function helper() { return 'helper'; }
```

(`outer.js` / `inner.js` / `store.js` / `reexported.js` are side-effect-free.)

- `lazyBarrel: true`  -> `store.js` is dropped, `ReferenceError: store is not defined`
- `lazyBarrel: false` -> runs fine, `['setup-ran', 'helper']`

## Root cause

The trigger is a **mixed import record**: one module imported both for local use (`setup`, used by the local export `build`) and for re-export (`helper`), on the same record.

When `B` is requested with `{ build, helper }`:

1. `take_needed_records` resolves `helper` (re-export) first. It is removed from the record's remaining specifiers and the record is inserted into `needs_records` as `{ helper }`. The locally-used `setup` stays behind in `imported_exports_per_record`.
2. `build` makes `has_local_export` true. That branch is meant to force-load every record the barrel body depends on. But for this record `needs_records.entry(rec)` is now `Entry::Occupied`, and the arm was `Entry::Occupied(_) => true` (keep it lazily tracked, do not merge `setup`), so `setup` was never added to the request.
3. `B` therefore asks `M` only for `helper`. In `M`, `setup` looks unused, so its own `./store.js` record gets no requested name, is deferred with `resolved_module = None`, and (since nothing requests `M` again) is never re-resolved.
4. `setup` is still pulled into the bundle by tree-shaking (it is referenced by `B.build`). During symbol binding, the `store` import is skipped because its record's `resolved_module` is `None`, so `store.js` is dropped and `store` is undefined at runtime.

In `@elastic/apm-rum` this is `apm-rum-core/index.js` (B), the mixed record is `import { registerServices, observeUserInteractions } from './performance-monitoring'`, and the dropped dependency is `serviceCreators` from `common/service-factory.js`.

`error-logging/index.js` is structurally similar but has no re-export, so its record never becomes `Occupied` and it was always loaded correctly. That is why only `performance-monitoring` broke.

## Fix

`crates/rolldown_common/src/types/lazy_barrel.rs`, the `has_local_export` branch of `take_needed_records`. Make `Entry::Occupied` distinguish re-export vs local-use records, exactly like `Entry::Vacant` already does:

```rust
// before
imported_exports_per_record.retain(|rec_idx, rec| match needs_records.entry(*rec_idx) {
  Entry::Occupied(_) => true,
  Entry::Vacant(vac) => {
    if reexports.contains(rec_idx) { vac.insert(Partial(default())); true }
    else { vac.insert(rec.clone()); false }
  }
});

// after
imported_exports_per_record.retain(|rec_idx, rec| match needs_records.entry(*rec_idx) {
  Entry::Occupied(mut occ) => {
    if reexports.contains(rec_idx) {
      true                       // pure re-export: stay lazy
    } else {
      occ.get_mut().merge(rec);  // mixed/local-use: load the rest too
      false
    }
  }
  Entry::Vacant(vac) => {
    if reexports.contains(rec_idx) { vac.insert(Partial(default())); true }
    else { vac.insert(rec.clone()); false }
  }
});
```

### Why pure re-exports must stay lazy

`has_local_export` only needs to force-load records the barrel's **own code** depends on. A pure re-export (`export { x } from './y'`) has no local binding, so the barrel body cannot reference it. Its leftover specifiers are re-exports nobody requested yet, so they stay deferred and are loaded on demand by whoever actually imports them. Merging them would eagerly pull in unrelated modules, which is precisely the bloat lazy barrel exists to avoid. Only mixed/local-use records (whose leftovers the barrel body really does reference) get merged.

## Tests

- New fixture `packages/rolldown/tests/fixtures/lazy-barrel/shared-record-local-import-and-reexport` with a runtime assertion (`_test.mjs`) that fails on `main` and passes here.
- All lazy-barrel fixtures (17) pass; full concurrent (265) and sequential (101) fixture suites pass.