### PR TITLE
fix(treeshake): track separately exported pure functions

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -17,7 +17,7 @@ use rolldown_common::{
 };
 #[cfg(debug_assertions)]
 use rolldown_ecmascript::ToSourceString;
-use rolldown_ecmascript_utils::{ExpressionExt, is_top_level};
+use rolldown_ecmascript_utils::{ExpressionExt, FunctionExt, is_top_level};
 use rolldown_error::BuildDiagnostic;
 use rolldown_std_utils::OptionExt;
 
@@ -73,6 +73,27 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       {
         self.current_stmt_idx = StmtInfoIdx::from_raw_unchecked(idx as u32 + 1);
       }
+      self.current_direct_root_var_decl_symbols.clear();
+      match stmt {
+        ast::Statement::VariableDeclaration(var_decl) => {
+          for decl in &var_decl.declarations {
+            if let BindingPattern::BindingIdentifier(id) = &decl.id {
+              self.current_direct_root_var_decl_symbols.insert(id.symbol_id());
+            }
+          }
+        }
+        ast::Statement::ExportNamedDeclaration(export_decl) => {
+          if let Some(Declaration::VariableDeclaration(var_decl)) = export_decl.declaration.as_ref()
+          {
+            for decl in &var_decl.declarations {
+              if let BindingPattern::BindingIdentifier(id) = &decl.id {
+                self.current_direct_root_var_decl_symbols.insert(id.symbol_id());
+              }
+            }
+          }
+        }
+        _ => {}
+      }
       let analyzer = StmtEvalAnalyzer::new(
         &self.result.symbol_ref_db.ast_scopes,
         self.immutable_ctx.flat_options,
@@ -99,6 +120,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         self.result.ecma_view_meta.insert(EcmaViewMeta::ExecutionOrderSensitive);
       }
       self.result.stmt_infos.add_stmt_info(std::mem::take(&mut self.current_stmt_info));
+      self.current_direct_root_var_decl_symbols.clear();
     }
 
     if self.untranspiled_syntax.contains(UntranspiledSyntax::TypeScript) {
@@ -119,6 +141,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     self.result.dynamic_import_rec_exports_usage =
       std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
     if self.result.ecma_view_meta.contains(EcmaViewMeta::Eval) {
+      self.discard_side_effect_free_function_symbols();
       // if there exists `eval` in current module, assume all dynamic import are completely used;
       for usage in self.result.dynamic_import_rec_exports_usage.values_mut() {
         *usage = DynamicImportExportsUsage::Complete;
@@ -342,16 +365,57 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
             if let Some(value) = self.extract_constant_value_from_expr(Some(init)) {
               self.add_constant_symbol(binding.symbol_id(), ConstExportMeta::new(value, false));
             }
+            let pure_annotation_only = match init {
+              Expression::FunctionExpression(func) => {
+                let empty = func.is_side_effect_free();
+                self.side_effect_free_function_pure_annotation_only(empty, func.pure)
+              }
+              Expression::ArrowFunctionExpression(func) => {
+                let empty = func.is_side_effect_free();
+                self.side_effect_free_function_pure_annotation_only(empty, func.pure)
+              }
+              _ => None,
+            };
+            if self.can_mark_var_initialized_export_side_effect_free(binding.symbol_id())
+              && let Some(pure_annotation_only) = pure_annotation_only
+            {
+              self.add_var_initialized_side_effect_free_function_symbol(
+                binding.symbol_id(),
+                pure_annotation_only,
+              );
+            }
           }
         }
       }
       _ => {
-        if self.immutable_ctx.flat_options.inline_const_enabled() && self.is_root_scope() {
+        if self.is_root_scope() {
+          let can_extract_const = self.immutable_ctx.flat_options.inline_const_enabled();
           for var_decl in &decl.declarations {
             if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
               if let Some(init) = &var_decl.init {
-                if let Some(value) = self.extract_constant_value_from_expr(Some(init)) {
+                if can_extract_const
+                  && let Some(value) = self.extract_constant_value_from_expr(Some(init))
+                {
                   self.add_constant_symbol(binding.symbol_id(), ConstExportMeta::new(value, false));
+                }
+                let pure_annotation_only = match init {
+                  Expression::FunctionExpression(func) => {
+                    let empty = func.is_side_effect_free();
+                    self.side_effect_free_function_pure_annotation_only(empty, func.pure)
+                  }
+                  Expression::ArrowFunctionExpression(func) => {
+                    let empty = func.is_side_effect_free();
+                    self.side_effect_free_function_pure_annotation_only(empty, func.pure)
+                  }
+                  _ => None,
+                };
+                if self.can_mark_var_initialized_export_side_effect_free(binding.symbol_id())
+                  && let Some(pure_annotation_only) = pure_annotation_only
+                {
+                  self.add_var_initialized_side_effect_free_function_symbol(
+                    binding.symbol_id(),
+                    pure_annotation_only,
+                  );
                 }
               }
             }
@@ -366,6 +430,17 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_declaration(&mut self, it: &ast::Declaration<'ast>) {
     match it {
       Declaration::FunctionDeclaration(function) => {
+        if let Some(binding) = &function.id {
+          let symbol_id = binding.symbol_id();
+          if self.is_root_symbol(symbol_id) {
+            let empty = function.is_side_effect_free();
+            if let Some(pure_annotation_only) =
+              self.side_effect_free_function_pure_annotation_only(empty, function.pure)
+            {
+              self.add_side_effect_free_function_symbol(symbol_id, pure_annotation_only);
+            }
+          }
+        }
         self.visit_function_decl(function, ScopeFlags::Function);
       }
       Declaration::ClassDeclaration(class) => {

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -168,6 +168,7 @@ pub struct AstScanner<'me, 'ast> {
   /// Whether the current position is at the top level (all parent scopes are block or top-level).
   /// A cache of [AstScanner::is_valid_tla_scope].
   is_top_level: bool,
+  current_direct_root_var_decl_symbols: FxHashSet<SymbolId>,
   current_comment_idx: usize,
   untranspiled_syntax: UntranspiledSyntax,
   /// Symbol IDs of namespace imports (`import * as ns from '...'`).
@@ -266,6 +267,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       )]),
       has_module_exports_reassignment: false,
       is_top_level: false,
+      current_direct_root_var_decl_symbols: FxHashSet::default(),
       current_comment_idx: 0,
       untranspiled_syntax: UntranspiledSyntax::empty(),
       namespace_object_symbol_ids: FxHashSet::default(),
@@ -291,6 +293,15 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
   pub fn is_root_scope(&self) -> bool {
     self.scope_stack.iter().rev().all(|flag| flag.is_top())
+  }
+
+  pub fn is_unconditionally_executed_root_var_decl_symbol(&self, symbol_id: SymbolId) -> bool {
+    self.current_direct_root_var_decl_symbols.contains(&symbol_id)
+  }
+
+  pub fn can_mark_var_initialized_export_side_effect_free(&self, symbol_id: SymbolId) -> bool {
+    self.is_unconditionally_executed_root_var_decl_symbol(symbol_id)
+      && !self.result.ecma_view_meta.has_eval()
   }
 
   pub fn scan(mut self, program: &Program<'ast>) -> BuildResult<ScanResult> {
@@ -554,8 +565,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     let symbol_ref: SymbolRef = (self.immutable_ctx.idx, local).into();
 
     // If there is any write reference to the local variable, it is reassigned.
-    let is_reassigned =
-      self.result.symbol_ref_db.get_resolved_references(local).any(Reference::is_write);
+    let is_reassigned = self.is_symbol_reassigned(local);
 
     let ref_flags = symbol_ref.flags_mut(&mut self.result.symbol_ref_db);
     if !is_reassigned {
@@ -570,17 +580,29 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         came_from_commonjs: false,
       },
     );
+
+    if self.is_not_reassigned_side_effect_free_function(local) {
+      self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
+    }
   }
 
   fn add_local_default_export(&mut self, local: SymbolId, span: Span) {
-    // The default symbol ref never get reassigned.
     let symbol_ref: SymbolRef = (self.immutable_ctx.idx, local).into();
-    symbol_ref.flags_mut(&mut self.result.symbol_ref_db).insert(SymbolRefFlags::IsNotReassigned);
+    if !self.is_symbol_reassigned(local) {
+      symbol_ref.flags_mut(&mut self.result.symbol_ref_db).insert(SymbolRefFlags::IsNotReassigned);
+    }
 
     self.result.named_exports.insert(
       "default".into(),
       LocalExport { referenced: symbol_ref, span, came_from_commonjs: false },
     );
+
+    if self.is_not_reassigned_side_effect_free_function(local) {
+      symbol_ref
+        .flags_mut(&mut self.result.symbol_ref_db)
+        .insert(SymbolRefFlags::DelayedDefaultExportSideEffectsFreeFunction);
+      self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
+    }
   }
 
   /// Record `export { [imported] as [export_name] } from ...` statement.
@@ -769,31 +791,28 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 if let Some(value) = self.extract_constant_value_from_expr(decl.init.as_ref()) {
                   self.add_constant_symbol(symbol_id, ConstExportMeta::new(value, false));
                 }
-                let (is_side_effect_free_function, is_pure_annotation_only) = decl
+                let pure_annotation_only = decl
                   .init
                   .as_ref()
                   .map(|expr| match expr {
                     Expression::FunctionExpression(func) => {
                       let empty = func.is_side_effect_free();
-                      (empty || func.pure, func.pure && !empty)
+                      self.side_effect_free_function_pure_annotation_only(empty, func.pure)
                     }
                     Expression::ArrowFunctionExpression(func) => {
                       let empty = func.is_side_effect_free();
-                      (empty || func.pure, func.pure && !empty)
+                      self.side_effect_free_function_pure_annotation_only(empty, func.pure)
                     }
-                    _ => (false, false),
+                    _ => None,
                   })
-                  .unwrap_or((false, false));
-                if is_side_effect_free_function {
-                  self
-                    .result
-                    .ecma_view_meta
-                    .insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-                  let flags = self.result.symbol_ref_db.flags.entry(symbol_id).or_default();
-                  flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
-                  if is_pure_annotation_only {
-                    flags.insert(SymbolRefFlags::PureAnnotationOnly);
-                  }
+                  .unwrap_or(None);
+                if self.can_mark_var_initialized_export_side_effect_free(symbol_id)
+                  && let Some(pure_annotation_only) = pure_annotation_only
+                {
+                  self.add_var_initialized_side_effect_free_function_symbol(
+                    symbol_id,
+                    pure_annotation_only,
+                  );
                 }
               }
             });
@@ -803,13 +822,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             let symbol_id = binding_id.symbol_id();
             self.add_local_export(binding_id.name.as_str(), symbol_id, binding_id.span);
             let empty = fn_decl.is_side_effect_free();
-            if empty || fn_decl.pure {
-              self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-              let flags = self.result.symbol_ref_db.flags.entry(symbol_id).or_default();
-              flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
-              if fn_decl.pure && !empty {
-                flags.insert(SymbolRefFlags::PureAnnotationOnly);
-              }
+            if let Some(pure_annotation_only) =
+              self.side_effect_free_function_pure_annotation_only(empty, fn_decl.pure)
+            {
+              self.add_side_effect_free_function_symbol(symbol_id, pure_annotation_only);
             }
           }
           ast::Declaration::ClassDeclaration(cls_decl) => {
@@ -863,18 +879,13 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       }
       ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => {
         let empty = fn_decl.is_side_effect_free();
-        if empty || fn_decl.pure {
-          self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-          let flags = self
-            .result
-            .symbol_ref_db
-            .flags
-            .entry(self.result.default_export_ref.symbol)
-            .or_default();
-          flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
-          if fn_decl.pure && !empty {
-            flags.insert(SymbolRefFlags::PureAnnotationOnly);
-          }
+        if let Some(pure_annotation_only) =
+          self.side_effect_free_function_pure_annotation_only(empty, fn_decl.pure)
+        {
+          self.add_side_effect_free_function_symbol(
+            self.result.default_export_ref.symbol,
+            pure_annotation_only,
+          );
         }
         fn_decl.id.as_ref().map(|id| {
           let symbol_id = id.symbol_id();
@@ -1123,6 +1134,88 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       return;
     }
     self.result.constant_export_map.insert(symbol_id, value);
+  }
+
+  pub fn side_effect_free_function_pure_annotation_only(
+    &self,
+    empty: bool,
+    pure: bool,
+  ) -> Option<bool> {
+    if empty {
+      Some(false)
+    } else if pure && !self.immutable_ctx.flat_options.ignore_annotations() {
+      Some(true)
+    } else {
+      None
+    }
+  }
+
+  pub fn add_side_effect_free_function_symbol(
+    &mut self,
+    symbol_id: SymbolId,
+    pure_annotation_only: bool,
+  ) -> bool {
+    if self.result.ecma_view_meta.has_eval()
+      || (pure_annotation_only && self.immutable_ctx.flat_options.ignore_annotations())
+    {
+      return false;
+    }
+    {
+      let flags = self.result.symbol_ref_db.flags.entry(symbol_id).or_default();
+      flags.insert(SymbolRefFlags::SideEffectsFreeFunction);
+      if pure_annotation_only {
+        flags.insert(SymbolRefFlags::PureAnnotationOnly);
+      }
+    }
+    let symbol_ref: SymbolRef = (self.immutable_ctx.idx, symbol_id).into();
+    if self.is_not_reassigned_side_effect_free_function(symbol_id)
+      && self.result.named_exports.values().any(|export| export.referenced == symbol_ref)
+    {
+      self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
+    }
+    true
+  }
+
+  pub fn add_var_initialized_side_effect_free_function_symbol(
+    &mut self,
+    symbol_id: SymbolId,
+    pure_annotation_only: bool,
+  ) {
+    if self.add_side_effect_free_function_symbol(symbol_id, pure_annotation_only) {
+      self
+        .result
+        .symbol_ref_db
+        .flags
+        .entry(symbol_id)
+        .or_default()
+        .insert(SymbolRefFlags::VarInitializedSideEffectsFreeFunction);
+    }
+  }
+
+  pub fn discard_side_effect_free_function_symbols(&mut self) {
+    for flags in self.result.symbol_ref_db.flags.values_mut() {
+      flags.remove(
+        SymbolRefFlags::SideEffectsFreeFunction
+          | SymbolRefFlags::PureAnnotationOnly
+          | SymbolRefFlags::VarInitializedSideEffectsFreeFunction
+          | SymbolRefFlags::DelayedDefaultExportSideEffectsFreeFunction,
+      );
+    }
+    self.result.ecma_view_meta.remove(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
+  }
+
+  fn is_symbol_reassigned(&self, symbol_id: SymbolId) -> bool {
+    self.result.symbol_ref_db.get_resolved_references(symbol_id).any(Reference::is_write)
+  }
+
+  fn is_not_reassigned_side_effect_free_function(&self, symbol_id: SymbolId) -> bool {
+    if self.result.ecma_view_meta.has_eval() {
+      return false;
+    }
+    self.result.symbol_ref_db.flags.get(&symbol_id).is_some_and(|flags| {
+      flags.contains(SymbolRefFlags::IsNotReassigned)
+        && flags.contains(SymbolRefFlags::SideEffectsFreeFunction)
+    })
   }
 
   fn is_import_expr_ignored_by_comment(&mut self, expr: &ImportExpression<'ast>) -> bool {

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -89,6 +89,7 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         transferred_import_record,
         rendered_concatenated_wrapped_module_parts: RenderedConcatenatedModuleParts::default(),
         json_module_inlined_prop: need_inline_json_prop.then(|| Box::new(FxHashMap::default())),
+        static_import_cycle_cache: FxHashMap::default(),
       };
       finalizer.visit_program(oxc_program);
       (finalizer.transferred_import_record, finalizer.rendered_concatenated_wrapped_module_parts)

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -430,8 +430,12 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             .and_then(|ref_id| self.scope.scoping().get_reference(ref_id).symbol_id())
             .map(|id| {
               let symbol_ref = self.ctx.symbol_db.canonical_ref_for((self.ctx.idx, id).into());
-              symbol_ref.is_side_effect_free_function(self.ctx.symbol_db, self.ctx.modules)
-                && symbol_ref.is_not_reassigned(self.ctx.symbol_db)
+              symbol_ref.is_side_effect_free_function_with_cycle_cache(
+                self.ctx.symbol_db,
+                self.ctx.modules,
+                self.ctx.idx,
+                &mut self.static_import_cycle_cache,
+              ) && symbol_ref.is_not_reassigned(self.ctx.symbol_db)
             })
             .unwrap_or(false);
           if is_empty_function {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -96,6 +96,7 @@ pub struct ScopeHoistingFinalizer<'me, 'ast: 'me> {
   pub transferred_import_record: FxIndexMap<ImportRecordIdx, String>,
   pub rendered_concatenated_wrapped_module_parts: RenderedConcatenatedModuleParts,
   pub json_module_inlined_prop: Option<Box<FxHashMap<SymbolId, ast::Expression<'ast>>>>,
+  pub static_import_cycle_cache: FxHashMap<ModuleIdx, bool>,
 }
 
 impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -208,6 +208,7 @@ impl LinkStage<'_> {
           let mut ctx = CrossModuleOptimizationRunnerContext {
             local_constant_symbol_map: FxHashMap::default(),
             tree_shaking_flags_mutations: FxHashMap::default(),
+            static_import_cycle_cache: FxHashMap::default(),
             side_effect_free_call_expr_node_ids: FxHashSet::default(),
             immutable_ctx: CrossModuleOptimizationImmutableCtx {
               eval_ctx: &eval_ctx,
@@ -300,6 +301,7 @@ struct CrossModuleOptimizationImmutableCtx<'a, 'ast: 'a> {
 struct CrossModuleOptimizationRunnerContext<'a, 'ast: 'a> {
   local_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
   tree_shaking_flags_mutations: FxHashMap<StmtInfoIdx, StmtEvalFlags>,
+  static_import_cycle_cache: FxHashMap<ModuleIdx, bool>,
   side_effect_free_call_expr_node_ids: FxHashSet<NodeId>,
   immutable_ctx: CrossModuleOptimizationImmutableCtx<'a, 'ast>,
   toplevel_stmt_idx: StmtInfoIdx,
@@ -418,9 +420,12 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
         // whose export binding is later reassigned would, at the call site, invoke the
         // replacement (which may have side effects), so the call must not be dropped. This
         // mirrors what finalization checks for identifier callees.
-        let is_free = symbol_ref
-          .is_side_effect_free_function(self.immutable_ctx.symbols, self.immutable_ctx.modules)
-          && symbol_ref.is_not_reassigned(self.immutable_ctx.symbols);
+        let is_free = symbol_ref.is_side_effect_free_function_with_cycle_cache(
+          self.immutable_ctx.symbols,
+          self.immutable_ctx.modules,
+          self.immutable_ctx.module_idx,
+          &mut self.static_import_cycle_cache,
+        ) && symbol_ref.is_not_reassigned(self.immutable_ctx.symbols);
         let is_annotation_only = is_free
           && self
             .immutable_ctx

--- a/crates/rolldown/tests/rolldown/issues/8793/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8793/artifacts.snap
@@ -31,7 +31,7 @@ console.log(class {
 	constructor() {
 		console.log(Ub);
 	}
-	static p = Ub$1({});
+	static p = /* @__PURE__ */ Ub$1({});
 });
 //#endregion
 

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -1,7 +1,10 @@
 use oxc::semantic::SymbolId;
 use rolldown_std_utils::OptionExt;
+use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{EcmaViewMeta, IndexModules, Module, ModuleIdx, SymbolRefDb, SymbolRefFlags};
+use crate::{
+  EcmaViewMeta, ImportKind, IndexModules, Module, ModuleIdx, SymbolRefDb, SymbolRefFlags,
+};
 
 use super::symbol_ref_db::{GetLocalDb, GetLocalDbMut};
 
@@ -48,13 +51,64 @@ impl SymbolRef {
   }
 
   pub fn is_side_effect_free_function(&self, db: &SymbolRefDb, modules: &IndexModules) -> bool {
+    let mut static_import_cycle_cache = FxHashMap::default();
+    // Without a caller module, variable-initialized functions must stay conservative because
+    // their initialization order cannot be checked.
+    self.is_side_effect_free_function_with_cycle_cache(
+      db,
+      modules,
+      self.owner,
+      &mut static_import_cycle_cache,
+    )
+  }
+
+  pub fn is_side_effect_free_function_with_cycle_cache(
+    &self,
+    db: &SymbolRefDb,
+    modules: &IndexModules,
+    callsite_module_idx: ModuleIdx,
+    static_import_cycle_cache: &mut FxHashMap<ModuleIdx, bool>,
+  ) -> bool {
     let Some(normal_module) = modules[self.owner].as_normal() else {
       return false;
     };
     if !normal_module.meta.contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction) {
       return false;
     }
-    self.flags(db).is_some_and(|flag| flag.contains(SymbolRefFlags::SideEffectsFreeFunction))
+    if normal_module.meta.has_eval() {
+      return false;
+    }
+    let Some(flag) = self.flags(db) else {
+      return false;
+    };
+    if !flag.contains(SymbolRefFlags::IsNotReassigned)
+      || !flag.contains(SymbolRefFlags::SideEffectsFreeFunction)
+    {
+      return false;
+    }
+    if flag.contains(SymbolRefFlags::VarInitializedSideEffectsFreeFunction)
+      && self.owner == callsite_module_idx
+    {
+      return false;
+    }
+    if flag.intersects(
+      SymbolRefFlags::VarInitializedSideEffectsFreeFunction
+        | SymbolRefFlags::DelayedDefaultExportSideEffectsFreeFunction,
+    ) {
+      if *static_import_cycle_cache
+        .entry(self.owner)
+        .or_insert_with(|| module_has_static_import_cycle(self.owner, modules))
+      {
+        return false;
+      }
+      if *static_import_cycle_cache
+        .entry(callsite_module_idx)
+        .or_insert_with(|| module_has_static_import_cycle(callsite_module_idx, modules))
+      {
+        return false;
+      }
+    }
+    true
   }
 
   pub fn is_declared_in_root_scope(&self, db: &SymbolRefDb) -> bool {
@@ -91,6 +145,34 @@ impl SymbolRef {
       Module::External(_) => true,
     }
   }
+}
+
+fn module_has_static_import_cycle(module_idx: ModuleIdx, modules: &IndexModules) -> bool {
+  let mut seen = FxHashSet::default();
+  has_static_import_path_to(module_idx, module_idx, modules, &mut seen)
+}
+
+fn has_static_import_path_to(
+  target: ModuleIdx,
+  current: ModuleIdx,
+  modules: &IndexModules,
+  seen: &mut FxHashSet<ModuleIdx>,
+) -> bool {
+  let Some(module) = modules[current].as_normal() else {
+    return false;
+  };
+  module.import_records.iter().any(|record| {
+    if !matches!(record.kind, ImportKind::Import | ImportKind::Require) {
+      return false;
+    }
+    let Some(next) = record.resolved_module else {
+      return false;
+    };
+    if next == target {
+      return true;
+    }
+    seen.insert(next) && has_static_import_path_to(target, next, modules, seen)
+  })
 }
 
 /// passing a `SymbolRef`, it will return it's string repr, the format:

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -24,7 +24,7 @@ pub struct SymbolRefDataClassic {
 
 bitflags::bitflags! {
   #[derive(Debug, Default, Clone, Copy)]
-  pub struct SymbolRefFlags: u8 {
+  pub struct SymbolRefFlags: u16 {
     const IsNotReassigned = 1;
     /// The function is side-effect-free solely because of a `@__NO_SIDE_EFFECTS__` annotation,
     /// NOT because its body is empty. Such functions may still use their arguments, so
@@ -58,6 +58,14 @@ bitflags::bitflags! {
     /// for facade (generated) symbols — user-defined names are left unchanged
     /// because `<obj.Foo>` is already a valid component reference in JSX.
     const UsedAsJSXMemberExprRoot = 1 << 6;
+    /// The side-effect-free function comes from a top-level variable initializer.
+    /// Unlike function declarations, this binding is not initialized until its
+    /// declaration executes.
+    const VarInitializedSideEffectsFreeFunction = 1 << 7;
+    /// This symbol is exposed through a delayed default export expression such as
+    /// `export default f`. In a static cycle, importing `default` can observe the
+    /// export binding before that export statement executes.
+    const DelayedDefaultExportSideEffectsFreeFunction = 1 << 8;
   }
 }
 

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/function.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/function.rs
@@ -6,7 +6,7 @@ pub trait FunctionExt {
 
 impl FunctionExt for oxc::ast::ast::FormalParameters<'_> {
   fn is_side_effect_free(&self) -> bool {
-    self.items.iter().all(|param| {
+    let simple_params = self.items.iter().all(|param| {
       // Check for default values with side effects
       // Type annotations are removed at compile time and cannot have side effects
       // No need to check for them
@@ -28,7 +28,12 @@ impl FunctionExt for oxc::ast::ast::FormalParameters<'_> {
           param.initializer.is_none()
         }
       }
-    })
+    });
+
+    simple_params
+      && self.rest.as_ref().is_none_or(|rest| {
+        matches!(rest.rest.argument, oxc::ast::ast::BindingPattern::BindingIdentifier(_))
+      })
   }
 }
 

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/_config.ts
@@ -1,0 +1,16 @@
+import type { OutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    platform: 'browser',
+    treeshake: true,
+  },
+  afterTest: (output) => {
+    const chunks = output.output.filter((chunk): chunk is OutputChunk => chunk.type === 'chunk');
+    const iconsChunk = chunks.find((chunk) => chunk.code.includes('UsedIcon'));
+    expect(iconsChunk?.code).toContain('UsedIcon');
+    expect(iconsChunk?.code).not.toContain('UnusedIcon');
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/app.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/app.js
@@ -1,0 +1,5 @@
+export function setup() {
+  void import('./icons.js');
+}
+
+export default setup;

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/icon-lib.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/icon-lib.js
@@ -1,0 +1,30 @@
+import { createVNode, defineComponent as component, isVNode } from './vue.js';
+
+const slice = Array.prototype.slice;
+function createElement(tag, props = null, children = null) {
+  if (arguments.length > 3 || isVNode(children)) {
+    children = slice.call(arguments, 2);
+  }
+  return createVNode(tag, props, children);
+}
+
+const UsedIcon = component({
+    name: 'UsedIcon',
+    props: {
+      size: { type: String, default: '24px' },
+    },
+    render() {
+      return createElement('svg', { width: this.size });
+    },
+  }),
+  UnusedIcon = component({
+    name: 'UnusedIcon',
+    props: {
+      size: { type: String, default: '24px' },
+    },
+    render() {
+      return createElement('svg', { width: this.size });
+    },
+  });
+
+export { UsedIcon, UnusedIcon };

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/icons.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/icons.js
@@ -1,0 +1,8 @@
+import { UsedIcon } from './icon-lib.js';
+import { createVNode, defineComponent, unref } from './vue.js';
+
+export default /* @__PURE__ */ defineComponent({
+  render() {
+    return createVNode(unref(UsedIcon));
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/main.js
@@ -1,0 +1,4 @@
+import { createApp } from './runtime.js';
+import App from './app.js';
+
+createApp(App);

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/runtime-dom.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/runtime-dom.js
@@ -1,0 +1,1 @@
+export * from './runtime.js';

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/runtime.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/runtime.js
@@ -1,0 +1,27 @@
+export function createApp(app) {
+  app();
+}
+
+export function createVNode(tag, props, children) {
+  return { tag, props, children };
+}
+
+const extend = Object.assign;
+const isFunction = (value) => typeof value === 'function';
+
+// @__NO_SIDE_EFFECTS__
+function defineComponent(options, extraOptions) {
+  return isFunction(options)
+    ? /* @__PURE__ */ (() => extend({ name: options.name }, extraOptions, { setup: options }))()
+    : options;
+}
+
+export function isVNode(value) {
+  return !!value;
+}
+
+export function unref(value) {
+  return value;
+}
+
+export { defineComponent };

--- a/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/vue.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/dynamic-import-side-effects-barrel/vue.js
@@ -1,0 +1,1 @@
+export * from './runtime-dom.js';

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/_config.ts
@@ -1,0 +1,20 @@
+import type { OutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    treeshake: {
+      annotations: false,
+    },
+  },
+  afterTest: (output) => {
+    const code = output.output
+      .filter((chunk): chunk is OutputChunk => chunk.type === 'chunk')
+      .map((chunk) => chunk.code)
+      .join('\n');
+
+    expect(code).toContain('annotatedSideEffect');
+    expect(code).toContain('annotated();');
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/annotated.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/annotated.js
@@ -1,0 +1,6 @@
+// @__NO_SIDE_EFFECTS__
+function annotated() {
+  globalThis.annotatedSideEffect = true;
+}
+
+export { annotated };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-annotations-false/main.js
@@ -1,0 +1,3 @@
+import { annotated } from './annotated.js';
+
+annotated();

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/_config.ts
@@ -1,0 +1,42 @@
+import type { OutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      // This fixture checks tree-shaker metadata before final chunk DCE reparses the output.
+      minify: false,
+    },
+    treeshake: true,
+  },
+  afterTest: (output) => {
+    const code = output.output
+      .filter((chunk): chunk is OutputChunk => chunk.type === 'chunk')
+      .map((chunk) => chunk.code)
+      .join('\n');
+
+    expect(code).toContain('reassignedSideEffect');
+    expect(code).toContain('reassignedResult = reassigned();');
+    expect(code).toContain('var maybeFn = function() {};');
+    expect(code).toContain('conditionalBinding = maybeFn;');
+    expect(code).toContain('evalReassigned = () =>');
+    expect(code).toContain('evalReassigned();');
+    expect(code).toContain('cyclic();');
+    expect(code).toContain('defaultCyclic();');
+    expect(code).toContain('defaultCycleAfterCall');
+    expect(code).toContain('localEarlyAccess();');
+    expect(code).toContain('barrelFn();');
+    expect(code).toContain('restDefaultSideEffect');
+    expect(code).toContain('restDefault();');
+    expect(code).not.toContain('/* @__PURE__ */ reassigned()');
+    expect(code).not.toContain('/* @__PURE__ */ maybeFn()');
+    expect(code).not.toContain('/* @__PURE__ */ evalReassigned()');
+    expect(code).not.toContain('/* @__PURE__ */ cyclic()');
+    expect(code).not.toContain('/* @__PURE__ */ defaultCyclic()');
+    expect(code).not.toContain('/* @__PURE__ */ localEarlyAccess()');
+    expect(code).not.toContain('/* @__PURE__ */ barrelFn()');
+    expect(code).not.toContain('/* @__PURE__ */ restDefault()');
+    expect(code).not.toContain('unusedDefaultMarker');
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-a.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-a.js
@@ -1,0 +1,3 @@
+const barrelFn = function () {};
+
+export { barrelFn };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-b.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-b.js
@@ -1,0 +1,3 @@
+import './barrel-c.js';
+
+export { barrelFn } from './barrel-a.js';

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-c.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/barrel-c.js
@@ -1,0 +1,3 @@
+import { barrelFn } from './barrel-b.js';
+
+barrelFn();

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/conditional.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/conditional.js
@@ -1,0 +1,5 @@
+if (globalThis.condition) {
+  var maybeFn = function () {};
+}
+
+export { maybeFn };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-a.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-a.js
@@ -1,0 +1,5 @@
+import './cycle-b.js';
+
+const cyclic = function () {};
+
+export { cyclic };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-b.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-b.js
@@ -1,0 +1,3 @@
+import { cyclic } from './cycle-a.js';
+
+cyclic();

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-entry.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/cycle-entry.js
@@ -1,0 +1,1 @@
+import './cycle-a.js';

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default-cycle-a.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default-cycle-a.js
@@ -1,0 +1,5 @@
+function defaultCyclic() {}
+
+import './default-cycle-b.js';
+
+export default defaultCyclic;

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default-cycle-b.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default-cycle-b.js
@@ -1,0 +1,4 @@
+import defaultCyclic from './default-cycle-a.js';
+
+defaultCyclic();
+globalThis.defaultCycleAfterCall = true;

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/default.js
@@ -1,0 +1,3 @@
+const defaultFn = function () {};
+
+export default defaultFn;

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/eval.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/eval.js
@@ -1,0 +1,5 @@
+function evalReassigned() {}
+
+eval('evalReassigned = () => { globalThis.evalHit = true }');
+
+export { evalReassigned };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/main.js
@@ -1,0 +1,15 @@
+import defaultFn from './default.js';
+import './barrel-b.js';
+import './cycle-entry.js';
+import './default-cycle-a.js';
+import './pre-init.js';
+import { maybeFn } from './conditional.js';
+import { evalReassigned } from './eval.js';
+import { reassigned } from './reassigned.js';
+import { restDefault } from './rest.js';
+
+defaultFn(() => import('./unused-default.js'));
+globalThis.reassignedResult = reassigned();
+globalThis.conditionalBinding = maybeFn;
+evalReassigned();
+restDefault();

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/pre-init.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/pre-init.js
@@ -1,0 +1,5 @@
+localEarlyAccess();
+
+const localEarlyAccess = function () {};
+
+export { localEarlyAccess };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/reassigned.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/reassigned.js
@@ -1,0 +1,7 @@
+function reassigned() {}
+
+reassigned = function () {
+  globalThis.reassignedSideEffect = true;
+};
+
+export { reassigned };

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/rest.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/rest.js
@@ -1,0 +1,1 @@
+export function restDefault(...[value = globalThis.restDefaultSideEffect()]) {}

--- a/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/unused-default.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/side-effect-free-export-safety/unused-default.js
@@ -1,0 +1,1 @@
+export const unusedDefaultMarker = 'unused-default-marker';


### PR DESCRIPTION
### Summary

- preserve side-effect-free function metadata when a top-level function is declared first and exported later via `export { foo }`
- let cross-module optimization mark calls to Vue-style `defineComponent` exports as pure in dynamically imported chunks
- add a regression fixture with a Vue-shaped runtime and a dynamic icon chunk

### Background

Vue declares `defineComponent` with `@__NO_SIDE_EFFECTS__` and then exports it from an export list. The scanner already handled `export function foo()` and exported function-valued variables, but it missed this separated declaration/export shape. In the Vite reproduction from vitejs/vite#22725, that meant unused icon component factories in a dynamic chunk were kept as side-effectful bare calls.

Addresses vitejs/vite#22725.

### Tests

- `PATH="$PWD/node_modules/.bin:$PATH" just build-rolldown`
- `PATH="$PWD/node_modules/.bin:$PATH" pnpm exec vp run --filter rolldown-tests test:main fixtures-concurrent.test.ts -t dynamic-import-side-effects-barrel`
- direct Rolldown smoke with the Vite-style repro: dynamic icon chunk is 2.2 kB and no longer contains `Ri24HoursFill`
- `git diff --check`
