### PR TITLE
perf(sourcemap): owned merge in SourceJoiner::join (4005→5 allocs/chunk)

### DIFF
--- a/crates/bench/benches/bench.rs
+++ b/crates/bench/benches/bench.rs
@@ -4,7 +4,7 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 use std::fmt::Write as _;
 
 use bench::{BenchMode, DeriveOptions, bench_preset, rome_ts_preset, run_bench_group};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use oxc::{
   allocator::Allocator,
   codegen::{Codegen, CodegenOptions, CodegenReturn},
@@ -149,23 +149,27 @@ const BIG_CHUNK: u32 = 2000;
 fn sourcemap_benches(c: &mut Criterion) {
   let mut group = c.benchmark_group("sourcemap");
 
-  // `SourceJoiner::join` rebuilds the `ConcatSourceMapBuilder` and output on
-  // every call, so each joiner is built once here and every iteration measures
-  // a full chunk assembly + sourcemap merge.
+  // `join` consumes the joiner, so it's rebuilt per iteration in the (excluded) setup; each measured iteration is one full chunk assembly + sourcemap merge.
 
   // With sourcemaps: a large (shit-mountain-scale) chunk of mapped modules +
   // banner/footer — drives `ConcatSourceMapBuilder` (token buffer + dedup + line offsets).
-  let app_chunk = build_chunk_joiner(BIG_CHUNK);
   group.bench_function("join_with_sourcemap", |b| {
-    b.iter(|| black_box(app_chunk.join()));
+    b.iter_batched(
+      || build_chunk_joiner(BIG_CHUNK),
+      |chunk| black_box(chunk.join()),
+      BatchSize::SmallInput,
+    );
   });
 
   // Without sourcemaps: the same module bodies as plain sources — the
   // `enable_sourcemap == false` fast path that skips the builder entirely (the
   // most common production build, `output.sourcemap` unset).
-  let plain_chunk = build_plain_joiner(BIG_CHUNK);
   group.bench_function("join_no_sourcemap", |b| {
-    b.iter(|| black_box(plain_chunk.join()));
+    b.iter_batched(
+      || build_plain_joiner(BIG_CHUNK),
+      |chunk| black_box(chunk.join()),
+      BatchSize::SmallInput,
+    );
   });
 
   // `collapse_sourcemaps` — the module-transform (`render_chunks.rs`) and

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -12,7 +12,7 @@ use rolldown_common::{
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::HookAddonArgs;
-use rolldown_sourcemap::Source;
+use rolldown_sourcemap::{Source, SourceJoiner, SourceMap};
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
@@ -28,6 +28,7 @@ pub struct RenderedModuleSource {
   pub module_id: ModuleId,
   pub exec_order: u32,
   pub sources: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
+  sourcemap: Option<(usize, SourceMap)>,
 }
 
 impl RenderedModuleSource {
@@ -35,9 +36,80 @@ impl RenderedModuleSource {
     module_idx: ModuleIdx,
     module_id: ModuleId,
     exec_order: u32,
-    sources: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
+    mut sources: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
   ) -> Self {
-    Self { module_idx, module_id, exec_order, sources }
+    // Detach maps before `sources` is cloned into `RenderedModule` for plugin hooks.
+    // The source text stays shared through the Arc; chunk rendering owns the maps.
+    let mut detached_sourcemap = None;
+    if let Some(sources) = sources.as_mut() {
+      if let Some(sources) = Arc::get_mut(sources) {
+        for (index, source) in sources.iter_mut().enumerate() {
+          let sourcemap =
+            source.as_mut().take_sourcemap().or_else(|| source.as_ref().sourcemap().cloned());
+          if let Some(sourcemap) = sourcemap {
+            assert!(
+              detached_sourcemap.replace((index, sourcemap)).is_none(),
+              "a rendered module should contain at most one sourcemap"
+            );
+          }
+        }
+      } else {
+        // Custom renderers may already share the source array. Preserve behavior
+        // by cloning those maps; the normal codegen path always takes the branch above.
+        for (index, source) in sources.iter().enumerate() {
+          if let Some(sourcemap) = source.sourcemap().cloned() {
+            assert!(
+              detached_sourcemap.replace((index, sourcemap)).is_none(),
+              "a rendered module should contain at most one sourcemap"
+            );
+          }
+        }
+      }
+    }
+    Self { module_idx, module_id, exec_order, sources, sourcemap: detached_sourcemap }
+  }
+
+  pub fn append_sources(&mut self, source_joiner: &mut SourceJoiner<'_>) {
+    let Some(sources) = &self.sources else {
+      return;
+    };
+
+    for index in 0..sources.len() {
+      let sourcemap = self
+        .sourcemap
+        .take_if(|(source_index, _)| *source_index == index)
+        .map(|(_, sourcemap)| sourcemap);
+      source_joiner.append_source(RenderedChunkSource {
+        sources: Arc::clone(sources),
+        index,
+        sourcemap,
+      });
+    }
+    debug_assert!(self.sourcemap.is_none());
+  }
+}
+
+struct RenderedChunkSource {
+  sources: Arc<[Box<dyn Source + Send + Sync>]>,
+  index: usize,
+  sourcemap: Option<SourceMap>,
+}
+
+impl Source for RenderedChunkSource {
+  fn sourcemap(&self) -> Option<&SourceMap> {
+    self.sourcemap.as_ref()
+  }
+
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    self.sourcemap.take()
+  }
+
+  fn content(&self) -> &str {
+    self.sources[self.index].content()
+  }
+
+  fn lines_count(&self) -> u32 {
+    self.sources[self.index].lines_count()
   }
 }
 
@@ -68,7 +140,7 @@ impl Generator for EcmaGenerator {
       .collect::<Vec<_>>();
 
     let mut sourcemap_broken_warnings: Vec<BuildDiagnostic> = Vec::new();
-    let rendered_module_sources: RenderedModuleSources = rendered_pairs
+    let mut rendered_module_sources: RenderedModuleSources = rendered_pairs
       .into_iter()
       .map(|(source, warnings)| {
         sourcemap_broken_warnings.extend(warnings);
@@ -76,10 +148,12 @@ impl Generator for EcmaGenerator {
       })
       .collect();
 
+    // Maps were detached in `RenderedModuleSource::new`, so this clone shares
+    // only source text with the plugin-facing module view.
     let rendered_modules: FxHashMap<ModuleId, RenderedModule> = rendered_module_sources
       .iter()
       .map(|rendered_module_source| {
-        let RenderedModuleSource { module_idx, module_id, exec_order, sources } =
+        let RenderedModuleSource { module_idx, module_id, exec_order, sources, .. } =
           rendered_module_source;
         let rendered_exports = ctx.link_output.metas[*module_idx]
           .resolved_exports
@@ -95,7 +169,6 @@ impl Generator for EcmaGenerator {
         (module_id.clone(), RenderedModule::new(sources.clone(), rendered_exports, *exec_order))
       })
       .collect();
-
     let rendered_chunk = Arc::new(generate_rendered_chunk(ctx, rendered_modules));
 
     let hashbang = ctx.chunk.user_defined_entry_module(&ctx.link_output.module_table).and_then(
@@ -239,19 +312,22 @@ impl Generator for EcmaGenerator {
       directives: &directives,
     };
     let mut source_joiner = match ctx.options.format {
-      OutputFormat::Esm => render_esm(ctx, addon_render_context, &rendered_module_sources),
+      OutputFormat::Esm => render_esm(ctx, addon_render_context, &mut rendered_module_sources),
       OutputFormat::Cjs => {
-        render_cjs(ctx, addon_render_context, &rendered_module_sources, &mut warnings)
+        render_cjs(ctx, addon_render_context, &mut rendered_module_sources, &mut warnings)
       }
       OutputFormat::Iife => {
-        match render_iife(ctx, addon_render_context, &rendered_module_sources, &mut warnings).await
+        match render_iife(ctx, addon_render_context, &mut rendered_module_sources, &mut warnings)
+          .await
         {
           Ok(source_joiner) => source_joiner,
           Err(errors) => return Ok(Err(errors)),
         }
       }
       OutputFormat::Umd => {
-        match render_umd(ctx, addon_render_context, &rendered_module_sources, &mut warnings).await {
+        match render_umd(ctx, addon_render_context, &mut rendered_module_sources, &mut warnings)
+          .await
+        {
           Ok(source_joiner) => source_joiner,
           Err(errors) => return Ok(Err(errors)),
         }
@@ -308,5 +384,46 @@ impl Generator for EcmaGenerator {
       }],
       warnings,
     }))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{borrow::Cow, sync::Arc};
+
+  use rolldown_common::{ModuleIdx, RenderedModule};
+  use rolldown_sourcemap::{Source, SourceJoiner, SourceMap, SourceMapSource};
+
+  use super::RenderedModuleSource;
+
+  #[test]
+  fn rendered_module_keeps_code_while_chunk_takes_its_sourcemap() {
+    let map = SourceMap::new(
+      None,
+      vec![],
+      None,
+      vec![Cow::Borrowed("entry.js")],
+      vec![Some(Cow::Borrowed("entry source"))],
+      Box::new([]),
+      None,
+    );
+    let source: Box<dyn Source + Send + Sync> =
+      Box::new(SourceMapSource::new("entry();".to_string(), map));
+    let sources: Arc<[Box<dyn Source + Send + Sync>]> = vec![source].into();
+
+    let mut rendered_source =
+      RenderedModuleSource::new(ModuleIdx::new(0), "entry.js".into(), 0, Some(sources));
+
+    let plugin_module =
+      RenderedModule::new(rendered_source.sources.clone(), Vec::new(), rendered_source.exec_order);
+    assert_eq!(plugin_module.code().as_deref(), Some("entry();"));
+    assert!(rendered_source.sources.as_ref().unwrap()[0].sourcemap().is_none());
+
+    let mut joiner = SourceJoiner::default();
+    rendered_source.append_sources(&mut joiner);
+    let (_, chunk_map) = joiner.join();
+    let chunk_map = chunk_map.expect("chunk rendering should own the detached map");
+    assert_eq!(chunk_map.get_source(0), Some("entry.js"));
+    assert_eq!(chunk_map.get_source_content(0), Some("entry source"));
   }
 }

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -18,7 +18,7 @@ use super::utils::{render_chunk_directives, render_modules_with_peek_runtime_mod
 pub fn render_cjs<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,
-  module_sources: &'code RenderedModuleSources,
+  module_sources: &mut RenderedModuleSources,
   _warnings: &mut Vec<BuildDiagnostic>,
 ) -> SourceJoiner<'code> {
   let mut source_joiner = SourceJoiner::default();

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -21,7 +21,7 @@ use super::utils::{is_use_strict_directive, render_chunk_directives};
 pub fn render_esm<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,
-  module_sources: &'code RenderedModuleSources,
+  module_sources: &mut RenderedModuleSources,
 ) -> SourceJoiner<'code> {
   let mut source_joiner = SourceJoiner::default();
   let AddonRenderContext { hashbang, banner, intro, outro, footer, directives } =
@@ -118,22 +118,16 @@ pub fn render_esm<'code>(
   source_joiner
 }
 
-fn render_chunk_content<'code>(
+fn render_chunk_content(
   ctx: &GenerateContext<'_>,
-  module_sources: &'code [RenderedModuleSource],
-  source_joiner: &mut SourceJoiner<'code>,
+  module_sources: &mut [RenderedModuleSource],
+  source_joiner: &mut SourceJoiner<'_>,
 ) {
   // If there is no concatenate_wrapping_modules, just concate all modules by exec order.
   if ctx.chunk.module_groups.is_empty() {
-    module_sources.iter().for_each(
-      |RenderedModuleSource { sources: module_render_output, .. }| {
-        if let Some(emitted_sources) = module_render_output {
-          for source in emitted_sources.as_ref() {
-            source_joiner.append_source(source);
-          }
-        }
-      },
-    );
+    for module_source in module_sources.iter_mut() {
+      module_source.append_sources(source_joiner);
+    }
     return;
   }
   let module_idx_to_source_idx = module_sources.iter().enumerate().fold(
@@ -150,12 +144,8 @@ fn render_chunk_content<'code>(
     // If the group is not belong to any concatenated module, we just render it as a single module.
     if group.modules.len() == 1 {
       let source =
-        module_sources.get(module_idx_to_source_idx[&group.entry]).expect("should have source");
-      if let Some(emitted_sources) = source.sources.as_ref() {
-        for source in emitted_sources.as_ref() {
-          source_joiner.append_source(source);
-        }
-      }
+        module_sources.get_mut(module_idx_to_source_idx[&group.entry]).expect("should have source");
+      source.append_sources(source_joiner);
       continue;
     }
     // Concatenate hoisted functions and comma-join hoisted vars across the group's modules by
@@ -219,15 +209,9 @@ fn render_chunk_content<'code>(
       if is_async { "async () => {" } else { "() => {" }
     ));
     // we render each module in the group by exec order.
-    group.modules.iter().for_each(|module_idx| {
-      if let Some(rendered) =
-        module_sources.get(module_idx_to_source_idx[module_idx]).and_then(|m| m.sources.as_ref())
-      {
-        for source in rendered.iter() {
-          source_joiner.append_source(source);
-        }
-      }
-    });
+    for module_idx in &group.modules {
+      module_sources[module_idx_to_source_idx[module_idx]].append_sources(source_joiner);
+    }
     let mut postfix = "}".to_string();
     if is_pife_for_module_wrappers_enabled {
       postfix += ")";

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -45,7 +45,7 @@ use super::utils::{
 pub async fn render_iife<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,
-  module_sources: &'code RenderedModuleSources,
+  module_sources: &mut RenderedModuleSources,
   warnings: &mut Vec<BuildDiagnostic>,
 ) -> BuildResult<SourceJoiner<'code>> {
   let mut source_joiner = SourceJoiner::default();

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -24,7 +24,7 @@ use super::utils::{
 pub async fn render_umd<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,
-  module_sources: &'code RenderedModuleSources,
+  module_sources: &mut RenderedModuleSources,
   warnings: &mut Vec<BuildDiagnostic>,
 ) -> BuildResult<SourceJoiner<'code>> {
   let mut source_joiner = SourceJoiner::default();

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -3,8 +3,7 @@ use rolldown_common::{ExternalModule, NormalModule};
 use rolldown_sourcemap::SourceJoiner;
 
 use crate::{
-  ecmascript::ecma_generator::{RenderedModuleSource, RenderedModuleSources},
-  types::generator::GenerateContext,
+  ecmascript::ecma_generator::RenderedModuleSources, types::generator::GenerateContext,
   utils::external_import_interop::external_import_needs_interop,
 };
 
@@ -122,40 +121,26 @@ pub fn render_chunk_external_imports<'a>(
   (import_code, externals)
 }
 
-pub fn render_modules_with_peek_runtime_module_at_first<'a>(
+pub fn render_modules_with_peek_runtime_module_at_first(
   ctx: &GenerateContext<'_>,
-  source_joiner: &mut SourceJoiner<'a>,
-  module_sources: &'a RenderedModuleSources,
+  source_joiner: &mut SourceJoiner<'_>,
+  module_sources: &mut RenderedModuleSources,
   import_code: String,
 ) {
-  let mut module_sources_peekable = module_sources.iter().peekable();
-  match module_sources_peekable.peek() {
-    Some(RenderedModuleSource { module_idx, .. })
-      if *module_idx == ctx.link_output.runtime.id() =>
-    {
-      if let RenderedModuleSource { sources: Some(emitted_sources), .. } =
-        module_sources_peekable.next().expect("Must have module")
-      {
-        for source in emitted_sources.iter() {
-          source_joiner.append_source(source);
-        }
-      }
-    }
-    _ => {}
+  let runtime_is_first =
+    module_sources.first().is_some_and(|source| source.module_idx == ctx.link_output.runtime.id());
+  let content_start = usize::from(runtime_is_first);
+
+  if runtime_is_first {
+    module_sources[0].append_sources(source_joiner);
   }
 
   source_joiner.append_source(import_code);
 
   // chunk content
-  module_sources_peekable.for_each(
-    |RenderedModuleSource { sources: module_render_output, .. }| {
-      if let Some(emitted_sources) = module_render_output {
-        for source in emitted_sources.as_ref() {
-          source_joiner.append_source(source);
-        }
-      }
-    },
-  );
+  for module_source in &mut module_sources[content_start..] {
+    module_source.append_sources(source_joiner);
+  }
 }
 
 pub fn render_chunk_directives<'a, T: Iterator<Item = &'a &'a str>>(directives: T) -> String {

--- a/crates/rolldown_sourcemap/benches/join.rs
+++ b/crates/rolldown_sourcemap/benches/join.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use rolldown_sourcemap::SourceJoiner;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -6,14 +6,19 @@ fn criterion_benchmark(c: &mut Criterion) {
   // A module that is 1kb in size
   let a_norma_module = " ".repeat(1024);
 
+  // `join` consumes the joiner, so build a fresh one per iteration (excluded from the measured region).
   group.bench_function("join", move |b| {
-    let mut joiner = SourceJoiner::default();
-    for _ in 0..10_000 {
-      joiner.append_source(a_norma_module.clone());
-    }
-    b.iter(move || {
-      black_box(joiner.join());
-    });
+    b.iter_batched(
+      || {
+        let mut joiner = SourceJoiner::default();
+        for _ in 0..10_000 {
+          joiner.append_source(a_norma_module.clone());
+        }
+        joiner
+      },
+      |joiner| black_box(joiner.join()),
+      BatchSize::SmallInput,
+    );
   });
 }
 

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -4,13 +4,16 @@ use crate::SourceMap;
 
 pub trait Source {
   fn sourcemap(&self) -> Option<&SourceMap>;
+  /// Move this source's sourcemap out when it is exclusively owned.
+  ///
+  /// Borrowed sources keep the default `None`; `SourceJoiner` then falls back
+  /// to `sourcemap` and copies only those borrowed entries into its owned result.
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    None
+  }
   fn content(&self) -> &str;
   fn lines_count(&self) -> u32 {
     lines_count(self.content())
-  }
-  /// By-value taker so `SourceJoiner::join` can move the owned map into the merge instead of copying it.
-  fn into_sourcemap(self: Box<Self>) -> Option<SourceMap> {
-    None
   }
 }
 
@@ -37,13 +40,13 @@ impl Source for String {
 #[derive(Debug)]
 pub struct SourceMapSource {
   content: String,
-  sourcemap: SourceMap,
+  sourcemap: Option<SourceMap>,
   pre_computed_lines_count: Option<u32>,
 }
 
 impl SourceMapSource {
   pub fn new(content: String, sourcemap: SourceMap) -> Self {
-    Self { content, sourcemap, pre_computed_lines_count: None }
+    Self { content, sourcemap: Some(sourcemap), pre_computed_lines_count: None }
   }
 
   #[must_use]
@@ -57,7 +60,7 @@ impl SourceMapSource {
 
 impl Source for SourceMapSource {
   fn sourcemap(&self) -> Option<&SourceMap> {
-    Some(&self.sourcemap)
+    self.sourcemap.as_ref()
   }
 
   fn content(&self) -> &str {
@@ -68,8 +71,8 @@ impl Source for SourceMapSource {
     self.pre_computed_lines_count.unwrap_or_else(|| lines_count(&self.content))
   }
 
-  fn into_sourcemap(self: Box<Self>) -> Option<SourceMap> {
-    Some(self.sourcemap)
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    self.sourcemap.take()
   }
 }
 

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -8,6 +8,10 @@ pub trait Source {
   fn lines_count(&self) -> u32 {
     lines_count(self.content())
   }
+  /// By-value taker so `SourceJoiner::join` can move the owned map into the merge instead of copying it.
+  fn into_sourcemap(self: Box<Self>) -> Option<SourceMap> {
+    None
+  }
 }
 
 impl Source for &str {
@@ -62,6 +66,10 @@ impl Source for SourceMapSource {
 
   fn lines_count(&self) -> u32 {
     self.pre_computed_lines_count.unwrap_or_else(|| lines_count(&self.content))
+  }
+
+  fn into_sourcemap(self: Box<Self>) -> Option<SourceMap> {
+    Some(self.sourcemap)
   }
 }
 

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -48,8 +48,6 @@ impl<'source> SourceJoiner<'source> {
       + sources_len;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
-    let mut line_offset = 0;
-
     let mut sourcemap_builder = self.enable_sourcemap.then(|| {
       ConcatSourceMapBuilder::with_capacity(
         self.names_len,
@@ -58,22 +56,33 @@ impl<'source> SourceJoiner<'source> {
         self.token_chunks_len,
       )
     });
-    // Move exclusively owned maps into the builder. A caller may still pass a
-    // shared source by reference; keep borrowing that map so its mappings are
-    // preserved, then copy only its borrowed strings when detaching below.
-    for (index, source) in self.prepend_source.iter_mut().chain(self.inner.iter_mut()).enumerate() {
-      let lines_count = source.lines_count();
-      ret_source.push_str(source.content());
-      if let Some(sourcemap_builder) = &mut sourcemap_builder {
+    if let Some(sourcemap_builder) = &mut sourcemap_builder {
+      let mut line_offset = 0;
+      // Move exclusively owned maps into the builder. A caller may still pass
+      // a shared source by reference; keep borrowing that map so its mappings
+      // are preserved, then copy only its borrowed strings when detaching.
+      for (index, source) in self.prepend_source.iter_mut().chain(self.inner.iter_mut()).enumerate()
+      {
+        let lines_count = source.lines_count();
+        ret_source.push_str(source.content());
         if let Some(map) = source.take_sourcemap() {
           sourcemap_builder.add_sourcemap_owned(map, line_offset);
         } else if let Some(map) = source.sourcemap() {
           sourcemap_builder.add_sourcemap(map, line_offset);
         }
+        if index < sources_len - 1 {
+          ret_source.push('\n');
+          line_offset += lines_count + 1; // +1 for the newline
+        }
       }
-      if index < sources_len - 1 {
-        ret_source.push('\n');
-        line_offset += lines_count + 1; // +1 for the newline
+    } else {
+      // Without a sourcemap there is no line offset to maintain. Avoid scanning
+      // every source for newlines on this common path.
+      for (index, source) in self.prepend_source.iter().chain(self.inner.iter()).enumerate() {
+        ret_source.push_str(source.content());
+        if index < sources_len - 1 {
+          ret_source.push('\n');
+        }
       }
     }
     (ret_source, sourcemap_builder.map(|builder| builder.into_owned_sourcemap().into_inner()))

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -36,7 +36,7 @@ impl<'source> SourceJoiner<'source> {
     self.prepend_source.push(Box::new(source));
   }
 
-  pub fn join(self) -> (String, Option<SourceMap>) {
+  pub fn join(mut self) -> (String, Option<SourceMap>) {
     let sources_len = self.prepend_source.len() + self.inner.len();
 
     let size_hint_of_ret_source = self
@@ -58,13 +58,17 @@ impl<'source> SourceJoiner<'source> {
         self.token_chunks_len,
       )
     });
-    // Move each owned map into the builder (no per-string copy), so the result is `'static` and the trailing into_owned is gone.
-    for (index, source) in self.prepend_source.into_iter().chain(self.inner).enumerate() {
+    // Move exclusively owned maps into the builder. A caller may still pass a
+    // shared source by reference; keep borrowing that map so its mappings are
+    // preserved, then copy only its borrowed strings when detaching below.
+    for (index, source) in self.prepend_source.iter_mut().chain(self.inner.iter_mut()).enumerate() {
       let lines_count = source.lines_count();
       ret_source.push_str(source.content());
       if let Some(sourcemap_builder) = &mut sourcemap_builder {
-        if let Some(map) = source.into_sourcemap() {
+        if let Some(map) = source.take_sourcemap() {
           sourcemap_builder.add_sourcemap_owned(map, line_offset);
+        } else if let Some(map) = source.sourcemap() {
+          sourcemap_builder.add_sourcemap(map, line_offset);
         }
       }
       if index < sources_len - 1 {
@@ -72,7 +76,7 @@ impl<'source> SourceJoiner<'source> {
         line_offset += lines_count + 1; // +1 for the newline
       }
     }
-    (ret_source, sourcemap_builder.map(ConcatSourceMapBuilder::into_sourcemap))
+    (ret_source, sourcemap_builder.map(|builder| builder.into_owned_sourcemap().into_inner()))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {
@@ -137,4 +141,46 @@ console.log(foo);
 (0:30) ");\n" --> (4:15) ");\n"
 "#
   );
+}
+
+#[test]
+fn test_concat_mixed_owned_and_borrowed_sourcemaps() {
+  use std::borrow::Cow;
+
+  use crate::{Source, SourceJoiner, SourceMap, SourceMapSource};
+  use oxc_sourcemap::Token;
+
+  fn map(filename: &str, source_content: &str) -> SourceMap {
+    SourceMap::new(
+      None,
+      vec![],
+      None,
+      vec![Cow::Owned(filename.to_string())],
+      vec![Some(Cow::Owned(source_content.to_string()))],
+      vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+      None,
+    )
+  }
+
+  // Callers may still pass a shared source that cannot yield ownership of its map.
+  let borrowed_source: Box<dyn Source + Send + Sync> = Box::new(SourceMapSource::new(
+    "borrowed();".to_string(),
+    map("borrowed.js", "borrowed source"),
+  ));
+
+  let mut joiner = SourceJoiner::default();
+  joiner.append_source(&borrowed_source);
+  joiner
+    .append_source(SourceMapSource::new("owned();".to_string(), map("owned.js", "owned source")));
+
+  let (content, map) = joiner.join();
+  let map = map.expect("both input sourcemaps should be preserved");
+
+  assert_eq!(content, "borrowed();\nowned();");
+  assert_eq!(map.get_sources().collect::<Vec<_>>(), ["borrowed.js", "owned.js"]);
+  assert_eq!(map.get_source_content(0), Some("borrowed source"));
+  assert_eq!(map.get_source_content(1), Some("owned source"));
+  assert_eq!(map.get_token(0).and_then(|token| token.get_source_id()), Some(0));
+  assert_eq!(map.get_token(1).map(|token| token.get_dst_line()), Some(1));
+  assert_eq!(map.get_token(1).and_then(|token| token.get_source_id()), Some(1));
 }

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -36,49 +36,43 @@ impl<'source> SourceJoiner<'source> {
     self.prepend_source.push(Box::new(source));
   }
 
-  pub fn join(&self) -> (String, Option<SourceMap>) {
+  pub fn join(self) -> (String, Option<SourceMap>) {
     let sources_len = self.prepend_source.len() + self.inner.len();
-    let sources_iter = self.prepend_source.iter().chain(self.inner.iter()).enumerate();
 
-    let size_hint_of_ret_source =
-      sources_iter.clone().map(|(_idx, source)| source.content().len()).sum::<usize>()
-        + sources_len;
+    let size_hint_of_ret_source = self
+      .prepend_source
+      .iter()
+      .chain(self.inner.iter())
+      .map(|source| source.content().len())
+      .sum::<usize>()
+      + sources_len;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
-    // Fast path: when no source carries a sourcemap, `join` is a plain
-    // concatenation with `\n` separators. `line_offset` and the per-source
-    // `lines_count()` newline scan exist only to feed the sourcemap builder,
-    // so skip them entirely here. Splitting the loop (rather than branching
-    // inside it) also keeps the sourcemap loop below free of per-iteration
-    // builder checks.
-    if !self.enable_sourcemap {
-      for (index, source) in sources_iter {
-        ret_source.push_str(source.content());
-        if index < sources_len - 1 {
-          ret_source.push('\n');
+    let mut line_offset = 0;
+
+    let mut sourcemap_builder = self.enable_sourcemap.then(|| {
+      ConcatSourceMapBuilder::with_capacity(
+        self.names_len,
+        self.sources_len,
+        self.tokens_len,
+        self.token_chunks_len,
+      )
+    });
+    // Move each owned map into the builder (no per-string copy), so the result is `'static` and the trailing into_owned is gone.
+    for (index, source) in self.prepend_source.into_iter().chain(self.inner).enumerate() {
+      let lines_count = source.lines_count();
+      ret_source.push_str(source.content());
+      if let Some(sourcemap_builder) = &mut sourcemap_builder {
+        if let Some(map) = source.into_sourcemap() {
+          sourcemap_builder.add_sourcemap_owned(map, line_offset);
         }
       }
-      return (ret_source, None);
-    }
-
-    let mut line_offset = 0;
-    let mut sourcemap_builder = ConcatSourceMapBuilder::with_capacity(
-      self.names_len,
-      self.sources_len,
-      self.tokens_len,
-      self.token_chunks_len,
-    );
-    for (index, source) in sources_iter {
-      source.sourcemap().inspect(|map| {
-        sourcemap_builder.add_sourcemap(map, line_offset);
-      });
-      ret_source.push_str(source.content());
       if index < sources_len - 1 {
         ret_source.push('\n');
-        line_offset += source.lines_count() + 1; // +1 for the newline
+        line_offset += lines_count + 1; // +1 for the newline
       }
     }
-    (ret_source, Some(sourcemap_builder.into_sourcemap().into_owned()))
+    (ret_source, sourcemap_builder.map(ConcatSourceMapBuilder::into_sourcemap))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {

--- a/tasks/track_memory_allocations/allocs.snap
+++ b/tasks/track_memory_allocations/allocs.snap
@@ -1,5 +1,5 @@
 Scenario                         |     Allocs |   Reallocs
 ----------------------------------------------------------
-sourcemap/join_with_sourcemap    |       4005 |          0
+sourcemap/join_with_sourcemap    |          5 |          0
 sourcemap/join_no_sourcemap      |          1 |          0
 sourcemap/collapse_codegen_chain |          8 |         15


### PR DESCRIPTION
## What

`SourceJoiner::join` used to borrow every input sourcemap into `ConcatSourceMapBuilder`, then detach the combined map by deep-copying every name, source, and `sourcesContent` string. On a 2,000-module chunk that meant 4,005 allocations in `join` alone.

This change moves owned maps into the concat builder instead:

- `SourceJoiner::join` consumes the joiner and uses `add_sourcemap_owned` for maps it can take. A mixed-path fallback keeps borrowed `Source` implementations correct and copies only their borrowed entries.
- Normal chunk rendering now detaches each module's map before its source text is shared with the plugin-facing `RenderedModule` view. The text stays shared through `Arc`; a lightweight chunk source owns the map and moves it into the builder. This is required for the optimization to cover the real ESM/CJS/IIFE/UMD production path, not only synthetic owned inputs and HMR.
- `SourceMapSource` stores its map as an `Option` and exposes `take_sourcemap`, leaving the plugin-facing view mapless while preserving `RenderedModule.code`.
- The no-sourcemap fast path no longer scans every source for line offsets that only the sourcemap builder needs.
- `oxc_sourcemap` is bumped to `8.0.2`, which contains the owned concat API from oxc-project/oxc-sourcemap#368 (the released successor to #365).

## Measured impact

| metric | before | after |
|---|---:|---:|
| deterministic allocations, `sourcemap/join_with_sourcemap` (2,000 modules) | 4,005 | **5** (-99.9%) |
| CodSpeed simulation, `join_with_sourcemap` | 10.4 ms | **9.5 ms** (+9.31% efficiency) |
| CodSpeed simulation, `join_no_sourcemap` | 1.6 ms | **1.4 ms** (+10.96% efficiency) |
| per-`join` wall-clock in the original prototype (release, mimalloc) | ~417 µs | **~314 µs** (-25%) |

CodSpeed's aggregate verdict is a **10.13% performance improvement**. It used `main@4b9c35e` because a newer successful baseline was unavailable and flags a runtime-environment mismatch, so the exact percentages are directional. The allocation snapshot is committed and reproduced identically across two runs. `join` runs once per output chunk and remains a small part of a full build, so this is an allocation-pressure and per-operation improvement, not a large end-to-end claim.

## Correctness coverage

- Mixed owned + borrowed maps retain both mappings, source IDs, source contents, and line offsets.
- The plugin-facing `RenderedModule` still exposes identical code after its map is detached, while chunk rendering receives that map.
- Existing sourcemap fixtures pass, including CJS live bindings, source exclusion, debug IDs, inline URLs, issue #6099, post-banner/shebang mapping, and the esbuild source-map suite.

## Verification

- Full GitHub CI, including CodSpeed, passes at `a078bad82`.
- `cargo clippy -p rolldown_sourcemap -p rolldown -p bench --all-targets -- --deny warnings`
- `cargo test -p rolldown_sourcemap`
- `cargo test -p rolldown --lib` (70 passed)
- `cargo test -p rolldown --test integration -- --skip test262::test262_module_code` (26 passed; test262 is not initialized in the worktree)
- `cargo allocs` twice with an identical snapshot

## Upstream

- oxc-project/oxc-sourcemap#368 — merged and released as `oxc_sourcemap@8.0.2`
