### PR TITLE
refactor: drop redundant with_commonjs on cjs source type

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -55,8 +55,7 @@ impl OutputFormat {
   pub fn source_type(&self) -> SourceType {
     match self {
       Self::Esm => SourceType::mjs(),
-      // TODO: remove `.with_commonjs(true)` when https://github.com/oxc-project/oxc/pull/18276 is released
-      Self::Cjs => SourceType::cjs().with_commonjs(true),
+      Self::Cjs => SourceType::cjs(),
       Self::Iife | Self::Umd => SourceType::cjs().with_script(true),
     }
   }


### PR DESCRIPTION
`SourceType::cjs()` already sets `ModuleKind::CommonJS` since oxc PR #18276 (released in oxc 0.111.0, the workspace is now on 0.137.0), so chaining `.with_commonjs(true)` is a no-op.

This drops the redundant call and the now-satisfied TODO. No behavior change.