### PR TITLE
perf: remove the `url` crate (-226 KB)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,6 @@ dependencies = [
  "testing_macros",
  "tokio",
  "tracing",
- "url",
  "walkdir",
  "xxhash-rust",
 ]
@@ -3136,7 +3135,6 @@ dependencies = [
  "string_wizard",
  "sugar_path",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -3752,7 +3750,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "url",
  "urlencoding",
 ]
 
@@ -4636,18 +4633,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
 
 [[package]]
 name = "urlencoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,6 @@ tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.19", default-features = false }
 ts-rs = "12.0"
 typedmap = "0.6.0"
-url = "2.5.4"
 urlencoding = "2.1.3"
 uuid = "1.23.3"
 vfs = "0.13.0"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -66,7 +66,6 @@ string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = { workspace = true }
-url = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]

--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 use futures::future::try_join_all;
 use oxc::ast::CommentKind;
 use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
-use rolldown_error::{BuildResult, ResultExt};
+use rolldown_error::BuildResult;
 use rolldown_sourcemap::SourceMap;
 use sugar_path::SugarPath;
-use url::Url;
 
 use super::uuid::uuid_v4_string_from_u128;
 
@@ -120,11 +119,13 @@ pub async fn process_code_and_sourcemap(
               source.push_str("# sourceMappingURL=");
 
               match &options.sourcemap_base_url {
-                Some(url_string) => {
-                  let url = Url::parse(url_string)
-                    .and_then(|base| base.join(&map_filename))
-                    .map_err_to_unhandleable()?;
-                  source.push_str(url.as_str());
+                Some(base_url) => {
+                  // `base_url` is normalized to end with `/` (see
+                  // `normalize_sourcemap_base_url` in rolldown_binding), so
+                  // resolving the relative map filename against it is a plain
+                  // append.
+                  source.push_str(base_url);
+                  source.push_str(&map_filename);
                 }
                 None => {
                   source.push_str(

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -73,7 +73,6 @@ rustc-hash = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 tracing = { workspace = true }
-url = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit", "v3"] }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -29,7 +29,6 @@ use rolldown_utils::indexmap::FxIndexMap;
 use rolldown_utils::rustc_hash::FxHashMapExt;
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
-use url::Url;
 
 #[cfg(not(target_family = "wasm"))]
 use crate::{options::plugin::ParallelJsPlugin, worker_manager::WorkerManager};
@@ -329,21 +328,14 @@ pub fn normalize_binding_options(
     sourcemap_base_url: output_options
       .sourcemap_base_url
       .map(|maybe_url| {
-        Url::parse(&maybe_url)
-          .map(|mut url| {
-            if !url.path().ends_with('/') {
-              url.set_path(&rolldown_utils::concat_string!(url.path(), "/"));
-            }
-            url.to_string()
-          })
-          .map_err(|_err| {
-            napi::Error::new(
-              napi::Status::GenericFailure,
-              format!(
-                "Invalid value for `sourcemapBaseUrl` option, should be a valid URL: {maybe_url}"
-              ),
-            )
-          })
+        normalize_sourcemap_base_url(&maybe_url).ok_or_else(|| {
+          napi::Error::new(
+            napi::Status::GenericFailure,
+            format!(
+              "Invalid value for `sourcemapBaseUrl` option, should be a valid URL: {maybe_url}"
+            ),
+          )
+        })
       })
       .transpose()?,
     sourcemap_ignore_list,
@@ -647,4 +639,77 @@ pub fn normalize_binding_options(
     .collect::<Result<Vec<_>, _>>()?;
 
   Ok(BundlerConfig::new(bundler_options, plugins))
+}
+
+/// Validate that `value` is an absolute URL (`scheme://authority…`) and ensure
+/// its path ends with `/` so that joining the sourcemap filename later is a
+/// plain append. Reproduces the previous `url::Url::parse` + `set_path`
+/// behaviour for `sourcemapBaseUrl` without depending on the `url` crate.
+/// Returns `None` for invalid input (surfaced as the "should be a valid URL"
+/// error by the caller).
+fn normalize_sourcemap_base_url(value: &str) -> Option<String> {
+  let scheme_end = value.find("://")?;
+  let scheme = &value[..scheme_end];
+  if scheme.is_empty()
+    || !scheme.as_bytes()[0].is_ascii_alphabetic()
+    || !scheme.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
+    || value.len() <= scheme_end + 3
+  {
+    return None;
+  }
+
+  // Append `/` to the end of the path, before any `?query` / `#fragment`.
+  let suffix_start = value.find(['?', '#']).unwrap_or(value.len());
+  let (head, suffix) = value.split_at(suffix_start);
+  let mut normalized = String::with_capacity(value.len() + 1);
+  normalized.push_str(head);
+  if !head.ends_with('/') {
+    normalized.push('/');
+  }
+  normalized.push_str(suffix);
+  Some(normalized)
+}
+
+#[cfg(test)]
+mod sourcemap_base_url_tests {
+  use super::normalize_sourcemap_base_url;
+
+  #[test]
+  fn appends_trailing_slash() {
+    assert_eq!(
+      normalize_sourcemap_base_url("https://example.com/foo/bar").as_deref(),
+      Some("https://example.com/foo/bar/")
+    );
+  }
+
+  #[test]
+  fn keeps_existing_trailing_slash() {
+    assert_eq!(
+      normalize_sourcemap_base_url("https://example.com/foo/bar/").as_deref(),
+      Some("https://example.com/foo/bar/")
+    );
+  }
+
+  #[test]
+  fn bare_authority_gets_root_path() {
+    assert_eq!(
+      normalize_sourcemap_base_url("https://example.com").as_deref(),
+      Some("https://example.com/")
+    );
+  }
+
+  #[test]
+  fn slash_inserted_before_query_and_fragment() {
+    assert_eq!(
+      normalize_sourcemap_base_url("https://example.com/foo?x=1#h").as_deref(),
+      Some("https://example.com/foo/?x=1#h")
+    );
+  }
+
+  #[test]
+  fn rejects_non_absolute_urls() {
+    assert_eq!(normalize_sourcemap_base_url("/foo/bar"), None);
+    assert_eq!(normalize_sourcemap_base_url("example.com/foo"), None);
+    assert_eq!(normalize_sourcemap_base_url("://no-scheme"), None);
+  }
 }

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -32,5 +32,4 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }
-url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/rolldown_plugin_vite_resolve/src/file_url.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/file_url.rs
@@ -1,20 +1,66 @@
 use anyhow::anyhow;
-use url::Url;
+
+/// A minimally-parsed `file:` URL.
+///
+/// rolldown only handles `file://` URLs here (which never carry an
+/// internationalized host), so a small ASCII split replaces `url::Url` and
+/// avoids pulling the whole `url`/`idna` stack into the binary.
+struct FileUrl<'a> {
+  /// The original input, used verbatim in error messages.
+  original: &'a str,
+  /// Authority/host component, empty for the usual `file:///…` form.
+  host: &'a str,
+  /// Percent-encoded path. Always begins with `/`.
+  path: &'a str,
+  /// Raw query, without the leading `?`.
+  query: Option<&'a str>,
+  /// Raw fragment, without the leading `#`.
+  fragment: Option<&'a str>,
+}
+
+impl<'a> FileUrl<'a> {
+  /// The caller should check that `url` has a `file` scheme.
+  fn parse(url: &'a str) -> anyhow::Result<Self> {
+    let rest = url.strip_prefix("file:").ok_or_else(|| anyhow!("Invalid file URL: {url}"))?;
+    // Drop the authority marker (`file://…`); `file:/…` has none.
+    let rest = rest.strip_prefix("//").unwrap_or(rest);
+
+    let (rest, fragment) = match rest.split_once('#') {
+      Some((head, fragment)) => (head, Some(fragment)),
+      None => (rest, None),
+    };
+    let (rest, query) = match rest.split_once('?') {
+      Some((head, query)) => (head, Some(query)),
+      None => (rest, None),
+    };
+    // Everything before the first `/` is the host (empty for `file:///…`).
+    let (host, path) = match rest.find('/') {
+      Some(index) => rest.split_at(index),
+      None => (rest, "/"),
+    };
+
+    Ok(Self { original: url, host, path, query, fragment })
+  }
+
+  fn has_host(&self) -> bool {
+    !self.host.is_empty()
+  }
+}
 
 /// The caller should check if the url has file scheme.
 pub fn file_url_str_to_path_and_postfix(url: &str) -> anyhow::Result<(String, String)> {
-  let url = Url::parse(url)?;
+  let url = FileUrl::parse(url)?;
 
   let postfix = {
     let postfix_len =
-      url.query().map_or(0, |q| q.len() + 1) + url.fragment().map_or(0, |f| f.len() + 1);
+      url.query.map_or(0, |q| q.len() + 1) + url.fragment.map_or(0, |f| f.len() + 1);
 
     let mut postfix = String::with_capacity(postfix_len);
-    if let Some(q) = url.query() {
+    if let Some(q) = url.query {
       postfix.push('?');
       postfix.push_str(q);
     }
-    if let Some(f) = url.fragment() {
+    if let Some(f) = url.fragment {
       postfix.push('#');
       postfix.push_str(f);
     }
@@ -24,19 +70,18 @@ pub fn file_url_str_to_path_and_postfix(url: &str) -> anyhow::Result<(String, St
   // it seems url.to_file_path() does not work in some cases
   // https://github.com/servo/rust-url/issues/505
   // implemented the same logic with fileURLToPath in Node.js for now
-  let path = file_url_to_path(url)?;
+  let path = file_url_to_path(&url)?;
   Ok((path, postfix))
 }
 
-fn file_url_to_path(url: Url) -> anyhow::Result<String> {
+fn file_url_to_path(url: &FileUrl) -> anyhow::Result<String> {
   #[cfg(target_family = "wasm")]
   {
     use crate::utils::is_windows_drive_path;
 
-    let pathname = url.path();
     // NOTE: should be decided if it's running on Windows or not
     //       for now, decide it if the path has a drive part
-    if is_windows_drive_path(&pathname[1..]) {
+    if is_windows_drive_path(&url.path[1..]) {
       get_path_from_url_windows(url)
     } else {
       get_path_from_url_posix(url)
@@ -53,46 +98,88 @@ fn file_url_to_path(url: Url) -> anyhow::Result<String> {
 }
 
 #[cfg(any(windows, target_family = "wasm"))]
-fn get_path_from_url_windows(url: Url) -> anyhow::Result<String> {
+fn get_path_from_url_windows(url: &FileUrl) -> anyhow::Result<String> {
   use crate::utils::is_windows_drive_path;
   use cow_utils::CowUtils;
 
-  let pathname = url.path();
+  let pathname = url.path;
   if pathname.contains("%2F") || pathname.contains("%5C") {
     return Err(anyhow!(
       "Invalid file URL path: must not include encoded \\ or / characters {}",
-      url
+      url.original
     ));
   }
 
   let pathname = pathname.cow_replace('/', "\\");
   let pathname = urlencoding::decode(&pathname)?;
 
-  if url.host_str().is_some() {
+  if url.has_host() {
     // NOTE: this is supported by Node.js, but is not supported by Vite.
-    return Err(anyhow!("Invalid file URL: must not contain hostname {}", url));
+    return Err(anyhow!("Invalid file URL: must not contain hostname {}", url.original));
   }
   let pathname = &pathname[1..];
   if !is_windows_drive_path(pathname) {
-    return Err(anyhow!("Invalid file URL: must be absolute {}", url));
+    return Err(anyhow!("Invalid file URL: must be absolute {}", url.original));
   }
   Ok(pathname.to_owned())
 }
 
 #[cfg(not(windows))]
-fn get_path_from_url_posix(url: Url) -> anyhow::Result<String> {
-  if url.host_str().is_some() {
-    return Err(anyhow!("Invalid file URL: must not contain hostname {}", url));
+fn get_path_from_url_posix(url: &FileUrl) -> anyhow::Result<String> {
+  if url.has_host() {
+    return Err(anyhow!("Invalid file URL: must not contain hostname {}", url.original));
   }
 
-  let pathname = url.path();
+  let pathname = url.path;
   if pathname.contains("%2F") {
     return Err(anyhow!(
       "Invalid file URL path: must not include encoded \\ or / characters {}",
-      url
+      url.original
     ));
   }
 
   let pathname = urlencoding::decode(pathname)?;
   Ok(pathname.into_owned())
+}
+
+#[cfg(all(test, not(windows), not(target_family = "wasm")))]
+mod tests {
+  use super::file_url_str_to_path_and_postfix;
+
+  #[test]
+  fn plain_file_url() {
+    let (path, postfix) = file_url_str_to_path_and_postfix("file:///foo/bar.js").unwrap();
+    assert_eq!(path, "/foo/bar.js");
+    assert_eq!(postfix, "");
+  }
+
+  #[test]
+  fn query_and_fragment_become_postfix() {
+    let (path, postfix) =
+      file_url_str_to_path_and_postfix("file:///foo/bar.js?v=1#frag").unwrap();
+    assert_eq!(path, "/foo/bar.js");
+    assert_eq!(postfix, "?v=1#frag");
+  }
+
+  #[test]
+  fn percent_encoded_path_is_decoded() {
+    let (path, _) = file_url_str_to_path_and_postfix("file:///foo/a%20b.js").unwrap();
+    assert_eq!(path, "/foo/a b.js");
+  }
+
+  #[test]
+  fn hostname_is_rejected() {
+    assert!(file_url_str_to_path_and_postfix("file://localhost/foo.js").is_err());
+  }
+
+  #[test]
+  fn encoded_slash_is_rejected() {
+    assert!(file_url_str_to_path_and_postfix("file:///foo%2Fbar.js").is_err());
+  }
+
+  #[test]
+  fn single_slash_form() {
+    let (path, _) = file_url_str_to_path_and_postfix("file:/foo/bar.js").unwrap();
+    assert_eq!(path, "/foo/bar.js");
+  }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/file_url.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/file_url.rs
@@ -155,8 +155,7 @@ mod tests {
 
   #[test]
   fn query_and_fragment_become_postfix() {
-    let (path, postfix) =
-      file_url_str_to_path_and_postfix("file:///foo/bar.js?v=1#frag").unwrap();
+    let (path, postfix) = file_url_str_to_path_and_postfix("file:///foo/bar.js?v=1#frag").unwrap();
     assert_eq!(path, "/foo/bar.js");
     assert_eq!(postfix, "?v=1#frag");
   }


### PR DESCRIPTION
## Do we really need the `url` crate?

This is a draft to ask exactly that. `url` is one of our heavier dependencies relative to what it actually does for us.

### What it costs

`url` is pulled in **only** by rolldown crates, and it drags the entire IDNA/Unicode stack along:

```
url -> idna -> idna_adapter -> ICU4X
                               (icu_normalizer / icu_properties + *_data + zerovec / yoke / tinystr / ... — ~21 crates)
```

That is **~226 KB** of the shipped `librolldown_binding.node` (`__const` Unicode tables + `url`/`idna` code), all for internationalized-domain-name handling (`münchen.de` -> `xn--mnchen-3ya.de`) that rolldown never needs. `url` mandates `idna` for special-scheme hosts (incl. `file:`) and has **no feature** to turn it off.

### What we actually use `url` for (3 sites)

| site | usage |
|---|---|
| `rolldown_plugin_vite_resolve/src/file_url.rs` | parse `file://` URLs -> path (Vite's `fileURLToPath`) |
| `rolldown_binding/.../normalize_binding_options.rs` | validate `sourcemapBaseUrl` + ensure trailing `/` |
| `rolldown/.../process_code_and_sourcemap.rs` | join the map filename onto `sourcemapBaseUrl` |

All three only ever see ASCII (file paths / sourcemap URLs), never IDN hosts.

### This PR

Replaces those three sites with targeted parsing and drops `url`:
- a hand `file://` splitter (host / path / query / fragment), keeping the exact posix/windows `fileURLToPath` rules and the `%2F` / hostname rejections
- `normalize_sourcemap_base_url()`: validate `scheme://…` and append a trailing `/`
- the base is normalized to end in `/`, so the join becomes a plain append

11 new unit tests, all passing; matches the existing `output/sourcemap-base-url` fixture's expected `//# sourceMappingURL=…` output.

### Impact (aarch64, LTO release, same worktree A/B)

| build | size |
|---|---|
| baseline (`url` + `idna` + ICU4X) | 23,675,392 |
| **this PR (`url` removed)** | **23,443,904 — −226 KB** |

`url` / `idna` / `idna_adapter` / `icu_*` are gone from the binary (`nm` confirms 0 symbols; they remain in `Cargo.lock` only behind the `jsonschema` **test** dependency).

### Open questions (why this is a draft)

- **Correctness trade-off**: we'd now own URL parsing / joining / validation at these 3 sites instead of `url`'s WHATWG-compliant implementation. Unit tests cover the common cases, but `url`'s edge cases (path `.`/`..` normalization, exotic percent-encoding) are no longer guaranteed. Acceptable for `sourcemapBaseUrl`, a public option that mirrors Rollup?
- **Not yet validated here**: the JS integration fixtures (need a full napi build + vitest) and the Windows `file://` path.
- **Less invasive alternative**: keep `url` and only swap `idna`'s ICU backend for a tiny ASCII-only `idna_adapter` via `[patch.crates-io]` — saves **~129 KB** (57% of this) with **zero** change to `url`'s behavior. Easy to switch to if we'd rather not bring URL handling in-house.

Opening as a draft to get a call on the size-vs-correctness trade before polishing.
