### PR TITLE
perf(sourcemap): skip newline scan on the no-sourcemap join fast path

### DIFF
--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -45,29 +45,40 @@ impl<'source> SourceJoiner<'source> {
         + sources_len;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
-    let mut line_offset = 0;
-
-    let mut sourcemap_builder = self.enable_sourcemap.then(|| {
-      ConcatSourceMapBuilder::with_capacity(
-        self.names_len,
-        self.sources_len,
-        self.tokens_len,
-        self.token_chunks_len,
-      )
-    });
-    for (index, source) in sources_iter {
-      if let Some(sourcemap_builder) = &mut sourcemap_builder {
-        source.sourcemap().inspect(|map| {
-          sourcemap_builder.add_sourcemap(map, line_offset);
-        });
+    // Fast path: when no source carries a sourcemap, `join` is a plain
+    // concatenation with `\n` separators. `line_offset` and the per-source
+    // `lines_count()` newline scan exist only to feed the sourcemap builder,
+    // so skip them entirely here. Splitting the loop (rather than branching
+    // inside it) also keeps the sourcemap loop below free of per-iteration
+    // builder checks.
+    if !self.enable_sourcemap {
+      for (index, source) in sources_iter {
+        ret_source.push_str(source.content());
+        if index < sources_len - 1 {
+          ret_source.push('\n');
+        }
       }
+      return (ret_source, None);
+    }
+
+    let mut line_offset = 0;
+    let mut sourcemap_builder = ConcatSourceMapBuilder::with_capacity(
+      self.names_len,
+      self.sources_len,
+      self.tokens_len,
+      self.token_chunks_len,
+    );
+    for (index, source) in sources_iter {
+      source.sourcemap().inspect(|map| {
+        sourcemap_builder.add_sourcemap(map, line_offset);
+      });
       ret_source.push_str(source.content());
       if index < sources_len - 1 {
         ret_source.push('\n');
         line_offset += source.lines_count() + 1; // +1 for the newline
       }
     }
-    (ret_source, sourcemap_builder.map(|builder| builder.into_sourcemap().into_owned()))
+    (ret_source, Some(sourcemap_builder.into_sourcemap().into_owned()))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {


### PR DESCRIPTION
## What

`SourceJoiner::join` advanced `line_offset` on every iteration via `source.lines_count()` — a `memchr` newline scan over the full content. But `line_offset` is only ever read by the sourcemap builder, so on the common no-sourcemap build (no source carries a map → builder is `None`) it is a dead value, and every module's content was scanned twice: once by `push_str` (the copy) and once by `lines_count()`.

This splits `join` into:

- a **no-sourcemap fast path** — plain concatenation with `\n` separators, no `lines_count()` scan;
- the existing **sourcemap loop**, with the per-iteration `if let Some(builder)` check hoisted out (so the sourcemap path is, if anything, slightly tighter than before).

## Numbers

Interleaved A/B (`--profile profile`, thin-LTO) against a *recompiled-original* control. The control matters: `join_with_sourcemap` is bandwidth-bound and swings ±27% between identical-source recompiles from code layout alone, so a saved baseline would falsely report a regression.

| bench | before | after | |
|---|---|---|---|
| `crates/bench` `sourcemap/join_no_sourcemap` | ~62.3 µs | ~42.2 µs | **−32%** |
| `rolldown_sourcemap/benches/join` (10k × 1KB modules) | ~391 µs | ~254 µs | **−35%** |
| `crates/bench` `sourcemap/join_with_sourcemap` | ~417 µs | ~411 µs | neutral |
| `bundle@threejs` (e2e, no-sourcemap) | ~23.25 ms | ~23.17 ms | no regression |

Two independent no-sourcemap join benches agree (~−32% / −35%). End-to-end magnitude is small (join is a thin slice of generate), but it is a clean, isolated win on a path every no-sourcemap build hits.

## Correctness

Behavior-preserving by construction — the no-sourcemap path emits the identical concatenation; only the dead `line_offset` bookkeeping is skipped.

- `cargo test -p rolldown_sourcemap` — 4/4 pass (exact-output assertions on both paths)
- `cargo test -p rolldown --test integration` — 1756 passed, 0 failed (byte-identical snapshots, all output formats)
- `cargo clippy -p rolldown_sourcemap` — clean
