### PR TITLE
docs: note Rust crates don't follow semver in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Rolldown is a JavaScript/TypeScript bundler written in Rust and TypeScript, desi
 
 - You are an expert Rust, JavaScript and TypeScript developer.
 - Rolldown's performance is critical for developers and tools built on top of it. As such, it is critical to aim for best possible performance when optimizing Rolldown.
+- The `rolldown_*` Rust crates do not follow semver (see `docs/apis/rust-crates.md`). Breaking API changes are expected and acceptable in any version — do not raise them as code-review findings as long as in-repo callers are updated.
 
 </tips>
 


### PR DESCRIPTION
## What

Adds a one-line tip to `AGENTS.md` telling reviewing agents that the `rolldown_*` Rust crates do not follow the semver contract, so breaking API changes should not be raised as code-review findings (as long as in-repo callers are updated).

## Why

The policy already exists in `docs/apis/rust-crates.md` (added in #9547):

> The crates will not follow the semver contract. Breaking changes may be introduced freely in any version.

But that doc isn't in the context an agent loads when reviewing a diff, so reviewers keep flagging internal crate API changes (e.g. a `&self` → `self` signature change) as breaking-change concerns. `AGENTS.md` is loaded at task start and is shared across agent tooling, making it the right place to surface this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)