### PR TITLE
ci: pin vite-plus (vp) CLI to 0.1.24 in setup-vp

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,6 +18,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17

--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -47,6 +47,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Setup Rust

--- a/.github/workflows/benchmark-rust.yml
+++ b/.github/workflows/benchmark-rust.yml
@@ -39,6 +39,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Setup Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Download Native Rolldown Build
@@ -239,6 +240,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Download Native Rolldown Build
@@ -296,6 +298,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Download Native Rolldown Build
@@ -349,6 +352,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Lint Filename

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,4 +35,5 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -38,6 +38,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Generate API reference
@@ -85,6 +86,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Deploy to Void

--- a/.github/workflows/metric.yml
+++ b/.github/workflows/metric.yml
@@ -58,6 +58,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Install dependencies and push metric

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,6 +34,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -71,6 +71,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Git Reset Hard

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -70,6 +70,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Git Reset Hard

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Run Test

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -41,6 +41,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Build Native Rolldown

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           node-version: ${{ inputs.node-version }}
           cache: true
 

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -42,6 +42,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           node-version: ${{ inputs.node-version }}
           cache: true
 

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -107,6 +107,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Build Binding
@@ -181,6 +182,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Build Node binding
@@ -233,6 +235,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Build Node binding
@@ -274,6 +277,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Build `@rolldown/debug`

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Add WASI target

--- a/.github/workflows/update-test-dependencies.yml
+++ b/.github/workflows/update-test-dependencies.yml
@@ -108,6 +108,7 @@ jobs:
       - if: steps.check-update.outputs.update_needed == 'true'
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - if: steps.check-update.outputs.update_needed == 'true'
@@ -227,6 +228,7 @@ jobs:
       - if: steps.check-update.outputs.update_needed == 'true'
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Run Test
@@ -347,6 +349,7 @@ jobs:
       - if: steps.check-update.outputs.update_needed == 'true'
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: '0.1.24'
           cache: true
 
       - name: Generate esbuild tests


### PR DESCRIPTION
## Problem

CI started failing on the Node 20 jobs (e.g. [this run](https://github.com/rolldown/rolldown/actions/runs/27690584904/job/81907492166?pr=9827)) with:

```
Node.js 20.20.2 is incompatible with Vite+ CLI.
Required by Vite+: ^22.18.0 || >=24.11.0
The command `vp install` exited with code 1
```

`vite-plus@0.2.0` was just published and bumped its Node engine requirement to `^22.18.0 || >=24.11.0`. The `voidzero-dev/setup-vp` action installs the `vp` CLI from its `version` input, which **defaults to `latest`** — so CI silently picked up `0.2.0`, which no longer runs on Node 20.

## Fix

Pin every `setup-vp` invocation to `version: '0.1.24'` (engines `^20.19.0 || >=22.12.0`), which covers the full `[20, 22, 24]` test matrix.

- 17 workflow files, 26 `setup-vp` steps pinned.
- No change to `package.json`: `"vite-plus": "^0.1.24"` already resolves to `>=0.1.24 <0.2.0` (caret on a `0.x` version), and the lockfile is at `0.1.24` — only the unpinned **CLI** was reaching `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)