### PR TITLE
perf(fs): use oxc_resolver::FileSystemOs directly instead of an OsFileSystem newtype

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -16,7 +16,7 @@ use arcstr::ArcStr;
 use rolldown_common::{GetLocalDbMut, Module, ScanMode, SharedFileEmitter, SymbolRefDb};
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult, Severity};
-use rolldown_fs::{FileSystem, OsFileSystem};
+use rolldown_fs::{FileSystem, FileSystemOs};
 use rolldown_plugin::{
   HookBuildEndArgs, HookCloseBundleArgs, HookRenderErrorArgs, SharedPluginDriver,
 };
@@ -28,7 +28,7 @@ use sugar_path::SugarPath;
   clippy::struct_field_names,
   reason = "`bundle_span` emphasizes this's a span for this bundle, not a session level span"
 )]
-pub struct Bundle<Fs: FileSystem + Clone + 'static = OsFileSystem> {
+pub struct Bundle<Fs: FileSystem + Clone + 'static = FileSystemOs> {
   pub(crate) fs: Fs,
   pub(crate) options: SharedOptions,
   pub(crate) resolver: SharedResolver<Fs>,

--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -7,7 +7,7 @@ use rolldown_common::{
   SharedModuleInfoDashMap,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, EventKindSwitcher};
-use rolldown_fs::{FileSystem, OsFileSystem};
+use rolldown_fs::{FileSystem, FileSystemOs};
 use rolldown_plugin::{__inner::SharedPluginable, PluginDriverFactory};
 use rolldown_plugin_lazy_compilation::LazyCompilationContext;
 use rolldown_utils::dashmap::FxDashSet;
@@ -34,9 +34,9 @@ pub struct BundleFactoryOptions {
 
 pub struct BundleFactory {
   pub plugin_driver_factory: PluginDriverFactory,
-  pub fs: OsFileSystem,
+  pub fs: FileSystemOs,
   pub options: SharedOptions,
-  pub resolver: SharedResolver<OsFileSystem>,
+  pub resolver: SharedResolver<FileSystemOs>,
   pub file_emitter: SharedFileEmitter,
   /// Warnings collected during bundle factory creation.
   /// These warnings are transferred to the first created `Bundle` via `create_bundle()` or `create_incremental_bundle()`.
@@ -110,7 +110,7 @@ impl BundleFactory {
     &mut self,
     bundle_mode: BundleMode,
     cache: Option<ScanStageCache>,
-  ) -> BuildResult<Bundle<OsFileSystem>> {
+  ) -> BuildResult<Bundle<FileSystemOs>> {
     let cache = if bundle_mode.is_incremental() {
       if let Some(cache) = cache {
         cache

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -10,7 +10,7 @@ use rolldown_common::{
   TreeshakeOptions, TsConfig, merge_transform_options_with_tsconfig, normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
-use rolldown_fs::{OsFileSystem, OxcResolverFileSystem as _};
+use rolldown_fs::{FileSystemOs, OxcResolverFileSystem as _};
 use rolldown_resolver::Resolver;
 use rolldown_utils::ecmascript::is_validate_identifier_name;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,8 +19,8 @@ use sugar_path::SugarPath;
 use crate::{SharedResolver, utils::determine_minify_internal_exports_default};
 
 pub struct PrepareBuildContext {
-  pub fs: OsFileSystem,
-  pub resolver: SharedResolver<OsFileSystem>,
+  pub fs: FileSystemOs,
+  pub resolver: SharedResolver<FileSystemOs>,
   pub options: Arc<NormalizedBundlerOptions>,
   pub warnings: Vec<BuildDiagnostic>,
 }
@@ -308,7 +308,7 @@ pub fn prepare_build_context(
 
   let tsconfig = raw_options.tsconfig.map(|tsconfig| tsconfig.with_base(&cwd)).unwrap_or_default();
   let yarn_pnp = raw_resolve.yarn_pnp.unwrap_or(false);
-  let fs = OsFileSystem::new(yarn_pnp);
+  let fs = FileSystemOs::new(yarn_pnp);
   let resolver = Arc::new(Resolver::new(fs.clone(), cwd.clone(), platform, &tsconfig, raw_resolve));
 
   let transform_options = {

--- a/crates/rolldown_fs/src/lib.rs
+++ b/crates/rolldown_fs/src/lib.rs
@@ -7,5 +7,5 @@ pub use memory::MemoryFileSystem;
 mod os;
 pub use crate::file_system::FileSystem;
 #[cfg(feature = "os")]
-pub use os::OsFileSystem;
+pub use os::FileSystemOs;
 pub use oxc_resolver::FileSystem as OxcResolverFileSystem;

--- a/crates/rolldown_fs/src/os.rs
+++ b/crates/rolldown_fs/src/os.rs
@@ -1,24 +1,19 @@
 use std::{
-  fmt, io,
+  io,
   path::{Path, PathBuf},
-  sync::Arc,
 };
-
-use oxc_resolver::{FileMetadata, FileSystem as OxcResolverFileSystem, FileSystemOs, ResolveError};
 
 use crate::file_system::FileSystem;
 
-/// Operating System
-#[derive(Clone)]
-pub struct OsFileSystem(Arc<FileSystemOs>);
+/// Operating system file system — oxc-resolver's [`FileSystemOs`], re-exported.
+///
+/// rolldown's write-capable [`FileSystem`] trait is implemented directly on it below — allowed by
+/// the orphan rule because the trait is local to this crate. Using oxc-resolver's type directly
+/// (rather than a newtype wrapper) means rolldown's bundler resolver and oxc-resolver share a
+/// single `Fs` type instead of two.
+pub use oxc_resolver::FileSystemOs;
 
-impl fmt::Debug for OsFileSystem {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "OsFileSystem")
-  }
-}
-
-impl FileSystem for OsFileSystem {
+impl FileSystem for FileSystemOs {
   fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
     std::fs::remove_dir_all(path)
   }
@@ -47,35 +42,5 @@ impl FileSystem for OsFileSystem {
 
   fn remove_file(&self, path: &Path) -> io::Result<()> {
     std::fs::remove_file(path)
-  }
-}
-
-impl OxcResolverFileSystem for OsFileSystem {
-  fn new(yarn_pnp: bool) -> Self {
-    Self(Arc::new(FileSystemOs::new(yarn_pnp)))
-  }
-
-  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-    self.0.read(path)
-  }
-
-  fn read_to_string(&self, path: &Path) -> io::Result<String> {
-    self.0.read_to_string(path)
-  }
-
-  fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    self.0.metadata(path)
-  }
-
-  fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    self.0.symlink_metadata(path)
-  }
-
-  fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError> {
-    self.0.read_link(path)
-  }
-
-  fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-    self.0.canonicalize(path)
   }
 }

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -14,7 +14,7 @@ use rolldown_common::{
   ImportKind, ModuleDefFormat, ModuleId, PackageJson, Platform, ResolveOptions, ResolvedId,
   TsConfig,
 };
-use rolldown_fs::{FileSystem, OsFileSystem};
+use rolldown_fs::{FileSystem, FileSystemOs};
 use rolldown_utils::dashmap::FxDashMap;
 use sugar_path::SugarPath as _;
 
@@ -22,7 +22,7 @@ use crate::resolver_config::ResolverConfig;
 
 #[derive(Debug)]
 #[expect(clippy::struct_field_names)]
-pub struct Resolver<Fs: FileSystem = OsFileSystem> {
+pub struct Resolver<Fs: FileSystem = FileSystemOs> {
   fs: Fs,
   cwd: PathBuf,
   default_resolver: ResolverGeneric<Fs>,


### PR DESCRIPTION
## What

rolldown wrapped `oxc_resolver::FileSystemOs` in an `OsFileSystem(Arc<FileSystemOs>)` newtype. Because that wrapper is a distinct Rust type, the bundler's resolver and the re-exported `oxc_resolver_napi` resolver each monomorphized `ResolverGeneric<Fs>` over a *different* `Fs`, so the resolver was emitted twice in the `.node`.

This drops the newtype: `rolldown_fs` re-exports `FileSystemOs` directly and implements rolldown's write-capable `FileSystem` trait on it (allowed by the orphan rule — the trait is local to `rolldown_fs`). One `Fs` type instead of two.

## Result

~99 KB smaller release `.node` (one fewer resolver monomorphization, measured on a fat-LTO build). Behavior-preserving: `FileSystemOs`'s pnp cache moves behind an `Arc`, so clones share it — the same sharing the old `Arc<FileSystemOs>` wrapper provided.

## ⚠️ Draft — blocked on oxc-resolver

Requires the unreleased oxc-resolver change making `FileSystemOs: Clone + Debug` (cheap clone via `Arc<pnp_lru>`). CI stays red until that ships and `oxc_resolver` / `oxc_resolver_napi` are bumped here.
