### PR TITLE
perf: drop owo-colors supports-colors feature in vite reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,17 +1322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,10 +1801,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
-]
 
 [[package]]
 name = "oxc"
@@ -3544,6 +3529,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_plugin",
  "sugar_path",
+ "supports-color",
  "terminal_size",
 ]
 
@@ -4084,16 +4070,6 @@ checksum = "36fe837e881ad5c3b60fadeb8e9b0bc5c907c4b7d84b4415a7f0bbc3f9073631"
 dependencies = [
  "memchr",
  "smallvec",
-]
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,7 @@ serde_yaml = "0.9.34"
 simdutf8 = "0.1.5"
 string_cache = "0.9.0"
 sugar_path = { version = "2.0.1", features = ["cached_current_dir"] }
+supports-color = "3"
 terminal_size = "0.4.2"
 testing_macros = "1.0.0"
 tokio = { version = "1.45.0", default-features = false }

--- a/crates/rolldown_plugin_vite_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_vite_reporter/Cargo.toml
@@ -22,9 +22,10 @@ cow-utils = { workspace = true }
 derive_more = { workspace = true }
 flate2 = { workspace = true }
 itoa = { workspace = true }
-owo-colors = { workspace = true, features = ["supports-colors"] }
+owo-colors = { workspace = true }
 rayon = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 sugar_path = { workspace = true }
+supports-color = { workspace = true }
 terminal_size = { workspace = true }

--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use cow_utils::CowUtils;
-use owo_colors::{OwoColorize, Stream};
+use owo_colors::Style;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_plugin::{HookUsage, Plugin, PluginContext};
 use sugar_path::SugarPath as _;
@@ -60,10 +60,10 @@ impl Plugin for ViteReporterPlugin {
         utils::write_line(&format!(
           "transforming ({}) {}",
           itoa::Buffer::new().format(transformed_count + 1),
-          Path::new(args.id)
-            .relative(&self.root)
-            .to_string_lossy()
-            .if_supports_color(Stream::Stdout, |text| { text.dimmed() })
+          utils::paint(
+            Path::new(args.id).relative(&self.root).to_string_lossy(),
+            Style::new().dimmed(),
+          )
         ));
 
         *self.latest_checkpoint.write().unwrap() = now;
@@ -95,7 +95,7 @@ impl Plugin for ViteReporterPlugin {
 
     utils::log_info(&format!(
       "{} {} modules transformed.",
-      "✓".if_supports_color(Stream::Stdout, |text| text.green()),
+      utils::paint("✓", Style::new().green()),
       self.transformed_count.load(Ordering::SeqCst)
     ));
 
@@ -226,21 +226,15 @@ impl Plugin for ViteReporterPlugin {
         }
         filtered.sort_by_key(|a| a.size);
         for log_entry in filtered {
-          let _ = write!(
-            &mut info,
-            "{}",
-            format!("{out_dir}/").if_supports_color(Stream::Stdout, |text| text.dimmed())
-          );
+          let _ =
+            write!(&mut info, "{}", utils::paint(format!("{out_dir}/"), Style::new().dimmed()));
 
           let is_asset = !self.is_lib && Path::new(log_entry.name).starts_with(&self.assets_dir);
           if is_asset {
             let _ = write!(
               &mut info,
               "{}",
-              self
-                .assets_dir
-                .cow_replace('\\', "/")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
+              utils::paint(self.assets_dir.cow_replace('\\', "/"), Style::new().dimmed())
             );
           }
 
@@ -253,30 +247,22 @@ impl Plugin for ViteReporterPlugin {
 
           let _ = match group {
             utils::AssetGroup::JS => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.cyan()))
+              write!(&mut info, "{}", utils::paint(&name, Style::new().cyan()))
             }
             utils::AssetGroup::Css => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.magenta()))
+              write!(&mut info, "{}", utils::paint(&name, Style::new().magenta()))
             }
             utils::AssetGroup::Assets => {
-              write!(&mut info, "{}", name.if_supports_color(Stream::Stdout, |text| text.green()))
+              write!(&mut info, "{}", utils::paint(&name, Style::new().green()))
             }
           };
 
           let size = format!("{:>size_pad$}", utils::display_size(log_entry.size));
           if group == utils::AssetGroup::JS && log_entry.size.div_ceil(1000) > self.chunk_limit {
             has_large_chunks = true;
-            let _ = write!(
-              &mut info,
-              "{}",
-              size.if_supports_color(Stream::Stdout, |text| text.bold().yellow().to_string())
-            );
+            let _ = write!(&mut info, "{}", utils::paint(&size, Style::new().bold().yellow()));
           } else {
-            let _ = write!(
-              &mut info,
-              "{}",
-              size.if_supports_color(Stream::Stdout, |text| text.bold().dimmed().to_string())
-            );
+            let _ = write!(&mut info, "{}", utils::paint(&size, Style::new().bold().dimmed()));
           }
 
           if let Some(compressed_size) = log_entry.compressed_size {
@@ -284,8 +270,7 @@ impl Plugin for ViteReporterPlugin {
             let _ = write!(
               &mut info,
               "{}",
-              format!(" │ gzip: {size:>compress_pad$}")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
+              utils::paint(format!(" │ gzip: {size:>compress_pad$}"), Style::new().dimmed())
             );
           }
 
@@ -294,8 +279,7 @@ impl Plugin for ViteReporterPlugin {
             let _ = write!(
               &mut info,
               "{}",
-              format!(" │ map: {size:>map_pad$}")
-                .if_supports_color(Stream::Stdout, |text| text.dimmed())
+              utils::paint(format!(" │ map: {size:>map_pad$}"), Style::new().dimmed())
             );
           }
 
@@ -313,10 +297,14 @@ impl Plugin for ViteReporterPlugin {
       });
     }
     if self.warn_large_chunks && has_large_chunks {
-      let message = format!(
-        "\n(!) Some chunks are larger than {} kB after minification. Consider:\n- Using dynamic import() to code-split the application\n- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting\n- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.",
-        itoa::Buffer::new().format(self.chunk_limit)
-      ).if_supports_color(Stream::Stdout, |text| { text.bold().yellow().to_string() }).to_string();
+      let message = utils::paint(
+        format!(
+          "\n(!) Some chunks are larger than {} kB after minification. Consider:\n- Using dynamic import() to code-split the application\n- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting\n- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.",
+          itoa::Buffer::new().format(self.chunk_limit)
+        ),
+        Style::new().bold().yellow(),
+      )
+      .to_string();
       ctx.warn(rolldown_common::LogWithoutPlugin { message, ..Default::default() });
     }
     Ok(())

--- a/crates/rolldown_plugin_vite_reporter/src/utils.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/utils.rs
@@ -1,6 +1,23 @@
 use std::io::{StdoutLock, Write};
 
 use flate2::{Compression, write::GzEncoder};
+use owo_colors::{Style, Styled};
+
+/// Apply `style` to `text` only when stdout supports color.
+///
+/// This is what owo-colors' `if_supports_color` does internally, but without its
+/// `supports-colors` feature (which would pull a duplicate `supports-color` into
+/// the tree). Like miette, the no-color path applies an empty [`Style`], which
+/// emits no escape codes. `on_cached` caches detection, so this is cheap per call.
+#[inline]
+pub fn paint<T: std::fmt::Display>(text: T, style: Style) -> Styled<T> {
+  let style = if supports_color::on_cached(supports_color::Stream::Stdout).is_some() {
+    style
+  } else {
+    Style::new()
+  };
+  style.style(text)
+}
 
 pub const COMPRESSIBLE_ASSETS: [&str; 7] =
   [".html", ".json", ".svg", ".txt", ".xml", ".xhtml", ".wasm"];


### PR DESCRIPTION
## What

`rolldown_plugin_vite_reporter` enabled owo-colors' `supports-colors` feature so it could call `text.if_supports_color(Stream::Stdout, …)`. That feature makes owo-colors depend on **two** major versions of `supports-color` at once (`2.1.0` + `3.0.2`), and `2.1.0` additionally drags in `is-terminal`.

`miette` (already in the tree via `oxc_diagnostics`) pulls owo-colors **without** that feature: it detects color support itself and uses owo-colors only as a `Style` painter, applying an empty `Style` when color is off (an empty `Style` emits no escape codes). This PR makes the reporter do the same:

- Add a `utils::paint(text, style)` helper that applies the `Style` only when stdout supports color, detecting via `supports_color::on_cached` — the same cached primitive owo-colors' `if_supports_color` uses internally.
- Replace each `if_supports_color(…, |t| t.green())` with `utils::paint(text, Style::new().green())`.
- Drop the `supports-colors` feature from owo-colors; add a direct `supports-color` dependency (v3, shared with miette).

## Result

`supports-color 2.1.0` and `is-terminal` are removed from the dependency tree; `owo-colors` now has zero dependencies, and `supports-color 3.0.2` is shared with miette:

```
-is-terminal v0.4.17
-supports-color v2.1.0
 owo-colors v4.3.0   (now 0 deps)
```

No behavior change — color is still emitted only when stdout supports it. `cargo test -p rolldown_plugin_vite_reporter` passes.