### PR TITLE
test(dev): error in lazy module should be catchable

### DIFF
--- a/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error.spec.ts
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { page, serverUrl } from '~utils';
+
+// `lazy-init-error.js` is lazily imported and throws while initializing. On the
+// first compile of the lazy chunk (the on-demand `@vite/lazy` response) the real
+// module is inlined into the proxy's `lazyExports` async IIFE, so its init runs
+// *synchronously* inside it:
+//
+//   var init_lazy_init_error_1 = createEsmInitializer(
+//     "...lazy-init-error.js?rolldown-lazy=1",
+//     (id) => { ...
+//       const lazyExports = (async () => {
+//         await (init_lazy_init_error_0(), Promise.resolve().then(() => loadExports("...lazy-init-error.js")));
+//         return __rolldown_runtime__.loadExports("...lazy-init-error.js");
+//       })();
+//     }, 1);
+//
+// `init_lazy_init_error_0()` throws synchronously, so this `lazyExports` rejects
+// immediately — before any consumer can attach a handler. The init error escapes
+// as an unhandled promise rejection, and the consumer's `await import(...)`
+// resolves as if nothing went wrong.
+//
+// NOTE: `test.fails` — the assertions below describe the DESIRED behavior, which
+// currently fails because the bug is unfixed: the init error should surface at
+// the consumer's `await import(...)` with no unhandled rejection. Once fixed, the
+// body will pass; drop `.fails` to turn this into a normal regression test.
+describe('lazy-init-error', () => {
+  test.fails(
+    'init error in a lazy module should be catchable, not unhandled',
+    { retry: 0 },
+    async () => {
+      // The bug shows on the very first compile of the lazy chunk (the on-demand
+      // `@vite/lazy` response), so navigate + click on a fresh server and do NOT
+      // reload — a rebuild splits the real module into a separate chunk reached
+      // via a real `await import(...)`, which is catchable.
+      await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
+      await page.click('#lazy-init-error-btn');
+      await expect.poll(() => page.textContent('#lazy-init-error-status')).toBe('done');
+
+      // Let any pending unhandled-rejection event fire before asserting.
+      await page.waitForTimeout(100);
+
+      // The consumer's try/catch should be the one that sees the init error...
+      const log = (await page.textContent('#lazy-init-error-log')) ?? '';
+      expect(log).toContain('caught: boom during lazy init');
+
+      // ...and nothing should escape the lazy proxy as an unhandled rejection.
+      const unhandled = (await page.textContent('#lazy-init-error-unhandled')) ?? '';
+      expect(unhandled).toBe('');
+    },
+  );
+});

--- a/packages/test-dev-server/tests/playground/lazy-compilation/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/index.html
@@ -45,6 +45,14 @@
       <div id="emitted-asset-container"></div>
     </section>
 
+    <section id="lazy-init-error">
+      <h2>lazy-init-error</h2>
+      <button id="lazy-init-error-btn">load</button>
+      <div id="lazy-init-error-status">pending</div>
+      <pre id="lazy-init-error-log"></pre>
+      <pre id="lazy-init-error-unhandled"></pre>
+    </section>
+
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/lazy-init-error.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/lazy-init-error.js
@@ -1,0 +1,19 @@
+// lazy-init-error: this module is lazily imported by `setup.js` and throws while
+// initializing. On the first compile of the lazy chunk (the on-demand
+// `@vite/lazy` response) the real module is inlined into the proxy's
+// eagerly-created `lazyExports` async IIFE, so its init runs synchronously:
+//
+//   var init_lazy_init_error_1 = createEsmInitializer(
+//     "...lazy-init-error.js?rolldown-lazy=1",
+//     (id) => { ...
+//       const lazyExports = (async () => {
+//         await (init_lazy_init_error_0(), Promise.resolve().then(() => loadExports("...lazy-init-error.js")));
+//         return __rolldown_runtime__.loadExports("...lazy-init-error.js");
+//       })();
+//     }, 1);
+//
+// `init_lazy_init_error_0()` throws synchronously, so this `lazyExports` rejects
+// immediately with no handler attached: the error escapes as an unhandled
+// promise rejection instead of surfacing at the consumer's `await import(...)`
+// try/catch (see setup.js).
+throw new Error('boom during lazy init');

--- a/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/setup.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/setup.js
@@ -1,0 +1,24 @@
+// lazy-init-error: the lazily imported module throws during init. The error must
+// surface at the consumer's `await import(...)` — not as an unhandled promise
+// rejection from the proxy's eagerly-created `lazyExports` promise.
+const log = (msg) => {
+  document.getElementById('lazy-init-error-log').textContent += msg + '\n';
+};
+
+// Record any unhandled rejection so the spec can assert there were none.
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason;
+  const message = reason && reason.message ? reason.message : String(reason);
+  document.getElementById('lazy-init-error-unhandled').textContent += message + '\n';
+});
+
+document.getElementById('lazy-init-error-btn').addEventListener('click', async () => {
+  log('--- loading lazy-init-error (throws during init) ---');
+  try {
+    await import('./lazy-init-error.js');
+    log('loaded');
+  } catch (e) {
+    log(`caught: ${e.message}`);
+  }
+  document.getElementById('lazy-init-error-status').textContent = 'done';
+});

--- a/packages/test-dev-server/tests/playground/lazy-compilation/main.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/main.js
@@ -7,3 +7,4 @@ import './aliased-import/setup.js';
 import './shared-module/setup.js';
 import './nested-dynamic-import/setup.js';
 import './emitted-asset/setup.js';
+import './lazy-init-error/setup.js';


### PR DESCRIPTION
This PR adds a failing test that covers a bug found in https://github.com/vitejs/vite/pull/21626.

When lazy bundling is enabled, the following bug exists:

```javascript
try {
  await import('./foo.js'); // throws an error inside
} catch (e) {
  // the error is not caught here and a unhandled error happens
}
```

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
--> 