### PR TITLE
refactor(options): support codeSplitting object form in CodeSplittingMode

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -70,7 +70,10 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
   }
 
   if let Some(format @ (OutputFormat::Umd | OutputFormat::Iife)) = raw_options.format {
-    if matches!(raw_options.code_splitting, Some(CodeSplittingMode::Bool(true))) {
+    if matches!(
+      &raw_options.code_splitting,
+      Some(CodeSplittingMode::Bool(true) | CodeSplittingMode::Advanced(_))
+    ) {
       warnings.push(
         BuildDiagnostic::invalid_option(InvalidOptionType::UnsupportedCodeSplittingFormat(
           format.to_string(),
@@ -80,7 +83,7 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
     }
   }
 
-  if matches!(raw_options.code_splitting, Some(CodeSplittingMode::Bool(false))) {
+  if matches!(&raw_options.code_splitting, Some(CodeSplittingMode::Bool(false))) {
     if let Some(input) = &raw_options.input
       && input.len() > 1
     {
@@ -100,7 +103,13 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
     }
   }
 
-  if let Some(manual_code_splitting) = &raw_options.manual_code_splitting {
+  // The grouping config may arrive either via the dedicated `manual_code_splitting`
+  // field or inline through the merged `codeSplitting` object form (`Advanced`).
+  let manual_code_splitting = match &raw_options.code_splitting {
+    Some(CodeSplittingMode::Advanced(options)) => Some(options),
+    _ => raw_options.manual_code_splitting.as_ref(),
+  };
+  if let Some(manual_code_splitting) = manual_code_splitting {
     let has_groups = manual_code_splitting.groups.as_ref().is_some_and(|groups| !groups.is_empty());
 
     if !has_groups {
@@ -162,8 +171,17 @@ pub fn prepare_build_context(
 
   let format = raw_options.format.unwrap_or(crate::OutputFormat::Esm);
 
-  let preserve_entry_signatures = if let Some(manual_code_splitting) =
-    &raw_options.manual_code_splitting
+  // Decompose the (possibly merged) `codeSplitting` option into the gate
+  // (`code_splitting`) and the grouping config (`manual_code_splitting`). The raw
+  // option may carry the object form (`Advanced`) mirroring the public JS
+  // `codeSplitting: { groups, ... }`; the normalized layer keeps them as two fields.
+  let (raw_code_splitting_mode, manual_code_splitting) = match raw_options.code_splitting.take() {
+    Some(CodeSplittingMode::Advanced(options)) => (CodeSplittingMode::Bool(true), Some(options)),
+    Some(mode @ CodeSplittingMode::Bool(_)) => (mode, raw_options.manual_code_splitting.take()),
+    None => (CodeSplittingMode::default(), raw_options.manual_code_splitting.take()),
+  };
+
+  let preserve_entry_signatures = if let Some(manual_code_splitting) = &manual_code_splitting
     && has_non_recursive_dependency_capture(manual_code_splitting)
     && raw_options.preserve_entry_signatures.is_none()
   {
@@ -269,7 +287,7 @@ pub fn prepare_build_context(
 
   let code_splitting = match format {
     OutputFormat::Umd | OutputFormat::Iife => CodeSplittingMode::Bool(false),
-    _ => raw_options.code_splitting.unwrap_or_default(),
+    _ => raw_code_splitting_mode,
   };
 
   // If the `file` is provided, use the parent directory of the file as the `out_dir`.
@@ -439,7 +457,7 @@ pub fn prepare_build_context(
     external_live_bindings: raw_options.external_live_bindings.unwrap_or(true),
     code_splitting,
     dynamic_import_in_cjs: raw_options.dynamic_import_in_cjs.unwrap_or(true),
-    manual_code_splitting: raw_options.manual_code_splitting,
+    manual_code_splitting,
     checks: raw_options.checks.unwrap_or_default().into(),
     watch: raw_options.watch.unwrap_or_default(),
     legal_comments: raw_options.legal_comments.unwrap_or(LegalComments::Inline),

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -139,8 +139,12 @@ impl BindingNormalizedOptions {
 
   #[napi(getter)]
   pub fn code_splitting(&self) -> bool {
-    match self.inner.code_splitting {
-      rolldown_common::CodeSplittingMode::Bool(v) => v,
+    // The normalized layer never holds the `Advanced` object form (it is decomposed
+    // into the gate + `manual_code_splitting` during normalization), but match it
+    // exhaustively as "enabled" for completeness.
+    match &self.inner.code_splitting {
+      rolldown_common::CodeSplittingMode::Bool(v) => *v,
+      rolldown_common::CodeSplittingMode::Advanced(_) => true,
     }
   }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/code_splitting_mode.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/code_splitting_mode.rs
@@ -5,11 +5,17 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-/// Controls how code splitting is performed.
+use super::manual_code_splitting_options::ManualCodeSplittingOptions;
+
+/// Controls how code splitting is performed. Mirrors the public
+/// `codeSplitting: boolean | CodeSplittingOptions` option.
 ///
 /// - `Bool(true)`: Default behavior, automatic code splitting with lazy-loaded dynamic imports.
 /// - `Bool(false)`: Inline all dynamic imports into a single bundle (no code splitting).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// - `Advanced(..)`: Automatic code splitting enabled, with user-directed chunk grouping
+///   (the object form). During normalization this is decomposed into the gate
+///   (`code_splitting`) plus the grouping config (`manual_code_splitting`).
+#[derive(Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
@@ -17,6 +23,7 @@ use serde::Deserialize;
 )]
 pub enum CodeSplittingMode {
   Bool(bool),
+  Advanced(ManualCodeSplittingOptions),
 }
 
 impl Default for CodeSplittingMode {
@@ -28,7 +35,7 @@ impl Default for CodeSplittingMode {
 impl CodeSplittingMode {
   /// Returns true if automatic code splitting is enabled
   pub fn is_automatic(&self) -> bool {
-    matches!(self, CodeSplittingMode::Bool(true))
+    matches!(self, CodeSplittingMode::Bool(true) | CodeSplittingMode::Advanced(_))
   }
 
   /// Returns true if dynamic imports should be inlined (no code splitting)
@@ -40,7 +47,7 @@ impl CodeSplittingMode {
 impl Display for CodeSplittingMode {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      CodeSplittingMode::Bool(true) => write!(f, "enabled"),
+      CodeSplittingMode::Bool(true) | CodeSplittingMode::Advanced(_) => write!(f, "enabled"),
       CodeSplittingMode::Bool(false) => write!(f, "disabled"),
     }
   }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1206,10 +1206,13 @@
       ]
     },
     "CodeSplittingMode": {
-      "description": "Controls how code splitting is performed.\n\n- `Bool(true)`: Default behavior, automatic code splitting with lazy-loaded dynamic imports.\n- `Bool(false)`: Inline all dynamic imports into a single bundle (no code splitting).",
+      "description": "Controls how code splitting is performed. Mirrors the public\n`codeSplitting: boolean | CodeSplittingOptions` option.\n\n- `Bool(true)`: Default behavior, automatic code splitting with lazy-loaded dynamic imports.\n- `Bool(false)`: Inline all dynamic imports into a single bundle (no code splitting).\n- `Advanced(..)`: Automatic code splitting enabled, with user-directed chunk grouping\n  (the object form). During normalization this is decomposed into the gate\n  (`code_splitting`) plus the grouping config (`manual_code_splitting`).",
       "anyOf": [
         {
           "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/ManualCodeSplittingOptions"
         }
       ]
     },

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -70,7 +70,7 @@ impl ConfigVariant {
       config.entry_filenames = Some(entry_filenames.clone().into());
     }
     if let Some(code_splitting) = &self.code_splitting {
-      config.code_splitting = Some(*code_splitting);
+      config.code_splitting = Some(code_splitting.clone());
     }
     if let Some(dynamic_import_in_cjs) = &self.dynamic_import_in_cjs {
       config.dynamic_import_in_cjs = Some(*dynamic_import_in_cjs);


### PR DESCRIPTION
## Summary

Widens `CodeSplittingMode` with an `Advanced(ManualCodeSplittingOptions)` variant so the raw `codeSplitting` option can carry chunk-grouping config inline, mirroring the public `codeSplitting: boolean | CodeSplittingOptions` API.

During normalization the object form is decomposed into the gate (`code_splitting`) plus `manual_code_splitting`, leaving downstream chunking unchanged.

## Notes

- **Additive / non-breaking** — the existing `manualCodeSplitting` field keeps working.
- Dropping `Copy` / `PartialEq` / `Eq` from `CodeSplittingMode` rippled to two call sites (the binding getter and `config_variant`), both updated.
- `_config.schema.json` regenerated: `codeSplitting` now accepts `boolean | ManualCodeSplittingOptions`.

Part of a 2-PR stack — followed by #9805, which migrates fixtures and removes the redundant `manualCodeSplitting` field.