### PR TITLE
perf: dedupe supports-color crate in vite-reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,23 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,10 +1918,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
-]
 
 [[package]]
 name = "oxc"
@@ -4241,25 +4220,6 @@ checksum = "36fe837e881ad5c3b60fadeb8e9b0bc5c907c4b7d84b4415a7f0bbc3f9073631"
 dependencies = [
  "memchr",
  "smallvec",
-]
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
 ]
 
 [[package]]

--- a/crates/rolldown_plugin_vite_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_vite_reporter/Cargo.toml
@@ -24,7 +24,7 @@ derive_more = { workspace = true }
 flate2 = { workspace = true }
 itoa = { workspace = true }
 num-format = { workspace = true }
-owo-colors = { workspace = true, features = ["supports-colors"] }
+owo-colors = { workspace = true }
 rayon = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use cow_utils::CowUtils;
-use owo_colors::{OwoColorize, Stream};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_plugin::{HookUsage, Plugin, PluginContext};
 use sugar_path::SugarPath as _;
@@ -60,10 +59,7 @@ impl Plugin for ViteReporterPlugin {
         utils::write_line(&format!(
           "transforming ({}) {}",
           itoa::Buffer::new().format(transformed_count + 1),
-          Path::new(args.id)
-            .relative(&self.root)
-            .to_string_lossy()
-            .if_supports_color(Stream::Stdout, |text| { text.dimmed() })
+          utils::dimmed(Path::new(args.id).relative(&self.root).to_string_lossy())
         ));
 
         *self.latest_checkpoint.write().unwrap() = now;
@@ -95,7 +91,7 @@ impl Plugin for ViteReporterPlugin {
 
     utils::log_info(&format!(
       "{} {} modules transformed.",
-      "✓".if_supports_color(Stream::Stdout, |text| text.green()),
+      utils::green("✓"),
       self.transformed_count.load(Ordering::SeqCst)
     ));
 
@@ -226,22 +222,11 @@ impl Plugin for ViteReporterPlugin {
         }
         filtered.sort_by_key(|a| a.size);
         for log_entry in filtered {
-          let _ = write!(
-            &mut info,
-            "{}",
-            format!("{out_dir}/").if_supports_color(Stream::Stdout, |text| text.dimmed())
-          );
+          let _ = write!(&mut info, "{}", utils::dimmed(format!("{out_dir}/")));
 
           let is_asset = !self.is_lib && Path::new(log_entry.name).starts_with(&self.assets_dir);
           if is_asset {
-            let _ = write!(
-              &mut info,
-              "{}",
-              self
-                .assets_dir
-                .cow_replace('\\', "/")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
-            );
+            let _ = write!(&mut info, "{}", utils::dimmed(self.assets_dir.cow_replace('\\', "/")));
           }
 
           let name = if is_asset {
@@ -252,51 +237,28 @@ impl Plugin for ViteReporterPlugin {
           };
 
           let _ = match group {
-            utils::AssetGroup::JS => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.cyan()))
-            }
-            utils::AssetGroup::Css => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.magenta()))
-            }
-            utils::AssetGroup::Assets => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.green()))
-            }
+            utils::AssetGroup::JS => write!(&mut info, "{}", utils::cyan(name)),
+            utils::AssetGroup::Css => write!(&mut info, "{}", utils::magenta(name)),
+            utils::AssetGroup::Assets => write!(&mut info, "{}", utils::green(name)),
           };
 
           let size = format!("{:>size_pad$}", utils::display_size(log_entry.size));
           if group == utils::AssetGroup::JS && log_entry.size.div_ceil(1000) > self.chunk_limit {
             has_large_chunks = true;
-            let _ = write!(
-              &mut info,
-              "{}",
-              size.if_supports_color(Stream::Stdout, |text| text.bold().yellow().to_string())
-            );
+            let _ = write!(&mut info, "{}", utils::bold_yellow(size));
           } else {
-            let _ = write!(
-              &mut info,
-              "{}",
-              size.if_supports_color(Stream::Stdout, |text| text.bold().dimmed().to_string())
-            );
+            let _ = write!(&mut info, "{}", utils::bold_dimmed(size));
           }
 
           if let Some(compressed_size) = log_entry.compressed_size {
             let size = utils::display_size(compressed_size);
-            let _ = write!(
-              &mut info,
-              "{}",
-              format!(" │ gzip: {size:>compress_pad$}")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
-            );
+            let _ =
+              write!(&mut info, "{}", utils::dimmed(format!(" │ gzip: {size:>compress_pad$}")));
           }
 
           if let Some(map_size) = log_entry.map_size {
             let size = utils::display_size(map_size);
-            let _ = write!(
-              &mut info,
-              "{}",
-              format!(" │ map: {size:>map_pad$}")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
-            );
+            let _ = write!(&mut info, "{}", utils::dimmed(format!(" │ map: {size:>map_pad$}")));
           }
 
           let _ = writeln!(&mut info);
@@ -313,10 +275,10 @@ impl Plugin for ViteReporterPlugin {
       });
     }
     if self.warn_large_chunks && has_large_chunks {
-      let message = format!(
+      let message = utils::bold_yellow(format!(
         "\n(!) Some chunks are larger than {} kB after minification. Consider:\n- Using dynamic import() to code-split the application\n- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting\n- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.",
         itoa::Buffer::new().format(self.chunk_limit)
-      ).if_supports_color(Stream::Stdout, |text| { text.bold().yellow().to_string() }).to_string();
+      ));
       ctx.warn(rolldown_common::LogWithoutPlugin { message, ..Default::default() });
     }
     Ok(())

--- a/crates/rolldown_plugin_vite_reporter/src/utils.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/utils.rs
@@ -1,7 +1,11 @@
-use std::io::{StdoutLock, Write};
+use std::{
+  io::{StdoutLock, Write},
+  sync::OnceLock,
+};
 
 use flate2::{Compression, write::GzEncoder};
 use num_format::{Locale, ToFormattedString as _};
+use owo_colors::OwoColorize as _;
 
 pub const COMPRESSIBLE_ASSETS: [&str; 7] =
   [".html", ".json", ".svg", ".txt", ".xml", ".xhtml", ".wasm"];
@@ -76,4 +80,75 @@ pub fn log_info(message: &str) {
   let mut lock = std::io::stdout().lock();
   let _ = writeln!(&mut lock, "{message}");
   let _ = lock.flush();
+}
+
+/// Returns whether colored output should be emitted on stdout.
+///
+/// This replicates the precedence used by the `supports-color` crate (which
+/// `owo-colors`' `if_supports_color` relies on) for the common cases, without
+/// pulling in that crate. The result is computed once and cached for the
+/// lifetime of the process, matching `supports_color::on_cached`.
+///
+/// Precedence (highest first):
+/// 1. `FORCE_COLOR` set to anything other than `"0"`/`"false"` -> color on.
+/// 2. `NO_COLOR` set to a non-empty, non-`"0"` value, or `TERM=dumb` -> color off.
+/// 3. otherwise, color on only when stdout is a terminal.
+pub fn should_color() -> bool {
+  fn compute() -> bool {
+    if let Ok(force) = std::env::var("FORCE_COLOR") {
+      return !matches!(force.as_str(), "0" | "false");
+    }
+    if matches!(std::env::var("NO_COLOR"), Ok(value) if !value.is_empty() && value != "0") {
+      return false;
+    }
+    if matches!(std::env::var("TERM"), Ok(term) if term == "dumb") {
+      return false;
+    }
+    std::io::IsTerminal::is_terminal(&std::io::stdout())
+  }
+
+  static CACHE: OnceLock<bool> = OnceLock::new();
+  *CACHE.get_or_init(compute)
+}
+
+/// Applies the `apply` color transformation to `value` when stdout supports
+/// color, otherwise returns the plain value. Mirrors
+/// `value.if_supports_color(Stream::Stdout, apply)` but gates on the local
+/// [`should_color`] check instead of the `supports-color` crate.
+///
+/// `apply` renders the colored form to a `String` (e.g. `|t| t.green().to_string()`)
+/// so that chained `owo-colors` styles, which borrow intermediate temporaries,
+/// don't escape the closure.
+#[inline]
+pub fn paint<T>(value: T, apply: impl FnOnce(&T) -> String) -> String
+where
+  T: std::fmt::Display,
+{
+  if should_color() { apply(&value) } else { value.to_string() }
+}
+
+/// Convenience wrappers around [`paint`] for the color methods used by the
+/// reporter, keeping the call sites terse.
+pub fn dimmed(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.dimmed().to_string())
+}
+
+pub fn green(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.green().to_string())
+}
+
+pub fn cyan(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.cyan().to_string())
+}
+
+pub fn magenta(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.magenta().to_string())
+}
+
+pub fn bold_yellow(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.bold().yellow().to_string())
+}
+
+pub fn bold_dimmed(value: impl std::fmt::Display) -> String {
+  paint(value, |t| t.bold().dimmed().to_string())
 }


### PR DESCRIPTION
## How to dedupe `supports-color`

### Root cause

`cargo tree -i supports-color` showed **two copies** linked into the `rolldown_binding` cdylib (`.node`):

```
supports-color v2.1.0  └── owo-colors v4.3.0
supports-color v3.0.2  └── owo-colors v4.3.0
```

The only crate that triggered this is `rolldown_plugin_vite_reporter`. It enabled `owo-colors`' **`supports-colors`** feature so it could call `.if_supports_color(Stream::Stdout, |t| t.green())` (~12 call sites) for terminal color detection.

`owo-colors 4.3.0`'s `supports-colors` feature depends on **both** `supports-color` v2 *and* v3 at once (v3 does the actual detection via `supports_color::on_cached`; v2 is only kept for a `From<supports_color_2::Stream>` compatibility impl). So enabling color-detection dragged in two copies of the crate plus their own deps (`is-terminal`, `is_ci`).

Verified that the reporter was the *sole* enabler:
```
owo-colors feature "supports-colors"
└── rolldown_plugin_vite_reporter
```
`oxc-miette` also depends on `owo-colors`, but without the `supports-colors` feature — so dropping the feature here fully removes it from the graph.

### The mechanism

1. **Drop the feature** in `crates/rolldown_plugin_vite_reporter/Cargo.toml`: `features = ["supports-colors"]` → removed. The direct `OwoColorize` coloring methods (`.green()`, `.dimmed()`, `.cyan()`, `.bold()`, …) do **not** require that feature; only `if_supports_color`/`Stream` do.
2. **Local color gate** `utils::should_color()` replicates supports-color v3's precedence (cached once via `OnceLock`, matching `on_cached`):
   - `FORCE_COLOR` set (and not `"0"`/`"false"`) → **on**
   - else `NO_COLOR` non-empty (non-`"0"`) or `TERM=dumb` → **off**
   - else `std::io::IsTerminal` on stdout
3. **Helpers** (`utils::dimmed/green/cyan/magenta/bold_yellow/bold_dimmed`, backed by a `paint` helper) replace each `x.if_supports_color(Stream::Stdout, |t| t.green())` call: apply the color when `should_color()`, else emit the plain value. Output is byte-for-byte identical (same ANSI codes on a TTY, none otherwise).

## Before / after `cargo tree -i supports-color`

**Before:**
```
supports-color v2.1.0
└── owo-colors v4.3.0 (… → rolldown_binding)
supports-color v3.0.2
└── owo-colors v4.3.0 (… → rolldown_binding)
```

**After:**
```
error: package ID specification `supports-color` did not match any packages
```

`Cargo.lock` drops `supports-color 2.1.0`, `supports-color 3.0.2`, `is-terminal 0.4.17`, and `is_ci 1.2.0`. `owo-colors` itself stays (still used by both the reporter for direct coloring and by `oxc-miette`), now built without the `supports-colors` feature.

**Binary size impact:** **−16 bytes (negligible)** on the stripped release cdylib (fat-LTO, `strip="symbols"`, baseline `697a7c4e58`). Removing the duplicate `supports-color` v2 (+ `is-terminal`, `is_ci`) is a dependency-graph **dedup / hygiene** win but does not measurably shrink the dead-stripped `.node` — the crates were tiny and already largely eliminated. Keep for the dedup, not for size.

## Behavior caveats

- The local gate matches supports-color's **common** precedence (`FORCE_COLOR` > `NO_COLOR`/`TERM=dumb` > TTY). It does not reproduce the deeper heuristics supports-color also applies on a TTY (e.g. `CI` detection via `is_ci`, `CLICOLOR`, `COLORTERM`/`TERM` 256/16m level probing). Those only affect *which level* of color or whether color is forced on in non-TTY CI; for this reporter we only ever needed basic on/off, and a non-TTY (the test/CI default) stays uncolored exactly as before.
- The result is cached on first use (same as `supports_color::on_cached`), so changing the env vars mid-process won't re-evaluate.
