### PR TITLE
chore: re-enable default lld linker on x86_64-unknown-linux-gnu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,10 +24,5 @@ rustflags = [
   "link-args=/DEFAULTLIB:ucrt.lib",
 ]
 
-# LLD linker is currently broken for us, opt out.
-# https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#what-s-in-1-90-0-stable
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "linker-features=-lld"]
-
 [target.wasm32-wasip1-threads]
 rustflags = ["-C", "target-feature=+simd128", "--cfg", "tokio_unstable"]


### PR DESCRIPTION
Drops the `linker-features=-lld` opt-out added in #6867, restoring the default LLD linker on `x86_64-unknown-linux-gnu`.

## Background
#6867 added the opt-out because LLD — the [default linker on this target since Rust 1.90](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/) — broke our build at the time (Rust ~1.90/1.91, napi 3.5). On the current toolchain (Rust 1.96) and napi 3.9.x that's no longer the case; the underlying issue has been fixed upstream.

## Verification
A 4-leg experiment matrix on `x86_64-unknown-linux-gnu` (Rust 1.96) that links every workspace test binary, links the `.node` cdylib, and runs the node suite. With **pure LLD** (no opt-out) everything links and all node tests pass — no link errors and no "Module did not self-register". Run: https://github.com/rolldown/rolldown/actions/runs/27745343534

Full CI on this PR is the final gate. Removing the opt-out restores LLD's faster linking on Linux.