### PR TITLE
perf: disable idna's ICU backend by pinning idna_adapter to 1.0.0 (-129 KB)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,17 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,88 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,13 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
+checksum = "cfdf4f5d937a025381f5ab13624b1c5f51414bfe5c9885663226eae8d6d39560"
 
 [[package]]
 name = "ignore"
@@ -1584,12 +1487,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2728,15 +2625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,6 +3577,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "fast-glob",
+ "idna_adapter",
  "nodejs-built-in-modules",
  "owo-colors",
  "oxc_resolver",
@@ -4164,12 +4053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,17 +4144,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4380,16 +4252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -5073,12 +4935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5089,29 +4945,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -5127,60 +4960,6 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,9 @@ futures = "0.3.31"
 glob = "0.3.2"
 heck = "0.5.0"
 html5gum = "0.8.1"
+# Pinned to the no-ICU 1.0.0 backend to keep IDNA support turned off.
+# See crates/rolldown_plugin_vite_resolve/Cargo.toml for the full rationale.
+idna_adapter = "=1.0.0"
 ignore = "0.4.23"
 indexmap = "2.9.0"
 infer = { version = "0.19.0", default-features = false }

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
-# NOTE: IDNA support is turned off: https://docs.rs/crate/idna_adapter/latest#:~:text=Turning%20off%20IDNA%20support
 arcstr = { workspace = true }
 cow-utils = { workspace = true }
 dashmap = { workspace = true }
@@ -34,3 +33,18 @@ serde_json = { workspace = true }
 sugar_path = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
+
+# `url` pulls in `idna`, which by default uses a heavy ICU Unicode backend. We keep IDNA
+# support turned off (ASCII-only) by pinning `idna_adapter` to its no-ICU 1.0.0 release.
+# See https://docs.rs/crate/idna_adapter/latest#:~:text=Turning%20off%20IDNA%20support
+#
+# `idna_adapter` is a transitive dependency we never import; the exact `=1.0.0` requirement
+# (declared in the workspace Cargo.toml) exists only to stop `cargo update` from resolving a
+# newer, ICU-backed version. It is excluded from the unused-dependency check by the
+# [package.metadata.cargo-shear] entry below.
+idna_adapter = { workspace = true }
+
+[package.metadata.cargo-shear]
+# `idna_adapter` is a build-only version pin (see the note in [dependencies]); it is never
+# imported, so exclude it from the unused-dependency check.
+ignored = ["idna_adapter"]


### PR DESCRIPTION
## Disable `idna`'s ICU backend instead of removing `url`

`url` is pulled in **only** by rolldown crates, and it drags the entire IDNA/Unicode stack along:

```
url -> idna -> idna_adapter -> ICU4X
                               (icu_normalizer / icu_properties + *_data + zerovec / yoke / tinystr / ... — ~20 crates)
```

That ships **~129 KB** of Unicode tables in `librolldown_binding.node` purely for internationalized-domain-name handling (`münchen.de` → `xn--mnchen-3ya.de`) that rolldown never needs. `url` mandates `idna` for special-scheme hosts (incl. `file:`) and has **no feature** to turn it off.

### This PR — the least-invasive option

[`idna_adapter`](https://docs.rs/crate/idna_adapter) is the indirection layer that lets `idna` pick a Unicode backend. Its **1.0.0** release is the official *no-ICU* backend (zero dependencies); **1.1+** switched to ICU4X. Pinning it to `=1.0.0` makes `idna` resolve to the ASCII-only implementation and drops the entire ICU4X stack from the build — while **`url` and its WHATWG behaviour stay exactly as-is (zero new code)**.

- `Cargo.toml`: `idna_adapter = "=1.0.0"` in `[workspace.dependencies]`, referenced from `rolldown_plugin_vite_resolve` (the crate behind the `url` edge).
- The exact `=1.0.0` requirement makes any ICU-backed version **unresolvable**, so a blanket `cargo update` can't silently pull it back in — verified: `cargo update -p idna_adapter --precise 1.2.2` is rejected with `failed to select a version for the requirement idna_adapter = "=1.0.0"`.
- Excluded from `cargo-shear` (`[package.metadata.cargo-shear]`) since it's a build-only pin we never import.

### Trade-off

Per the [`idna_adapter` docs](https://docs.rs/crate/idna_adapter/latest#:~:text=Turning%20off%20IDNA%20support), the no-Unicode backend rejects non-ASCII domain inputs and skips UTS-46 enforcement on Punycode labels. rolldown only ever feeds `url` ASCII (file paths / sourcemap URLs), so this is a no-op in practice.

### Impact (darwin-arm64, fat-LTO release, same-machine A/B)

| build | `rolldown-binding.node` | saved |
|---|---|---|
| baseline (`url` + `idna` + ICU4X) | 23,409,856 | — |
| **this PR (no-ICU `idna_adapter`)** | **23,277,696** | **−132,160 bytes (−129 KB)** |

The `icu_*` / `zerovec` / `yoke` / `tinystr` / … crates are gone from the build (`idna` + ICU remain in `Cargo.lock` only behind the `jsonschema` **test** dependency). The −132,160-byte saving is byte-for-byte the same as the "keep `url`" row measured in #9794, confirming the official `idna_adapter 1.0.0` matches a vendored ASCII stub.

### Relationship to #9790 / #9794

Both #9790 (hand-rolled parser, −226 KB) and #9794 (`iri-string`, −210 KB) removed `url` entirely and explicitly flagged this as the safe, minimal alternative. This captures ~57% of the maximum saving with **no behaviour change and no URL-parsing code to own**, so it supersedes both — they're closed in favour of this.
