### PR TITLE
test(dev): restore shared-page reliability conventions in AGENTS.md

### DIFF
--- a/packages/test-dev-server/tests/AGENTS.md
+++ b/packages/test-dev-server/tests/AGENTS.md
@@ -38,6 +38,10 @@ describe('<name>', () => {
 
 Synchronize on the server's async work — never `sleep`. Poll the DOM with `expect.poll`, `await waitForBuildStable()` before a follow-up edit, or wait on a browser log with `untilBrowserLogAfter`.
 
+Tests in one spec file share a single `page` and run sequentially, so don't let them perturb one another. Keep **edits forward-only** — or restore what they changed, since a later test must not rely on an earlier one's edit being reverted. And **re-acquire element handles after any reload** (`page.locator(...)` / a fresh `page.$`); a reload invalidates the old ones.
+
+Prefer giving each scenario its **own DOM node** so one test's edits can't disturb another's assertions — `hmr-full-bundle-mode` keeps `.app`, `.hmr`, `.hmr-error`, and `.rebuild-error` separate, one per scenario.
+
 Build once (after changing rust or the dev-server `src/`):
 
 ```sh


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->


Clarify cases in https://github.com/rolldown/rolldown/pull/9763#issuecomment-4708694806