### PR TITLE
perf(sourcemap): reserve token buffer capacity in collapse_sourcemaps

### DIFF
--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -72,29 +72,26 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
     .map(|sourcemap| (*sourcemap, sourcemap.generate_lookup_table()))
     .collect();
 
-  let tokens: Box<[Token]> = last_map
-    .get_source_view_tokens()
-    .filter_map(|token| {
-      let original_token =
-        sourcemap_and_lookup_table.iter().try_fold(token, |token, (sourcemap, lookup_table)| {
-          sourcemap.lookup_source_view_token(
-            lookup_table,
-            token.get_src_line(),
-            token.get_src_col(),
-          )
-        });
-      original_token.map(|original_token| {
-        Token::new(
-          token.get_dst_line(),
-          token.get_dst_col(),
-          original_token.get_src_line(),
-          original_token.get_src_col(),
-          original_token.get_source_id(),
-          original_token.get_name_id(),
-        )
-      })
+  // `filter_map` hides the slice's exact `size_hint`, so reserve the upper bound ourselves.
+  let source_view_tokens = last_map.get_source_view_tokens();
+  let mut tokens_vec = Vec::with_capacity(source_view_tokens.size_hint().0);
+  tokens_vec.extend(source_view_tokens.filter_map(|token| {
+    let original_token =
+      sourcemap_and_lookup_table.iter().try_fold(token, |token, (sourcemap, lookup_table)| {
+        sourcemap.lookup_source_view_token(lookup_table, token.get_src_line(), token.get_src_col())
+      });
+    original_token.map(|original_token| {
+      Token::new(
+        token.get_dst_line(),
+        token.get_dst_col(),
+        original_token.get_src_line(),
+        original_token.get_src_col(),
+        original_token.get_source_id(),
+        original_token.get_name_id(),
+      )
     })
-    .collect();
+  }));
+  let tokens: Box<[Token]> = tokens_vec.into_boxed_slice();
 
   SourceMap::new(
     None,


### PR DESCRIPTION
`collapse_sourcemaps` built its output `Box<[Token]>` via `last_map.get_source_view_tokens().filter_map(..).collect()`. The source iterator is slice-backed (exact `size_hint`), but `filter_map` resets the lower size-hint to `0`, so `collect` reserved nothing and grew the buffer through ~log2(n) reallocations. Nearly every token remaps successfully, so reserving the upper bound up front is safe.

Measured on `collapse_codegen_chain` (52,004 tokens, counting allocator):

- **15 → 0 reallocs**, 4.84 MB → 1.70 MB allocator traffic.

Degrades gracefully: if the iterator ever loses its exact `size_hint`, this reverts to the original grow-from-zero behaviour. All `rolldown_sourcemap` tests pass and the output token count is unchanged.
