### PR TITLE
refactor: remove redundant Arc around tracing spans

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -36,11 +36,11 @@ pub struct Bundle<Fs: FileSystem + Clone + 'static = OsFileSystem> {
   pub(crate) plugin_driver: SharedPluginDriver,
   pub(crate) warnings: Vec<BuildDiagnostic>,
   pub(crate) cache: ScanStageCache,
-  pub(crate) bundle_span: Arc<tracing::Span>,
+  pub(crate) bundle_span: tracing::Span,
 }
 
 impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn write(mut self) -> BuildResult<BundleOutput> {
     let start = self.plugin_driver.start_timing();
@@ -58,7 +58,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     self.append_plugin_timings_warning(result)
   }
 
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn generate(mut self) -> BuildResult<BundleOutput> {
     let start = self.plugin_driver.start_timing();
@@ -79,7 +79,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     self.append_plugin_timings_warning(result)
   }
 
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn scan(mut self) -> BuildResult<()> {
     self.scan_modules(ScanMode::Full).await?;
@@ -87,7 +87,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     Ok(())
   }
 
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   pub async fn scan_modules(
     &mut self,
     scan_mode: ScanMode<ArcStr>,
@@ -151,7 +151,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     }
   }
 
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   pub async fn bundle_write(
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,
@@ -220,7 +220,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     Ok(output)
   }
 
-  #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
+  #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   pub async fn bundle_generate(
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,

--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -93,17 +93,17 @@ impl BundleFactory {
     })
   }
 
-  fn generate_unique_bundle_span(&mut self) -> Arc<tracing::Span> {
+  fn generate_unique_bundle_span(&mut self) -> tracing::Span {
     let bundle_id = rolldown_devtools::generate_build_id(self.bundle_id_seed);
     self.bundle_id_seed += 1;
-    Arc::new(tracing::info_span!(
+    tracing::info_span!(
       parent: &self.session.span,
       "build",
       CONTEXT_build_id = bundle_id.as_ref(),
       // - This behaves like default value for `${hook_resolve_id_trigger}`.
       // - For case like injecting `manual`, we will override this field by adding a child span to shadow this one.
       CONTEXT_hook_resolve_id_trigger = "automatic"
-    ))
+    )
   }
 
   pub fn create_bundle(

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -42,11 +42,11 @@ pub struct NativePluginContextImpl {
   pub(crate) module_infos: SharedModuleInfoDashMap,
   pub(crate) tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<ModuleLoaderMsg>>>>,
   pub(crate) session: rolldown_devtools::Session,
-  pub(crate) bundle_span: Arc<tracing::Span>,
+  pub(crate) bundle_span: tracing::Span,
   // `resolve_id` hook not only will be triggered by the rolldown's resolve process, but also could be triggered
   // by manual calls of `PluginContext.resolve()`. We use a dedicated span here to distinguish whether the call is
   // - automatic (by rolldown) or manual (by `PluginContext.resolve()`)
-  pub(crate) manual_resolve_span: Arc<tracing::Span>,
+  pub(crate) manual_resolve_span: tracing::Span,
 }
 
 impl NativePluginContextImpl {
@@ -129,7 +129,7 @@ impl NativePluginContextImpl {
       )
       .await
     }
-    .instrument(self.manual_resolve_span.as_ref().clone())
+    .instrument(self.manual_resolve_span.clone())
     .await
   }
 

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -62,8 +62,8 @@ impl PluginContext {
         module_infos: Arc::clone(&ctx.module_infos),
         tx: Arc::clone(&ctx.tx),
         session: ctx.session.clone(),
-        bundle_span: Arc::clone(&ctx.bundle_span),
-        manual_resolve_span: Arc::clone(&ctx.manual_resolve_span),
+        bundle_span: ctx.bundle_span.clone(),
+        manual_resolve_span: ctx.manual_resolve_span.clone(),
       })),
     }
   }

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -34,7 +34,7 @@ impl PluginDriverFactory {
     file_emitter: &SharedFileEmitter,
     options: &SharedNormalizedBundlerOptions,
     session: &rolldown_devtools::Session,
-    initial_bundle_span: &Arc<tracing::Span>,
+    initial_bundle_span: &tracing::Span,
     module_infos: SharedModuleInfoDashMap,
     transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   ) -> Arc<crate::plugin_driver::PluginDriver> {
@@ -43,15 +43,14 @@ impl PluginDriverFactory {
     let tx = Arc::new(std::sync::Mutex::new(None));
     let mut plugin_usage_vec = IndexVec::new();
 
-    // Clone the Arc to share across contexts
-    let bundle_span_arc = Arc::clone(initial_bundle_span);
+    let bundle_span = initial_bundle_span.clone();
 
     // Create derived span for manual resolve calls
-    let manual_resolve_span_arc = Arc::new(tracing::debug_span!(
-      parent: bundle_span_arc.as_ref(),
+    let manual_resolve_span = tracing::debug_span!(
+      parent: &bundle_span,
       "plugin_context_resolve",
       CONTEXT_hook_resolve_id_trigger = "manual"
-    ));
+    );
 
     // Create timing collector only if checks.pluginTimings is enabled
     let hook_timing_collector = if options.checks.contains(EventKindSwitcher::PluginTimings) {
@@ -89,8 +88,8 @@ impl PluginDriverFactory {
           watch_files: Arc::clone(&watch_files),
           tx: Arc::clone(&tx),
           session: session.clone(),
-          bundle_span: Arc::clone(&bundle_span_arc),
-          manual_resolve_span: Arc::clone(&manual_resolve_span_arc),
+          bundle_span: bundle_span.clone(),
+          manual_resolve_span: manual_resolve_span.clone(),
         })));
       });
 

--- a/meta/design/rust-bundler.md
+++ b/meta/design/rust-bundler.md
@@ -63,7 +63,7 @@ pub struct Bundle {
     plugin_driver: SharedPluginDriver,
     warnings: Vec<BuildDiagnostic>,
     cache: ScanStageCache,
-    bundle_span: Arc<tracing::Span>,
+    bundle_span: tracing::Span,
 }
 ```
 


### PR DESCRIPTION
`tracing::Span` is already a cheap, cloneable handle. Cloning it does not clone the full span data or create a new tracing span; it just creates another handle pointing at the same underlying span state.

That means Arc<tracing::Span> is redundant here:

```
Arc::clone(&span)
```
  and
```
span.clone()
```

both represent shared ownership of the same span handle, but `Arc` adds an extra allocation/refcount layer around a type that already has its own cheap handle semantics.
