### PR TITLE
chore(rolldown_plugin_vite_manifest): remove unused is_enable_v2 code path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,6 @@ dependencies = [
  "derive_more",
  "rolldown_common",
  "rolldown_plugin",
- "rolldown_plugin_utils",
  "rolldown_utils",
  "rustc-hash",
  "serde",

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_manifest_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_manifest_plugin_config.rs
@@ -12,7 +12,6 @@ use crate::types::{
 pub struct BindingViteManifestPluginConfig {
   pub root: String,
   pub out_path: String,
-  pub is_enable_v2: Option<bool>,
   #[napi(ts_type = "(args: BindingNormalizedOptions) => boolean")]
   pub is_legacy: Option<JsCallback<BindingNormalizedOptions, bool>>,
   #[napi(ts_type = "() => Record<string, string>")]
@@ -24,7 +23,6 @@ impl From<BindingViteManifestPluginConfig> for ViteManifestPlugin {
     Self {
       root: value.root,
       out_path: value.out_path,
-      is_enable_v2: value.is_enable_v2.unwrap_or_default(),
       is_legacy: value.is_legacy.map(|cb| -> Arc<IsLegacyFn> {
         Arc::new(move |opts| {
           let opts = Arc::clone(opts);

--- a/crates/rolldown_plugin_vite_manifest/Cargo.toml
+++ b/crates/rolldown_plugin_vite_manifest/Cargo.toml
@@ -22,7 +22,6 @@ cow-utils = { workspace = true }
 derive_more = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["rc"] }

--- a/crates/rolldown_plugin_vite_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/lib.rs
@@ -4,7 +4,6 @@ use std::{borrow::Cow, collections::BTreeMap, path::Path, pin::Pin, sync::Arc};
 
 use rolldown_common::{EmittedAsset, NormalizedBundlerOptions, Output};
 use rolldown_plugin::{HookNoopReturn, HookUsage, Plugin, PluginContext};
-use rolldown_plugin_utils::constants::{CSSEntriesCache, ViteMetadata};
 use rolldown_utils::rustc_hash::FxHashMapExt as _;
 use rustc_hash::FxHashMap;
 
@@ -20,7 +19,6 @@ pub type CssEntriesFn = dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<F
 pub struct ViteManifestPlugin {
   pub root: String,
   pub out_path: String,
-  pub is_enable_v2: bool,
   #[debug(skip)]
   pub is_legacy: Option<Arc<IsLegacyFn>>,
   #[debug(skip)]
@@ -50,37 +48,13 @@ impl Plugin for ViteManifestPlugin {
       match file {
         Output::Chunk(chunk) => {
           let name = self.get_chunk_name(chunk, is_legacy);
-          let vite_metadata = if self.is_enable_v2 {
-            ctx.meta().get::<ViteMetadata>().and_then(|cache| {
-              cache.inner.get(chunk.preliminary_filename.as_str()).map(|v| v.clone())
-            })
-          } else {
-            None
-          };
-          let chunk_manifest = Arc::new(self.create_chunk(
-            args.bundle,
-            chunk,
-            &name,
-            is_legacy,
-            vite_metadata.as_ref(),
-          ));
+          let chunk_manifest = Arc::new(self.create_chunk(args.bundle, chunk, &name, is_legacy));
           manifest.insert(name, chunk_manifest);
         }
         Output::Asset(asset) => {
           if !asset.names.is_empty() {
             if css_entries.is_none() {
-              let reference_ids = if self.is_enable_v2 {
-                ctx
-                  .meta()
-                  .get::<CSSEntriesCache>()
-                  .expect("CSSEntriesCache is missing")
-                  .inner
-                  .iter()
-                  .map(|entry| (entry.key().to_string(), entry.value().to_string()))
-                  .collect::<FxHashMap<_, _>>()
-              } else {
-                (self.css_entries)().await?
-              };
+              let reference_ids = (self.css_entries)().await?;
               let mut filenames = FxHashMap::with_capacity(reference_ids.len());
               for (reference_id, name) in reference_ids {
                 if let Ok(filename) = ctx.get_file_name(&reference_id) {

--- a/crates/rolldown_plugin_vite_manifest/src/utils.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/utils.rs
@@ -1,9 +1,8 @@
-use std::{ffi::OsString, sync::Arc};
+use std::ffi::OsString;
 
 use arcstr::ArcStr;
 use cow_utils::CowUtils;
 use rolldown_common::{Output, OutputAsset, OutputChunk};
-use rolldown_plugin_utils::constants::ChunkMetadata;
 use rolldown_utils::pattern_filter::normalize_path;
 use serde::Serialize;
 
@@ -77,15 +76,7 @@ impl ViteManifestPlugin {
     chunk: &OutputChunk,
     src: &str,
     is_legacy: bool,
-    vite_metadata: Option<&Arc<ChunkMetadata>>,
   ) -> ManifestChunk {
-    let css = vite_metadata
-      .as_ref()
-      .map(|meta| meta.imported_css.iter().map(|s| s.to_string()).collect::<Vec<_>>());
-    let assets = vite_metadata
-      .as_ref()
-      .map(|meta| meta.imported_assets.iter().map(|s| s.to_string()).collect::<Vec<_>>());
-
     ManifestChunk {
       file: chunk.filename.to_string(),
       name: Some(chunk.name.to_string()),
@@ -94,8 +85,8 @@ impl ViteManifestPlugin {
       is_dynamic_entry: chunk.is_dynamic_entry,
       imports: self.get_internal_imports(bundle, &chunk.imports, is_legacy),
       dynamic_imports: self.get_internal_imports(bundle, &chunk.dynamic_imports, is_legacy),
-      css,
-      assets,
+      css: None,
+      assets: None,
       ..Default::default()
     }
   }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2867,7 +2867,6 @@ export type BindingViteJsonPluginStringify =
 export interface BindingViteManifestPluginConfig {
   root: string
   outPath: string
-  isEnableV2?: boolean
   isLegacy?: (args: BindingNormalizedOptions) => boolean
   cssEntries: () => Record<string, string>
 }


### PR DESCRIPTION
### Description

Follow-up to #9889. The unexposed native Vite plugins removed there (`vite_css_post`, `vite_asset`, ...) were the producers of the `ViteMetadata` / `ChunkMetadata` / `CSSEntriesCache` meta caches that fed the `is_enable_v2` branch of `ViteManifestPlugin`.

With those plugins gone, the v2 path has no data source and is dead code, so this removes:

- the `is_enable_v2` field on `ViteManifestPlugin`
- the `ViteMetadata` / `CSSEntriesCache` lookups in `render_chunk`, falling back to the single `(self.css_entries)()` path
- the `vite_metadata` parameter of `create_chunk`; `css` / `assets` on `ManifestChunk` are now always `None`
- the `is_enable_v2` option from `BindingViteManifestPluginConfig` and its `From` impl, and from the JS binding that passes it
