### PR TITLE
docs(replace): explain the delimiters left and right boundaries

### DIFF
--- a/docs/builtin-plugins/replace.md
+++ b/docs/builtin-plugins/replace.md
@@ -37,7 +37,12 @@ export default defineConfig({
 - **Type:** `[string, string]`
 - **Default:** `["\\b", "\\b(?!\\.)"]`
 
-Customizes how strings are matched. The default ensures word boundaries and prevents replacing property access (e.g., won't replace `process` in `process.env`).
+Customizes how each key is matched. A key only matches when it's surrounded by these two patterns:
+
+- `delimiters[0]` (**left**): what must come right before the key.
+- `delimiters[1]` (**right**): what must come right after the key.
+
+Both are regular expressions. The default `["\\b", "\\b(?!\\.)"]` matches a key only at word boundaries and skips property accesses, so `process` in `process.env` is left untouched.
 
 ### `preventAssignment`
 


### PR DESCRIPTION
### What this solves

The replace plugin's `delimiters` option is a `[string, string]` tuple, but the docs never said what the two elements mean. This clarifies that the first value is matched immediately before a key (left) and the second immediately after it (right), and that both are regular expressions, so the default keeps replacements at word boundaries while skipping property accesses.

Docs-only change, no code affected.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

