### PR TITLE
refactor(common): return bool from SymbolRef::is_not_reassigned

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -437,7 +437,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             .map(|id| {
               let symbol_ref = self.ctx.symbol_db.canonical_ref_for((self.ctx.idx, id).into());
               symbol_ref.is_side_effect_free_function(self.ctx.symbol_db, self.ctx.modules)
-                && symbol_ref.is_not_reassigned(self.ctx.symbol_db) == Some(true)
+                && symbol_ref.is_not_reassigned(self.ctx.symbol_db)
             })
             .unwrap_or(false);
           if is_empty_function {

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -416,7 +416,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
         // mirrors what finalization checks for identifier callees.
         let is_free = symbol_ref
           .is_side_effect_free_function(self.immutable_ctx.symbols, self.immutable_ctx.modules)
-          && symbol_ref.is_not_reassigned(self.immutable_ctx.symbols) == Some(true);
+          && symbol_ref.is_not_reassigned(self.immutable_ctx.symbols);
         let is_annotation_only = is_free
           && self
             .immutable_ctx

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -379,7 +379,7 @@ fn must_keep_live_binding(
     return false;
   }
 
-  if canonical_ref.is_not_reassigned(symbol_db).unwrap_or(false) {
+  if canonical_ref.is_not_reassigned(symbol_db) {
     // For unknown case, we consider it as reassigned.
     return false;
   }

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -41,11 +41,10 @@ impl SymbolRef {
     db.local_db(self.owner).ast_scopes.scoping().symbol_flags(self.symbol).is_const_variable()
   }
 
-  /// `None` means we don't know if it gets reassigned.
-  pub fn is_not_reassigned(&self, db: &SymbolRefDb) -> Option<bool> {
-    let flags = self.flags(db)?;
-    // Not having this flag means we don't know
-    flags.contains(SymbolRefFlags::IsNotReassigned).then_some(true)
+  /// Whether the binding is guaranteed never reassigned. A missing flag means we don't know,
+  /// which is treated conservatively as "possibly reassigned" (`false`).
+  pub fn is_not_reassigned(&self, db: &SymbolRefDb) -> bool {
+    self.flags(db).is_some_and(|flags| flags.contains(SymbolRefFlags::IsNotReassigned))
   }
 
   pub fn is_side_effect_free_function(&self, db: &SymbolRefDb, modules: &IndexModules) -> bool {


### PR DESCRIPTION
## Summary

`SymbolRef::is_not_reassigned` returned `Option<bool>`, but it only ever produced `None` or `Some(true)` — it never returned `Some(false)`. Every caller already collapsed the `None` ("don't know") case to `false`:

- `cross_module_optimization.rs` (the namespace/identifier no-side-effects gate) and `impl_visit_mut.rs` (finalizer) used `== Some(true)`
- `render_chunk_exports.rs` used `.unwrap_or(false)`

So the `Option` carried no information the callers used. This changes the return type to a plain `bool` (unknown → conservatively `false`) and simplifies all three call sites.

No behavior change.

## Stacking

Stacked on top of #9960 (`fix/9956-...`). One of the updated call sites — the namespace-member gate in `cross_module_optimization.rs` — only exists on that branch, which is why this is stacked rather than branched off `main`.

## Verification

- `cargo test -p rolldown`: 1761 integration + 69 unit, 0 failed (no snapshot changes)
- `cargo clippy --workspace --all-targets -- --deny warnings`: clean
- `cargo check --all-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)