### PR TITLE
fix(generator): correct contradictory panic message in cjs cross-chunk symbol lookup

### DIFF
--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -67,7 +67,7 @@ impl GenerateContext<'_> {
           // Scoped symbols don't get assigned a `ChunkIdx`. There are skipped for performance reason, because they are surely
           // belong to the chunk they are declared in and won't link to other chunks.
           let symbol_name = canonical_ref.name(symbol_db);
-          panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which isn't unexpected");
+          panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected");
         });
 
         let is_symbol_in_other_chunk = cur_chunk_idx != chunk_idx_of_canonical_symbol;


### PR DESCRIPTION
The `unwrap_or_else` panic fires only on an invariant violation (a canonical symbol with no `chunk_idx`), so reaching it is unexpected — but the message read `which isn't unexpected`, which is self-contradictory. The sibling path in `module_finalizers` already reads `which is unexpected`; this aligns them.

Prepared with AI assistance.