### PR TITLE
fix(release): dry-run step no longer publishes binding packages

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -119,6 +119,11 @@ jobs:
           find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
 
       - name: Publish(Dry Run)
+        # `NAPI_DRY_RUN` makes rolldown's `prepublishOnly` hook pass `--dry-run`
+        # through to `napi pre-publish`. Without it, the hook publishes the
+        # `@rolldown/binding-*` packages for real during this "dry run" step.
+        env:
+          NAPI_DRY_RUN: '1'
         run: |
           vp pm publish -r --tag latest --dry-run --no-git-checks
 

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -115,7 +115,7 @@
     "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi|node)$/'",
     "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi:release|node)$/'",
     "# Scrips for docs #": "_",
-    "prepublishOnly": "napi pre-publish -t npm --no-gh-release",
+    "prepublishOnly": "napi pre-publish -t npm --no-gh-release ${NAPI_DRY_RUN:+--dry-run}",
     "publint": "publint ."
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The `Publish to NPM` workflow logs `npm error You cannot publish over the previously published versions: <version>` for every `@rolldown/binding-*` package on each release (e.g. [v1.1.2 run](https://github.com/rolldown/rolldown/actions/runs/27761822196/job/82140346755)).

The job stays green only because `napi` swallows that specific error as "already published, skipping" — but the bindings really are being published twice.

## Root cause

The `Publish npm Packages` job has two steps: `Publish(Dry Run)` then `Publish`. Both run `vp pm publish`, which runs rolldown's `prepublishOnly` hook:

```
"prepublishOnly": "napi pre-publish -t npm --no-gh-release"
```

`napi pre-publish` publishes the per-platform `@rolldown/binding-*` packages itself (via `npm publish` in each `npm/<triple>` dir). `vp`'s `--dry-run` only suppresses **its own** uploads (`rolldown`, `@rolldown/browser`, `@rolldown/debug`) — it cannot inject `--dry-run` into an opaque lifecycle-script command string, and `napi` only honors its own explicit `--dry-run` flag. So during the **dry-run** step `napi` publishes all bindings for real, and the real `Publish` step then re-attempts them → the duplicate-version errors.

Binding publish timestamps in the v1.1.2 run all fall inside the `Publish(Dry Run)` window (13:30–13:32), confirming the dry run did the real publish.

## Fix

`napi` gates its entire publish on its own `--dry-run`, so forward it:

- `prepublishOnly` appends `--dry-run` when `NAPI_DRY_RUN` is set (unquoted `${NAPI_DRY_RUN:+--dry-run}` so it expands to zero args when unset).
- The `Publish(Dry Run)` step sets `NAPI_DRY_RUN: '1'`; the real `Publish` step leaves it unset.

Result: the dry-run step becomes a true dry run, and the bindings are published exactly once, by the real `Publish` step.
