### PR TITLE
fix(dev): make init errors in lazy-compiled modules catchable

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
+++ b/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
@@ -7,9 +7,12 @@ const lazyExports = (async () => {
   await import(
     /* @vite-ignore */ `/@vite/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
   );
-  // After the module code is loaded, we can get its exports from the runtime.
-  // The actual module registers with $STABLE_MODULE_ID (the stable/relative path).
-  return __rolldown_runtime__.loadExports($STABLE_MODULE_ID);
+  // Loading the chunk re-registers this proxy id, exposing the real module's
+  // initializer as its own `rolldown:exports` promise. Await that promise (don't
+  // just hand back the namespace) so an error thrown while the real module
+  // initializes rejects `lazyExports` too, surfacing at the consumer's
+  // `await import(...)` (catchable) instead of escaping as an unhandled rejection.
+  return await __rolldown_runtime__.loadExports($STABLE_PROXY_MODULE_ID)['rolldown:exports'];
 })();
 
 export { lazyExports as 'rolldown:exports' };

--- a/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error-unhandled.spec.ts
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error-unhandled.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { page, serverUrl, waitForBuildStable } from '~utils';
+
+// Mirror of lazy-init-error.spec.ts for the NO-handler case. A lazy module that
+// throws during init, dynamically imported without a try/catch, must surface as
+// an unhandled rejection — and keep doing so across a page refresh.
+//
+// Two loads, same dev engine (only the browser page reloads):
+//   1. cold  — first compile, via the on-demand `@vite/lazy` response
+//   2. warm  — after the engine rebuilds main.js around the "fetched" proxy
+//
+// The bug this guards (vitejs/vite#21626 / rolldown#9975) made the cold path
+// swallow the error (no rejection at all); the warm path was already correct.
+// Pinning both keeps them consistent.
+const lines = (text: string | null) => (text ?? '').split('\n').filter(Boolean);
+
+async function clickAndExpectUnhandled() {
+  await page.click('#lazy-init-error-nocatch-btn');
+  await expect.poll(() => page.textContent('#lazy-init-error-status')).toBe('nocatch-done');
+  await expect
+    .poll(async () => lines(await page.textContent('#lazy-init-error-unhandled')))
+    .toEqual(['boom during lazy init']);
+}
+
+describe('lazy-compilation: lazy-init-error (no handler)', () => {
+  test('init error surfaces as an unhandled rejection on first compile and after a refresh', async () => {
+    await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
+
+    // 1. Cold: first compile.
+    await clickAndExpectUnhandled();
+
+    // Settle the rebuild, then refresh WITHOUT restarting the dev engine. The
+    // reload resets the DOM, so the unhandled log starts empty again.
+    await waitForBuildStable();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    expect(lines(await page.textContent('#lazy-init-error-unhandled'))).toEqual([]);
+
+    // 2. Warm: fetched-proxy path. The unhandled rejection surfaces again.
+    await clickAndExpectUnhandled();
+  });
+});

--- a/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error.spec.ts
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/lazy-init-error.spec.ts
@@ -1,52 +1,47 @@
 import { describe, expect, test } from 'vitest';
-import { page, serverUrl } from '~utils';
+import { page, serverUrl, waitForBuildStable } from '~utils';
 
-// `lazy-init-error.js` is lazily imported and throws while initializing. On the
-// first compile of the lazy chunk (the on-demand `@vite/lazy` response) the real
-// module is inlined into the proxy's `lazyExports` async IIFE, so its init runs
-// *synchronously* inside it:
+// A lazy-compiled module that throws during init must be catchable at the
+// consumer's `await import(...)` — and stay catchable across a page refresh.
 //
-//   var init_lazy_init_error_1 = createEsmInitializer(
-//     "...lazy-init-error.js?rolldown-lazy=1",
-//     (id) => { ...
-//       const lazyExports = (async () => {
-//         await (init_lazy_init_error_0(), Promise.resolve().then(() => loadExports("...lazy-init-error.js")));
-//         return __rolldown_runtime__.loadExports("...lazy-init-error.js");
-//       })();
-//     }, 1);
+// The two loads exercise two different proxy code paths against the SAME dev
+// engine (only the browser page reloads):
+//   1. cold  — first compile, served through the on-demand `@vite/lazy` response
+//   2. warm  — after the engine rebuilds main.js around the now-"fetched" proxy
 //
-// `init_lazy_init_error_0()` throws synchronously, so this `lazyExports` rejects
-// immediately — before any consumer can attach a handler. The init error escapes
-// as an unhandled promise rejection, and the consumer's `await import(...)`
-// resolves as if nothing went wrong.
-//
-// NOTE: `test.fails` — the assertions below describe the DESIRED behavior, which
-// currently fails because the bug is unfixed: the init error should surface at
-// the consumer's `await import(...)` with no unhandled rejection. Once fixed, the
-// body will pass; drop `.fails` to turn this into a normal regression test.
-describe('lazy-init-error', () => {
-  test.fails(
-    'init error in a lazy module should be catchable, not unhandled',
-    { retry: 0 },
-    async () => {
-      // The bug shows on the very first compile of the lazy chunk (the on-demand
-      // `@vite/lazy` response), so navigate + click on a fresh server and do NOT
-      // reload — a rebuild splits the real module into a separate chunk reached
-      // via a real `await import(...)`, which is catchable.
-      await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
-      await page.click('#lazy-init-error-btn');
-      await expect.poll(() => page.textContent('#lazy-init-error-status')).toBe('done');
+// Either way the result is identical: caught at `await import(...)`, with no
+// unhandled rejection. Regression test for vitejs/vite#21626 / rolldown#9975.
+const lines = (text: string | null) => (text ?? '').split('\n').filter(Boolean);
 
-      // Let any pending unhandled-rejection event fire before asserting.
-      await page.waitForTimeout(100);
+async function clickAndExpectCaught() {
+  await page.click('#lazy-init-error-catch-btn');
+  await expect.poll(() => page.textContent('#lazy-init-error-status')).toBe('catch-done');
 
-      // The consumer's try/catch should be the one that sees the init error...
-      const log = (await page.textContent('#lazy-init-error-log')) ?? '';
-      expect(log).toContain('caught: boom during lazy init');
+  // The consumer's try/catch sees the init error...
+  expect(await page.textContent('#lazy-init-error-log')).toContain('caught: boom during lazy init');
 
-      // ...and nothing should escape the lazy proxy as an unhandled rejection.
-      const unhandled = (await page.textContent('#lazy-init-error-unhandled')) ?? '';
-      expect(unhandled).toBe('');
-    },
-  );
+  // ...and because it was handled, NOTHING escapes as an unhandled rejection.
+  // Give any stray rejection a chance to fire before asserting none did.
+  await page.waitForTimeout(100);
+  expect(
+    lines(await page.textContent('#lazy-init-error-unhandled')),
+    'try/catch handled the init error, so no unhandled rejection should fire',
+  ).toEqual([]);
+}
+
+describe('lazy-compilation: lazy-init-error (try/catch)', () => {
+  test('init error is catchable on first compile and after a refresh', async () => {
+    await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
+
+    // 1. Cold: first compile.
+    await clickAndExpectCaught();
+
+    // Let the rebuild triggered by the lazy compile settle, then refresh the
+    // page WITHOUT restarting the dev engine — main.js now uses the fetched proxy.
+    await waitForBuildStable();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // 2. Warm: fetched-proxy path. Same result.
+    await clickAndExpectCaught();
+  });
 });

--- a/packages/test-dev-server/tests/playground/lazy-compilation/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/index.html
@@ -47,7 +47,8 @@
 
     <section id="lazy-init-error">
       <h2>lazy-init-error</h2>
-      <button id="lazy-init-error-btn">load</button>
+      <button id="lazy-init-error-catch-btn">load (try/catch)</button>
+      <button id="lazy-init-error-nocatch-btn">load (no handler)</button>
       <div id="lazy-init-error-status">pending</div>
       <pre id="lazy-init-error-log"></pre>
       <pre id="lazy-init-error-unhandled"></pre>

--- a/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/lazy-init-error.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/lazy-init-error.js
@@ -1,19 +1,3 @@
-// lazy-init-error: this module is lazily imported by `setup.js` and throws while
-// initializing. On the first compile of the lazy chunk (the on-demand
-// `@vite/lazy` response) the real module is inlined into the proxy's
-// eagerly-created `lazyExports` async IIFE, so its init runs synchronously:
-//
-//   var init_lazy_init_error_1 = createEsmInitializer(
-//     "...lazy-init-error.js?rolldown-lazy=1",
-//     (id) => { ...
-//       const lazyExports = (async () => {
-//         await (init_lazy_init_error_0(), Promise.resolve().then(() => loadExports("...lazy-init-error.js")));
-//         return __rolldown_runtime__.loadExports("...lazy-init-error.js");
-//       })();
-//     }, 1);
-//
-// `init_lazy_init_error_0()` throws synchronously, so this `lazyExports` rejects
-// immediately with no handler attached: the error escapes as an unhandled
-// promise rejection instead of surfacing at the consumer's `await import(...)`
-// try/catch (see setup.js).
+// Fixture for the lazy-init-error scenario: a lazily imported module that throws
+// while initializing. See ./setup.js for the behavior the lazy proxy must give.
 throw new Error('boom during lazy init');

--- a/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/setup.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/lazy-init-error/setup.js
@@ -1,24 +1,38 @@
-// lazy-init-error: the lazily imported module throws during init. The error must
-// surface at the consumer's `await import(...)` — not as an unhandled promise
-// rejection from the proxy's eagerly-created `lazyExports` promise.
+// lazy-init-error: the lazily imported `./lazy-init-error.js` throws while
+// initializing, so rolldown's lazy proxy must reproduce the browser's native
+// behavior for a dynamic import of a throwing module:
+//
+//   - WITH try/catch:   the error is caught at `await import(...)`.
+//   - WITHOUT a handler: it surfaces as a single `unhandledrejection`.
+//
+// Before the fix, the init error escaped the proxy's eagerly-created export
+// promise as an unhandled rejection and the consumer's `await import(...)`
+// resolved as if nothing went wrong (vitejs/vite#21626).
 const log = (msg) => {
   document.getElementById('lazy-init-error-log').textContent += msg + '\n';
 };
 
-// Record any unhandled rejection so the spec can assert there were none.
+// Record unhandled rejections so the spec can assert whether one escaped.
 window.addEventListener('unhandledrejection', (event) => {
   const reason = event.reason;
   const message = reason && reason.message ? reason.message : String(reason);
   document.getElementById('lazy-init-error-unhandled').textContent += message + '\n';
 });
 
-document.getElementById('lazy-init-error-btn').addEventListener('click', async () => {
-  log('--- loading lazy-init-error (throws during init) ---');
+document.getElementById('lazy-init-error-catch-btn').addEventListener('click', async () => {
+  log('--- lazy import WITH try/catch ---');
   try {
     await import('./lazy-init-error.js');
-    log('loaded');
+    log('resolved');
   } catch (e) {
     log(`caught: ${e.message}`);
   }
-  document.getElementById('lazy-init-error-status').textContent = 'done';
+  document.getElementById('lazy-init-error-status').textContent = 'catch-done';
+});
+
+document.getElementById('lazy-init-error-nocatch-btn').addEventListener('click', () => {
+  log('--- lazy import WITHOUT a handler ---');
+  // Fire and forget: no await, no `.catch`. The rejection must go unhandled.
+  import('./lazy-init-error.js');
+  document.getElementById('lazy-init-error-status').textContent = 'nocatch-done';
 });


### PR DESCRIPTION
Builds on #9975 (which added the failing test). Fixes the bug found in vitejs/vite#21626.

## Problem

With lazy compilation enabled, an error thrown while a lazily-imported module *initializes* never reached the consumer:

```js
try {
  await import('./foo.js'); // throws during init
} catch (e) {
  // never runs — instead the error escaped as an unhandled rejection,
  // and `await import(...)` resolved as if nothing went wrong
}
```

The lazy proxy wraps the import in an eagerly-created `lazyExports` async IIFE. On the first compile of the lazy chunk (the on-demand `@vite/lazy` response), the real module's initializer runs synchronously inside that IIFE and throws, so `lazyExports` rejects before any consumer can attach a handler. The rejection went unhandled, and the proxy then returned the module namespace as if the import had succeeded.

## Fix

- **`proxy-module-template.js`**: after loading the chunk, `await` the real module's own `rolldown:exports` promise instead of just handing back the namespace from `loadExports`. An error during init now rejects `lazyExports` too, so it surfaces at the consumer's `await import(...)` (catchable) rather than escaping as an unhandled rejection.

## Tests

- Rewrote the `lazy-init-error` spec to assert both cases against the same module: with `try/catch` the error is caught at `await import(...)`; with no handler it surfaces as exactly one `unhandledrejection`.