### PR TITLE
perf: reduce addon hook tracing size

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -32,11 +32,6 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[tracing::instrument(
-    level = "trace",
-    target = "rolldown_plugin::plugin_driver::output_hooks::total::banner",
-    skip_all
-  )]
   pub async fn banner(&self, args: HookAddonArgs, mut banner: String) -> Result<Option<String>> {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_banner_meta)
@@ -55,11 +50,6 @@ impl PluginDriver {
     Ok(Some(banner))
   }
 
-  #[tracing::instrument(
-    level = "trace",
-    target = "rolldown_plugin::plugin_driver::output_hooks::total::footer",
-    skip_all
-  )]
   pub async fn footer(&self, args: HookAddonArgs, mut footer: String) -> Result<Option<String>> {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_footer_meta)
@@ -78,11 +68,6 @@ impl PluginDriver {
     Ok(Some(footer))
   }
 
-  #[tracing::instrument(
-    level = "trace",
-    target = "rolldown_plugin::plugin_driver::output_hooks::total::intro",
-    skip_all
-  )]
   pub async fn intro(&self, args: HookAddonArgs, mut intro: String) -> Result<Option<String>> {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_intro_meta)
@@ -101,11 +86,6 @@ impl PluginDriver {
     Ok(Some(intro))
   }
 
-  #[tracing::instrument(
-    level = "trace",
-    target = "rolldown_plugin::plugin_driver::output_hooks::total::outro",
-    skip_all
-  )]
   pub async fn outro(&self, args: HookAddonArgs, mut outro: String) -> Result<Option<String>> {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_outro_meta)


### PR DESCRIPTION
Removes trace instrumentation wrappers from addon output hook dispatchers while keeping hook execution unchanged.

Measured `cargo build -p rolldown_binding --release --lib` on macOS arm64:
23,675,392 -> 23,675,344 bytes (-48).