### PR TITLE
fix: align vite-resolve get_extension with path.extname

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -26,7 +26,11 @@ pub fn is_deep_import(id: &str) -> bool {
 }
 
 pub fn get_extension(id: &str) -> &str {
-  id.rsplit_once('.').map_or("", |(_, ext)| ext)
+  // Match Node's `path.extname` (the extension without its leading dot): only
+  // inspect the basename, and treat a leading-dot basename (dotfiles such as
+  // `.bashrc`) as having no extension. A dot in a directory segment (e.g. pnpm's
+  // `.pnpm`/`.store` stores or `pkg@1.2.3` dirs) must not be read as the extension.
+  std::path::Path::new(id).extension().and_then(|ext| ext.to_str()).unwrap_or_default()
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape#w


### PR DESCRIPTION
`get_extension` derived the extension from the whole path via `rsplit_once('.')`, but Vite's `canExternalizeFile` / deep-import logic use Node `path.extname`, which only inspects the basename. For a resolved id whose final segment has no extension but an earlier directory segment contains a dot (pnpm's `.pnpm`/`.store` stores, `pkg@1.2.3` version dirs), the old code returned a bogus extension, so `can_externalize_file` wrongly rejected the file and the `resolver.rs` deep-import extname comparison diverged from Vite.

Compute the extension from the basename only via `Path::extension`, which also correctly treats a leading-dot basename (dotfiles like `.bashrc`) as having no extension, matching `path.extname`. The returned extension keeps the existing no-leading-dot convention, so `can_externalize_file`'s `"js"`/`"mjs"`/`"cjs"` checks are unaffected. Paths with a normal extension are unchanged.