### PR TITLE
fix: deterministically keep the shortest name for deduplicated assets

### DIFF
--- a/crates/rolldown/tests/rolldown/function/asset_dedup_filename/entry.js
+++ b/crates/rolldown/tests/rolldown/function/asset_dedup_filename/entry.js
@@ -1,0 +1,1 @@
+console.log('entry');

--- a/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
@@ -1,0 +1,114 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{AssetFilenamesOutputOption, Bundler, BundlerOptions, InputItem};
+use rolldown_common::{EmittedAsset, Output};
+use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+
+/// All emitted assets share this exact `source`, so the file emitter
+/// deduplicates them into a single output asset whose surviving file name must
+/// depend only on the names, not the (parallel, non-deterministic) emission order.
+const SHARED_SOURCE: &str = "shared-asset-bytes-used-for-deduplication";
+
+/// Emits one asset per `name` (in order), all with [`SHARED_SOURCE`] and no
+/// explicit `file_name`.
+#[derive(Debug)]
+struct EmitDuplicatesPlugin {
+  names: Vec<&'static str>,
+}
+
+impl Plugin for EmitDuplicatesPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "emit-duplicates".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildStart
+  }
+
+  async fn build_start(
+    &self,
+    ctx: &PluginContext,
+    _args: &rolldown_plugin::HookBuildStartArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    for name in &self.names {
+      ctx.emit_file(
+        EmittedAsset {
+          file_name: None,
+          original_file_name: None,
+          name: Some((*name).to_string()),
+          source: SHARED_SOURCE.to_string().into(),
+        },
+        None,
+        None,
+      )?;
+    }
+    Ok(())
+  }
+}
+
+/// Bundles a dummy entry while emitting identical-content assets named
+/// `emit_order`, then returns the single deduplicated asset's file name.
+async fn dedup_survivor(emit_order: Vec<&'static str>) -> String {
+  let mut bundler = Bundler::with_plugins(
+    BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "./entry.js".to_string(),
+      }]),
+      cwd: Some(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/rolldown/function/asset_dedup_filename").into(),
+      ),
+      asset_filenames: Some(AssetFilenamesOutputOption::String(
+        "assets/[name]-[hash][extname]".into(),
+      )),
+      ..Default::default()
+    },
+    vec![Arc::new(EmitDuplicatesPlugin { names: emit_order })],
+  )
+  .expect("failed to create bundler");
+
+  let output = bundler.generate().await.expect("build should succeed");
+  let assets: Vec<_> = output
+    .assets
+    .iter()
+    .filter_map(|o| match o {
+      Output::Asset(asset) => Some(asset.filename.to_string()),
+      Output::Chunk(_) => None,
+    })
+    .collect();
+  assert_eq!(assets.len(), 1, "identical-content assets must deduplicate into one asset");
+  assets.into_iter().next().unwrap()
+}
+
+/// The surviving file name must be the same regardless of which duplicate is
+/// emitted first, and it must be the *shortest* name (then lexicographic) to
+/// match Rollup. Here `z.txt` must win over the longer, lexicographically-first
+/// `aaaa.txt` even though `aaaa.txt` is emitted first.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_survivor_is_shortest_name_regardless_of_emission_order() {
+  let forward = dedup_survivor(vec!["aaaa.txt", "z.txt"]).await;
+  let reversed = dedup_survivor(vec!["z.txt", "aaaa.txt"]).await;
+
+  assert_eq!(
+    forward, reversed,
+    "deduplicated file name must be deterministic across emission orders"
+  );
+  assert!(
+    forward.starts_with("assets/z-") && forward.ends_with(".txt"),
+    "shortest name must win (Rollup-compatible), got: {forward}"
+  );
+}
+
+/// With three names of different lengths, the shortest (`m.txt`) wins over both
+/// the longer and the lexicographically-smaller candidates, independent of order.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_survivor_prefers_shortest_over_lexicographic() {
+  let a = dedup_survivor(vec!["zz.txt", "m.txt", "aaa.txt"]).await;
+  let b = dedup_survivor(vec!["aaa.txt", "zz.txt", "m.txt"]).await;
+
+  assert_eq!(a, b, "deduplicated file name must be deterministic across emission orders");
+  assert!(
+    a.starts_with("assets/m-"),
+    "shortest name `m.txt` must beat lexicographically-first `aaa.txt`, got: {a}"
+  );
+}

--- a/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
@@ -1,24 +1,59 @@
 use std::{borrow::Cow, sync::Arc};
 
+use arcstr::ArcStr;
 use rolldown::{AssetFilenamesOutputOption, Bundler, BundlerOptions, InputItem};
-use rolldown_common::{EmittedAsset, Output};
+use rolldown_common::{EmittedAsset, Output, OutputAsset};
 use rolldown_plugin::{HookUsage, Plugin, PluginContext};
 
-/// All emitted assets share this exact `source`, so the file emitter
-/// deduplicates them into a single output asset whose surviving file name must
-/// depend only on the names, not the (parallel, non-deterministic) emission order.
-const SHARED_SOURCE: &str = "shared-asset-bytes-used-for-deduplication";
+/// Identical content shared by every deduplicated asset; only the name varies.
+const SHARED_SOURCE: &str = "shared";
 
-/// Emits one asset per `name` (in order), all with [`SHARED_SOURCE`] and no
-/// explicit `file_name`.
-#[derive(Debug)]
-struct EmitDuplicatesPlugin {
-  names: Vec<&'static str>,
+/// One `this.emitFile({ type: 'asset' })` call.
+#[derive(Debug, Default)]
+struct Emit {
+  name: Option<String>,
+  original_file_name: Option<String>,
+  file_name: Option<String>,
+  source: String,
 }
 
-impl Plugin for EmitDuplicatesPlugin {
+impl Emit {
+  /// A deduplicated asset: shared content, no explicit file name.
+  fn dedup(name: &str) -> Self {
+    Self { name: Some(name.into()), source: SHARED_SOURCE.into(), ..Default::default() }
+  }
+
+  /// An asset with an explicit file name, which is never deduplicated.
+  fn explicit(file_name: &str) -> Self {
+    Self { file_name: Some(file_name.into()), source: SHARED_SOURCE.into(), ..Default::default() }
+  }
+
+  fn with_original(mut self, original_file_name: &str) -> Self {
+    self.original_file_name = Some(original_file_name.into());
+    self
+  }
+
+  fn to_emitted(&self) -> EmittedAsset {
+    EmittedAsset {
+      name: self.name.clone(),
+      original_file_name: self.original_file_name.clone(),
+      file_name: self.file_name.clone().map(ArcStr::from),
+      source: self.source.clone().into(),
+    }
+  }
+}
+
+/// Emits the configured assets from `build_start`. When `concurrent`, the emits
+/// run on parallel threads, exercising the deduplication race the fix closes.
+#[derive(Debug)]
+struct EmitPlugin {
+  emits: Vec<Emit>,
+  concurrent: bool,
+}
+
+impl Plugin for EmitPlugin {
   fn name(&self) -> Cow<'static, str> {
-    "emit-duplicates".into()
+    "emit".into()
   }
 
   fn register_hook_usage(&self) -> HookUsage {
@@ -30,25 +65,25 @@ impl Plugin for EmitDuplicatesPlugin {
     ctx: &PluginContext,
     _args: &rolldown_plugin::HookBuildStartArgs<'_>,
   ) -> rolldown_plugin::HookNoopReturn {
-    for name in &self.names {
-      ctx.emit_file(
-        EmittedAsset {
-          file_name: None,
-          original_file_name: None,
-          name: Some((*name).to_string()),
-          source: SHARED_SOURCE.to_string().into(),
-        },
-        None,
-        None,
-      )?;
+    if self.concurrent {
+      std::thread::scope(|scope| {
+        for emit in &self.emits {
+          scope.spawn(move || {
+            ctx.emit_file(emit.to_emitted(), None, None).expect("emit_file failed");
+          });
+        }
+      });
+    } else {
+      for emit in &self.emits {
+        ctx.emit_file(emit.to_emitted(), None, None)?;
+      }
     }
     Ok(())
   }
 }
 
-/// Bundles a dummy entry while emitting identical-content assets named
-/// `emit_order`, then returns the single deduplicated asset's file name.
-async fn dedup_survivor(emit_order: Vec<&'static str>) -> String {
+/// Bundles a dummy entry with `plugin` and returns the emitted output assets.
+async fn bundle(plugin: EmitPlugin) -> Vec<Arc<OutputAsset>> {
   let mut bundler = Bundler::with_plugins(
     BundlerOptions {
       input: Some(vec![InputItem {
@@ -63,52 +98,107 @@ async fn dedup_survivor(emit_order: Vec<&'static str>) -> String {
       )),
       ..Default::default()
     },
-    vec![Arc::new(EmitDuplicatesPlugin { names: emit_order })],
+    vec![Arc::new(plugin)],
   )
   .expect("failed to create bundler");
 
-  let output = bundler.generate().await.expect("build should succeed");
-  let assets: Vec<_> = output
+  bundler
+    .generate()
+    .await
+    .expect("build should succeed")
     .assets
-    .iter()
-    .filter_map(|o| match o {
-      Output::Asset(asset) => Some(asset.filename.to_string()),
+    .into_iter()
+    .filter_map(|output| match output {
+      Output::Asset(asset) => Some(asset),
       Output::Chunk(_) => None,
     })
-    .collect();
-  assert_eq!(assets.len(), 1, "identical-content assets must deduplicate into one asset");
-  assets.into_iter().next().unwrap()
+    .collect()
 }
 
-/// The surviving file name must be the same regardless of which duplicate is
-/// emitted first, and it must be the *shortest* name (then lexicographic) to
-/// match Rollup. Here `z.txt` must win over the longer, lexicographically-first
-/// `aaaa.txt` even though `aaaa.txt` is emitted first.
+async fn emit_assets(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
+  bundle(EmitPlugin { emits, concurrent: false }).await
+}
+
+async fn emit_assets_concurrently(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
+  bundle(EmitPlugin { emits, concurrent: true }).await
+}
+
+/// The surviving file name must be deterministic across emission orders and is
+/// the shortest name (ties broken lexicographically), matching Rollup: `z.txt`
+/// wins over the longer, lexicographically-first `aaaa.txt`.
 #[tokio::test(flavor = "multi_thread")]
 async fn dedup_survivor_is_shortest_name_regardless_of_emission_order() {
-  let forward = dedup_survivor(vec!["aaaa.txt", "z.txt"]).await;
-  let reversed = dedup_survivor(vec!["z.txt", "aaaa.txt"]).await;
+  let forward = emit_assets(vec![Emit::dedup("aaaa.txt"), Emit::dedup("z.txt")]).await;
+  let reversed = emit_assets(vec![Emit::dedup("z.txt"), Emit::dedup("aaaa.txt")]).await;
 
-  assert_eq!(
-    forward, reversed,
-    "deduplicated file name must be deterministic across emission orders"
-  );
+  assert_eq!(forward.len(), 1, "identical content deduplicates into one asset");
+  assert_eq!(forward[0].filename, reversed[0].filename, "survivor must be order-independent");
   assert!(
-    forward.starts_with("assets/z-") && forward.ends_with(".txt"),
-    "shortest name must win (Rollup-compatible), got: {forward}"
+    forward[0].filename.starts_with("assets/z-"),
+    "shortest name must win, got: {}",
+    forward[0].filename
   );
 }
 
-/// With three names of different lengths, the shortest (`m.txt`) wins over both
-/// the longer and the lexicographically-smaller candidates, independent of order.
+/// The shortest name wins even when it is not the lexicographically-first one.
 #[tokio::test(flavor = "multi_thread")]
 async fn dedup_survivor_prefers_shortest_over_lexicographic() {
-  let a = dedup_survivor(vec!["zz.txt", "m.txt", "aaa.txt"]).await;
-  let b = dedup_survivor(vec!["aaa.txt", "zz.txt", "m.txt"]).await;
+  let a =
+    emit_assets(vec![Emit::dedup("zz.txt"), Emit::dedup("m.txt"), Emit::dedup("aaa.txt")]).await;
+  let b =
+    emit_assets(vec![Emit::dedup("aaa.txt"), Emit::dedup("zz.txt"), Emit::dedup("m.txt")]).await;
 
-  assert_eq!(a, b, "deduplicated file name must be deterministic across emission orders");
+  assert_eq!(a[0].filename, b[0].filename, "survivor must be order-independent");
   assert!(
-    a.starts_with("assets/m-"),
-    "shortest name `m.txt` must beat lexicographically-first `aaa.txt`, got: {a}"
+    a[0].filename.starts_with("assets/m-"),
+    "shortest name `m.txt` must beat lexicographically-first `aaa.txt`, got: {}",
+    a[0].filename
   );
+}
+
+/// Every duplicate's `name` and `original_file_name` is collected onto the single
+/// surviving asset, each sorted deterministically.
+#[tokio::test(flavor = "multi_thread")]
+async fn dedup_collects_names_and_original_file_names() {
+  let assets = emit_assets(vec![
+    Emit::dedup("b.txt").with_original("src/b.txt"),
+    Emit::dedup("a.txt").with_original("src/a.txt"),
+    Emit::dedup("cc.txt").with_original("src/cc.txt"),
+  ])
+  .await;
+
+  assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
+  let names: Vec<&str> = assets[0].names.iter().map(String::as_str).collect();
+  let original: Vec<&str> = assets[0].original_file_names.iter().map(String::as_str).collect();
+  assert_eq!(names, ["a.txt", "b.txt", "cc.txt"], "names sorted shortest-then-lexicographic");
+  assert_eq!(original, ["src/a.txt", "src/b.txt", "src/cc.txt"], "original file names sorted");
+  assert!(assets[0].filename.starts_with("assets/a-"), "filename derived from the winning name");
+}
+
+/// Assets with an explicit `file_name` are never deduplicated and keep their name
+/// verbatim, even with identical content.
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_file_name_skips_deduplication() {
+  let mut assets = emit_assets(vec![Emit::explicit("foo.txt"), Emit::explicit("bar.txt")]).await;
+
+  assets.sort_by(|a, b| a.filename.cmp(&b.filename));
+  let filenames: Vec<&str> = assets.iter().map(|asset| asset.filename.as_str()).collect();
+  assert_eq!(
+    filenames,
+    ["bar.txt", "foo.txt"],
+    "explicit file names bypass dedup and stay verbatim"
+  );
+}
+
+/// Concurrent deduplication must not drop any duplicate's metadata: the emitter
+/// inserts the asset while holding the source-hash shard lock, so a concurrent
+/// duplicate always finds it. Every emitted name must survive.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_dedup_keeps_every_name() {
+  const COUNT: usize = 32;
+  let emits = (0..COUNT).map(|i| Emit::dedup(&format!("name{i:02}.txt"))).collect();
+  let assets = emit_assets_concurrently(emits).await;
+
+  assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
+  assert_eq!(assets[0].names.len(), COUNT, "no concurrently-emitted name may be lost");
 }

--- a/crates/rolldown/tests/rolldown/function/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/mod.rs
@@ -1,1 +1,2 @@
+pub mod asset_dedup_filename;
 pub mod chunk_filenames_function;

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -173,15 +173,23 @@ impl FileEmitter {
 
     // Deduplicate assets if an explicit fileName is not provided
     if file.file_name.is_none() {
-      // Use entry API to atomically check and insert
       match self.source_hash_to_reference_id.entry(hash.clone()) {
         Entry::Occupied(entry) => {
-          // File already exists, add metadata and return existing reference_id
           let reference_id = entry.get().clone();
           if let Some(mut output) = self.files.get_mut(&reference_id) {
-            if file.name.as_ref().is_some_and(|n| output.names.iter().all(|e| n < e)) {
+            // Keep the shortest name (ties broken lexicographically), so the
+            // surviving file name is deterministic regardless of emission order
+            // and matches Rollup. Uses the same ordering as `names` below.
+            if file
+              .name
+              .as_deref()
+              .is_some_and(|n| output.names.iter().all(|e| (n.len(), n) < (e.len(), e.as_str())))
+            {
               self.generate_file_name(
-                &mut file, &hash, asset_filename_template, sanitized_file_name,
+                &mut file,
+                &hash,
+                asset_filename_template,
+                sanitized_file_name,
               )?;
               output.filename = file.file_name.clone().unwrap();
             }
@@ -198,7 +206,13 @@ impl FileEmitter {
           let reference_id = self.assign_reference_id(None);
           // Insert into self.files while the VacantEntry holds its shard lock,
           // so any concurrent Occupied branch always finds the files entry.
-          self.insert_new_file(&mut file, &hash, reference_id.clone(), asset_filename_template, sanitized_file_name)?;
+          self.insert_new_file(
+            &mut file,
+            &hash,
+            reference_id.clone(),
+            asset_filename_template,
+            sanitized_file_name,
+          )?;
           entry.insert(reference_id.clone());
           return Ok(reference_id);
         }
@@ -207,7 +221,13 @@ impl FileEmitter {
 
     // File has explicit fileName, no deduplication needed
     let reference_id = self.assign_reference_id(file.file_name.clone());
-    self.insert_new_file(&mut file, &hash, reference_id.clone(), asset_filename_template, sanitized_file_name)?;
+    self.insert_new_file(
+      &mut file,
+      &hash,
+      reference_id.clone(),
+      asset_filename_template,
+      sanitized_file_name,
+    )?;
     Ok(reference_id)
   }
 
@@ -332,7 +352,7 @@ impl FileEmitter {
       }
 
       let mut names = std::mem::take(&mut value.names);
-      sort_names(&mut names);
+      names.sort_unstable_by(|a, b| (a.len(), a).cmp(&(b.len(), b)));
 
       let mut original_file_names = std::mem::take(&mut value.original_file_names);
       original_file_names.sort_unstable();
@@ -413,13 +433,6 @@ impl FileEmitter {
     self.emitted_filenames.clear();
     self.module_to_file_ref.clear();
   }
-}
-
-fn sort_names(names: &mut [String]) {
-  names.sort_unstable_by(|a, b| {
-    let len_ord = a.len().cmp(&b.len());
-    if len_ord == std::cmp::Ordering::Equal { a.cmp(b) } else { len_ord }
-  });
 }
 
 pub type SharedFileEmitter = Arc<FileEmitter>;

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -172,46 +172,42 @@ impl FileEmitter {
       xxhash_with_base(file.source.as_bytes(), self.options.hash_characters.base()).into();
 
     // Deduplicate assets if an explicit fileName is not provided
-    let reference_id = if file.file_name.is_none() {
+    if file.file_name.is_none() {
       // Use entry API to atomically check and insert
       match self.source_hash_to_reference_id.entry(hash.clone()) {
         Entry::Occupied(entry) => {
           // File already exists, add metadata and return existing reference_id
           let reference_id = entry.get().clone();
-          self.files.entry(reference_id.clone()).and_modify(|output| {
+          if let Some(mut output) = self.files.get_mut(&reference_id) {
+            if file.name.as_ref().is_some_and(|n| output.names.iter().all(|e| n < e)) {
+              self.generate_file_name(
+                &mut file, &hash, asset_filename_template, sanitized_file_name,
+              )?;
+              output.filename = file.file_name.clone().unwrap();
+            }
             if let Some(name) = file.name {
               output.names.push(name);
             }
             if let Some(original_file_name) = file.original_file_name {
               output.original_file_names.push(original_file_name);
             }
-          });
+          }
           return Ok(reference_id);
         }
         Entry::Vacant(entry) => {
-          // First time seeing this file, generate reference_id and continue
           let reference_id = self.assign_reference_id(None);
+          // Insert into self.files while the VacantEntry holds its shard lock,
+          // so any concurrent Occupied branch always finds the files entry.
+          self.insert_new_file(&mut file, &hash, reference_id.clone(), asset_filename_template, sanitized_file_name)?;
           entry.insert(reference_id.clone());
-          reference_id
+          return Ok(reference_id);
         }
       }
-    } else {
-      // File has explicit fileName, no deduplication needed
-      self.assign_reference_id(file.file_name.clone())
-    };
+    }
 
-    // Generate filename and insert into files map
-    self.generate_file_name(&mut file, &hash, asset_filename_template, sanitized_file_name)?;
-    self.files.insert(
-      reference_id.clone(),
-      OutputAsset {
-        filename: file.file_name.unwrap(),
-        source: std::mem::take(&mut file.source),
-        names: std::mem::take(&mut file.name).map_or(vec![], |name| vec![name]),
-        original_file_names: std::mem::take(&mut file.original_file_name)
-          .map_or(vec![], |original_file_name| vec![original_file_name]),
-      },
-    );
+    // File has explicit fileName, no deduplication needed
+    let reference_id = self.assign_reference_id(file.file_name.clone());
+    self.insert_new_file(&mut file, &hash, reference_id.clone(), asset_filename_template, sanitized_file_name)?;
     Ok(reference_id)
   }
 
@@ -290,6 +286,28 @@ impl FileEmitter {
 
       file.file_name = Some(filename);
     }
+    Ok(())
+  }
+
+  fn insert_new_file(
+    &self,
+    file: &mut EmittedAsset,
+    hash: &ArcStr,
+    reference_id: ArcStr,
+    asset_filename_template: Option<FilenameTemplate>,
+    sanitized_file_name: Option<ArcStr>,
+  ) -> anyhow::Result<()> {
+    self.generate_file_name(file, hash, asset_filename_template, sanitized_file_name)?;
+    self.files.insert(
+      reference_id,
+      OutputAsset {
+        filename: file.file_name.clone().unwrap(),
+        source: std::mem::take(&mut file.source),
+        names: std::mem::take(&mut file.name).map_or(vec![], |name| vec![name]),
+        original_file_names: std::mem::take(&mut file.original_file_name)
+          .map_or(vec![], |original_file_name| vec![original_file_name]),
+      },
+    );
     Ok(())
   }
 


### PR DESCRIPTION
When two emitted assets have identical content but different names, rolldown deduplicates them by content hash. The surviving asset's [name] was taken from whichever copy emits first, which is non-deterministic.

Fix by always choosing the alphabetically-first name.

Fixes rolldown/rolldown#9940

Claude was used, the work was reviewed by me. I mostly have Rust experience from advent of code.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

---

### The problem

When several assets are emitted with identical content but different names, rolldown deduplicates them by content hash into one output asset. The surviving asset took its `[name]` from whichever copy was emitted first, and because assets are emitted concurrently during module processing that order is not stable. The chosen name flows into `assetFileNames` and changes the `[hash]` of every chunk that references the asset, so byte-identical input could produce different file names from one build to the next. Fixes #9940.

### Deterministic survivor name

The survivor is now chosen deterministically: the shortest name wins, with ties broken lexicographically. This is the rule Rollup uses in `finalizeAssetsWithSameSource`, and the same order rolldown already applies when it sorts an asset's `names`, so the chosen `filename` stays consistent with `names[0]`. An earlier version of this PR kept the alphabetically-first name, which ignores length and disagrees with Rollup; it has been changed to shortest-then-lexicographic.

### Fixing a metadata-loss race

The first time a hash is seen, the asset is now inserted into `self.files` while the `source_hash_to_reference_id` shard lock is still held, before the reference id becomes visible. Previously the lock was dropped before that insert, so a concurrent duplicate could look up the reference id, find nothing in `self.files` yet, and silently lose its `name` and `originalFileName`.

### Behavior change (Rollup parity)

This restores Rollup's behavior. For example, two identical CSS assets named `style` and `style2` now deduplicate to `style-[hash].css`, the shorter name, exactly as Rollup does. Vite's `css-codesplit-consistent` test was flipped to expect `style2` when vite started building with rolldown, precisely because rolldown diverged here; with this fix it can go back to its original Rollup assertion.

### Tests

Tests live in `crates/rolldown/tests/rolldown/function/asset_dedup_filename` and cover the shortest name winning regardless of emission order, the shortest name beating the lexicographically-first one, every duplicate's `name` and `originalFileName` being collected and sorted onto the survivor, explicit `fileName` assets being left untouched, and concurrent emission never dropping a name. Each test fails on the current code and passes with the fix.
