### PR TITLE
fix(error): preserve id, plugin, and frame on plugin-wrapped errors

### DIFF
--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -105,13 +105,12 @@ pub fn to_binding_error(diagnostic: &BuildDiagnostic, cwd: std::path::PathBuf) -
         clippy::cast_possible_truncation,
         reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
       )]
-      let (loc, pos) = if let Some((_file, line, column, position)) = diag.get_primary_location() {
+      let (loc, pos) = if let Some((file, line, column, position)) = diag.get_primary_location() {
         (
           Some(super::binding_log::BindingLogLocation {
             line: line as u32,
             column: column as u32,
-            // Use error.id() for the file path since the diagnostic may only store the filename.
-            file: error.id(),
+            file: error.id().or(Some(file)),
           }),
           Some(position as u32),
         )
@@ -123,6 +122,8 @@ pub fn to_binding_error(diagnostic: &BuildDiagnostic, cwd: std::path::PathBuf) -
         kind: error.kind().to_string(),
         message: diag.to_color_string(),
         id: error.id(),
+        plugin: error.plugin(),
+        frame: diag.frame(),
         exporter: error.exporter(),
         loc,
         pos,

--- a/crates/rolldown_binding/src/types/error/native_error.rs
+++ b/crates/rolldown_binding/src/types/error/native_error.rs
@@ -8,6 +8,10 @@ pub struct NativeError {
   pub message: String,
   /// The id of the file associated with the error
   pub id: Option<String>,
+  /// The name of the plugin that threw the error
+  pub plugin: Option<String>,
+  /// Code frame around the error location
+  pub frame: Option<String>,
   /// The exporter associated with the error (for import/export errors)
   pub exporter: Option<String>,
   /// Location information (line, column, file)

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -227,6 +227,14 @@ impl Diagnostic {
     self.kind.clone()
   }
 
+  /// Code frame around the error's first label.
+  pub fn frame(&self) -> Option<String> {
+    let span = self.labels.first()?.span();
+    let source = self.files.get(span.source())?;
+    let frame = render_code_frame(source, span.start());
+    (!frame.is_empty()).then_some(frame)
+  }
+
   /// Render many diagnostics at once, sharing per-source work across all of them.
   ///
   /// Rendering diagnostics one by one rebuilds the ariadne `Source` (its rope and
@@ -282,6 +290,67 @@ impl Diagnostic {
   }
 }
 
+const LINE_TRUNCATE_LENGTH: usize = 120;
+const MIN_CHARACTERS_SHOWN_AFTER_LOCATION: usize = 10;
+const ELLIPSIS: &str = "...";
+
+// Only leading tabs are expanded, each to two spaces.
+fn tabs_to_spaces(value: &str) -> String {
+  let leading_tabs = value.bytes().take_while(|&byte| byte == b'\t').count();
+  if leading_tabs == 0 {
+    return value.to_string();
+  }
+  let mut expanded = "  ".repeat(leading_tabs);
+  expanded.push_str(&value[leading_tabs..]);
+  expanded
+}
+
+fn render_code_frame(source: &str, byte_offset: usize) -> String {
+  let offset = byte_offset.min(source.len());
+  let before = source.get(..offset).unwrap_or(source);
+  let line = before.bytes().filter(|&byte| byte == b'\n').count() + 1;
+  let byte_column = offset - before.rfind('\n').map_or(0, |index| index + 1);
+
+  let all: Vec<&str> = source.split('\n').collect();
+  if line > all.len() {
+    return String::new();
+  }
+  let error_line = all[line - 1];
+  let location_width =
+    tabs_to_spaces(error_line.get(..byte_column).unwrap_or(error_line)).chars().count();
+  let max_line_length = (location_width + MIN_CHARACTERS_SHOWN_AFTER_LOCATION + ELLIPSIS.len())
+    .max(LINE_TRUNCATE_LENGTH);
+
+  let frame_start = line.saturating_sub(3);
+  let mut frame_end = (line + 2).min(all.len());
+  let mut lines: Vec<&str> = all[frame_start..frame_end].to_vec();
+  while lines.last().is_some_and(|last| last.trim().is_empty()) {
+    lines.pop();
+    frame_end -= 1;
+  }
+
+  let digits = frame_end.to_string().len();
+  lines
+    .iter()
+    .enumerate()
+    .map(|(index, source_line)| {
+      let line_no = frame_start + index + 1;
+      let mut displayed = tabs_to_spaces(source_line);
+      if displayed.chars().count() > max_line_length {
+        displayed = displayed.chars().take(max_line_length - ELLIPSIS.len()).collect();
+        displayed.push_str(ELLIPSIS);
+      }
+      if line_no == line {
+        let indent = digits + 2 + location_width;
+        format!("{line_no:>digits$}: {displayed}\n{:indent$}^", "")
+      } else {
+        format!("{line_no:>digits$}: {displayed}")
+      }
+    })
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
 /// Primary source location of a diagnostic's first label.
 #[derive(Debug, Clone)]
 pub struct DiagnosticPrimaryLocation {
@@ -303,5 +372,38 @@ pub struct RenderedDiagnostic {
 impl Display for Diagnostic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.convert_to_string(false).fmt(f)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Severity, render_code_frame};
+
+  #[test]
+  fn code_frame_points_at_offset() {
+    assert_eq!(render_code_frame("a\nbcd\nef", 3), "1: a\n2: bcd\n    ^\n3: ef");
+  }
+
+  #[test]
+  fn code_frame_expands_tabs_and_aligns_caret() {
+    assert_eq!(render_code_frame("\tfoo", 1), "1:   foo\n     ^");
+  }
+
+  #[test]
+  fn code_frame_preserves_non_leading_tabs() {
+    assert_eq!(render_code_frame("ab\tcd", 3), "1: ab\tcd\n      ^");
+  }
+
+  #[test]
+  fn code_frame_truncates_long_lines() {
+    let frame = render_code_frame(&"x".repeat(200), 0);
+    let first_line = frame.lines().next().unwrap();
+    assert_eq!(first_line, format!("1: {}...", "x".repeat(117)));
+  }
+
+  #[test]
+  fn frame_returns_none_without_labels() {
+    let diagnostic = super::Diagnostic::new("X".to_string(), "title".to_string(), Severity::Error);
+    assert_eq!(diagnostic.frame(), None);
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
@@ -36,6 +36,14 @@ impl BuildEvent for PluginError {
     EventKind::PluginError
   }
 
+  fn id(&self) -> Option<String> {
+    self.error.downcast_ref::<BuildDiagnostic>().and_then(BuildDiagnostic::id)
+  }
+
+  fn plugin(&self) -> Option<String> {
+    Some(self.plugin.name.to_string())
+  }
+
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     if self.error.downcast_ref::<BuildDiagnostic>().is_some() {
       String::default()

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -267,4 +267,21 @@ mod tests {
       "expected non-empty underlying message in Debug output, got: {debug_output}"
     );
   }
+
+  #[test]
+  fn plugin_error_preserves_id_and_plugin() {
+    let inner = BuildDiagnostic::missing_global_name(
+      "/project/src/main.tsx".to_string(),
+      "main".into(),
+      "Main".into(),
+    );
+    assert_eq!(inner.id().as_deref(), Some("/project/src/main.tsx"));
+
+    let plugin_diag = BuildDiagnostic::plugin_error(
+      CausedPlugin::new("builtin:vite-transform".into()),
+      inner.into(),
+    );
+    assert_eq!(plugin_diag.id().as_deref(), Some("/project/src/main.tsx"));
+    assert_eq!(plugin_diag.plugin().as_deref(), Some("builtin:vite-transform"));
+  }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3017,6 +3017,10 @@ export interface NativeError {
   message: string
   /** The id of the file associated with the error */
   id?: string
+  /** The name of the plugin that threw the error */
+  plugin?: string
+  /** Code frame around the error location */
+  frame?: string
   /** The exporter associated with the error (for import/export errors) */
   exporter?: string
   /** Location information (line, column, file) */

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -34,6 +34,8 @@ export function normalizeBindingError(e: BindingError): Error {
         kind: e.field0.kind,
         message: e.field0.message,
         id: e.field0.id,
+        plugin: e.field0.plugin,
+        frame: e.field0.frame,
         exporter: e.field0.exporter,
         loc: e.field0.loc,
         pos: e.field0.pos,

--- a/packages/rolldown/tests/fixtures/misc/error/plugin-transform-parse-frame/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/plugin-transform-parse-frame/_config.ts
@@ -1,0 +1,25 @@
+import { join } from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'my-plugin',
+        transform(_code, id) {
+          if (id.startsWith('\0')) return;
+          return 'export const x = ;\n';
+        },
+      },
+    ],
+  },
+  catchError(e: any) {
+    const id = join(import.meta.dirname, 'main.js');
+    const error = e.errors[0];
+    expect(error.code).toBe('PARSE_ERROR');
+    expect(error.id).toBe(id);
+    expect(error.loc).toMatchObject({ line: 1, column: 17, file: id });
+    expect(error.frame).toBe(`1: export const x = ;\n${' '.repeat(20)}^`);
+  },
+});

--- a/packages/rolldown/tests/fixtures/misc/error/plugin-transform-parse-frame/main.js
+++ b/packages/rolldown/tests/fixtures/misc/error/plugin-transform-parse-frame/main.js
@@ -1,0 +1,1 @@
+export const y = 1;


### PR DESCRIPTION
When a build diagnostic is re-wrapped in a PluginError, `id`, `plugin`, and `frame` were dropped from the error objects exposed to JS, so `err.errors[0]` lost fields that rollup@4 provided. PluginError now delegates `id()` to its inner diagnostic and reports `plugin()`, and the napi binding surfaces `plugin` plus a `frame` rendered to match rollup's getCodeFrame (mirrors the existing packages/rolldown/src/utils/code-frame.ts), with `loc.file` falling back to the diagnostic path.

Closes #9843

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
