### PR TITLE
perf(size): use unstable sort where stability is unneeded

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -104,7 +104,7 @@ impl ChunkGraph {
         }
       }
       side_effects_free_leaf_modules
-        .sort_by_key(|idx| link_output.module_table[*idx].id().as_str());
+        .sort_unstable_by_key(|idx| link_output.module_table[*idx].id().as_str());
       rest.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
       runtime_related.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -1058,7 +1058,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     // FIXME(hyf0): In practice, the order of importers doesn't matter since we're going to traverse all of them.
     // However, non-deterministic order causes unstable snapshots.
     importers_idx
-      .sort_by_key(|importer_idx| self.module_table().modules[*importer_idx].stable_id());
+      .sort_unstable_by_key(|importer_idx| self.module_table().modules[*importer_idx].stable_id());
 
     for importer_idx in importers_idx {
       let Module::Normal(importer) = &self.module_table().modules[importer_idx] else {

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -648,7 +648,7 @@ impl GenerateStage<'_> {
         }
       }
       let mut vec = entry_level_external_modules.into_iter().collect_vec();
-      vec.sort_by_key(|idx| self.link_output.module_table[*idx].exec_order());
+      vec.sort_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order());
       chunk_graph.chunk_table[chunk_idx].entry_level_external_module_idx = vec;
     }
     // re propagate `meta.has_dynamic_exports` for affect modules

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -77,7 +77,8 @@ impl GenerateStage<'_> {
           .copied()
           .chain(chunk_graph.chunk_table[chunk_idx].imports_from_other_chunks.keys().copied())
           .collect::<Vec<_>>();
-        cross_chunk_imports.sort_by_key(|chunk_id| chunk_graph.chunk_table[*chunk_id].exec_order);
+        cross_chunk_imports
+          .sort_unstable_by_key(|chunk_id| chunk_graph.chunk_table[*chunk_id].exec_order);
         cross_chunk_imports
       })
       .collect::<Vec<_>>();

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -392,7 +392,7 @@ impl ManualSplitter<'_> {
   ) -> Option<(ModuleGroup, ModuleGroup)> {
     let mut modules = group.modules.iter().copied().collect::<Vec<_>>();
     // Split by lexical relevance first (stable module id), then by size constraints.
-    modules.sort_by(|lhs, rhs| {
+    modules.sort_unstable_by(|lhs, rhs| {
       let lhs_module = &self.link_output.module_table[*lhs];
       let rhs_module = &self.link_output.module_table[*rhs];
       lhs_module

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -86,7 +86,7 @@ impl ScanStageCache {
       }
       rolldown_common::HybridIndexVec::Map(map) => {
         let mut modules = map.into_iter().collect_vec();
-        modules.sort_by_key(|(k, _)| *k);
+        modules.sort_unstable_by_key(|(k, _)| *k);
         modules
       }
     };

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -39,7 +39,7 @@ pub struct Modules {
 impl From<FxHashMap<ModuleId, RenderedModule>> for Modules {
   fn from(value: FxHashMap<ModuleId, RenderedModule>) -> Self {
     let mut kvs = value.into_iter().collect::<Vec<_>>();
-    kvs.sort_by_key(|a| a.1.exec_order);
+    kvs.sort_unstable_by_key(|a| a.1.exec_order);
     let mut keys = Vec::with_capacity(kvs.len());
     let mut values = Vec::with_capacity(kvs.len());
     for (k, v) in kvs {

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -447,8 +447,8 @@ impl BuildDiagnostic {
     mut static_importers: Vec<String>,
     mut dynamic_importers: Vec<String>,
   ) -> Self {
-    static_importers.sort();
-    dynamic_importers.sort();
+    static_importers.sort_unstable();
+    dynamic_importers.sort_unstable();
     Self::new_inner(super::events::ineffective_dynamic_import::IneffectiveDynamicImport {
       module_id,
       static_importers,

--- a/crates/rolldown_error/src/build_diagnostic/events/tsconfig_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/tsconfig_error.rs
@@ -28,7 +28,7 @@ impl BuildEvent for TsConfigError {
   fn message(&self, opts: &DiagnosticOptions) -> String {
     let mut stabilized_paths =
       self.file_paths.iter().map(|p| opts.stabilize_path(p)).collect::<Vec<_>>();
-    stabilized_paths.sort();
+    stabilized_paths.sort_unstable();
     let file_list =
       stabilized_paths.into_iter().map(|p| format!("'{p}'")).collect::<Vec<_>>().join(", ");
     format!(

--- a/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
+++ b/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
@@ -367,7 +367,7 @@ fn render_full_module_graph(
 
   // Sort modules alphabetically by path for consistent output
   let mut sorted_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
-  sorted_modules.sort_by(|a, b| a.1.path.cmp(&b.1.path));
+  sorted_modules.sort_unstable_by(|a, b| a.1.path.cmp(&b.1.path));
 
   for &(idx, module) in &sorted_modules {
     writeln!(out, "### `{}`\n", module.path).unwrap();
@@ -430,7 +430,7 @@ fn render_raw_data(
 
   // All Imports
   let mut sorted_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
-  sorted_modules.sort_by(|a, b| a.1.path.cmp(&b.1.path));
+  sorted_modules.sort_unstable_by(|a, b| a.1.path.cmp(&b.1.path));
 
   out.push_str("### All Imports\n\n```\n");
   for &(idx, module) in &sorted_modules {


### PR DESCRIPTION
Flip stable slice sorts to **unstable** in rolldown's own crates where stability is not needed. `std`'s stable sort monomorphizes to a larger driver than the unstable sort; at sites whose sort key is unique (or that sort full values), stable and unstable produce **identical** output, so this is a free code-size trim.

## Sites flipped (12, output-identical)
Unique key ⇒ no ties ⇒ order is deterministic regardless of stability:
- `rolldown/src/chunk_graph.rs` — by module `id()` (unique; neighbours were already `sort_unstable`)
- `rolldown/src/hmr/hmr_stage.rs` — by `stable_id()` (unique; comment notes the sort is only for deterministic snapshots)
- `rolldown/.../generate_stage/compute_cross_chunk_links.rs` & `code_splitting.rs` — by `exec_order` (unique)
- `rolldown/.../generate_stage/manual_code_splitting.rs` — by `stable_id().then(exec_order)` (`stable_id` unique ⇒ no ties)
- `rolldown/src/types/scan_stage_cache.rs` — by map key (unique)
- `rolldown_common/src/types/output_chunk.rs` — by `exec_order` (unique)
- `rolldown_plugin_bundle_analyzer/src/render_markdown.rs` (×2) — by unique module path

Full-value `.sort()` (equal elements are identical, so order is unobservable):
- `rolldown_error/.../events/tsconfig_error.rs` — `Vec<path>`
- `rolldown_error/.../constructors.rs` (×2) — `Vec<String>` importer lists

## Left stable (ties possible / order matters)
`tree_shaking/include_statements.rs` (bailout entries tie on `Reverse(MAX)`), `scan_stage.rs` (sourcemap-chain plugin order), and the `Reverse(len)` / `size` / `file_name` / `duration` projection sorts.

## Verification
All 1752 runnable integration/snapshot fixtures pass with **no snapshot changes** (the only failures in an isolated worktree are pre-existing environment issues — missing `node_modules`/`test262` submodule — which fail identically on the unchanged base). `cargo clippy` (with `--features experimental`, the shipped config) and `cargo fmt` clean.

**Binary size impact:** **−16,544 bytes (−16.15 KiB)** on the release `librolldown_binding.dylib` (fat-LTO, `codegen-units=1`, `strip="symbols"`): base `23,459,424` → branch `23,442,880`.
