### PR TITLE
fix(watch): make close reentrant in event callbacks

### DIFF
--- a/crates/rolldown_watcher/src/handler.rs
+++ b/crates/rolldown_watcher/src/handler.rs
@@ -1,8 +1,9 @@
 use crate::event::WatchEvent;
 use rolldown_common::WatcherChangeKind;
 
-/// Handler for watcher events. All methods are async and awaited by the coordinator,
-/// providing blocking semantics matching Rollup's behavior.
+/// Handler for watcher events. Methods are async and normally awaited by the coordinator,
+/// providing blocking semantics matching Rollup's behavior. A close request may interrupt the
+/// wait for `on_event`, `on_change`, or `on_restart` so callbacks can close their own watcher.
 ///
 /// NAPI bindings will implement this trait in a follow-up PR.
 pub trait WatcherEventHandler: Send + Sync {

--- a/crates/rolldown_watcher/src/watch_coordinator.rs
+++ b/crates/rolldown_watcher/src/watch_coordinator.rs
@@ -8,9 +8,12 @@ use crate::watcher_state::WatcherState;
 use oxc_index::IndexVec;
 use rolldown_common::WatcherChangeKind;
 use rolldown_utils::indexmap::FxIndexMap;
+use std::future::Future;
 use std::mem;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 
 /// The coordinator actor that owns all state and runs the event loop.
 pub struct WatchCoordinator<H: WatcherEventHandler> {
@@ -19,6 +22,8 @@ pub struct WatchCoordinator<H: WatcherEventHandler> {
   state: WatcherState,
   debounce_duration: Duration,
   tasks: IndexVec<WatchTaskIdx, WatchTask>,
+  closed: Arc<AtomicBool>,
+  close_notify: Arc<Notify>,
 }
 
 impl<H: WatcherEventHandler> WatchCoordinator<H> {
@@ -27,6 +32,8 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
     handler: H,
     tasks: IndexVec<WatchTaskIdx, WatchTask>,
     config: &WatcherConfig,
+    closed: Arc<AtomicBool>,
+    close_notify: Arc<Notify>,
   ) -> Self {
     Self {
       rx,
@@ -34,13 +41,18 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
       state: WatcherState::Idle,
       debounce_duration: config.debounce_duration(),
       tasks,
+      closed,
+      close_notify,
     }
   }
 
   /// Main event loop: initial build → loop on state
   pub(crate) async fn run(mut self) {
     // Perform initial build
-    self.run_initial_build().await;
+    if !self.run_initial_build().await {
+      self.handle_close().await;
+      return;
+    }
 
     loop {
       match &self.state {
@@ -66,7 +78,10 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
               self.state = new_state;
 
               if let Some(changes) = changes {
-                self.run_build_sequence(changes).await;
+                if !self.run_build_sequence(changes).await {
+                  self.handle_close().await;
+                  break;
+                }
               }
             }
             msg = self.rx.recv() => {
@@ -91,23 +106,31 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
   }
 
   /// Run the initial build for all tasks
-  async fn run_initial_build(&mut self) {
-    self.handler.on_event(WatchEvent::Start).await;
+  async fn run_initial_build(&mut self) -> bool {
+    if !self.dispatch_event(WatchEvent::Start).await {
+      return false;
+    }
 
     for task_index in self.tasks.indices() {
       let task = &self.tasks[task_index];
-      self.handler.on_event(WatchEvent::BundleStart(task.start_event_data(task_index))).await;
+      if !self.dispatch_event(WatchEvent::BundleStart(task.start_event_data(task_index))).await {
+        return false;
+      }
 
       let task = &mut self.tasks[task_index];
       match task.build(task_index).await {
         Ok(BuildOutcome::Success(data)) => {
-          self.handler.on_event(WatchEvent::BundleEnd(data)).await;
+          if !self.dispatch_event(WatchEvent::BundleEnd(data)).await {
+            return false;
+          }
         }
         Ok(BuildOutcome::Error(data)) => {
-          self.handler.on_event(WatchEvent::Error(data)).await;
+          if !self.dispatch_event(WatchEvent::Error(data)).await {
+            return false;
+          }
         }
         Ok(BuildOutcome::Skipped) => {}
-        Ok(BuildOutcome::Closed) => return,
+        Ok(BuildOutcome::Closed) => return false,
         Err(errs) => {
           let error_messages: Vec<String> =
             errs.iter().map(|e| e.to_diagnostic().to_string()).collect();
@@ -116,7 +139,7 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
       }
     }
 
-    self.handler.on_event(WatchEvent::End).await;
+    self.dispatch_event(WatchEvent::End).await
   }
 
   /// The rebuild sequence matching Rollup's semantics (spec §2.8):
@@ -127,10 +150,12 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
   /// 5. For each task needing rebuild: BundleStart → build → BundleEnd/Error
   /// 6. handler.on_event(End)
   /// 7. drain_buffered_events
-  async fn run_build_sequence(&mut self, changes: FxIndexMap<String, WatcherChangeKind>) {
+  async fn run_build_sequence(&mut self, changes: FxIndexMap<String, WatcherChangeKind>) -> bool {
     // Step 1 & 2: Notify handler and plugin hooks for each change
     for (path, kind) in &changes {
-      self.handler.on_change(path.as_str(), *kind).await;
+      if !self.dispatch_change(path.as_str(), *kind).await {
+        return false;
+      }
     }
 
     for task in &self.tasks {
@@ -140,10 +165,14 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
     }
 
     // Step 3: Restart notification
-    self.handler.on_restart().await;
+    if !self.dispatch_restart().await {
+      return false;
+    }
 
     // Step 4: Start event
-    self.handler.on_event(WatchEvent::Start).await;
+    if !self.dispatch_event(WatchEvent::Start).await {
+      return false;
+    }
 
     // Step 5: Build each task that needs it
     for task_index in self.tasks.indices() {
@@ -152,18 +181,24 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
       }
 
       let task = &self.tasks[task_index];
-      self.handler.on_event(WatchEvent::BundleStart(task.start_event_data(task_index))).await;
+      if !self.dispatch_event(WatchEvent::BundleStart(task.start_event_data(task_index))).await {
+        return false;
+      }
 
       let task = &mut self.tasks[task_index];
       match task.build(task_index).await {
         Ok(BuildOutcome::Success(data)) => {
-          self.handler.on_event(WatchEvent::BundleEnd(data)).await;
+          if !self.dispatch_event(WatchEvent::BundleEnd(data)).await {
+            return false;
+          }
         }
         Ok(BuildOutcome::Error(data)) => {
-          self.handler.on_event(WatchEvent::Error(data)).await;
+          if !self.dispatch_event(WatchEvent::Error(data)).await {
+            return false;
+          }
         }
         Ok(BuildOutcome::Skipped) => {}
-        Ok(BuildOutcome::Closed) => return,
+        Ok(BuildOutcome::Closed) => return false,
         Err(errs) => {
           let error_messages: Vec<String> =
             errs.iter().map(|e| e.to_diagnostic().to_string()).collect();
@@ -173,10 +208,48 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
     }
 
     // Step 6: End event
-    self.handler.on_event(WatchEvent::End).await;
+    if !self.dispatch_event(WatchEvent::End).await {
+      return false;
+    }
 
     // Step 7: Drain buffered events that arrived during the build
     self.drain_buffered_events().await;
+    true
+  }
+
+  async fn dispatch_event(&self, event: WatchEvent) -> bool {
+    self.await_handler_or_close(self.handler.on_event(event)).await
+  }
+
+  async fn dispatch_change(&self, path: &str, kind: WatcherChangeKind) -> bool {
+    self.await_handler_or_close(self.handler.on_change(path, kind)).await
+  }
+
+  async fn dispatch_restart(&self) -> bool {
+    self.await_handler_or_close(self.handler.on_restart()).await
+  }
+
+  /// Await a consumer event callback while keeping close re-entrant.
+  ///
+  /// A callback may call and await `watcher.close()`. Waiting only for the callback would deadlock:
+  /// close waits for this coordinator, while the coordinator waits for the callback. On close, drop
+  /// only the Rust-side wait for the callback; the JavaScript promise keeps running, and the
+  /// coordinator performs the complete close sequence before `watcher.close()` resolves.
+  async fn await_handler_or_close<F>(&self, handler: F) -> bool
+  where
+    F: Future<Output = ()>,
+  {
+    let wait_for_close = async {
+      if !self.closed.load(Ordering::Relaxed) {
+        self.close_notify.notified().await;
+      }
+    };
+
+    tokio::select! {
+      biased;
+      () = wait_for_close => false,
+      () = handler => !self.closed.load(Ordering::Relaxed),
+    }
   }
 
   /// Process file changes: call on_invalidate per file, mark task for rebuild,

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -14,7 +14,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 
 /// Default debounce duration in milliseconds.
 /// Matches Rollup's default buildDelay of 0ms.
@@ -76,6 +76,7 @@ pub struct Watcher {
   coordinator_state: std::sync::Mutex<CoordinatorState>,
   tx: mpsc::UnboundedSender<WatcherMsg>,
   closed: Arc<AtomicBool>,
+  close_notify: Arc<Notify>,
 }
 
 impl Watcher {
@@ -88,8 +89,16 @@ impl Watcher {
   ) -> BuildResult<Self> {
     let (tx, rx) = mpsc::unbounded_channel();
     let closed = Arc::new(AtomicBool::new(false));
+    let close_notify = Arc::new(Notify::new());
     let tasks = Self::create_tasks(configs, watcher_config, &tx, &closed)?;
-    let coordinator = WatchCoordinator::new(rx, handler, tasks, watcher_config);
+    let coordinator = WatchCoordinator::new(
+      rx,
+      handler,
+      tasks,
+      watcher_config,
+      Arc::clone(&closed),
+      Arc::clone(&close_notify),
+    );
     let coordinator_future: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(coordinator.run());
 
     Ok(Self {
@@ -99,6 +108,7 @@ impl Watcher {
       }),
       tx,
       closed,
+      close_notify,
     })
   }
 
@@ -126,6 +136,9 @@ impl Watcher {
   /// Must be called after `run()` — calling before `run()` will skip cleanup hooks.
   pub async fn close(&self) -> Result<()> {
     self.closed.store(true, std::sync::atomic::Ordering::Relaxed);
+    // Wake the coordinator even when it is waiting for a user event callback. The mpsc message
+    // remains the normal state-machine input when the coordinator is idle or debouncing.
+    self.close_notify.notify_one();
     let _ = self.tx.send(WatcherMsg::Close);
     self.wait_for_close().await;
     Ok(())

--- a/internal-docs/watch-mode/design.md
+++ b/internal-docs/watch-mode/design.md
@@ -15,6 +15,7 @@ design and the open questions; the machinery lives in
 ## Design Principles
 
 - **JS API aligns with Rollup** — The TypeScript surface (events, options, plugin hooks, lifecycle ordering) should match Rollup's behavior unless there's a technical reason not to. Divergences are documented explicitly.
+- **Close is re-entrant** — A watcher event listener may call and await `watcher.close()`. The close promise still means cleanup is complete; the coordinator must not break the deadlock by resolving it after merely queueing the request.
 - **Rust code follows Rust idioms** — The Rust core should feel native: ownership-driven, enum state machines, trait-based extensibility, no unnecessary `Arc`/`Mutex` beyond what the architecture requires.
 - **Consistent naming across the stack** — Rollup defines the canonical event/concept names (e.g. `BUNDLE_START`/`BUNDLE_END`). The Rust side should use the same terminology so there's a clean 1:1 mapping and no mental translation at the NAPI boundary.
 

--- a/internal-docs/watch-mode/implementation.md
+++ b/internal-docs/watch-mode/implementation.md
@@ -50,7 +50,10 @@ type RolldownWatcherEvent =
   | { code: 'ERROR'; error: Error; result: RolldownWatchBuild };
 ```
 
-All event listeners are **awaited** before proceeding — blocking semantics matching Rollup.
+Event listeners are normally **awaited** before proceeding — blocking semantics matching Rollup.
+The coordinator may stop waiting for an `event`, `change`, or `restart` listener only when a close
+request wins the close-aware dispatch race described below. The JavaScript callback itself keeps
+running, and `watcher.close()` still waits for the complete close sequence.
 
 ### Rust API
 
@@ -60,7 +63,7 @@ watcher.run();       // spawns the coordinator (non-blocking)
 watcher.close().await?;  // sends Close, awaits completion
 ```
 
-Follows the same `new → run → close` pattern as `DevEngine`. `new()` creates the coordinator future but doesn't spawn it. `run()` spawns it on the tokio runtime. `close()` sends a fire-and-forget `Close` message and awaits the shared completion future. `wait_for_close()` gives consumers a reliable way to await the watcher's completion without closing it.
+Follows the same `new → run → close` pattern as `DevEngine`. `new()` creates the coordinator future but doesn't spawn it. `run()` spawns it on the tokio runtime. `close()` sets the shared close signal, sends a fire-and-forget `Close` message, and awaits the shared completion future. `wait_for_close()` gives consumers a reliable way to await the watcher's completion without closing it.
 
 ### Known Divergences from Rollup
 
@@ -77,7 +80,8 @@ Follows the same `new → run → close` pattern as `DevEngine`. `new()` creates
 
 ```
 Watcher (public API)
-  └── tx: mpsc::Sender ──→ WatchCoordinator (actor, owns everything)
+  ├── tx: mpsc::Sender ──→ WatchCoordinator (actor, owns everything)
+  └── close_notify ──────→ wakes the coordinator while it awaits a consumer callback
                                ├── handler: H (WatcherEventHandler impl)
                                ├── state: WatcherState
                                └── tasks: IndexVec<WatchTaskIdx, WatchTask>
@@ -90,12 +94,15 @@ Watcher (public API)
 
 Data flow:
   DynFsWatcher ──(TaskFsEventHandler: maps notify events → FileChangeEvent)──→ WatcherMsg::FileChanges ──→ WatchCoordinator
-  WatchCoordinator ──(handler.on_event().await)──→ Consumer (NAPI/Rust)
+  WatchCoordinator ──→ dispatch_event / dispatch_change / dispatch_restart
+                         └── await_handler_or_close()
+                               ├── handler.on_*().await ──→ Consumer (NAPI/Rust)
+                               └── close_notify ─────────→ stop the callback wait and run handle_close()
 ```
 
 **Ownership rules:**
 
-- `Watcher` only holds `tx` and `coordinator_state` — lightweight, no bundler access.
+- `Watcher` only holds lifecycle state (`tx`, the close signal, and `coordinator_state`) — lightweight, no bundler access.
 - `WatchCoordinator` owns ALL mutable state. No external mutation.
 - Each `WatchTask` owns its `DynFsWatcher`. Per-task watchers mean isolated watch sets and simpler ownership.
 - Bundler is `Arc<TokioMutex<>>` because event data structs carry a clone for consumer access (e.g. `BUNDLE_END.result`).
@@ -252,6 +259,7 @@ File change detected by per-task FsWatcher
 
 ```
 watcher.close() sends WatcherMsg::Close (fire-and-forget)
+  → sets the close flag and notifies any in-progress consumer callback wait
   → awaits shared coordinator future (wait_for_close)
   → handle_close():
       1. State → Closing
@@ -261,6 +269,14 @@ watcher.close() sends WatcherMsg::Close (fire-and-forget)
       5. State → Closed
       6. coordinator future completes → all wait_for_close() callers resolve
 ```
+
+Consumer callbacks are normally blocking, but the coordinator waits for them together with the
+dedicated close signal. If an `event`, `change`, or `restart` listener calls and awaits
+`watcher.close()`, the close signal wins the wait and the coordinator drops only its Rust-side wait
+for that callback. The JavaScript callback and its promise continue running. The coordinator then
+runs the normal close hooks, closes every bundler, and emits `close`; only after that does the
+original `watcher.close()` promise resolve. This breaks the self-wait cycle without weakening the
+meaning of a resolved close promise.
 
 ### Error Recovery
 
@@ -348,13 +364,15 @@ pub trait WatcherEventHandler: Send + Sync {
 }
 ```
 
-All methods are awaited — the coordinator blocks on handler calls, ensuring Rollup-compatible sequential semantics.
+All methods are awaited during normal operation, ensuring Rollup-compatible sequential semantics.
+The `on_event`, `on_change`, and `on_restart` waits are close-aware so an awaited listener can close
+its own watcher without deadlocking. `on_close` remains fully awaited as part of the close sequence.
 
 ## NAPI Bridge
 
 ### Event Handler
 
-`NapiWatcherEventHandler` implements `WatcherEventHandler`, bridging all 4 trait methods to a single JS callback via `ThreadsafeFunction`. Each method wraps its data in a `BindingWatcherEvent` variant and calls `listener.await_call()`, which awaits the JS Promise — ensuring the Rust coordinator blocks until JS handlers finish.
+`NapiWatcherEventHandler` implements `WatcherEventHandler`, bridging all 4 trait methods to a single JS callback via `ThreadsafeFunction`. Each method wraps its data in a `BindingWatcherEvent` variant and calls `listener.await_call()`, which awaits the JS Promise. During normal dispatch the coordinator therefore blocks until the JS handlers finish; if the close signal wins, the close-aware dispatch wrapper drops only this Rust-side wait as described above.
 
 ```rust
 struct NapiWatcherEventHandler {
@@ -400,14 +418,19 @@ Lives in `watcher.ts` (`createEventCallback()` — a standalone function), not i
 
 ```
 WatchCoordinator.run_build_sequence()
-  → handler.on_event(WatchEvent::BundleEnd(data)).await
-  → NapiWatcherEventHandler.on_event()
-    → BindingWatcherEvent::from_watch_event(event)
-    → listener.await_call(binding_event).await → ThreadsafeFunction calls JS
-  → JS: createEventCallback() receives BindingWatcherEvent
-    → Maps to RolldownWatcherEvent { code: 'BUNDLE_END', ... }
-    → emitter.emit('event', mapped_event) → sequential for...of await
-  → Rust: await_call resolves → coordinator continues
+  → dispatch_event(WatchEvent::BundleEnd(data))
+    → await_handler_or_close(handler.on_event(...))
+      ├── callback branch:
+      │     → NapiWatcherEventHandler.on_event()
+      │       → BindingWatcherEvent::from_watch_event(event)
+      │       → listener.await_call(binding_event).await → ThreadsafeFunction calls JS
+      │     → JS: createEventCallback() receives BindingWatcherEvent
+      │       → Maps to RolldownWatcherEvent { code: 'BUNDLE_END', ... }
+      │       → emitter.emit('event', mapped_event) → sequential for...of await
+      │     → await_call resolves → coordinator continues
+      └── close branch:
+            → close_notify resolves → dispatch returns close requested
+            → coordinator runs handle_close() and completes the close sequence
 ```
 
 ## Configuration

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -176,6 +176,65 @@ test.concurrent(
   },
 );
 
+// https://github.com/rolldown/rolldown/issues/9462
+test.concurrent(
+  'watcher.close() can be awaited inside an event callback',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { input, output, dir } = createTestInputAndOutput('watch-close-inside-event', retryCount);
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const closeWatcherFn = vi.fn();
+    const watcher = watch({
+      input,
+      output: { file: output },
+      plugins: [
+        {
+          name: 'test closeWatcher',
+          async closeWatcher() {
+            await sleep(10);
+            closeWatcherFn();
+          },
+        },
+      ],
+    });
+
+    const closeFn = vi.fn();
+    watcher.on('close', async () => {
+      // Closing again from the close listener must remain re-entrant as well.
+      await watcher.close();
+      closeFn();
+    });
+
+    const events: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      watcher.on('event', async (event) => {
+        events.push(event.code);
+        if (event.code !== 'BUNDLE_END') return;
+
+        try {
+          await event.result.close();
+          await watcher.close();
+
+          // close() must not resolve after merely queueing the request. All cleanup and the close
+          // event are complete before its promise settles.
+          expect(closeWatcherFn).toHaveBeenCalledTimes(1);
+          expect(closeFn).toHaveBeenCalledTimes(1);
+          expect(events).not.toContain('END');
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  },
+);
+
 test.concurrent(
   'watch event',
   { retry: TEST_RETRY, timeout: TEST_TIMEOUT },


### PR DESCRIPTION
## Summary

- add an out-of-band close notification so the coordinator remains responsive while awaiting consumer event callbacks
- stop waiting for an in-flight `event`, `change`, or `restart` callback when that callback closes its own watcher, then run the normal complete close sequence
- preserve sequential async listener behavior and the contract that `await watcher.close()` settles only after hooks, bundler cleanup, and the `close` event finish
- document the re-entrant close lifecycle and add an end-to-end regression test

## Root cause

The coordinator awaited the JavaScript event callback, while a callback awaiting `watcher.close()` waited for that same coordinator to finish:

```text
coordinator -> JS callback -> watcher.close() -> coordinator
```

The queued `WatcherMsg::Close` could not be processed until the callback returned, so neither side could make progress.

## Design

`Watcher::close()` now both queues the normal state-machine message and wakes a dedicated close notification. Consumer callback dispatch waits on the callback and that notification together. If close wins, only the Rust-side wait for the callback is dropped; the JavaScript promise continues running while the coordinator executes the existing close hooks, bundler cleanup, and close event. The original close promise then resolves and the callback resumes.

This differs from the request-only approach in #9475: a re-entrant `close()` does not resolve early before cleanup has completed.

Fixes #9462.

## Tests

- `just build-rolldown`
- `just build-rolldown-test-dev-server`
- `RUST_BACKTRACE=1 ROLLDOWN_TEST=1 pnpm --filter rolldown-tests test:watcher` (36 passed)
- `cargo test -p rolldown_watcher --lib` (17 passed)
- `cargo clippy -p rolldown_watcher --all-targets -- --deny warnings`
- `just lint-repo`
- `vp check`
