### PR TITLE
refactor: remove unnecessary `Arc` around sourcemap sender

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -116,7 +116,7 @@ pub struct ModuleLoader<'a, Fs: FileSystem + Clone + 'static> {
   new_added_modules_from_partial_scan: FxIndexSet<ModuleIdx>,
   cache: &'a mut ScanStageCache,
   pub flat_options: FlatOptions,
-  pub magic_string_tx: Option<Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+  pub magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
   tla_module_count: usize,
   /// Centralized map from modules that contain top-level `await` to the span
   /// of the first TLA keyword. Stored here instead of on every `EcmaView`
@@ -166,7 +166,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     plugin_driver: SharedPluginDriver,
     cache: &'a mut ScanStageCache,
     is_full_scan: bool,
-    magic_string_tx: Option<Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+    magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
   ) -> BuildResult<Self> {
     if is_full_scan {
       // TODO: drop the cache in another thread

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -51,7 +51,7 @@ pub struct ModuleTask<Fs: FileSystem + Clone + 'static> {
   /// The module is asserted to be this specific module type.
   asserted_module_type: Option<ModuleType>,
   flat_options: FlatOptions,
-  magic_string_tx: Option<std::sync::Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+  magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
 }
 
 impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
@@ -64,7 +64,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     is_user_defined_entry: bool,
     assert_module_type: Option<ModuleType>,
     flat_options: FlatOptions,
-    magic_string_tx: Option<std::sync::Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+    magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
   ) -> Self {
     Self {
       ctx,
@@ -251,7 +251,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     &self,
     sourcemap_chain: &mut Vec<SourcemapChainElement>,
     hook_side_effects: &mut Option<rolldown_common::side_effects::HookSideEffects>,
-    magic_string_tx: Option<std::sync::Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+    magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
   ) -> BuildResult<(StrOrBytes, ModuleType)> {
     let mut is_read_from_disk = true;
     let result = load_source(

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 type SourcemapChannel = (
-  Option<Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>>,
+  Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
   Option<thread::JoinHandle<FxHashMap<ModuleIdx, Vec<SourcemapChainElement>>>>,
 );
 
@@ -232,7 +232,7 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
         }
         map
       });
-      (Some(Arc::new(tx)), Some(handler))
+      (Some(tx), Some(handler))
     } else {
       (None, None)
     }

--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::sync::mpsc::Sender;
 
 use anyhow::Result;
@@ -20,7 +19,7 @@ pub async fn transform_source(
   sourcemap_chain: &mut Vec<SourcemapChainElement>,
   side_effects: &mut Option<HookSideEffects>,
   module_type: &mut ModuleType,
-  magic_string_tx: Option<Arc<Sender<SourceMapGenMsg>>>,
+  magic_string_tx: Option<Sender<SourceMapGenMsg>>,
 ) -> Result<String> {
   plugin_driver
     .transform(

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -16,7 +16,7 @@ pub struct TransformPluginContext {
   id: ArcStr,
   module_idx: ModuleIdx,
   plugin_idx: PluginIdx,
-  magic_string_tx: Option<Arc<mpsc::Sender<SourceMapGenMsg>>>,
+  magic_string_tx: Option<mpsc::Sender<SourceMapGenMsg>>,
 }
 
 impl TransformPluginContext {
@@ -27,7 +27,7 @@ impl TransformPluginContext {
     id: ArcStr,
     module_idx: ModuleIdx,
     plugin_idx: PluginIdx,
-    magic_string_tx: Option<Arc<mpsc::Sender<SourceMapGenMsg>>>,
+    magic_string_tx: Option<mpsc::Sender<SourceMapGenMsg>>,
   ) -> Self {
     Self { inner, sourcemap_chain, original_code, id, module_idx, plugin_idx, magic_string_tx }
   }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -257,7 +257,7 @@ impl PluginDriver {
     sourcemap_chain: &mut Vec<SourcemapChainElement>,
     side_effects: &mut Option<HookSideEffects>,
     module_type: &mut ModuleType,
-    magic_string_tx: Option<Arc<std::sync::mpsc::Sender<rolldown_common::SourceMapGenMsg>>>,
+    magic_string_tx: Option<std::sync::mpsc::Sender<rolldown_common::SourceMapGenMsg>>,
     code_changed_by_plugins: &mut Option<Vec<String>>,
   ) -> Result<String> {
     let mut code = original_code;


### PR DESCRIPTION
This PR replaces `Arc<std::sync::mpsc::Sender<SourceMapGenMsg>>` with a cloned `Sender<SourceMapGenMsg>`.

`std::sync::mpsc::Sender is already a clonable multi-producer handle. Cloning a sender creates another handle to the same channel, so wrapping it in an `Arc` ads another unnecessary layer of shared ownership witout chaning semantics.

Before, callsers shared

```
  Arc<Sender<SourceMapGenMsg>>
```

After, callers pass:

```
  Sender<SourceMapGenMsg>
```

Each cloned Sender still sends to the same receiver owned by the sourcemap worker thread. The receiver, shutdown behavior, and message propagation remain the same; this change only removes the extra Arc allocation/refcount indirection around a type that already provides the sharing model needed here.