### PR TITLE
perf: borrow owner_filename in build-import-analysis AddDeps

### DIFF
--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -265,7 +265,7 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
               s: &mut s,
               ctx,
               deps: &mut deps,
-              owner_filename: chunk.filename.to_string(),
+              owner_filename: chunk.filename.as_str(),
               analyzed: FxHashSet::default(),
               has_removed_pure_css_chunks: &mut has_removed_pure_css_chunks,
               expr_range: import.start..import.end,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
@@ -12,7 +12,7 @@ pub struct AddDeps<'a, 'b> {
   pub s: &'a mut MagicString<'b>,
   pub ctx: &'a PluginContext,
   pub deps: &'a mut FxHashSet<String>,
-  pub owner_filename: String,
+  pub owner_filename: &'a str,
   pub analyzed: FxHashSet<String>,
   pub has_removed_pure_css_chunks: &'a mut bool,
   pub expr_range: std::ops::Range<usize>,


### PR DESCRIPTION
`AddDeps` is constructed once per import, and `owner_filename: chunk.filename.to_string()` allocated an identical `String` on every iteration. `owner_filename` is only used for a `&str` equality check, so make the field a `&'a str` borrowing `chunk.filename` and drop the per-import allocation. No behavior change.