### PR TITLE
feat: add option names for invalid return type errors

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -8,7 +8,7 @@ use rolldown::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule};
 use rolldown_utils::js_regex::HybridRegex;
 
 use crate::{
-  types::js_callback::{JsCallback, JsCallbackExt},
+  types::js_callback::{JsCallback, JsCallbackExt, JsCallbackResultExt},
   types::js_regex::JsRegExp,
 };
 
@@ -85,7 +85,11 @@ impl TryFrom<BindingTreeshake> for rolldown::TreeshakeOptions {
           let id = id.to_string();
           let ts_fn = Arc::clone(&ts_fn);
           Box::pin(async move {
-            ts_fn.invoke_async((id.clone(), is_external).into()).await.map_err(anyhow::Error::from)
+            ts_fn
+              .invoke_async((id.clone(), is_external).into())
+              .await
+              .context("treeshake.moduleSideEffects option")
+              .map_err(anyhow::Error::from)
           })
         }))
       }

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -120,10 +120,30 @@ where
   async fn invoke_async(&self, args: Args) -> Result<Ret, napi::Error> {
     match self.call_async_catch(args).await? {
       Either::A(ret) => Ok(ret),
-      Either::B(invalid) => {
-        Err(create_invalid_return_error(invalid.value_type, Ret::value_type(), Ret::type_name()))
-      }
+      Either::B(invalid) => Err(create_invalid_return_error(invalid.value_type, Ret::value_type())),
     }
+  }
+}
+
+/// Extension trait for attaching a human-readable name (e.g. the option or hook
+/// name) to errors returned by [`JsCallbackExt::invoke_async`] /
+/// [`MaybeAsyncJsCallbackExt::await_call`].
+///
+/// Errors that cross the JS boundary (such as the "invalid return value" error
+/// from [`create_invalid_return_error`]) have no knowledge of the user-facing
+/// option/hook they belong to. Call `.context("external option")` on the result
+/// to prefix the name so the message points at the option instead of the
+/// internal callback type.
+pub trait JsCallbackResultExt<T> {
+  fn context(self, name: &str) -> napi::Result<T>;
+}
+
+impl<T> JsCallbackResultExt<T> for napi::Result<T> {
+  fn context(self, name: &str) -> napi::Result<T> {
+    self.map_err(|mut err| {
+      err.reason = format!("{name}: {}", err.reason);
+      err
+    })
   }
 }
 
@@ -142,15 +162,11 @@ fn js_type_name(value_type: ValueType) -> &'static str {
   }
 }
 
-fn create_invalid_return_error(
-  received: ValueType,
-  expected: ValueType,
-  expected_type_name: &'static str,
-) -> napi::Error {
+fn create_invalid_return_error(received: ValueType, expected: ValueType) -> napi::Error {
   napi::Error::new(
     Status::InvalidArg,
     format!(
-      "The function returned `{}`, but expected `{}` for `{expected_type_name}`.",
+      "The function returned `{}`, but expected `{}`.",
       js_type_name(received),
       js_type_name(expected),
     ),
@@ -172,9 +188,7 @@ where
     match self.call_async_catch(args).await? {
       Either::A(Either::A(promise)) => promise.await,
       Either::A(Either::B(ret)) => Ok(ret),
-      Either::B(invalid) => {
-        Err(create_invalid_return_error(invalid.value_type, Ret::value_type(), Ret::type_name()))
-      }
+      Either::B(invalid) => Err(create_invalid_return_error(invalid.value_type, Ret::value_type())),
     }
   }
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -13,7 +13,9 @@ use crate::types::binding_string_or_regex::{
 use crate::types::defer_sync_scan_data::BindingDeferSyncScanData;
 use crate::{
   options::binding_inject_import::normalize_binding_inject_import,
-  types::js_callback::{JsCallback, JsCallbackExt},
+  types::js_callback::{
+    JsCallbackResultExt, {JsCallback, JsCallbackExt},
+  },
 };
 #[cfg_attr(target_family = "wasm", allow(unused))]
 use crate::{
@@ -62,6 +64,7 @@ fn normalize_generated_code_option(
 
 fn normalize_addon_option(
   addon_option: Option<crate::options::AddonOutputOption>,
+  name: &'static str,
 ) -> Option<AddonOutputOption> {
   addon_option.map(move |value| match value {
     // Static string - no JS function call needed
@@ -73,6 +76,7 @@ fn normalize_addon_option(
         fn_js
           .await_call(FnArgs { data: (BindingRenderedChunk::new(chunk),) })
           .await
+          .context(name)
           .map_err(anyhow::Error::from)
       })
     })),
@@ -81,6 +85,7 @@ fn normalize_addon_option(
 
 fn normalize_chunk_file_names_option(
   option: Option<ChunkFileNamesOutputOption>,
+  name: &'static str,
 ) -> napi::Result<Option<ChunkFilenamesOutputOption>> {
   option
     .map(move |value| match value {
@@ -89,7 +94,7 @@ fn normalize_chunk_file_names_option(
         let func = Arc::clone(&func);
         let chunk = (chunk.clone().into(),);
         Box::pin(async move {
-          func.invoke_async(FnArgs { data: chunk }).await.map_err(anyhow::Error::from)
+          func.invoke_async(FnArgs { data: chunk }).await.context(name).map_err(anyhow::Error::from)
         })
       }))),
     })
@@ -106,7 +111,11 @@ fn normalize_sanitize_filename(
         let func = Arc::clone(&func);
         let name = name.to_string();
         Box::pin(async move {
-          func.invoke_async(FnArgs { data: (name,) }).await.map_err(anyhow::Error::from)
+          func
+            .invoke_async(FnArgs { data: (name,) })
+            .await
+            .context("sanitizeFileName option")
+            .map_err(anyhow::Error::from)
         })
       }))),
     })
@@ -123,7 +132,11 @@ fn normalize_asset_file_names_option(
         let func = Arc::clone(&func);
         let asset = (asset.clone().into(),);
         Box::pin(async move {
-          func.invoke_async(FnArgs { data: asset }).await.map_err(anyhow::Error::from)
+          func
+            .invoke_async(FnArgs { data: asset })
+            .await
+            .context("assetFileNames option")
+            .map_err(anyhow::Error::from)
         })
       }))),
     })
@@ -138,7 +151,13 @@ fn normalize_globals_option(
     Either::B(func) => rolldown_common::GlobalsOutputOption::Fn(Arc::new(move |name| {
       let func = Arc::clone(&func);
       let name = name.to_string();
-      Box::pin(async move { func.invoke_async((name,).into()).await.map_err(anyhow::Error::from) })
+      Box::pin(async move {
+        func
+          .invoke_async((name,).into())
+          .await
+          .context("globals option")
+          .map_err(anyhow::Error::from)
+      })
     })),
   })
 }
@@ -151,7 +170,9 @@ fn normalize_paths_option(
     Either::B(func) => rolldown_common::PathsOutputOption::Fn(Arc::new(move |id| {
       let func = Arc::clone(&func);
       let id = id.to_string();
-      Box::pin(async move { func.invoke_async((id,).into()).await.map_err(anyhow::Error::from) })
+      Box::pin(async move {
+        func.invoke_async((id,).into()).await.context("paths option").map_err(anyhow::Error::from)
+      })
     })),
   })
 }
@@ -211,6 +232,7 @@ fn normalize_external_option(
           is_external
             .invoke_async((source.clone(), importer, is_resolved).into())
             .await
+            .context("external option")
             .map_err(anyhow::Error::from)
         })
       })))
@@ -448,8 +470,14 @@ pub fn normalize_binding_options(
     shim_missing_exports: input_options.shim_missing_exports,
     name: output_options.name,
     asset_filenames: normalize_asset_file_names_option(output_options.asset_file_names)?,
-    entry_filenames: normalize_chunk_file_names_option(output_options.entry_file_names)?,
-    chunk_filenames: normalize_chunk_file_names_option(output_options.chunk_file_names)?,
+    entry_filenames: normalize_chunk_file_names_option(
+      output_options.entry_file_names,
+      "entryFileNames option",
+    )?,
+    chunk_filenames: normalize_chunk_file_names_option(
+      output_options.chunk_file_names,
+      "chunkFileNames option",
+    )?,
     sanitize_filename: normalize_sanitize_filename(output_options.sanitize_file_name)?,
     dir: output_options.dir,
     file: output_options.file,
@@ -458,12 +486,12 @@ pub fn normalize_binding_options(
       Either::A(es_module_bool) => es_module_bool.into(),
       Either::B(es_module_string) => es_module_string.into(),
     }),
-    banner: normalize_addon_option(output_options.banner),
-    footer: normalize_addon_option(output_options.footer),
-    post_banner: normalize_addon_option(output_options.post_banner),
-    post_footer: normalize_addon_option(output_options.post_footer),
-    intro: normalize_addon_option(output_options.intro),
-    outro: normalize_addon_option(output_options.outro),
+    banner: normalize_addon_option(output_options.banner, "banner option"),
+    footer: normalize_addon_option(output_options.footer, "footer option"),
+    post_banner: normalize_addon_option(output_options.post_banner, "post_banner option"),
+    post_footer: normalize_addon_option(output_options.post_footer, "post_footer option"),
+    intro: normalize_addon_option(output_options.intro, "intro option"),
+    outro: normalize_addon_option(output_options.outro, "outro option"),
     sourcemap_base_url: output_options
       .sourcemap_base_url
       .map(|maybe_url| {

--- a/packages/rolldown/tests/fixtures/external/invalid-function-return/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/invalid-function-return/_config.ts
@@ -1,0 +1,15 @@
+import { stripAnsi } from 'consola/utils';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    // @ts-expect-error - this is intentionally wrong to trigger the error
+    external: (source: string) => (source.startsWith('external') ? 1 : 0),
+  },
+  catchError(err: any) {
+    expect(stripAnsi(err.toString())).toContain(
+      'external option: The function returned `number`, but expected `boolean`.',
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/external/invalid-function-return/main.js
+++ b/packages/rolldown/tests/fixtures/external/invalid-function-return/main.js
@@ -1,0 +1,3 @@
+import external from 'external';
+import './foo';
+console.log(external);


### PR DESCRIPTION
Made it possible to add a message to the type error by `.context` and included the option name in it.  
  
close #9545