### PR TITLE
test: cover preserveModules named export via namespace re-export (#6010)

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/6010/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6010/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Test for issue #6010: With preserveModules, a named export (`myVariable`) is dropped from the emitted chunk when the module is only consumed through a namespace re-export (`export * as three`). `dist/three.js` should keep `export { myVariable, three_exports }`.",
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "./index.js"
+      }
+    ],
+    "preserveModules": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6010/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6010/_test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+// #6010: the named export must survive on the individual preserved module file.
+// Without the fix `dist/three.js` omits `myVariable`, so this import would be
+// `undefined` (and fail at ESM link time in stricter loaders).
+import { myVariable } from './dist/three.js';
+// It must also stay reachable through the `export * as` namespace chain.
+import { two } from './dist/index.js';
+
+assert.strictEqual(myVariable, 'world');
+assert.strictEqual(two.three.myVariable, 'world');

--- a/crates/rolldown/tests/rolldown/issues/6010/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6010/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/_rolldown/runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll };
+
+```
+
+## index.js
+
+```js
+import { two_exports } from "./two.js";
+export { two_exports as two };
+
+```
+
+## three.js
+
+```js
+import { __exportAll } from "./_virtual/_rolldown/runtime.js";
+//#region three.js
+var three_exports = /* @__PURE__ */ __exportAll({ myVariable: () => myVariable });
+const myVariable = "world";
+//#endregion
+export { myVariable, three_exports };
+
+```
+
+## two.js
+
+```js
+import { __exportAll } from "./_virtual/_rolldown/runtime.js";
+import { three_exports } from "./three.js";
+//#region two.js
+var two_exports = /* @__PURE__ */ __exportAll({ three: () => three_exports });
+//#endregion
+export { three_exports as three, two_exports };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/6010/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6010/index.js
@@ -1,0 +1,1 @@
+export * as two from './two.js';

--- a/crates/rolldown/tests/rolldown/issues/6010/three.js
+++ b/crates/rolldown/tests/rolldown/issues/6010/three.js
@@ -1,0 +1,1 @@
+export const myVariable = 'world';

--- a/crates/rolldown/tests/rolldown/issues/6010/two.js
+++ b/crates/rolldown/tests/rolldown/issues/6010/two.js
@@ -1,0 +1,1 @@
+export * as three from './three.js';


### PR DESCRIPTION
## What

Adds a regression fixture for #6010. Under `preserveModules`, a named export reached **only** through an `export * as` namespace chain was dropped from its module's emitted export list.

Reproduction (`index → two → three`):

```js
// index.js
export * as two from './two.js';
// two.js
export * as three from './three.js';
// three.js
export const myVariable = 'world';
```

- **Before:** `dist/three.js` emitted `export { three_exports };` — `myVariable` dropped.
- **After:** `dist/three.js` emits `export { myVariable, three_exports };` — matching the issue's expected output and Rollup.

## Fix location

This is the same root cause as #9122 — the named export's home survives tree-shaking (the namespace getter references it) but it was missing from the module's declared interface. The fix lands in the stacked PR #9934 (`preserve_reexported_interfaces` post-pass + full declared-interface emission in `compute_cross_chunk_links`), which already produces the correct output for this namespace-chain variant.

**This PR is test-only** — it adds the `issues/6010` fixture covering the `export * as` chain, a distinct scenario from #9122's `export { x } from` re-export facades.

> Stacked on #9934. Verified: the fixture fails on `main` (drops `myVariable`) and passes with #9934's fix in place.

Closes #6010

🤖 Generated with [Claude Code](https://claude.com/claude-code)