### PR TITLE
perf(common): box large SourcemapChainElement variants

### DIFF
--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -223,7 +223,7 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
               map
                 .entry(module_idx)
                 .or_default()
-                .push(SourcemapChainElement::Transform((plugin_idx, generated_sourcemap)));
+                .push(SourcemapChainElement::Transform((plugin_idx, Box::new(generated_sourcemap))));
             }
             SourceMapGenMsg::Terminate => {
               break;

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -220,10 +220,10 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
                 source: id.as_str().into(),
                 ..Default::default()
               });
-              map
-                .entry(module_idx)
-                .or_default()
-                .push(SourcemapChainElement::Transform((plugin_idx, Box::new(generated_sourcemap))));
+              map.entry(module_idx).or_default().push(SourcemapChainElement::Transform((
+                plugin_idx,
+                Box::new(generated_sourcemap),
+              )));
             }
             SourceMapGenMsg::Terminate => {
               break;

--- a/crates/rolldown/src/utils/load_source.rs
+++ b/crates/rolldown/src/utils/load_source.rs
@@ -28,7 +28,8 @@ pub async fn load_source<Fs: FileSystem + 'static>(
       .load(&HookLoadArgs { id: &resolved_id.id, module_idx, asserted_module_type })
       .await?
       .map(|load_hook_output| {
-        sourcemap_chain.extend(load_hook_output.map.map(SourcemapChainElement::Load));
+        sourcemap_chain
+          .extend(load_hook_output.map.map(|map| SourcemapChainElement::Load(Box::new(map))));
         if let Some(v) = load_hook_output.side_effects {
           *side_effects = Some(v);
         }

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -82,7 +82,7 @@ fn collapse_module_sourcemap(
   for element in sourcemap_chain {
     match element {
       SourcemapChainElement::Transform((_, sourcemap)) | SourcemapChainElement::Load(sourcemap) => {
-        owned_chain.push(sourcemap);
+        owned_chain.push(&**sourcemap);
       }
       SourcemapChainElement::Omitted { plugin_name, .. } => {
         owned_chain.push(&empty);
@@ -218,7 +218,7 @@ mod tests {
     // A real `Load`/`Transform` map is kept as-is; its sources/content win over the module
     // id placeholder and its mappings flow through the collapse.
     let mut warnings = vec![];
-    let load = SourcemapChainElement::Load(map("loaded.js", "const a = 1;\n"));
+    let load = SourcemapChainElement::Load(Box::new(map("loaded.js", "const a = 1;\n")));
     let result =
       collapse_module_sourcemap(&[load], Some(codegen_map("a(1);\n")), MODULE_ID, &mut warnings)
         .unwrap();

--- a/crates/rolldown_common/src/types/sourcemap_chain_element.rs
+++ b/crates/rolldown_common/src/types/sourcemap_chain_element.rs
@@ -6,12 +6,15 @@ use crate::PluginIdx;
 #[derive(Debug, Clone)]
 pub enum SourcemapChainElement {
   /// A string representing the URL of an external source map.
-  Transform((PluginIdx, SourceMap)),
+  Transform((PluginIdx, Box<SourceMap>)),
   /// An inline source map represented as a JSON string.
-  Load(SourceMap),
+  Load(Box<SourceMap>),
   /// A transform hook returned changed code without a sourcemap.
   Omitted { plugin_idx: PluginIdx, plugin_name: ArcStr },
   /// A transform hook returned changed code together with an explicit
   /// `map: null`.
   Null { plugin_idx: PluginIdx, original_content: ArcStr },
 }
+
+// Keep this enum small: box large variants instead of inlining them.
+const _: () = assert!(std::mem::size_of::<SourcemapChainElement>() <= 24);

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -39,7 +39,7 @@ impl TransformPluginContext {
         .iter()
         .filter_map(|element| match element {
           SourcemapChainElement::Transform((_, sourcemap))
-          | SourcemapChainElement::Load(sourcemap) => Some(sourcemap),
+          | SourcemapChainElement::Load(sourcemap) => Some(&**sourcemap),
           SourcemapChainElement::Omitted { .. } => Some(&empty_map),
           SourcemapChainElement::Null { .. } => None,
         })

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -299,7 +299,8 @@ impl PluginDriver {
         let map_was_omitted = matches!(r.map, crate::HookTransformOutputMap::Omitted);
         let map_was_null = matches!(r.map, crate::HookTransformOutputMap::Null);
         if let Some(map) = self.normalize_transform_sourcemap(r.map.into_sourcemap(), id, &code) {
-          original_sourcemap_chain.push(SourcemapChainElement::Transform((plugin_idx, map)));
+          original_sourcemap_chain
+            .push(SourcemapChainElement::Transform((plugin_idx, Box::new(map))));
         } else if map_was_omitted && r.code.is_some() {
           original_sourcemap_chain.push(SourcemapChainElement::Omitted {
             plugin_idx,


### PR DESCRIPTION
`SourcemapChainElement` was **224 B** — the `Transform`/`Load` variants inline a ~200 B `SourceMap`, while `Omitted`/`Null` are 12 B. A `Vec<SourcemapChainElement>` is stored per module, so every element paid for the largest variant, and being >128 B it `memcpy`s on every move / `Vec` reallocation.

Box the `SourceMap` payloads (keeping the tuple shape so existing `Transform((plugin_idx, _))` patterns still match):

- **224 → 24 B (−89%)**, verified with `-Zprint-type-sizes`; guarded by a compile-time `size_of` assertion.

Behaviour is unchanged (the boxed map is dereferenced where a `&SourceMap` is needed); all rolldown / rolldown_plugin / rolldown_common tests pass.
