### PR TITLE
chore(deps): test mimalloc-safe upstream-mimalloc switch in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,8 +1183,7 @@ dependencies = [
 [[package]]
 name = "libmimalloc-sys2"
 version = "0.1.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9aa481aef14f119fb6d06536fd475dff463130ba19c5d5eb0821a5763e0d75"
+source = "git+https://github.com/napi-rs/mimalloc-safe?branch=06-23-chore_deps_switch_mimalloc3_to_upstream_microsoft_mimalloc#e7364eb05470c391721ec40d2a9f5929e728a603"
 dependencies = [
  "cc",
  "cmake",
@@ -1240,8 +1239,7 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 [[package]]
 name = "mimalloc-safe"
 version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb255e42b32f2e317b73c3c7285556cfd5a1bcf5ce272d4adce8c49e5e828ec2"
+source = "git+https://github.com/napi-rs/mimalloc-safe?branch=06-23-chore_deps_switch_mimalloc3_to_upstream_microsoft_mimalloc#e7364eb05470c391721ec40d2a9f5929e728a603"
 dependencies = [
  "libmimalloc-sys2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ json-escape-simd = "3"
 json-strip-comments = "3"
 jsonschema = { version = "0.46.5", default-features = false }
 memchr = "2.8.2"
-mimalloc-safe = "0.1.63"
+mimalloc-safe = { git = "https://github.com/napi-rs/mimalloc-safe", branch = "06-23-chore_deps_switch_mimalloc3_to_upstream_microsoft_mimalloc" }
 mime = "0.3.17"
 nodejs-built-in-modules = "1.0.0"
 nom = "8.0.0"


### PR DESCRIPTION
### What

Temporarily point `mimalloc-safe` at the [`napi-rs/mimalloc-safe` branch `06-23-chore_deps_switch_mimalloc3_to_upstream_microsoft_mimalloc`](https://github.com/napi-rs/mimalloc-safe/tree/06-23-chore_deps_switch_mimalloc3_to_upstream_microsoft_mimalloc) (commit `e7364eb`) instead of the crates.io `0.1.63` release — `Cargo.toml` + `Cargo.lock` only.

### Why

That branch switches mimalloc-safe's bundled mimalloc v3 from the `napi-rs/mimalloc` fork to upstream `microsoft/mimalloc`, now that the Apple fixed-TLS-slot collision is fixed upstream ([microsoft/mimalloc#1301](https://github.com/microsoft/mimalloc/issues/1301)). The minimal reproduction already passes locally; this runs rolldown's full CI/test suite against it to confirm no regression — in particular the worker-thread segfault from #9722.

### Notes

- **Not for merge as-is.** This is a git dependency for CI validation. Once mimalloc-safe publishes a release containing the switch, revert `Cargo.toml`/`Cargo.lock` to the versioned crates.io dependency.
- The dead-main-thread fix (#9722 / microsoft/mimalloc#1287) is already in the upstream source the branch points to, so the switch does not regress it.