### PR TITLE
fix: reconstruct nested rest patterns in into_expression

### DIFF
--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -96,12 +96,9 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
           )));
         });
         if let Some(rest) = obj_pat.rest.take() {
-          let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
-            unreachable!("The rest element should be `BindingIdentifier`")
-          };
           properties.push(ObjectPropertyKind::SpreadProperty(
             ast_factory
-              .alloc_spread_element(SPAN, ast_factory.expression_identifier(SPAN, id.name)),
+              .alloc_spread_element(SPAN, rest.unbox().argument.into_expression(ast_factory)),
           ));
         }
         Expression::ObjectExpression(ast_factory.alloc_object_expression(SPAN, properties))
@@ -116,12 +113,9 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
           ));
         });
         if let Some(rest) = arg_pat.rest.take() {
-          let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
-            unreachable!("The rest element should be `BindingIdentifier`")
-          };
           elements.push(ArrayExpressionElement::SpreadElement(
             ast_factory
-              .alloc_spread_element(SPAN, ast_factory.expression_identifier(SPAN, id.name)),
+              .alloc_spread_element(SPAN, rest.unbox().argument.into_expression(ast_factory)),
           ));
         }
         Expression::ArrayExpression(ast_factory.alloc_array_expression(SPAN, elements))
@@ -177,5 +171,21 @@ mod tests {
     };
     // `[a, ...rest]` must round-trip with a spread, not a plain element.
     assert!(matches!(arr.elements.last(), Some(ArrayExpressionElement::SpreadElement(_))));
+  }
+
+  #[test]
+  fn array_nested_rest_round_trips_to_spread() {
+    let allocator = Allocator::default();
+    let Expression::ArrayExpression(arr) =
+      pattern_into_expression(&allocator, "const [a, ...[b, c]] = x;")
+    else {
+      unreachable!("expected an array expression")
+    };
+    // A nested rest pattern (`...[b, c]`) is legal JS; it must round-trip as a spread of
+    // the rebuilt inner pattern rather than panicking on the non-identifier argument.
+    let Some(ArrayExpressionElement::SpreadElement(spread)) = arr.elements.last() else {
+      unreachable!("expected a spread element")
+    };
+    assert!(matches!(spread.argument, Expression::ArrayExpression(_)));
   }
 }


### PR DESCRIPTION
Stacked on #9976.

### What this solves

After #9976, `BindingPattern::into_expression` rebuilds rest elements as spreads, but it still assumes the rest *argument* is a `BindingIdentifier` and panics via `unreachable!` otherwise:

```rust
let BindingPattern::BindingIdentifier(ref id) = rest.argument else {
  unreachable!("The rest element should be `BindingIdentifier`")
};
```

That assumption holds for **object** rest — the grammar forces `{ a, ...rest }` to bind an identifier — but not for **array** rest. Both of these are legal JS where the rest argument is a nested pattern:

```js
const [a, ...[b, c]] = x;   // rest argument is an ArrayPattern
const [a, ...{ length }] = x; // rest argument is an ObjectPattern
```

So `into_expression` could panic on a perfectly valid pattern. (As noted in #9976, the array path isn't reached today by the only caller — the Vite `__vitePreload` rewrite — because a namespace object isn't iterable, so this is a latent panic rather than an active miscompile.)

### The fix

Recurse through `into_expression` on the rest argument instead of asserting it is an identifier, mirroring the sibling `into_assignment_target`, which already does exactly this for both object and array rest with no guard. The rebuilt spread now round-trips any nested rest pattern. The object path is unchanged behaviorally (its argument is always an identifier) but now shares the same uniform code path.

Adds a regression test (`const [a, ...[b, c]] = x;`) that would hit the old `unreachable!`.