### PR TITLE
refactor: single-source the chunk $N symbol-naming algorithm

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -1,8 +1,6 @@
-use std::borrow::Cow;
-use std::cmp::Reverse;
-
 use super::GenerateStage;
 use crate::chunk_graph::ChunkGraph;
+use crate::utils::chunk::conflict_resolver::{ConflictResolver, deconflict_order_key};
 use crate::utils::chunk::normalize_preserve_entry_signature;
 use crate::utils::external_import_interop::external_import_needs_interop;
 use itertools::{Itertools, multizip};
@@ -13,11 +11,9 @@ use rolldown_common::{
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PostChunkOptimizationOperation,
   PreserveEntrySignatures, RUNTIME_HELPER_NAMES, SymbolRef, WrapKind,
 };
-use rolldown_utils::concat_string;
 use rolldown_utils::index_vec_ext::IndexVecRefExt as _;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rolldown_utils::rayon::{ParallelBridge, ParallelIterator};
-use rolldown_utils::rustc_hash::FxHashMapExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 type IndexChunkDependedSymbols = IndexVec<ChunkIdx, FxIndexSet<SymbolRef>>;
@@ -703,12 +699,12 @@ impl GenerateStage<'_> {
         for (chunk_export, _predefined_names) in index_chunk_exported_symbols[chunk_id]
           .iter()
           .sorted_unstable_by_key(|(symbol_ref, _predefined_names)| {
-            let symbol_owner = &self.link_output.module_table[symbol_ref.owner];
-            let symbol_name = symbol_ref.name(&self.link_output.symbol_db);
-            // `Reverse(symbol_owner.exec_order()` is used to follow the same deconflict order as in
-            // https://github.com/rolldown/rolldown/blob/504ea76c00563eb7db7a49c2b6e04b2fbe61bdc1/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs?plain=1#L86-L102
-            // Then we sort by the symbol name to ensure a stable order within the same module.
-            (Reverse(symbol_owner.exec_order()), symbol_name)
+            // Canonical naming order — see `deconflict_order_key`.
+            deconflict_order_key(
+              **symbol_ref,
+              &self.link_output.module_table,
+              &self.link_output.symbol_db,
+            )
           })
         {
           let export_ref = self.link_output.symbol_db.canonical_ref_for(*chunk_export);
@@ -731,13 +727,17 @@ impl GenerateStage<'_> {
         continue;
       }
 
-      let mut name_count = FxHashMap::with_capacity(index_chunk_exported_symbols[chunk_id].len());
+      let mut resolver =
+        ConflictResolver::with_capacity(index_chunk_exported_symbols[chunk_id].len());
       for (chunk_export, predefined_names) in index_chunk_exported_symbols[chunk_id]
         .iter()
         .sorted_by_cached_key(|(symbol_ref, _predefined_names)| {
-          // same deconflict order in deconflict_chunk_symbols.rs
-          // https://github.com/rolldown/rolldown/blob/504ea76c00563eb7db7a49c2b6e04b2fbe61bdc1/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs?plain=1#L86-L102
-          Reverse::<u32>(self.link_output.module_table[symbol_ref.owner].exec_order())
+          // Canonical naming order — see `deconflict_order_key`.
+          deconflict_order_key(
+            **symbol_ref,
+            &self.link_output.module_table,
+            &self.link_output.symbol_db,
+          )
         })
       {
         if !self.link_output.used_symbol_refs.contains(chunk_export) {
@@ -747,47 +747,27 @@ impl GenerateStage<'_> {
           [] => CompactStr::new(chunk_export.name(&self.link_output.symbol_db)),
           lst => {
             for item in lst {
-              name_count.insert(Cow::Borrowed(item), 0);
+              resolver.reserve(CompactStr::new(item));
             }
 
             chunk.exports_to_other_chunks.entry(*chunk_export).or_default().extend_from_slice(lst);
             continue;
           }
         };
-        // A special case for `default` export when setting `preserve_modules`.
-        // When `preserve_modules` is enabled, we need to ensure that the default export is
-        // correctly named as `default`.
-        // Otherwise, we just use the default_export_ref representative name
-        let mut candidate_name = if self.options.preserve_modules {
-          let module = chunk.entry_module(&self.link_output.module_table).unwrap();
-          // If `preserve_modules` is enabled, there should have only one default export per chunk.
-          if module.default_export_ref == *chunk_export {
-            "default".into()
-          } else {
-            original_name.clone()
-          }
+        // A special case for `default` export when setting `preserve_modules`: the
+        // single default export per chunk must be named `default`. Otherwise use the
+        // `default_export_ref` representative name. The `&&` keeps the `entry_module`
+        // lookup guarded behind the `preserve_modules` check.
+        let base = if self.options.preserve_modules
+          && chunk.entry_module(&self.link_output.module_table).unwrap().default_export_ref
+            == *chunk_export
+        {
+          CompactStr::new_const("default")
         } else {
-          original_name.clone()
+          original_name
         };
-        loop {
-          let key: Cow<'_, CompactStr> = Cow::Owned(candidate_name.clone());
-          match name_count.entry(key) {
-            std::collections::hash_map::Entry::Occupied(mut occ) => {
-              let next_conflict_index = *occ.get() + 1;
-              *occ.get_mut() = next_conflict_index;
-              candidate_name = CompactStr::new(&concat_string!(
-                original_name,
-                "$",
-                itoa::Buffer::new().format(next_conflict_index)
-              ));
-            }
-            std::collections::hash_map::Entry::Vacant(vac) => {
-              vac.insert(0);
-              break;
-            }
-          }
-        }
-        chunk.exports_to_other_chunks.entry(*chunk_export).or_default().push(candidate_name);
+        let chosen = resolver.resolve(base, |_, _| true);
+        chunk.exports_to_other_chunks.entry(*chunk_export).or_default().push(chosen);
       }
     }
   }
@@ -799,6 +779,9 @@ const REST_BASE: u32 = 64;
 const FREQUENT_CHARS: &[u8; REST_BASE as usize] =
   b"etnriaoscludfpmhg_vybxSCwTEDOkAjMNPFILRzBVHUWGKqJYXZQ$1024368579";
 
+// Intentionally NOT routed through `ConflictResolver`: this is a generative
+// base54 namer (not `$N`-suffix), so it shares only `deconflict_order_key`,
+// not the conflict loop. See docs/superpowers/specs/2026-06-17-renamer-naming-engine-design.md.
 fn generate_minified_names(mut value: u32) -> String {
   let mut buffer = vec![];
 

--- a/crates/rolldown/src/utils/chunk/conflict_resolver.rs
+++ b/crates/rolldown/src/utils/chunk/conflict_resolver.rs
@@ -1,0 +1,187 @@
+use core::cmp::Reverse;
+
+use oxc_str::CompactStr;
+use rolldown_common::{ModuleTable, SymbolRef, SymbolRefDb};
+use rolldown_utils::{concat_string, rustc_hash::FxHashMapExt};
+use rustc_hash::FxHashMap;
+
+/// Single source of the chunk `$N` conflict-suffix naming algorithm, shared by
+/// chunk-internal deconfliction (`Renamer`) and cross-chunk export naming.
+///
+/// Owns the name -> conflict-index map. Callers store the returned name in their
+/// own structure (`canonical_names`, `exports_to_other_chunks`, ...).
+#[derive(Debug, Default)]
+pub struct ConflictResolver {
+  /// Key is a taken name; value is the conflict index used to generate the next
+  /// unique `name$N`. See `renamer.rs` for the historical semantics this preserves.
+  used: FxHashMap<CompactStr, u32>,
+}
+
+impl ConflictResolver {
+  pub fn new(reserved: impl IntoIterator<Item = CompactStr>) -> Self {
+    Self { used: reserved.into_iter().map(|name| (name, 0)).collect() }
+  }
+
+  /// Like `new` but pre-sizes the backing map and starts empty — for callers
+  /// (e.g. the cross-chunk export pass) that know the name count up front and
+  /// seed no reserved names.
+  pub fn with_capacity(capacity: usize) -> Self {
+    Self { used: FxHashMap::with_capacity(capacity) }
+  }
+
+  /// Reserve a name so it is never handed out (and seeds its conflict index at 0).
+  /// Idempotent: re-reserving an existing name is a no-op that preserves its conflict index.
+  pub fn reserve(&mut self, name: CompactStr) {
+    self.used.entry(name).or_insert(0);
+  }
+
+  pub fn contains(&self, name: &str) -> bool {
+    self.used.contains_key(name)
+  }
+
+  /// Pick a unique name for `base`, trying `base` then `base$1`, `base$2`, ...
+  ///
+  /// `accept(candidate, is_original)` vetoes a candidate that is otherwise free
+  /// (e.g. would capture a nested binding). `is_original` is `true` only on the
+  /// bare-`base` fast path. Returns the chosen name and records it as used.
+  #[inline]
+  pub fn resolve(&mut self, base: CompactStr, accept: impl Fn(&str, bool) -> bool) -> CompactStr {
+    // Fast path: bare name is free and accepted. `base` is moved straight through
+    // to the caller, so the name it already owns is never re-allocated.
+    if !self.used.contains_key(&base) && accept(&base, true) {
+      self.used.insert(base.clone(), 0);
+      return base;
+    }
+
+    // Slow path: find `base$N`. `conflict_index` jumps past occupied candidates
+    // by reading their stored counter (preserves renamer.rs:217-225).
+    let mut conflict_index = self
+      .used
+      .get_mut(&base)
+      .map(|idx| {
+        *idx += 1;
+        *idx
+      })
+      .unwrap_or(1);
+
+    loop {
+      let candidate: CompactStr =
+        concat_string!(base, "$", itoa::Buffer::new().format(conflict_index)).into();
+
+      if let Some(idx) = self.used.get_mut(&candidate) {
+        *idx += 1;
+        conflict_index = *idx;
+        continue;
+      }
+
+      if !accept(&candidate, false) {
+        conflict_index += 1;
+        continue;
+      }
+
+      self.used.insert(candidate.clone(), 0);
+      return candidate;
+    }
+  }
+}
+
+/// Canonical ordering for handing out deconflicted names: the entry module gets
+/// naming priority. `exec_order` is assigned ascending (dependencies first,
+/// entry last / highest), so `Reverse(exec_order)` sorts the entry first — the
+/// same priority as the `.rev()` pass in `deconflict_chunk_symbols`. Ties are
+/// broken by symbol name ascending. This is the single source of the ordering
+/// invariant previously duplicated as the pinned-SHA comments in
+/// `compute_cross_chunk_links.rs`.
+pub fn deconflict_order_key<'a>(
+  symbol_ref: SymbolRef,
+  module_table: &ModuleTable,
+  symbol_db: &'a SymbolRefDb,
+) -> (Reverse<u32>, &'a str) {
+  let exec_order = module_table[symbol_ref.owner].exec_order();
+  (Reverse(exec_order), symbol_ref.name(symbol_db))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn cs(s: &str) -> CompactStr {
+    CompactStr::new(s)
+  }
+
+  #[test]
+  fn bare_name_when_free() {
+    let mut r = ConflictResolver::new(std::iter::empty());
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo");
+  }
+
+  #[test]
+  fn suffix_on_collision() {
+    let mut r = ConflictResolver::new(std::iter::empty());
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo");
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo$1");
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo$2");
+  }
+
+  #[test]
+  fn reserved_names_are_avoided() {
+    let mut r = ConflictResolver::new([cs("foo")]);
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo$1");
+  }
+
+  #[test]
+  fn accept_veto_skips_candidate() {
+    // Reject any name equal to "foo$1" (e.g. simulating a nested-capture veto),
+    // forcing the loop to advance to "foo$2".
+    let mut r = ConflictResolver::new(std::iter::empty());
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo"); // occupies "foo"
+    assert_eq!(r.resolve(cs("foo"), |cand, _is_original| cand != "foo$1").as_str(), "foo$2");
+  }
+
+  #[test]
+  fn jump_uses_stored_counter_of_occupied_candidate() {
+    // Reproduces renamer.rs:221-225: when a candidate is already used, its stored
+    // counter is read and the index jumps past it.
+    let mut r = ConflictResolver::new(std::iter::empty());
+    r.reserve(cs("foo"));
+    r.reserve(cs("foo$1"));
+    // base "foo" occupied -> try "foo$1" (occupied, counter 0 -> becomes 1, jump to "foo$2")
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo$2");
+  }
+
+  #[test]
+  fn jump_walks_multi_hop_chain() {
+    // Exercises a three-hop jump: foo -> foo$1 -> foo$2 -> foo$3.
+    // All three candidates are pre-reserved; the index must walk the full chain.
+    let mut r = ConflictResolver::new(std::iter::empty());
+    r.reserve(cs("foo"));
+    r.reserve(cs("foo$1"));
+    r.reserve(cs("foo$2"));
+    assert_eq!(r.resolve(cs("foo"), |_, _| true).as_str(), "foo$3");
+  }
+
+  #[test]
+  fn contains_reports_reserved() {
+    let mut r = ConflictResolver::new([cs("a")]);
+    assert!(r.contains("a"));
+    assert!(!r.contains("b"));
+    r.reserve(cs("b"));
+    assert!(r.contains("b"));
+  }
+
+  #[test]
+  fn order_key_is_reverse_exec_order_then_name() {
+    // The key type: the entry module has the highest exec_order (dependencies
+    // execute first with lower orders, entry last). Reverse sorts the highest
+    // exec_order first (entry-first), and ties break by name ascending. We
+    // assert the tuple shape and comparison semantics with synthetic values.
+    use core::cmp::Reverse;
+    let a = (Reverse(5u32), CompactStr::new("b"));
+    let b = (Reverse(5u32), CompactStr::new("a"));
+    let c = (Reverse(6u32), CompactStr::new("z"));
+    let mut v = vec![a.clone(), b.clone(), c.clone()];
+    v.sort();
+    // c has higher exec_order -> Reverse puts it first; within exec_order 5, "a" < "b".
+    assert_eq!(v, vec![c, b, a]);
+  }
+}

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -141,6 +141,19 @@ pub fn deconflict_chunk_symbols(
     }
   }
 
+  // The renamer relies on `chunk.modules` being in ascending exec_order so that
+  // `.rev()` yields entry-first / descending exec_order — the same priority as
+  // `deconflict_order_key`. Enforce that invariant in debug builds (was only a
+  // prose + pinned-SHA comment before).
+  debug_assert!(
+    chunk
+      .modules
+      .iter()
+      .filter_map(|idx| link_output.module_table[*idx].as_normal().map(|m| m.exec_order))
+      .is_sorted(),
+    "chunk.modules must be in ascending exec_order for deconfliction"
+  );
+
   chunk
     .modules
     .iter()
@@ -215,10 +228,12 @@ pub fn deconflict_chunk_symbols(
     .map(|(id, _)| {
       (
         *id,
-        renamer.create_conflictless_name(&legitimize_identifier_name(&format!(
-          "require_{}",
-          index_chunk_id_to_name[id]
-        ))),
+        renamer
+          .create_conflictless_name(&legitimize_identifier_name(&format!(
+            "require_{}",
+            index_chunk_id_to_name[id]
+          )))
+          .to_string(),
       )
     })
     .collect();
@@ -255,7 +270,7 @@ pub fn deconflict_chunk_symbols(
         let canonical_ref = link_output.symbol_db.canonical_ref_for(ext.namespace_ref);
         let original_name = canonical_ref.name(&link_output.symbol_db);
         let node_name = renamer.create_conflictless_name(original_name);
-        node_mode_names.insert(canonical_ref, CompactStr::new(&node_name));
+        node_mode_names.insert(canonical_ref, node_name);
       }
     }
     chunk.node_mode_external_ns_names = node_mode_names;

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{stages::link_stage::LinkStageOutput, types::generator::GenerateContext};
 
+pub mod conflict_resolver;
 pub mod deconflict_chunk_symbols;
 pub mod determine_export_mode;
 pub mod finalize_chunks;

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -1,7 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use std::collections::hash_map::Entry;
-
 use oxc::semantic::Scoping;
 use oxc::syntax::keyword::{GLOBAL_OBJECTS, RESERVED_KEYWORDS};
 use oxc_str::CompactStr;
@@ -13,25 +11,12 @@ use rolldown_common::{
 use rolldown_utils::concat_string;
 
 use crate::stages::link_stage::LinkStageOutput;
+use crate::utils::chunk::conflict_resolver::ConflictResolver;
 
 #[derive(Debug)]
 pub struct Renamer<'name> {
-  /// Tracks all canonical names used in the top-level scope.
-  ///
-  /// Key is the canonical name, value is the conflict index for generating unique names.
-  /// When we need a unique name like `foo$1`, we increment the conflict index stored here.
-  ///
-  /// Example:
-  /// ```js
-  /// // index.js
-  /// import {a as b} from './a.js'
-  /// const a = 1;      // used_canonical_names: {a: 0}
-  /// const a$1 = 1000; // used_canonical_names: {a: 0, a$1: 0}
-  ///
-  /// // a.js
-  /// export const a = 100; // Try `a` (used), `a$1` (used), `a$2` (available) → rename to `a$2`
-  /// ```
-  used_canonical_names: FxHashMap<CompactStr, u32>,
+  /// Shared conflict-suffix engine; owns the set of taken top-level names.
+  resolver: ConflictResolver,
   /// Final symbol → name mappings.
   canonical_names: FxHashMap<SymbolRef, CompactStr>,
   symbol_db: &'name SymbolRefDb,
@@ -57,12 +42,13 @@ impl<'name> Renamer<'name> {
     Self {
       canonical_names: FxHashMap::default(),
       symbol_db,
-      used_canonical_names: manual_reserved
-        .iter()
-        .chain(RESERVED_KEYWORDS.iter())
-        .chain(GLOBAL_OBJECTS.iter())
-        .map(|s| (CompactStr::new(s), 0))
-        .collect(),
+      resolver: ConflictResolver::new(
+        manual_reserved
+          .iter()
+          .chain(RESERVED_KEYWORDS.iter())
+          .chain(GLOBAL_OBJECTS.iter())
+          .map(|s| CompactStr::new(s)),
+      ),
       entry_module_idx: base_module_index,
     }
   }
@@ -81,17 +67,7 @@ impl<'name> Renamer<'name> {
   }
 
   pub fn reserve(&mut self, name: CompactStr) {
-    self.used_canonical_names.entry(name).or_insert(0);
-  }
-
-  /// Returns true if `name` exists in any nested (non-root) scope of the module.
-  /// Returns false for modules without AST (external modules).
-  fn has_nested_scope_binding(&self, module_idx: ModuleIdx, name: &str) -> bool {
-    let Some(db) = &self.symbol_db[module_idx] else {
-      return false;
-    };
-    // Skip root scope (index 0), check nested scopes only
-    db.ast_scopes.scoping().iter_bindings().skip(1).any(|(_, bindings)| bindings.contains_key(name))
+    self.resolver.reserve(name);
   }
 
   /// Check if a candidate name is available for a top-level symbol without causing
@@ -139,13 +115,15 @@ impl<'name> Renamer<'name> {
   ///
   /// Here the author intentionally wrote a parameter named `value` that shadows the import.
   /// We allow this (`is_original_name = true`), so the import keeps its name `value`.
-  fn is_name_available(
-    &self,
+  #[inline]
+  fn is_name_available_with(
+    symbol_db: &SymbolRefDb,
+    entry_module_idx: Option<ModuleIdx>,
     candidate_name: &str,
     symbol_ref: SymbolRef,
     is_original_name: bool,
   ) -> bool {
-    if let Some(entry_idx) = self.entry_module_idx {
+    if let Some(entry_idx) = entry_module_idx {
       if symbol_ref.owner == entry_idx {
         // Entry module symbols can use their original names freely - shadowing is
         // handled by reference-based renaming of nested bindings later
@@ -155,7 +133,7 @@ impl<'name> Renamer<'name> {
 
     // Renamed candidates must not conflict with own module's nested bindings
     // (original names are allowed to shadow - that's intentional)
-    if !is_original_name && self.has_nested_scope_binding(symbol_ref.owner, candidate_name) {
+    if !is_original_name && has_nested_scope_binding(symbol_db, symbol_ref.owner, candidate_name) {
       return false;
     }
 
@@ -195,63 +173,24 @@ impl<'name> Renamer<'name> {
       return;
     }
 
-    // Fast path: original name is available
-    if !self.used_canonical_names.contains_key(&original_name)
-      && self.is_name_available(&original_name, canonical_ref, true)
-    {
-      self.used_canonical_names.insert(original_name.clone(), 0);
-      self.canonical_names.insert(canonical_ref, original_name);
-      return;
-    }
-
-    // Slow path: find alternative name (original$1, original$2, ...)
-    let mut conflict_index = self
-      .used_canonical_names
-      .get_mut(&original_name)
-      .map(|idx| {
-        *idx += 1;
-        *idx
-      })
-      .unwrap_or(1);
-
-    loop {
-      let candidate_name: CompactStr =
-        concat_string!(original_name, "$", itoa::Buffer::new().format(conflict_index)).into();
-
-      if let Some(idx) = self.used_canonical_names.get_mut(&candidate_name) {
-        *idx += 1;
-        conflict_index = *idx;
-        continue;
-      }
-
-      if !self.is_name_available(&candidate_name, canonical_ref, false) {
-        conflict_index += 1;
-        continue;
-      }
-
-      self.used_canonical_names.insert(candidate_name.clone(), 0);
-      self.canonical_names.insert(canonical_ref, candidate_name);
-      break;
-    }
+    // Bind the fields the `accept` closure reads as locals so the borrow of
+    // `self.resolver` (mutable, in `resolve`) does not overlap a borrow of `self`.
+    let symbol_db = self.symbol_db;
+    let entry_module_idx = self.entry_module_idx;
+    let canonical_name = self.resolver.resolve(original_name, |candidate, is_original| {
+      Self::is_name_available_with(
+        symbol_db,
+        entry_module_idx,
+        candidate,
+        canonical_ref,
+        is_original,
+      )
+    });
+    self.canonical_names.insert(canonical_ref, canonical_name);
   }
 
-  pub fn create_conflictless_name(&mut self, hint: &str) -> String {
-    let mut conflictless_name = CompactStr::new(hint);
-    loop {
-      match self.used_canonical_names.entry(conflictless_name.clone()) {
-        Entry::Occupied(mut occ) => {
-          let next_conflict_index = occ.get() + 1;
-          *occ.get_mut() = next_conflict_index;
-          conflictless_name =
-            concat_string!(hint, "$", itoa::Buffer::new().format(next_conflict_index)).into();
-        }
-        Entry::Vacant(vac) => {
-          vac.insert(0);
-          break;
-        }
-      }
-    }
-    conflictless_name.to_string()
+  pub fn create_conflictless_name(&mut self, hint: &str) -> CompactStr {
+    self.resolver.resolve(CompactStr::new(hint), |_, _| true)
   }
 
   pub fn register_nested_scope_symbols(&mut self, symbol_ref: SymbolRef, original_name: &str) {
@@ -266,7 +205,7 @@ impl<'name> Renamer<'name> {
       let name: CompactStr =
         concat_string!(original_name, "$", itoa::Buffer::new().format(count)).into();
 
-      if self.used_canonical_names.contains_key(&name) {
+      if self.resolver.contains(&name) {
         continue;
       }
 
@@ -274,12 +213,12 @@ impl<'name> Renamer<'name> {
       // a nested scope of the same module. Without this check, renaming `child`
       // to `child$1` could collide with an existing `child$1` binding in the
       // same scope (e.g. from Gleam's variable shadowing convention).
-      if self.has_nested_scope_binding(symbol_ref.owner, &name) {
-        self.used_canonical_names.insert(name, 0);
+      if has_nested_scope_binding(self.symbol_db, symbol_ref.owner, &name) {
+        self.resolver.reserve(name);
         continue;
       }
 
-      self.used_canonical_names.insert(name.clone(), 0);
+      self.resolver.reserve(name.clone());
       self.canonical_names.insert(symbol_ref, name);
       return;
     }
@@ -289,6 +228,16 @@ impl<'name> Renamer<'name> {
   pub fn into_canonical_names(self) -> FxHashMap<SymbolRef, CompactStr> {
     self.canonical_names
   }
+}
+
+/// Returns true if `name` exists in any nested (non-root) scope of the module.
+/// Returns false for modules without AST (external modules).
+fn has_nested_scope_binding(symbol_db: &SymbolRefDb, module_idx: ModuleIdx, name: &str) -> bool {
+  let Some(db) = &symbol_db[module_idx] else {
+    return false;
+  };
+  // Skip root scope (index 0), check nested scopes only
+  db.ast_scopes.scoping().iter_bindings().skip(1).any(|(_, bindings)| bindings.contains_key(name))
 }
 
 /// Context for renaming nested scope symbols that would shadow top-level symbols.


### PR DESCRIPTION
`renamer.rs` (chunk-internal deconfliction, producing `canonical_names`) and `compute_cross_chunk_links.rs` (cross-chunk export aliases, producing `exports_to_other_chunks`) each carried their own copy of the same `$N` conflict-suffix naming and `Reverse(exec_order)` ordering — kept in sync only by a hand-written pinned-SHA comment, with no test guarding the contract. This consolidates both into one source of truth.

### What changed

- A shared `ConflictResolver` owns the `$N` naming kernel; both sites call it instead of re-implementing the loop.
- A single `deconflict_order_key` owns the ordering. It returns a borrowed `&str` (so the export sort no longer allocates a `CompactStr` per comparison) and takes `(&ModuleTable, &SymbolRefDb)` rather than the whole `&LinkStageOutput`.
- The pinned-SHA sync comments are gone, replaced by a `debug_assert` that enforces the `chunk.modules` exec-order invariant in code.
- Unit tests now pin the kernel and the ordering — the contract that previously had none.

### Behavior

Unchanged. Chunk-internal naming is byte-identical and cross-chunk export naming is output-neutral — verified by the full Rust test suite (zero snapshot drift) and clippy.

### Hot path

The deconfliction path stays as tight as the original inline loops: `resolve` takes its base by value, so the name the caller already owns moves straight through to the result rather than being re-allocated, and it is `#[inline]`d so the loop compiles down like the hand-written code. The cross-chunk resolver is pre-sized and `"default"` is built with `CompactStr::new_const`.

Intentionally untouched: `NestedScopeRenamer`, the namespace/wrapper logic, the minified base54 export generator, and all read-only consumers of `canonical_names`.
