### PR TITLE
test(dev): full-bundle-mode regression test for cyclic import binding (#9946)

### DIFF
--- a/packages/test-dev-server/tests/playground/circular-import-binding/__tests__/circular-import-binding.spec.ts
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/__tests__/circular-import-binding.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { page } from '~utils';
+
+// Regression test for https://github.com/rolldown/rolldown/issues/9946.
+//
+// In full-bundle-mode (`experimental.devMode`), an imported binding used at
+// MODULE INIT (top-level) inside an import cycle is emitted unbound. The served
+// chunk references `B` (`export const defaults = { button: B }` in a.js) but
+// never declares/imports it, so the page throws `ReferenceError: B is not
+// defined` at load and `.app` never renders.
+//
+// `a.js` -> `b.js` -> `a.js` is the cycle; `b.js` exports `class B`, used by
+// `a.js` at module init. Sibling imports used only inside function bodies bind
+// correctly — only the module-init reference breaks.
+describe('circular-import-binding', () => {
+  test('a cyclic import used at module init is bound (#9946)', async () => {
+    await expect.poll(() => page.textContent('.app')).toBe('button=B');
+  });
+});

--- a/packages/test-dev-server/tests/playground/circular-import-binding/a.js
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/a.js
@@ -1,0 +1,6 @@
+import { B } from './b.js';
+
+// Module-init (top-level) use of a cyclic import. In full-bundle-mode this
+// reference is emitted unbound -> `ReferenceError: B is not defined`.
+// See https://github.com/rolldown/rolldown/issues/9946.
+export const defaults = { button: B };

--- a/packages/test-dev-server/tests/playground/circular-import-binding/b.js
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/b.js
@@ -1,0 +1,8 @@
+// Back-edge that forms the import cycle a.js -> b.js -> a.js.
+import { defaults } from './a.js';
+
+export class B {}
+
+// `defaults` is used only inside a function body, so its binding resolves
+// fine — only the module-init use of `B` over in a.js breaks.
+export const usesA = () => defaults;

--- a/packages/test-dev-server/tests/playground/circular-import-binding/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/dev.config.mjs
@@ -1,0 +1,11 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: { main: 'main.js' },
+    platform: 'browser',
+    treeshake: false,
+    experimental: { devMode: {} },
+  },
+});

--- a/packages/test-dev-server/tests/playground/circular-import-binding/index.html
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/index.html
@@ -1,0 +1,5 @@
+<h1>circular-import-binding</h1>
+
+<div class="app"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/circular-import-binding/main.js
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/main.js
@@ -1,0 +1,6 @@
+import { defaults } from './a.js';
+
+// `B` is a class; `.name` is 'B'. If the cyclic import is bound correctly the
+// page renders `button=B`; if it is emitted unbound the module-init throws
+// `ReferenceError: B is not defined` and `.app` stays empty.
+document.querySelector('.app').textContent = 'button=' + defaults.button.name;

--- a/packages/test-dev-server/tests/playground/circular-import-binding/package.json
+++ b/packages/test-dev-server/tests/playground/circular-import-binding/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-circular-import-binding",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}


### PR DESCRIPTION
### What

Adds a minimal full-bundle-mode (`experimental.devMode`) browser playground that
exercises a cyclic import whose binding is used at **module init**.

Files: `a.js -> b.js -> a.js`. `b.js` exports `class B`; `a.js` uses it at the top
level:

```js
// a.js
import { B } from './b.js';
export const defaults = { button: B };   // module-init use of a cyclic import
```

`main.js` renders `button=B`. The spec asserts `.app` reads `button=B`.

### Why

Regression test for #9946. In full-bundle-mode the served chunk references `B`
but never declares/imports it, so the page throws `ReferenceError: B is not
defined` at load and `.app` stays empty. Sibling imports used only inside
function bodies bind correctly — only the module-init reference over a cycle
breaks. The same pattern broke `@sentry/core` (`class ServerRuntimeClient
extends BaseClient`), `@datadog/browser-core` (`ONE_SECOND`), and first-party
app code when enabling `bundledDev`.

Reproduces on the published rolldown **1.1.2**. CI here will confirm against
`main` — if it already passes, the test stands as a regression guard; if it
fails, it's a live repro for #9946.

Related: #9691 (lazy mode drops an import), #9485 (the CJS-interop circular
variant, fixed by #9419 — this pure-ESM module-init case is distinct and still
reproduces on 1.1.2).