### PR TITLE
fix: avoid spurious leading newline in addon hooks (banner/footer/intro/outro)

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -45,7 +45,9 @@ impl PluginDriver {
       let result = plugin.call_banner(ctx, &args).await;
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
-        banner.push('\n');
+        if !banner.is_empty() {
+          banner.push('\n');
+        }
         banner.push_str(r.as_str());
       }
     }
@@ -68,7 +70,9 @@ impl PluginDriver {
       let result = plugin.call_footer(ctx, &args).await;
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
-        footer.push('\n');
+        if !footer.is_empty() {
+          footer.push('\n');
+        }
         footer.push_str(r.as_str());
       }
     }
@@ -91,7 +95,9 @@ impl PluginDriver {
       let result = plugin.call_intro(ctx, &args).await;
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
-        intro.push('\n');
+        if !intro.is_empty() {
+          intro.push('\n');
+        }
         intro.push_str(r.as_str());
       }
     }
@@ -114,7 +120,9 @@ impl PluginDriver {
       let result = plugin.call_outro(ctx, &args).await;
       self.record_timing(plugin_idx, start);
       if let Some(r) = result.with_context(|| CausedPlugin::new(plugin.call_name()))? {
-        outro.push('\n');
+        if !outro.is_empty() {
+          outro.push('\n');
+        }
         outro.push_str(r.as_str());
       }
     }

--- a/packages/rolldown/tests/fixtures/plugin/banner-shebang/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/banner-shebang/_config.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const entry = path.join(__dirname, './main.js');
+
+// A shebang added via the `banner` hook (with no `output.banner` option) must land
+// on the first line. The addon driver used to prepend a spurious `\n`, which both
+// pushed the shebang off line 1 and broke shebang detection.
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        banner: () => '#!/usr/bin/env node',
+      },
+    ],
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code.startsWith('#!/usr/bin/env node')).toBe(true);
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/banner-shebang/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/banner-shebang/main.js
@@ -1,0 +1,1 @@
+console.log();


### PR DESCRIPTION
### What this solves

The addon driver joins each plugin's `banner` / `footer` / `intro` / `outro` result with `\n`, but it pushes the `\n` separator before every result, including the first one. When there is no corresponding output option the accumulator starts as an empty string (`injection.unwrap_or_default()` in `ecma_generator.rs`), so the first plugin result becomes `"\n" + result`.

This adds a spurious blank first line, and it breaks the common pattern of adding a shebang via the `banner` hook:

```js
// plugin
{ name: 'cli', banner: () => '#!/usr/bin/env node' }
```

```js
// before (no output.banner): shebang is no longer on line 1
\n#!/usr/bin/env node
...
```

A shebang is only valid on the first line, so it is no longer recognized; the downstream `banner.starts_with("#!")` shebang detection in `ecma_generator.rs` also evaluates to false. Rollup joins addons with `\n` and skips empty parts, so it does not emit the leading newline.

### The fix

Only push the `\n` separator when the accumulator is non-empty, so it sits between results rather than before the first one. Applied identically to `banner`, `footer`, `intro`, and `outro`.