### PR TITLE
fix: reconstruct rest patterns as spread in into_expression

### DIFF
--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -99,15 +99,10 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
           let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
             unreachable!("The rest element should be `BindingIdentifier`")
           };
-          properties.push(ObjectPropertyKind::ObjectProperty(ast_factory.alloc_object_property(
-            SPAN,
-            PropertyKind::Init,
-            ast_factory.property_key_static_identifier(SPAN, id.name),
-            ast_factory.expression_identifier(SPAN, id.name),
-            false,
-            true,
-            false,
-          )));
+          properties.push(ObjectPropertyKind::SpreadProperty(
+            ast_factory
+              .alloc_spread_element(SPAN, ast_factory.expression_identifier(SPAN, id.name)),
+          ));
         }
         Expression::ObjectExpression(ast_factory.alloc_object_expression(SPAN, properties))
       }
@@ -124,8 +119,9 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
           let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
             unreachable!("The rest element should be `BindingIdentifier`")
           };
-          elements.push(ArrayExpressionElement::Identifier(
-            ast_factory.alloc_identifier_reference(SPAN, id.name),
+          elements.push(ArrayExpressionElement::SpreadElement(
+            ast_factory
+              .alloc_spread_element(SPAN, ast_factory.expression_identifier(SPAN, id.name)),
           ));
         }
         Expression::ArrayExpression(ast_factory.alloc_array_expression(SPAN, elements))
@@ -134,5 +130,52 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
         assign_pat.left.take_in(ast_factory.allocator).into_expression(ast_factory)
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use oxc::{
+    allocator::{Allocator, CloneIn},
+    ast::ast::{ArrayExpressionElement, Expression, ObjectPropertyKind, Statement},
+    parser::Parser,
+    span::SourceType,
+  };
+
+  use crate::{AstFactory, BindingPatternExt as _};
+
+  /// Round-trips the first declarator's binding pattern back to an expression via
+  /// `into_expression`. `source` must be a single `const <pattern> = x;` statement.
+  fn pattern_into_expression<'a>(allocator: &'a Allocator, source: &'a str) -> Expression<'a> {
+    let program = Parser::new(allocator, source, SourceType::default()).parse().program;
+    let Some(Statement::VariableDeclaration(decl)) = program.body.first() else {
+      unreachable!("expected a variable declaration")
+    };
+    let pattern = decl.declarations[0].id.clone_in(allocator);
+    pattern.into_expression(&AstFactory::new(allocator))
+  }
+
+  #[test]
+  fn object_rest_round_trips_to_spread_property() {
+    let allocator = Allocator::default();
+    let Expression::ObjectExpression(obj) =
+      pattern_into_expression(&allocator, "const { a, ...rest } = x;")
+    else {
+      unreachable!("expected an object expression")
+    };
+    // `{ a, ...rest }` must round-trip with a spread, not a `rest` shorthand property.
+    assert!(matches!(obj.properties.last(), Some(ObjectPropertyKind::SpreadProperty(_))));
+  }
+
+  #[test]
+  fn array_rest_round_trips_to_spread_element() {
+    let allocator = Allocator::default();
+    let Expression::ArrayExpression(arr) =
+      pattern_into_expression(&allocator, "const [a, ...rest] = x;")
+    else {
+      unreachable!("expected an array expression")
+    };
+    // `[a, ...rest]` must round-trip with a spread, not a plain element.
+    assert!(matches!(arr.elements.last(), Some(ArrayExpressionElement::SpreadElement(_))));
   }
 }


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite/pull/22780

### What this solves

`BindingPattern::into_expression` is meant to be the inverse of a destructuring pattern, but it rebuilt rest elements without the spread:

- `{ a, ...rest }` became `{ a, rest }` (a property named `rest`, not a spread)
- `[a, ...rest]` became `[a, rest]` (a plain element, not a spread)

The only caller, the Vite build-import-analysis plugin's `__vitePreload` rewrite, relies on this being a true inverse. So object-rest destructuring of a dynamic import was silently miscompiled: `import('./m').then(({ a, ...rest }) => ...)` ended up with `rest` nested one level deeper (`{ rest: {...} }`), dropping the sibling exports, with no error.

### The fix

Emit `ObjectPropertyKind::SpreadProperty` / `ArrayExpressionElement::SpreadElement` for the rest element so the rebuilt expression round-trips correctly. (The array-rest path is latently unreachable today since a namespace object isn't iterable, but it had the same defect.)