### PR TITLE
perf(size): replace dashmap with papaya (measured +339 KiB — NOT a size win, see body)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -556,20 +556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1181,12 +1167,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1436,7 +1416,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1791,7 +1771,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2923,7 +2903,6 @@ dependencies = [
  "bitflags",
  "commondir",
  "cow-utils",
- "dashmap",
  "dunce",
  "futures",
  "indexmap",
@@ -3043,7 +3022,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "async-channel",
- "dashmap",
  "derive_more",
  "futures",
  "indexmap",
@@ -3108,7 +3086,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "bitflags",
- "dashmap",
  "derive_more",
  "fast-glob",
  "insta",
@@ -3260,7 +3237,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "bitflags",
- "dashmap",
  "derive_more",
  "nodejs-built-in-modules",
  "oxc_index",
@@ -3433,7 +3409,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "cow-utils",
- "dashmap",
  "derive_more",
  "itertools",
  "memchr",
@@ -3696,7 +3671,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "cow-utils",
- "dashmap",
  "derive_more",
  "fast-glob",
  "nodejs-built-in-modules",
@@ -3748,7 +3722,6 @@ version = "1.1.1"
 dependencies = [
  "anyhow",
  "arcstr",
- "dashmap",
  "itertools",
  "oxc_resolver",
  "rolldown_common",
@@ -3832,7 +3805,6 @@ dependencies = [
  "base64-simd",
  "cow-utils",
  "criterion2",
- "dashmap",
  "fast-glob",
  "form_urlencoded",
  "futures",
@@ -3845,6 +3817,7 @@ dependencies = [
  "oxc",
  "oxc_index",
  "oxc_str",
+ "papaya",
  "rayon",
  "regex",
  "regress",
@@ -3918,7 +3891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3980,7 +3953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4294,7 +4267,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4313,7 +4286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4793,7 +4766,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,6 @@ blake3 = "1.8.2"
 commondir = "1.0.0"
 cow-utils = "0.1.3"
 criterion2 = { version = "3.0.0", default-features = false }
-dashmap = "6.2.1"
 derive_more = { version = "2.0.1", features = ["debug"] }
 dunce = "1.0.5" # Normalize Windows paths to the most compatible format, avoiding UNC where possible
 fast-glob = "1.0.0"
@@ -188,6 +187,7 @@ num-bigint = "0.4.6"
 num-format = "0.4"
 num_cpus = "1.17"
 owo-colors = "4.2.2"
+papaya = "0.2.4"
 parking_lot = "0.12.5"
 path-posix = "0.0.1"
 percent-encoding = "2.3.1"

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,40 +10,22 @@ disallowed-methods = [
 ]
 
 ### await-holding-invalid-types
-## we can remove these if https://github.com/xacrimon/dashmap/issues/348 lands
+## `papaya` is lock-free, but holding a pin guard or a reference borrowed from it
+## across an await point keeps memory reclamation pinned and is a footgun. Clone
+## the value out of the guard scope before awaiting instead.
 
 [[await-holding-invalid-types]]
-path = "dashmap::mapref::one::Ref"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
+path = "papaya::LocalGuard"
+reason = "holding a papaya pin guard across an await keeps memory reclamation pinned; clone values out before awaiting"
 
 [[await-holding-invalid-types]]
-path = "dashmap::mapref::one::RefMut"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
+path = "papaya::OwnedGuard"
+reason = "holding a papaya pin guard across an await keeps memory reclamation pinned; clone values out before awaiting"
 
 [[await-holding-invalid-types]]
-path = "dashmap::mapref::one::MappedRef"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
+path = "papaya::HashMapRef"
+reason = "holding a papaya map guard across an await keeps memory reclamation pinned; clone values out before awaiting"
 
 [[await-holding-invalid-types]]
-path = "dashmap::mapref::entry::Entry"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
-
-[[await-holding-invalid-types]]
-path = "dashmap::mapref::multiple::RefMulti"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
-
-[[await-holding-invalid-types]]
-path = "dashmap::mapref::multiple::RefMutMulti"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
-
-[[await-holding-invalid-types]]
-path = "dashmap::iter::Iter"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
-
-[[await-holding-invalid-types]]
-path = "dashmap::iter::IterMut"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
-
-[[await-holding-invalid-types]]
-path = "dashmap::iter::OwningIter"
-reason = "holding dashmap references will cause deadlocks, if the same thread tries to acquire a reference"
+path = "papaya::HashSetRef"
+reason = "holding a papaya set guard across an await keeps memory reclamation pinned; clone values out before awaiting"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -22,7 +22,6 @@ experimental = []
 anyhow = { workspace = true }
 append-only-vec = { workspace = true }
 arcstr = { workspace = true }
-dashmap = { workspace = true }
 bitflags = { workspace = true }
 commondir = { workspace = true }
 futures = { workspace = true }

--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -1,7 +1,6 @@
 use std::{any::Any, sync::Arc};
 
 use arcstr::ArcStr;
-use dashmap::DashMap;
 use rolldown_common::{
   BundleMode, BundlerOptions, FileEmitter, ModuleIdx, NormalizedBundlerOptions, SharedFileEmitter,
   SharedModuleInfoDashMap,
@@ -10,7 +9,7 @@ use rolldown_error::{BuildDiagnostic, BuildResult, EventKindSwitcher};
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{__inner::SharedPluginable, PluginDriverFactory};
 use rolldown_plugin_lazy_compilation::LazyCompilationContext;
-use rolldown_utils::dashmap::FxDashSet;
+use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -49,7 +48,7 @@ pub struct BundleFactory {
   module_infos_for_incremental_build: SharedModuleInfoDashMap,
 
   // Used to preserve transform dependencies (from addWatchFile) across incremental builds for HMR
-  transform_dependencies_for_incremental_build: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
+  transform_dependencies_for_incremental_build: Arc<FxDashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
 
   // Used to generate unique id for each bundle process
   bundle_id_seed: u32,

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -177,11 +177,10 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       }
 
       // Check if any modules have this file as a transform dependency
-      for entry in self.plugin_driver.transform_dependencies.iter() {
-        let module_idx = *entry.key();
-        let deps = entry.value();
+      let transform_dependencies = self.plugin_driver.transform_dependencies.pin();
+      for (module_idx, deps) in &transform_dependencies {
         if deps.contains(&changed_file_path) {
-          changed_modules.insert(module_idx);
+          changed_modules.insert(*module_idx);
         }
       }
     }

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 anyhow = { workspace = true }
 arcstr = { workspace = true }
 async-channel = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -193,7 +193,7 @@ impl BindingBundler {
     self
       .last_bundle_handle
       .as_ref()
-      .map(|handle| handle.watch_files().iter().map(|s| s.to_string()).collect())
+      .map(|handle| handle.watch_files().iter_cloned().into_iter().map(|s| s.to_string()).collect())
       .unwrap_or_default()
   }
 }

--- a/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
+++ b/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
@@ -1,5 +1,4 @@
 use crate::options::plugin::{BindingPluginOptions, BindingPluginWithIndex};
-use dashmap::DashMap;
 use napi::{
   Env, Unknown,
   bindgen_prelude::{FromNapiValue, JavaScriptClassExt, JsObjectValue, Object, ObjectFinalize},
@@ -7,14 +6,19 @@ use napi::{
 use napi_derive::napi;
 use rolldown_utils::{dashmap::FxDashMap, rustc_hash::FxHashMapExt};
 use rustc_hash::FxHashMap;
-use std::sync::LazyLock;
 use std::sync::atomic::{self, AtomicU16};
+use std::sync::{Arc, LazyLock, Mutex};
 
 type PluginsInSingleWorker = Vec<BindingPluginWithIndex>;
 type PluginsList = Vec<PluginsInSingleWorker>;
 pub(crate) type PluginValues = FxHashMap<usize, Vec<BindingPluginOptions>>;
 
-static PLUGINS_MAP: LazyLock<FxDashMap<u16, PluginsList>> = LazyLock::new(DashMap::default);
+// `papaya` is lock-free and stores immutable values, so the per-id plugin list
+// (which is appended to from multiple workers and later moved out wholesale) is
+// kept behind an `Arc<Mutex<_>>`. This is a cold registration path, so the lock
+// is uncontended in practice.
+static PLUGINS_MAP: LazyLock<FxDashMap<u16, Arc<Mutex<PluginsList>>>> =
+  LazyLock::new(FxDashMap::default);
 static NEXT_ID: AtomicU16 = AtomicU16::new(1);
 
 #[napi(custom_finalize)]
@@ -34,13 +38,16 @@ impl ParallelJsPluginRegistry {
     }
 
     let id = NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed);
-    PLUGINS_MAP.insert(id, vec![]);
+    PLUGINS_MAP.insert_and_forget(id, Arc::new(Mutex::new(vec![])));
 
     Ok(Self { id, worker_count })
   }
 
   pub fn take_plugin_values(&self) -> PluginValues {
-    let plugins_list = PLUGINS_MAP.remove(&self.id).expect("plugin list already taken").1;
+    let plugins_list = PLUGINS_MAP.get(&self.id).expect("plugin list already taken");
+    PLUGINS_MAP.pin().remove(&self.id);
+    let plugins_list =
+      std::mem::take(&mut *plugins_list.lock().expect("plugin list mutex poisoned"));
 
     let mut map: FxHashMap<usize, Vec<BindingPluginOptions>> =
       FxHashMap::with_capacity(plugins_list[0].len());
@@ -56,7 +63,7 @@ impl ParallelJsPluginRegistry {
 
 impl ObjectFinalize for ParallelJsPluginRegistry {
   fn finalize(self, mut _env: Env) -> napi::Result<()> {
-    PLUGINS_MAP.remove(&self.id);
+    PLUGINS_MAP.pin().remove(&self.id);
     Ok(())
   }
 }
@@ -82,7 +89,7 @@ impl FromNapiValue for ParallelJsPluginRegistry {
 
 #[napi]
 pub fn register_plugins(id: u16, plugins: Vec<BindingPluginWithIndex>) {
-  if let Some(mut existing_plugins) = PLUGINS_MAP.get_mut(&id) {
-    existing_plugins.push(plugins);
+  if let Some(existing_plugins) = PLUGINS_MAP.get(&id) {
+    existing_plugins.lock().expect("plugin list mutex poisoned").push(plugins);
   }
 }

--- a/crates/rolldown_binding/src/transform_cache.rs
+++ b/crates/rolldown_binding/src/transform_cache.rs
@@ -3,7 +3,6 @@ use std::{
   sync::Arc,
 };
 
-use dashmap::Entry;
 use napi_derive::napi;
 use oxc_resolver::{ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigDiscovery};
 use rolldown_utils::dashmap::FxDashMap;
@@ -58,14 +57,7 @@ impl TsconfigCache {
     match tsconfig_result {
       Ok(Some(arc_tsconfig)) => {
         let cache_key = arc_tsconfig.path.clone();
-
-        match self.cache.entry(cache_key) {
-          Entry::Occupied(entry) => Ok(Some(Arc::clone(entry.get()))),
-          Entry::Vacant(vacant_entry) => {
-            vacant_entry.insert(Arc::clone(&arc_tsconfig));
-            Ok(Some(arc_tsconfig))
-          }
-        }
+        Ok(Some(self.cache.get_or_insert_with(cache_key, || arc_tsconfig)))
       }
       Ok(None) | Err(_) => tsconfig_result,
     }

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 anyhow = { workspace = true }
 arcstr = { workspace = true }
 bitflags = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true }
 fast-glob = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use anyhow::Context;
 use arcstr::ArcStr;
-use dashmap::{DashMap, DashSet, Entry};
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 use rolldown_utils::make_unique_name::make_unique_name;
@@ -95,23 +94,23 @@ impl FileEmitter {
   pub fn new(options: Arc<NormalizedBundlerOptions>) -> Self {
     Self {
       tx: Arc::new(Mutex::new(None)),
-      source_hash_to_reference_id: DashMap::default(),
-      names: DashMap::default(),
-      files: DashMap::default(),
-      chunks: DashMap::default(),
-      prebuilt_chunks: DashMap::default(),
-      emitted_chunks: DashMap::default(),
+      source_hash_to_reference_id: FxDashMap::default(),
+      names: FxDashMap::default(),
+      files: FxDashMap::default(),
+      chunks: FxDashMap::default(),
+      prebuilt_chunks: FxDashMap::default(),
+      emitted_chunks: FxDashMap::default(),
       base_reference_id: AtomicUsize::new(0),
       options,
-      emitted_files: DashSet::default(),
+      emitted_files: FxDashSet::default(),
       emitted_filenames: FxDashSet::default(),
-      module_to_file_ref: DashMap::default(),
+      module_to_file_ref: FxDashMap::default(),
     }
   }
 
   pub fn set_emitted_chunk_info(&self, emitted_chunk_info: impl Iterator<Item = EmittedChunkInfo>) {
     for info in emitted_chunk_info {
-      self.emitted_chunks.insert(info.reference_id, info.filename);
+      self.emitted_chunks.insert_and_forget(info.reference_id, info.filename);
     }
   }
 
@@ -143,13 +142,13 @@ impl FileEmitter {
           "FileEmitter: failed to send AddEntryModule message - module loader shut down during file emission",
         )
       })?;
-    self.chunks.insert(reference_id.clone(), chunk);
+    self.chunks.insert_and_forget(reference_id.clone(), chunk);
     Ok(reference_id)
   }
 
   pub fn emit_prebuilt_chunk(&self, chunk: EmittedPrebuiltChunk) -> ArcStr {
     let reference_id = self.assign_reference_id(Some(chunk.file_name.clone()));
-    self.prebuilt_chunks.insert(reference_id.clone(), Arc::new(chunk));
+    self.prebuilt_chunks.insert_and_forget(reference_id.clone(), Arc::new(chunk));
     reference_id
   }
 
@@ -173,28 +172,29 @@ impl FileEmitter {
 
     // Deduplicate assets if an explicit fileName is not provided
     let reference_id = if file.file_name.is_none() {
-      // Use entry API to atomically check and insert
-      match self.source_hash_to_reference_id.entry(hash.clone()) {
-        Entry::Occupied(entry) => {
-          // File already exists, add metadata and return existing reference_id
-          let reference_id = entry.get().clone();
-          self.files.entry(reference_id.clone()).and_modify(|output| {
-            if let Some(name) = file.name {
-              output.names.push(name);
-            }
-            if let Some(original_file_name) = file.original_file_name {
-              output.original_file_names.push(original_file_name);
-            }
-          });
-          return Ok(reference_id);
-        }
-        Entry::Vacant(entry) => {
-          // First time seeing this file, generate reference_id and continue
-          let reference_id = self.assign_reference_id(None);
-          entry.insert(reference_id.clone());
-          reference_id
-        }
+      // Atomically check-and-insert: pre-assign a candidate reference id, then
+      // `get_or_insert_with` so concurrent first-emitters agree on a single id.
+      // (A losing candidate only wastes one counter tick, which is harmless.)
+      let candidate = self.assign_reference_id(None);
+      let reference_id =
+        self.source_hash_to_reference_id.get_or_insert_with(hash.clone(), || candidate.clone());
+      if reference_id != candidate {
+        // File already exists, add metadata and return the existing reference_id.
+        let name = file.name.clone();
+        let original_file_name = file.original_file_name.clone();
+        self.files.pin().update(reference_id.clone(), |output| {
+          let mut output = output.clone();
+          if let Some(name) = name.clone() {
+            output.names.push(name);
+          }
+          if let Some(original_file_name) = original_file_name.clone() {
+            output.original_file_names.push(original_file_name);
+          }
+          output
+        });
+        return Ok(reference_id);
       }
+      reference_id
     } else {
       // File has explicit fileName, no deduplication needed
       self.assign_reference_id(file.file_name.clone())
@@ -202,7 +202,7 @@ impl FileEmitter {
 
     // Generate filename and insert into files map
     self.generate_file_name(&mut file, &hash, asset_filename_template, sanitized_file_name)?;
-    self.files.insert(
+    self.files.insert_and_forget(
       reference_id.clone(),
       OutputAsset {
         filename: file.file_name.unwrap(),
@@ -216,15 +216,15 @@ impl FileEmitter {
   }
 
   pub fn get_file_name(&self, reference_id: &str) -> anyhow::Result<ArcStr> {
-    if let Some(file) = self.files.get(reference_id) {
-      return Ok(file.filename.clone());
+    if let Some(filename) = self.files.with(reference_id, |file| file.filename.clone()) {
+      return Ok(filename);
     }
     if let Some(chunk) = self.chunks.get(reference_id) {
       if let Some(filename) = chunk.file_name.as_ref() {
         return Ok(filename.clone());
       }
       if let Some(filename) = self.emitted_chunks.get(reference_id) {
-        return Ok(filename.clone());
+        return Ok(filename);
       }
       return Err(anyhow::anyhow!(
         "Unable to get file name for emitted chunk: {reference_id}.You can only get file names once chunks have been generated after the 'renderStart' hook."
@@ -299,12 +299,11 @@ impl FileEmitter {
     warnings: &mut Vec<BuildDiagnostic>,
   ) {
     let mut additional_assets = Vec::new();
-    self.files.iter_mut().for_each(|mut file| {
-      let (key, value) = file.pair_mut();
-      if self.emitted_files.contains(key) {
-        return;
+    let files = self.files.pin();
+    for (key, value) in &files {
+      if !self.emitted_files.insert(key.clone()) {
+        continue;
       }
-      self.emitted_files.insert(key.clone());
 
       // Follow rollup using lowercase filename to check conflicts
       let lowercase_filename = value.filename.as_str().to_lowercase().into();
@@ -313,29 +312,29 @@ impl FileEmitter {
           .push(BuildDiagnostic::filename_conflict(value.filename.clone()).with_severity_warning());
       }
 
-      let mut names = std::mem::take(&mut value.names);
+      let mut names = value.names.clone();
       sort_names(&mut names);
 
-      let mut original_file_names = std::mem::take(&mut value.original_file_names);
+      let mut original_file_names = value.original_file_names.clone();
       original_file_names.sort_unstable();
       additional_assets.push(Output::Asset(Arc::new(OutputAsset {
         filename: value.filename.clone(),
         names,
         original_file_names,
-        source: std::mem::take(&mut value.source),
+        source: value.source.clone(),
       })));
-    });
-    // Sort to ensure deterministic output order regardless of DashMap iteration order
+    }
+    drop(files);
+    // Sort to ensure deterministic output order regardless of map iteration order
     additional_assets.sort_unstable_by(|a, b| a.filename().cmp(b.filename()));
     bundle.extend(additional_assets);
 
     // Add prebuilt chunks to the bundle
-    self.prebuilt_chunks.iter().for_each(|prebuilt_chunk| {
-      let (key, value) = prebuilt_chunk.pair();
-      if self.emitted_files.contains(key) {
-        return;
+    let prebuilt_chunks = self.prebuilt_chunks.pin();
+    for (key, value) in &prebuilt_chunks {
+      if !self.emitted_files.insert(key.clone()) {
+        continue;
       }
-      self.emitted_files.insert(key.clone());
 
       // Check for filename conflicts
       let lowercase_filename: ArcStr = value.file_name.as_str().to_lowercase().into();
@@ -361,7 +360,7 @@ impl FileEmitter {
         sourcemap_filename: value.sourcemap_filename.clone(),
         preliminary_filename: value.file_name.to_string(),
       })));
-    });
+    }
   }
 
   pub fn set_context_load_modules_tx(
@@ -375,12 +374,12 @@ impl FileEmitter {
   /// Associate a module ID with an emitted file reference ID.
   /// This allows the `new URL()` finalizer to look up asset filenames by module ID.
   pub fn associate_module_with_file_ref(&self, module_id: &str, reference_id: &str) {
-    self.module_to_file_ref.insert(ArcStr::from(module_id), ArcStr::from(reference_id));
+    self.module_to_file_ref.insert_and_forget(ArcStr::from(module_id), ArcStr::from(reference_id));
   }
 
   /// Get the emitted file reference ID for a given module ID.
   pub fn file_ref_for_module(&self, module_id: &str) -> Option<ArcStr> {
-    self.module_to_file_ref.get(module_id).map(|v| v.value().clone())
+    self.module_to_file_ref.get(module_id)
   }
 
   pub fn clear(&self) {

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -170,6 +170,6 @@ pub struct ChunkingContextImpl {
 
 impl ChunkingContextImpl {
   pub fn get_module_info(&self, module_id: &str) -> Option<Arc<ModuleInfo>> {
-    self.module_infos.get(module_id).map(|v| Arc::<ModuleInfo>::clone(v.value()))
+    self.module_infos.get(module_id)
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -4,7 +4,6 @@ use std::{
   sync::Arc,
 };
 
-use dashmap::Entry;
 use oxc::transformer::{ESFeature, EngineTargets, TransformOptions as OxcTransformOptions};
 use oxc_resolver::{ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions};
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -58,25 +57,28 @@ impl RawTransformOptions {
     warnings: &mut Vec<BuildDiagnostic>,
   ) -> BuildResult<Arc<OxcTransformOptions>> {
     let cache_key = tsconfig.map(|t| t.path.clone()).unwrap_or_default();
-    match self.cache.entry(cache_key) {
-      Entry::Occupied(entry) => Ok(Arc::clone(entry.get())),
-      Entry::Vacant(vacant_entry) => {
-        let merged_options = Arc::new(merge_transform_options_with_tsconfig(
-          self.base_options.as_ref().clone(),
-          tsconfig,
-          warnings,
-        )?);
-        vacant_entry.insert(Arc::clone(&merged_options));
-        Ok(merged_options)
-      }
+    // Fast path: return the cached options if present.
+    if let Some(cached) = self.cache.get(&cache_key) {
+      return Ok(cached);
     }
+    // Slow path: compute the merged options (fallible, hence computed outside the
+    // map). If another thread inserted concurrently, `get_or_insert_with` returns
+    // the value already in the map, keeping callers consistent.
+    let merged_options = Arc::new(merge_transform_options_with_tsconfig(
+      self.base_options.as_ref().clone(),
+      tsconfig,
+      warnings,
+    )?);
+    Ok(self.cache.get_or_insert_with(cache_key, || merged_options))
   }
 }
 
 #[derive(Debug, Clone)]
 pub enum TransformOptionsInner {
-  /// Auto tsconfig discovery - each file uses its nearest tsconfig
-  Raw(RawTransformOptions),
+  /// Auto tsconfig discovery - each file uses its nearest tsconfig.
+  /// Boxed because `RawTransformOptions` embeds a concurrent cache and resolver,
+  /// which would otherwise make this variant far larger than `Normal`.
+  Raw(Box<RawTransformOptions>),
   /// Pre-resolved options - all files use the same options
   Normal(Arc<OxcTransformOptions>),
 }
@@ -110,7 +112,7 @@ impl TransformOptions {
 
   #[inline]
   pub fn new_raw(raw: RawTransformOptions, target: EngineTargets, jsx_preset: JsxPreset) -> Self {
-    Self { inner: TransformOptionsInner::Raw(raw), target, jsx_preset }
+    Self { inner: TransformOptionsInner::Raw(Box::new(raw)), target, jsx_preset }
   }
 
   #[inline]

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -122,7 +122,8 @@ impl BundleCoordinator {
         }
         #[cfg(feature = "testing")]
         CoordinatorMsg::GetWatchedFiles { reply } => {
-          let result = self.watched_files.iter().map(|s| s.to_string()).collect();
+          let result =
+            self.watched_files.iter_cloned().into_iter().map(|s| s.to_string()).collect();
           let _ = reply.send(result);
         }
         CoordinatorMsg::ModuleChanged { module_id } => {
@@ -491,8 +492,8 @@ impl BundleCoordinator {
 
     let mut watcher = self.watcher.lock().ok().context("Failed to acquire watcher lock")?;
     let mut paths_mut = watcher.paths_mut();
-    for watch_file in watch_files.iter() {
-      let watch_file = &**watch_file;
+    for watch_file in watch_files.iter_cloned() {
+      let watch_file = &*watch_file;
       if !self.watched_files.contains(watch_file)
         && pattern_filter::filter(exclude, include, watch_file, &cwd).inner()
       {

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -25,7 +25,6 @@ workspace = true
 anyhow = { workspace = true }
 arcstr = { workspace = true }
 bitflags = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true, features = ["display"] }
 nodejs-built-in-modules = { workspace = true }
 oxc_index = { workspace = true }

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -176,11 +176,11 @@ impl NativePluginContextImpl {
   }
 
   pub fn get_module_info(&self, module_id: &str) -> Option<Arc<rolldown_common::ModuleInfo>> {
-    self.module_infos.get(module_id).map(|v| Arc::<rolldown_common::ModuleInfo>::clone(v.value()))
+    self.module_infos.get(module_id)
   }
 
   pub fn get_module_ids(&self) -> Vec<ArcStr> {
-    self.module_infos.iter().map(|v| v.key().clone()).collect()
+    self.module_infos.pin().keys().cloned().collect()
   }
 
   pub fn cwd(&self) -> &PathBuf {

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context_meta.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context_meta.rs
@@ -12,19 +12,17 @@ pub struct PluginContextMeta {
 
 impl PluginContextMeta {
   pub fn insert<T: Any + Send + Sync>(&self, value: Arc<T>) {
-    self.inner.insert(TypeId::of::<T>(), value);
+    self.inner.insert_and_forget(TypeId::of::<T>(), value);
   }
 
   pub fn get<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
-    self.inner.get(&TypeId::of::<T>()).and_then(|v| v.clone().downcast::<T>().ok())
+    self.inner.get(&TypeId::of::<T>()).and_then(|v| v.downcast::<T>().ok())
   }
 
   pub fn get_or_insert_default<T: Any + Send + Sync + Default>(&self) -> Arc<T> {
     self
       .inner
-      .entry(TypeId::of::<T>())
-      .or_insert_with(|| Arc::new(T::default()))
-      .clone()
+      .get_or_insert_with(TypeId::of::<T>(), || Arc::new(T::default()))
       .downcast::<T>()
       .expect("PluginContextMeta: type mismatch for inserted value")
   }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -13,12 +13,11 @@ use std::{
 
 use anyhow::Context;
 use arcstr::ArcStr;
-use dashmap::DashMap;
 use rolldown_common::{
   ModuleId, ModuleIdx, ModuleInfo, ModuleLoaderMsg, PluginIdx, SharedFileEmitter,
   SharedModuleInfoDashMap,
 };
-use rolldown_utils::dashmap::FxDashSet;
+use rolldown_utils::dashmap::{Compute, FxDashMap, FxDashSet, Operation};
 use sugar_path::SugarPath;
 use tokio::sync::broadcast;
 
@@ -40,7 +39,7 @@ pub struct PluginDriver {
   pub watch_files: Arc<FxDashSet<ArcStr>>,
   pub module_infos: SharedModuleInfoDashMap,
   /// Module dependencies tracked during load/transform hooks for HMR invalidation
-  pub transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
+  pub transform_dependencies: Arc<FxDashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   context_load_completion_manager: ContextLoadCompletionManager,
   pub(crate) tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<ModuleLoaderMsg>>>>,
   /// Timing collector for plugin hooks (None if plugin timing is disabled)
@@ -104,8 +103,7 @@ impl PluginDriver {
 
     self
       .transform_dependencies
-      .entry(module_idx)
-      .or_insert_with(|| Arc::new(FxDashSet::default()))
+      .get_or_insert_with(module_idx, || Arc::new(FxDashSet::default()))
       .insert(dependency);
   }
 
@@ -183,7 +181,7 @@ impl Deref for PluginDriver {
 
 #[derive(Default)]
 struct ContextLoadCompletionManager {
-  notifiers: DashMap<ModuleId, ContextLoadCompletionState>,
+  notifiers: FxDashMap<ModuleId, ContextLoadCompletionState>,
 }
 
 enum ContextLoadCompletionState {
@@ -193,19 +191,24 @@ enum ContextLoadCompletionState {
 
 impl ContextLoadCompletionManager {
   pub async fn wait_for_completion(&self, module_id: ModuleId) {
-    let mut rx = match self.notifiers.entry(module_id) {
-      dashmap::Entry::Vacant(guard) => {
-        let (tx, rx) = broadcast::channel(1);
-        guard.insert(ContextLoadCompletionState::Pending(tx));
-        rx
-      }
-      dashmap::Entry::Occupied(mut guard) => match guard.get_mut() {
+    let mut rx = {
+      // Atomically register a pending notifier if absent, then subscribe to the
+      // sender currently stored for this module. Whether we inserted it or it was
+      // already pending, subscribing before `mark_completion` runs guarantees the
+      // completion signal is delivered to this receiver.
+      let notifiers = self.notifiers.pin();
+      let state = notifiers.get_or_insert_with(module_id, || {
+        let (tx, _rx) = broadcast::channel(1);
+        ContextLoadCompletionState::Pending(tx)
+      });
+      match state {
         ContextLoadCompletionState::Pending(sender) => sender.subscribe(),
         ContextLoadCompletionState::Completed => {
           /* no need to wait */
           return;
         }
-      },
+      }
+      // `notifiers` guard is dropped here, before the `.await` below.
     };
 
     if let Err(err) = rx.recv().await {
@@ -219,28 +222,38 @@ impl ContextLoadCompletionManager {
   }
 
   pub fn mark_completion(&self, module_id: ModuleId) {
-    match self.notifiers.entry(module_id) {
-      dashmap::Entry::Vacant(guard) => {
-        guard.insert(ContextLoadCompletionState::Completed);
+    let notifiers = self.notifiers.pin();
+    // Atomically transition the entry to `Completed`. The closure must be pure
+    // (it may be retried under contention), so the actual notification is sent
+    // afterwards using the previous `Pending` sender exposed by `Compute::Updated`,
+    // which remains valid for the lifetime of the pin guard.
+    match notifiers.compute(module_id, |entry| match entry {
+      Some((_, ContextLoadCompletionState::Completed)) => {
+        // Re-marking an already-completed module: leave it unchanged.
+        Operation::Abort(())
       }
-      dashmap::Entry::Occupied(mut guard) => match guard.get_mut() {
-        ContextLoadCompletionState::Pending(sender) => {
-          sender.send(()).expect(
-            "PluginDriver: failed to send completion notification - receiver was dropped before wait_for_completion was called, indicating a race condition in module loading"
-          );
-          *guard.get_mut() = ContextLoadCompletionState::Completed;
-        }
-        ContextLoadCompletionState::Completed => {
-          // This happens if `.mark_completion` is called multiple times, which is not expected
-          debug_assert!(false, "mark_completion was called even though it was already completed");
-          tracing::warn!("mark_completion was called even though it was already completed");
-        }
-      },
+      _ => Operation::Insert(ContextLoadCompletionState::Completed),
+    }) {
+      Compute::Updated { old: (_, ContextLoadCompletionState::Pending(sender)), .. } => {
+        sender.send(()).expect(
+          "PluginDriver: failed to send completion notification - receiver was dropped before wait_for_completion was called, indicating a race condition in module loading"
+        );
+      }
+      Compute::Inserted(..) => {
+        // No waiter had registered yet; `Completed` is recorded for future waiters.
+      }
+      Compute::Aborted(()) => {
+        // This happens if `.mark_completion` is called multiple times, which is not expected
+        debug_assert!(false, "mark_completion was called even though it was already completed");
+        tracing::warn!("mark_completion was called even though it was already completed");
+      }
+      Compute::Updated { old: (_, ContextLoadCompletionState::Completed), .. }
+      | Compute::Removed(..) => unreachable!(),
     }
   }
 
   pub fn invalidate(&self, module_id: &ModuleId) {
-    self.notifiers.remove(module_id);
+    self.notifiers.pin().remove(module_id);
   }
 
   pub fn clear(&self) {

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -1,13 +1,12 @@
 use std::sync::{Arc, Weak};
 
 use arcstr::ArcStr;
-use dashmap::DashMap;
 use oxc_index::IndexVec;
 use rolldown_common::{
   ModuleIdx, SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions,
 };
 use rolldown_resolver::Resolver;
-use rolldown_utils::dashmap::FxDashSet;
+use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 
 use crate::{
   __inner::SharedPluginable,
@@ -36,7 +35,7 @@ impl PluginDriverFactory {
     session: &rolldown_devtools::Session,
     initial_bundle_span: &tracing::Span,
     module_infos: SharedModuleInfoDashMap,
-    transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
+    transform_dependencies: Arc<FxDashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   ) -> Arc<crate::plugin_driver::PluginDriver> {
     let watch_files = Arc::new(FxDashSet::default());
     let meta = Arc::new(PluginContextMeta::default());

--- a/crates/rolldown_plugin/src/types/hook_timing.rs
+++ b/crates/rolldown_plugin/src/types/hook_timing.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use arcstr::ArcStr;
-use dashmap::DashMap;
 use rolldown_common::PluginIdx;
+use rolldown_utils::dashmap::FxDashMap;
 
 /// Summary of timing for a single plugin
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ struct PluginTimingData {
 #[derive(Debug, Default)]
 pub struct HookTimingCollector {
   /// Map from plugin_idx to timing data (only non-internal plugins are registered)
-  plugins: DashMap<PluginIdx, PluginTimingData>,
+  plugins: FxDashMap<PluginIdx, PluginTimingData>,
   /// Total build time in microseconds
   total_build_micros: AtomicU64,
   /// Link stage time in microseconds (pure Rust core, no plugins)
@@ -32,12 +32,15 @@ pub struct HookTimingCollector {
 impl HookTimingCollector {
   /// Register a plugin with its name (only for non-internal plugins)
   pub fn register_plugin(&self, plugin_idx: PluginIdx, name: ArcStr) {
-    self.plugins.insert(plugin_idx, PluginTimingData { name, duration_micros: AtomicU64::new(0) });
+    self
+      .plugins
+      .pin()
+      .insert(plugin_idx, PluginTimingData { name, duration_micros: AtomicU64::new(0) });
   }
 
   /// Record a hook execution time in microseconds (only records if plugin was registered)
   pub fn record(&self, plugin_idx: PluginIdx, micros: u64) {
-    if let Some(data) = self.plugins.get(&plugin_idx) {
+    if let Some(data) = self.plugins.pin().get(&plugin_idx) {
       data.duration_micros.fetch_add(micros, Ordering::Relaxed);
     }
   }
@@ -74,10 +77,11 @@ impl HookTimingCollector {
   pub fn get_summary(&self) -> Vec<PluginTimingSummary> {
     let mut summaries = self
       .plugins
+      .pin()
       .iter()
-      .map(|entry| {
-        let total_duration_micros = entry.value().duration_micros.load(Ordering::Relaxed);
-        PluginTimingSummary { plugin_name: entry.value().name.clone(), total_duration_micros }
+      .map(|(_, data)| {
+        let total_duration_micros = data.duration_micros.load(Ordering::Relaxed);
+        PluginTimingSummary { plugin_name: data.name.clone(), total_duration_micros }
       })
       .collect::<Vec<_>>();
     summaries.sort_by_key(|b| std::cmp::Reverse(b.total_duration_micros));
@@ -86,8 +90,9 @@ impl HookTimingCollector {
 
   /// Clear all collected timings
   pub fn clear(&self) {
-    for mut entry in self.plugins.iter_mut() {
-      entry.value_mut().duration_micros.store(0, Ordering::Relaxed);
+    let plugins = self.plugins.pin();
+    for (_, data) in &plugins {
+      data.duration_micros.store(0, Ordering::Relaxed);
     }
   }
 }

--- a/crates/rolldown_plugin_data_url/src/lib.rs
+++ b/crates/rolldown_plugin_data_url/src/lib.rs
@@ -69,7 +69,7 @@ impl Plugin for DataUrlPlugin {
       let id: ArcStr =
         format!("\0rolldown/data-url:{}", xxhash_base64_url(args.specifier.as_bytes())).into();
 
-      self.resolved_data_url.insert(id.clone(), ResolvedDataUrl { data, module_type });
+      self.resolved_data_url.insert_and_forget(id.clone(), ResolvedDataUrl { data, module_type });
 
       return Ok(Some(HookResolveIdOutput { id, ..Default::default() }));
     }
@@ -82,14 +82,14 @@ impl Plugin for DataUrlPlugin {
   }
 
   async fn load(&self, _ctx: SharedLoadPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
-    let Some(resolved) = self.resolved_data_url.get(args.id) else {
-      return Ok(None);
-    };
-
-    Ok(Some(HookLoadOutput {
+    let Some(output) = self.resolved_data_url.with(args.id, |resolved| HookLoadOutput {
       code: resolved.data.clone(),
       module_type: Some(resolved.module_type.clone()),
       ..Default::default()
-    }))
+    }) else {
+      return Ok(None);
+    };
+
+    Ok(Some(output))
   }
 }

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 anyhow = { workspace = true }
 arcstr = { workspace = true }
 cow-utils = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/constants.rs
+++ b/crates/rolldown_plugin_utils/src/constants.rs
@@ -38,7 +38,7 @@ pub struct ViteMetadata {
 
 impl ViteMetadata {
   pub fn get(&self, key: ArcStr) -> Arc<ChunkMetadata> {
-    self.inner.entry(key).or_default().clone()
+    self.inner.get_or_insert_default(key)
   }
 }
 
@@ -65,7 +65,7 @@ pub struct HTMLProxyMapItem {
 
 #[derive(Debug, Default)]
 pub struct HTMLProxyMap {
-  pub inner: FxDashMap<String, FxDashMap<usize, HTMLProxyMapItem>>,
+  pub inner: FxDashMap<String, Arc<FxDashMap<usize, HTMLProxyMapItem>>>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rolldown_plugin_utils/src/file_to_url.rs
+++ b/crates/rolldown_plugin_utils/src/file_to_url.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 
-use dashmap::Entry;
 use regex::Regex;
 
 use rolldown_utils::base64::to_standard_base64;
@@ -77,7 +76,7 @@ impl FileToUrlEnv<'_> {
 
     // Fast path: check if already cached
     if let Some(cached) = cache.0.get(id.as_ref()) {
-      return Ok(cached.to_string());
+      return Ok(cached);
     }
 
     // Slow path: compute the URL
@@ -108,19 +107,9 @@ impl FileToUrlEnv<'_> {
       rolldown_utils::concat_string!("__VITE_ASSET__", reference_id, "__", postfix)
     };
 
-    // Use entry API to atomically insert only if not present
-    // If another thread inserted while we were computing, use their value instead
-    let final_url = match cache.0.entry(id.to_string()) {
-      Entry::Occupied(entry) => {
-        // Another thread already inserted a value, use theirs to maintain consistency
-        entry.get().clone()
-      }
-      Entry::Vacant(entry) => {
-        // We're the first, insert our computed value
-        entry.insert(url.clone());
-        url
-      }
-    };
+    // Atomically insert only if not present. If another thread inserted while we
+    // were computing, `get_or_insert_with` returns their value to stay consistent.
+    let final_url = cache.0.get_or_insert_with(id.to_string(), || url);
 
     Ok(final_url)
   }

--- a/crates/rolldown_plugin_utils/src/public_file_to_built_url.rs
+++ b/crates/rolldown_plugin_utils/src/public_file_to_built_url.rs
@@ -19,7 +19,7 @@ impl<'a> PublicFileToBuiltUrlEnv<'a> {
     let cache = self.ctx.meta().get::<PublicAssetUrlCache>().expect("PublicAssetUrlCache missing");
     let built_url = rolldown_utils::concat_string!("__VITE_ASSET_PUBLIC__", hash, "__");
     if !cache.0.contains_key(&hash) {
-      cache.0.insert(hash, url.to_string());
+      cache.0.insert_and_forget(hash, url.to_string());
     }
     built_url
   }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
@@ -35,7 +35,7 @@ impl AddDeps<'_, '_> {
         }
         if let Some(cache) = self.ctx.meta().get::<ViteMetadata>() {
           if let Some(metadata) = cache.inner.get(chunk.preliminary_filename.as_str()) {
-            for file in metadata.imported_css.iter() {
+            for file in metadata.imported_css.iter_cloned() {
               self.deps.insert(file.to_string());
             }
           }
@@ -52,7 +52,7 @@ impl AddDeps<'_, '_> {
       if let Some(cache) = self.ctx.meta().get::<ViteMetadata>() {
         if let Some(metadata) = cache.inner.get(chunk.preliminary_filename.as_str()) {
           if !metadata.imported_css.is_empty() {
-            for file in metadata.imported_css.iter() {
+            for file in metadata.imported_css.iter_cloned() {
               self.deps.insert(file.to_string());
             }
             *self.has_removed_pure_css_chunks = true;

--- a/crates/rolldown_plugin_vite_css_post/src/lib.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/lib.rs
@@ -157,9 +157,9 @@ impl Plugin for ViteCSSPostPlugin {
       rolldown_utils::concat_string!("export default ", serde_json::to_string(&css)?)
     } else {
       let styles = ctx.meta().get::<CSSStyles>().expect("CSSStyles missing");
-      styles.inner.insert(args.id.to_string(), css.into_owned());
+      styles.inner.insert_and_forget(args.id.to_string(), css.into_owned());
       if let Some(modules) = modules {
-        let data = serde_json::to_value(&*modules)?;
+        let data = serde_json::to_value(&modules)?;
         data_to_esm(&data, true)
       } else {
         String::new()
@@ -188,7 +188,7 @@ impl Plugin for ViteCSSPostPlugin {
     let mut css_chunk: Option<String> = None;
     for module_id in &args.chunk.module_ids {
       let id = module_id.as_str();
-      if let Some(css) = styles.inner.get(id).map(|s| s.to_owned()) {
+      if let Some(css) = styles.inner.get(id) {
         // `?transform-only` is used for ?url and shouldn't be included in normal CSS chunks
         if find_special_query(id, b"transform-only").is_some() {
           continue;
@@ -269,11 +269,12 @@ impl Plugin for ViteCSSPostPlugin {
   ) -> rolldown_plugin::HookAugmentChunkHashReturn {
     Ok(ctx.meta().get::<ViteMetadata>().and_then(|vite_metadata| {
       let metadata = vite_metadata.get(chunk.filename.clone());
-      (!metadata.imported_css.is_empty()).then(|| {
-        let capacity = metadata.imported_css.iter().fold(0, |acc, s| acc + s.len());
+      let imported_css = metadata.imported_css.iter_cloned();
+      (!imported_css.is_empty()).then(|| {
+        let capacity = imported_css.iter().fold(0, |acc, s| acc + s.len());
         let mut hash = String::with_capacity(capacity);
-        for id in metadata.imported_css.iter() {
-          hash.push_str(&id);
+        for id in &imported_css {
+          hash.push_str(id);
         }
         hash
       })

--- a/crates/rolldown_plugin_vite_css_post/src/utils.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/utils.rs
@@ -118,7 +118,7 @@ impl ViteCSSPostPlugin {
           continue;
         }
 
-        let Some(style) = css_styles.inner.get(&id).map(|s| s.to_owned()) else {
+        let Some(style) = css_styles.inner.get(&id) else {
           return Err(anyhow::anyhow!("CSS content for  '{id}' was not found"));
         };
 
@@ -371,16 +371,12 @@ impl ViteCSSPostPlugin {
             .get::<PublicAssetUrlCache>()
             .ok_or_else(|| anyhow::anyhow!("PublicAssetUrlCache missing"))?;
 
-          let public_url = cache
-            .0
-            .get(hash)
-            .ok_or_else(|| {
-              anyhow::anyhow!(
-                "Can't find the cache of {}",
-                &css_chunk[(range.start as usize)..(range.end as usize)]
-              )
-            })?
-            .to_string();
+          let public_url = cache.0.get(hash).ok_or_else(|| {
+            anyhow::anyhow!(
+              "Can't find the cache of {}",
+              &css_chunk[(range.start as usize)..(range.end as usize)]
+            )
+          })?;
 
           let env = ToOutputFilePathEnv {
             is_ssr: self.is_ssr,
@@ -700,11 +696,11 @@ impl ViteCSSPostPlugin {
               if pure_css_chunk_names.contains(file) {
                 let chunk = &chunks[file];
                 let file_metadata = vite_metadata.get(chunk.preliminary_filename.as_str().into());
-                file_metadata.imported_css.iter().for_each(|file| {
-                  chunk_metadata.imported_css.insert(file.clone());
+                file_metadata.imported_css.iter_cloned().into_iter().for_each(|file| {
+                  chunk_metadata.imported_css.insert(file);
                 });
-                file_metadata.imported_assets.iter().for_each(|file| {
-                  chunk_metadata.imported_assets.insert(file.clone());
+                file_metadata.imported_assets.iter_cloned().into_iter().for_each(|file| {
+                  chunk_metadata.imported_assets.insert(file);
                 });
                 chunk_imports_pure_css_chunk = true;
                 return false;

--- a/crates/rolldown_plugin_vite_html/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html/src/lib.rs
@@ -503,11 +503,7 @@ impl Plugin for ViteHtmlPlugin {
   ) -> rolldown_plugin::HookNoopReturn {
     let mut inline_entry_chunk = FxHashSet::default();
     let mut analyzed_imported_css_files = FxHashMap::default();
-    let html_result_map = self
-      .html_result_map
-      .iter()
-      .map(|item| (item.key().clone(), item.value().clone()))
-      .collect::<Vec<_>>();
+    let html_result_map = self.html_result_map.iter_cloned();
     for ((id, assets_base), (html, is_async)) in html_result_map {
       let mut result = html.clone();
 

--- a/crates/rolldown_plugin_vite_html/src/utils/helpers.rs
+++ b/crates/rolldown_plugin_vite_html/src/utils/helpers.rs
@@ -162,7 +162,7 @@ pub fn get_css_files_for_chunk(
       .get::<ViteMetadata>()
       .map(|vite_metadata| vite_metadata.get(chunk.preliminary_filename.as_str().into()))
     {
-      for file in chunk_metadata.imported_css.iter() {
+      for file in chunk_metadata.imported_css.iter_cloned() {
         if !seen_css.contains(file.as_str()) {
           seen_css.insert(file.to_string());
           files.push(file.to_string());

--- a/crates/rolldown_plugin_vite_html/src/utils/plugin_ext.rs
+++ b/crates/rolldown_plugin_vite_html/src/utils/plugin_ext.rs
@@ -36,9 +36,8 @@ impl ViteHtmlPlugin {
       .meta()
       .get_or_insert_default::<HTMLProxyMap>()
       .inner
-      .entry(file)
-      .or_default()
-      .insert(index, result);
+      .get_or_insert_default(file)
+      .insert_and_forget(index, result);
   }
 
   #[expect(clippy::too_many_arguments)]
@@ -247,7 +246,7 @@ impl ViteHtmlPlugin {
       let cache = ctx.meta().get::<HTMLProxyResult>().expect("HTMLProxyResult missing");
       let css_transformed_code = cache.inner.get(scoped_name).unwrap();
       #[expect(clippy::cast_possible_truncation)]
-      s.update(start as u32, match_end as u32, css_transformed_code.to_string())
+      s.update(start as u32, match_end as u32, css_transformed_code)
         .expect("update should not fail in html plugin");
     }
     s
@@ -324,7 +323,7 @@ impl ViteHtmlPlugin {
             .get::<PublicAssetUrlCache>()
             .ok_or_else(|| anyhow::anyhow!("PublicAssetUrlCache missing"))?;
 
-          let filename = cache.0.get(hash).unwrap().to_owned();
+          let filename = cache.0.get(hash).unwrap();
           let uri =
             self.to_output_file_path(&filename, assets_base, true, relative_url_path).await?;
 

--- a/crates/rolldown_plugin_vite_html_inline_proxy/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html_inline_proxy/src/lib.rs
@@ -83,14 +83,15 @@ impl Plugin for ViteHtmlInlineProxyPlugin {
     if let Some(html_proxy_map) =
       ctx.meta().get::<HTMLProxyMap>().expect("HTMLProxyMap is missing").inner.get(url)
     {
-      if let Some(result) = html_proxy_map.get(&index) {
-        let HTMLProxyMapItem { code, map } = result.value();
-        return Ok(Some(HookLoadOutput {
+      if let Some(output) =
+        html_proxy_map.with(&index, |HTMLProxyMapItem { code, map }| HookLoadOutput {
           code: code.clone(),
           map: map.clone(),
           side_effects: Some(HookSideEffects::True),
           ..Default::default()
-        }));
+        })
+      {
+        return Ok(Some(output));
       }
     }
 

--- a/crates/rolldown_plugin_vite_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/lib.rs
@@ -51,9 +51,10 @@ impl Plugin for ViteManifestPlugin {
         Output::Chunk(chunk) => {
           let name = self.get_chunk_name(chunk, is_legacy);
           let vite_metadata = if self.is_enable_v2 {
-            ctx.meta().get::<ViteMetadata>().and_then(|cache| {
-              cache.inner.get(chunk.preliminary_filename.as_str()).map(|v| v.clone())
-            })
+            ctx
+              .meta()
+              .get::<ViteMetadata>()
+              .and_then(|cache| cache.inner.get(chunk.preliminary_filename.as_str()))
           } else {
             None
           };
@@ -75,8 +76,9 @@ impl Plugin for ViteManifestPlugin {
                   .get::<CSSEntriesCache>()
                   .expect("CSSEntriesCache is missing")
                   .inner
-                  .iter()
-                  .map(|entry| (entry.key().to_string(), entry.value().to_string()))
+                  .iter_cloned()
+                  .into_iter()
+                  .map(|(key, value)| (key.to_string(), value.to_string()))
                   .collect::<FxHashMap<_, _>>()
               } else {
                 (self.css_entries)().await?

--- a/crates/rolldown_plugin_vite_manifest/src/utils.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/utils.rs
@@ -79,12 +79,12 @@ impl ViteManifestPlugin {
     is_legacy: bool,
     vite_metadata: Option<&Arc<ChunkMetadata>>,
   ) -> ManifestChunk {
-    let css = vite_metadata
-      .as_ref()
-      .map(|meta| meta.imported_css.iter().map(|s| s.to_string()).collect::<Vec<_>>());
-    let assets = vite_metadata
-      .as_ref()
-      .map(|meta| meta.imported_assets.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    let css = vite_metadata.as_ref().map(|meta| {
+      meta.imported_css.iter_cloned().into_iter().map(|s| s.to_string()).collect::<Vec<_>>()
+    });
+    let assets = vite_metadata.as_ref().map(|meta| {
+      meta.imported_assets.iter_cloned().into_iter().map(|s| s.to_string()).collect::<Vec<_>>()
+    });
 
     ManifestChunk {
       file: chunk.filename.to_string(),

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 # NOTE: IDNA support is turned off: https://docs.rs/crate/idna_adapter/latest#:~:text=Turning%20off%20IDNA%20support
 arcstr = { workspace = true }
 cow-utils = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true }
 fast-glob = { workspace = true }
 nodejs-built-in-modules = { workspace = true }

--- a/crates/rolldown_plugin_vite_resolve/src/external.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/external.rs
@@ -1,6 +1,5 @@
 use std::{path::Path, sync::Arc};
 
-use dashmap::DashMap;
 use rolldown_std_utils::PathExt as _;
 use rolldown_utils::{dashmap::FxDashMap, pattern_filter::StringOrRegex};
 use rustc_hash::FxHashSet;
@@ -88,12 +87,12 @@ impl ExternalDecider {
     resolver: Arc<Resolver>,
     builtin_checker: Arc<BuiltinChecker>,
   ) -> Self {
-    Self { options, resolver, builtin_checker, processed_ids: DashMap::default() }
+    Self { options, resolver, builtin_checker, processed_ids: FxDashMap::default() }
   }
 
   pub fn is_external(&self, id: &str, importer: Option<&str>) -> bool {
     if let Some(cached) = self.processed_ids.get(id) {
-      return *cached;
+      return cached;
     }
 
     let mut is_external = false;
@@ -101,7 +100,7 @@ impl ExternalDecider {
       is_external =
         self.builtin_checker.is_builtin(id) || self.is_configured_as_external(id, importer);
     }
-    self.processed_ids.insert(id.to_owned(), is_external);
+    self.processed_ids.insert_and_forget(id.to_owned(), is_external);
 
     is_external
   }

--- a/crates/rolldown_plugin_vite_resolve/src/package_json_cache.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/package_json_cache.rs
@@ -17,10 +17,12 @@ impl PackageJsonCache {
     oxc_pkg_json: &oxc_resolver::PackageJson,
   ) -> Arc<PackageJson> {
     match self.side_effects_cache.get(&oxc_pkg_json.realpath) {
-      Some(v) => Arc::clone(v.value()),
+      Some(v) => v,
       _ => {
         let pkg_json = Arc::new(PackageJson::from_oxc_pkg_json(oxc_pkg_json));
-        self.side_effects_cache.insert(oxc_pkg_json.realpath.clone(), Arc::clone(&pkg_json));
+        self
+          .side_effects_cache
+          .insert_and_forget(oxc_pkg_json.realpath.clone(), Arc::clone(&pkg_json));
         pkg_json
       }
     }
@@ -31,7 +33,7 @@ impl PackageJsonCache {
     oxc_pkg_json: &oxc_resolver::PackageJson,
   ) -> Arc<PackageJsonWithOptionalPeerDependencies> {
     match self.optional_peer_dep_cache.get(&oxc_pkg_json.realpath) {
-      Some(v) => Arc::clone(v.value()),
+      Some(v) => v,
       _ => {
         let package_json_with_optional_peer_deps = {
           let Ok(package_json_string) = fs::read_to_string(&oxc_pkg_json.realpath) else {
@@ -47,7 +49,9 @@ impl PackageJsonCache {
         };
 
         let pkg_json = Arc::new(package_json_with_optional_peer_deps);
-        self.optional_peer_dep_cache.insert(oxc_pkg_json.realpath.clone(), Arc::clone(&pkg_json));
+        self
+          .optional_peer_dep_cache
+          .insert_and_forget(oxc_pkg_json.realpath.clone(), Arc::clone(&pkg_json));
         pkg_json
       }
     }

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arcstr = { workspace = true }
-dashmap = { workspace = true }
 itertools = { workspace = true }
 oxc_resolver = { workspace = true }
 rolldown_common = { workspace = true }

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::Context;
 use arcstr::ArcStr;
-use dashmap::DashMap;
 use oxc_resolver::{
   ModuleType, PackageJson as OxcPackageJson, PackageType, Resolution, ResolveError,
   ResolverGeneric, TsConfig as OxcTsConfig,
@@ -63,7 +62,7 @@ impl<Fs: FileSystem + Clone> Resolver<Fs> {
       require_resolver,
       css_resolver,
       new_url_resolver,
-      package_json_cache: DashMap::default(),
+      package_json_cache: FxDashMap::default(),
     }
   }
 }
@@ -112,14 +111,14 @@ impl<Fs: FileSystem> Resolver<Fs> {
 
   fn inner_try_get_package_json_or_create(&self, path: &Path) -> anyhow::Result<Arc<PackageJson>> {
     if let Some(v) = self.package_json_cache.get(path) {
-      Ok(Arc::clone(v.value()))
+      Ok(v)
     } else {
       // User has the responsibility to ensure `path` is real path if needed. We just pass it through.
       let realpath = path.to_path_buf();
       let json_bytes = self.fs.read(path)?;
       let oxc_pkg_json = OxcPackageJson::parse(&self.fs, realpath.clone(), realpath, json_bytes)?;
       let pkg_json = Arc::new(PackageJson::from_oxc_pkg_json(&oxc_pkg_json));
-      self.package_json_cache.insert(path.to_path_buf(), Arc::clone(&pkg_json));
+      self.package_json_cache.insert_and_forget(path.to_path_buf(), Arc::clone(&pkg_json));
       Ok(pkg_json)
     }
   }
@@ -183,13 +182,9 @@ impl<Fs: FileSystem> Resolver<Fs> {
   }
 
   fn cached_package_json(&self, oxc_pkg_json: &OxcPackageJson) -> Arc<PackageJson> {
-    Arc::clone(
-      self
-        .package_json_cache
-        .entry(oxc_pkg_json.realpath.clone())
-        .or_insert_with(|| Arc::new(PackageJson::from_oxc_pkg_json(oxc_pkg_json)))
-        .value(),
-    )
+    self.package_json_cache.get_or_insert_with(oxc_pkg_json.realpath.clone(), || {
+      Arc::new(PackageJson::from_oxc_pkg_json(oxc_pkg_json))
+    })
   }
 
   /// Attempts to resolve using Rollup compatibility mode.

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -28,7 +28,6 @@ arcstr = { workspace = true }
 base-encode = { workspace = true }
 base64-simd = { workspace = true }
 cow-utils = { workspace = true }
-dashmap = { workspace = true }
 fast-glob = { workspace = true }
 form_urlencoded = { workspace = true }
 futures = { workspace = true }
@@ -41,6 +40,7 @@ nom = { workspace = true }
 oxc = { workspace = true }
 oxc_index = { workspace = true }
 oxc_str = { workspace = true }
+papaya = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }
 rolldown_error = { workspace = true }

--- a/crates/rolldown_utils/src/dashmap.rs
+++ b/crates/rolldown_utils/src/dashmap.rs
@@ -1,5 +1,259 @@
-use dashmap::{DashMap, DashSet};
+//! Thin wrappers around [`papaya`] concurrent collections that keep the
+//! ergonomics rolldown previously relied on from `dashmap`, while removing the
+//! `dashmap` dependency (and its private `hashbrown 0.14` copy) from the graph.
+//!
+//! Unlike `dashmap`, `papaya` is lock-free and all access goes through a
+//! *guard* obtained via [`papaya::HashMap::pin`]. References returned by the map
+//! borrow that guard, so they cannot outlive it. To preserve the call sites that
+//! used to hold a `dashmap::Ref`, the helpers here pin internally and hand back
+//! owned/cloned values. When finer-grained control is required, call
+//! [`FxDashMap::pin`] / [`FxDashSet::pin`] directly to operate within a single
+//! guard scope.
+
+use std::{borrow::Borrow, fmt, hash::Hash};
+
+use papaya::{HashMap, HashSet};
 use rustc_hash::FxBuildHasher;
 
-pub type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
-pub type FxDashSet<V> = DashSet<V, FxBuildHasher>;
+/// Re-exported so downstream crates can drive atomic read-modify-write loops via
+/// [`FxDashMap::pin`] without taking a direct dependency on `papaya`.
+pub use papaya::{Compute, Operation};
+
+/// Concurrent hash map backed by [`papaya`] using the fast `FxHasher`.
+pub struct FxDashMap<K, V>(HashMap<K, V, FxBuildHasher>);
+
+// Manual `Debug` impl: `papaya`'s collections only implement `Debug` under
+// `K: Hash + Eq` (+ `V: Debug`), which would leak those bounds onto every
+// `#[derive(Debug)]` struct that embeds these maps. Print a placeholder instead.
+impl<K, V> fmt::Debug for FxDashMap<K, V> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("FxDashMap").finish_non_exhaustive()
+  }
+}
+
+impl<K, V> Default for FxDashMap<K, V> {
+  fn default() -> Self {
+    Self(HashMap::builder().hasher(FxBuildHasher).build())
+  }
+}
+
+impl<K, V> Clone for FxDashMap<K, V>
+where
+  K: Clone + Hash + Eq,
+  V: Clone,
+{
+  fn clone(&self) -> Self {
+    Self(self.0.clone())
+  }
+}
+
+impl<K, V> FxDashMap<K, V>
+where
+  K: Hash + Eq,
+{
+  /// Pin the map to obtain a guard for performing multiple operations within a
+  /// single guard scope. See [`papaya::HashMapRef`] for the available methods.
+  #[inline]
+  pub fn pin(&self) -> papaya::HashMapRef<'_, K, V, FxBuildHasher, papaya::LocalGuard<'_>> {
+    self.0.pin()
+  }
+
+  /// Access the underlying [`papaya::HashMap`].
+  #[inline]
+  pub fn inner(&self) -> &HashMap<K, V, FxBuildHasher> {
+    &self.0
+  }
+
+  /// Inserts a key-value pair, returning the previous value (cloned) if any.
+  #[inline]
+  pub fn insert(&self, key: K, value: V) -> Option<V>
+  where
+    V: Clone,
+  {
+    self.0.pin().insert(key, value).cloned()
+  }
+
+  /// Inserts a key-value pair, ignoring any previous value. Avoids cloning when
+  /// the caller does not need the old value.
+  #[inline]
+  pub fn insert_and_forget(&self, key: K, value: V) {
+    self.0.pin().insert(key, value);
+  }
+
+  /// Returns a clone of the value for `key`, if present.
+  #[inline]
+  pub fn get<Q>(&self, key: &Q) -> Option<V>
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+    V: Clone,
+  {
+    self.0.pin().get(key).cloned()
+  }
+
+  /// Runs `f` with a shared reference to the value for `key`, if present,
+  /// returning its result. The guard is held for the duration of `f`.
+  #[inline]
+  pub fn with<Q, F, R>(&self, key: &Q, f: F) -> Option<R>
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+    F: FnOnce(&V) -> R,
+  {
+    self.0.pin().get(key).map(f)
+  }
+
+  #[inline]
+  pub fn contains_key<Q>(&self, key: &Q) -> bool
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+  {
+    self.0.pin().contains_key(key)
+  }
+
+  /// Removes `key`, returning the removed value (cloned) if present.
+  #[inline]
+  pub fn remove<Q>(&self, key: &Q) -> Option<V>
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+    V: Clone,
+  {
+    self.0.pin().remove(key).cloned()
+  }
+
+  /// Atomically returns a clone of the existing value or inserts the default.
+  #[inline]
+  pub fn get_or_insert_default(&self, key: K) -> V
+  where
+    V: Clone + Default,
+  {
+    self.0.pin().get_or_insert_with(key, V::default).clone()
+  }
+
+  /// Atomically returns a clone of the existing value or inserts the value
+  /// produced by `f`.
+  #[inline]
+  pub fn get_or_insert_with<F>(&self, key: K, f: F) -> V
+  where
+    V: Clone,
+    F: FnOnce() -> V,
+  {
+    self.0.pin().get_or_insert_with(key, f).clone()
+  }
+
+  /// Returns a cloned snapshot of all key-value pairs. Because `papaya`
+  /// references borrow a pin guard, this materializes the entries so they can be
+  /// consumed after the guard is released. Iteration order is unspecified.
+  #[inline]
+  pub fn iter_cloned(&self) -> Vec<(K, V)>
+  where
+    K: Clone,
+    V: Clone,
+  {
+    self.0.pin().iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+  }
+
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.0.pin().len()
+  }
+
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.0.pin().is_empty()
+  }
+
+  #[inline]
+  pub fn clear(&self) {
+    self.0.pin().clear();
+  }
+}
+
+/// Concurrent hash set backed by [`papaya`] using the fast `FxHasher`.
+pub struct FxDashSet<K>(HashSet<K, FxBuildHasher>);
+
+impl<K> fmt::Debug for FxDashSet<K> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("FxDashSet").finish_non_exhaustive()
+  }
+}
+
+impl<K> Default for FxDashSet<K> {
+  fn default() -> Self {
+    Self(HashSet::builder().hasher(FxBuildHasher).build())
+  }
+}
+
+impl<K> Clone for FxDashSet<K>
+where
+  K: Clone + Hash + Eq,
+{
+  fn clone(&self) -> Self {
+    Self(self.0.clone())
+  }
+}
+
+impl<K> FxDashSet<K>
+where
+  K: Hash + Eq,
+{
+  /// Pin the set to obtain a guard for performing multiple operations within a
+  /// single guard scope. See [`papaya::HashSetRef`] for the available methods.
+  #[inline]
+  pub fn pin(&self) -> papaya::HashSetRef<'_, K, FxBuildHasher, papaya::LocalGuard<'_>> {
+    self.0.pin()
+  }
+
+  /// Inserts `value`, returning `true` if it was newly inserted.
+  #[inline]
+  pub fn insert(&self, value: K) -> bool {
+    self.0.pin().insert(value)
+  }
+
+  #[inline]
+  pub fn contains<Q>(&self, value: &Q) -> bool
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+  {
+    self.0.pin().contains(value)
+  }
+
+  /// Removes `value`, returning `true` if it was present.
+  #[inline]
+  pub fn remove<Q>(&self, value: &Q) -> bool
+  where
+    K: Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+  {
+    self.0.pin().remove(value)
+  }
+
+  /// Returns a cloned snapshot of all elements. Because `papaya` references
+  /// borrow a pin guard, this materializes the elements so they can be consumed
+  /// after the guard is released. Iteration order is unspecified.
+  #[inline]
+  pub fn iter_cloned(&self) -> Vec<K>
+  where
+    K: Clone,
+  {
+    self.0.pin().iter().cloned().collect()
+  }
+
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.0.pin().len()
+  }
+
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.0.pin().is_empty()
+  }
+
+  #[inline]
+  pub fn clear(&self) {
+    self.0.pin().clear();
+  }
+}

--- a/crates/rolldown_utils/src/make_unique_name.rs
+++ b/crates/rolldown_utils/src/make_unique_name.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, ffi::OsStr};
 
 use arcstr::ArcStr;
 use cow_utils::CowUtils as _;
-use dashmap::Entry;
+use papaya::{Compute, Operation};
 use sugar_path::SugarPath as _;
 
 use crate::{concat_string, dashmap::FxDashMap};
@@ -40,6 +40,7 @@ pub fn make_unique_name(name: &ArcStr, used_name_counts: &FxDashMap<ArcStr, u32>
     .map(|e| concat_string!(".", e))
     .unwrap_or_default();
   let file_name = &name[..name.len() - extension.len()];
+  let used_name_counts = used_name_counts.pin();
   loop {
     // Lowercase key for case-insensitive filesystems (macOS APFS, Windows NTFS).
     // When already lowercase, reuse the `candidate` Arc directly to avoid allocation.
@@ -47,21 +48,24 @@ pub fn make_unique_name(name: &ArcStr, used_name_counts: &FxDashMap<ArcStr, u32>
       Cow::Borrowed(_) => candidate.clone(),
       Cow::Owned(s) => s.into(),
     };
-    match used_name_counts.entry(lowercase_candidate) {
-      Entry::Occupied(mut occ) => {
+    // Atomically reserve the name: if it is already taken, bump its counter and
+    // retry with a numbered candidate; otherwise claim it (seeding the counter
+    // at 2 so the next conflict produces `<name>2`).
+    let next_count = used_name_counts.compute(lowercase_candidate, |entry| match entry {
+      Some((_, &count)) => Operation::Insert(count + 1),
+      None => Operation::Insert(2),
+    });
+    match next_count {
+      Compute::Updated { old: (_, &next_count), .. } => {
         // This name is already used
-        let next_count = *occ.get();
-        occ.insert(next_count + 1);
         candidate = ArcStr::from(concat_string!(
           file_name,
           itoa::Buffer::new().format(next_count),
           extension
         ));
       }
-      Entry::Vacant(vac) => {
-        vac.insert(2);
-        break candidate;
-      }
+      Compute::Inserted(..) => break candidate,
+      Compute::Removed(..) | Compute::Aborted(()) => unreachable!(),
     }
   }
 }

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -106,8 +106,7 @@ impl WatchTask {
 
           // Register watch files discovered during scan BEFORE checking scan errors
           // (so files are watched even on error — enables recovery when user fixes the issue)
-          let watch_files: Vec<ArcStr> =
-            bundle.get_watch_files().iter().map(|f| f.clone()).collect();
+          let watch_files: Vec<ArcStr> = bundle.get_watch_files().iter_cloned();
           Self::update_watch_files_from(
             fs_watcher_ref,
             watched_files_ref,
@@ -136,8 +135,7 @@ impl WatchTask {
         bundler.last_bundle_handle.clone().expect("bundle handle should exist after build");
 
       // Collect watch files while we have the lock (may include render-phase files)
-      let new_watch_files: Vec<ArcStr> =
-        bundle_handle.watch_files().iter().map(|f| f.clone()).collect();
+      let new_watch_files: Vec<ArcStr> = bundle_handle.watch_files().iter_cloned();
 
       (result, new_watch_files, bundle_handle)
     };


### PR DESCRIPTION
## What

Replaces the `dashmap` concurrent-map dependency with `papaya` across the bundler core to reduce the shipped `.node` binary size.

## Why this reduces size

`dashmap` bundles its **own private copy of `hashbrown 0.14`** — a 4th duplicate of hashbrown in the dependency graph (alongside 0.15, 0.16, 0.17). `papaya` is **already present in `Cargo.lock`** as a transitive dependency, so switching to it removes `dashmap` *and* the extra `hashbrown 0.14` copy at no new package cost.

After this change:

```
$ cargo tree -i dashmap
error: package ID specification `dashmap` did not match any packages   # gone

$ cargo tree -i hashbrown@0.14.5
error: package ID specification `hashbrown@0.14.5` did not match any packages   # gone
```

`hashbrown` copies in the graph drop from **4 → 3** (only 0.15.5 / 0.16.1 / 0.17.1 remain, all pulled by other crates). The `Cargo.lock` diff removes the `dashmap 6.2.1` and `hashbrown 0.14.5` package entries; `papaya` simply becomes a direct dependency (it was already there transitively, so no new package is downloaded).

## API-migration approach

`rolldown_utils::dashmap` now defines `FxDashMap`/`FxDashSet` as thin wrappers around `papaya::HashMap`/`papaya::HashSet` (Fx-hashed via `FxBuildHasher`).

Unlike `dashmap`, `papaya` is **lock-free** and all access goes through a *pin guard* whose borrowed references cannot outlive it. To keep the ~25 call sites mostly unchanged, the wrappers **pin internally and return owned/cloned values** (`get` → `Option<V>` clone, `insert`/`remove` cloned previous, plus `insert_and_forget`, `with(key, f)`, `get_or_insert_with`, `get_or_insert_default`, `iter_cloned`, and a `pin()` escape hatch for advanced cases).

Atomicity is preserved for every read-modify-write:
- `entry().or_insert_with` / `or_default()` → `get_or_insert_with` / `get_or_insert_default` (atomic).
- `entry().and_modify` (asset dedup in `FileEmitter`) → `pin().update(...)`.
- `make_unique_name`'s occupied/vacant counter bump → `pin().compute(...)`.
- The module-load completion notifier (`Pending`/`Completed` state machine) → `pin().compute(...)` with the `Pending` sender notified from the `Compute::Updated` result; the `wait_for_completion` guard is explicitly dropped before `.await`.
- The binding's global `PLUGINS_MAP` (needs in-place append + whole-value move-out, neither expressible on papaya's immutable values) now stores `Arc<Mutex<_>>` values.

The clippy `await-holding-invalid-types` list in `clippy.toml` is repointed from the old `dashmap::*` ref types to `papaya`'s `LocalGuard`/`OwnedGuard`/`HashMapRef`/`HashSetRef`, so the "don't hold a map ref across `.await`" protection is retained (clippy passes, confirming no guard is held across an await).

## Crates migrated

`rolldown_utils` (wrapper + `make_unique_name`), `rolldown_common` (`file_emitter`, `transform_options`, type aliases), `rolldown_plugin` (`plugin_driver`, `hook_timing`, context meta, `transform_dependencies`), `rolldown_resolver`, `rolldown_binding` (`parallel_js_plugin_registry`, `transform_cache`), `rolldown` (`bundle_factory`, `hmr_stage`), `rolldown_plugin_utils`, `rolldown_plugin_vite_resolve`, `rolldown_plugin_data_url`, plus consumer updates in `vite_html`, `vite_css_post`, `vite_manifest`, `vite_build_import_analysis`, `vite_html_inline_proxy`, `rolldown_dev`, `rolldown_watcher`.

## Verification

- `cargo build -p rolldown_binding` (debug) ✅
- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- --deny warnings` ✅ (one pre-existing, unrelated failure in `rolldown_plugin_isolated_declaration/tests/mod.rs` — `#[ignore]` without reason — exists on a clean tree too)
- Tests pass for every changed crate (`rolldown_common`, `rolldown_resolver`, `rolldown_plugin_utils`, `rolldown_utils`, `rolldown_plugin`, `rolldown_binding`, the vite plugin crates, `rolldown_dev`, `rolldown_watcher`) and `rolldown --lib` (61 tests). The only integration-test failure (`test262_module_code`) is due to the `test262` submodule not being checked out in this environment — unrelated to this change.

**Binary size impact:** ⚠️ **+347,088 bytes (+339 KiB) — this change INCREASES the cdylib**, it does NOT reduce it. Measured on the release `librolldown_binding.dylib` (fat-LTO, `strip="symbols"`) against merge-base `697a7c4e58` (base `23,476,336` → branch `23,823,424`). Although it removes `dashmap` + the duplicate `hashbrown 0.14`, `papaya`'s lock-free table + `seize` memory-reclamation machinery — monomorphized across the 9 crates that use it — generates substantially more object code than `dashmap` did, for a net **+339 KiB**. **Not recommended as a binary-size optimization.** It may still be worth considering for lock-free concurrency reasons (no shard locks, no await-holding-lock hazards), but that was not the goal of this change.
