### PR TITLE
fix(deps): bump mimalloc-safe to 0.1.63 to fix worker_threads segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys2"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52406d0c46b81d2f65422a6d6086172f4e6b2753414cbee48be53850f90b804e"
+checksum = "9f9aa481aef14f119fb6d06536fd475dff463130ba19c5d5eb0821a5763e0d75"
 dependencies = [
  "cc",
  "cmake",
@@ -1664,9 +1664,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mimalloc-safe"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8b607e1874a1962cca1b926ffcf66c62aeda8cb62634acd904ee39582ed323"
+checksum = "fb255e42b32f2e317b73c3c7285556cfd5a1bcf5ce272d4adce8c49e5e828ec2"
 dependencies = [
  "libmimalloc-sys2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ json-escape-simd = "3"
 json-strip-comments = "3"
 jsonschema = { version = "0.46.5", default-features = false }
 memchr = "2.8.2"
-mimalloc-safe = "0.1.62"
+mimalloc-safe = "0.1.63"
 mime = "0.3.17"
 nodejs-built-in-modules = "1.0.0"
 nom = "8.0.0"


### PR DESCRIPTION
### What

Bumps `mimalloc-safe` `0.1.62` → `0.1.63` (which bumps `libmimalloc-sys2` `0.1.58` → `0.1.59`).

Fixes #9722.

### Why

`mimalloc-safe` 0.1.62 vendors mimalloc **v3.3.2**, which has a v3.3.x regression in the per-thread heap teardown. The thread that first initializes mimalloc is recorded as the "main" thread (`tld_main.thread_id`) and owns the static `theap_main`. When that thread exits while the process keeps running, mimalloc tears `theap_main` down (`heap = NULL`, `tld = NULL`) but **never resets `tld_main.thread_id`**. The OS then recycles that thread id for a later thread, which `_mi_is_main_thread()` now misidentifies as "main" and adopts the torn-down `theap_main` → `NULL` deref → **SIGSEGV**.

In a Node `worker_threads` host this is deterministic: the first worker to `dlopen` the addon becomes mimalloc's main thread; after it exits and is joined, the next worker's thread reuses the same pthread id and crashes on its first allocation (inside `napi_register_module_v1`). That's exactly the "second worker segfaults" symptom in #9722. macOS + Linux affected, Windows not.

This was fixed upstream in `microsoft/mimalloc` dev3 — `b92c116b` ("allow initial main thread to terminate before the process terminates") + follow-up `e5047591`, tracked as upstream issue [microsoft/mimalloc#1287](https://github.com/microsoft/mimalloc/issues/1287). `mimalloc-safe` 0.1.63 vendors that fix.

### Verification

Built the release binding against published `mimalloc-safe` 0.1.63 and ran the #9722 reproduction (`worker_threads` loading rolldown N times in one process) on macOS arm64:

- **0.1.62 (before):** segfaults on the 2nd worker, `exit=139` — reproduces the issue deterministically.
- **0.1.63 (after):** 5/5 runs pass, all workers exit 0.

Confirmed the crate pulled from crates.io contains the upstream fix (`MI_THREADID_INVALID` reset in `mi_tld_free`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
