### PR TITLE
fix(camel-case): correct camel case for nested values

### DIFF
--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -74,14 +74,17 @@ function kebabToCamelCase(input: string) {
   });
 }
 
-function camelizeNestedKeys(value: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+function camelizeNestedKeys(value: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
 
   for (const [key, nestedValue] of Object.entries(value)) {
-    result[kebabToCamelCase(key)] =
-      nestedValue && typeof nestedValue === 'object'
-        ? camelizeNestedKeys(nestedValue as Record<string, unknown>)
-        : nestedValue;
+    if (Array.isArray(nestedValue)) {
+      result[kebabToCamelCase(key)] = nestedValue;
+    } else if (nestedValue && typeof nestedValue === 'object') {
+      result[kebabToCamelCase(key)] = camelizeNestedKeys(nestedValue as Record<string, any>);
+    } else {
+      result[kebabToCamelCase(key)] = nestedValue;
+    }
   }
 
   return result;

--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -68,6 +68,25 @@ for (const config of Object.values(alias)) {
   }
 }
 
+function kebabToCamelCase(input: string) {
+  return input.replaceAll(/([a-z])-([a-z])/g, (_, p1, p2) => {
+    return p1 + p2.toUpperCase();
+  });
+}
+
+function camelizeNestedKeys(value: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    result[kebabToCamelCase(key)] =
+      nestedValue && typeof nestedValue === 'object'
+        ? camelizeNestedKeys(nestedValue as Record<string, unknown>)
+        : nestedValue;
+  }
+
+  return result;
+}
+
 export function parseCliArguments(): NormalizedCliOptions & {
   rawArgs: Record<string, any>;
 } {
@@ -170,6 +189,8 @@ export function parseCliArguments(): NormalizedCliOptions & {
     );
   }
 
+  //convert nested options to camelCase , cac only converts the top level Option
+  parsedOptions = camelizeNestedKeys(parsedOptions);
   // rawArgs assembly — snapshot before removing unknown keys
   const rawArgs: Record<string, any> = { ...parsedOptions };
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -675,6 +675,12 @@ export { cli_option_nested_default as default };
 "
 `;
 
+exports[`cli options for bundling > should handle options with dot when the name after dot is in kebab-case 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
+"
+`;
+
 exports[`cli options for bundling > should handle single array options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.14 kB
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -675,12 +675,6 @@ export { cli_option_nested_default as default };
 "
 `;
 
-exports[`cli options for bundling > should handle options with dot when the name after dot is in kebab-case 1`] = `
-"<DIR>/index.js  chunk │ size: 0.09 kB
-
-"
-`;
-
 exports[`cli options for bundling > should handle single array options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.14 kB
 

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -149,14 +149,19 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
-  it('should handle options with dot when the name after dot is in kebab-case', async () => {
-    const cwd = cliFixturesDir('cli-option-object');
+  it('camelCases kebab-case keys in nested dot options', async () => {
+    // cac only camelCases top-level option names; nested dot-notation keys
+    // (e.g. `--generated-code.profiler-names`) must be camelCased too (#9932).
+    // Every option below is a real rolldown option spanning several families
+    // (output: generated-code / advanced-chunks; input: transform / optimization
+    // / checks). The config function asserts the camelCased shape it receives,
+    // so an unconverted (or non-existent) key throws and fails the run.
+    const cwd = cliFixturesDir('cli-option-nested-kebab');
     const status = await $({
       cwd,
-    })`rolldown index.ts --generated-code.profiler-names --module-types .123:text,notjson:json --module-types .b64:base64 -d dist`;
+    })`rolldown -c rolldown.config.js --generated-code.symbols --generated-code.profiler-names --advanced-chunks.min-share-count 2 --transform.assumptions.object-rest-no-symbols --transform.typescript.only-remove-type-imports --optimization.inline-const --checks.circular-dependency`;
 
     expect(status.exitCode).toBe(0);
-    expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
   it('should handle comma-separated object options mixed with single object', async () => {

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -149,6 +149,16 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
+  it('should handle options with dot when the name after dot is in kebab-case', async () => {
+    const cwd = cliFixturesDir('cli-option-object');
+    const status = await $({
+      cwd,
+    })`rolldown index.ts --generated-code.profiler-names --module-types .123:text,notjson:json --module-types .b64:base64 -d dist`;
+
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+  });
+
   it('should handle comma-separated object options mixed with single object', async () => {
     const cwd = cliFixturesDir('cli-option-object');
     const status = await $({

--- a/packages/rolldown/tests/cli/fixtures/cli-option-nested-kebab/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-option-nested-kebab/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!';

--- a/packages/rolldown/tests/cli/fixtures/cli-option-nested-kebab/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-option-nested-kebab/rolldown.config.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { defineConfig } from 'rolldown';
+
+// Every option below is a real rolldown option reached via CLI dot-notation.
+// cac only camelCases top-level option names, leaving nested keys in kebab-case;
+// rolldown must camelCase them too (#9932) so they match the JS option names.
+//
+// This config function receives the parsed CLI args and asserts the converted
+// shape. Because the CLI validates options against the schema *before* calling
+// this function (strict objects reject unknown fields), and because the CLI
+// options are then merged into the real build, reaching these assertions with a
+// clean exit also proves each key actually exists in rolldown's options.
+export default defineConfig((args) => {
+  // output options
+  assert.deepStrictEqual(args.generatedCode, {
+    symbols: true,
+    profilerNames: true,
+  });
+  assert.deepStrictEqual(args.advancedChunks, { minShareCount: 2 });
+
+  // input options (incl. deeply nested)
+  assert.deepStrictEqual(args.transform, {
+    assumptions: { objectRestNoSymbols: true },
+    typescript: { onlyRemoveTypeImports: true },
+  });
+  assert.deepStrictEqual(args.optimization, { inlineConst: true });
+  assert.deepStrictEqual(args.checks, { circularDependency: true });
+
+  return { input: './index.js' };
+});


### PR DESCRIPTION

fixes #9932 

The cac library does not produce camel Case for nested options. So if you pass `rolldown -c rolldown.config.js --generated-code.profiler-names` it would end up as 
```
 {
  generatedCode:{
      profiler-names: " "
  }
}  

```
instead of
```
 {
  generatedCode:{
      profilerNames: " "
  }
}  
```

This PR fixes that my using recursive logic to add camelCase for nested properties in object.

The camel case logic is copied from the cac library.