### PR TITLE
perf: drop urlencoding crate in favor of percent-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,11 +3190,11 @@ version = "1.1.1"
 dependencies = [
  "arcstr",
  "base64-simd",
+ "percent-encoding",
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
  "simdutf8",
- "urlencoding",
 ]
 
 [[package]]
@@ -3548,6 +3548,7 @@ dependencies = [
  "owo-colors",
  "oxc_resolver",
  "parking_lot",
+ "percent-encoding",
  "pnp",
  "rolldown_common",
  "rolldown_plugin",
@@ -3559,7 +3560,6 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -3630,6 +3630,7 @@ dependencies = [
  "json-strip-comments",
  "jsonschema",
  "oxc",
+ "percent-encoding",
  "regex",
  "rolldown",
  "rolldown_common",
@@ -3643,7 +3644,6 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "tokio",
- "urlencoding",
 ]
 
 [[package]]
@@ -4399,12 +4399,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,6 @@ tracing-subscriber = { version = "0.3.19", default-features = false }
 ts-rs = "12.0"
 typedmap = "0.6.0"
 url = "2.5.4"
-urlencoding = "2.1.3"
 uuid = "1.23.3"
 vfs = "0.13.0"
 walkdir = "2.5.0"

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -14,8 +14,8 @@ test = false
 [dependencies]
 arcstr = { workspace = true }
 base64-simd = { workspace = true }
+percent-encoding = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }
 simdutf8 = { workspace = true }
-urlencoding = { workspace = true }

--- a/crates/rolldown_plugin_data_url/src/lib.rs
+++ b/crates/rolldown_plugin_data_url/src/lib.rs
@@ -63,7 +63,7 @@ impl Plugin for DataUrlPlugin {
         // SAFETY: `data` is valid utf8
         unsafe { String::from_utf8_unchecked(data) }.into()
       } else {
-        urlencoding::decode(parsed.data)?.as_ref().into()
+        percent_encoding::percent_decode_str(parsed.data).decode_utf8()?.as_ref().into()
       };
 
       let id: ArcStr =

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -21,6 +21,7 @@ nodejs-built-in-modules = { workspace = true }
 owo-colors = { workspace = true }
 oxc_resolver = { workspace = true }
 parking_lot = { workspace = true }
+percent-encoding = { workspace = true }
 pnp = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
@@ -32,7 +33,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }
 url = { workspace = true }
-urlencoding = { workspace = true }
 
 # `url` pulls in `idna`, which by default uses a heavy ICU Unicode backend. We keep IDNA
 # support turned off (ASCII-only) by pinning `idna_adapter` to its no-ICU 1.0.0 release.

--- a/crates/rolldown_plugin_vite_resolve/src/file_url.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/file_url.rs
@@ -66,7 +66,7 @@ fn get_path_from_url_windows(url: Url) -> anyhow::Result<String> {
   }
 
   let pathname = pathname.cow_replace('/', "\\");
-  let pathname = urlencoding::decode(&pathname)?;
+  let pathname = percent_encoding::percent_decode_str(&pathname).decode_utf8()?;
 
   if url.host_str().is_some() {
     // NOTE: this is supported by Node.js, but is not supported by Vite.
@@ -93,6 +93,6 @@ fn get_path_from_url_posix(url: Url) -> anyhow::Result<String> {
     ));
   }
 
-  let pathname = urlencoding::decode(pathname)?;
+  let pathname = percent_encoding::percent_decode_str(pathname).decode_utf8()?;
   Ok(pathname.into_owned())
 }

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -23,6 +23,7 @@ insta = { workspace = true }
 json-strip-comments = { workspace = true }
 jsonschema = { workspace = true }
 oxc = { workspace = true }
+percent-encoding = { workspace = true }
 regex = { workspace = true }
 rolldown = { workspace = true, features = ["testing"] }
 rolldown_common = { workspace = true }
@@ -35,7 +36,6 @@ rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }
-urlencoding = { workspace = true }
 
 [build-dependencies]
 rolldown_testing_config = { workspace = true }

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -30,6 +30,11 @@ use crate::types::{
   BuildArtifactsSnapshot, BuildRoundOutput, DevArtifactsSnapshot, DevRoundOutput, HmrStepOutput,
 };
 
+/// RFC 3986 unreserved set — matches the former `urlencoding::encode`: percent-encode
+/// everything except `A-Za-z0-9` and `-._~`.
+const DATA_URL_ENCODE_SET: &percent_encoding::AsciiSet =
+  &percent_encoding::NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+
 #[derive(Default)]
 pub struct IntegrationTest {
   test_meta: TestMeta,
@@ -641,8 +646,10 @@ impl IntegrationTest {
       Self::generate_globals_injection_for_execute_output(config_name, patch_chunks, options);
 
     if !globals_injection.is_empty() {
-      let inject_script_url =
-        format!("data:text/javascript,{}", urlencoding::encode(&globals_injection));
+      let inject_script_url = format!(
+        "data:text/javascript,{}",
+        percent_encoding::utf8_percent_encode(&globals_injection, DATA_URL_ENCODE_SET)
+      );
       node_command.arg("--import");
       node_command.arg(inject_script_url);
     }
@@ -677,8 +684,10 @@ impl IntegrationTest {
       let post_globals_injection =
         Self::generate_post_globals_injection_for_execute_output(patch_chunks, &dist_folder);
       if !post_globals_injection.is_empty() {
-        let inject_script_url =
-          format!("data:text/javascript,{}", urlencoding::encode(&post_globals_injection));
+        let inject_script_url = format!(
+          "data:text/javascript,{}",
+          percent_encoding::utf8_percent_encode(&post_globals_injection, DATA_URL_ENCODE_SET)
+        );
         compiled_entries.push(inject_script_url);
       }
 


### PR DESCRIPTION
## What

Remove the `urlencoding` dependency and migrate its 3 consumers to `percent-encoding`, which is already in the dependency tree (it's a dependency of `url`).

- `rolldown_plugin_vite_resolve` (`file_url.rs`) — 2 decode sites
- `rolldown_plugin_data_url` (`lib.rs`) — 1 decode site
- `rolldown_testing` (`integration_test.rs`) — 2 encode sites

`urlencoding` is dropped from the workspace `Cargo.toml` and disappears from `Cargo.lock`.

## Why

It overlapped with `percent-encoding` (the canonical crate from the `url`/rust-url family), which is compiled regardless. This removes one crate from the dependency graph. `rolldown_plugin_utils` already uses `percent-encoding` (`src/uri.rs`), so this also unifies the codebase on a single percent-encoding library.

## Correctness

- **Decode** is semantically identical: `urlencoding::decode(s)?` → `percent_encoding::percent_decode_str(s).decode_utf8()?`. Both decode only `%XX`, leave `+` literal (these are percent-encoded paths / data URLs, not form bodies), and error on invalid UTF-8. All sites are in `anyhow::Result` fns, and both error types satisfy `?`.
- **Encode** uses an `AsciiSet` matching `urlencoding::encode`'s RFC 3986 unreserved set:
  ```rust
  const DATA_URL_ENCODE_SET: &AsciiSet =
      &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
  ```
  i.e. encode everything except `A-Za-z0-9` and `-._~` — so the generated `data:text/javascript,…` URLs round-trip identically through the decode path.

## Verification

- `cargo check` / `cargo test` pass for all three crates (`rolldown_plugin_vite_resolve` unit tests green; `rolldown_plugin_data_url` has `test = false`).
- `urlencoding` removed from `Cargo.lock`; no version churn elsewhere.

## Note on impact

This is dependency-surface hygiene rather than a perf/size win — `urlencoding` is a tiny, zero-dependency crate and its replacement was already present. Net effect is one fewer crate in the graph.