### PR TITLE
fix: deconflict chunk symbols by exec_order, not chunk render order

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -1,3 +1,6 @@
+use std::cmp::Reverse;
+
+use itertools::Itertools;
 use oxc_str::CompactStr;
 
 use crate::{
@@ -141,25 +144,15 @@ pub fn deconflict_chunk_symbols(
     }
   }
 
-  // The renamer relies on `chunk.modules` being in ascending exec_order so that
-  // `.rev()` yields entry-first / descending exec_order — the same priority as
-  // `deconflict_order_key`. Enforce that invariant in debug builds (was only a
-  // prose + pinned-SHA comment before).
-  debug_assert!(
-    chunk
-      .modules
-      .iter()
-      .filter_map(|idx| link_output.module_table[*idx].as_normal().map(|m| m.exec_order))
-      .is_sorted(),
-    "chunk.modules must be in ascending exec_order for deconfliction"
-  );
-
+  // Deconflict in descending exec_order (entry first / highest exec_order), the same
+  // priority as `deconflict_order_key` used for cross-chunk export naming. This is
+  // driven by `exec_order` explicitly rather than by `chunk.modules`'s order, which
+  // under `chunkModulesOrder: "moduleId"` is not exec-order-sorted.
   chunk
     .modules
     .iter()
     .copied()
-    // Starts with entry module
-    .rev()
+    .sorted_by_key(|idx| Reverse(link_output.module_table[*idx].exec_order()))
     .filter_map(|id| link_output.module_table[id].as_normal())
     .for_each(|module| {
       if let Some(hmr_hot_ref) = module.hmr_hot_ref {

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/_config.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Two side-effect-free leaf modules (a.js, z.js) that both declare a top-level `dup`, with id order (a, z) opposite to exec_order (z, a). `chunkModulesOrder: moduleId` renders them by id, but deconfliction must still follow exec_order: the higher-exec_order module (a) keeps `dup`, matching the default ExecOrder mode. Previously this panicked the deconfliction debug_assert; before that (release) it picked the wrong winner.",
+  "config": {
+    "experimental": {
+      "chunkModulesOrder": "moduleId"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/a.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/a.js
@@ -1,0 +1,3 @@
+export function dup() {
+  return 'from-a';
+}

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region a.js
+function dup() {
+	return "from-a";
+}
+//#endregion
+//#region z.js
+function dup$1() {
+	return "from-z";
+}
+//#endregion
+//#region main.js
+console.log(dup$1(), dup());
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/main.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/main.js
@@ -1,0 +1,4 @@
+import { dup as dz } from './z.js';
+import { dup as da } from './a.js';
+
+console.log(dz(), da());

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/z.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules/z.js
@@ -1,0 +1,3 @@
+export function dup() {
+  return 'from-z';
+}


### PR DESCRIPTION
### What this solves

With `experimental.chunkModulesOrder: "moduleId"`, chunk-symbol deconfliction used the wrong priority order. When a chunk holds two or more side-effect-free leaf modules (e.g. modules that only `export function foo() {}`, so they are not constant-folded away) whose id order differs from their exec_order, a debug build panics:

```
chunk.modules must be in ascending exec_order for deconfliction
```

In a release build (the `debug_assert` is compiled out) it does not panic but picks the wrong deconfliction winner: when two modules declare the same top-level name, the module that keeps the clean name depends on the `moduleId` render order instead of `exec_order`, so it disagrees with the `exec_order` priority used everywhere else (including cross-chunk export naming).

### Root cause

Deconfliction must process modules in descending `exec_order` (entry first) so the entry's symbols keep their clean names; this is the canonical order encoded by `deconflict_order_key` = `(Reverse(exec_order), name)`. `deconflict_chunk_symbols` achieved it with `chunk.modules.iter().rev()`, which only yields descending exec_order because the default `ExecOrder` mode happens to sort `chunk.modules` ascending by exec_order. `chunkModulesOrder: "moduleId"` intentionally orders leaf modules by id for the output, so `chunk.modules.rev()` is no longer exec_order-descending. PR #9831 added a `debug_assert` to document this invariant, but the `moduleId` branch violates it.

### The fix

Drive the deconfliction order from `exec_order` directly — `sorted_by_key(Reverse(exec_order))` — instead of relying on `chunk.modules`'s order, and drop the now-redundant `debug_assert`. This decouples the deconfliction priority (always exec_order) from the chunk's render order, so it is correct for every `chunkModulesOrder`, matching `deconflict_order_key` and the cross-chunk naming. For the default `ExecOrder` mode the order is unchanged (exec_order is a unique total order, so the explicit sort equals the previous `.rev()`), confirmed by zero snapshot drift across the suite.

### Tests

Added `tests/rolldown/topics/chunk_modules_order/side_effect_free_leaf_modules`: two side-effect-free leaf modules that both declare `dup`, with id order opposite to exec_order, under `chunkModulesOrder: "moduleId"`. It panicked without the fix; the snapshot now pins the exec_order winner (the higher-exec_order module keeps `dup`), which matches the default `ExecOrder` output. The full integration suite passes with no other snapshot changes.