### PR TITLE
perf: skip enum member value extraction for non-TypeScript modules

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -109,7 +109,10 @@ impl PreProcessEcmaAst {
     // Tree-shaking in `include_statements.rs` skips including the enum declaration
     // when a member access will be inlined. Regular enum IIFEs are `@__PURE__`, so
     // they are naturally tree-shaken if no other references keep them alive.
-    let enum_member_value_map = {
+    // Enums are a TypeScript-only construct, so only Ts/Tsx modules can declare
+    // them. For plain JS/JSX modules, skip the full symbol-table walk and the map
+    // allocation entirely (the result would always be empty).
+    let enum_member_value_map = if matches!(parsed_type, OxcParseType::Ts | OxcParseType::Tsx) {
       let scoping_ref = scoping.as_mut().unwrap();
       let mut enum_values: FxHashMap<CompactStr, FxHashMap<CompactStr, ConstExportMeta>> =
         FxHashMap::default();
@@ -142,6 +145,8 @@ impl PreProcessEcmaAst {
         }
       }
       enum_values
+    } else {
+      FxHashMap::default()
     };
 
     // Step 2: Run define plugin.


### PR DESCRIPTION
### What

`PreProcessEcmaAst::build` extracts enum member values from every module so that const / regular enum member accesses can be inlined later (during tree-shaking in `include_statements.rs`). This change gates that extraction on the module's parsed type so it only runs for `Ts` / `Tsx` modules.

```rust
// crates/rolldown/src/utils/pre_process_ecma_ast.rs
let enum_member_value_map = if matches!(parsed_type, OxcParseType::Ts | OxcParseType::Tsx) {
    // ... walk symbol table, collect enum member values ...
    enum_values
} else {
    FxHashMap::default()
};
```

### Why

`enum` is TypeScript-only syntax: a `TSEnumDeclaration` is only produced when parsing with `Ts` / `Tsx`. A plain `Js` / `Jsx` module can never contain an enum, so the extraction loop never matches anything and always returns an empty map for those modules.

Despite that, the old code ran the loop for every module: a full walk of the module's symbol table (`scoping.symbol_ids()`, one `symbol_flags()` lookup per symbol) plus an `FxHashMap` allocation that ends up empty. This is pure overhead for every JS/JSX module in the graph, and real-world graphs are JS-heavy (most `node_modules` dependencies ship plain JS), so it runs a lot. Gating on the parsed type removes the walk and the allocation for those modules entirely.

### Correctness

- Enums only exist in TS/TSX, so the gated-out branch could only ever produce an empty map. Behavior for JS/JSX is unchanged (empty map either way), and TS/TSX modules take exactly the same path as before.
- Bundle output is byte-identical: the full rolldown integration snapshot suite passes with no snapshot changes (1754 passed, 0 failed; `rolldown` + `esbuild` + `rollup` + `test262` fixtures), run with `INSTA_UPDATE=no` so any output drift would fail rather than silently update.
- `clippy` is clean on the changed crate.