### PR TITLE
fix(treeshake): apply @__NO_SIDE_EFFECTS__ to cross-chunk namespace calls

### DIFF
--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -3,16 +3,16 @@ use oxc::{
     AstBuilder, AstKind,
     ast::{
       BindingIdentifier, BindingPattern, Declaration, ExportDefaultDeclaration,
-      ExportDefaultDeclarationKind, ExportNamedDeclaration,
+      ExportDefaultDeclarationKind, ExportNamedDeclaration, Expression,
     },
   },
   ast_visit::{Visit, walk},
-  semantic::NodeId,
+  semantic::{NodeId, SymbolId},
 };
 use rolldown_common::{
-  AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, IndexModules, ModuleIdx,
-  SharedNormalizedBundlerOptions, SideEffectDetail, StmtInfoIdx, SymbolRef, SymbolRefDb,
-  SymbolRefFlags,
+  AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, IndexModules,
+  MemberExprRefResolutionMap, ModuleIdx, SharedNormalizedBundlerOptions, SideEffectDetail,
+  Specifier, StmtInfoIdx, SymbolRef, SymbolRefDb, SymbolRefFlags,
 };
 use rolldown_ecmascript_utils::ExpressionExt;
 use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
@@ -193,6 +193,18 @@ impl LinkStage<'_> {
             module_idx_and_stmt_idx_to_dynamic_import_expr_node_id_map
               .get(&module_idx)
               .unwrap_or(&default_stmt_idx_to_dynamic_import_expr_node_ids);
+          // Local symbols of `import * as ns` bindings. Property reads on ES module namespace
+          // objects are side-effect-free, so the `SideEffectDetector` re-run below must know
+          // about them to drop `ns.fn()` calls to `@__NO_SIDE_EFFECTS__` functions. The scanner
+          // builds the same set (see `add_star_import`), but it isn't persisted, so reconstruct
+          // it here from the persisted named imports.
+          let namespace_object_symbol_ids: FxHashSet<SymbolId> = module
+            .named_imports
+            .iter()
+            .filter_map(|(local_ref, named_import)| {
+              matches!(named_import.imported, Specifier::Star).then_some(local_ref.symbol)
+            })
+            .collect();
           let mut ctx = CrossModuleOptimizationRunnerContext {
             local_constant_symbol_map: FxHashMap::default(),
             side_effect_detail_mutations: FxHashMap::default(),
@@ -208,6 +220,8 @@ impl LinkStage<'_> {
               options: self.options,
               ast_scope: &self.symbols.local_db(module_idx).ast_scopes,
               stmt_idx_to_dynamic_import_expr_node_ids,
+              resolved_member_expr_refs: &self.metas[module_idx].resolved_member_expr_refs,
+              namespace_object_symbol_ids: &namespace_object_symbol_ids,
             },
             // `0` is preserved for namespace stmt
             toplevel_stmt_idx: StmtInfoIdx::from_raw_unchecked(1),
@@ -275,6 +289,12 @@ struct CrossModuleOptimizationImmutableCtx<'a, 'ast: 'a> {
   options: &'a SharedNormalizedBundlerOptions,
   ast_scope: &'a AstScopes,
   stmt_idx_to_dynamic_import_expr_node_ids: &'a FxHashMap<StmtInfoIdx, FxHashSet<NodeId>>,
+  /// Resolution of namespace/named member expressions (`ns.fn`) to their target symbol,
+  /// used to recognize `ns.fn()` calls to `@__NO_SIDE_EFFECTS__` functions.
+  resolved_member_expr_refs: &'a MemberExprRefResolutionMap,
+  /// Local symbols of `import * as ns` bindings, so property reads on them are treated as
+  /// side-effect-free when re-detecting side effects of statements.
+  namespace_object_symbol_ids: &'a FxHashSet<SymbolId>,
 }
 
 struct CrossModuleOptimizationRunnerContext<'a, 'ast: 'a> {
@@ -295,6 +315,40 @@ impl<'a, 'ast: 'a> std::ops::Deref for CrossModuleOptimizationRunnerContext<'a, 
 
   fn deref(&self) -> &Self::Target {
     &self.immutable_ctx
+  }
+}
+
+impl<'ast> CrossModuleOptimizationRunnerContext<'_, 'ast> {
+  /// Resolve a call expression's callee to the canonical declaration symbol it targets, if it is
+  /// a reference we can statically reason about:
+  /// - a bare identifier callee (`fn()`), or
+  /// - a namespace/named member-access callee that fully resolves to an exported binding
+  ///   (`ns.fn()`).
+  ///
+  /// Handling the member-access form is what makes `@__NO_SIDE_EFFECTS__` apply to namespace
+  /// imports across chunk boundaries (the call stays as `ns.fn()` until finalization, long after
+  /// side-effect detection has run).
+  fn resolve_callee_canonical_symbol(&self, callee: &Expression<'ast>) -> Option<SymbolRef> {
+    if let Some(ident) = callee.as_identifier() {
+      let ref_id = ident.reference_id.get()?;
+      let symbol_id = self.immutable_ctx.eval_ctx.scope.get_reference(ref_id).symbol_id()?;
+      return Some(
+        self
+          .immutable_ctx
+          .symbols
+          .canonical_ref_for((self.immutable_ctx.module_idx, symbol_id).into()),
+      );
+    }
+
+    let member_expr = callee.as_member_expression()?;
+    let resolution = self.immutable_ctx.resolved_member_expr_refs.get(&member_expr.node_id())?;
+    // Only treat it as a direct call to the resolved binding when the whole member expression
+    // resolves to it (e.g. `ns.fn`). If trailing properties remain (e.g. `ns.fn.bar`), the call
+    // targets something else.
+    if !resolution.prop_and_related_span_list.is_empty() {
+      return None;
+    }
+    Some(self.immutable_ctx.symbols.canonical_ref_for(resolution.resolved?))
   }
 }
 
@@ -319,7 +373,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
           self.immutable_ctx.flat_options,
           self.immutable_ctx.options,
           Some(&self.side_effect_free_call_expr_node_ids),
-          None,
+          Some(self.immutable_ctx.namespace_object_symbol_ids),
         )
         .detect_side_effect_of_stmt(stmt);
         self.side_effect_detail_mutations.insert(stmt_info_idx, side_effect_detail);
@@ -353,19 +407,16 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
 
   fn visit_call_expression(&mut self, it: &oxc::ast::ast::CallExpression<'ast>) {
     let mut pre_node_id = None;
-    let (is_side_effects_free_function, is_pure_annotation_only) = it
-      .callee
-      .as_identifier()
-      .and_then(|item| {
-        let ref_id = item.reference_id.get()?;
-        let symbol_id = self.immutable_ctx.eval_ctx.scope.get_reference(ref_id).symbol_id()?;
-
-        let symbol_ref = self
-          .immutable_ctx
-          .symbols
-          .canonical_ref_for((self.immutable_ctx.module_idx, symbol_id).into());
+    let (is_side_effects_free_function, is_pure_annotation_only) = self
+      .resolve_callee_canonical_symbol(&it.callee)
+      .map(|symbol_ref| {
+        // The binding must also be guaranteed unassigned: a `@__NO_SIDE_EFFECTS__` function
+        // whose export binding is later reassigned would, at the call site, invoke the
+        // replacement (which may have side effects), so the call must not be dropped. This
+        // mirrors what finalization checks for identifier callees.
         let is_free = symbol_ref
-          .is_side_effect_free_function(self.immutable_ctx.symbols, self.immutable_ctx.modules);
+          .is_side_effect_free_function(self.immutable_ctx.symbols, self.immutable_ctx.modules)
+          && symbol_ref.is_not_reassigned(self.immutable_ctx.symbols) == Some(true);
         let is_annotation_only = is_free
           && self
             .immutable_ctx
@@ -374,7 +425,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
             .flags
             .get(&symbol_ref.symbol)
             .is_some_and(|f| f.contains(SymbolRefFlags::PureAnnotationOnly));
-        Some((is_free, is_annotation_only))
+        (is_free, is_annotation_only)
       })
       .unwrap_or((false, false));
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9956 — `@__NO_SIDE_EFFECTS__` should apply to namespace-member calls (`ns.fn()`) even when the annotated module is emitted as a shared chunk. Two entries force `shared.js` into a shared chunk; both `ns.fn()` calls should be eliminated.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+
+```
+
+## entry-b.js
+
+```js
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/entry-a.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/entry-a.js
@@ -1,0 +1,3 @@
+import * as ns from './shared.js';
+
+ns.fn();

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/entry-b.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/entry-b.js
@@ -1,0 +1,3 @@
+import * as ns from './shared.js';
+
+ns.fn();

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/shared.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk/shared.js
@@ -1,0 +1,4 @@
+/* @__NO_SIDE_EFFECTS__ */
+export function fn() {
+  console.log('side effect');
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Companion to `no_side_effects_namespace_cross_chunk` (#9956). Covers the boundaries of the namespace-member `@__NO_SIDE_EFFECTS__` optimization: computed access and the function-expression form are eliminated; calls whose result is used, and `ns.fn.call(...)` (a trailing property access, not a direct call to `fn`), must be preserved. Two entries keep `shared.js` a shared chunk.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+import { t as fn } from "./shared.js";
+//#region entry-a.js
+const used = fn();
+console.log(used);
+fn.call(null);
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+
+```
+
+## shared.js
+
+```js
+//#region shared.js
+/* @__NO_SIDE_EFFECTS__ */
+function fn() {
+	console.log("fn side effect");
+}
+//#endregion
+export { fn as t };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/entry-a.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/entry-a.js
@@ -1,0 +1,16 @@
+import * as ns from './shared.js';
+
+// Eliminated: direct namespace-member call to a `@__NO_SIDE_EFFECTS__` function.
+ns.fn();
+// Eliminated: computed namespace-member access resolves the same way.
+ns['fn']();
+// Eliminated: the function-expression form is annotated and handled identically.
+ns.fnExpr();
+
+// Preserved: the result is used, so the call cannot be dropped.
+const used = ns.fn();
+console.log(used);
+
+// Preserved: `ns.fn.call(...)` is not a direct call to `fn` (trailing property
+// access), so the annotation must not apply.
+ns.fn.call(null);

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/entry-b.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/entry-b.js
@@ -1,0 +1,4 @@
+import * as ns from './shared.js';
+
+// Second consumer so `shared.js` stays a shared chunk.
+ns.fn();

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/shared.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/shared.js
@@ -1,0 +1,8 @@
+/* @__NO_SIDE_EFFECTS__ */
+export function fn() {
+  console.log('fn side effect');
+}
+
+export const fnExpr = /* @__NO_SIDE_EFFECTS__ */ function () {
+  console.log('fnExpr side effect');
+};


### PR DESCRIPTION
## Summary

`@__NO_SIDE_EFFECTS__`-annotated functions called through a namespace import (`ns.fn()`) were **not** tree-shaken when the annotated module landed in a separate/shared chunk, even though the same calls via named imports (`fn()`) and single-chunk namespace calls were eliminated correctly.

Fixes #9956.

## Root cause

There are two independent DCE mechanisms for `@__NO_SIDE_EFFECTS__`:

1. **Link-stage `cross_module_optimization`** — runs before chunking, resolves symbols cross-module, marks side-effect-free call statements for tree-shaking. But it only inspected `it.callee.as_identifier()`, so namespace-member callees (`ns.fn`, a `StaticMemberExpression`) were never recognized.
2. **Per-chunk `dce-only` minifier** — reads the annotation directly, but only works when the annotated declaration and the call land in the *same* chunk.

So a namespace call across a chunk boundary fell through both: mechanism (1) skipped the member-expression callee, and mechanism (2) couldn't see the annotation living in the other chunk.

## Fix

Two coordinated changes in `cross_module_optimization.rs`:

1. New `resolve_callee_canonical_symbol()` unifies identifier callees with member-expression callees. For the latter it resolves `ns.fn` via the module's `resolved_member_expr_refs`, guarded by `prop_and_related_span_list.is_empty()` so `ns.fn.bar()` isn't misattributed to `fn`.
2. The `SideEffectDetector` re-run previously passed `None` for `namespace_object_symbol_ids`. Even after marking the call pure, the detector recurses into the `ns.fn` callee *read*, which looks impure unless it knows `ns` is a namespace object. The set is reconstructed per-module from `named_imports` (the `Specifier::Star` entries — mirroring the scanner's `add_star_import`, which isn't persisted).

Both halves are required: marking the call pure alone leaves it kept because the callee read still reports a side effect.

## Tests

- `no_side_effects_namespace_cross_chunk` — minimal regression: two entries force `shared.js` into a shared chunk; both `ns.fn()` calls (and the chunk) are now eliminated.
- `no_side_effects_namespace_cross_chunk_cases` — boundary matrix: computed access (`ns['fn']()`) and the function-expression form are eliminated; results that are used and `ns.fn.call(...)` (trailing property access) are preserved.

Both fixtures were verified to reproduce the bug on `main` (calls remain) and pass with the fix. Full Rust suite green: `cargo test -p rolldown` (1760 integration + 69 unit), clippy `--deny warnings`, `fmt --check`, and `cargo check --all-features` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)