### PR TITLE
test: port rspack lazy-barrel parity scenarios

### DIFF
--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/_config.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// Ported from rspack `tests/rspack-test/configCases/lazy-barrel/basic/mixed-barrel`.
+//
+// barrel/index.js mixes a default re-export, a star re-export, an aliased named
+// re-export and an own export:
+//   export { default as a } from "./a";  // default re-export -> a.js
+//   export * from "./b";                 // star -> b.js (also exports `b`)
+//   export { value as b } from "./c";    // named re-export `b` -> c.js.value
+//   export const d = 'd';                // own export
+//
+// The requested specifier `b` is satisfied by the EXPLICIT named re-export
+// (c.js.value), which shadows the `export * from "./b"` `b`. Because `b` is found
+// in named exports, the star export is NOT searched, so neither the default
+// re-export target (a.js) nor the star target (b.js) is loaded.
+//
+// DEVIATION FROM RSPACK: rspack's basic test imports `{ b as c, d }` and still
+// skips a.js + b.js. rolldown, by contrast, treats any use of an OWN export
+// (`d`) as forcing the barrel to execute, which loads ALL of its import records
+// (documented behavior; see treeshake-behavior/case-own-export*). So importing
+// `d` here would defeat the skip. To isolate the named-resolution skip this
+// scenario demonstrates, main.js imports only `{ b as c }`.
+const transformedIds: string[] = [];
+
+export default defineTest({
+  config: {
+    input: { main: './src/main.js' },
+    experimental: {
+      lazyBarrel: true,
+    },
+    plugins: [
+      {
+        name: 'track-transforms',
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
+          transformedIds.push(id);
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    const relativeIds = transformedIds.map((id) =>
+      path.relative(import.meta.dirname, id).replace(/\\/g, '/'),
+    );
+    // `b` resolves to the named re-export of c.js.value -> c.js loaded.
+    expect(relativeIds).toContain('src/main.js');
+    expect(relativeIds).toContain('src/mixed-barrel/index.js');
+    expect(relativeIds).toContain('src/mixed-barrel/c.js');
+    // Unused default re-export target is skipped (rspack skips this too).
+    expect(relativeIds).not.toContain('src/mixed-barrel/a.js');
+    // `export * from "./b"` target is skipped because `b` was found in named
+    // exports, so star exports are never searched (rspack skips this too).
+    expect(relativeIds).not.toContain('src/mixed-barrel/b.js');
+    expect(transformedIds.length).toBe(3);
+
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/_test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { c } from './dist/main.js';
+
+// Runtime parity with rspack's `expect(c).toBe('c')`. `b` resolves through the
+// explicit named re-export `export { value as b } from "./c"`, so it is c.js's
+// `value` ('c'), proving the star export `export * from "./b"` was correctly
+// shadowed and skipped.
+assert.strictEqual(c, 'c');

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/main.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/main.js
@@ -1,0 +1,3 @@
+import { b as c } from './mixed-barrel';
+
+export { c };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/a.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/b.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/c.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/c.js
@@ -1,0 +1,1 @@
+export const value = 'c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/index.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/mixed-barrel/index.js
@@ -1,0 +1,4 @@
+export { default as a } from './a';
+export * from './b';
+export { value as b } from './c';
+export const d = 'd';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/package.json
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-mixed-barrel/src/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/_config.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// Ported from rspack `tests/rspack-test/configCases/lazy-barrel/basic/named-barrel`.
+// rspack asserts a specific set of modules is never created; the rolldown-native
+// equivalent records every loaded (transformed) id and asserts the exact
+// loaded-vs-skipped set.
+//
+// barrel/index.js is a PURE re-export barrel (no own export):
+//   export { a as b } from "./a";   // named re-export -> a.js
+//   export { b as c } from "./b";   // named re-export -> b.js
+//   import { c as cc } from "./c";  // import-then-export (shared record)
+//   import { d as dd } from "./d";  // import-then-export (shared record)
+//   export { cc, dd };
+// main.js imports { b as a, cc }.
+const transformedIds: string[] = [];
+
+export default defineTest({
+  config: {
+    input: { main: './src/main.js' },
+    experimental: {
+      lazyBarrel: true,
+    },
+    plugins: [
+      {
+        name: 'track-transforms',
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
+          transformedIds.push(id);
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    const relativeIds = transformedIds.map((id) =>
+      path.relative(import.meta.dirname, id).replace(/\\/g, '/'),
+    );
+    // `b` resolves to the named re-export `a` from a.js  -> a.js loaded.
+    // `cc` resolves to the import-then-export of c.js     -> c.js loaded.
+    expect(relativeIds).toContain('src/main.js');
+    expect(relativeIds).toContain('src/named-barrel/index.js');
+    expect(relativeIds).toContain('src/named-barrel/a.js');
+    expect(relativeIds).toContain('src/named-barrel/c.js');
+    // `c` (re-export of b.js) is unused -> b.js skipped (rspack skips this too).
+    expect(relativeIds).not.toContain('src/named-barrel/b.js');
+    // `dd` (import-then-export of d.js) is unused and the barrel has no own
+    // export forcing execution, so rolldown skips d.js as a lazy re-export.
+    // (rspack loads d.js because it treats the plain `import { d as dd }` as
+    // eager; rolldown is more aggressive here and still correct since dd is
+    // never used.)
+    expect(relativeIds).not.toContain('src/named-barrel/d.js');
+    expect(transformedIds.length).toBe(4);
+
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/_test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { a, cc } from './dist/main.js';
+
+// Runtime parity with rspack's `expect(a).toBe('a')` / `expect(cc).toBe('c')`.
+// Proves the lazy-barrel skip (b.js + d.js not loaded) did not corrupt the
+// values that ARE used.
+assert.strictEqual(a, 'a');
+assert.strictEqual(cc, 'c');

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/main.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/main.js
@@ -1,0 +1,3 @@
+import { b as a, cc } from './named-barrel';
+
+export { a, cc };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/a.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/b.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/c.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/d.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/d.js
@@ -1,0 +1,1 @@
+export const d = 'd';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/index.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/named-barrel/index.js
@@ -1,0 +1,6 @@
+export { a as b } from './a';
+export { b as c } from './b';
+
+import { c as cc } from './c';
+import { d as dd } from './d';
+export { cc, dd };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/package.json
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-named-barrel/src/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/_config.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// Ported from rspack `tests/rspack-test/configCases/lazy-barrel/basic/nested-barrel`.
+//
+// barrel/index.js re-exports from nested barrels:
+//   export { a } from "./a";   // a.js: import { b as a } from "./b"; export { a };
+//   export { c } from "./c";   //       export { c } from "./c";
+// main.js does `import * as nested from "./nested-barrel"` and uses `nested.a`.
+//
+// DIVERGENCE FROM RSPACK (intentional, documented): rspack performs namespace
+// member-usage analysis for `import * as ns` and therefore skips nested-barrel/c.js
+// (only `nested.a` is used). rolldown intentionally does NOT skip namespace
+// members — `import * as ns`, entry files, `import()` and `require()` all cause a
+// barrel to load ALL of its exports (see docs/in-depth/lazy-barrel-optimization.md
+// "Limitations"). So every re-export target IS loaded here.
+//
+// The expectation is ADAPTED to rolldown's behavior: assert the EXACT full
+// loaded set (count === 5, nothing skipped). This is a precise structural check
+// that encodes the documented `import * as` = load-all rule, not merely "it built".
+const transformedIds: string[] = [];
+
+export default defineTest({
+  config: {
+    input: { main: './src/main.js' },
+    experimental: {
+      lazyBarrel: true,
+    },
+    plugins: [
+      {
+        name: 'track-transforms',
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
+          transformedIds.push(id);
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    const relativeIds = transformedIds.map((id) =>
+      path.relative(import.meta.dirname, id).replace(/\\/g, '/'),
+    );
+    // `import * as nested` loads every export of the barrel (and, recursively,
+    // every export reachable from it), so all four module files plus the entry
+    // are loaded.
+    expect(relativeIds).toContain('src/main.js');
+    expect(relativeIds).toContain('src/nested-barrel/index.js');
+    expect(relativeIds).toContain('src/nested-barrel/a.js');
+    expect(relativeIds).toContain('src/nested-barrel/b.js');
+    // Unlike rspack (which skips it), rolldown loads c.js for `import * as`.
+    expect(relativeIds).toContain('src/nested-barrel/c.js');
+    expect(transformedIds.length).toBe(5);
+
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/_test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { nested } from './dist/main.js';
+
+// Runtime parity with rspack's `expect(nested.a).toBe('b')`.
+// nested-barrel/a.js does `import { b as a } from "./b"; export { a }`, so the
+// namespace's `a` is b.js's `b` ('b'). `c` comes from c.js ('c').
+assert.strictEqual(nested.a, 'b');
+assert.strictEqual(nested.c, 'c');

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/main.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/main.js
@@ -1,0 +1,3 @@
+import * as nested from './nested-barrel';
+
+export { nested };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/a.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/a.js
@@ -1,0 +1,3 @@
+import { b as a } from './b';
+export { a };
+export { c } from './c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/b.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/c.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/index.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/nested-barrel/index.js
@@ -1,0 +1,2 @@
+export { a } from './a';
+export { c } from './c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/package.json
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-nested-barrel/src/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/_config.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// Ported from rspack `tests/rspack-test/configCases/lazy-barrel/basic/star-barrel`.
+//
+// barrel/index.js exposes one named re-export, two star re-exports and an own
+// export:
+//   export { c } from "./c";  // named re-export `c` -> c.js
+//   export * from "./a";      // star -> a.js
+//   export * from "./b";      // star -> b.js
+//   export const d = 'd';     // own export (not requested here)
+//
+// main.js imports { b }. `b` is NOT an explicit named re-export, so it cannot be
+// resolved without searching the star re-exports. rolldown therefore loads ALL
+// star targets (a.js AND b.js) to resolve it, while the unused named re-export
+// target c.js is skipped. This matches rspack, which skips only star-barrel/c.js.
+const transformedIds: string[] = [];
+
+export default defineTest({
+  config: {
+    input: { main: './src/main.js' },
+    experimental: {
+      lazyBarrel: true,
+    },
+    plugins: [
+      {
+        name: 'track-transforms',
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
+          transformedIds.push(id);
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    const relativeIds = transformedIds.map((id) =>
+      path.relative(import.meta.dirname, id).replace(/\\/g, '/'),
+    );
+    // `b` is reachable only through `export *`, so every star target loads.
+    expect(relativeIds).toContain('src/main.js');
+    expect(relativeIds).toContain('src/star-barrel/index.js');
+    expect(relativeIds).toContain('src/star-barrel/a.js');
+    expect(relativeIds).toContain('src/star-barrel/b.js');
+    // The unused named re-export `c` is skipped (rspack skips this too).
+    expect(relativeIds).not.toContain('src/star-barrel/c.js');
+    expect(transformedIds.length).toBe(4);
+
+    await import('./_test.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/_test.mjs
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/_test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import { b } from './dist/main.js';
+
+// Runtime parity with rspack's `expect(b).toBe('b')`. `b` is not an explicit
+// named re-export, so it is resolved by searching the star re-exports
+// (`export * from "./a"`, `export * from "./b"`); it comes from b.js.
+assert.strictEqual(b, 'b');

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/main.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/main.js
@@ -1,0 +1,3 @@
+import { b } from './star-barrel';
+
+export { b };

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/package.json
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/a.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/b.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/c.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/index.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/rspack-star-barrel/src/star-barrel/index.js
@@ -1,0 +1,4 @@
+export { c } from './c';
+export * from './a';
+export * from './b';
+export const d = 'd';


### PR DESCRIPTION
While looking for parity with rspack's barrel-file optimization, I ported rspack's
lazy-barrel scenarios into rolldown's fixture suite. I'm opening this PR mainly to see
whether they're useful for rolldown or not — it's **totally fine to not land this**.

## What this adds

Four fixtures under `packages/rolldown/tests/fixtures/lazy-barrel/`, taken from rspack's
[`configCases/lazy-barrel/basic`](https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/lazy-barrel/basic)
(`named-barrel`, `mixed-barrel`, `star-barrel`, `nested-barrel`):

- `rspack-named-barrel`
- `rspack-mixed-barrel`
- `rspack-star-barrel`
- `rspack-nested-barrel`

rspack hooks `normalModuleFactory.createModule` to assert which modules are never
created. I reproduced that as the rolldown-native equivalent: each fixture marks the
barrel side-effect-free via `package.json` `"sideEffects": false`, enables
`experimental.lazyBarrel`, records every loaded module id in a `transform` hook, and
asserts the exact loaded-vs-skipped set + count. A small `_test.mjs` additionally checks
the runtime values rspack asserts.

## rspack parity & intentional divergences

Where rolldown documents different behavior than rspack, I adapted the expectations and
commented why in each `_config.ts`:

- **mixed-barrel** — skips `a.js` (default re-export) and `b.js` (`export *`): exact match with rspack.
- **star-barrel** — skips `c.js` (unused named re-export) while loading both `export *` targets: exact match with rspack.
- **named-barrel** — skips `b.js` (matches rspack) and *also* `d.js`: rolldown treats the import-then-export pattern as a lazy re-export when the barrel has no executing own export, so it's slightly more aggressive than rspack here.
- **nested-barrel** (`import * as`) — loads all exports, unlike rspack which skips `nested-barrel/c.js` via namespace member-usage analysis. Per rolldown's docs, `import * as ns` loads all of a barrel's exports, so the expectation is adapted to that documented behavior.

One small source-level note: mixed-barrel imports only the named re-export `b` (not
rspack's extra `d`), because using an own export forces rolldown to load all of the
barrel's import records — which would defeat the skip this scenario is meant to show.

## Notes

- Test files only; no changes to bundler/core code.
- The full `lazy-barrel` fixture suite passes locally (17 existing + 4 new = 21 passing)
  against a freshly built binding.
