### PR TITLE
perf: drop throwaway Vec in wrapped esm init stmt

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -262,23 +262,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
 
-    let init_modules = self
+    let init_exprs = self
       .collect_wrapped_esm_init_modules_for_import_record(rec_idx)
       .into_iter()
+      .filter_map(|module_idx| {
+        if !self.generated_init_esm_importee_ids.insert(module_idx) {
+          return None;
+        }
+        // `add_wrapped_esm_init_module_for_symbol` only collects modules with a `wrapper_ref`.
+        Some(self.wrapped_esm_init_call_expr(module_idx, SPAN, true, true))
+      })
       .collect::<Vec<_>>();
-    if init_modules.is_empty() {
-      return None;
-    }
-
-    let init_exprs = init_modules.into_iter().filter_map(|module_idx| {
-      if !self.generated_init_esm_importee_ids.insert(module_idx) {
-        return None;
-      }
-      // `add_wrapped_esm_init_module_for_symbol` only collects modules with a `wrapper_ref`.
-      Some(self.wrapped_esm_init_call_expr(module_idx, SPAN, true, true))
-    });
-
-    let init_exprs = init_exprs.collect::<Vec<_>>();
     match init_exprs.len() {
       0 => None,
       1 => init_exprs


### PR DESCRIPTION
`wrapped_esm_init_stmt_for_import_record` collected the owned `FxIndexSet` returned by `collect_wrapped_esm_init_modules_for_import_record` into an intermediate `Vec` (with a redundant `is_empty` guard) before iterating it exactly once. The returned set is owned, so the `&self` borrow ends at the call and the `filter_map` (`&mut self`) can chain directly off `into_iter()`.

Drop the throwaway `Vec` and the `is_empty` guard (already covered by the `match init_exprs.len() { 0 => None, .. }` dispatch), removing one heap allocation per wrapped-ESM import record on the finalize path. No behavior change.