### PR TITLE
perf(deps): disable `infer` default features to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,17 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
-dependencies = [
- "byteorder",
- "fnv",
- "uuid",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,12 +803,6 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1412,9 +1395,6 @@ name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
-dependencies = [
- "cfb",
-]
 
 [[package]]
 name = "inotify"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ heck = "0.5.0"
 html5gum = "0.8.1"
 ignore = "0.4.23"
 indexmap = "2.9.0"
-infer = "0.19.0"
+infer = { version = "0.19.0", default-features = false }
 insta = "1.48.0"
 itertools = "0.14.0"
 itoa = "1.0.15"


### PR DESCRIPTION
`rolldown_utils` uses `infer` only via `infer::get()` on in-memory bytes for asset MIME detection (`crates/rolldown_utils/src/mime.rs`).

`infer`'s default `std` feature pulls in `cfb` (Microsoft Compound File Binary / legacy OLE detection for `.doc`/`.xls`/`.ppt`/`.msi`) plus `fnv`, neither of which rolldown needs — it only fingerprints web assets (images, fonts, wasm, archives, …), none of which are OLE containers.

Disabling default features drops `cfb` + `fnv` from the dependency graph and the shipped binary, with no functional change: the image/font/audio/video/archive matchers don't require `std`.
