### PR TITLE
refactor: drop commondir crate in favor of in-house helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -361,15 +361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "commondir"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab552acb7c0a751c75c3dd4f9b95d31ed85c985ce5c70232a2952ffbe7ecfda5"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1836,7 +1827,7 @@ dependencies = [
  "postcard",
  "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1849,7 +1840,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2230,7 +2221,7 @@ dependencies = [
  "serde_json",
  "simd-json",
  "simdutf8",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "windows",
 ]
@@ -2574,7 +2565,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2764,7 +2755,6 @@ dependencies = [
  "append-only-vec",
  "arcstr",
  "bitflags",
- "commondir",
  "cow-utils",
  "dashmap",
  "dunce",
@@ -4153,31 +4143,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4312,7 +4282,7 @@ version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
  "ts-rs-macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ base-encode = "0.3.1"
 base64-simd = "0.8.0"
 bitflags = "2.13.0"
 blake3 = "1.8.2"
-commondir = "1.0.0"
 cow-utils = "0.1.3"
 criterion2 = { version = "3.0.0", default-features = false }
 dashmap = "6.2.1"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -24,7 +24,6 @@ append-only-vec = { workspace = true }
 arcstr = { workspace = true }
 dashmap = { workspace = true }
 bitflags = { workspace = true }
-commondir = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   ResolvedId,
 };
 use rolldown_error::BuildResult;
-use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
+use rolldown_utils::{commondir, ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
 use sugar_path::SugarPath;
 
 use rolldown_fs::FileSystem;
@@ -71,12 +71,11 @@ impl<Fs: FileSystem> ExternalModuleTask<Fs> {
       && Path::new(resolved_id.id.as_str()).is_absolute();
 
     let file_name: ArcStr = if need_renormalize_render_path {
-      let entries_common_dir = commondir::CommonDir::try_new(
+      let entries_common_dir = commondir::common_dir(
         self.user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.as_str()),
       )
       .expect("should have common dir for entries");
-      let relative_path =
-        Path::new(resolved_id.id.as_str()).relative(entries_common_dir.common_root());
+      let relative_path = Path::new(resolved_id.id.as_str()).relative(&entries_common_dir);
       relative_path.to_slash_lossy().into()
     } else {
       resolved_id.id.as_arc_str().clone()

--- a/crates/rolldown_utils/src/commondir.rs
+++ b/crates/rolldown_utils/src/commondir.rs
@@ -1,4 +1,33 @@
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
+
+/// Finds the common root directory of a set of paths.
+///
+/// The returned directory is the deepest ancestor of (or equal to) the parent of
+/// the first path that is also a prefix of every input path. When no deeper common
+/// ancestor exists, the parent of the first path is returned.
+///
+/// Returns `None` when `paths` is empty or the first path has no parent directory.
+/// Paths are expected to be absolute.
+///
+/// This is a port of the [`commondir`](https://crates.io/crates/commondir) crate's
+/// `CommonDir::common_root`, kept in-tree to avoid the extra dependency.
+pub fn common_dir<P, I>(paths: I) -> Option<PathBuf>
+where
+  P: AsRef<Path>,
+  I: IntoIterator<Item = P> + Clone,
+{
+  let first = paths.clone().into_iter().next()?;
+  let path_trunk = first.as_ref().parent()?;
+  let set = paths.into_iter().map(|p| p.as_ref().to_path_buf()).collect::<Vec<_>>();
+
+  for ancestor in path_trunk.ancestors() {
+    if set.iter().all(|path| path.starts_with(ancestor)) {
+      return Some(ancestor.to_path_buf());
+    }
+  }
+
+  Some(path_trunk.to_path_buf())
+}
 
 /// Extracts the longest common path from two given file paths.
 ///
@@ -76,5 +105,24 @@ mod tests {
       let path_mixed2 = "/Users/user/Documents/report.txt";
       assert_eq!(extract_longest_common_path(path_mixed1, path_mixed2), "");
     }
+  }
+
+  #[test]
+  #[cfg(not(windows))]
+  fn test_common_dir() {
+    // Multiple files sharing a directory -> that directory.
+    assert_eq!(
+      common_dir(["/my/common/path/a.png", "/my/common/path/b.png", "/my/common/path/c.png"]),
+      Some(PathBuf::from("/my/common/path"))
+    );
+    // Partially shared paths -> the deepest shared ancestor.
+    assert_eq!(
+      common_dir(["/my/common/path/a.png", "/my/common/path/b.png", "/my/uncommon/path/c.png"]),
+      Some(PathBuf::from("/my"))
+    );
+    // A single file -> its parent directory (bounded by the first path's parent).
+    assert_eq!(common_dir(["/my/common/path/a.png"]), Some(PathBuf::from("/my/common/path")));
+    // Empty input -> None.
+    assert_eq!(common_dir(Vec::<&str>::new()), None);
   }
 }


### PR DESCRIPTION
## What

The external [`commondir`](https://crates.io/crates/commondir) crate was used in a single place (`external_module_task.rs`) and only for `CommonDir::try_new(...).common_root()` — duplicating the existing in-house `rolldown_utils::commondir` module of the same name.

This ports that one function into the internal module as `common_dir` and drops the dependency.

## Details

- The port preserves the original semantics exactly: the common root is the **deepest common ancestor bounded by the first path's parent**. This matters for the single-entry case (returns the entry's parent dir, not the entry itself), so a naive longest-common-prefix fold would have silently changed external-module render paths.
- Added unit tests for the multi-file, partially-shared, single-file, and empty-input cases.
- Updating the only caller and removing the dep also drops `thiserror` v1 (+ `thiserror-impl` v1) from the tree — `commondir` was its last remaining user, so everything now dedupes onto `thiserror` v2.