### PR TITLE
fix(dev): cancel pending full reload on build error

### DIFF
--- a/packages/test-dev-server/src/environments/full-bundle-dev-environment.ts
+++ b/packages/test-dev-server/src/environments/full-bundle-dev-environment.ts
@@ -302,6 +302,8 @@ export class FullBundleDevEnvironment {
     if (result instanceof Error) {
       this.logger.error('Build error:', result);
       this.#lastBuildError = result;
+      // Cancel any queued full reload so we never reload onto a broken bundle.
+      this.#fullReloadPending = false;
       this.#broadcastError(result);
       this.#buildSeq++;
       return;


### PR DESCRIPTION
## What

In `FullBundleDevEnvironment.#onOutput`, when a full build errors, clear `#fullReloadPending` before broadcasting the error.

## Why

A `FullReload` HMR update queues a deferred reload by setting `#fullReloadPending = true`, expecting the auto-upgraded rebuild to land in `#onOutput` and trigger the reload. If that rebuild instead *errors*, the pending flag would otherwise survive and could fire a full reload onto the broken bundle. Clearing it here keeps the error overlay up and avoids reloading onto a bad build.

## Reference

Ports vite commit `63fb591d1f3b17750fdad553ce881670f4df6ad0`, which made the equivalent change in `bundledDev.ts`'s `onOutput` error branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)