### PR TITLE
test: add cjs named export mutation test

### DIFF
--- a/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region target.cjs
+var require_target = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { existing: "existing" };
+}));
+//#endregion
+//#region augment.cjs
+var require_augment = /* @__PURE__ */ __commonJSMin((() => {
+	const target = require_target();
+	target.added = function added() {
+		return "added";
+	};
+}));
+//#endregion
+//#region main.js
+var import_target = /* @__PURE__ */ __toESM(require_target());
+require_augment();
+assert.equal(import_target.existing, "existing");
+assert.equal(typeof import_target.added, "undefined");
+assert.equal(typeof import_target.default?.added, "function");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/augment.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/augment.cjs
@@ -1,0 +1,7 @@
+const target = require('./target.cjs');
+
+// Side-effect mutation: add a new property to another CommonJS module's
+// exports object after it has been evaluated.
+target.added = function added() {
+  return 'added';
+};

--- a/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/main.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import * as target from './target.cjs';
+import './augment.cjs';
+
+// `import * as` from a CommonJS module produces a namespace via `__toESM`,
+// which snapshots the own properties of `module.exports` at the moment the
+// wrapper is created — that is, BEFORE `augment.cjs` runs `target.added = ...`.
+// So the property added later by the side-effect module is NOT visible as a
+// named export on the namespace object.
+//
+// This matches esbuild. Rollup (+ @rollup/plugin-commonjs) would instead show
+// `typeof target.added === 'function'` because it keeps reading from the live
+// CJS exports object. Rolldown intentionally follows the esbuild semantics
+// here: named exports should not be addable by other modules.
+//
+// See https://github.com/rolldown/rolldown/issues/9512
+assert.equal(target.existing, 'existing');
+assert.equal(typeof target.added, 'undefined');
+
+// The `default` export still points at the live CommonJS exports object, so the
+// late mutation IS observable through it. This is the documented workaround.
+assert.equal(typeof target.default?.added, 'function');

--- a/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/target.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/cjs_namespace_late_mutation/target.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  existing: 'existing',
+};


### PR DESCRIPTION
Added a test for the case described in #9512 so that we preserve the current behavior.

close #9512