### PR TITLE
feat(experimental): minChunkSize small-leaf chunk merging (splitChunks.minSize parity)

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,5 +1,6 @@
 use arcstr::ArcStr;
 use itertools::Itertools;
+use oxc_str::CompactStr;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
@@ -32,6 +33,16 @@ pub struct ChunkGraph {
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
   pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
+  /// Modules that `experimental.minChunkSize` duplicated out of a small common
+  /// "leaf" chunk into each importing chunk. A duplicated leaf is treated as
+  /// **local to every chunk that references it** (it is copied into all of them),
+  /// so cross-chunk imports for its symbols are skipped.
+  /// See `internal-docs/min-size-chunk-merging/design.md`.
+  pub duplicated_leaf_modules: FxHashSet<ModuleIdx>,
+  /// Globally-unique pinned name for every declared symbol of a duplicated leaf.
+  /// The same name is used in every chunk the leaf is duplicated into, so the
+  /// single finalized AST stays valid everywhere. Keys are canonical symbol refs.
+  pub duplicated_leaf_pinned_names: FxHashMap<SymbolRef, CompactStr>,
 }
 
 impl ChunkGraph {
@@ -46,6 +57,8 @@ impl ChunkGraph {
       common_chunk_exported_facade_chunk_namespace: FxHashMap::default(),
       common_chunk_preserve_export_names_modules: FxHashMap::default(),
       post_chunk_optimization_operations: FxHashMap::default(),
+      duplicated_leaf_modules: FxHashSet::default(),
+      duplicated_leaf_pinned_names: FxHashMap::default(),
     }
   }
 

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,7 +1,7 @@
 use arcstr::ArcStr;
 use itertools::Itertools;
-use oxc_str::CompactStr;
 use oxc_index::{IndexVec, index_vec};
+use oxc_str::CompactStr;
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
   PostChunkOptimizationOperation, RuntimeHelper, SymbolRef,

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -263,7 +263,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       let importee_linking_info = &self.ctx.linking_infos[importee_idx];
       matches!(importee_linking_info.wrap_kind(), WrapKind::None)
         && importee_linking_info.is_included
-        && self.ctx.chunk_graph.module_to_chunk[importee_idx] == Some(self.ctx.chunk_idx)
+        && (self.ctx.chunk_graph.module_to_chunk[importee_idx] == Some(self.ctx.chunk_idx)
+          // A duplicated leaf (experimental.minChunkSize) is local to every chunk
+          // it was copied into.
+          || self.ctx.chunk_graph.duplicated_leaf_modules.contains(&importee_idx))
     }) {
       return None;
     }

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -302,6 +302,12 @@ impl GenerateStage<'_> {
     for (chunk_idx, symbol_list) in chunk_id_to_symbols_vec {
       for declared in symbol_list {
         let declared = declared.inner();
+        // Duplicated leaves (experimental.minChunkSize) live in several chunks;
+        // their symbol chunk_idx was pinned in `merge_small_common_leaf_chunks`,
+        // so skip the one-chunk assignment + its debug assertion here.
+        if chunk_graph.duplicated_leaf_modules.contains(&declared.owner) {
+          continue;
+        }
         if cfg!(debug_assertions) {
           let symbol_data = symbols.get(declared);
           debug_assert!(
@@ -501,6 +507,12 @@ impl GenerateStage<'_> {
         let chunk_meta_imports = &index_chunk_depended_symbols[chunk_id];
         for import_ref in chunk_meta_imports.iter().copied() {
           if !self.link_output.used_symbol_refs.contains(&import_ref) {
+            continue;
+          }
+          // A duplicated leaf (experimental.minChunkSize) is copied into every
+          // chunk that references it, so it is always local — never import it
+          // across chunks.
+          if chunk_graph.duplicated_leaf_modules.contains(&import_ref.owner) {
             continue;
           }
           // If the symbol from external module and the format is commonjs, we might need to insert runtime

--- a/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
+++ b/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
@@ -1,0 +1,252 @@
+//! `experimental.minChunkSize`: webpack/rspack `splitChunks.minSize`-style merging.
+//!
+//! A small, side-effect-free common "leaf" chunk (its modules have no imports of
+//! their own) is *duplicated* into each chunk that imports it instead of being
+//! emitted as a standalone shared chunk. This reduces chunk / request count for
+//! the price of duplicating a tiny module.
+//!
+//! Correctness relies on three facts (see
+//! `internal-docs/min-size-chunk-merging/design.md`):
+//! - leaves have no outgoing cross-chunk refs, so a single finalized AST has
+//!   nothing chunk-specific except its own declared-symbol names;
+//! - those names are pinned to one globally-unique name used by every chunk
+//!   (`ChunkGraph::duplicated_leaf_pinned_names`), so the one finalized AST is
+//!   valid everywhere;
+//! - a duplicated leaf is recorded in `ChunkGraph::duplicated_leaf_modules` and
+//!   treated as **local to every chunk that references it** by
+//!   `compute_cross_chunk_links` and the module finalizer.
+//!
+//! This pass runs after chunk formation and before `compute_cross_chunk_links`.
+
+use rolldown_common::{
+  ChunkIdx, ChunkKind, EcmaViewMeta, ImportKind, ImportRecordMeta, ModuleIdx,
+  PostChunkOptimizationOperation, SymbolRef, TaggedSymbolRef,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{chunk_graph::ChunkGraph, utils::renamer::Renamer};
+
+use super::GenerateStage;
+
+impl GenerateStage<'_> {
+  pub(super) fn merge_small_common_leaf_chunks(&mut self, chunk_graph: &mut ChunkGraph) {
+    let Some(min_size) = self.options.experimental.min_chunk_size() else {
+      return;
+    };
+
+    // 1. Modules re-exported anywhere are conservatively excluded: their symbols
+    //    may be referenced through cross-chunk re-export chains that the direct
+    //    import-edge scan below would miss.
+    let reexported_modules = self.collect_reexported_modules();
+
+    // 2. Eligible chunks: Common (not runtime), all included side-effect-free
+    //    leaves, not re-exported, total source size under the threshold.
+    let runtime_chunk = chunk_graph.module_to_chunk[self.link_output.runtime.id()];
+    let eligible: Vec<ChunkIdx> = chunk_graph
+      .chunk_table
+      .iter_enumerated()
+      .filter(|(chunk_idx, chunk)| {
+        matches!(chunk.kind, ChunkKind::Common)
+          && Some(*chunk_idx) != runtime_chunk
+          && !chunk.modules.is_empty()
+          && chunk_graph.post_chunk_optimization_operations.get(chunk_idx).copied()
+            != Some(PostChunkOptimizationOperation::Removed)
+          && self.is_small_leaf_chunk(&chunk.modules, &reexported_modules, min_size)
+      })
+      .map(|(chunk_idx, _)| chunk_idx)
+      .collect();
+    if eligible.is_empty() {
+      return;
+    }
+
+    // 3. Map each eligible leaf module to its (soon-to-be-removed) owner chunk,
+    //    then find the importing chunks via direct import edges.
+    let mut module_eligible_chunk: FxHashMap<ModuleIdx, ChunkIdx> = FxHashMap::default();
+    for &s in &eligible {
+      for &m in &chunk_graph.chunk_table[s].modules {
+        module_eligible_chunk.insert(m, s);
+      }
+    }
+    let importers = self.collect_importers(chunk_graph, &module_eligible_chunk);
+
+    // 4. Duplicate each eligible leaf chunk into its importers.
+    let mut duplicated_leaf_modules: FxHashSet<ModuleIdx> = FxHashSet::default();
+    let mut leaf_symbols: FxHashSet<SymbolRef> = FxHashSet::default();
+    let mut leaf_primary_chunk: FxHashMap<ModuleIdx, ChunkIdx> = FxHashMap::default();
+
+    for &s in &eligible {
+      let Some(importer_set) = importers.get(&s) else {
+        continue;
+      };
+      if importer_set.is_empty() {
+        continue;
+      }
+      let mut importer_chunks: Vec<ChunkIdx> = importer_set.iter().copied().collect();
+      importer_chunks.sort_unstable();
+      let primary = importer_chunks[0];
+
+      let s_modules = chunk_graph.chunk_table[s].modules.clone();
+      let s_runtime_helper = chunk_graph.chunk_table[s].depended_runtime_helper;
+      for &c in &importer_chunks {
+        for &m in &s_modules {
+          chunk_graph.chunk_table[c].modules.push(m);
+        }
+        chunk_graph.chunk_table[c].depended_runtime_helper.insert(s_runtime_helper);
+      }
+
+      for &m in &s_modules {
+        duplicated_leaf_modules.insert(m);
+        leaf_primary_chunk.insert(m, primary);
+        self.collect_declared_symbols(m, &mut leaf_symbols);
+      }
+
+      // Tombstone the now-empty shared chunk.
+      chunk_graph.chunk_table[s].modules.clear();
+      chunk_graph
+        .post_chunk_optimization_operations
+        .insert(s, PostChunkOptimizationOperation::Removed);
+    }
+
+    if duplicated_leaf_modules.is_empty() {
+      return;
+    }
+
+    // 5. Compute globally-unique pinned names for every duplicated-leaf symbol.
+    let mut ordered: Vec<SymbolRef> = leaf_symbols.into_iter().collect();
+    ordered.sort_unstable_by(|a, b| {
+      let a_key = self.link_output.module_table[a.owner].exec_order();
+      let b_key = self.link_output.module_table[b.owner].exec_order();
+      a_key
+        .cmp(&b_key)
+        .then_with(|| a.name(&self.link_output.symbol_db).cmp(b.name(&self.link_output.symbol_db)))
+    });
+    let mut renamer = Renamer::new(None, &self.link_output.symbol_db, self.options.format);
+    for &sym in &ordered {
+      renamer.add_symbol_in_root_scope(sym, true);
+    }
+    let pinned_names = renamer.into_canonical_names();
+
+    // 6. Point duplicated leaves' module/symbol chunk metadata at the primary
+    //    importer so the one finalized AST renders with the pinned names, and the
+    //    `compute_cross_chunk_links` symbol-assignment skip stays consistent.
+    for (&m, &primary) in &leaf_primary_chunk {
+      chunk_graph.module_to_chunk[m] = Some(primary);
+    }
+    {
+      let symbol_db = &mut self.link_output.symbol_db;
+      for &sym in &ordered {
+        if let Some(&primary) = leaf_primary_chunk.get(&sym.owner) {
+          let canonical = sym.canonical_ref(symbol_db);
+          symbol_db.get_mut(canonical).chunk_idx = Some(primary);
+        }
+      }
+    }
+
+    chunk_graph.duplicated_leaf_modules = duplicated_leaf_modules;
+    chunk_graph.duplicated_leaf_pinned_names = pinned_names;
+
+    // 7. Re-sort modules within every chunk so the deconflicter's ascending
+    //    exec-order invariant holds after the insertions.
+    chunk_graph.sort_chunk_modules(self.link_output, self.options);
+  }
+
+  fn collect_reexported_modules(&self) -> FxHashSet<ModuleIdx> {
+    let mut reexported = FxHashSet::default();
+    // Scan ALL modules (not just included ones): a pure re-export pass-through
+    // module (`export { k } from './util'`) is often tree-shaken out
+    // (`is_included == false`), yet a consumer can still reference the leaf's
+    // symbol through it. Excluding such leaves keeps the direct-import-edge
+    // importer scan sound.
+    for (_m_idx, module) in self.link_output.module_table.modules.iter_enumerated() {
+      let Some(normal) = module.as_normal() else {
+        continue;
+      };
+      for rec in &normal.import_records {
+        if rec.meta.contains(ImportRecordMeta::IsExportStar) {
+          if let Some(t) = rec.resolved_module {
+            reexported.insert(t);
+          }
+        }
+      }
+      for local_export in normal.named_exports.values() {
+        if let Some(named_import) = normal.named_imports.get(&local_export.referenced) {
+          if let Some(t) = normal.import_records[named_import.record_idx].resolved_module {
+            reexported.insert(t);
+          }
+        }
+      }
+    }
+    reexported
+  }
+
+  #[expect(clippy::cast_precision_loss)] // module byte sizes are well within f64 range
+  fn is_small_leaf_chunk(
+    &self,
+    modules: &[ModuleIdx],
+    reexported_modules: &FxHashSet<ModuleIdx>,
+    min_size: f64,
+  ) -> bool {
+    let mut size = 0.0f64;
+    let all_leaves = modules.iter().all(|&m| {
+      let Some(normal) = self.link_output.module_table[m].as_normal() else {
+        return false;
+      };
+      size += self.link_output.module_table[m].size() as f64;
+      self.link_output.metas[m].is_included
+        && normal.import_records.is_empty()
+        && !self.link_output.module_table[m].side_effects().has_side_effects()
+        && !normal.meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
+        && !reexported_modules.contains(&m)
+    });
+    all_leaves && size < min_size
+  }
+
+  fn collect_importers(
+    &self,
+    chunk_graph: &ChunkGraph,
+    module_eligible_chunk: &FxHashMap<ModuleIdx, ChunkIdx>,
+  ) -> FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> {
+    let mut importers: FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> = FxHashMap::default();
+    for (m_idx, module) in self.link_output.module_table.modules.iter_enumerated() {
+      let Some(normal) = module.as_normal() else {
+        continue;
+      };
+      if !self.link_output.metas[m_idx].is_included {
+        continue;
+      }
+      let Some(importer_chunk) = chunk_graph.module_to_chunk[m_idx] else {
+        continue;
+      };
+      for rec in &normal.import_records {
+        if rec.kind != ImportKind::Import {
+          continue;
+        }
+        let Some(importee) = rec.resolved_module else {
+          continue;
+        };
+        if let Some(&s) = module_eligible_chunk.get(&importee) {
+          if s != importer_chunk {
+            importers.entry(s).or_default().insert(importer_chunk);
+          }
+        }
+      }
+    }
+    importers
+  }
+
+  fn collect_declared_symbols(&self, module_idx: ModuleIdx, out: &mut FxHashSet<SymbolRef>) {
+    let meta = &self.link_output.metas[module_idx];
+    for (stmt_idx, stmt_info) in self.link_output.stmt_infos[module_idx].iter_enumerated() {
+      if !meta.stmt_info_included.has_bit(stmt_idx) {
+        continue;
+      }
+      for declared in &stmt_info.declared_symbols {
+        if let TaggedSymbolRef::Normal(sym) = declared {
+          if sym.owner == module_idx {
+            out.insert(*sym);
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -106,6 +106,7 @@ mod detect_ineffective_dynamic_imports;
 mod dynamic_already_loaded;
 mod finalize_modules;
 mod manual_code_splitting;
+mod min_chunk_size;
 mod minify_chunks;
 mod on_demand_wrapping;
 mod post_banner_footer;
@@ -139,6 +140,11 @@ impl<'a> GenerateStage<'a> {
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
     let mut chunk_graph = self.generate_chunks().await?;
+
+    // `experimental.minChunkSize`: duplicate small side-effect-free common leaf
+    // chunks into their importers (webpack `splitChunks.minSize` parity). Must run
+    // before `compute_cross_chunk_links` so duplicated leaves are accounted for.
+    self.merge_small_common_leaf_chunks(&mut chunk_graph);
 
     // Count only live chunks. Chunks merged away during chunk optimization (e.g.
     // the standalone runtime chunk folded back into its host) stay in
@@ -176,12 +182,17 @@ impl<'a> GenerateStage<'a> {
     set_emitted_chunk_preliminary_filenames(&self.plugin_driver.file_emitter, &chunk_graph);
 
     debug_span!("deconflict_chunk_symbols").in_scope(|| {
-      chunk_graph.chunk_table.par_iter_mut().for_each(|chunk| {
+      // Disjoint borrow: `chunk_table` mutably, `duplicated_leaf_pinned_names`
+      // immutably, so the deconflicter can pin duplicated-leaf names per chunk.
+      let ChunkGraph { chunk_table, duplicated_leaf_pinned_names, .. } = &mut chunk_graph;
+      let pinned_names = &*duplicated_leaf_pinned_names;
+      chunk_table.par_iter_mut().for_each(|chunk| {
         deconflict_chunk_symbols(
           chunk,
           self.link_output,
           self.options.format,
           &index_chunk_id_to_name,
+          pinned_names,
         );
       });
     });

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -9,10 +9,31 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, TaggedSymbolRef, WrapKind,
+  Chunk, ChunkIdx, ChunkKind, GetLocalDb, ModuleIdx, NormalModule, OutputFormat, SymbolRef,
+  TaggedSymbolRef, WrapKind,
 };
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Pin every duplicated-leaf symbol (`experimental.minChunkSize`) present in this
+/// chunk to its globally-unique name and reserve it *before* the normal
+/// deconfliction pass, so author symbols (including entry-module symbols, which
+/// otherwise bypass the `accept` veto) yield to the pinned name instead.
+fn pin_duplicated_leaf_names(
+  renamer: &mut Renamer,
+  chunk: &Chunk,
+  duplicated_leaf_pinned_names: &FxHashMap<SymbolRef, CompactStr>,
+) {
+  if duplicated_leaf_pinned_names.is_empty() {
+    return;
+  }
+  let chunk_modules: FxHashSet<ModuleIdx> = chunk.modules.iter().copied().collect();
+  for (&symbol_ref, name) in duplicated_leaf_pinned_names {
+    if chunk_modules.contains(&symbol_ref.owner) {
+      renamer.pin_name(symbol_ref, name.clone());
+    }
+  }
+}
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn deconflict_chunk_symbols(
@@ -20,8 +41,11 @@ pub fn deconflict_chunk_symbols(
   link_output: &LinkStageOutput,
   format: OutputFormat,
   index_chunk_id_to_name: &FxHashMap<ChunkIdx, ArcStr>,
+  duplicated_leaf_pinned_names: &FxHashMap<SymbolRef, CompactStr>,
 ) {
   let mut renamer = Renamer::new(chunk.entry_module_idx(), &link_output.symbol_db, format);
+
+  pin_duplicated_leaf_names(&mut renamer, chunk, duplicated_leaf_pinned_names);
   // Reserve global scope symbols (unresolved references) to prevent generating conflicting names.
   // These are identifiers referenced but not defined in the module's scope (e.g., `console`, `window`).
   chunk

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -71,6 +71,19 @@ impl<'name> Renamer<'name> {
     self.resolver.reserve(name);
   }
 
+  /// Force a symbol to a specific name and reserve that name so no other symbol
+  /// in this chunk can take it. Used by `experimental.minChunkSize` to give a
+  /// duplicated leaf symbol the same globally-pinned name in every chunk it is
+  /// copied into. Must be called before the normal deconfliction pass so the
+  /// reservation wins over author symbols (including entry-module symbols, which
+  /// otherwise bypass `accept` — `ConflictResolver::resolve` still checks the
+  /// reserved `used` set first).
+  pub fn pin_name(&mut self, symbol_ref: SymbolRef, name: CompactStr) {
+    let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
+    self.resolver.reserve(name.clone());
+    self.canonical_names.insert(canonical_ref, name);
+  }
+
   /// Check if a candidate name is available for a top-level symbol without causing
   /// unintended variable capture in nested scopes.
   ///

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -14,6 +14,7 @@ pub struct BindingExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<Either<bool, BindingChunkOptimizationOptions>>,
   pub lazy_barrel: Option<bool>,
+  pub min_chunk_size: Option<f64>,
 }
 
 impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -38,6 +39,7 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
         Either::B(v) => rolldown_common::ChunkOptimizationOption::Options(v.into()),
       }),
       lazy_barrel: value.lazy_barrel,
+      min_chunk_size: value.min_chunk_size,
     })
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -80,6 +80,15 @@ pub struct ExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<ChunkOptimizationOption>,
   pub lazy_barrel: Option<bool>,
+  /// Minimum chunk size, in bytes, below which a side-effect-free common "leaf"
+  /// chunk (whose modules have no imports of their own) is duplicated into each
+  /// importing chunk instead of being emitted as a standalone shared chunk.
+  ///
+  /// This mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are
+  /// inlined into their consumers to reduce chunk/request count. `None` (the
+  /// default) disables the optimization. See
+  /// `internal-docs/min-size-chunk-merging/design.md`.
+  pub min_chunk_size: Option<f64>,
 }
 
 impl ExperimentalOptions {
@@ -124,5 +133,11 @@ impl ExperimentalOptions {
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
     self.lazy_barrel.unwrap_or(true)
+  }
+
+  /// Returns the configured min chunk size (bytes) when the small-common-leaf
+  /// duplication optimization is enabled, i.e. a positive threshold was set.
+  pub fn min_chunk_size(&self) -> Option<f64> {
+    self.min_chunk_size.filter(|size| *size > 0.0)
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1033,6 +1033,14 @@
             "boolean",
             "null"
           ]
+        },
+        "minChunkSize": {
+          "description": "Minimum chunk size, in bytes, below which a side-effect-free common \"leaf\"\nchunk (whose modules have no imports of their own) is duplicated into each\nimporting chunk instead of being emitted as a standalone shared chunk.\n\nThis mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are\ninlined into their consumers to reduce chunk/request count. `None` (the\ndefault) disables the optimization. See\n`internal-docs/min-size-chunk-merging/design.md`.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
         }
       },
       "additionalProperties": false

--- a/internal-docs/min-size-chunk-merging/design.md
+++ b/internal-docs/min-size-chunk-merging/design.md
@@ -1,0 +1,123 @@
+# Min-size chunk merging (`experimental.minChunkSize`)
+
+Status: **in progress** — Stage 1 (option) implemented; Stages 2–4 (the linker
+duplication) are the remaining work. See the staged plan below.
+
+## Why
+
+Rolldown (Rollup model) extracts _every_ shared module into a shared chunk with no
+size floor. Empirically (4 code-split shapes probed), a shared chunk always has
+≥2 importers — so a "merge into one importer" pass has no clean targets, and the
+chunking algorithm already folds single-reachability modules into their consumer.
+
+webpack/rspack `splitChunks.minSize` (default ~20 KB) instead **does not extract**
+a sub-threshold shared module: it stays _duplicated_ in each consumer. For a tiny
+shared leaf used by two entries that means 2 chunks instead of 3 — fewer requests,
+less cross-chunk `import` boilerplate, better gzip. This is the win we want.
+
+So min-size merging fundamentally requires **duplicating a module into multiple
+chunks**, which Rollup/rolldown deliberately never does. That is the whole cost.
+
+## What makes it hard (validated against the code)
+
+Rolldown assumes _one module ⇒ one chunk_ throughout the back half of generate:
+
+| Stage             | File                                                                        | 1:1 assumption                                                    |
+| ----------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| cross-chunk links | `stages/generate_stage/compute_cross_chunk_links.rs` (≈186/462/583/619)     | import-vs-local via `module_to_chunk[m] == chunk`                 |
+| deconfliction     | `utils/chunk/deconflict_chunk_symbols.rs`                                   | per-chunk, exec-order-dependent renamer (`chunk.canonical_names`) |
+| finalize          | `module_finalizers/mod.rs:266`, `stages/generate_stage/finalize_modules.rs` | each module AST finalized **once** against its single chunk       |
+| render            | `stages/generate_stage/render_chunk_to_assets.rs:~259`                      | codegens `ast_table[m]` once per `chunk.modules` entry            |
+
+Good news from the render path: it codegens the _same_ finalized AST for every
+`chunk.modules` entry, so a module listed in two chunks renders in both **without
+AST cloning** — _iff_ that single finalized AST is valid in every chunk.
+
+## Approach: leaf-only duplication with globally-pinned names
+
+Restrict to **side-effect-free leaf modules** (no import records, no side effects):
+
+- No outgoing refs ⇒ the finalized AST contains nothing chunk-specific except its
+  own declared-symbol names.
+- Side-effect-free ⇒ executing it in N chunks is observationally identical (only
+  declarations), so duplication is safe.
+
+Make the one finalized AST valid everywhere by giving each duplicated-leaf symbol a
+**single name used by every chunk**:
+
+1. Pre-name all duplicated-leaf declared symbols once (a `Renamer`) → unique among
+   the duplicated set; store `pinned_names: FxHashMap<SymbolRef, CompactStr>`.
+2. In each chunk that receives a leaf, _reserve_ those names and pin
+   `canonical_names[symbol] = pinned` before deconflicting the chunk's own symbols
+   (so any colliding author symbol is renamed instead). Needs a small
+   `Renamer::pin_name` helper.
+
+Then references resolve to the pinned name in every chunk, and the leaf's def uses
+the same pinned name. (minify re-shortens per chunk afterwards; each chunk is
+self-contained.)
+
+### Local-vs-cross rule
+
+Add `duplicated_leaf_modules: FxHashSet<ModuleIdx>` to `ChunkGraph`. The
+import-vs-local checks become `module_to_chunk[m] == chunk || duplicated_leaf_modules.contains(m)`
+— a duplicated leaf is local to any chunk that references it, because we copy it
+into every importer.
+
+### Importer-set completeness (the subtle part)
+
+The leaf must be duplicated into **every** chunk that references its symbols, incl.
+cross-chunk re-export chains (module A in C1 re-exports S's symbol; B in C2 imports
+from A ⇒ C2 references S's canonical symbol although its direct edge is to A). Two
+ways to get the authoritative set:
+
+- **Run the pass AFTER `compute_cross_chunk_links`** and read each chunk's
+  `imports_from_other_chunks` (authoritative; includes re-export chains). Cost:
+  must scrub those link structures + `exports_to_other_chunks` when removing S, and
+  downstream passes (`on_demand_wrapping`, `compute_chunk_output_exports`) consume
+  them.
+- **Run BEFORE** and detect importers from direct import edges, but then restrict
+  eligibility to leaves whose symbols are **not re-exported across chunks**
+  (conservative; provably complete via direct edges). Simpler mutation, narrower
+  applicability. **Recommended for the first landed version.**
+
+## Touchpoints
+
+1. Option: `experimental.minChunkSize?: number` — **done** (TS `input-options.ts`,
+   `bindingify-input-options.ts`; Rust `experimental_options.rs` +
+   `binding_experimental_options.rs`; helper `min_chunk_size()`).
+2. New pass after chunk formation: detect eligible chunks (Common, not runtime, all
+   side-effect-free leaves via `import_records.is_empty()` +
+   `side_effects().has_side_effects() == false`, size < min, has importers, not
+   re-exported across chunks), compute pinned names, mutate (`chunk.modules` += leaf
+   into each importer; tombstone S via `post_chunk_optimization_operations::Removed`;
+   record `duplicated_leaf_modules`), re-run `sort_chunk_modules`.
+3. `Renamer::pin_name` + `deconflict_chunk_symbols` pins/reserves duplicated-leaf
+   names (reads `pinned_names`).
+4. Local-vs-cross set-membership in `compute_cross_chunk_links.rs` +
+   `module_finalizers/mod.rs:266`.
+
+## Staged plan (option stays default-off until Stage 4)
+
+- **S1 (done):** option plumbing; compiles. Behavior-neutral.
+- **S2:** detector + graph mutation + pinned-name computation behind the option;
+  unit-test the pure detector predicate + the pinned-name uniqueness.
+- **S3:** set-membership local-vs-cross; verify default-off snapshots unchanged.
+- **S4:** ON fixtures (multi-export leaf, 3-way share, minify on/off, re-export
+  exclusion) asserting chunk-count drop + correct runtime; off-vs-on benchmark.
+
+## Risks / edge cases
+
+CJS-wrapped leaves and IIFE/UMD factory-param capture (exclude CJS for v1), HMR
+`hot` refs, external-namespace symbols, a leaf shared by 3+ chunks, a leaf that is
+also a dynamic-import target/entry (excluded — those are `EntryPoint`, not
+`Common`), `preserveModules`/manual chunks (excluded). The full
+`crates/rolldown/tests` + `packages/rolldown-tests` suites must stay green with the
+option OFF, and the ON fixtures must execute correctly (no duplicate-symbol /
+ReferenceError) before considering default-on.
+
+## Rejected alternatives
+
+- Clean single-importer merge (no duplication): no targets in rolldown's model.
+- Merging small shared chunks together: over-fetch (different reachability sets).
+- Finalize-per-(module,chunk) with AST cloning: oxc arena ASTs make re-finalization
+  heavy; the pinned-name trick keeps it single-pass.

--- a/internal-docs/min-size-chunk-merging/design.md
+++ b/internal-docs/min-size-chunk-merging/design.md
@@ -1,7 +1,8 @@
 # Min-size chunk merging (`experimental.minChunkSize`)
 
-Status: **in progress** — Stage 1 (option) implemented; Stages 2–4 (the linker
-duplication) are the remaining work. See the staged plan below.
+Status: **implemented** (experimental, default-off). Pass lives in
+`crates/rolldown/src/stages/generate_stage/min_chunk_size.rs`
+(`GenerateStage::merge_small_common_leaf_chunks`).
 
 ## Why
 
@@ -96,14 +97,24 @@ ways to get the authoritative set:
 4. Local-vs-cross set-membership in `compute_cross_chunk_links.rs` +
    `module_finalizers/mod.rs:266`.
 
-## Staged plan (option stays default-off until Stage 4)
+## Staged plan (all landed)
 
-- **S1 (done):** option plumbing; compiles. Behavior-neutral.
-- **S2:** detector + graph mutation + pinned-name computation behind the option;
-  unit-test the pure detector predicate + the pinned-name uniqueness.
-- **S3:** set-membership local-vs-cross; verify default-off snapshots unchanged.
-- **S4:** ON fixtures (multi-export leaf, 3-way share, minify on/off, re-export
-  exclusion) asserting chunk-count drop + correct runtime; off-vs-on benchmark.
+- **S1 (done):** option plumbing; behavior-neutral.
+- **S2 (done):** detector + graph mutation + pinned-name computation behind the option.
+- **S3 (done):** duplicated-leaf "local everywhere" rule in
+  `compute_cross_chunk_links.rs` (symbol-assign skip + cross-import skip) and
+  `module_finalizers/mod.rs`; `Renamer::pin_name` + deconflict pinning.
+- **S4 (done):** ON fixtures in `packages/rolldown/tests/fixtures/min-chunk-size/`
+  (`basic`, `multi-export-leaf` with minify, `re-export-excluded`) asserting
+  chunk-count drop + correct runtime.
+
+### Note: re-export completeness (learned during S4)
+
+The conservative re-export exclusion must scan **all** modules, not just
+`is_included` ones — a pure re-export pass-through (`export { k } from './util'`)
+is typically tree-shaken (`is_included == false`) yet a consumer can still
+reference the leaf through it. The `re-export-excluded` fixture pins this: it
+failed with `ReferenceError: k is not defined` before the all-modules scan.
 
 ## Risks / edge cases
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2235,6 +2235,7 @@ export interface BindingExperimentalOptions {
   nativeMagicString?: boolean
   chunkOptimization?: boolean | BindingChunkOptimizationOptions
   lazyBarrel?: boolean
+  minChunkSize?: number
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -718,6 +718,19 @@ export interface InputOptions {
      * @default true
      */
     lazyBarrel?: boolean;
+    /**
+     * Minimum chunk size, in bytes, below which a side-effect-free common "leaf"
+     * chunk (whose modules have no imports of their own) is duplicated into each
+     * importing chunk instead of being emitted as a standalone shared chunk.
+     *
+     * This mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are
+     * inlined into their consumers to reduce the number of emitted chunks and
+     * network requests, at the cost of duplicating the small module.
+     *
+     * @experimental
+     * @default undefined (disabled)
+     */
+    minChunkSize?: number;
   };
   /**
    * Configure how the code is transformed. This process happens after the `transform` hook.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -179,6 +179,7 @@ function bindingifyExperimental(
     nativeMagicString: experimental?.nativeMagicString,
     chunkOptimization: experimental?.chunkOptimization,
     lazyBarrel: experimental?.lazyBarrel,
+    minChunkSize: experimental?.minChunkSize,
   };
 }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -668,6 +668,7 @@ const InputOptionsSchema = v.strictObject({
         ]),
       ),
       lazyBarrel: v.optional(v.boolean()),
+      minChunkSize: v.optional(v.number()),
     }),
   ),
   transform: v.optional(TransformOptionsSchema),

--- a/packages/rolldown/tests/fixtures/min-chunk-size/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/basic/_config.ts
@@ -1,0 +1,38 @@
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// `experimental.minChunkSize`: two entries share a tiny side-effect-free leaf
+// (`util.js`). Without the option rolldown emits 3 chunks (entry-a, entry-b, and
+// a standalone shared chunk for util.js). With minChunkSize large enough, the
+// leaf is duplicated into each entry chunk instead, yielding 2 chunks and no
+// cross-chunk import.
+export default defineTest({
+  config: {
+    input: {
+      'entry-a': './entry-a.js',
+      'entry-b': './entry-b.js',
+    },
+    experimental: {
+      minChunkSize: 100_000,
+    },
+  },
+  afterTest: async (output) => {
+    const chunks = output.output.filter((c) => c.type === 'chunk');
+    // Shared leaf merged into both entries -> 2 chunks, no standalone shared chunk.
+    expect(chunks.length).toBe(2);
+    // util.js is duplicated into BOTH entry chunks.
+    const chunksWithUtil = chunks.filter((c) =>
+      c.moduleIds.some((id) => id.replace(/\\/g, '/').endsWith('/util.js')),
+    );
+    expect(chunksWithUtil.length).toBe(2);
+    // No cross-chunk import remains between the entries.
+    for (const c of chunks) {
+      expect(c.imports.length).toBe(0);
+    }
+    // Runtime correctness: the duplicated leaf's bindings resolve in each chunk.
+    const a = await import('./dist/entry-a.js');
+    const b = await import('./dist/entry-b.js');
+    expect(a.a).toBe('shared-value-a');
+    expect(b.b).toBe('shared-valueshared-value-b');
+  },
+});

--- a/packages/rolldown/tests/fixtures/min-chunk-size/basic/entry-a.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/basic/entry-a.js
@@ -1,0 +1,3 @@
+import { getValue } from './util.js';
+
+export const a = getValue() + '-a';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/basic/entry-b.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/basic/entry-b.js
@@ -1,0 +1,3 @@
+import { getValue, value } from './util.js';
+
+export const b = getValue() + value + '-b';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/basic/util.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/basic/util.js
@@ -1,0 +1,4 @@
+export const value = 'shared-value';
+export function getValue() {
+  return value;
+}

--- a/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/_config.ts
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/_config.ts
@@ -1,0 +1,39 @@
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// A multi-export leaf shared by THREE entries, with minify ON. Verifies that the
+// duplicated leaf's globally-pinned names stay consistent within each chunk after
+// minification (def + references both rename together), with no cross-chunk import.
+export default defineTest({
+  config: {
+    input: {
+      e1: './e1.js',
+      e2: './e2.js',
+      e3: './e3.js',
+    },
+    output: {
+      minify: true,
+    },
+    experimental: {
+      minChunkSize: 100_000,
+    },
+  },
+  afterTest: async (output) => {
+    const chunks = output.output.filter((c) => c.type === 'chunk');
+    // Leaf duplicated into all three entries -> 3 chunks, no standalone shared chunk.
+    expect(chunks.length).toBe(3);
+    const chunksWithUtil = chunks.filter((c) =>
+      c.moduleIds.some((id) => id.replace(/\\/g, '/').endsWith('/util.js')),
+    );
+    expect(chunksWithUtil.length).toBe(3);
+    for (const c of chunks) {
+      expect(c.imports.length).toBe(0);
+    }
+    const e1 = await import('./dist/e1.js');
+    const e2 = await import('./dist/e2.js');
+    const e3 = await import('./dist/e3.js');
+    expect(e1.r1).toBe('A1');
+    expect(e2.r2).toBe('B2');
+    expect(e3.r3).toBe('AB3');
+  },
+});

--- a/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e1.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e1.js
@@ -1,0 +1,3 @@
+import { a } from './util.js';
+
+export const r1 = a() + '1';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e2.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e2.js
@@ -1,0 +1,3 @@
+import { b } from './util.js';
+
+export const r2 = b() + '2';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e3.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/e3.js
@@ -1,0 +1,3 @@
+import { a, b } from './util.js';
+
+export const r3 = a() + b() + '3';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/util.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/multi-export-leaf/util.js
@@ -1,0 +1,6 @@
+export function a() {
+  return 'A';
+}
+export function b() {
+  return 'B';
+}

--- a/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/_config.ts
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/_config.ts
@@ -1,0 +1,33 @@
+import { expect } from 'vitest';
+import { defineTest } from 'rolldown-tests';
+
+// Conservative-eligibility guard: `util.js`'s `k` is re-exported by
+// `re-exporter.js`, and entry `b` imports it through that re-export chain. The
+// direct-import-edge importer scan can't see `b` as an importer of `util.js`, so
+// duplicating the leaf would drop `k` from `b`'s chunk. The pass therefore
+// EXCLUDES re-exported leaves: `util.js` must stay a single shared chunk (never
+// duplicated), and both entries must still run correctly.
+export default defineTest({
+  config: {
+    input: {
+      a: './a.js',
+      b: './b.js',
+    },
+    experimental: {
+      minChunkSize: 100_000,
+    },
+  },
+  afterTest: async (output) => {
+    const chunks = output.output.filter((c) => c.type === 'chunk');
+    const chunksWithUtil = chunks.filter((c) =>
+      c.moduleIds.some((id) => id.replace(/\\/g, '/').endsWith('/util.js')),
+    );
+    // util.js was NOT duplicated (it is re-exported) -> present in exactly one chunk.
+    expect(chunksWithUtil.length).toBe(1);
+    // Runtime stays correct for both the direct importer and the re-export chain.
+    const a = await import('./dist/a.js');
+    const b = await import('./dist/b.js');
+    expect(a.a).toBe('Ka');
+    expect(b.b).toBe('Kb');
+  },
+});

--- a/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/a.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/a.js
@@ -1,0 +1,3 @@
+import { k } from './util.js';
+
+export const a = k() + 'a';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/b.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/b.js
@@ -1,0 +1,3 @@
+import { k } from './re-exporter.js';
+
+export const b = k() + 'b';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/re-exporter.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/re-exporter.js
@@ -1,0 +1,1 @@
+export { k } from './util.js';

--- a/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/util.js
+++ b/packages/rolldown/tests/fixtures/min-chunk-size/re-export-excluded/util.js
@@ -1,0 +1,3 @@
+export function k() {
+  return 'K';
+}


### PR DESCRIPTION
## What

Adds an experimental, **default-off** `experimental.minChunkSize` option that brings
webpack/rspack `splitChunks.minSize`-style behavior to rolldown: a small,
side-effect-free **common "leaf" chunk** (modules with no imports of their own) is
*duplicated* into each importing chunk instead of being emitted as a standalone
shared chunk. This trades a tiny bit of duplication for fewer chunks / network
requests.

Opening this mainly **for discussion** — it intentionally introduces module
duplication, which goes against rolldown's Rollup-style "each module in exactly one
chunk" design, so it's gated behind an experimental flag and it's completely fine
not to land it. I went looking for an rspack optimization rolldown lacked and this
was the one real gap I could find (rolldown already matches rspack on mangleExports,
const inlining, inner-graph tree-shaking, realContentHash, and size-based splitting
for *manual* chunks).

### Motivating case
Two entries sharing one tiny leaf:

```
// off (today):   entry-a.js, entry-b.js, shared-<hash>.js   (3 chunks)
// on:            entry-a.js, entry-b.js                      (2 chunks, leaf duplicated)
```

## How it stays correct

The renderer already reuses a single finalized AST per `chunk.modules` entry, so a
leaf listed in N chunks renders in all N — *if* that one AST is valid in every
chunk. The pass makes that hold:

- **`merge_small_common_leaf_chunks`** (runs before `compute_cross_chunk_links`):
  finds eligible `Common` leaf chunks (all modules side-effect-free, no imports, not
  re-exported, total `size() < minChunkSize`), copies their modules into every
  importing chunk, tombstones the shared chunk, and records
  `ChunkGraph::duplicated_leaf_modules`.
- **One globally-unique pinned name** per duplicated-leaf symbol
  (`ChunkGraph::duplicated_leaf_pinned_names`), pinned + reserved per chunk via
  `Renamer::pin_name` *before* the normal deconfliction pass — so even entry-module
  symbols (which bypass the `accept` veto) yield, since `ConflictResolver::resolve`
  checks the reserved set first.
- **"Local everywhere" rule**: a duplicated leaf is local to any chunk that
  references it — `compute_cross_chunk_links` skips its symbol-assignment + cross
  chunk import, and the module finalizer treats it as same-chunk.
- **Conservative exclusion**: leaves re-exported anywhere are excluded (the scan
  covers *all* modules, including tree-shaken re-export pass-throughs) so the
  direct-import importer scan stays sound.

Design + rationale + rejected alternatives: `internal-docs/min-size-chunk-merging/design.md`.

## Scope / limitations (first slice)
Leaf-only (no imports), side-effect-free, not re-exported, ESM. CJS-wrapped leaves
and namespace/factory-param cases are intentionally out of scope for now.

## Tests
`packages/rolldown/tests/fixtures/min-chunk-size/`:
- `basic` — 2 entries + tiny shared leaf → 2 chunks, no cross-chunk import, correct runtime.
- `multi-export-leaf` — 3 entries, multi-export leaf, **minify on** (pinned names survive mangling).
- `re-export-excluded` — a re-exported leaf is *not* duplicated (guards the cross-chunk re-export chain; this test caught a real bug during development — a tree-shaken re-export pass-through made a leaf wrongly eligible → `ReferenceError`, fixed by scanning all modules).

Verification: default-off is non-regressing (rolldown crate snapshot suite + full node fixture suite pass), clippy clean.
