### PR TITLE
docs(contribution-guide): code-format \main\ branch references

### DIFF
--- a/docs/contribution-guide/index.md
+++ b/docs/contribution-guide/index.md
@@ -71,6 +71,6 @@ If your pull request is still a work in progress, please open it as a [draft](ht
 
 ### Branch organization
 
-Submit all pull requests directly to the `main` branch. We only use separate branches for upcoming releases / breaking changes, otherwise, everything points to main.
+Submit all pull requests directly to the `main` branch. We only use separate branches for upcoming releases / breaking changes, otherwise, everything points to `main`.
 
-Code that lands in main must be compatible with the latest stable release. It may contain additional features, but no breaking changes. We should be able to release a new minor version from the tip of main at any time.
+Code that lands in `main` must be compatible with the latest stable release. It may contain additional features, but no breaking changes. We should be able to release a new minor version from the tip of `main` at any time.


### PR DESCRIPTION
## What

Code-format every `main` branch-name reference in the "Branch organization" section of the contribution guide.

The opening sentence already wrote the `main` branch as code, but the remaining references in the same section were plain text, leaving the section internally inconsistent:

- `… otherwise, everything points to main.` → `` … points to `main`. ``
- `Code that lands in main …` → `` Code that lands in `main` … ``
- `… from the tip of main at any time.` → `` … from the tip of `main` at any time. ``

