### PR TITLE
perf: cheaper deterministic ordering in external import binding merger

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -187,17 +187,29 @@ impl LinkStage<'_> {
     self.external_import_namespace_merger = binding_ctx.external_import_namespace_merger;
 
     for (module_idx, map) in &binding_ctx.external_import_binding_merger {
-      let mut imported_binding_merger = map.iter().collect::<Vec<_>>();
-      imported_binding_merger.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
-
-      for (key, symbol_set) in imported_binding_merger {
+      // `map` is a `FxHashMap` with randomized iteration order. Facade symbols must be created
+      // deterministically, but only an external imported under more than one name has anything to
+      // order — so sort by name only in that (rare) case and skip the work otherwise.
+      // `sort_unstable_by` is fine here: the names are `FxHashMap` keys, so they're unique and
+      // there are no ties for a stable sort to preserve.
+      let mut entries = map.iter().collect::<Vec<_>>();
+      if entries.len() > 1 {
+        entries.sort_unstable_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+      }
+      for (key, symbol_set) in entries {
         let name = if key.as_str() == "default" {
+          // The default export has no intrinsic name, so we derive one from the local names that
+          // import it. `symbol_set` collects them in non-deterministic module-load order, so pick
+          // the candidate with the smallest `(exec_order, name)`: `exec_order` is a deterministic
+          // `u32` assigned by `sort_modules` (which runs before this stage), so the chosen name is
+          // stable across builds and the comparison is a cheap integer compare. This also matches
+          // how the sibling `external_import_namespace_merger` is ordered (by `exec_order` in
+          // `code_splitting.rs`).
           let key = symbol_set
             .iter()
-            .min_by_key(|symbol_ref| {
-              let symbol_ref = **symbol_ref;
+            .min_by_key(|&&symbol_ref| {
               (
-                self.module_table.modules[symbol_ref.owner].stable_id().as_str(),
+                self.module_table.modules[symbol_ref.owner].exec_order(),
                 symbol_ref.name(&self.symbols),
               )
             })


### PR DESCRIPTION
#9755 already made the external default-import name deterministic via `min_by_key((stable_id, name))` plus an always-on stable sort. This refines that path without changing output:

- `sort_by` -> `sort_unstable_by`, guarded by `len > 1`: stability is needless since the names are unique `FxHashMap` keys, and this matches the project direction in #9803 (use unstable sort where stability is unneeded).
- default-name selection uses `exec_order()` (u32 compare) instead of `stable_id().as_str()` (string compare): cheaper, and consistent with the sibling `external_import_namespace_merger`, which `code_splitting.rs` already orders by `exec_order()`.

All rolldown integration snapshot tests pass unchanged.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
