### PR TITLE
perf(rolldown_error): remove Debug supertrait from BuildEvent

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Debug};
+use std::any::Any;
 
 use arcstr::ArcStr;
 use oxc::span::Span;
@@ -57,7 +57,7 @@ pub mod unsupported_feature;
 pub mod unsupported_tsconfig_option;
 pub mod untranspiled_syntax;
 
-pub trait BuildEvent: Debug + Sync + Send + AsAny + AsAnyMut {
+pub trait BuildEvent: Sync + Send + AsAny + AsAnyMut {
   fn kind(&self) -> EventKind;
 
   fn message(&self, opts: &DiagnosticOptions) -> String;

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -22,10 +22,22 @@ pub enum Severity {
   Warning,
 }
 
-#[derive(Debug)]
 pub struct BuildDiagnostic {
   inner: Box<dyn BuildEvent>,
   severity: Severity,
+}
+
+// `BuildEvent` is not `Debug` (dropping the supertrait lets the per-event `Debug`
+// impls be dead-stripped from release builds), so format the diagnostic via its
+// public accessors instead of the boxed event's `Debug`.
+impl std::fmt::Debug for BuildDiagnostic {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("BuildDiagnostic")
+      .field("severity", &self.severity)
+      .field("kind", &self.kind())
+      .field("message", &self.inner.message(&DiagnosticOptions::default()))
+      .finish()
+  }
 }
 
 impl std::error::Error for BuildDiagnostic {}
@@ -114,8 +126,14 @@ impl From<anyhow::Error> for BuildDiagnostic {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct BatchedBuildDiagnostic(Vec<BuildDiagnostic>);
+
+impl std::fmt::Debug for BatchedBuildDiagnostic {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("BatchedBuildDiagnostic").field(&self.0).finish()
+  }
+}
 
 impl BatchedBuildDiagnostic {
   pub fn new(vec: Vec<BuildDiagnostic>) -> Self {

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -30,13 +30,22 @@ pub struct BuildDiagnostic {
 // `BuildEvent` is not `Debug` (dropping the supertrait lets the per-event `Debug`
 // impls be dead-stripped from release builds), so format the diagnostic via its
 // public accessors instead of the boxed event's `Debug`.
+//
+// We render through `to_diagnostic()` rather than reading `inner.message()`
+// directly: for plugin-wrapped diagnostics `PluginError::message()` intentionally
+// returns an empty string (the real text is injected later by `on_diagnostic`), so
+// using the raw message here would print an empty `message`. `to_diagnostic()` runs
+// `on_diagnostic`, which populates the real content. This is the error/cold path.
 impl std::fmt::Debug for BuildDiagnostic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let diagnostic = self.to_diagnostic();
+    // `inner` is rendered (via `to_diagnostic`) rather than printed directly, so the
+    // struct is intentionally non-exhaustive over its raw fields.
     f.debug_struct("BuildDiagnostic")
       .field("severity", &self.severity)
-      .field("kind", &self.kind())
-      .field("message", &self.inner.message(&DiagnosticOptions::default()))
-      .finish()
+      .field("kind", &diagnostic.kind)
+      .field("message", &diagnostic.title)
+      .finish_non_exhaustive()
   }
 }
 
@@ -235,4 +244,27 @@ pub fn consolidate_diagnostics(diagnostics: Vec<BuildDiagnostic>) -> Vec<BuildDi
     }
   }
   result
+}
+
+#[cfg(test)]
+mod tests {
+  use super::BuildDiagnostic;
+  use crate::build_diagnostic::events::plugin_error::CausedPlugin;
+
+  // A plugin-wrapped diagnostic's inner `PluginError::message()` is intentionally
+  // empty (the real text is injected via `on_diagnostic`). `Debug` must still render
+  // the underlying error text, so render through `to_diagnostic()`.
+  #[test]
+  fn debug_renders_nested_plugin_diagnostic_message() {
+    let inner =
+      BuildDiagnostic::bundler_initialize_error("the underlying failure text".to_string(), None);
+    let plugin_diag =
+      BuildDiagnostic::plugin_error(CausedPlugin::new("my-plugin".into()), inner.into());
+
+    let debug_output = format!("{plugin_diag:?}");
+    assert!(
+      debug_output.contains("the underlying failure text"),
+      "expected non-empty underlying message in Debug output, got: {debug_output}"
+    );
+  }
 }


### PR DESCRIPTION
Removes the `Debug` supertrait from `BuildEvent` — no `cfg`, no `debug_assertions`, just an unconditional removal.

## Why this shrinks the release binary
`BuildDiagnostic` stores a `Box<dyn BuildEvent>`, and `trait BuildEvent: Debug + …` forced a `Debug::fmt` slot into the `dyn BuildEvent` vtable. Every concrete event coerced into the trait object emitted a vtable referencing its `<Event as Debug>::fmt`, so those ~48 impls were reachable through live vtables and survived `strip="symbols"` + fat-LTO + `-dead_strip` — even though nothing ever `{:?}`-formats an event (verified: the only `{:?}` sites in `rolldown_error` format a `Span`/`anyhow::Error`/path). Dropping the supertrait removes the vtable slot, the per-event `Debug::fmt` impls become unreferenced, and dead-strip removes them.

## Change (2 files; the ~45 event structs are untouched)
- `events/mod.rs`: `BuildEvent: Debug + Sync + Send + …` → `BuildEvent: Sync + Send + …`.
- `mod.rs`: `BuildDiagnostic`/`BatchedBuildDiagnostic` can no longer derive `Debug` (they hold `Box<dyn BuildEvent>`), so each gets a small manual `Debug` impl (`severity`/`kind`/`message`).
- Every event struct keeps its `#[derive(Debug)]` — still `{:?}`-able in dev, and dead-stripped from release on its own now that the vtable no longer pins it.

## Tradeoff
`dyn BuildEvent` is no longer `Debug`: you can't `{:?}` the trait object, and `BuildDiagnostic`'s `Debug` prints `severity`/`kind`/`message` rather than the full event fields. Concrete event types remain fully `{:?}`-able.

**Binary size impact:** **−16,896 bytes (−16.5 KiB)** in release — measured on `librolldown_binding.dylib` (fat-LTO, `codegen-units=1`, `strip="symbols"`): base `697a7c4e58` = 23,476,336 B → this branch `14c71b4e74` = 23,459,440 B.
