### PR TITLE
docs: document why the napi tracing feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,8 @@ quote = "1"
 syn = { version = "2", default-features = false }
 
 # napi
+# Keep the `tracing` feature on: `#[napi]` logs every binding call, which helps debug deadlocks
+# (e.g. #7289) by showing which napi function is pending.
 napi = { version = "3.0.0", features = ["async", "anyhow", "tracing", "object_indexmap"] }
 napi-build = { version = "2.2.2" }
 napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }


### PR DESCRIPTION
Keep the napi `tracing` feature enabled and document the reason in `Cargo.toml`.

With the feature on, `#[napi]` logs every binding call, which helps debug deadlock issues like #7289 by showing which napi function is pending.