### PR TITLE
perf(common): pack TaggedSymbolRef into 8 bytes

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -461,14 +461,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     self
       .current_stmt_info
       .declared_symbols
-      .push(TaggedSymbolRef::Normal((self.immutable_ctx.idx, id).into()));
+      .push(TaggedSymbolRef::normal((self.immutable_ctx.idx, id).into()));
   }
 
   fn declare_link_only_symbol_ref(&mut self, id: SymbolId) {
     self
       .current_stmt_info
       .declared_symbols
-      .push(TaggedSymbolRef::LinkOnly((self.immutable_ctx.idx, id).into()));
+      .push(TaggedSymbolRef::link_only((self.immutable_ctx.idx, id).into()));
   }
 
   fn get_root_binding(&self, name: &str) -> Option<SymbolId> {
@@ -629,7 +629,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     self
       .current_stmt_info
       .declared_symbols
-      .push(rolldown_common::TaggedSymbolRef::Normal(generated_imported_as_ref));
+      .push(rolldown_common::TaggedSymbolRef::normal(generated_imported_as_ref));
     let name_import = NamedImport {
       imported: imported.into(),
       imported_as: generated_imported_as_ref,
@@ -660,7 +660,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     self
       .current_stmt_info
       .declared_symbols
-      .push(rolldown_common::TaggedSymbolRef::Normal(generated_imported_as_ref));
+      .push(rolldown_common::TaggedSymbolRef::normal(generated_imported_as_ref));
     let name_import = NamedImport {
       imported: Specifier::Star,
       span_imported: span_for_export_name,

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -74,7 +74,7 @@ impl LinkStage<'_> {
       // tree-shaking process.
       linking_info.shimmed_missing_exports.iter().for_each(|(_name, symbol_ref)| {
         let stmt_info = StmtInfo {
-          declared_symbols: vec![TaggedSymbolRef::Normal(*symbol_ref)],
+          declared_symbols: vec![TaggedSymbolRef::normal(*symbol_ref)],
           referenced_symbols: vec![],
           side_effect: false.into(),
           import_records: Vec::new(),
@@ -112,7 +112,7 @@ impl LinkStage<'_> {
                 }
                 referenced_symbols.push(rec.namespace_ref.into());
                 declared_symbols
-                  .push(TaggedSymbolRef::Normal(ecma_module.import_records[rec_idx].namespace_ref));
+                  .push(TaggedSymbolRef::normal(ecma_module.import_records[rec_idx].namespace_ref));
               });
             }
             OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {}
@@ -120,7 +120,7 @@ impl LinkStage<'_> {
         }
         // Create a StmtInfo to represent the statement that declares and constructs the Module Namespace Object.
         // Corresponding AST for this statement will be created by the finalizer.
-        declared_symbols.push(TaggedSymbolRef::Normal(ecma_module.namespace_object_ref));
+        declared_symbols.push(TaggedSymbolRef::normal(ecma_module.namespace_object_ref));
         let namespace_stmt_info = StmtInfo {
           declared_symbols,
           referenced_symbols,

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -141,7 +141,7 @@ fn update_module_default_export_info(
     LocalExport { span: SPAN, referenced: default_symbol_ref, came_from_commonjs: false },
   );
   stmt_infos
-    .declare_symbol_for_stmt(FIRST_TOP_LEVEL_STMT_IDX, TaggedSymbolRef::Normal(default_symbol_ref));
+    .declare_symbol_for_stmt(FIRST_TOP_LEVEL_STMT_IDX, TaggedSymbolRef::normal(default_symbol_ref));
 }
 
 /// return true if the json is a ObjectExpression
@@ -282,7 +282,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     let symbol_ref: SymbolRef = (module_idx, symbol_id).into();
     all_declared_symbols.push(SymbolOrMemberExprRef::from(symbol_ref));
     let stmt_info =
-      StmtInfo::default().with_declared_symbols(vec![TaggedSymbolRef::Normal(symbol_ref)]);
+      StmtInfo::default().with_declared_symbols(vec![TaggedSymbolRef::normal(symbol_ref)]);
     stmt_infos.add_stmt_info(stmt_info);
     module.named_exports.insert(
       exported.clone(),
@@ -291,7 +291,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   }
   // declare default export statement
   let stmt_info = StmtInfo::default()
-    .with_declared_symbols(vec![TaggedSymbolRef::Normal(default_export_ref)])
+    .with_declared_symbols(vec![TaggedSymbolRef::normal(default_export_ref)])
     .with_referenced_symbols(all_declared_symbols.clone());
 
   stmt_infos.add_stmt_info(stmt_info);
@@ -304,7 +304,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   module.exports_kind = ExportsKind::Esm;
   stmt_infos.replace_namespace_stmt_info(
     StmtInfo::default()
-      .with_declared_symbols(vec![TaggedSymbolRef::Normal(namespace_object_ref)])
+      .with_declared_symbols(vec![TaggedSymbolRef::normal(namespace_object_ref)])
       .with_referenced_symbols(all_declared_symbols),
   );
   // for a es json module it did not needs to be wrapped anyway.

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -261,7 +261,7 @@ impl LinkStage<'_> {
         });
 
         symbols_to_be_declared.into_iter().for_each(|(symbol_ref, idx)| {
-          stmt_infos.declare_symbol_for_stmt(idx, TaggedSymbolRef::Normal(symbol_ref));
+          stmt_infos.declare_symbol_for_stmt(idx, TaggedSymbolRef::normal(symbol_ref));
         });
         (importer_idx, DeferUpdateInfo { record_meta_pairs })
       })

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -225,7 +225,7 @@ pub fn create_wrapper(
         .create_facade_root_symbol_ref(module.idx, &format!("require_{}", &module.repr_name));
 
       let stmt_info = StmtInfo {
-        declared_symbols: vec![TaggedSymbolRef::Normal(wrapper_ref)],
+        declared_symbols: vec![TaggedSymbolRef::normal(wrapper_ref)],
         referenced_symbols: vec![if options.profiler_names {
           runtime.resolve_symbol("__commonJS").into()
         } else {
@@ -256,7 +256,7 @@ pub fn create_wrapper(
         symbols.create_facade_root_symbol_ref(module.idx, &format!("init_{}", &module.repr_name));
 
       let stmt_info = StmtInfo {
-        declared_symbols: vec![TaggedSymbolRef::Normal(wrapper_ref)],
+        declared_symbols: vec![TaggedSymbolRef::normal(wrapper_ref)],
         referenced_symbols: vec![if options.profiler_names {
           runtime.resolve_symbol("__esm").into()
         } else {

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, TaggedSymbolRef, WrapKind,
+  Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, WrapKind,
 };
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -174,11 +174,7 @@ pub fn deconflict_chunk_symbols(
         .iter_enumerated()
         .filter(|(idx, _)| meta.stmt_info_included.has_bit(*idx))
         .for_each(|(_, stmt_info)| {
-          for declared_symbol in stmt_info
-            .declared_symbols
-            .iter()
-            .filter(|item| matches!(item, TaggedSymbolRef::Normal(_)))
-          {
+          for declared_symbol in stmt_info.declared_symbols.iter().filter(|item| item.is_normal()) {
             let symbol_ref = declared_symbol.inner();
             let canonical_ref = link_output.symbol_db.canonical_ref_for(symbol_ref);
             // Import statement declared some symbols that come from other module, those symbol should be skipped

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -61,10 +61,8 @@ impl StmtInfos {
 
   pub fn replace_namespace_stmt_info(&mut self, info: StmtInfo) -> StmtInfoIdx {
     self.infos[Self::NAMESPACE_STMT_IDX] = info;
-    for symbol_ref in self.infos[Self::NAMESPACE_STMT_IDX]
-      .declared_symbols
-      .iter()
-      .filter(|item| matches!(item, TaggedSymbolRef::Normal(_)))
+    for symbol_ref in
+      self.infos[Self::NAMESPACE_STMT_IDX].declared_symbols.iter().filter(|item| item.is_normal())
     {
       self
         .symbol_ref_to_declared_stmt_idx

--- a/crates/rolldown_common/src/types/symbol_or_member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_or_member_expr_ref.rs
@@ -1,4 +1,6 @@
-use crate::SymbolRef;
+use oxc::semantic::SymbolId;
+
+use crate::{ModuleIdx, SymbolRef};
 
 use super::member_expr_ref::MemberExprRef;
 
@@ -32,23 +34,126 @@ impl From<SymbolRef> for SymbolOrMemberExprRef {
   }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum TaggedSymbolRef {
-  /// Some symbols are only used during linking, and will not generate actual symbol in output.
-  /// e.g. cjs exports
-  /// ```js
-  /// exports['foo'] = 1;
-  /// ```
-  /// Aiming to support cjs tree shaking we need to declare some facade symbol that actual did not
-  /// exists in original code, also they should not be
-  LinkOnly(SymbolRef),
-  Normal(SymbolRef),
+/// Bit of [`TaggedSymbolRef::symbol_with_flag`] that marks a link-only symbol.
+const LINK_ONLY_FLAG: u32 = 1 << 31;
+
+/// A [`SymbolRef`] plus a one-bit "link-only" tag, packed into the same 8 bytes as a bare
+/// `SymbolRef` (instead of the 12 bytes a `enum { LinkOnly(SymbolRef), Normal(SymbolRef) }`
+/// would cost, since two payload-carrying variants force a separate, 4-byte-aligned discriminant).
+///
+/// A *link-only* symbol is only used during linking and never generates an actual binding in the
+/// output, e.g. the facade symbols created for CJS named exports so that
+/// ```js
+/// exports['foo'] = 1;
+/// ```
+/// can participate in tree-shaking even though `foo` has no real declaration in the original code.
+///
+/// The tag lives in the high bit of the `SymbolId`. This is sound because a single module can never
+/// reach `2^31` symbols: oxc caps a source file at <4GB (`u32` spans) and the densest binding that
+/// still introduces distinct symbols (`a=>a=>…`, 3 bytes each) tops out around `1.4e9`, well under
+/// `2^31`; the handful of bundler-created facade symbols don't change that. [`Self::pack`] asserts
+/// the invariant so a pathological input panics instead of silently corrupting a symbol id.
+#[derive(Clone, Copy)]
+pub struct TaggedSymbolRef {
+  owner: ModuleIdx,
+  /// Low 31 bits: the `SymbolId`. High bit (`LINK_ONLY_FLAG`): set iff this is a link-only symbol.
+  symbol_with_flag: u32,
 }
 
+const _: () = assert!(size_of::<TaggedSymbolRef>() == size_of::<SymbolRef>());
+
 impl TaggedSymbolRef {
-  pub fn inner(&self) -> SymbolRef {
-    match self {
-      TaggedSymbolRef::LinkOnly(s) | TaggedSymbolRef::Normal(s) => *s,
+  fn pack(symbol_ref: SymbolRef, link_only: bool) -> Self {
+    let raw = symbol_ref.symbol.raw().get();
+    assert!(
+      (raw & LINK_ONLY_FLAG) == 0,
+      "SymbolId {raw} reaches 2^31; the high bit is needed to tag link-only symbols"
+    );
+    Self {
+      owner: symbol_ref.owner,
+      symbol_with_flag: if link_only { raw | LINK_ONLY_FLAG } else { raw },
     }
+  }
+
+  pub fn normal(symbol_ref: SymbolRef) -> Self {
+    Self::pack(symbol_ref, false)
+  }
+
+  pub fn link_only(symbol_ref: SymbolRef) -> Self {
+    Self::pack(symbol_ref, true)
+  }
+
+  pub fn is_link_only(&self) -> bool {
+    (self.symbol_with_flag & LINK_ONLY_FLAG) != 0
+  }
+
+  pub fn is_normal(&self) -> bool {
+    !self.is_link_only()
+  }
+
+  pub fn inner(&self) -> SymbolRef {
+    SymbolRef {
+      owner: self.owner,
+      symbol: SymbolId::from_usize((self.symbol_with_flag & !LINK_ONLY_FLAG) as usize),
+    }
+  }
+}
+
+impl std::fmt::Debug for TaggedSymbolRef {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("TaggedSymbolRef")
+      .field("inner", &self.inner())
+      .field("link_only", &self.is_link_only())
+      .finish()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn symbol_ref(owner: u32, symbol: u32) -> SymbolRef {
+    SymbolRef::from((ModuleIdx::from_raw(owner), SymbolId::from_usize(symbol as usize)))
+  }
+
+  #[test]
+  fn normal_roundtrips() {
+    let s = symbol_ref(7, 42);
+    let tagged = TaggedSymbolRef::normal(s);
+    assert!(tagged.is_normal());
+    assert!(!tagged.is_link_only());
+    assert_eq!(tagged.inner(), s);
+  }
+
+  #[test]
+  fn link_only_roundtrips() {
+    let s = symbol_ref(7, 42);
+    let tagged = TaggedSymbolRef::link_only(s);
+    assert!(tagged.is_link_only());
+    assert!(!tagged.is_normal());
+    assert_eq!(tagged.inner(), s);
+  }
+
+  #[test]
+  fn largest_taggable_symbol_id_roundtrips() {
+    // The biggest symbol id that still leaves the tag bit (`1 << 31`) free.
+    let s = symbol_ref(12345, (1u32 << 31) - 1);
+    assert_eq!(TaggedSymbolRef::normal(s).inner(), s);
+    let link = TaggedSymbolRef::link_only(s);
+    assert!(link.is_link_only());
+    assert_eq!(link.inner(), s);
+  }
+
+  #[test]
+  #[should_panic(expected = "the high bit is needed")]
+  fn panics_when_symbol_id_uses_tag_bit() {
+    // A symbol id with bit 31 set would collide with the link-only tag.
+    let _ = TaggedSymbolRef::normal(symbol_ref(0, 1u32 << 31));
+  }
+
+  #[test]
+  fn same_size_as_symbol_ref() {
+    assert_eq!(size_of::<TaggedSymbolRef>(), size_of::<SymbolRef>());
+    assert_eq!(size_of::<TaggedSymbolRef>(), 8);
   }
 }


### PR DESCRIPTION
### What

Replace the `TaggedSymbolRef` enum

```rust
enum { LinkOnly(SymbolRef), Normal(SymbolRef) } // 12 bytes
```

with a packed struct that stores the link-only tag in the **high bit of the `SymbolId`**, bringing it down to **8 bytes** (same size as `SymbolRef`).

### Why 12 bytes?

`SymbolRef` is `{ owner: ModuleIdx (u32), symbol: SymbolId (NonMaxU32) }` = 8 bytes. The `NonMaxU32` niche could host a discriminant for a *single* payload variant, but two payload-carrying variants force Rust to add a separate 4-byte-aligned discriminant → 12 bytes.

### Why the bit-steal is sound

A single module can never reach 2³¹ symbols: oxc caps a source file at <4GB (u32 spans), and the densest distinct-symbol binding (`a=>a=>…`, 3 bytes each) tops out well under 2³¹. `pack()` asserts this invariant, so a pathological input panics loudly instead of silently corrupting a symbol id.

### Impact

Shrinks every `StmtInfo::declared_symbols` element from 12 → 8 bytes, with **no growth of `StmtInfo` itself**. A `const` assertion pins `size_of::<TaggedSymbolRef>() == size_of::<SymbolRef>()`.

### Verification

- Unit tests: normal / link-only roundtrip, largest taggable `SymbolId`, panic-on-overflow, size invariant.
- `cargo clippy` + `cargo fmt`: clean.
- Snapshot tests: identical (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
