### PR TITLE
fix(plugin): make lazy hook metadata enumerable

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -218,6 +218,7 @@ export function bindingifyTransform(
             magicStringInstance = new RolldownMagicString(code);
             return magicStringInstance;
           },
+          enumerable: true,
         },
         ast: {
           get() {
@@ -241,6 +242,7 @@ export function bindingifyTransform(
             });
             return astInstance;
           },
+          enumerable: true,
         },
       });
       const transformCtx = new TransformPluginContextImpl(

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -77,6 +77,7 @@ export function bindingifyRenderChunk(
             magicStringInstance = new RolldownMagicString(code);
             return magicStringInstance;
           },
+          enumerable: true,
           configurable: true,
         });
       }

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
@@ -22,6 +22,13 @@ export default defineTest({
             return null;
           }
 
+          expect(Object.keys(meta)).toEqual(
+            expect.arrayContaining(['moduleType', 'magicString', 'ast']),
+          );
+          const spreadMeta = { ...meta };
+          expect(spreadMeta.magicString).toBe(meta.magicString);
+          expect(spreadMeta.ast).toBe(meta.ast);
+
           // Test 1: Verify that multiple accesses return the same cached instance
           // The magicString getter caches the instance on first access
           meta.magicString.overwrite(0, code.length, 'replaced;');

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/native-magic-string/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/native-magic-string/_config.ts
@@ -18,6 +18,11 @@ export default defineTest({
             throw new Error('magicString should be available when nativeMagicString is enabled');
           }
 
+          expect(Object.keys(meta)).toEqual(expect.arrayContaining(['chunks', 'magicString']));
+          const spreadMeta = { ...meta };
+          expect(spreadMeta.chunks).toBe(meta.chunks);
+          expect(spreadMeta.magicString).toBe(meta.magicString);
+
           meta.magicString.replaceAll('name', 'userName');
           // Test 1: Verify that multiple accesses return the same cached instance
           const ref1 = meta.magicString;


### PR DESCRIPTION
This is more my alley :D 

These properties should be `enumerable` (oversight that they aren't). Otherwise they don't behave like normal JS objects and they are not listed when spreading or using `Object.keys` (and others).

Related: https://github.com/vitejs/vite/pull/22765