### PR TITLE
fix: snap diagnostic label spans to char boundaries before rendering

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -106,9 +106,25 @@ impl Diagnostic {
     message: String,
   ) -> &mut Self {
     let range = range.into();
-    let range = range.start as usize..range.end as usize;
+    let mut start = range.start as usize;
+    let mut end = range.end as usize;
+    // `convert_to_string` renders with `IndexType::Byte`, so ariadne slices the source by
+    // raw byte offsets and panics if a label boundary falls inside a multibyte UTF-8
+    // character. Clamp to the source length and snap to char boundaries so a malformed
+    // span degrades gracefully instead of crashing diagnostic rendering.
+    if let Some(source) = self.files.get(file_id) {
+      let len = source.len();
+      start = start.min(len);
+      end = end.clamp(start, len);
+      while start > 0 && !source.is_char_boundary(start) {
+        start -= 1;
+      }
+      while end < len && !source.is_char_boundary(end) {
+        end += 1;
+      }
+    }
     let label =
-      Label::new(RolldownLabelSpan(file_id.0.clone().into(), range)).with_message(message);
+      Label::new(RolldownLabelSpan(file_id.0.clone().into(), start..end)).with_message(message);
     self.labels.push(label);
     self
   }
@@ -218,5 +234,27 @@ impl Diagnostic {
 impl Display for Diagnostic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.convert_to_string(false).fmt(f)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Regression test: a label span whose boundary falls inside a multibyte UTF-8
+  /// character (or runs past EOF) must not panic when the diagnostic is rendered.
+  /// `convert_to_string` uses `IndexType::Byte`, so rolldown-ariadne slices the
+  /// source by raw byte offsets and previously panicked on such spans.
+  #[test]
+  fn label_span_inside_multibyte_char_does_not_panic() {
+    // `é` occupies bytes 3..5; byte 4 is a UTF-8 continuation byte.
+    let src = "{ \"é\": }";
+    for range in [4u32..4, 3u32..4, 4u32..5, 0u32..200] {
+      let mut d = Diagnostic::new("X".to_string(), "t".to_string(), Severity::Error);
+      let f = d.add_file("a.json", src);
+      d.add_label(&f, range.clone(), "here".to_string());
+      let out = d.convert_to_string(false);
+      assert!(!out.is_empty(), "rendering produced no output for span {range:?}");
+    }
   }
 }


### PR DESCRIPTION
## Problem

Rendering a diagnostic whose label span starts or ends inside a multibyte UTF-8 character panics, crashing the build while reporting an error.

`Diagnostic::convert_to_string` renders with `IndexType::Byte`:

```rust
.with_index_type(ariadne::IndexType::Byte)
```

so rolldown-ariadne slices the source line by raw byte offsets. `add_label` previously stored the span unchanged:

```rust
let range = range.start as usize..range.end as usize;
```

If a label boundary lands inside a multibyte char, the slice panics. Confirmed empirically by feeding such a span to the renderer:

```
thread '...' panicked at rolldown-ariadne-0.6.0/src/write.rs:135:59:
end byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5) of `{ "é": }`
```

So a diagnostic carrying a span that ends mid-character crashes inside the formatter that was supposed to render it. (An out-of-range span, by contrast, already rendered fine, so this is specifically about char boundaries.)

## Fix

Clamp the range to the source length and snap both ends to char boundaries in `add_label`, so a malformed span degrades gracefully instead of crashing. Because this lives in `add_label`, it protects every diagnostic rather than a single constructor.

```rust
if let Some(source) = self.files.get(file_id) {
  let len = source.len();
  start = start.min(len);
  end = end.clamp(start, len);
  while start > 0 && !source.is_char_boundary(start) { start -= 1; }
  while end < len && !source.is_char_boundary(end) { end += 1; }
}
```

## Test

Added a regression test that renders labels with spans landing inside a multibyte char (`4..4`, `3..4`, `4..5`) and past EOF (`0..200`); all must render without panicking. Verified the mid-char cases panic without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
