### PR TITLE
feat(tracing): gate chrome-json trace layer behind `chrome-tracing` feature

### DIFF
--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -92,5 +92,6 @@ mimalloc-safe = { workspace = true, features = [
 napi-build = { workspace = true }
 
 [features]
+chrome-tracing = ["rolldown_tracing/chrome-tracing"]
 default_global_allocator = []
 disable_panic_hook = []

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -22,5 +22,10 @@ test = false
 
 [dependencies]
 tracing = { workspace = true, features = ["valuable"] }
-tracing-chrome = { workspace = true }
-tracing-subscriber = { workspace = true, default-features = false, features = ["std"] }
+tracing-chrome = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, default-features = false, features = ["fmt", "ansi"] }
+
+[features]
+# Enables the `RD_LOG_OUTPUT=chrome-json` profiling trace layer. Off by default so
+# it is excluded from release builds; enable it for profile builds when needed.
+chrome-tracing = ["dep:tracing-chrome"]

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -4,10 +4,14 @@
 ///   - https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 /// - Using `RD_LOG=trace RD_LOG_OUTPUT=chrome-json` to collect tracing events into a json file.
 ///   - Using `RD_LOG_OUTPUT_STYLE=async` to record traces as a group of asynchronous operations.
+///   - Requires building with the `chrome-tracing` feature, which is enabled for profile
+///     builds but disabled in release builds to keep the shipped binary smaller.
 use std::sync::atomic::AtomicBool;
 use std::{any::Any, str::FromStr};
 
+#[cfg(feature = "chrome-tracing")]
 use tracing_chrome::ChromeLayerBuilder;
+#[cfg(feature = "chrome-tracing")]
 use tracing_chrome::TraceStyle;
 use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::{
@@ -44,15 +48,39 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
 
   match output_mode.as_str() {
     "chrome-json" | "chrome-json-threaded" => {
-      let trace_style =
-        if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
-      let (chrome_layer, guard) =
-        ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
-      tracing_subscriber::registry()
-        .with(Targets::from_str(&env_var).unwrap())
-        .with(chrome_layer.with_filter(filter_for_removing_devtools_event))
-        .init();
-      Some(Box::new(guard))
+      #[cfg(feature = "chrome-tracing")]
+      {
+        let trace_style =
+          if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
+        let (chrome_layer, guard) =
+          ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
+        tracing_subscriber::registry()
+          .with(Targets::from_str(&env_var).unwrap())
+          .with(chrome_layer.with_filter(filter_for_removing_devtools_event))
+          .init();
+        Some(Box::new(guard))
+      }
+      #[cfg(not(feature = "chrome-tracing"))]
+      {
+        #![expect(clippy::print_stderr, reason = "Warn before tracing is initialized")]
+        eprintln!(
+          "`RD_LOG_OUTPUT={output_mode}` requires building with the `chrome-tracing` feature, \
+           which is disabled in release builds. Falling back to readable stdout output. \
+           Build a profile binary (`pnpm build-binding:profile`) to enable chrome tracing."
+        );
+        tracing_subscriber::registry()
+          .with(filter_for_removing_devtools_event)
+          .with(Targets::from_str(&env_var).unwrap())
+          .with(
+            fmt::layer()
+              .pretty()
+              .with_span_events(FmtSpan::NONE)
+              .with_level(true)
+              .with_target(false),
+          )
+          .init();
+        None
+      }
     }
     "json" => {
       panic!("`json` output mode is not implemented yet");

--- a/docs/development-guide/tracing-logging.md
+++ b/docs/development-guide/tracing-logging.md
@@ -13,6 +13,8 @@ RD_LOG=debug [executing rolldown]
 RD_LOG=debug RD_LOG_OUTPUT=chrome-json [executing rolldown]
 ```
 
+`RD_LOG_OUTPUT=chrome-json` requires building with the `chrome-tracing` cargo feature, which is enabled for profile builds (`pnpm build-binding:profile`) but disabled in release builds to keep the shipped binary smaller. Without it, rolldown falls back to readable stdout output and prints a warning.
+
 ## Add logging
 
 It's fine to add `tracing::debug!` or `tracing::trace!` calls in your PRs. However, to avoid noise in the logs, you should be careful about choosing `tracing::debug!` or `tracing::trace!`.

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -99,7 +99,7 @@
     "artifacts": "napi artifacts --cwd ./src --package-json-path ../package.json -o=../artifacts --npm-dir ../npm",
     "build-binding": "oxnode ./build-binding.ts",
     "build-binding:release": "pnpm build-binding --release",
-    "build-binding:profile": "pnpm build-binding --profile profile",
+    "build-binding:profile": "pnpm build-binding --profile profile --features chrome-tracing",
     "build-binding:wasi": "pnpm build-binding --target wasm32-wasip1-threads",
     "build-binding:wasi:release": "pnpm build-binding --profile release-wasi --target wasm32-wasip1-threads",
     "# Scrips for node #": "_",


### PR DESCRIPTION
### What

- Make `tracing-chrome` an optional dependency, gated behind a new non-default `chrome-tracing` cargo feature in `rolldown_tracing`.
- `RD_LOG_OUTPUT=chrome-json` / `chrome-json-threaded` now compile only when `chrome-tracing` is enabled.
- `rolldown_binding` re-exports the feature as `chrome-tracing = ["rolldown_tracing/chrome-tracing"]`.
- `build-binding:profile` passes `--features chrome-tracing`, so profile builds keep the trace layer; `build-native:memory-profile` inherits it via that script.
- Release builds (`build-binding:release`) carry no extra features, so `tracing-chrome` is fully excluded from the shipped binary.

### Why

- Per the discussion in Discord (cc @Boshen / sapphi), the chrome-json profiling trace layer is not needed in release builds; dropping it trims ~150–300KB from the shipped binary.
- It stays available in profile builds, so we can still ask users with perf issues to capture a chrome trace when needed.

### Behavior when the feature is off

- Normal `RD_LOG` tracing (readable/stdout) is unchanged.
- Setting `RD_LOG_OUTPUT=chrome-json` on a release binary prints a warning and falls back to readable stdout output instead of failing.

### Verification

- `cargo check`/`clippy` pass for `rolldown_tracing`, `rolldown`, and `rolldown_binding` both with and without `chrome-tracing`.
- `cargo tree -i tracing-chrome` confirms the crate is absent by default and present only with the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)