### PR TITLE
fix(deconflict): rename CJS-wrapped locals that shadow chunk-root bindings

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -312,5 +312,6 @@ fn rename_shadowing_symbols_in_nested_scopes<'a>(
       output_format,
       OutputFormat::Iife | OutputFormat::Umd | OutputFormat::Cjs
     ));
+    ctx.rename_cjs_locals_shadowing_referenced_chunk_bindings();
   }
 }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -216,6 +216,37 @@ impl<'name> Renamer<'name> {
     }
   }
 
+  /// Override the chunk-root name of a CJS closure-internal binding that shadows a chunk-root
+  /// binding the closure references. The main deconfliction loop already gave this binding its
+  /// original name (CJS root-scope symbols are exempt there, so `register_nested_scope_symbols`
+  /// would skip it as already-named) — hence the override. The replacement skips names reserved at
+  /// chunk scope and names used by any binding in the same module (root or nested); the latter
+  /// stops it from landing on a sibling closure-local (the #9882 second-order case).
+  pub fn override_root_scope_binding(
+    &mut self,
+    symbol_ref: SymbolRef,
+    original_name: &str,
+    scoping: &Scoping,
+  ) {
+    let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
+    for count in 1u32.. {
+      let candidate: CompactStr =
+        concat_string!(original_name, "$", itoa::Buffer::new().format(count)).into();
+      if self.resolver.contains(&candidate) {
+        continue;
+      }
+      if scoping.iter_bindings().any(|(_, bindings)| bindings.contains_key(candidate.as_str())) {
+        // Reserve so a later-deconflicted chunk-root symbol can't be renamed onto this
+        // module-binding name and then be shadowed by it.
+        self.resolver.reserve(candidate);
+        continue;
+      }
+      self.resolver.reserve(candidate.clone());
+      self.canonical_names.insert(canonical_ref, candidate);
+      return;
+    }
+  }
+
   #[inline]
   pub fn into_canonical_names(self) -> FxHashMap<SymbolRef, CompactStr> {
     self.canonical_names
@@ -445,6 +476,89 @@ impl NestedScopeRenamer<'_, '_> {
           self.renamer.register_nested_scope_symbols(symbol_ref, name.as_str());
         }
       }
+    }
+  }
+
+  /// Rename a CJS-wrapped module's *root-scope* locals that shadow a chunk-root binding the closure
+  /// actually references.
+  ///
+  /// A CJS module's real top-level statements render *inside* its `__commonJS((exports, module) =>
+  /// { ... })` closure, and that closure captures every name at chunk-root scope. The main
+  /// deconfliction loop leaves these root-scope locals with their original name (CJS root-scope
+  /// symbols are exempt there), so a same-named binding rendered at chunk root ends up shadowed
+  /// inside the closure — issue #9882. Unlike the other passes, the shadowing binding lives at
+  /// module-root scope and is already named, so we *override* it via `override_root_scope_binding`
+  /// (which also steers clear of sibling locals — the #9882 second-order case).
+  ///
+  /// This is reference-precise: a root-scope local is renamed only when the module genuinely
+  /// references a chunk-root binding of the same final name, leaving unrelated same-named locals
+  /// untouched.
+  pub fn rename_cjs_locals_shadowing_referenced_chunk_bindings(&mut self) {
+    if !matches!(self.link_output.metas[self.module_idx].wrap_kind(), WrapKind::Cjs) {
+      return;
+    }
+    let root_scope_id = self.scoping.root_scope_id();
+
+    // Resolve against the immutable views first, then override (a `&mut self` step). A *root-scope*
+    // local shadows a referenced chunk-root binding when it shares that binding's final name. The
+    // `binding != reference` guard is essential: the referenced binding is itself a root-scope
+    // binding (e.g. `import * as m` accessed as `m.default`), so without it we'd "rename" the
+    // reference onto itself (issue #7444). Looking only at the root scope keeps us off bindings the
+    // other (nested-scope) passes already handle.
+    let mut shadowing_locals: FxHashSet<SymbolRef> = FxHashSet::default();
+
+    // `import { x } from ...` — a root-scope local sharing the import's final name shadows it.
+    for (import_ref, _) in &self.module.named_imports {
+      if self.db.is_facade_symbol(import_ref.symbol) {
+        continue;
+      }
+      // Unused imports aren't referenced, so nothing shadows them.
+      if self.scoping.get_resolved_references(import_ref.symbol).next().is_none() {
+        continue;
+      }
+      let Some(canonical_name) = self.renamer.get_canonical_name(*import_ref).cloned() else {
+        continue;
+      };
+      if let Some(binding) = self.scoping.get_binding(root_scope_id, canonical_name.as_str().into())
+        && binding != import_ref.symbol
+      {
+        let local_ref: SymbolRef = (self.module_idx, binding).into();
+        if self.link_output.symbol_db.canonical_ref_for(local_ref).owner == self.module_idx {
+          shadowing_locals.insert(local_ref);
+        }
+      }
+    }
+
+    // `ns.foo` star-import member accesses — a root-scope local sharing the resolved export's final
+    // name shadows the namespace reference.
+    for member_expr_ref in
+      self.link_output.metas[self.module_idx].resolved_member_expr_refs.values()
+    {
+      let Some(reference_id) = member_expr_ref.reference_id else {
+        continue;
+      };
+      let Some(reference_symbol) = self.scoping.get_reference(reference_id).symbol_id() else {
+        continue;
+      };
+      let Some(resolved_symbol) = member_expr_ref.resolved else {
+        continue;
+      };
+      let Some(canonical_name) = self.renamer.get_canonical_name(resolved_symbol).cloned() else {
+        continue;
+      };
+      if let Some(binding) = self.scoping.get_binding(root_scope_id, canonical_name.as_str().into())
+        && binding != reference_symbol
+      {
+        let local_ref: SymbolRef = (self.module_idx, binding).into();
+        if self.link_output.symbol_db.canonical_ref_for(local_ref).owner == self.module_idx {
+          shadowing_locals.insert(local_ref);
+        }
+      }
+    }
+
+    for local_ref in shadowing_locals {
+      let original_name = self.scoping.symbol_name(local_ref.symbol);
+      self.renamer.override_root_scope_binding(local_ref, original_name, self.scoping);
     }
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/9882/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9882/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9882/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9882/_test.mjs
@@ -1,0 +1,5 @@
+// Regression test for #9882. `export default require_main()` eval's the wrapped entry on import.
+// Pre-fix, the entry's `var sharedValue` shadowed the dependency's chunk-root `sharedValue`, so
+// `SharedEnum.EventMatch` read `undefined.EventMatch` and threw. Importing without throwing means
+// the local was deconflicted (e.g. to `sharedValue$1`) and no longer shadows.
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/issues/9882/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9882/artifacts.snap
@@ -1,0 +1,26 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dependency.js
+var sharedValue;
+var init_dependency = __esmMin((() => {
+	sharedValue = { EventMatch: "event_match" };
+}));
+//#endregion
+//#region main.js
+var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
+	init_dependency();
+	exports.kind = sharedValue.EventMatch;
+	var sharedValue$1 = class {};
+	exports.local = sharedValue$1;
+}));
+//#endregion
+export default require_main();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9882/dependency.js
+++ b/crates/rolldown/tests/rolldown/issues/9882/dependency.js
@@ -1,0 +1,6 @@
+// Re-exported under a different name (`SharedEnum`) so the entry can declare a colliding local
+// named `sharedValue` without clashing with the import binding. `sharedValue` is the chunk-root
+// name the entry's local shadows. Imported by the CJS-wrapped entry, so this module is wrapped
+// with `__esmMin` and `sharedValue` is hoisted to chunk-root scope.
+let sharedValue = { EventMatch: 'event_match' };
+export { sharedValue as SharedEnum };

--- a/crates/rolldown/tests/rolldown/issues/9882/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9882/main.js
@@ -1,0 +1,10 @@
+// Repro for #9882. The `exports` reference makes rolldown wrap this entry in
+// `__commonJSMin((exports, module) => { ... })`. The local `var sharedValue` collides with the
+// dependency's chunk-root `sharedValue` binding; pre-fix it hoists to the top of the closure and
+// shadows it, so `SharedEnum.EventMatch` reads the inner `undefined` -> TypeError. The local is a
+// `class {}` (not a constant) so it survives as a real declaration instead of being inlined away.
+import { SharedEnum } from './dependency.js';
+
+exports.kind = SharedEnum.EventMatch;
+var sharedValue = class {};
+exports.local = sharedValue;

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/_test.mjs
@@ -1,0 +1,8 @@
+import { strict as assert } from 'node:assert';
+
+// Regression test for a CJS closure shadowing a chunk-root binding after that binding is
+// renamed by normal root-scope deconfliction.
+await import('./dist/main.js');
+
+// Reaching this line means the wrapped entry executed without throwing.
+assert.ok(true);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dependency.js
+var sharedValue;
+var init_dependency = __esmMin((() => {
+	sharedValue = ((value) => {
+		value.EventMatch = "event_match";
+		return value;
+	})(sharedValue || {});
+}));
+//#endregion
+//#region main.js
+var require_main = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	init_dependency();
+	var freeModule = typeof exports == "object" && exports && !exports.nodeType && exports && typeof module == "object" && module && !module.nodeType && module;
+	var eventKind = sharedValue.EventMatch;
+	var sharedValue$2 = class {};
+	var sharedValue$1 = class {};
+	console.log(eventKind, sharedValue$2, sharedValue$1, freeModule);
+}));
+//#endregion
+export default require_main();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/dependency.js
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/dependency.js
@@ -1,0 +1,6 @@
+var sharedValue = ((value) => {
+  value.EventMatch = 'event_match';
+  return value;
+})(sharedValue || {});
+
+export { sharedValue as SharedEnum };

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/main.js
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/main.js
@@ -1,0 +1,18 @@
+import { SharedEnum } from './dependency.js';
+
+var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module;
+
+// Reads the imported dependency binding, whose chunk-root name stays `sharedValue` (the CJS entry
+// locals below don't reserve chunk-scope names, so the dependency keeps the bare name). The
+// `var sharedValue` local shadows it inside the `__commonJS` closure and must be deconflicted.
+var eventKind = SharedEnum.EventMatch;
+
+// Second-order case: deconflicting the `sharedValue` local can't simply pick `sharedValue$1` —
+// that name is already taken by the sibling local below. The override must skip it and land on
+// `sharedValue$2`, which is why it checks every binding in the module (root + nested), not just
+// the chunk scope. (The dependency binding itself is NOT renamed here; only the entry locals are.)
+var sharedValue = class {};
+var sharedValue$1 = class {};
+
+console.log(eventKind, sharedValue, sharedValue$1, freeModule);


### PR DESCRIPTION
### What this PR solves

Fixes #9882.

A CJS-wrapped module's author-local `var` declared inside the generated `__commonJS` closure could shadow a same-named **chunk-root binding** imported from a peer ESM module. Because `var` declarations are hoisted to the top of the closure, the local shadowed the captured outer binding for the whole closure body, so references read the (still-`undefined`) local instead of the initialized import — producing a runtime `TypeError` (e.g. `Cannot read properties of undefined (reading 'EventMatch')`).

Example shape: an entry is CJS-wrapped (`typeof exports`/`typeof module` probing), declares `var sharedValue = …`, and also imports `{ SharedEnum }` from a peer ESM module whose hoisted `var sharedValue;` is the chunk-root binding. The local shadows the import.

### Fix

Adds a post-deconfliction pass `NestedScopeRenamer::rename_cjs_locals_shadowing_referenced_chunk_bindings` (in `renamer.rs`), run from `rename_shadowing_symbols_in_nested_scopes` **after** all final names are assigned. For `WrapKind::Cjs` modules only, for each *referenced* named import / star-import member-expression it takes the import's final canonical name, looks up the module's root scope, and if a *different* module-owned binding shadows that name it renames **only the shadowing local** (never the chunk-root binding) via `Renamer::override_root_scope_binding`.

The override picks the next `$N` suffix skipping both resolver-reserved names and every binding in the module, so it cannot collide with a sibling local (covers the second-order case where the entry already has `sharedValue` *and* `sharedValue$1`). It is order-independent, so it also covers the reverse-ordering case (non-entry CJS module).

### Alternatives explored

- **Widen `chunk_scope_captured_names`** to include peer ESM/None chunk-root bindings, and/or reserve names on the non-deconflict path in `renamer.rs`. Both worked but over-approximated, producing harmless-but-noisy snapshot churn across unrelated fixtures. The reference-precise post-pass renames only genuine shadows, with **zero** snapshot churn beyond the new fixtures.

### Notes for reviewers

- The `binding != reference` guard is load-bearing: without it an `import * as m` whose member expr is `m.default` would rename `m` onto itself (regression risk for #7444). The existing star/named-import passes use the same guard.
- Why a separate pass: the shadow is a module-root-scope binding already named by the main loop, and `register_nested_scope_symbols` bails on already-named symbols — so the existing `rename_bindings_shadowing_named_imports` can't reach it.

### Tests

Two regression fixtures, both executing the built bundle via `_test.mjs`:

- `crates/rolldown/tests/rolldown/issues/9882/` — the original report.
- `crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_renamed_chunk_binding/` — second-order variant (entry already has `sharedValue` + `sharedValue$1`).

Full `rolldown` integration suite passes; clippy clean.
