### PR TITLE
fix: preserve export keyword on multi-declarator exports under keepNames

### DIFF
--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -20,6 +20,11 @@ pub struct PreProcessor<'ast, 'a> {
   drop_labels: Option<&'a FxHashSet<String>>,
   statement_stack: Vec<Address>,
   statement_replace_map: FxHashMap<Address, Vec<Statement<'ast>>>,
+  /// Set before walking an `ExportNamedDeclaration`'s inner declaration and taken by
+  /// `visit_declaration`, so the export's direct declaration skips the non-export
+  /// multi-declarator split (which would drop the `export` keyword) while nested
+  /// declarations still split. Reset after the walk for exports without a declaration.
+  next_declaration_is_exported: bool,
   /// Spans of `import defer ...` statements / expressions whose `defer` phase
   /// was lowered to a regular import. Read after `visit_program` to emit the
   /// `UNSUPPORTED_FEATURE` warning.
@@ -39,6 +44,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
       drop_labels: drop_labels.filter(|set| !set.is_empty()),
       statement_stack: vec![],
       statement_replace_map: FxHashMap::default(),
+      next_declaration_is_exported: false,
       defer_spans: vec![],
     }
   }
@@ -188,9 +194,10 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_declaration(&mut self, it: &mut Declaration<'ast>) {
+    let is_exported = std::mem::take(&mut self.next_declaration_is_exported);
     match it {
       Declaration::VariableDeclaration(decl) => {
-        if decl.declarations.len() > 1 && self.keep_names {
+        if !is_exported && decl.declarations.len() > 1 && self.keep_names {
           let stmt_addr = self.statement_stack.last().copied().unwrap();
           let new_stmts = self.split_var_declaration(decl, None);
           self.statement_replace_map.insert(stmt_addr, new_stmts);
@@ -209,7 +216,9 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_export_named_declaration(&mut self, named_decl: &mut ast::ExportNamedDeclaration<'ast>) {
+    self.next_declaration_is_exported = true;
     walk_mut::walk_export_named_declaration(self, named_decl);
+    self.next_declaration_is_exported = false;
 
     let Some(Declaration::VariableDeclaration(ref mut var_decl)) = named_decl.declaration else {
       return;

--- a/crates/rolldown/tests/rolldown/issues/9973/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9973/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./main.js",
+        "name": "main"
+      }
+    ],
+    "external": ["node:assert"],
+    "keepNames": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9973/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9973/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+//#region main.js
+assert.strictEqual(1, 1);
+assert.strictEqual(2, 2);
+assert.strictEqual(3, 3);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9973/dep.js
+++ b/crates/rolldown/tests/rolldown/issues/9973/dep.js
@@ -1,0 +1,3 @@
+export const a = 1,
+  b = 2;
+export const c = 3;

--- a/crates/rolldown/tests/rolldown/issues/9973/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9973/main.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+// Importing the multi-declarator export by name fails to build (MISSING_EXPORT)
+// if the `export` keyword is dropped (#9973).
+import { a, b, c } from './dep.js';
+
+assert.strictEqual(a, 1);
+assert.strictEqual(b, 2);
+assert.strictEqual(c, 3);


### PR DESCRIPTION
### What this solves

fixes #9973

With `keepNames: true`, a multi-declarator export loses its `export` keyword. The exported names are silently dropped from the bundle, or the build fails with `MISSING_EXPORT` when another module imports them by name. Single-declarator exports are unaffected.

```js
// input
export const a = 1, b = 2;
export const c = 3;

// before (keepNames: true)  ->  a, b are gone
const c = 3;
export { c };

// after (keepNames: true)
const a = 1;
const b = 2;
const c = 3;
export { a, b, c };
```

### Root cause

`visit_declaration` is shared by both a standalone declaration statement and an export's inner declaration (oxc calls it from `walk_statement` and from `walk_export_named_declaration`). Under `keepNames` it splits a multi-declarator `VariableDeclaration` into separate non-export statements and empties the original declarators. For an export, this runs first and clears the list, so the export-aware split in `visit_export_named_declaration` (`declarations.len() > 1`) is skipped and the `export` is lost.

### The fix

`visit_export_named_declaration` sets a flag before walking its inner declaration. `visit_declaration` consumes the flag (`std::mem::take`) and skips the non-export split for that direct declaration, so the export-aware split runs instead. Consuming the flag keeps it scoped to the direct child only, so nested multi-declarator declarations inside an export's initializer still split.

### Alternatives considered

- Doing the export-aware split before the walk: would move declarators out early and skip nested transforms (dynamic import / `require` transpose / `defer`).
- Detecting the export parent by AST address comparison: relies on oxc `GetAddress` aliasing internals, fragile.

### Tests

Added `tests/rolldown/issues/9973`: a module imports the multi-declarator export by name and asserts the values, which fails to build (`MISSING_EXPORT`) without this fix. Full `rolldown` integration suite passes with no other snapshot changes.