### PR TITLE
fix: wrap node require helper in pure IIFE

### DIFF
--- a/crates/rolldown/src/runtime/runtime-tail-node.js
+++ b/crates/rolldown/src/runtime/runtime-tail-node.js
@@ -1,4 +1,4 @@
 // This is created by the rolldown. It's used to polyfill the global `require` function when you bundling code
 // with target `format: 'es'` and `platform: 'node'`. It's used to make sure the global `require` could
 // works in Node.js esm environment.
-export var __require = /* @__PURE__ */ createRequire(import.meta.url);
+export var __require = /* #__PURE__ */ (() => createRequire(import.meta.url))();

--- a/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { createRequire } from "node:module";
 //#endregion
 //#region main.js
-(/* @__PURE__ */ createRequire(import.meta.url))("fs");
+(/* @__PURE__ */ (() => createRequire(import.meta.url))())("fs");
 //#endregion
 export {};
 

--- a/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { createRequire } from "node:module";
 //#endregion
 //#region main.js
-var main_default = (/* @__PURE__ */ createRequire(import.meta.url))("path").join;
+var main_default = (/* @__PURE__ */ (() => createRequire(import.meta.url))())("path").join;
 //#endregion
 export { main_default as default };
 

--- a/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "treeshake": false,
+    "platform": "node"
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/_test.mjs
@@ -1,0 +1,11 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const main = fs.readFileSync(path.join(distDir, 'main.js'), 'utf8');
+
+assert(
+  !main.includes('import.meta.url'),
+  'There should not be an import.meta.url in the main.js file',
+);

--- a/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/artifacts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import "node:module";
+//#endregion
+export {};
+
+```


### PR DESCRIPTION
fixes #9782
Hi Team,
This PR fixes an issue where `import.meta.url` was preserved in the output even when the `createRequire(import.meta.url)` helper was unused and removed.

The issue happens because the pure annotation on `createRequire(import.meta.url)` only marks the function call as pure, but not the argument. Because of that, `import.meta.url` can still be left in the final output as a standalone expression.

This PR wraps the helper initialization in a pure IIFE, so the whole expression can be removed when the helper is unused.


