### PR TITLE
fix(plugin_error): preserve inner diagnostic's file id through plugin-error wrapping

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
@@ -36,6 +36,13 @@ impl BuildEvent for PluginError {
     EventKind::PluginError
   }
 
+  fn id(&self) -> Option<String> {
+    // A `PluginError` wraps an inner diagnostic (e.g. an `OxcError` carrying the
+    // offending file path). Delegate to it so the file id is preserved; otherwise
+    // it defaults to `None` and is lost in the error object exposed to JS.
+    self.error.downcast_ref::<BuildDiagnostic>().and_then(BuildDiagnostic::id)
+  }
+
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     if self.error.downcast_ref::<BuildDiagnostic>().is_some() {
       String::default()

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -267,4 +267,27 @@ mod tests {
       "expected non-empty underlying message in Debug output, got: {debug_output}"
     );
   }
+
+  // Regression test for #9843: re-wrapping a diagnostic in a `PluginError` must not
+  // drop the inner diagnostic's file id. That id feeds `NativeError.id` / `loc.file`
+  // in the error object exposed to JS, so losing it makes `err.errors[0].id`
+  // `undefined` (a regression from rollup@4).
+  #[test]
+  fn plugin_error_preserves_inner_diagnostic_id() {
+    let inner = BuildDiagnostic::missing_global_name(
+      "/project/src/main.tsx".to_string(),
+      "main".into(),
+      "Main".into(),
+    );
+    // Sanity check: the inner diagnostic carries the id.
+    assert_eq!(inner.id().as_deref(), Some("/project/src/main.tsx"));
+
+    let plugin_diag =
+      BuildDiagnostic::plugin_error(CausedPlugin::new("my-plugin".into()), inner.into());
+    assert_eq!(
+      plugin_diag.id().as_deref(),
+      Some("/project/src/main.tsx"),
+      "PluginError must delegate id() to the inner diagnostic (#9843)"
+    );
+  }
 }


### PR DESCRIPTION
`PluginError` re-wraps each inner diagnostic but did not override `id()`, so the offending file path was dropped from the error objects exposed to JS (`err.errors[0].id` was `undefined` — a regression from rollup@4). Delegate `id()` to the inner diagnostic so `NativeError.id` / `loc.file` are populated. Addresses the `id` field of #9843 (`plugin`/`frame` need new binding fields — separate follow-up).

Prepared with AI assistance.