### PR TITLE
fix(plugin_timings): point doc link to existing checks reference page

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
@@ -18,7 +18,7 @@ impl BuildEvent for PluginTimings {
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
-    const DOC_LINK: &str = "https://rolldown.rs/options/checks#plugintimings";
+    const DOC_LINK: &str = "https://rolldown.rs/reference/InputOptions.checks#plugintimings";
 
     match self.plugins.len() {
       0 => unreachable!("PluginTimings should have at least one plugin"),


### PR DESCRIPTION
The `[PLUGIN_TIMINGS]` warning linked to `https://rolldown.rs/options/checks#plugintimings`, which 404s; the page lives at `https://rolldown.rs/reference/InputOptions.checks#plugintimings`. Fixes #9833.

Prepared with AI assistance.