### PR TITLE
perf: cache chunk manifest names in vite-manifest plugin

### DIFF
--- a/crates/rolldown_plugin_vite_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/lib.rs
@@ -46,10 +46,24 @@ impl Plugin for ViteManifestPlugin {
     let mut manifest = BTreeMap::default();
     let mut css_entries = None;
 
+    // Compute each chunk's manifest name once, keyed by output filename, so that
+    // both the chunk's own entry and any chunk importing it reuse it instead of
+    // recomputing the name (and rescanning the bundle) for every import.
+    let chunk_names = args
+      .bundle
+      .iter()
+      .filter_map(|output| match output {
+        Output::Chunk(chunk) => {
+          Some((chunk.filename.clone(), self.get_chunk_name(chunk, is_legacy)))
+        }
+        Output::Asset(_) => None,
+      })
+      .collect::<FxHashMap<_, _>>();
+
     for file in args.bundle.iter() {
       match file {
         Output::Chunk(chunk) => {
-          let name = self.get_chunk_name(chunk, is_legacy);
+          let name = chunk_names[&chunk.filename].clone();
           let vite_metadata = if self.is_enable_v2 {
             ctx.meta().get::<ViteMetadata>().and_then(|cache| {
               cache.inner.get(chunk.preliminary_filename.as_str()).map(|v| v.clone())
@@ -57,13 +71,8 @@ impl Plugin for ViteManifestPlugin {
           } else {
             None
           };
-          let chunk_manifest = Arc::new(self.create_chunk(
-            args.bundle,
-            chunk,
-            &name,
-            is_legacy,
-            vite_metadata.as_ref(),
-          ));
+          let chunk_manifest =
+            Arc::new(self.create_chunk(&chunk_names, chunk, &name, vite_metadata.as_ref()));
           manifest.insert(name, chunk_manifest);
         }
         Output::Asset(asset) => {

--- a/crates/rolldown_plugin_vite_manifest/src/utils.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/utils.rs
@@ -2,9 +2,10 @@ use std::{ffi::OsString, sync::Arc};
 
 use arcstr::ArcStr;
 use cow_utils::CowUtils;
-use rolldown_common::{Output, OutputAsset, OutputChunk};
+use rolldown_common::{OutputAsset, OutputChunk};
 use rolldown_plugin_utils::constants::ChunkMetadata;
 use rolldown_utils::pattern_filter::normalize_path;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 
 use super::ViteManifestPlugin;
@@ -73,10 +74,9 @@ impl ViteManifestPlugin {
 
   pub fn create_chunk(
     &self,
-    bundle: &Vec<Output>,
+    chunk_names: &FxHashMap<ArcStr, String>,
     chunk: &OutputChunk,
     src: &str,
-    is_legacy: bool,
     vite_metadata: Option<&Arc<ChunkMetadata>>,
   ) -> ManifestChunk {
     let css = vite_metadata
@@ -92,8 +92,8 @@ impl ViteManifestPlugin {
       src: chunk.facade_module_id.is_some().then(|| src.to_string()),
       is_entry: chunk.is_entry,
       is_dynamic_entry: chunk.is_dynamic_entry,
-      imports: self.get_internal_imports(bundle, &chunk.imports, is_legacy),
-      dynamic_imports: self.get_internal_imports(bundle, &chunk.dynamic_imports, is_legacy),
+      imports: Self::get_internal_imports(chunk_names, &chunk.imports),
+      dynamic_imports: Self::get_internal_imports(chunk_names, &chunk.dynamic_imports),
       css,
       assets,
       ..Default::default()
@@ -101,23 +101,10 @@ impl ViteManifestPlugin {
   }
 
   fn get_internal_imports(
-    &self,
-    bundle: &Vec<Output>,
-    imports: &Vec<ArcStr>,
-    is_legacy: bool,
+    chunk_names: &FxHashMap<ArcStr, String>,
+    imports: &[ArcStr],
   ) -> Vec<String> {
-    let mut filtered_imports = vec![];
-    for file in imports {
-      for output in bundle {
-        if let Output::Chunk(chunk) = output {
-          if chunk.filename == *file {
-            filtered_imports.push(self.get_chunk_name(chunk, is_legacy));
-            break;
-          }
-        }
-      }
-    }
-    filtered_imports
+    imports.iter().filter_map(|file| chunk_names.get(file).cloned()).collect()
   }
 }
 


### PR DESCRIPTION
`get_chunk_name` was recomputed for every place a chunk appeared as an import: a chunk imported by K others had its name (path normalization + extension rewrite + replace) derived K+1 times, and `get_internal_imports` rescanned the whole bundle for each import.

Compute each chunk's name once into a `FxHashMap<filename, name>` up front, and resolve a chunk's own entry and its imports via lookups. This also turns the per-import `O(imports × bundle)` scan into `O(imports)`. No behavior change.