### PR TITLE
perf: avoid rebuilding replace plugin values

### DIFF
--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -88,7 +88,7 @@ impl ReplacePlugin {
     Ok(Self {
       matcher,
       prevent_assignment: options.prevent_assignment,
-      values: values.into_iter().collect(),
+      values,
       sourcemap: options.sourcemap,
     })
   }


### PR DESCRIPTION
Avoids collecting replace plugin values into the same map type after they have already been normalized.

Measured `cargo build -p rolldown_binding --release --lib` on macOS arm64:
23,675,392 -> 23,675,376 bytes (-16).