### PR TITLE
fix(deconflict): rename CJS locals shadowing wrapped-ESM namespace objects

### DIFF
--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -7,7 +7,8 @@ use oxc::syntax::keyword::{GLOBAL_OBJECTS, RESERVED_KEYWORDS};
 use oxc_str::CompactStr;
 
 use rolldown_common::{
-  ModuleIdx, NormalModule, OutputFormat, SymbolRef, SymbolRefDb, SymbolRefDbForModule, WrapKind,
+  ExportsKind, ImportRecordMeta, ModuleIdx, NormalModule, OutputFormat, SymbolRef, SymbolRefDb,
+  SymbolRefDbForModule, WrapKind,
 };
 use rolldown_utils::concat_string;
 
@@ -548,6 +549,39 @@ impl NestedScopeRenamer<'_, '_> {
       };
       if let Some(binding) = self.scoping.get_binding(root_scope_id, canonical_name.as_str().into())
         && binding != reference_symbol
+      {
+        let local_ref: SymbolRef = (self.module_idx, binding).into();
+        if self.link_output.symbol_db.canonical_ref_for(local_ref).owner == self.module_idx {
+          shadowing_locals.insert(local_ref);
+        }
+      }
+    }
+
+    // `require()` of a wrapped-ESM importee — the finalizer rewrites it to
+    // `(init_x(), __toCommonJS(xxx_exports))`, so a root-scope local sharing the importee's
+    // namespace-object final name shadows that read (issue #9882, require()/namespace channel).
+    // We mirror the finalizer's gate (`module_finalizers/mod.rs`): a non-CommonJS importee whose
+    // require is actually used. The namespace object lives in the importee module, never in
+    // `self.module`, so any same-named root-scope local here is a genuine shadowing local.
+    for rec in &self.module.import_records {
+      let Some(importee_idx) = rec.resolved_module else {
+        continue;
+      };
+      if rec.meta.contains(ImportRecordMeta::IsRequireUnused) {
+        continue;
+      }
+      let Some(importee) = self.link_output.module_table[importee_idx].as_normal() else {
+        continue;
+      };
+      if matches!(importee.exports_kind, ExportsKind::CommonJs) {
+        continue;
+      }
+      let Some(canonical_name) =
+        self.renamer.get_canonical_name(importee.namespace_object_ref).cloned()
+      else {
+        continue;
+      };
+      if let Some(binding) = self.scoping.get_binding(root_scope_id, canonical_name.as_str().into())
       {
         let local_ref: SymbolRef = (self.module_idx, binding).into();
         if self.link_output.symbol_db.canonical_ref_for(local_ref).owner == self.module_idx {

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }]
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/_test.mjs
@@ -1,0 +1,9 @@
+import { strict as assert } from 'node:assert';
+
+// Regression test for the #9882 require()/namespace-object shadowing variant. The CJS entry's
+// local `var lib_exports` collided with the dependency's chunk-root namespace object
+// `lib_exports`, turning the require initializer into `__toCommonJS(undefined)` and throwing at
+// module-eval time. After the fix the local is deconflicted and the bundle evaluates cleanly.
+const mod = await import('./dist/main.js');
+
+assert.equal(mod.default, 'lib-default:lib-named');

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({
+	default: () => makeValue,
+	named: () => named
+});
+function makeValue() {
+	return "lib-default";
+}
+var named;
+var init_lib = __esmMin((() => {
+	named = "lib-named";
+}));
+//#endregion
+//#region main.js
+var require_main = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	var lib_exports$1 = (init_lib(), __toCommonJS(lib_exports));
+	module.exports = lib_exports$1.default() + ":" + lib_exports$1.named;
+}));
+//#endregion
+export default require_main();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/lib.js
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/lib.js
@@ -1,0 +1,7 @@
+// ESM module `require()`d by the CJS entry. Because it is require()d (not statically imported),
+// rolldown wraps it with `__esmMin` and renders its namespace object `var lib_exports = ...` at
+// chunk root, which the entry's closure reads via `(init_lib(), __toCommonJS(lib_exports))`.
+export default function makeValue() {
+  return 'lib-default';
+}
+export const named = 'lib-named';

--- a/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/main.js
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/cjs_shadowing_require_namespace_object/main.js
@@ -1,0 +1,13 @@
+// CJS entry: `require()` of the ESM `./lib.js` forces CJS wrapping (`__commonJSMin`). The
+// dependency's namespace object renders at chunk root as `var lib_exports = ...` and is read
+// inside this closure as `(init_lib(), __toCommonJS(lib_exports))`.
+//
+// The author-local below is deliberately named `lib_exports` -- exactly the generated
+// namespace-object name. Pre-fix it shadowed the captured chunk-root `lib_exports` inside the
+// closure, so the require initializer became the self-referential
+// `var lib_exports = (init_lib(), __toCommonJS(lib_exports))` -> `__toCommonJS(undefined)` ->
+// `TypeError: Cannot convert undefined or null to object` (issue #9882, require()/namespace
+// channel). After the fix the local is deconflicted (e.g. `lib_exports$1`).
+var lib_exports = require('./lib.js');
+
+module.exports = lib_exports.default() + ':' + lib_exports.named;


### PR DESCRIPTION
Standalone PR on `main` (the #9921 / #10006 stack it followed is now merged).

Extends the #9882 chunk-root shadowing fix to one more channel: a CJS closure local that shadows a wrapped-ESM **namespace object** read via `require()`.

### Problem

When a CJS-wrapped module `require()`s a wrapped-ESM module, the finalizer rewrites the require to `(init_x(), __toCommonJS(xxx_exports))` — reading the importee's chunk-root namespace object. An author-local sharing that namespace object's final name shadows the read, producing a self-referential declaration:

```js
var xxx_exports = (init_x(), __toCommonJS(xxx_exports)); // reads itself → undefined
```

→ `TypeError: Cannot convert undefined or null to object` at module-eval time.

### Fix

Handle this in the **precise** `rename_cjs_locals_shadowing_referenced_chunk_bindings` post-pass — the same mechanism #9921 already uses for named-import and star-member shadowing. For each `require()` of a non-CommonJS importee (mirroring the finalizer's gate), rename a root-scope local that shares the importee namespace object's **final** name.

Why the post-pass rather than the chunk-root captured-name set: it runs *after* root-scope names are assigned, so it sees the namespace object's real (possibly renamed) name, and it only touches modules that actually reference the namespace — renaming the shadowing **local**, never the namespace.

### Test

`cjs_shadowing_require_namespace_object` — throws `__toCommonJS(undefined)` without the fix, passes with it (the namespace keeps its bare name, the colliding local is suffixed). The shared sibling-suffix-skipping path of the renamer is already covered by `cjs_shadowing_renamed_chunk_binding`.

Full integration suite: 1778 passed, 0 failed.
