### PR TITLE
chore(deps): update napi to 3.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.2"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d3c7dd60231116a47854321c9ac8df6f13435d11aa3a59d8533a76e07a3730"
+checksum = "fbd9f9295f3ff5921e78a71222c3361a8216f7760b1a99a6ad4e8441de18bbb9"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,9 +240,9 @@ syn = { version = "2", default-features = false }
 # napi
 # Keep the `tracing` feature on: `#[napi]` logs every binding call, which helps debug deadlocks
 # (e.g. #7289) by showing which napi function is pending.
-napi = { version = "3.0.0", features = ["async", "anyhow", "tracing", "object_indexmap"] }
-napi-build = { version = "2.2.2" }
-napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }
+napi = { version = "3", features = ["async", "anyhow", "tracing", "object_indexmap"] }
+napi-build = { version = "2" }
+napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
 oxc = { version = "0.137.0", features = [


### PR DESCRIPTION
## Summary

- Bump the resolved `napi` crate `3.9.2` → `3.9.3` in `Cargo.lock`.
- Relax the `napi` / `napi-build` / `napi-derive` version requirements in `Cargo.toml` to their major version (`3` / `2` / `3`); the lockfile keeps the latest patch releases (`napi 3.9.3`, `napi-build 2.3.2`, `napi-derive 3.5.6`).
- The emnapi (`@emnapi/core`, `@emnapi/runtime`, `emnapi` at `1.11.1`) and `@napi-rs/*` (`@napi-rs/cli` `3.7.2`, `@napi-rs/wasm-runtime` `1.1.5`) npm packages are already on their latest stable releases, so no change there.

## Test plan

- `cargo check -p rolldown_binding` passes (patch bump, no breaking changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)