### PR TITLE
chore: clarify `rolldown_plugin_vite_*` is compatible for the same minor

### DIFF
--- a/crates/rolldown_plugin_vite_alias/README.md
+++ b/crates/rolldown_plugin_vite_alias/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_asset/README.md
+++ b/crates/rolldown_plugin_vite_asset/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_asset_import_meta_url/README.md
+++ b/crates/rolldown_plugin_vite_asset_import_meta_url/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_build_import_analysis/README.md
+++ b/crates/rolldown_plugin_vite_build_import_analysis/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is xclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_css/README.md
+++ b/crates/rolldown_plugin_vite_css/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_css_post/README.md
+++ b/crates/rolldown_plugin_vite_css_post/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/README.md
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_html/README.md
+++ b/crates/rolldown_plugin_vite_html/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_html_inline_proxy/README.md
+++ b/crates/rolldown_plugin_vite_html_inline_proxy/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_import_glob/README.md
+++ b/crates/rolldown_plugin_vite_import_glob/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_json/README.md
+++ b/crates/rolldown_plugin_vite_json/README.md
@@ -1,8 +1,11 @@
 # Maintenance Guide
 
-A plugin for `rolldown-vite` that handles the transformation of JSON files into JavaScript modules, ported from `Vite`'s [jsonPlugin](https://github.com/vitejs/rolldown-vite/blob/fa33494/packages/vite/src/node/plugins/json.ts).
+A plugin for `vite` that handles the transformation of JSON files into JavaScript modules, ported from `Vite`'s [jsonPlugin](https://github.com/vitejs/rolldown-vite/blob/fa33494/packages/vite/src/node/plugins/json.ts).
 
-**This plugin is exclusive to `rolldown-vite` and is not recommended for external use.**
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.
 
 ## 📦 What it does
 

--- a/crates/rolldown_plugin_vite_load_fallback/README.md
+++ b/crates/rolldown_plugin_vite_load_fallback/README.md
@@ -1,8 +1,11 @@
 # Maintenance Guide
 
-A plugin for `rolldown-vite` that handles loading files with `query` or `hash` fragments, ported from `Vite`'s [loadFallbackPlugin](https://github.com/vitejs/rolldown-vite/blob/fa334944/packages/vite/src/node/plugins/loadFallback.ts).
+A plugin for `vite` that handles loading files with `query` or `hash` fragments, ported from `Vite`'s [loadFallbackPlugin](https://github.com/vitejs/rolldown-vite/blob/fa334944/packages/vite/src/node/plugins/loadFallback.ts).
 
-**This plugin is exclusive to `rolldown-vite` and is not recommended for external use.**
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.
 
 ## 📦 What it does
 

--- a/crates/rolldown_plugin_vite_manifest/README.md
+++ b/crates/rolldown_plugin_vite_manifest/README.md
@@ -1,8 +1,11 @@
 # Maintenance Guide
 
-A plugin for `rolldown-vite` that generates a `manifest.json` mapping original filenames to emitted assets/chunks, ported from `Vite`'s [manifestPlugin](https://github.com/vitejs/rolldown-vite/blob/fa33494/packages/vite/src/node/plugins/manifest.ts).
+A plugin for `vite` that generates a `manifest.json` mapping original filenames to emitted assets/chunks, ported from `Vite`'s [manifestPlugin](https://github.com/vitejs/rolldown-vite/blob/fa33494/packages/vite/src/node/plugins/manifest.ts).
 
-**This plugin is exclusive to `rolldown-vite` and is not recommended for external use.**
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.
 
 ## 📦 What it does
 

--- a/crates/rolldown_plugin_vite_module_preload_polyfill/README.md
+++ b/crates/rolldown_plugin_vite_module_preload_polyfill/README.md
@@ -1,8 +1,11 @@
 # Maintenance Guide
 
-A plugin for [rolldown-vite](https://github.com/vitejs/rolldown-vite) that injects a `modulepreload` polyfill for legacy browsers, ported from [Vite's `modulePreloadPolyfillPlugin`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/modulePreloadPolyfill.ts#L34).
+A plugin for [vite](https://github.com/vitejs/rolldown-vite) that injects a `modulepreload` polyfill for legacy browsers, ported from [Vite's `modulePreloadPolyfillPlugin`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/modulePreloadPolyfill.ts#L34).
 
-**This plugin is exclusive to `rolldown-vite` and is currently considered unstable for external use.**
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.
 
 ## 📦 What it does
 

--- a/crates/rolldown_plugin_vite_react_refresh_wrapper/README.md
+++ b/crates/rolldown_plugin_vite_react_refresh_wrapper/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_reporter/README.md
+++ b/crates/rolldown_plugin_vite_reporter/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_resolve/README.md
+++ b/crates/rolldown_plugin_vite_resolve/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_transform/README.md
+++ b/crates/rolldown_plugin_vite_transform/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.

--- a/crates/rolldown_plugin_vite_web_worker_post/README.md
+++ b/crates/rolldown_plugin_vite_web_worker_post/README.md
@@ -1,0 +1,6 @@
+# Maintenance Guide
+
+> [!NOTE]
+> This plugin is exclusive to `vite`; external use is not recommended.
+> Its API may change between minor versions of `rolldown`, but
+> stays compatible within the same minor version.


### PR DESCRIPTION
tsdown only pins Rolldown with `~` (https://github.com/rolldown/tsdown/issues/966) and Vite is also going to use `~`. This PR adds READMEs to clarify that `rolldown_plugin_vite_*` should be compatible for the same minor version.