### PR TITLE
perf(utils): avoid wasted allocation in legitimize_identifier_name

### DIFF
--- a/crates/rolldown_utils/src/ecmascript.rs
+++ b/crates/rolldown_utils/src/ecmascript.rs
@@ -54,7 +54,6 @@ pub fn legitimize_json_local_binding_name(
 }
 
 pub fn legitimize_identifier_name(name: &str) -> Cow<'_, str> {
-  let mut legitimized = String::with_capacity(name.len());
   let mut chars_indices = name.char_indices();
 
   let mut first_invalid_char_index = None;
@@ -74,6 +73,8 @@ pub fn legitimize_identifier_name(name: &str) -> Cow<'_, str> {
     return Cow::Borrowed(name);
   };
 
+  // Allocate only on the path that actually legitimizes the name.
+  let mut legitimized = String::with_capacity(name.len());
   let (first_valid_part, rest_part) = name.split_at(first_invalid_char_index);
   legitimized.push_str(first_valid_part);
   if first_invalid_char_index == 0 {


### PR DESCRIPTION
`legitimize_identifier_name` allocated `String::with_capacity(name.len())` at the top of the function, but the common case — a name that is already a valid identifier — returns `Cow::Borrowed(name)` early and never touches that String. So every already-valid identifier allocated and immediately freed a String. Move the allocation past the early return so it only happens when the name actually needs legitimizing.

Measured with a dhat heap profile of a three.js bundle:

- `legitimize_identifier_name`: **1,334 → 256 allocations (−81%)**; whole-bundle 84,652 → 83,566.

No behaviour change (all 57 `rolldown_utils` tests pass); identical output, the String is just allocated later.
