### PR TITLE
perf(sourcemap): move owned maps into the concat builder when joining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,8 +1997,7 @@ dependencies = [
 [[package]]
 name = "oxc_sourcemap"
 version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
+source = "git+https://github.com/oxc-project/oxc-sourcemap.git?branch=perf%2Fconcat-owned-move-in#dbd6ef9f13e2721279bcbc7f8bbd65523447c323"
 dependencies = [
  "base64-simd",
  "json-escape-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,3 +310,9 @@ opt-level = "s"
 # it will strip these information for non-debug files
 debug = "full"
 strip = "none"
+
+# TEMPORARY: use the unreleased owned move-in concat API (`from_owned_sourcemaps`) from
+# https://github.com/oxc-project/oxc-sourcemap/pull/368. Remove this patch and bump the
+# `oxc_sourcemap` version once that PR is merged and released.
+[patch.crates-io]
+oxc_sourcemap = { git = "https://github.com/oxc-project/oxc-sourcemap.git", branch = "perf/concat-owned-move-in" }

--- a/crates/rolldown_sourcemap/benches/join.rs
+++ b/crates/rolldown_sourcemap/benches/join.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use rolldown_sourcemap::SourceJoiner;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -6,14 +6,21 @@ fn criterion_benchmark(c: &mut Criterion) {
   // A module that is 1kb in size
   let a_norma_module = " ".repeat(1024);
 
-  group.bench_function("join", move |b| {
-    let mut joiner = SourceJoiner::default();
-    for _ in 0..10_000 {
-      joiner.append_source(a_norma_module.clone());
-    }
-    b.iter(move || {
-      black_box(joiner.join());
-    });
+  group.bench_function("join", |b| {
+    // `join` consumes the joiner, so rebuild it in the (untimed) setup of each iteration.
+    b.iter_batched(
+      || {
+        let mut joiner = SourceJoiner::default();
+        for _ in 0..10_000 {
+          joiner.append_source(a_norma_module.clone());
+        }
+        joiner
+      },
+      |joiner| {
+        black_box(joiner.join());
+      },
+      BatchSize::LargeInput,
+    );
   });
 }
 

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -4,6 +4,14 @@ use crate::SourceMap;
 
 pub trait Source {
   fn sourcemap(&self) -> Option<&SourceMap>;
+  /// Take ownership of this source's sourcemap, leaving none behind.
+  ///
+  /// Defaults to `None` (sources without a map, e.g. `&str` / `String`). `SourceJoiner::join`
+  /// uses this to *move* owned maps into the concat builder instead of borrowing and recopying
+  /// them — see `ConcatSourceMapBuilder::add_sourcemap_owned`.
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    None
+  }
   fn content(&self) -> &str;
   fn lines_count(&self) -> u32 {
     lines_count(self.content())
@@ -54,6 +62,10 @@ impl SourceMapSource {
 impl Source for SourceMapSource {
   fn sourcemap(&self) -> Option<&SourceMap> {
     Some(&self.sourcemap)
+  }
+
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    Some(std::mem::take(&mut self.sourcemap))
   }
 
   fn content(&self) -> &str {

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -55,19 +55,17 @@ impl<'source> SourceJoiner<'source> {
 
     let source_count = prepend_source.len() + inner.len();
 
-    let size_hint_of_ret_source = prepend_source
-      .iter()
-      .chain(inner.iter())
-      .map(|source| source.content().len())
-      .sum::<usize>()
-      + source_count;
+    let size_hint_of_ret_source =
+      prepend_source.iter().chain(inner.iter()).map(|source| source.content().len()).sum::<usize>()
+        + source_count;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
     let mut line_offset = 0;
 
-    let mut sourcemap_builder: Option<ConcatSourceMapBuilder<'static>> = enable_sourcemap.then(|| {
-      ConcatSourceMapBuilder::with_capacity(names_len, sources_len, tokens_len, token_chunks_len)
-    });
+    let mut sourcemap_builder: Option<ConcatSourceMapBuilder<'static>> =
+      enable_sourcemap.then(|| {
+        ConcatSourceMapBuilder::with_capacity(names_len, sources_len, tokens_len, token_chunks_len)
+      });
     // Consume the sources, *moving* each owned sourcemap into the builder — no string is copied.
     for (index, mut source) in prepend_source.into_iter().chain(inner).enumerate() {
       if let Some(sourcemap_builder) = &mut sourcemap_builder {

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -36,38 +36,53 @@ impl<'source> SourceJoiner<'source> {
     self.prepend_source.push(Box::new(source));
   }
 
-  pub fn join(&self) -> (String, Option<SourceMap>) {
-    let sources_len = self.prepend_source.len() + self.inner.len();
-    let sources_iter = self.prepend_source.iter().chain(self.inner.iter()).enumerate();
+  /// Concatenate the pushed sources into one string + combined sourcemap.
+  ///
+  /// Consumes `self` so the owned input sourcemaps can be **moved** into the concat builder
+  /// (`add_sourcemap_owned`) rather than borrowed and recopied — no name/source/sourcesContent
+  /// string is copied. For rolldown's `'static` maps, `into_sourcemap` then returns the combined
+  /// `'static` map by moving the vectors out.
+  pub fn join(self) -> (String, Option<SourceMap>) {
+    let Self {
+      inner,
+      prepend_source,
+      enable_sourcemap,
+      names_len,
+      sources_len,
+      tokens_len,
+      token_chunks_len,
+    } = self;
 
-    let size_hint_of_ret_source =
-      sources_iter.clone().map(|(_idx, source)| source.content().len()).sum::<usize>()
-        + sources_len;
+    let source_count = prepend_source.len() + inner.len();
+
+    let size_hint_of_ret_source = prepend_source
+      .iter()
+      .chain(inner.iter())
+      .map(|source| source.content().len())
+      .sum::<usize>()
+      + source_count;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
     let mut line_offset = 0;
 
-    let mut sourcemap_builder = self.enable_sourcemap.then(|| {
-      ConcatSourceMapBuilder::with_capacity(
-        self.names_len,
-        self.sources_len,
-        self.tokens_len,
-        self.token_chunks_len,
-      )
+    let mut sourcemap_builder: Option<ConcatSourceMapBuilder<'static>> = enable_sourcemap.then(|| {
+      ConcatSourceMapBuilder::with_capacity(names_len, sources_len, tokens_len, token_chunks_len)
     });
-    for (index, source) in sources_iter {
+    // Consume the sources, *moving* each owned sourcemap into the builder — no string is copied.
+    for (index, mut source) in prepend_source.into_iter().chain(inner).enumerate() {
       if let Some(sourcemap_builder) = &mut sourcemap_builder {
-        source.sourcemap().inspect(|map| {
-          sourcemap_builder.add_sourcemap(map, line_offset);
-        });
+        if let Some(map) = source.take_sourcemap() {
+          sourcemap_builder.add_sourcemap_owned(map, line_offset);
+        }
       }
       ret_source.push_str(source.content());
-      if index < sources_len - 1 {
+      if index < source_count - 1 {
         ret_source.push('\n');
         line_offset += source.lines_count() + 1; // +1 for the newline
       }
     }
-    (ret_source, sourcemap_builder.map(|builder| builder.into_sourcemap().into_owned()))
+    // `into_sourcemap` moves the accumulated `'static` entries out — no copy.
+    (ret_source, sourcemap_builder.map(ConcatSourceMapBuilder::into_sourcemap))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {


### PR DESCRIPTION
## Summary

`SourceJoiner::join` borrowed each input `SourceMap` into `ConcatSourceMapBuilder` and then `into_owned_sourcemap` deep-copied every string — including the full `sourcesContent` (the original module text) — to produce the owned result. The joiner's inputs are owned (`SourceMapSource`) and discarded after the join, so we can **move** them in instead of borrowing and recopying.

- `Source::take_sourcemap(&mut self)` — new trait method (default `None`); `SourceMapSource` yields its map via `mem::take`.
- `SourceJoiner::join` now **consumes `self`** and feeds owned maps to the new `ConcatSourceMapBuilder::add_sourcemap_owned`, returning via `into_sourcemap` (no `into_owned`). All `join` call sites are terminal, so no caller changes were needed.

No name/source/`sourcesContent` string is copied during the join; the cost no longer scales with total source text size.

## Performance

From the upstream `concat_owned` bench (200 owned module maps, sweeping `sourcesContent` size) — median time per join:

| content/module | borrow + `into_owned_sourcemap` | move-in |
|---|---|---|
| 256 B | 37 µs | 32 µs |
| 2 KB | 47 µs | 32 µs |
| 8 KB | 70 µs | 33 µs |
| 32 KB | 542 µs | 33 µs |

Move-in is flat (it moves heap buffers, not bytes); the old path grows linearly with `sourcesContent`. Output `mappings` are byte-identical.

## Blocked on

Depends on the unreleased owned move-in API in oxc-project/oxc-sourcemap#368. Pinned via a temporary `[patch.crates-io]` git dependency on that branch. **Before merge:** that PR must land and be released, then drop the patch and bump the `oxc_sourcemap` version. Draft until then.