### PR TITLE
fix: don't classify await in a strict-mode function as top-level await

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -285,11 +285,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   /// }
   /// ```
   pub fn is_valid_tla_scope(&self) -> bool {
-    self
-      .scope_stack
-      .iter()
-      .rev()
-      .all(|flag| flag.intersects(ScopeFlags::Top | ScopeFlags::StrictMode) || flag.is_block())
+    self.scope_stack.iter().rev().all(|flag| flag.is_top() || flag.is_block())
   }
 
   pub fn is_root_scope(&self) -> bool {

--- a/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/_config.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "`await` inside a function with its own `\"use strict\"` directive is not top-level await, so a non-ESM (cjs) build must not reject it as unsupported TLA.",
+  "config": {
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region main.js
+async function f() {
+	"use strict";
+	await Promise.resolve();
+}
+//#endregion
+exports.f = f;
+
+```

--- a/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/main.js
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla/main.js
@@ -1,0 +1,4 @@
+export async function f() {
+  'use strict';
+  await Promise.resolve();
+}


### PR DESCRIPTION
### What this solves

`is_valid_tla_scope` accepted any scope whose flags intersected `Top | StrictMode`. oxc marks a class scope as exactly `StrictMode` (so a class computed key like `class T { [await x]() {} }` counts as top-level), but it also adds `StrictMode` to a function or arrow that carries its own `"use strict"` directive (`Function | StrictMode`). So `await` inside such a function was misclassified as top-level await.

For a non-ESM output format this produced a spurious build error:

```js
// bundled to cjs
export async function f() {
  'use strict'
  await Promise.resolve() // "Top-level await is currently not supported with the 'cjs' output format"
}
```

even though the `await` is inside an async function and is valid for any output format.

### The fix

Use `flag.is_top() || flag.is_block()`. `is_block()` is `is_empty() || self == StrictMode`, so it still covers block scopes and class scopes, while a strict function (`Function | StrictMode`) is neither top nor block and is correctly rejected.

### Tests

Added `tests/rolldown/misc/use_strict/await_in_strict_function_is_not_tla`: a cjs build of an async function with a `"use strict"` directive and an inner `await`. It fails with the spurious TLA error without the fix and passes with it, and the full integration suite passes with no other snapshot changes.