### PR TITLE
docs(dev): move test-dev-server test guidance into the testing docs

### DIFF
--- a/docs/development-guide/testing.md
+++ b/docs/development-guide/testing.md
@@ -196,6 +196,98 @@ To run the `tests/fixtures/resolve/alias` test, you could use `just test-node-ro
 
 :::
 
+## Dev server tests
+
+[`@rolldown/test-dev-server`](https://github.com/rolldown/rolldown/tree/main/packages/test-dev-server) is a small Vite-style dev server used to exercise rolldown's **dev engine** — HMR, lazy compilation, and error recovery. Its tests live in `packages/test-dev-server/tests` and come in two suites:
+
+| Suite        | Platform  | What it drives                                                                              |
+| ------------ | --------- | ------------------------------------------------------------------------------------------- |
+| **browser**  | `browser` | A real Chromium page against an **in-process** dev server. Most dev-engine tests live here. |
+| **fixtures** | `node`    | The dev server building to **disk**, with the built artifact run as a `node` child process. |
+
+The architecture and the reasoning behind the harness are captured in the [Dev Server Test Harness design doc](https://github.com/rolldown/rolldown/blob/main/meta/design/dev-server-test-harness.md) — read it before changing the harness itself.
+
+### Browser playgrounds
+
+Most dev-engine regressions are tested as **browser playgrounds**, not unit tests. A playground is a tiny app the in-process dev server serves to a real Chromium page, under:
+
+```text
+playground/<name>/
+```
+
+Each playground normally contains:
+
+```text
+dev.config.mjs            # rolldown dev config (browser platform, no dev.port)
+index.html                # served at /
+main.js                   # entry; relative input paths resolve from this dir
+package.json              # workspace member (copy an existing one)
+__tests__/<name>.spec.ts  # the spec (stays in source, never copied)
+```
+
+The harness discovers the playground from the spec's path, copies it to `playground-temp/<name>/`, starts an in-process dev server on an OS-assigned port, opens a Chromium page, and navigates to it — so **adding a test is a folder plus a spec, with no central registry to edit**.
+
+A spec imports helpers from the `~utils` alias; by the time it runs, the harness has already started the server and navigated `page`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+describe('<name>', () => {
+  test('applies an HMR update', async () => {
+    editFile('main.js', (code) => code.replace('hello', 'world'));
+    await expect.poll(() => page.textContent('h1')).toBe('world');
+  });
+});
+```
+
+:::warning Synchronize on the server's async work — never sleep
+Poll the DOM with `expect.poll`, `await waitForBuildStable()` before a follow-up edit, or wait on a browser log with `untilBrowserLogAfter`. A fixed `sleep` is both flaky and slow.
+:::
+
+#### Building and running
+
+Rebuild once after changing Rust or the dev-server `src/` — the tests import the compiled `dist/`, not the TypeScript source:
+
+```sh
+just build-rolldown
+pnpm --filter @rolldown/test-dev-server build
+```
+
+Then, from `packages/test-dev-server/tests/`:
+
+```sh
+# a single playground
+pnpm exec vitest run --config=vitest.config.e2e.mts playground/<name>
+
+# the whole browser suite
+pnpm test:browser
+```
+
+#### One spec vs. several specs
+
+**Multiple spec files in one playground run concurrently** (file parallelism), each forking its own dev server against the shared `playground-temp/<name>/` copy. That is safe only when the scenarios are **disjoint** — each spec navigates its own DOM and edits only its own files (how `lazy-compilation`'s four specs coexist). When scenarios share one bundle/entry, so that an edit by one would rebuild another spec's page, put them in a **single spec file** instead (why `hmr-full-bundle-mode`'s scenarios are one spec).
+
+Tests in one spec file share a single `page` and run sequentially, so don't let them perturb one another. Keep **edits forward-only** — or restore what they changed, since a later test must not rely on an earlier one's edit being reverted. And **re-acquire element handles after any reload** (`page.locator(...)` / a fresh `page.$`); a reload invalidates the old ones.
+
+Prefer giving each scenario its **own DOM node** so one test's edits can't disturb another's assertions — `hmr-full-bundle-mode` keeps `.app`, `.hmr`, `.hmr-error`, and `.rebuild-error` separate, one per scenario.
+
+#### Cold-start playgrounds
+
+Some lazy-compilation bugs only reproduce on the **first** request to a fresh server. Add `__tests__/serve.ts` so the harness starts the server but does not navigate, letting the spec fire the first request itself:
+
+```ts
+import type { DevServerHandle, ServeContext } from '~utils';
+
+export async function serve(ctx: ServeContext): Promise<DevServerHandle> {
+  return ctx.createServer();
+}
+```
+
+### Node fixtures
+
+Use `fixtures/<name>/` plus `fixtures.test.ts` (run with `pnpm test:fixtures`) for the **node** platform — the dev server building to disk and running the built artifact as a `node` child process. Do not add ordinary HMR / lazy / overlay regressions there when a browser playground can cover the behavior.
+
 ## Rollup behavior alignment tests
 
 We also aim for behavior alignment with Rollup by running Rollup's own tests against Rolldown.

--- a/packages/test-dev-server/tests/AGENTS.md
+++ b/packages/test-dev-server/tests/AGENTS.md
@@ -2,79 +2,14 @@
 
 ## Testing dev-server behavior
 
-Most dev-engine regressions (HMR, lazy compilation, error recovery) are tested as **browser playgrounds**, not unit tests. A playground is a tiny app the in-process dev server serves to a real Chromium page.
+The guide for writing these tests — browser playgrounds vs. node fixtures, the
+playground layout, the synchronize-don't-`sleep` rule, when to split specs, the
+shared-`page` reliability rules, cold-start playgrounds, and the build/run
+commands — lives in the **Dev server tests** section of the testing docs. Read
+it before adding or changing a test here:
 
-Use:
+- [`docs/development-guide/testing.md`](../../../docs/development-guide/testing.md#dev-server-tests)
+  (published at <https://rolldown.rs/development-guide/testing>)
 
-```text
-playground/<name>/
-```
-
-Each playground normally contains:
-
-```text
-dev.config.mjs            # rolldown dev config (browser platform, no dev.port)
-index.html                # served at /
-main.js                   # entry; relative input paths resolve from this dir
-package.json              # workspace member (copy an existing one)
-__tests__/<name>.spec.ts  # the spec (stays in source, never copied)
-```
-
-**Multiple spec files in one playground run concurrently** (file parallelism), each forking its own dev server against the shared `playground-temp/<name>/` copy. That is safe only when the scenarios are **disjoint** — each spec navigates its own DOM and edits only its own files (how `lazy-compilation`'s four specs coexist). When scenarios share one bundle/entry, so an edit by one would rebuild another spec's page, put them in a **single spec file** instead (why `hmr-full-bundle-mode`'s scenarios are one spec).
-
-The spec imports helpers from the `~utils` alias; the harness has already started the server and navigated `page`:
-
-```ts
-import { describe, expect, test } from 'vitest';
-import { editFile, page, waitForBuildStable } from '~utils';
-
-describe('<name>', () => {
-  test('applies an HMR update', async () => {
-    editFile('main.js', (code) => code.replace('hello', 'world'));
-    await expect.poll(() => page.textContent('h1')).toBe('world');
-  });
-});
-```
-
-Synchronize on the server's async work — never `sleep`. Poll the DOM with `expect.poll`, `await waitForBuildStable()` before a follow-up edit, or wait on a browser log with `untilBrowserLogAfter`.
-
-Tests in one spec file share a single `page` and run sequentially, so don't let them perturb one another. Keep **edits forward-only** — or restore what they changed, since a later test must not rely on an earlier one's edit being reverted. And **re-acquire element handles after any reload** (`page.locator(...)` / a fresh `page.$`); a reload invalidates the old ones.
-
-Prefer giving each scenario its **own DOM node** so one test's edits can't disturb another's assertions — `hmr-full-bundle-mode` keeps `.app`, `.hmr`, `.hmr-error`, and `.rebuild-error` separate, one per scenario.
-
-Build once (after changing rust or the dev-server `src/`):
-
-```sh
-just build-rolldown
-pnpm --filter @rolldown/test-dev-server build
-```
-
-Run a focused playground with (from `packages/test-dev-server/tests/`):
-
-```sh
-pnpm exec vitest run --config=vitest.config.e2e.mts playground/<name>
-```
-
-Run the whole browser suite with:
-
-```sh
-pnpm test:browser
-```
-
-## Cold-start playgrounds
-
-Some lazy-compilation bugs only reproduce on the **first** request to a fresh server. Add `__tests__/serve.ts` so the harness starts the server but does not navigate, and the spec fires the first request itself:
-
-```ts
-import type { DevServerHandle, ServeContext } from '~utils';
-
-export async function serve(ctx: ServeContext): Promise<DevServerHandle> {
-  return ctx.createServer();
-}
-```
-
-## When to use the node fixtures suite
-
-Use `fixtures/<name>/` + `fixtures.test.ts` (run with `pnpm test:fixtures`) for the **node** platform — the dev server building to disk and running the built artifact as a `node` child process.
-
-Do not add ordinary HMR / lazy / overlay regressions there when a browser playground can cover the behavior.
+The deeper "why" behind the harness is in
+[`meta/design/dev-server-test-harness.md`](../../../meta/design/dev-server-test-harness.md).


### PR DESCRIPTION
Follow-up to #9763, acting on [the review suggestion](https://github.com/rolldown/rolldown/pull/9763#issuecomment-4709109311):

> Maybe we should add the content to https://rolldown.rs/development-guide/testing and then tell agents to read that?

## What changed

- **`docs/development-guide/testing.md`** — adds a new **"Dev server tests"** section (between Node.js and the Rollup-alignment section). It:
  - recovers the two-suite overview (browser playgrounds vs. node fixtures) from the README that #9763 deleted,
  - ports the playground guidance from `AGENTS.md` (layout, `~utils` spec example, the synchronize-don't-`sleep` rule, build/run commands, one-spec-vs-several disjointness, cold-start playgrounds, when to use node fixtures),
  - links to `meta/design/dev-server-test-harness.md` for the deeper "why".
- **`packages/test-dev-server/tests/AGENTS.md`** — reduced from a duplicated copy to a pointer to that docs section, so the guidance is **single-sourced**. The directory-scoped `AGENTS.md` still serves its purpose: it tells an agent working here where to read.

## Verification

- `vp fmt` clean, `typos` clean.
- Relative links from `AGENTS.md` resolve on disk; the `#dev-server-tests` anchor matches the new heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)