### PR TITLE
refactor: drop dead is_css_module handling in resolve_dependencies

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -153,7 +153,6 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       &raw_import_records,
       ecma_view.source.clone(),
       &mut warnings,
-      &module_type,
     )
     .await?;
 

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use futures::future::join_all;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
-  ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId, ModuleType,
+  ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId,
   NormalizedBundlerOptions, RUNTIME_MODULE_KEY, RawImportRecord, ResolvedId,
 };
 use rolldown_error::{
@@ -51,7 +51,6 @@ pub async fn resolve_id<Fs: FileSystem>(
   .await
 }
 
-#[expect(clippy::too_many_arguments)]
 pub async fn resolve_dependencies<Fs: FileSystem>(
   self_resolved_id: &ResolvedId,
   options: &SharedOptions,
@@ -60,7 +59,6 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
   dependencies: &IndexVec<ImportRecordIdx, RawImportRecord>,
   source: ArcStr,
   warnings: &mut Vec<BuildDiagnostic>,
-  module_type: &ModuleType,
 ) -> BuildResult<IndexVec<ImportRecordIdx, ResolvedId>> {
   // NOTE: this dedupes the identical (specifier, kind) resolve calls
   let dedup_map: FxHashMap<(&str, ImportKind), ImportRecordIdx> = dependencies
@@ -87,9 +85,6 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
     sparse_results[repr_idx].as_ref().expect("dedup representative should be resolved")
   });
 
-  // FIXME: if the import records came from css view, but source from ecma view,
-  // the span will not matched.
-  let is_css_module = matches!(module_type, ModuleType::Css);
   let mut ret = IndexVec::with_capacity(dependencies.len());
   let mut build_errors = vec![];
   for (dep, resolved_id) in dependencies.iter().zip(resolved_results) {
@@ -110,7 +105,7 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
                 build_errors.push(BuildDiagnostic::resolve_error(
                   source.clone(),
                   self_resolved_id.id.as_arc_str().clone(),
-                  if dep.is_unspanned() || is_css_module {
+                  if dep.is_unspanned() {
                     DiagnosableArcstr::String(specifier.as_str().into())
                   } else {
                     DiagnosableArcstr::Span(dep.state.span)
@@ -127,7 +122,7 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
                   BuildDiagnostic::resolve_error(
                     source.clone(),
                     self_resolved_id.id.as_arc_str().clone(),
-                    if dep.is_unspanned() || is_css_module {
+                    if dep.is_unspanned() {
                       DiagnosableArcstr::String(specifier.as_str().into())
                     } else {
                       DiagnosableArcstr::Span(dep.state.span)
@@ -150,7 +145,7 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
             build_errors.push(BuildDiagnostic::resolve_error(
                 source.clone(),
                 self_resolved_id.id.as_arc_str().clone(),
-                if dep.is_unspanned() || is_css_module {
+                if dep.is_unspanned() {
                   DiagnosableArcstr::String(specifier.as_str().into())
                 } else {
                   DiagnosableArcstr::Span(dep.state.span)
@@ -165,7 +160,7 @@ pub async fn resolve_dependencies<Fs: FileSystem>(
             build_errors.push(BuildDiagnostic::resolve_error(
               source.clone(),
               self_resolved_id.id.as_arc_str().clone(),
-              if dep.is_unspanned() || is_css_module {
+              if dep.is_unspanned() {
                 DiagnosableArcstr::String(specifier.as_str().into())
               } else {
                 DiagnosableArcstr::Span(dep.state.span)

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -147,7 +147,6 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
       &raw_import_records,
       source.clone(),
       &mut vec![],
-      &module_type,
     )
     .await?;
 


### PR DESCRIPTION
After builtin CSS bundling was removed (#8399), CSS modules now error in `module_task` before `resolve_dependencies` is ever reached, so `is_css_module` is always `false` and its branches are dead.

This removes the stale `is_css_module` binding and its FIXME, simplifies the four `dep.is_unspanned() || is_css_module` guards to `dep.is_unspanned()`, and drops the now-unused `module_type` parameter from `resolve_dependencies` and its callers.

No behavior change.