### PR TITLE
feat: add self-sufficient, scoped pure top-level call treeshaking

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -25,6 +25,26 @@ pub struct SideEffectDetector<'a> {
   namespace_object_symbol_ids: Option<&'a FxHashSet<SymbolId>>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct ExprSideEffectContext {
+  assignment_context: bool,
+  in_callee: bool,
+}
+
+impl ExprSideEffectContext {
+  fn assignment_context(self) -> Self {
+    Self { assignment_context: true, ..self }
+  }
+
+  fn callee(self) -> Self {
+    Self { in_callee: true, ..self }
+  }
+
+  fn argument(self) -> Self {
+    Self { in_callee: false, ..self }
+  }
+}
+
 impl<'a> SideEffectDetector<'a> {
   pub fn new(
     scope: &'a AstScopes,
@@ -136,36 +156,46 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
-  fn detect_side_effect_of_call_expr(&self, expr: &CallExpression) -> SideEffectDetail {
+  fn detect_side_effect_of_call_expr(
+    &self,
+    expr: &CallExpression,
+    context: ExprSideEffectContext,
+  ) -> SideEffectDetail {
     let is_pure_annotated =
       !self.flat_options.ignore_annotations() && (expr.pure || self.is_call_expr_marked_pure(expr));
+    let is_pure_top_level_call =
+      self.flat_options.pure_top_level_calls() && context.assignment_context && !context.in_callee;
+    let is_pure_call = is_pure_annotated || is_pure_top_level_call;
 
     // For pure-annotated calls, the call itself is side-effect-free.
     // We must check args via Rolldown's detector (not Oxc's) because Rolldown
     // has bundler-specific overrides (e.g. import.meta.url is side-effect-free).
     // Oxc's pure-call handling would still check args via its own may_have_side_effects,
     // which doesn't know about these overrides.
-    let has_side_effect = if is_pure_annotated { false } else { expr.may_have_side_effects(self) };
+    let has_side_effect = if is_pure_call { false } else { expr.may_have_side_effects(self) };
 
     let is_global_call = !has_side_effect
       && matches!(&expr.callee, Expression::Identifier(id) if self.is_unresolved_reference(id));
 
     let mut detail = SideEffectDetail::from(has_side_effect);
-    detail.set(SideEffectDetail::PureAnnotation, is_pure_annotated);
+    detail.set(SideEffectDetail::PureAnnotation, is_pure_call);
     detail.set(SideEffectDetail::GlobalVarAccess, is_global_call);
 
     if !has_side_effect {
       // Strip the Unknown flag from callee since the call itself is known-pure/safe.
-      detail |= self.detect_side_effect_of_expr(&expr.callee) - SideEffectDetail::Unknown;
+      detail |= self.detect_side_effect_of_expr_with_context(&expr.callee, context.callee())
+        - SideEffectDetail::Unknown;
 
-      if is_pure_annotated {
+      if is_pure_call {
         // Pure-annotated calls bypass Oxc's arg checking, so we must check args
         // through Rolldown's detector which has bundler-specific overrides
         // (e.g. import.meta.url is side-effect-free).
         for arg in &expr.arguments {
           detail |= match arg {
             Argument::SpreadElement(_) => true.into(),
-            _ => self.detect_side_effect_of_expr(arg.to_expression()),
+            _ => {
+              self.detect_side_effect_of_expr_with_context(arg.to_expression(), context.argument())
+            }
           };
           if detail.has_side_effect() {
             break;
@@ -177,8 +207,9 @@ impl<'a> SideEffectDetector<'a> {
           if let Argument::SpreadElement(_) = arg {
             break;
           }
-          detail |=
-            self.detect_side_effect_of_expr(arg.to_expression()) - SideEffectDetail::Unknown;
+          detail |= self
+            .detect_side_effect_of_expr_with_context(arg.to_expression(), context.argument())
+            - SideEffectDetail::Unknown;
         }
       }
     }
@@ -195,6 +226,14 @@ impl<'a> SideEffectDetector<'a> {
   }
 
   fn detect_side_effect_of_expr(&self, expr: &Expression) -> SideEffectDetail {
+    self.detect_side_effect_of_expr_with_context(expr, ExprSideEffectContext::default())
+  }
+
+  fn detect_side_effect_of_expr_with_context(
+    &self,
+    expr: &Expression,
+    context: ExprSideEffectContext,
+  ) -> SideEffectDetail {
     // Peel transparent wrappers (`(x)`, `x as T`, `x satisfies T`, `x!`, `<T>x`, `x<T>`)
     // — they add no runtime semantics, so we recurse into the inner expression.
     let expr = expr.get_inner_expression();
@@ -208,7 +247,20 @@ impl<'a> SideEffectDetector<'a> {
         // Bundler-specific: CJS `exports.foo = ...` must be checked before Oxc,
         // because Oxc would see a write to an unresolved global and return true.
         if let Some(pure_cjs) = check_pure_cjs_export(self.scope, &assign_expr.left) {
-          return pure_cjs | self.detect_side_effect_of_expr(&assign_expr.right);
+          return pure_cjs
+            | self.detect_side_effect_of_expr_with_context(
+              &assign_expr.right,
+              context.assignment_context(),
+            );
+        }
+        if self.flat_options.pure_top_level_calls()
+          && let AssignmentTarget::AssignmentTargetIdentifier(ident) = &assign_expr.left
+          && !self.is_unresolved_reference(ident)
+        {
+          return self.detect_side_effect_of_expr_with_context(
+            &assign_expr.right,
+            context.assignment_context(),
+          );
         }
         if assign_expr.may_have_side_effects(self) {
           return true.into();
@@ -218,9 +270,11 @@ impl<'a> SideEffectDetector<'a> {
       }
 
       Expression::ChainExpression(chain_expr) => match &chain_expr.expression {
-        ChainElement::CallExpression(call_expr) => self.detect_side_effect_of_call_expr(call_expr),
+        ChainElement::CallExpression(call_expr) => {
+          self.detect_side_effect_of_call_expr(call_expr, context)
+        }
         ChainElement::TSNonNullExpression(ts_expr) => {
-          self.detect_side_effect_of_expr(&ts_expr.expression)
+          self.detect_side_effect_of_expr_with_context(&ts_expr.expression, context)
         }
         match_member_expression!(ChainElement) => {
           self.detect_side_effect_of_member_expr(chain_expr.expression.to_member_expression())
@@ -234,31 +288,44 @@ impl<'a> SideEffectDetector<'a> {
         self.collect_write_target_metadata(&update_expr.argument)
       }
       Expression::NewExpression(expr) => {
-        let has_side_effect = expr.may_have_side_effects(self);
+        let is_pure_top_level_call = self.flat_options.pure_top_level_calls()
+          && context.assignment_context
+          && !context.in_callee;
+        let has_side_effect =
+          if is_pure_top_level_call { false } else { expr.may_have_side_effects(self) };
 
         // METADATA: GlobalVarAccess — constructor is a known global
         let is_global_constructor = !has_side_effect
           && matches!(&expr.callee, Expression::Identifier(id) if self.is_unresolved_reference(id));
         // METADATA: PureAnnotation — marked with /*@__PURE__*/
-        let is_pure_annotated = !self.flat_options.ignore_annotations() && expr.pure;
+        let is_pure_annotated =
+          (!self.flat_options.ignore_annotations() && expr.pure) || is_pure_top_level_call;
 
         let mut detail = SideEffectDetail::from(has_side_effect);
         detail.set(SideEffectDetail::GlobalVarAccess, is_global_constructor);
         detail.set(SideEffectDetail::PureAnnotation, is_pure_annotated);
 
         if !has_side_effect {
+          detail |= self.detect_side_effect_of_expr_with_context(&expr.callee, context.callee())
+            - SideEffectDetail::Unknown;
           // Oxc already verified args are side-effect-free; only collect metadata flags.
           for arg in &expr.arguments {
             if let Argument::SpreadElement(_) = arg {
+              detail |= true.into();
               break;
             }
-            detail |=
-              self.detect_side_effect_of_expr(arg.to_expression()) - SideEffectDetail::Unknown;
+            let arg_detail =
+              self.detect_side_effect_of_expr_with_context(arg.to_expression(), context.argument());
+            detail |= if is_pure_top_level_call {
+              arg_detail
+            } else {
+              arg_detail - SideEffectDetail::Unknown
+            };
           }
         }
         detail
       }
-      Expression::CallExpression(expr) => self.detect_side_effect_of_call_expr(expr),
+      Expression::CallExpression(expr) => self.detect_side_effect_of_call_expr(expr, context),
 
       // Transparent wrappers: oxc validates the boolean side-effect status,
       // we then recurse children to harvest metadata flags
@@ -281,6 +348,7 @@ impl<'a> SideEffectDetector<'a> {
             ast::ObjectPropertyKind::SpreadProperty(s) => [Some(&s.argument), None],
           })
           .flatten(),
+        context,
       ),
       Expression::ArrayExpression(arr) => self.fold_compound(
         expr,
@@ -289,15 +357,16 @@ impl<'a> SideEffectDetector<'a> {
           ast::ArrayExpressionElement::Elision(_) => None,
           e => Some(e.to_expression()),
         }),
+        context,
       ),
-      Expression::SequenceExpression(s) => self.fold_compound(expr, &s.expressions),
-      Expression::TemplateLiteral(t) => self.fold_compound(expr, &t.expressions),
+      Expression::SequenceExpression(s) => self.fold_compound(expr, &s.expressions, context),
+      Expression::TemplateLiteral(t) => self.fold_compound(expr, &t.expressions, context),
       Expression::ConditionalExpression(c) => {
-        self.fold_compound(expr, [&c.test, &c.consequent, &c.alternate])
+        self.fold_compound(expr, [&c.test, &c.consequent, &c.alternate], context)
       }
-      Expression::LogicalExpression(e) => self.fold_compound(expr, [&e.left, &e.right]),
-      Expression::BinaryExpression(e) => self.fold_compound(expr, [&e.left, &e.right]),
-      Expression::UnaryExpression(e) => self.fold_compound(expr, [&e.argument]),
+      Expression::LogicalExpression(e) => self.fold_compound(expr, [&e.left, &e.right], context),
+      Expression::BinaryExpression(e) => self.fold_compound(expr, [&e.left, &e.right], context),
+      Expression::UnaryExpression(e) => self.fold_compound(expr, [&e.argument], context),
 
       // Everything else: delegate entirely to Oxc.
       // Covers literals, function/arrow/class expressions (bodies not evaluated
@@ -322,18 +391,21 @@ impl<'a> SideEffectDetector<'a> {
     &self,
     expr: &Expression,
     children: impl IntoIterator<Item = &'e Expression<'e>>,
+    context: ExprSideEffectContext,
   ) -> SideEffectDetail {
-    if expr.may_have_side_effects(self) {
+    let use_custom_child_detection =
+      self.flat_options.pure_top_level_calls() && context.assignment_context;
+    if !use_custom_child_detection && expr.may_have_side_effects(self) {
       return true.into();
     }
     let mut detail = SideEffectDetail::empty();
     for child in children {
-      detail |= self.detect_side_effect_of_expr(child);
+      detail |= self.detect_side_effect_of_expr_with_context(child, context);
       if detail.has_side_effect() {
         break;
       }
     }
-    detail - SideEffectDetail::Unknown
+    if use_custom_child_detection { detail } else { detail - SideEffectDetail::Unknown }
   }
 
   fn detect_side_effect_of_var_decl(
@@ -362,7 +434,12 @@ impl<'a> SideEffectDetector<'a> {
             _ => declarator
               .init
               .as_ref()
-              .map(|init| self.detect_side_effect_of_expr(init))
+              .map(|init| {
+                self.detect_side_effect_of_expr_with_context(
+                  init,
+                  ExprSideEffectContext::default().assignment_context(),
+                )
+              })
               .unwrap_or(false.into()),
           };
         }
@@ -438,9 +515,11 @@ impl<'a> SideEffectDetector<'a> {
       ast::ModuleDeclaration::ExportDefaultDeclaration(default_decl) => {
         use oxc::ast::ast::ExportDefaultDeclarationKind;
         match &default_decl.declaration {
-          decl @ oxc::ast::match_expression!(ExportDefaultDeclarationKind) => {
-            self.detect_side_effect_of_expr(decl.to_expression())
-          }
+          decl @ oxc::ast::match_expression!(ExportDefaultDeclarationKind) => self
+            .detect_side_effect_of_expr_with_context(
+              decl.to_expression(),
+              ExprSideEffectContext::default().assignment_context(),
+            ),
           ast::ExportDefaultDeclarationKind::FunctionDeclaration(_) => false.into(),
           ast::ExportDefaultDeclarationKind::ClassDeclaration(decl) => {
             decl.may_have_side_effects(self).into()
@@ -655,6 +734,13 @@ mod test {
   use rolldown_common::FlatOptions;
 
   fn get_statements_side_effect(code: &str) -> bool {
+    get_statements_side_effect_with_pure_top_level_calls(code, false)
+  }
+
+  fn get_statements_side_effect_with_pure_top_level_calls(
+    code: &str,
+    pure_top_level_calls: bool,
+  ) -> bool {
     let source_type = SourceType::tsx();
     let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
     let semantic = EcmaAst::make_semantic(ast.program());
@@ -662,7 +748,8 @@ mod test {
     let ast_scopes = AstScopes::new(scoping);
 
     let options = Arc::new(NormalizedBundlerOptions::default());
-    let flags = FlatOptions::from_shared_options(&options);
+    let mut flags = FlatOptions::from_shared_options(&options);
+    flags.set(FlatOptions::PureTopLevelCalls, pure_top_level_calls);
     ast.program().body.iter().any(|stmt| {
       SideEffectDetector::new(&ast_scopes, flags, &options, None, None)
         .detect_side_effect_of_stmt(stmt)
@@ -688,6 +775,35 @@ mod test {
           .detect_side_effect_of_stmt(stmt)
       })
       .collect_vec()
+  }
+
+  #[test]
+  fn test_pure_top_level_calls() {
+    assert!(get_statements_side_effect("const a = fn()"));
+    assert!(!get_statements_side_effect_with_pure_top_level_calls("const a = fn()", true));
+
+    assert!(get_statements_side_effect("const a = fn(arg())"));
+    assert!(!get_statements_side_effect_with_pure_top_level_calls("const a = fn(arg())", true,));
+
+    assert!(get_statements_side_effect("fn(arg())"));
+    assert!(get_statements_side_effect_with_pure_top_level_calls("fn(arg())", true));
+
+    assert!(get_statements_side_effect_with_pure_top_level_calls(
+      "(() => console.log('side effect'))()",
+      true,
+    ));
+
+    assert!(get_statements_side_effect("export default fn(arg())"));
+    assert!(!get_statements_side_effect_with_pure_top_level_calls(
+      "export default fn(arg())",
+      true,
+    ));
+
+    assert!(get_statements_side_effect("const a = fn(arg1())(arg2())(arg3())"));
+    assert!(!get_statements_side_effect_with_pure_top_level_calls(
+      "const a = fn(arg1())(arg2())(arg3())",
+      true,
+    ));
   }
 
   #[test]

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -41,6 +41,9 @@ pub async fn create_ecma_view(
   ctx.warnings.extend(warnings);
 
   let module_id = ctx.resolved_id.id.clone();
+  let pure_top_level_calls = resolve_pure_top_level_calls(ctx.options, ctx.resolved_id).await?;
+  let mut scan_flat_options = ctx.flat_options;
+  scan_flat_options.set(FlatOptions::PureTopLevelCalls, pure_top_level_calls);
 
   let repr_name = module_id.representative_name();
   let repr_name = legitimize_identifier_name(&repr_name);
@@ -57,7 +60,7 @@ pub async fn create_ecma_view(
       &program.comments,
       ctx.options,
       fields.allocator,
-      ctx.flat_options,
+      scan_flat_options,
     );
     scanner.scan(program)
   })?;
@@ -157,6 +160,23 @@ pub async fn create_ecma_view(
   let ecma_related =
     EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage, preserve_jsx, stmt_infos };
   Ok(CreateEcmaViewReturn { ecma_view, ecma_related, raw_import_records, tla_keyword_span })
+}
+
+async fn resolve_pure_top_level_calls(
+  options: &SharedNormalizedBundlerOptions,
+  resolved_id: &ResolvedId,
+) -> BuildResult<bool> {
+  let Some(config) = options.treeshake.pure_top_level_calls() else {
+    return Ok(false);
+  };
+
+  let resolved = if config.is_fn() {
+    config.ffi_resolve(&resolved_id.id, resolved_id.external.is_external()).await?
+  } else {
+    config.native_resolve(&resolved_id.id, resolved_id.external.is_external())
+  };
+
+  Ok(resolved.unwrap_or(false))
 }
 
 /// The side effects priority is:

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -4,12 +4,17 @@ use std::{collections::HashSet, sync::Arc};
 
 use napi::bindgen_prelude::{Either4, FnArgs};
 use napi_derive::napi;
-use rolldown::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule};
+use rolldown::{
+  InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, PureTopLevelCalls, PureTopLevelCallsRule,
+};
 use rolldown_utils::js_regex::HybridRegex;
 
 use crate::{
-  types::js_callback::{JsCallback, JsCallbackExt, JsCallbackResultExt},
   types::js_regex::JsRegExp,
+  types::{
+    binding_string_or_regex::BindingStringOrRegex,
+    js_callback::{JsCallback, JsCallbackExt, JsCallbackResultExt},
+  },
 };
 
 #[napi]
@@ -33,6 +38,13 @@ pub type BindingModuleSideEffects = Either4<
   JsCallback<FnArgs<(String, bool)>, Option<bool>>,
 >;
 
+pub type BindingPureTopLevelCalls = Either4<
+  bool,
+  Vec<BindingStringOrRegex>,
+  Vec<BindingPureTopLevelCallsRule>,
+  JsCallback<FnArgs<(String, bool)>, Option<bool>>,
+>;
+
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
 pub struct BindingTreeshake {
@@ -44,6 +56,11 @@ pub struct BindingTreeshake {
   pub annotations: Option<bool>,
   #[napi(ts_type = "ReadonlyArray<string>")]
   pub manual_pure_functions: Option<FxHashSet<String>>,
+  #[napi(
+    ts_type = "boolean | ReadonlyArray<BindingStringOrRegex> | BindingPureTopLevelCallsRule[] | ((id: string, external: boolean) => boolean | undefined)"
+  )]
+  #[debug("PureTopLevelCalls(...)")]
+  pub pure_top_level_calls: Option<BindingPureTopLevelCalls>,
   pub unknown_global_side_effects: Option<bool>,
   pub invalid_import_side_effects: Option<bool>,
   pub commonjs: Option<bool>,
@@ -57,6 +74,15 @@ pub struct BindingModuleSideEffectsRule {
   #[napi(ts_type = "RegExp | undefined")]
   pub test: Option<JsRegExp>,
   pub side_effects: bool,
+  pub external: Option<bool>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug, Default)]
+pub struct BindingPureTopLevelCallsRule {
+  #[napi(ts_type = "RegExp | undefined")]
+  pub test: Option<JsRegExp>,
+  pub pure: bool,
   pub external: Option<bool>,
 }
 
@@ -95,6 +121,40 @@ impl TryFrom<BindingTreeshake> for rolldown::TreeshakeOptions {
       }
     };
 
+    let pure_top_level_calls = match value.pure_top_level_calls {
+      Some(value) => Some(match value {
+        Either4::A(value) => PureTopLevelCalls::Boolean(value),
+        Either4::B(patterns) => {
+          PureTopLevelCalls::Patterns(patterns.into_iter().map(Into::into).collect())
+        }
+        Either4::C(rules) => {
+          let mut ret = Vec::with_capacity(rules.len());
+          for rule in rules {
+            let test = match rule.test {
+              Some(test) => Some(HybridRegex::try_from(test)?),
+              None => None,
+            };
+            ret.push(PureTopLevelCallsRule { test, pure: rule.pure, external: rule.external });
+          }
+          PureTopLevelCalls::Rules(ret)
+        }
+        Either4::D(ts_fn) => {
+          PureTopLevelCalls::Function(Arc::new(move |id: &str, is_external: bool| {
+            let id = id.to_string();
+            let ts_fn = Arc::clone(&ts_fn);
+            Box::pin(async move {
+              ts_fn
+                .invoke_async((id.clone(), is_external).into())
+                .await
+                .context("treeshake.pureTopLevelCalls option")
+                .map_err(anyhow::Error::from)
+            })
+          }))
+        }
+      }),
+      None => None,
+    };
+
     let property_read_side_effects = value.property_read_side_effects.map(|v| match v {
       BindingPropertyReadSideEffects::Always => rolldown::PropertyReadSideEffects::Always,
       BindingPropertyReadSideEffects::False => rolldown::PropertyReadSideEffects::False,
@@ -109,6 +169,7 @@ impl TryFrom<BindingTreeshake> for rolldown::TreeshakeOptions {
       module_side_effects,
       annotations: value.annotations,
       manual_pure_functions: value.manual_pure_functions,
+      pure_top_level_calls,
       unknown_global_side_effects: value.unknown_global_side_effects,
       invalid_import_side_effects: value.invalid_import_side_effects,
       commonjs: value.commonjs,

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -340,6 +340,7 @@ where
         module_side_effects: types::treeshake::ModuleSideEffects::Boolean(true),
         annotations: Some(true),
         manual_pure_functions: None,
+        pure_top_level_calls: None,
         unknown_global_side_effects: None,
         commonjs: Some(true),
         property_read_side_effects: None,
@@ -400,6 +401,23 @@ where
           _ => Err(serde::de::Error::custom("manualPureFunctions should be a `Vec<String>`")),
         },
       )?;
+      let pure_top_level_calls = obj.get("pureTopLevelCalls").map_or_else(
+        || Ok(None),
+        |v| match v {
+          Value::Bool(value) => Ok(Some(types::treeshake::PureTopLevelCalls::Boolean(*value))),
+          Value::Array(v) => Ok(Some(types::treeshake::PureTopLevelCalls::Patterns(
+            v.iter()
+              .map(|item| {
+                item.as_str().expect("pureTopLevelCalls should be a `Vec<String>`").to_string()
+              })
+              .map(rolldown_utils::pattern_filter::StringOrRegex::String)
+              .collect::<Vec<_>>(),
+          ))),
+          _ => Err(serde::de::Error::custom(
+            "pureTopLevelCalls should be a `true`, `false`, or `Vec<String>`",
+          )),
+        },
+      )?;
       // Use string to make deserialization logic easier
       let property_read_side_effects = obj.get("propertyReadSideEffects").map_or_else(
         || Ok(None),
@@ -433,6 +451,7 @@ where
         module_side_effects,
         annotations,
         manual_pure_functions: Some(manual_pure_functions),
+        pure_top_level_calls,
         unknown_global_side_effects,
         commonjs,
         property_read_side_effects,

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -2,6 +2,7 @@ use std::{future::Future, ops::Deref, pin::Pin, sync::Arc};
 
 use derive_more::Debug;
 use rolldown_utils::js_regex::HybridRegex;
+use rolldown_utils::pattern_filter::StringOrRegex;
 use rustc_hash::FxHashSet;
 #[cfg(feature = "deserialize_bundler_options")]
 use schemars::JsonSchema;
@@ -98,6 +99,10 @@ impl NormalizedTreeshakeOptions {
   pub fn manual_pure_functions(&self) -> Option<&FxHashSet<String>> {
     self.as_ref().and_then(|item| item.manual_pure_functions.as_ref())
   }
+
+  pub fn pure_top_level_calls(&self) -> Option<&PureTopLevelCalls> {
+    self.as_ref().and_then(|item| item.pure_top_level_calls.as_ref())
+  }
 }
 
 impl Default for TreeshakeOptions {
@@ -119,6 +124,26 @@ pub enum ModuleSideEffects {
   Function(Arc<ModuleSideEffectsFn>),
 }
 
+#[derive(Clone, Debug)]
+pub enum PureTopLevelCalls {
+  #[debug("Rules({_0:?})")]
+  Rules(Vec<PureTopLevelCallsRule>),
+  #[debug("Boolean({_0})")]
+  Boolean(bool),
+  #[debug("Patterns({_0:?})")]
+  Patterns(Vec<StringOrRegex>),
+  #[debug("Function")]
+  Function(Arc<PureTopLevelCallsFn>),
+}
+
+type PureTopLevelCallsFn = dyn Fn(
+    &str, // id
+    bool, // external
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>
+  + Send
+  + Sync
+  + 'static;
+
 type ModuleSideEffectsFn = dyn Fn(
     &str, // id
     bool, // external
@@ -132,6 +157,13 @@ pub struct ModuleSideEffectsRule {
   pub test: Option<HybridRegex>,
   pub external: Option<bool>,
   pub side_effects: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct PureTopLevelCallsRule {
+  pub test: Option<HybridRegex>,
+  pub external: Option<bool>,
+  pub pure: bool,
 }
 
 impl ModuleSideEffects {
@@ -177,6 +209,45 @@ impl ModuleSideEffects {
   }
 }
 
+impl PureTopLevelCalls {
+  pub fn is_fn(&self) -> bool {
+    matches!(self, PureTopLevelCalls::Function(_))
+  }
+
+  pub fn native_resolve(&self, path: &str, is_external: bool) -> Option<bool> {
+    match self {
+      PureTopLevelCalls::Rules(rules) => {
+        for PureTopLevelCallsRule { test, external, pure } in rules {
+          let is_match_rule = match (test, external) {
+            (Some(test), Some(external)) => test.matches(path) && *external == is_external,
+            (None, Some(external)) => *external == is_external,
+            (Some(test), None) => test.matches(path),
+            // At least one of `test` or `external` should be defined.
+            (None, None) => unreachable!(),
+          };
+          if is_match_rule {
+            return Some(*pure);
+          }
+        }
+        None
+      }
+      PureTopLevelCalls::Boolean(value) => Some(*value),
+      PureTopLevelCalls::Patterns(patterns) => Some(patterns.iter().any(|pattern| match pattern {
+        StringOrRegex::String(value) => value == path,
+        StringOrRegex::Regex(value) => value.matches(path),
+      })),
+      PureTopLevelCalls::Function(_) => unreachable!(),
+    }
+  }
+
+  pub async fn ffi_resolve(&self, path: &str, is_external: bool) -> anyhow::Result<Option<bool>> {
+    match self {
+      PureTopLevelCalls::Function(f) => Ok(f(path, is_external).await?),
+      _ => unreachable!(),
+    }
+  }
+}
+
 impl TreeshakeOptions {
   pub fn enabled(&self) -> bool {
     matches!(self, TreeshakeOptions::Option(_))
@@ -206,6 +277,8 @@ pub struct InnerOptions {
   pub module_side_effects: ModuleSideEffects,
   pub annotations: Option<bool>,
   pub manual_pure_functions: Option<FxHashSet<String>>,
+  #[cfg_attr(feature = "deserialize_bundler_options", serde(skip), schemars(skip))]
+  pub pure_top_level_calls: Option<PureTopLevelCalls>,
   pub unknown_global_side_effects: Option<bool>,
   pub commonjs: Option<bool>,
   pub property_read_side_effects: Option<PropertyReadSideEffects>,
@@ -219,6 +292,7 @@ impl Default for InnerOptions {
       module_side_effects: ModuleSideEffects::Boolean(true),
       annotations: Some(true),
       manual_pure_functions: None,
+      pure_top_level_calls: None,
       unknown_global_side_effects: None,
       commonjs: None,
       property_read_side_effects: None,
@@ -259,5 +333,47 @@ impl From<&NormalizedTreeshakeOptions> for oxc::minifier::TreeShakeOptions {
       unknown_global_side_effects: value.unknown_global_side_effects(),
       invalid_import_side_effects: value.invalid_import_side_effects(),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn pure_top_level_calls_patterns_match_module_ids() {
+    let config = PureTopLevelCalls::Patterns(vec![
+      StringOrRegex::String("/project/src/index.js".to_string()),
+      StringOrRegex::Regex(HybridRegex::new(r"/generated/").unwrap()),
+    ]);
+
+    assert_eq!(config.native_resolve("/project/src/index.js", false), Some(true));
+    assert_eq!(config.native_resolve("/project/src/generated/schema.js", false), Some(true));
+    assert_eq!(config.native_resolve("/project/src/other.js", false), Some(false));
+  }
+
+  #[test]
+  fn pure_top_level_calls_rules_match_in_order() {
+    let config = PureTopLevelCalls::Rules(vec![
+      PureTopLevelCallsRule {
+        test: Some(HybridRegex::new(r"/generated/unsafe/").unwrap()),
+        external: None,
+        pure: false,
+      },
+      PureTopLevelCallsRule {
+        test: Some(HybridRegex::new(r"/generated/").unwrap()),
+        external: Some(false),
+        pure: true,
+      },
+      PureTopLevelCallsRule { test: None, external: Some(true), pure: false },
+    ]);
+
+    assert_eq!(config.native_resolve("/project/src/generated/schema.js", false), Some(true));
+    assert_eq!(
+      config.native_resolve("/project/src/generated/unsafe/polyfill.js", false),
+      Some(false)
+    );
+    assert_eq!(config.native_resolve("external-package", true), Some(false));
+    assert_eq!(config.native_resolve("/project/src/other.js", false), None);
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -86,7 +86,7 @@ pub mod bundler_options {
       },
       treeshake::{
         InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, PropertyReadSideEffects,
-        PropertyWriteSideEffects, TreeshakeOptions,
+        PropertyWriteSideEffects, PureTopLevelCalls, PureTopLevelCallsRule, TreeshakeOptions,
       },
       tsconfig::TsConfig,
       tsconfig_merge::merge_transform_options_with_tsconfig as merge_tsconfig,

--- a/crates/rolldown_common/src/types/flat_options.rs
+++ b/crates/rolldown_common/src/types/flat_options.rs
@@ -36,6 +36,9 @@ bitflags! {
     /// If set, lazy barrel optimization is enabled.
     /// Usage: `self.options.experimental.is_lazy_barrel_enabled()`
     const LazyBarrelEnabled = 1 << 10;
+    /// If set, configured top-level call/new initializers are treated as side-effect-free.
+    /// Resolved per module before AST scanning.
+    const PureTopLevelCalls = 1 << 11;
   }
 }
 
@@ -127,5 +130,10 @@ impl FlatOptions {
   #[inline]
   pub fn is_lazy_barrel_enabled(self) -> bool {
     self.contains(Self::LazyBarrelEnabled)
+  }
+
+  #[inline]
+  pub fn pure_top_level_calls(self) -> bool {
+    self.contains(Self::PureTopLevelCalls)
   }
 }

--- a/docs/in-depth/dead-code-elimination.md
+++ b/docs/in-depth/dead-code-elimination.md
@@ -120,6 +120,64 @@ const input = createComponent('input');
 
 This can be more convenient than adding `@__PURE__` to every call site when you know the function itself is always pure.
 
+### `treeshake.pureTopLevelCalls`
+
+Some libraries create many module-level constants by calling factory functions during module initialization:
+
+```js
+const Button = makeComponent('button');
+const Card = makeComponent('card');
+```
+
+Rolldown normally keeps these calls when it cannot prove they are side-effect-free. If you know that these initializer calls are safe to remove when their results are unused, you can enable [`treeshake.pureTopLevelCalls`](/reference/InputOptions.treeshake#puretoplevelcalls) for trusted modules.
+
+When enabled for a module, Rolldown treats call and `new` expressions as side-effect-free only when they are executed during module initialization and appear in assignment-like contexts:
+
+```js
+// Removed if Button is unused
+const Button = makeComponent('button');
+
+// Removed if Widget is unused
+const Widget = new Component('widget');
+
+// Nested argument calls are covered in the same initializer context
+const Route = defineRoute(loadData());
+
+// Not affected: standalone expression statements are still preserved
+registerGlobalHandler();
+```
+
+You should scope this option narrowly:
+
+```js [rolldown.config.js]
+export default {
+  treeshake: {
+    pureTopLevelCalls: /\/src\/generated\//,
+  },
+};
+```
+
+For more control, use rules. Rules are evaluated in order, and the first matching rule decides whether the behavior applies:
+
+```js [rolldown.config.js]
+export default {
+  treeshake: {
+    pureTopLevelCalls: [
+      { test: /\/src\/generated\//, pure: true },
+      { test: /\/src\/generated\/polyfills\//, pure: false },
+    ],
+  },
+};
+```
+
+:::: warning Use with care
+
+`treeshake.pureTopLevelCalls` can remove real side effects. Only enable it for code where top-level call/new initializers are intentionally side-effect-free.
+
+It is different from marking an entire module as side-effect-free with `moduleSideEffects: false`: modules can still execute and keep other top-level side effects. This option only changes how matching call/new initializer expressions are analyzed.
+
+::::
+
 ## Marking Entire Modules as Side-Effect-Free
 
 While you can mark individual expressions or functions, you can also mark entire modules as side-effect-free. If you mark a module as side-effect-free, Rolldown will treat every statement in that module as side-effect-free when none of its exports are used.

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -314,6 +314,10 @@ export default {
 };
 ```
 
+::: note
+[`treeshake.pureTopLevelCalls`](/reference/InputOptions.treeshake#puretoplevelcalls) can help remove unused top-level call initializers inside a module, but it does not mark the module itself as side-effect-free. Lazy barrel optimization still requires `moduleSideEffects: false` through one of the mechanisms above.
+:::
+
 ## When to use
 
 Lazy barrel optimization is particularly beneficial when:

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2662,6 +2662,12 @@ export declare enum BindingPropertyWriteSideEffects {
   False = 1
 }
 
+export interface BindingPureTopLevelCallsRule {
+  test?: RegExp | undefined
+  pure: boolean
+  external?: boolean
+}
+
 export declare enum BindingRebuildStrategy {
   Always = 0,
   Auto = 1,
@@ -2737,6 +2743,7 @@ export interface BindingTreeshake {
   moduleSideEffects: boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, external: boolean) => boolean | undefined)
   annotations?: boolean
   manualPureFunctions?: ReadonlyArray<string>
+  pureTopLevelCalls?: boolean | ReadonlyArray<BindingStringOrRegex> | BindingPureTopLevelCallsRule[] | ((id: string, external: boolean) => boolean | undefined)
   unknownGlobalSideEffects?: boolean
   invalidImportSideEffects?: boolean
   commonjs?: boolean

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -1,7 +1,15 @@
+import type { StringOrRegExp } from './utils';
+
 interface ModuleSideEffectsRule {
   test?: RegExp;
   external?: boolean;
   sideEffects: boolean;
+}
+
+interface PureTopLevelCallsRule {
+  test?: RegExp;
+  external?: boolean;
+  pure: boolean;
 }
 
 type ModuleSideEffectsOption =
@@ -10,6 +18,13 @@ type ModuleSideEffectsOption =
   | ModuleSideEffectsRule[]
   | ((id: string, external: boolean) => boolean | undefined)
   | 'no-external';
+
+type PureTopLevelCallsOption =
+  | boolean
+  | StringOrRegExp
+  | readonly StringOrRegExp[]
+  | PureTopLevelCallsRule[]
+  | ((id: string, external: boolean) => boolean | undefined);
 
 /**
  * When passing an object, you can fine-tune the tree-shaking behavior.
@@ -105,6 +120,49 @@ export type TreeshakingOptions = {
    * @default []
    */
   manualPureFunctions?: readonly string[];
+  /**
+   * Treat call and `new` expressions executed during module initialization as side-effect-free when
+   * they appear in assignment-like contexts for matching modules.
+   *
+   * This includes variable initializers, assignment right-hand sides for local bindings, exported
+   * expression values, and nested argument calls in those contexts. Calls used as the callee of
+   * another call or `new` expression, and standalone expression statements such as `fn()`, are not
+   * made pure by this option.
+   *
+   * **Values:**
+   *
+   * - **`true`**: Enable the behavior for every module that Rolldown scans.
+   * - **`false`**: Disable the behavior.
+   * - **`string | RegExp | Array<string | RegExp>`**: Enable the behavior for matching module IDs.
+   * - **`PureTopLevelCallsRule[]`**: Array of rules with `test`, `external`, and `pure` properties for fine-grained control.
+   * - **`function`**: Function that receives `(id, external)` and returns whether this behavior applies.
+   *
+   * **Important:** This is intentionally aggressive and can remove real side effects. Prefer
+   * scoping it to trusted modules with a string/RegExp pattern or rule.
+   *
+   * > [!NOTE]
+   * > **Performance: Prefer `PureTopLevelCallsRule[]` or patterns over functions**
+   * >
+   * > Rules and string/RegExp patterns are processed in Rust. JavaScript callbacks require runtime
+   * > calls between Rust and JavaScript and should be reserved for logic that cannot be expressed
+   * > declaratively.
+   *
+   * @example
+   * ```js
+   * treeshake: {
+   *   pureTopLevelCalls: /\/src\//
+   * }
+   *
+   * treeshake: {
+   *   pureTopLevelCalls: [
+   *     { test: /\/src\//, pure: true },
+   *     { test: /\/src\/unsafe\//, pure: false },
+   *   ]
+   * }
+   * ```
+   * @default false
+   */
+  pureTopLevelCalls?: PureTopLevelCallsOption;
   /**
    * Whether to assume that accessing unknown global properties might have side effects.
    *

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -324,10 +324,11 @@ function bindingifyTreeshakeOptions(
     };
   }
 
-  let normalizedConfig: BindingInputOptions['treeshake'] = {
+  let normalizedConfig: BindingInputOptions['treeshake'] & { pureTopLevelCalls?: unknown } = {
     moduleSideEffects: true,
     annotations: config.annotations,
     manualPureFunctions: config.manualPureFunctions,
+    pureTopLevelCalls: bindingifyPureTopLevelCalls(config.pureTopLevelCalls),
     unknownGlobalSideEffects: config.unknownGlobalSideEffects,
     invalidImportSideEffects: config.invalidImportSideEffects,
     commonjs: config.commonjs,
@@ -362,6 +363,24 @@ function bindingifyTreeshakeOptions(
   }
 
   return normalizedConfig;
+}
+
+function bindingifyPureTopLevelCalls(
+  config: Exclude<InputOptions['treeshake'], boolean | undefined>['pureTopLevelCalls'],
+) {
+  if (config === undefined || typeof config === 'boolean' || typeof config === 'function') {
+    return config;
+  }
+  if (Array.isArray(config) && config.some(isPureTopLevelCallsRule)) {
+    return config;
+  }
+  return normalizedStringOrRegex(config as string | RegExp | readonly (string | RegExp)[]);
+}
+
+function isPureTopLevelCallsRule(input: unknown): boolean {
+  return (
+    input !== null && typeof input === 'object' && !(input instanceof RegExp) && 'pure' in input
+  );
 }
 
 function bindingifyMakeAbsoluteExternalsRelative(

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -528,6 +528,7 @@ const TreeshakingOptionsSchema = v.strictObject({
   manualPureFunctions: v.optional(
     v.custom<readonly string[]>((input) => v.is(v.array(v.string()), input), 'string array'),
   ),
+  pureTopLevelCalls: v.optional(v.any()),
   unknownGlobalSideEffects: v.optional(v.boolean()),
   invalidImportSideEffects: v.optional(v.boolean()),
   commonjs: v.optional(v.boolean()),


### PR DESCRIPTION
## Summary

Adds `treeshake.pureTopLevelCalls`, an opt-in DCE escape hatch for trusted modules whose top-level call/new initializers are intentionally side-effect-free.

No linked issue.

## Details

- Supports boolean, string/RegExp patterns, ordered rules, and callbacks.
- Resolves the option per module before scanning, then stores the result in `FlatOptions`.
- Documents the option in the treeshake reference and DCE guide.
- Keeps the behavior scoped because it can remove real side effects.

## Alternatives

Considered emitting source-level PURE annotations, but implementing this directly in side-effect analysis avoids rewriting source and keeps the behavior explicit in Rolldown config.

## Review Notes

The main review focus should be the exact side-effect semantics and the rule/callback option shape.

## Validation

- `cargo +1.95.0 fmt --check`
- `cargo test -p rolldown_common pure_top_level_calls --lib`
- `cargo test -p rolldown ast_scanner::side_effect_detector::test::test_pure_top_level_calls`
- `cargo check -p rolldown_common -p rolldown -p rolldown_binding`
- `pnpm exec tsc --noEmit`

## Checklist

- Read the contribution guide.
- Searched open PRs; #9898 is related but not a duplicate.
- Updated docs.
- Included focused tests.
- AI assistance was used; changes were reviewed and validated locally.