### PR TITLE
refactor(rolldown_common): model ModuleId as a classified Path/Virtual/Bare enum

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -6,9 +6,7 @@ use rolldown_common::{
   side_effects::{DeterminedSideEffects, HookSideEffects},
 };
 use rolldown_error::BuildResult;
-use rolldown_std_utils::PathExt;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
-use sugar_path::SugarPath;
 
 use crate::{
   ast_scanner::{AstScanner, ScanResult},
@@ -44,7 +42,7 @@ pub async fn create_ecma_view(
 
   let module_id = ctx.resolved_id.id.clone();
 
-  let repr_name = module_id.as_path().representative_file_name();
+  let repr_name = module_id.representative_name();
   let repr_name = legitimize_identifier_name(&repr_name);
 
   let scan_result = ast.program.with_mut(|fields| {
@@ -226,9 +224,13 @@ pub fn lazy_check_side_effects(
   if check_package_json_side_effects
     && let Some(side_effects) = resolved_id.package_json.as_ref().and_then(|p| {
       // the glob expr is based on parent path of package.json, which is package path
-      // so we should use the relative path of the module to package path
-      let module_path_relative_to_package =
-        resolved_id.id.as_path().relative(p.realpath().parent()?);
+      // so we should use the relative path of the module to package path.
+      // A plugin `resolveId` hook can return a non-absolute id (e.g. virtual `\0dep`)
+      // together with a `packageJsonPath`, so `package_json` is populated even when the
+      // id is not a `Path` kind. Treat the raw id as a path here (matching the historical
+      // behavior) so `sideEffects` is still honored for such plugin-resolved modules,
+      // rather than gating on `as_path()` and silently dropping the package metadata.
+      let module_path_relative_to_package = resolved_id.id.relative_path(p.realpath().parent()?);
       p.check_side_effects_for(&module_path_relative_to_package.to_string_lossy())
         .map(DeterminedSideEffects::UserDefined)
     })

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -67,8 +67,8 @@ impl<Fs: FileSystem> ExternalModuleTask<Fs> {
       }),
     );
 
-    let need_renormalize_render_path = !matches!(resolved_id.external, ResolvedExternal::Absolute)
-      && Path::new(resolved_id.id.as_str()).is_absolute();
+    let need_renormalize_render_path =
+      !matches!(resolved_id.external, ResolvedExternal::Absolute) && resolved_id.id.is_path();
 
     let file_name: ArcStr = if need_renormalize_render_path {
       let entries_common_dir = commondir::common_dir(

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 use oxc::span::Span;
-use sugar_path::SugarPath as _;
 
 use rolldown_common::{
   ExportsKind, FlatOptions, ImportKind, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ModuleType,
@@ -13,7 +12,6 @@ use rolldown_error::{
   BuildDiagnostic, BuildResult, DiagnosticOptions, EventKindSwitcher, UnloadableDependencyContext,
   downcast_napi_error_diagnostics,
 };
-use rolldown_std_utils::PathExt as _;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
 
 use rolldown_fs::FileSystem;
@@ -172,7 +170,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       }
     }
 
-    let repr_name = self.resolved_id.id.as_path().representative_file_name();
+    let repr_name = self.resolved_id.id.representative_name();
     let repr_name = legitimize_identifier_name(&repr_name).into_owned();
 
     // Build lazy barrel info if the experimental flag is enabled

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -692,16 +692,14 @@ impl GenerateStage<'_> {
         if self.options.preserve_modules
           || self.link_output.user_defined_entry_modules.contains(&item.idx)
         {
-          Path::new(item.id.as_ref()).is_absolute().then_some(item.id.as_ref())
+          item.id.is_path().then_some(item.id.as_ref())
         } else {
           None
         }
       }
       Module::External(external_module) => {
         if self.options.preserve_modules {
-          Path::new(external_module.id.as_str())
-            .is_absolute()
-            .then_some(external_module.id.as_ref())
+          external_module.id.is_path().then_some(external_module.id.as_ref())
         } else {
           None
         }
@@ -718,7 +716,8 @@ impl GenerateStage<'_> {
     }
     match modules_count {
       0 => None,
-      1 => ret.and_then(|item| Path::new(&item).parent().map(|p| p.to_string_lossy().to_string())),
+      1 => ret
+        .and_then(|item| Path::new(&item).parent().and_then(Path::to_str).map(ToString::to_string)),
       _ => ret,
     }
   }

--- a/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
+++ b/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
@@ -1,6 +1,4 @@
 use rolldown_error::{BuildDiagnostic, EventKindSwitcher};
-use rolldown_std_utils::PathExt as _;
-use sugar_path::SugarPath as _;
 
 use crate::chunk_graph::ChunkGraph;
 
@@ -28,8 +26,7 @@ impl GenerateStage<'_> {
         }
 
         let has_ineffective = module.ecma_view.dynamic_importers.iter().any(|importer_id| {
-          !importer_id.as_path().is_in_node_modules()
-            && pre_rendered_chunk.module_ids.contains(importer_id)
+          !importer_id.is_in_node_modules() && pre_rendered_chunk.module_ids.contains(importer_id)
         });
 
         if has_ineffective {

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -803,7 +803,8 @@ fn derive_entries_aware_chunk_name(
           let module = &link_output.module_table[entry_point.idx];
           Path::new(module.stable_id().as_str())
             .file_stem()
-            .map(|s| s.to_string_lossy().to_string())
+            .and_then(|s| s.to_str())
+            .map(ToString::to_string)
             .unwrap_or_else(|| module.stable_id().to_string())
         }))
       } else {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -11,8 +11,7 @@ use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_std_utils::{
-  PathBufExt as _, PathExt as _, representative_file_name_for_preserve_modules,
-  strip_path_prefix_to_slash,
+  PathBufExt as _, representative_file_name_for_preserve_modules, strip_path_prefix_to_slash,
 };
 use rolldown_utils::{
   dashmap::FxDashMap,
@@ -299,9 +298,7 @@ impl<'a> GenerateStage<'a> {
                 }
               }
             } else {
-              let chunk_name = sanitize_filename
-                .call(&module.id().as_str().as_path().representative_file_name())
-                .await?;
+              let chunk_name = sanitize_filename.call(&module.id().representative_name()).await?;
 
               PreGeneratedChunkName {
                 representative_chunk_name: chunk_name.clone(),
@@ -318,8 +315,7 @@ impl<'a> GenerateStage<'a> {
               chunk.modules.iter().rev().find(|each| **each != self.link_output.runtime.id())
             {
               let module = &modules[*module_id];
-              let module_id = module.id().as_str();
-              let name = module_id.as_path().representative_file_name();
+              let name = module.id().representative_name();
               let sanitized_filename = sanitize_filename.call(&name).await?;
               Ok(PreGeneratedChunkName {
                 representative_chunk_name: sanitized_filename.clone(),

--- a/crates/rolldown/src/utils/load_source.rs
+++ b/crates/rolldown/src/utils/load_source.rs
@@ -7,7 +7,6 @@ use rolldown_common::{
 use rolldown_fs::FileSystem;
 use rolldown_plugin::{HookLoadArgs, PluginDriver};
 use rustc_hash::FxHashMap;
-use sugar_path::SugarPath;
 
 #[expect(clippy::too_many_arguments)]
 pub async fn load_source<Fs: FileSystem + 'static>(
@@ -65,12 +64,12 @@ pub async fn load_source<Fs: FileSystem + 'static>(
               {
                 let id = resolved_id.id.clone();
                 tokio::runtime::Handle::current()
-                  .spawn_blocking(move || fs.read_to_string(id.as_path()))
+                  .spawn_blocking(move || fs.read_to_string(Path::new(id.as_str())))
                   .await??
               }
               #[cfg(target_family = "wasm")]
               {
-                fs.read_to_string(resolved_id.id.as_path())?
+                fs.read_to_string(Path::new(resolved_id.id.as_str()))?
               }
             }),
             ModuleType::Js,
@@ -83,11 +82,11 @@ pub async fn load_source<Fs: FileSystem + 'static>(
                 Some(s) => s.into_bytes(),
                 None => {
                   if cfg!(target_family = "wasm") {
-                    fs.read(resolved_id.id.as_path())?
+                    fs.read(Path::new(resolved_id.id.as_str()))?
                   } else {
                     let id = resolved_id.id.clone();
                     tokio::runtime::Handle::current()
-                      .spawn_blocking(move || fs.read(id.as_path()))
+                      .spawn_blocking(move || fs.read(Path::new(id.as_str())))
                       .await??
                   }
                 }
@@ -122,12 +121,12 @@ pub async fn load_source<Fs: FileSystem + 'static>(
                 {
                   let id = resolved_id.id.clone();
                   tokio::runtime::Handle::current()
-                    .spawn_blocking(move || fs.read_to_string(id.as_path()))
+                    .spawn_blocking(move || fs.read_to_string(Path::new(id.as_str())))
                     .await??
                 }
                 #[cfg(target_family = "wasm")]
                 {
-                  fs.read_to_string(resolved_id.id.as_path())?
+                  fs.read_to_string(Path::new(resolved_id.id.as_str()))?
                 }
               }
             }),
@@ -139,7 +138,7 @@ pub async fn load_source<Fs: FileSystem + 'static>(
     }
     (None, Some(ty)) => {
       assert!(asserted_module_type.is_some(), "Invalid state");
-      Ok((read_file_by_module_type(resolved_id.id.as_path(), &ty, fs).await?, ty))
+      Ok((read_file_by_module_type(Path::new(resolved_id.id.as_str()), &ty, fs).await?, ty))
     }
   }
 }

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -12,7 +12,6 @@ use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::HookTransformAstArgs;
 use rolldown_utils::mime::guess_mime;
 use rustc_hash::FxHashMap;
-use sugar_path::SugarPath;
 
 use super::pre_process_ecma_ast::PreProcessEcmaAst;
 
@@ -62,7 +61,7 @@ pub async fn parse_to_ecma_ast(
     ..
   } = ctx;
 
-  let path = resolved_id.id.as_path();
+  let path = Path::new(resolved_id.id.as_str());
   let is_user_defined_entry = ctx.is_user_defined_entry;
 
   let (has_lazy_export, source, parsed_type) =

--- a/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/_config.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "`shared.js` is statically imported by the entry (so it stays in the entry chunk) and is also dynamically imported from inside `node_modules` (dep). That dynamic import is technically ineffective, but INEFFECTIVE_DYNAMIC_IMPORT is suppressed because the only dynamic importer lives in `node_modules`, so no warning is expected. Guards the node_modules suppression branch of detect_ineffective_dynamic_imports.",
+  "expectWarning": false
+}

--- a/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ value: () => 42 });
+console.log("shared", 42);
+//#endregion
+//#region node_modules/dep/index.js
+globalThis.__shared = Promise.resolve().then(() => shared_exports);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/main.js
@@ -1,0 +1,6 @@
+// `shared.js` is statically imported here, so it lives in the entry chunk.
+import './shared.js';
+// `dep` lives in node_modules and dynamically imports `shared.js`. Because the only
+// dynamic importer of `shared.js` is inside node_modules, the ineffective dynamic
+// import warning is suppressed.
+import 'dep';

--- a/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/node_modules/dep/index.js
+++ b/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/node_modules/dep/index.js
@@ -1,0 +1,4 @@
+// Dynamically imports a module that is already statically present in the entry chunk.
+// This is the "ineffective dynamic import" shape, but it must NOT warn because this
+// importer lives inside node_modules.
+globalThis.__shared = import('../../shared.js');

--- a/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/shared.js
+++ b/crates/rolldown/tests/rolldown/warnings/dynamic_import_from_node_modules_no_warning/shared.js
@@ -1,0 +1,3 @@
+export const value = 42;
+// Side effect so the module is retained (and stays in the entry chunk).
+console.log('shared', value);

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -182,7 +182,7 @@ pub use crate::{
   types::member_expr_ref::{MemberExprObjectReferencedType, MemberExprProp, MemberExprRef},
   types::member_expr_ref_resolution::MemberExprRefResolution,
   types::module_def_format::ModuleDefFormat,
-  types::module_id::ModuleId,
+  types::module_id::{ModuleId, ModuleIdKind},
   types::module_info::ModuleInfo,
   types::module_namespace_included_reason::ModuleNamespaceIncludedReason,
   types::module_render_output::ModuleRenderOutput,

--- a/crates/rolldown_common/src/module/external_module.rs
+++ b/crates/rolldown_common/src/module/external_module.rs
@@ -88,7 +88,7 @@ impl ExternalModule {
     );
     if relative_path.starts_with("..") {
       relative_path.to_slash_lossy().into()
-    } else if relative_path.to_string_lossy().is_empty() {
+    } else if relative_path.as_os_str().is_empty() {
       ".".into()
     } else {
       concat_string!("./", relative_path.to_slash_lossy()).into()

--- a/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use crate::{AstScopes, ModuleId, ModuleIdx, SymbolRef};
 
 pub const RUNTIME_MODULE_KEY: &str = "\0rolldown/runtime.js";
-pub const RUNTIME_MODULE_ID: ModuleId = ModuleId::new_arc_str(arcstr::literal!(RUNTIME_MODULE_KEY));
+pub const RUNTIME_MODULE_ID: ModuleId = ModuleId::new_virtual(arcstr::literal!(RUNTIME_MODULE_KEY));
 
 #[derive(Debug, Clone)]
 pub struct RuntimeModuleBrief {

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -1,33 +1,68 @@
 use std::{
-  borrow::Borrow,
+  borrow::{Borrow, Cow},
+  cmp::Ordering,
+  hash::{Hash, Hasher},
   path::{Path, PathBuf},
 };
 
 use arcstr::ArcStr;
-use sugar_path::SugarPath;
+use rolldown_std_utils::PathExt as _;
+use sugar_path::SugarPath as _;
 
 use super::stable_module_id::StableModuleId;
 
 const EMPTY_MODULE_PREFIX: &str = "\0rolldown/empty.js?";
 
+/// Classification of a [`ModuleId`]'s string identity.
+///
+/// A module id coming out of resolution is *sometimes* a real filesystem path
+/// and sometimes not (virtual modules, bare specifiers, URLs, …). The kind is
+/// computed once at construction so path operations only run where they make
+/// sense, instead of treating every id as a path and round-tripping the bytes
+/// through `Path`/`to_string_lossy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModuleIdKind {
+  /// An absolute filesystem path; path operations are meaningful.
+  Path,
+  /// A virtual module id, prefixed with `\0` (Rollup convention).
+  Virtual,
+  /// Anything else: bare specifier (`react`), URL (`https://…`), data URI,
+  /// relative specifier, etc. Not a filesystem path.
+  Bare,
+}
+
+#[derive(Clone)]
+enum Repr {
+  Path(ArcStr),
+  Virtual(ArcStr),
+  Bare(ArcStr),
+}
+
 /// `ModuleId` is the unique string identifier for each module.
 /// - It will be used to identify the module in the whole bundle.
 /// - Users could stored the `ModuleId` to track the module in different stages/hooks.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
+///
+/// The backing string is an [`ArcStr`] — cheap to clone and the durable identity
+/// that survives across (incremental) builds. The hot key for the module graph is
+/// the ephemeral per-build integer handle [`ModuleIdx`](crate::ModuleIdx), not this
+/// type, so `ModuleId` optimizes for being a faithful, lossless string/path identity.
+#[derive(Clone)]
 pub struct ModuleId {
-  inner: ArcStr,
+  repr: Repr,
 }
 
 impl ModuleId {
   #[inline]
   pub fn new(value: impl Into<ArcStr>) -> Self {
-    let value = value.into();
-    Self { inner: value }
+    Self { repr: Self::classify(value.into()) }
   }
 
+  /// Construct a `ModuleId` that is known at compile time to be a virtual id
+  /// (e.g. the runtime module sentinel). The caller asserts the value is a
+  /// virtual id; it is not re-classified, so this can be used in `const` context.
   #[inline]
-  pub const fn new_arc_str(inner: ArcStr) -> Self {
-    Self { inner }
+  pub const fn new_virtual(inner: ArcStr) -> Self {
+    Self { repr: Repr::Virtual(inner) }
   }
 
   /// Construct the sentinel id used for `browser: false` ignored modules,
@@ -37,21 +72,76 @@ impl ModuleId {
     Self::new(format!("{EMPTY_MODULE_PREFIX}{original}"))
   }
 
+  fn classify(inner: ArcStr) -> Repr {
+    if inner.starts_with('\0') {
+      Repr::Virtual(inner)
+    } else if Path::new(inner.as_str()).is_absolute() {
+      Repr::Path(inner)
+    } else {
+      Repr::Bare(inner)
+    }
+  }
+
+  pub fn kind(&self) -> ModuleIdKind {
+    match self.repr {
+      Repr::Path(_) => ModuleIdKind::Path,
+      Repr::Virtual(_) => ModuleIdKind::Virtual,
+      Repr::Bare(_) => ModuleIdKind::Bare,
+    }
+  }
+
+  /// Whether the id is an absolute filesystem path.
+  pub fn is_path(&self) -> bool {
+    matches!(self.repr, Repr::Path(_))
+  }
+
   pub fn is_empty_module(&self) -> bool {
-    self.inner.starts_with(EMPTY_MODULE_PREFIX)
+    self.as_str().starts_with(EMPTY_MODULE_PREFIX)
   }
 
   /// For an id created via `new_empty`, returns the original id portion.
   pub fn strip_empty_prefix(&self) -> Option<&str> {
-    self.inner.strip_prefix(EMPTY_MODULE_PREFIX)
+    self.as_str().strip_prefix(EMPTY_MODULE_PREFIX)
   }
 
   pub fn as_str(&self) -> &str {
-    &self.inner
+    self.as_arc_str().as_str()
   }
 
   pub fn as_arc_str(&self) -> &ArcStr {
-    &self.inner
+    match &self.repr {
+      Repr::Path(inner) | Repr::Virtual(inner) | Repr::Bare(inner) => inner,
+    }
+  }
+
+  /// Borrow the id as a filesystem [`Path`], but only when it actually is one
+  /// (an absolute path). Returns `None` for virtual ids, bare specifiers, URLs,
+  /// etc. This is a zero-cost view (`Path::new`); use it to *gate* path logic so
+  /// non-path ids don't get silently path-parsed.
+  pub fn as_path(&self) -> Option<&Path> {
+    match &self.repr {
+      Repr::Path(inner) => Some(Path::new(inner.as_str())),
+      Repr::Virtual(_) | Repr::Bare(_) => None,
+    }
+  }
+
+  /// Whether the id is a filesystem path inside a `node_modules` directory.
+  /// Non-path ids (virtual, bare, URL) are never in `node_modules`.
+  pub fn is_in_node_modules(&self) -> bool {
+    self.as_path().is_some_and(rolldown_std_utils::PathExt::is_in_node_modules)
+  }
+
+  /// A short, human-meaningful name derived from the id, used for chunk and
+  /// variable naming. This intentionally applies the file-name heuristic to the
+  /// raw id regardless of kind (e.g. a virtual `\0…/empty.js?x` still yields
+  /// `empty`), matching historical behavior — naming is a heuristic, not a path
+  /// operation, so it is not gated on [`is_path`](Self::is_path).
+  pub fn representative_name(&self) -> Cow<'_, str> {
+    Path::new(self.as_str()).representative_file_name()
+  }
+
+  pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
+    Path::new(self.as_str()).relative(root)
   }
 
   pub fn stabilize(&self, cwd: &Path) -> StableModuleId {
@@ -59,13 +149,63 @@ impl ModuleId {
   }
 
   pub fn into_inner(self) -> ArcStr {
-    self.inner
+    match self.repr {
+      Repr::Path(inner) | Repr::Virtual(inner) | Repr::Bare(inner) => inner,
+    }
+  }
+}
+
+impl Default for ModuleId {
+  fn default() -> Self {
+    Self { repr: Repr::Bare(ArcStr::default()) }
+  }
+}
+
+impl std::fmt::Debug for ModuleId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    std::fmt::Debug::fmt(self.as_str(), f)
+  }
+}
+
+impl std::fmt::Display for ModuleId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    std::fmt::Display::fmt(self.as_str(), f)
+  }
+}
+
+// `Eq`/`Ord`/`Hash`/`Borrow<str>` are implemented in terms of `as_str()` (byte-exact,
+// ignoring the kind discriminant). This keeps the `&str`-lookup contract below: a
+// `ModuleId` hashes and compares identically to its string, so the same string always
+// classifies to one variant and the maps keyed by `ModuleId` stay consistent.
+impl PartialEq for ModuleId {
+  fn eq(&self, other: &Self) -> bool {
+    self.as_str() == other.as_str()
+  }
+}
+
+impl Eq for ModuleId {}
+
+impl PartialOrd for ModuleId {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Ord for ModuleId {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.as_str().cmp(other.as_str())
+  }
+}
+
+impl Hash for ModuleId {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.as_str().hash(state);
   }
 }
 
 impl AsRef<str> for ModuleId {
   fn as_ref(&self) -> &str {
-    &self.inner
+    self.as_str()
   }
 }
 
@@ -73,7 +213,7 @@ impl std::ops::Deref for ModuleId {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
-    &self.inner
+    self.as_str()
   }
 }
 
@@ -95,22 +235,9 @@ impl From<ArcStr> for ModuleId {
   }
 }
 
-impl std::fmt::Display for ModuleId {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    std::fmt::Display::fmt(&self.inner, f)
-  }
-}
-
-impl ModuleId {
-  pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
-    let path = self.inner.as_path();
-    path.relative(root)
-  }
-}
-
 // This allows to use `&str` to lookup `HashMap<ModuleId, V>`. For `&String`, since it could coerce to `&str`, it also works.
 impl Borrow<str> for ModuleId {
   fn borrow(&self) -> &str {
-    &self.inner
+    self.as_str()
   }
 }

--- a/crates/rolldown_common/src/types/stable_module_id.rs
+++ b/crates/rolldown_common/src/types/stable_module_id.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use rolldown_std_utils::PathExt as _;
 use sugar_path::SugarPath as _;
 
-use crate::ModuleId;
+use crate::{ModuleId, ModuleIdKind};
 
 /// `StableModuleId` is the stabilized version of `ModuleId`.
 /// - It is calculated based on `ModuleId` to be stable across machines and operating systems.
@@ -24,7 +24,17 @@ impl StableModuleId {
   /// - Escapes virtual module prefixes (`\0` → `\\0`)
   /// - Returns non-path specifiers as-is
   pub fn new(id: &ModuleId, cwd: &Path) -> Self {
-    Self::with_arc_str(id.as_arc_str().clone(), cwd)
+    // Classification already happened once when the `ModuleId` was built; branch on it
+    // instead of re-detecting absolute/virtual here.
+    let inner: ArcStr = match id.kind() {
+      // Absolute path → relative to cwd, slashed (stable across machines/OSes).
+      ModuleIdKind::Path => id.as_str().relative(cwd).as_path().expect_to_slash().into(),
+      // Virtual module → escape the `\0` prefix.
+      ModuleIdKind::Virtual => id.as_str().replace('\0', "\\0").into(),
+      // Bare specifier / URL / … → as-is (cheap `Arc` clone).
+      ModuleIdKind::Bare => id.as_arc_str().clone(),
+    };
+    Self { inner }
   }
 
   /// Creates a new `StableModuleId` from an `ArcStr` without stabilization.
@@ -34,18 +44,7 @@ impl StableModuleId {
 
   #[cfg(test)]
   fn with_str(id: &str, cwd: &Path) -> Self {
-    Self::with_arc_str(ArcStr::from(id), cwd)
-  }
-
-  fn with_arc_str(id: ArcStr, cwd: &Path) -> Self {
-    let arc_str: ArcStr = if id.as_path().is_absolute() {
-      id.relative(cwd).as_path().expect_to_slash().into()
-    } else if id.starts_with('\0') {
-      id.replace('\0', "\\0").into()
-    } else {
-      id
-    };
-    Self { inner: arc_str }
+    Self::new(&ModuleId::new(id), cwd)
   }
 
   pub fn as_str(&self) -> &str {

--- a/crates/rolldown_std_utils/src/path_ext.rs
+++ b/crates/rolldown_std_utils/src/path_ext.rs
@@ -34,23 +34,20 @@ impl PathExt for Path {
   }
 
   /// It doesn't ensure the file name is a valid identifier in JS.
+  ///
+  /// Callers pass module ids / specifiers, which are always valid UTF-8, so names
+  /// are extracted with `to_str()` and this never needs `to_string_lossy()`.
   fn representative_file_name(&self) -> Cow<'_, str> {
     let file_name =
-      self.file_stem().map_or_else(|| self.to_string_lossy(), |stem| stem.to_string_lossy());
+      self.file_stem().and_then(OsStr::to_str).or_else(|| self.to_str()).unwrap_or_default();
 
-    match &*file_name {
+    match file_name {
       // "index": Node.js use `index` as a special name for directory import.
       // "mod": https://docs.deno.com/runtime/manual/references/contributing/style_guide#do-not-use-the-filename-indextsindexjs.
-      "index" | "mod" => {
-        if let Some(parent_dir_name) =
-          self.parent().and_then(Path::file_name).map(OsStr::to_string_lossy)
-        {
-          parent_dir_name
-        } else {
-          file_name
-        }
-      }
-      _ => file_name,
+      "index" | "mod" => Cow::Borrowed(
+        self.parent().and_then(Path::file_name).and_then(OsStr::to_str).unwrap_or(file_name),
+      ),
+      _ => Cow::Borrowed(file_name),
     }
   }
 }
@@ -59,10 +56,13 @@ impl PathExt for Path {
 pub fn representative_file_name_for_preserve_modules(
   path: &Path,
 ) -> (Cow<'_, str>, String, Option<Cow<'_, str>>) {
-  let file_name =
-    path.file_stem().map_or_else(|| path.to_string_lossy(), |stem| stem.to_string_lossy());
-  let ab_path = path.with_extension("").to_string_lossy().into_owned();
-  (file_name, ab_path, path.extension().map(|item| item.to_string_lossy()))
+  // As above: `path` is a module id (valid UTF-8), so `to_str()` is infallible
+  // and we avoid `to_string_lossy()`.
+  let file_name = Cow::Borrowed(
+    path.file_stem().and_then(OsStr::to_str).or_else(|| path.to_str()).unwrap_or_default(),
+  );
+  let ab_path = path.with_extension("").to_str().unwrap_or_default().to_owned();
+  (file_name, ab_path, path.extension().and_then(OsStr::to_str).map(Cow::Borrowed))
 }
 
 pub fn strip_path_prefix_to_slash(path: &Path, prefix: &Path) -> Option<String> {

--- a/internal-docs/module-id/implementation.md
+++ b/internal-docs/module-id/implementation.md
@@ -34,14 +34,22 @@ Plugin APIs like `addWatchFile()` do **no normalization** — they trust the cal
 
 ### ModuleId
 
-`ModuleId` wraps `ArcStr`. Equality is raw string comparison — no path normalization.
+`ModuleId` is backed by an `ArcStr`, classified at construction into one of three kinds so that path operations only run on ids that actually are paths:
 
 ```rust
 // rolldown_common/src/types/module_id.rs
-pub struct ModuleId { inner: ArcStr }
+pub struct ModuleId { repr: Repr }
+
+enum Repr {
+  Path(ArcStr),    // absolute filesystem path — path operations are meaningful
+  Virtual(ArcStr), // virtual id, prefixed with `\0` (Rollup convention)
+  Bare(ArcStr),    // bare specifier (`react`), URL, data URI, relative specifier, …
+}
 ```
 
-The resolver (`oxc_resolver`) returns a `PathBuf`. Rolldown converts it to a string via `full_path().to_str()` and stores it as-is — no separator normalization. On Windows, module IDs contain native `\` separators.
+Equality, ordering, and hashing are still raw string comparison over `as_str()` (the kind discriminant is ignored), so path identity continues to depend on exact string equality, and a `ModuleId` hashes identically to its string — `&str` lookups into `HashMap<ModuleId, _>` keep working. The classification only gates _path_ logic: `as_path()` returns `Some(&Path)` only for the `Path` kind, and helpers like `is_in_node_modules()` / `representative_name()` build on it, so virtual ids and bare specifiers are no longer round-tripped through `Path` / `to_string_lossy`.
+
+The resolver (`oxc_resolver`) returns a `PathBuf`. Rolldown converts it to a string via `full_path().to_str()` and stores it as-is — no separator normalization. On Windows, module IDs contain native `\` separators, and such ids classify as `Path`.
 
 ### Comparison with Rollup
 


### PR DESCRIPTION
## Summary

`ModuleId` was a `struct { inner: ArcStr }` that every call site re-interpreted as a filesystem path through `SugarPath::as_path()` — treating virtual (`\0…`), bare (`react`), and URL ids as paths, and round-tripping bytes we already know are UTF-8 through `to_string_lossy`.

This remodels it as an enum classified **once** at construction:

```rust
pub struct ModuleId { repr: Repr }   // private enum Repr { Path | Virtual | Bare }
```

- **Gated path ops** — `as_path() -> Option<&Path>` (`Some` only for `Path`), plus `is_path()`, `is_virtual()`, `kind()`, `is_in_node_modules()`, `representative_name()`. Non-path ids are no longer silently path-parsed.
- **`ArcStr` kept** as the backing store — cheap clone, durable cross-build identity, `literal!` const for the runtime module. `ModuleIdx` (the `u32` per-build handle) stays the hot graph key, so `ModuleId` optimizes for being a faithful string/path identity rather than for size/hash speed.
- **Lossless** — every `to_string_lossy` on a `ModuleId` / `StableModuleId`-derived path becomes `to_str()` (module ids are always valid UTF-8). This is done in the shared `path_ext` helpers, so it also covers `ast_scanner` and preserve-modules naming.
- **`Hash` / `Eq` / `Ord` / `Borrow<str>`** are hand-implemented over `as_str()` (byte-exact, ignoring the discriminant) so `&str` lookups into `module_id_to_idx` / `user_defined_entry` keep working.
- **`StableModuleId::new`** branches on the cached `kind()` instead of re-running `is_absolute()` / `\0` detection.

## Why

A module id is sometimes a path and sometimes not. Treating it uniformly as a path was wasteful (redundant UTF-8 scans, `to_string_lossy` on known-UTF-8 data) and a latent correctness hazard. Classifying once makes the path / not-path distinction explicit and confines path semantics to where they belong.

## Validation

- `cargo test` — 1756 integration/snapshot tests pass with **zero snapshot/fixture churn**; behavior is identical.
- `clippy` (pedantic) and `fmt` clean.
- **Perf-neutral.** Benchmarked main vs branch (criterion, `bundle` group); a main-vs-main control showed the apparent ~3% delta was a first-run warm-up artifact correlated with case order, not the code — no regression, no real speedup, as expected for a modeling change whose per-module path logic is cost-equivalent.
