### PR TITLE
fix(binding): validate replace plugin delimiters length instead of panicking

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -89,7 +89,7 @@ impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
         } else {
           BindingReplacePluginConfig::default()
         };
-        Arc::new(ReplacePlugin::with_options(config.into())?)
+        Arc::new(ReplacePlugin::with_options(config.try_into()?)?)
       }
       BindingBuiltinPluginName::ViteAlias => {
         let plugin = if let Some(options) = plugin.options {

--- a/crates/rolldown_binding/src/options/plugin/config/binding_replace_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_replace_plugin_config.rs
@@ -15,14 +15,26 @@ pub struct BindingReplacePluginConfig {
   pub sourcemap: Option<bool>,
 }
 
-impl From<BindingReplacePluginConfig> for ReplaceOptions {
-  fn from(config: BindingReplacePluginConfig) -> Self {
-    Self {
+impl TryFrom<BindingReplacePluginConfig> for ReplaceOptions {
+  type Error = napi::Error;
+
+  fn try_from(config: BindingReplacePluginConfig) -> Result<Self, Self::Error> {
+    let delimiters = match config.delimiters {
+      None => None,
+      Some(raw) if raw.len() == 2 => Some((raw[0].clone(), raw[1].clone())),
+      Some(raw) => {
+        return Err(napi::Error::new(
+          napi::Status::InvalidArg,
+          format!("`delimiters` expects a tuple of two strings, but got {} element(s)", raw.len()),
+        ));
+      }
+    };
+    Ok(Self {
       values: config.values,
-      delimiters: config.delimiters.map(|raw| (raw[0].clone(), raw[1].clone())),
+      delimiters,
       prevent_assignment: config.prevent_assignment.unwrap_or(false),
       object_guards: config.object_guards.unwrap_or(false),
       sourcemap: config.sourcemap.unwrap_or(false),
-    }
+    })
   }
 }


### PR DESCRIPTION
### What this solves

The builtin replace plugin's `delimiters` option is typed as `[string, string]` in TypeScript, but on the binding side it is an `Option<Vec<String>>` read with `delimiters[0]` / `delimiters[1]`. The `ts_type` annotation is a compile-time hint only; napi accepts an array of any length at runtime and there is no runtime validation, so a malformed value from JS panics the whole build:

- `replacePlugin({ delimiters: [] })` -> index out of bounds on `[0]`
- `replacePlugin({ delimiters: ['x'] })` -> index out of bounds on `[1]`

### The fix

Convert `BindingReplacePluginConfig` into `ReplaceOptions` via `TryFrom` instead of `From`: when `delimiters` is present but not exactly two elements, return a `napi::Error` (`InvalidArg`) with a clear message instead of indexing and panicking. The call site now uses `config.try_into()?`.