### PR TITLE
perf: drop unused regex unicode property tables from the binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,15 @@ petgraph = "0.8.1"
 phf = "0.13.0"
 pnp = "0.12.9"
 rayon = "1.10.0"
-regex = "1.12.4"
+# Default features drop the `\p{…}` Unicode property tables (gencat/script/age/bool/segment),
+# which no hardcoded pattern uses. `unicode-perl`/`unicode-case` are kept so `\w \d \s \b` and
+# `(?i)` stay Unicode-aware. User patterns needing `\p{…}` fall back to `regress` via `HybridRegex`.
+regex = { version = "1.12.4", default-features = false, features = [
+  "std",
+  "perf",
+  "unicode-perl",
+  "unicode-case",
+] }
 regress = "0.11.0"
 rolldown-notify = "10.2.0"
 rolldown-notify-debouncer-full = "0.7.5"


### PR DESCRIPTION
## What

Switch the workspace `regex` dependency to `default-features = false`, keeping only the features actually used:

```toml
regex = { version = "1.12.4", default-features = false, features = [
  "std", "perf", "unicode-perl", "unicode-case",
] }
```

All 13 crates that use `regex` inherit this via `workspace = true`, so it's a single-line change.

## Why

`regex`'s default feature set compiles the full Unicode property tables (`unicode-gencat`, `unicode-script`, `unicode-age`, `unicode-bool`, `unicode-segment`) — the data backing `\p{…}` property classes. An audit of every pattern in the codebase found **zero** uses of `\p{…}`, so these tables are dead weight in the shipped napi binding.

`unicode-perl` and `unicode-case` are deliberately kept so `\w \d \s \b` and `(?i)` stay Unicode-aware (important for JS source, where whitespace/identifiers can be non-ASCII).

## Binary size impact: ~242 KB smaller

Measured with a standalone binary built using this repo's exact release profile (`codegen-units=1`, `lto="fat"`, `strip="symbols"`, `opt-level=3`), with the pattern supplied at runtime so LTO can't strip the parser/tables:

| Build | Size |
|---|---|
| `regex` full default features | 1,411,344 B |
| `regex` trimmed (this PR) | 1,163,632 B |
| **Delta** | **247,712 B (~242 KB)** |

This transfers ~1:1 to the `.node` artifact (the dropped data is additive `const` tables, present once and identical regardless of surrounding code), taking it from ~21.98 MB to ~21.74 MB. No double-counting with oxc's identifier tables — those come from a separate crate, not `regex-syntax`.

## Safety

- No hardcoded pattern uses `\p{…}`, so nothing in our own code regresses.
- Any **user-supplied** `\p{…}` pattern still works: `HybridRegex` (`crates/rolldown_utils/src/js_regex.rs`) already falls back to the `regress` engine whenever the Rust `regex` engine can't compile a pattern — the same path already used for lookahead/backreferences.

## Verification

- The authoritative build record for `rolldown_binding` shows `regex` compiled with exactly `perf*, std, unicode-case, unicode-perl` — the property tables are dropped from the artifact.
- `cargo check -p rolldown_binding` passes.
- `Cargo.lock` is unchanged (feature-only change, no version churn).

Note: workspace-wide `cargo test`/`cargo tree` still resolve full `unicode` because the `generator` task and the test-only `jsonschema` pull `regex` defaults and feature-unify. That only affects dev/test/tooling builds — the per-package npm binding build gets the trimmed set.