### PR TITLE
perf(rolldown): skip redundant canonical_ref lookup in chunk symbol deconfliction

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -195,7 +195,9 @@ pub fn deconflict_chunk_symbols(
             } else {
               true
             };
-            renamer.add_symbol_in_root_scope(symbol_ref, needs_deconflict);
+            // `canonical_ref` was already resolved above; pass it directly to skip a
+            // redundant `canonical_ref` union-find lookup in this hot deconflict loop.
+            renamer.add_canonical_symbol_in_root_scope(canonical_ref, needs_deconflict);
           }
         });
     });

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -166,6 +166,23 @@ impl<'name> Renamer<'name> {
   /// other top-level names and nested scope names that could cause capture.
   pub fn add_symbol_in_root_scope(&mut self, symbol_ref: SymbolRef, needs_deconflict: bool) {
     let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
+    self.add_canonical_symbol_in_root_scope(canonical_ref, needs_deconflict);
+  }
+
+  /// Same as [`Self::add_symbol_in_root_scope`] but takes an already-canonicalized
+  /// `canonical_ref`. Hot callers (e.g. `deconflict_chunk_symbols`) that have already
+  /// resolved the canonical ref use this to avoid a redundant `canonical_ref` union-find
+  /// walk. `canonical_ref` MUST be canonical (i.e. `symbol_ref.canonical_ref(db)`).
+  pub fn add_canonical_symbol_in_root_scope(
+    &mut self,
+    canonical_ref: SymbolRef,
+    needs_deconflict: bool,
+  ) {
+    debug_assert_eq!(
+      canonical_ref,
+      canonical_ref.canonical_ref(self.symbol_db),
+      "add_canonical_symbol_in_root_scope requires an already-canonical ref"
+    );
     let canonical_name = canonical_ref.name(self.symbol_db);
 
     // Dedup-before-alloc: in the deconflict path, a re-add of an already-present


### PR DESCRIPTION
Skip a redundant `canonical_ref` union-find lookup per declared symbol in `deconflict_chunk_symbols`: the caller already resolved the canonical ref, so pass it to a new `add_canonical_symbol_in_root_scope` instead of re-resolving it inside `add_symbol_in_root_scope`. Behavior-preserving.

Prepared with AI assistance.
