### PR TITLE
perf(rolldown): use unstable sort for itertools sorted_by at unique-key sites

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -248,7 +248,7 @@ impl GenerateStage<'_> {
     let sorted_chunk_idx_vec = chunk_graph
       .chunk_table
       .iter_enumerated()
-      .sorted_by_key(|(index, chunk)| match &chunk.kind {
+      .sorted_unstable_by_key(|(index, chunk)| match &chunk.kind {
         ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry) => {
           (0, index.raw())
         }

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -91,7 +91,7 @@ impl GenerateStage<'_> {
         }
         importee_map
           .into_iter()
-          .sorted_by_key(|(importee_chunk_id, _)| {
+          .sorted_unstable_by_key(|(importee_chunk_id, _)| {
             chunk_graph.chunk_table[*importee_chunk_id].exec_order
           })
           .collect::<FxIndexMap<_, _>>()
@@ -104,7 +104,7 @@ impl GenerateStage<'_> {
         .map(|imports_from_external_modules| {
           imports_from_external_modules
             .into_iter()
-            .sorted_by_key(|(external_module_id, _)| {
+            .sorted_unstable_by_key(|(external_module_id, _)| {
               self.link_output.module_table[*external_module_id].exec_order()
             })
             .collect_vec()
@@ -265,7 +265,7 @@ impl GenerateStage<'_> {
             for export_ref in entry_meta
               .resolved_exports
               .iter()
-              .sorted_by_key(|(name, _)| *name)
+              .sorted_unstable_by_key(|(name, _)| *name)
               .map(|(_, export)| export)
               // A chunk should always consume a cjs export symbol by property access, so filter
               // out a exported symbol that came from a cjs module.

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -133,7 +133,7 @@ impl ManualSplitter<'_> {
       .modules
       .iter()
       .filter_map(Module::as_normal)
-      .sorted_by(|a, b| a.stable_id.cmp(&b.stable_id));
+      .sorted_unstable_by(|a, b| a.stable_id.cmp(&b.stable_id));
 
     for normal_module in sorted_normal_modules {
       if !metas[normal_module.idx].is_included {


### PR DESCRIPTION
Use the **unstable** itertools sort (`sorted_unstable_by`/`sorted_unstable_by_key`) instead of the stable one at sites where the sort key is **unique**, so stability buys nothing. Stable sort only differs from unstable in the relative order of *equal* elements — and at these sites no two elements compare equal, so the output is identical. Unstable sort is also marginally faster (no scratch allocation, smaller routine). This mirrors how the std slice sorts are already used.

## Flipped (key is unique ⇒ output unchanged)
- `generate_stage/manual_code_splitting.rs` — by `stable_id` (unique)
- `generate_stage/compute_cross_chunk_links.rs` (×3) — by chunk `exec_order` (the unique `chunk.exec_order = i` index), external-module map entries by `exec_order`, and by export `name` (unique map key)
- `generate_stage/code_splitting.rs` — the `(group, chunk-index / chunk exec_order)` tuple key (unique across all chunks)

## Left stable (on purpose)
- `compute_cross_chunk_links` cjs-namespace sort by `owner.exec_order()` — multiple ns bindings can share an owner (→ equal keys), and the surrounding logic relies on the relative order ("first reference").
- `code_splitting.rs` chunk comparator (`:194`) — its same-kind branches return `Equal` when two chunks' representative **module** `exec_order`s tie. Assigned `exec_order`s are unique (`sort_modules.rs` monotonic counter), but unvisited modules keep the `u32::MAX` sentinel; the cross-kind `if a == b { a_should_be_first }` tiebreaks and the trailing comment *"other chunks has stable order at per entry chunk level"* show the code relies on stable ordering to break those ties deterministically. (Reverted from an earlier revision of this PR after review.)

## Verification
The full bundler-output integration/snapshot suite passes with **no snapshot changes** (the only failures in an isolated worktree are pre-existing environment issues — a missing `node_modules` package and the `test262` submodule — which fail identically on `main`). `cargo clippy` (with `--features experimental`) and `cargo fmt` are clean.
