### PR TITLE
perf: size Oxc AST allocators from source shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ name = "rolldown_ecmascript"
 version = "1.1.2"
 dependencies = [
  "arcstr",
+ "memchr",
  "oxc",
  "oxc_sourcemap",
  "oxc_str",
@@ -2989,6 +2990,7 @@ dependencies = [
  "memchr",
  "oxc",
  "rolldown_common",
+ "rolldown_ecmascript",
  "rolldown_plugin",
  "rolldown_utils",
  "string_wizard",
@@ -3005,6 +3007,7 @@ dependencies = [
  "oxc",
  "path-posix",
  "rolldown_common",
+ "rolldown_ecmascript",
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arcstr::ArcStr;
-use oxc::allocator::Allocator;
 use oxc::diagnostics::{OxcDiagnostic, Severity as OxcSeverity};
 use oxc::parser::{ParseOptions, Parser};
 use oxc::transformer::{Helper, HelperLoaderOptions};
@@ -23,7 +22,7 @@ use oxc::{
   },
 };
 use oxc_resolver::TsConfig;
-use rolldown_ecmascript::semantic_builder_for_transform;
+use rolldown_ecmascript::{allocator_for_source, semantic_builder_for_transform};
 use rolldown_error::{BuildDiagnostic, EventKind, Severity};
 use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
 use rustc_hash::FxHashMap;
@@ -322,7 +321,7 @@ pub fn enhanced_transform(
 
   let source: ArcStr = source_text.into();
 
-  let allocator = Allocator::default();
+  let allocator = allocator_for_source(&source);
   let parse_ret = Parser::new(&allocator, &source, source_type)
     .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
     .parse();

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 arcstr = { workspace = true }
+memchr = { workspace = true }
 oxc = { workspace = true }
 oxc_sourcemap = { workspace = true }
 oxc_str = { workspace = true }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -21,7 +21,7 @@ pub struct EcmaCompiler;
 impl EcmaCompiler {
   pub fn parse(id: &str, source: impl Into<ArcStr>, ty: SourceType) -> BuildResult<EcmaAst> {
     let source: ArcStr = source.into();
-    let allocator = oxc::allocator::Allocator::default();
+    let allocator = allocator_for_source(&source);
     let inner =
       ProgramCell::try_new(ProgramCellOwner { source: source.clone(), allocator }, |owner| {
         let parser = Parser::new(&owner.allocator, &owner.source, ty).with_options(ParseOptions {
@@ -50,7 +50,7 @@ impl EcmaCompiler {
     ty: SourceType,
   ) -> BuildResult<EcmaAst> {
     let source: ArcStr = source.into();
-    let allocator = oxc::allocator::Allocator::default();
+    let allocator = allocator_for_source(&source);
     let inner =
       ProgramCell::try_new(ProgramCellOwner { source: source.clone(), allocator }, |owner| {
         let builder = AstBuilder::new(&owner.allocator);
@@ -128,11 +128,50 @@ impl EcmaCompiler {
   }
 }
 
+/// Create an Oxc AST allocator with initial capacity derived from the source shape.
+pub fn allocator_for_source(source: &str) -> Allocator {
+  initial_ast_capacity(source).map_or_else(Allocator::default, Allocator::with_capacity)
+}
+
+fn initial_ast_capacity(source: &str) -> Option<usize> {
+  // Oxc's default first chunk is 16 KiB, which over-allocates heavily for
+  // projects containing thousands of small modules. Source size is a useful
+  // baseline, while import-dense modules need extra room for their many short
+  // AST nodes. Larger estimates use Oxc's default growth policy to avoid a
+  // large upfront allocation for sources containing mostly comments or data.
+  const BYTES_PER_SOURCE_BYTE: usize = 8;
+  const BYTES_PER_IMPORT: usize = 1024;
+  const FIXED_HEADROOM: usize = 2048;
+  const MAX_INITIAL_CAPACITY: usize = 64 * 1024;
+
+  if source.is_empty() {
+    return Some(0);
+  }
+
+  let base_capacity =
+    source.len().saturating_mul(BYTES_PER_SOURCE_BYTE).saturating_add(FIXED_HEADROOM);
+  if base_capacity > MAX_INITIAL_CAPACITY {
+    return None;
+  }
+
+  let import_count = memchr::memmem::find_iter(source.as_bytes(), b"import").count();
+  let capacity = base_capacity.saturating_add(import_count.saturating_mul(BYTES_PER_IMPORT));
+  (capacity <= MAX_INITIAL_CAPACITY).then_some(capacity)
+}
+
 #[test]
 fn basic_test() {
   let ast = EcmaCompiler::parse("", "const a = 1;".to_string(), SourceType::default()).unwrap();
   let code = EcmaCompiler::print_with(&ast, PrintOptions::default()).code;
   assert_eq!(code, "const a = 1;\n");
+}
+
+#[test]
+fn initial_ast_capacity_accounts_for_source_shape_and_limit() {
+  let source = "import a from 'a';\nimport b from 'b';\nexport { a, b };";
+  assert_eq!(initial_ast_capacity(source), Some(source.len() * 8 + 2 * 1024 + 2048));
+  assert_eq!(initial_ast_capacity(""), Some(0));
+  assert_eq!(initial_ast_capacity(&"x".repeat(8 * 1024)), None);
 }
 #[derive(Debug, Default)]
 

--- a/crates/rolldown_ecmascript/src/lib.rs
+++ b/crates/rolldown_ecmascript/src/lib.rs
@@ -11,5 +11,5 @@ pub use crate::{
   ecma_ast::{
     EcmaAst, ToSourceString, program_cell::WithMutFields, semantic_builder_for_transform,
   },
-  ecma_compiler::{EcmaCompiler, PrintCommentsOptions, PrintOptions},
+  ecma_compiler::{EcmaCompiler, PrintCommentsOptions, PrintOptions, allocator_for_source},
 };

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -24,6 +24,7 @@ derive_more = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
+rolldown_ecmascript = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }
 string_wizard = { workspace = true }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, pin::Pin, sync::Arc};
 
 use oxc::ast_visit::Visit;
 use rolldown_common::ModuleType;
+use rolldown_ecmascript::allocator_for_source;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
   HookResolveIdReturn, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
@@ -72,7 +73,7 @@ impl Plugin for ViteDynamicImportVarsPlugin {
       ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
     ) && utils::has_dynamic_import(args.code)
     {
-      let allocator = oxc::allocator::Allocator::default();
+      let allocator = allocator_for_source(args.code);
       let source_type = match args.module_type {
         ModuleType::Js => oxc::span::SourceType::mjs(),
         ModuleType::Jsx => oxc::span::SourceType::jsx(),

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -24,6 +24,7 @@ itoa = { workspace = true }
 oxc = { workspace = true }
 path-posix = { workspace = true }
 rolldown_common = { workspace = true }
+rolldown_ecmascript = { workspace = true }
 rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -4,6 +4,7 @@ use std::{borrow::Cow, path::PathBuf};
 
 use oxc::ast_visit::Visit;
 use rolldown_common::ModuleType;
+use rolldown_ecmascript::allocator_for_source;
 use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
 use sugar_path::SugarPath as _;
 
@@ -33,7 +34,7 @@ impl Plugin for ViteImportGlobPlugin {
       ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
     ) && args.code.contains("import.meta.glob")
     {
-      let allocator = oxc::allocator::Allocator::default();
+      let allocator = allocator_for_source(args.code);
       let source_type = match args.module_type {
         ModuleType::Js => oxc::span::SourceType::mjs(),
         ModuleType::Jsx => oxc::span::SourceType::jsx(),

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -7,7 +7,7 @@ use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
 use oxc::parser::Parser;
 use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
-use rolldown_ecmascript::semantic_builder_for_transform;
+use rolldown_ecmascript::{allocator_for_source, semantic_builder_for_transform};
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, EventKind, Severity};
 use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
@@ -58,7 +58,7 @@ impl Plugin for ViteTransformPlugin {
     let (source_type, transform_options) =
       self.get_modified_transform_options(&ctx, args.id, &cwd, extension, args.code)?;
 
-    let allocator = oxc::allocator::Allocator::default();
+    let allocator = allocator_for_source(args.code);
     let ret = Parser::new(&allocator, args.code, source_type).parse();
     if ret.panicked || !ret.diagnostics.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(


### PR DESCRIPTION
## What

Add a shared `allocator_for_source` helper for Oxc AST parsing.

For small sources, the initial arena capacity is estimated from:

```text
source bytes * 8 + raw "import" occurrences * 1024 + 2048
```

The estimate is bounded at 64 KiB. Larger or unusually import-dense sources use
Oxc's default lazy growth policy instead, avoiding a large upfront allocation
for comment-heavy, generated, or data-heavy files.

The helper is used by:

- `EcmaCompiler::parse`
- `EcmaCompiler::parse_expr_as_program`
- the enhanced transform API
- the native Vite transform plugin
- the Vite import-glob plugin
- the Vite dynamic-import-vars plugin

## Why

Oxc's default first arena chunk is approximately 16 KiB. That is a good general
default, but it over-allocates heavily for projects with thousands of tiny
modules.

On `rolldown-benchmarks/apps/10000`, per-AST instrumentation measured:

| Metric | Current main | This PR |
| --- | ---: | ---: |
| Retained AST used bytes | 85.2 MB | 85.2 MB |
| Retained AST capacity | 339.7 MB | 188.0 MB |

The source-shaped allocator keeps used bytes unchanged while reducing unused
arena capacity.

## How the formula was derived

The constants are empirical, not an existing Oxc formula.

I instrumented every retained AST in `apps/10000` and recorded source length,
raw `import` substring count, `Allocator::used_bytes()`, and
`Allocator::capacity()` for 20,014 ASTs:

| Distribution | Source bytes | AST used bytes |
| --- | ---: | ---: |
| Total | 9,969,856 | 85,176,456 |
| p50 | 333 | 4,896 |
| p95 | 904 | 15,176 |
| p99 | 1,273 | 15,176 |

Source length alone fitted the ordinary modules reasonably well, but
import-dense fixture modules created many short AST nodes relative to their
source length. I evaluated several initial-capacity policies against the
measured `used_bytes`:

| Candidate estimate | Requested total | Underestimated ASTs | Total shortfall |
| --- | ---: | ---: | ---: |
| `8 * source + 768 * imports + 2 KiB` | 151.5 MB | 113 | 267.6 KiB |
| `6 * source + 1 KiB * imports + 2 KiB` | 141.8 MB | 6 | 707.9 KiB |
| `8 * source + 1 KiB * imports + 2 KiB` | 161.7 MB | 2 | 38.6 KiB |

That produced the selected constants:

- `8 * source`: observed baseline AST density;
- `2 KiB`: fixed program/scope/node headroom for small modules;
- `1 KiB * imports`: correction for import-dense modules that source size alone
  underestimated.

Underestimation is safe because the arena grows normally. The 6x variant saved
only about another 10 MB of actual retained capacity and cost roughly 1% CPU
and wall time in the full build, so the 8x variant was retained.

The 64 KiB cutoff was added after checking large sources. For example, the
536 KiB React DOM client source used about 3.46 MB of AST arena; an uncapped
estimate reserved 4.29 MB while Oxc's default growth reached about 4.18 MB.
Large estimates therefore fall back to the default allocator.

This remains a workload-fitted heuristic. In particular, a sparse source made
mostly of comments or a long literal can reserve more than Oxc's default first
chunk despite having a small AST. The cutoff bounds that downside but does not
eliminate it. An Oxc-owned parser estimate or allocator policy would be more
principled and reusable across consumers.

## Results

Measured against merge base `b311823d9` with profile bindings on an Apple M4
Pro. Six independent `/usr/bin/time -lp` runs per binary:

| Maximum RSS | Current main | This PR |
| --- | ---: | ---: |
| Mean | 1.296 GB | 1.106 GB |
| Range | 1.279-1.309 GB | 1.098-1.110 GB |

This reduces mean maximum RSS by approximately **190 MB / 14.7%**.

Two reversed-order Hyperfine rounds, 15 measured runs per command per round:

| Process wall time | Mean | Standard deviation |
| --- | ---: | ---: |
| Current main | 1126.7 ms | 16.4 ms |
| This PR | 1130.4 ms | 11.7 ms |

The measured difference is `+0.33%`, with a 95% interval of approximately
`-3.6 ms` to `+11.1 ms`, so no wall-time change is claimed.

Generated artifacts are byte-identical:

| Artifact | SHA-256 |
| --- | --- |
| `main.js` | `c979866916f92e457f6d8c31edc0bf04505a7e34ac89e26ee2c6d8ccbfbf5947` |
| `main.js.map` | `1219277cd29fe7820c3e5f7efb0ac051448df6003ab33492ac9c812fe8efbb35` |

## Alternatives explored

- A 6x source-size multiplier saved only about another 10 MB and added roughly
  1% CPU/wall-time cost.
- Compacting AST arenas after parsing added CPU work and did not improve peak
  RSS because the old and new arenas overlap during cloning.
- Leaving the estimate unbounded can over-allocate large sources, which is why
  estimates above 64 KiB fall back to Oxc's default allocator.

The main reviewer-sensitive part is the sizing heuristic and 64 KiB cutoff.
Underestimates are safe because Oxc grows the arena normally.

## Tests

- `cargo clippy --workspace --all-targets -- --deny warnings`
- `cargo test -p rolldown_ecmascript -p rolldown_common -p rolldown_plugin_vite_dynamic_import_vars -p rolldown_plugin_vite_import_glob -p rolldown_plugin_vite_transform`
- `vp run --filter @rolldown/test-dev-server build`
- `vp run --filter rolldown-tests test:main` (`763` passed, `16` skipped)
- `vp run --filter rolldown-tests test:watcher` (`36` passed)
- `vp run --filter rolldown build-native:profile`
- `cargo fmt --all --check`
- `git diff --check`
