### PR TITLE
refactor: remove unused EcmaAst::is_body_empty

### DIFF
--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -20,10 +20,6 @@ pub fn semantic_builder_for_transform<'a>() -> SemanticBuilder<'a> {
 }
 
 impl EcmaAst {
-  pub fn is_body_empty(&self) -> bool {
-    self.program().is_empty()
-  }
-
   pub fn make_semantic<'ast>(program: &'ast Program<'ast>) -> Semantic<'ast> {
     SemanticBuilder::new().build(program).semantic
   }


### PR DESCRIPTION
`EcmaAst::is_body_empty` has no callers anywhere in the workspace. Removing it as dead code.