### PR TITLE
fix(error): enrich INVALID_OPTION filename substitution with chunk context

### DIFF
--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -124,6 +124,7 @@ pub fn to_binding_error(diagnostic: &BuildDiagnostic, cwd: std::path::PathBuf) -
         message: diag.to_color_string(),
         id: error.id(),
         exporter: error.exporter(),
+        ids: error.ids(),
         loc,
         pos,
       })

--- a/crates/rolldown_binding/src/types/error/native_error.rs
+++ b/crates/rolldown_binding/src/types/error/native_error.rs
@@ -10,6 +10,8 @@ pub struct NativeError {
   pub id: Option<String>,
   /// The exporter associated with the error (for import/export errors)
   pub exporter: Option<String>,
+  /// Related module ids (e.g. the modules of the chunk that produced an invalid filename)
+  pub ids: Option<Vec<String>>,
   /// Location information (line, column, file)
   pub loc: Option<BindingLogLocation>,
   /// Position in the source file in UTF-16 code units

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use crate::{
-  ChunkIdx, ChunkKind, FilenameTemplate, ImportRecordIdx, ModuleIdx, ModuleTable, NamedImport,
-  NormalModule, NormalizedBundlerOptions, OutputExports, PreserveEntrySignatures,
-  RenderedConcatenatedModuleParts, RollupPreRenderedChunk, RuntimeHelper, SymbolRef,
+  ChunkIdx, ChunkKind, FilenameSubstitutionContext, FilenameTemplate, ImportRecordIdx, ModuleId,
+  ModuleIdx, ModuleTable, NamedImport, NormalModule, NormalizedBundlerOptions, OutputExports,
+  PreserveEntrySignatures, RenderedConcatenatedModuleParts, RollupPreRenderedChunk, RuntimeHelper,
+  SymbolRef,
   chunk::types::{
     chunk_debug_info::ChunkDebugInfo, chunk_reason_type::ChunkReasonType, module_group::ModuleGroup,
   },
@@ -218,8 +219,22 @@ impl Chunk {
     });
     let chunk_name = self.get_preserve_modules_chunk_name(options, chunk_name.as_str());
 
+    // Pass chunk context so an invalid `[name]` substitution (e.g. a `../node_modules/...` name from
+    // an emitted/dynamic chunk that resolves outside the input base) can point users at the module
+    // that produced it instead of just reporting the offending string.
+    let substitution_context = FilenameSubstitutionContext {
+      facade_module_id: rollup_pre_rendered_chunk.facade_module_id.as_ref().map(ModuleId::as_str),
+      module_ids: &rollup_pre_rendered_chunk.module_ids,
+    };
+
     let filename = filename_template
-      .render(Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)?
+      .render(
+        Some(&chunk_name),
+        Some(options.format.as_str()),
+        None,
+        hash_replacer,
+        substitution_context,
+      )?
       .into();
 
     let name = make_unique_name(&filename, used_name_counts);

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -1,7 +1,7 @@
 use crate::{
-  AddEntryModuleMsg, FilenameTemplate, ModuleId, ModuleLoaderMsg, Modules,
-  NormalizedBundlerOptions, Output, OutputAsset, OutputChunk, PreserveEntrySignatures, StrOrBytes,
-  is_path_fragment,
+  AddEntryModuleMsg, FilenameSubstitutionContext, FilenameTemplate, ModuleId, ModuleLoaderMsg,
+  Modules, NormalizedBundlerOptions, Output, OutputAsset, OutputChunk, PreserveEntrySignatures,
+  StrOrBytes, is_path_fragment,
 };
 use anyhow::Context;
 use arcstr::ArcStr;
@@ -297,6 +297,7 @@ impl FileEmitter {
           None,
           Some(extension.unwrap_or_default()),
           Some(|len: Option<usize>| Ok(&hash[..len.map_or(8, |len| len.clamp(1, 21))])),
+          FilenameSubstitutionContext::default(),
         )?
         .into();
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
@@ -3,6 +3,19 @@ use std::path::Path;
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rolldown_utils::replace_all_placeholder::{ReplaceAllPlaceholder, Replacer};
 
+use crate::ModuleId;
+
+/// Extra context passed to [`FilenameTemplate::render`] so that an invalid `[name]` substitution
+/// can be reported together with the chunk it came from. Borrowed and only materialized into owned
+/// strings on the error path, so it stays cheap for the common (successful) case.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FilenameSubstitutionContext<'a> {
+  /// Facade (entry) module id of the chunk being rendered, if any.
+  pub facade_module_id: Option<&'a str>,
+  /// Module ids contained in the chunk being rendered.
+  pub module_ids: &'a [ModuleId],
+}
+
 /// Check if a string is a path fragment (absolute or relative path).
 /// Patterns can be neither absolute nor relative paths.
 ///
@@ -56,6 +69,7 @@ impl FilenameTemplate {
     format: Option<&str>,
     extension: Option<&str>,
     hash_replacer: Option<impl Replacer>,
+    context: FilenameSubstitutionContext<'_>,
   ) -> Result<String, BuildDiagnostic> {
     let pattern_name = self.pattern_name;
 
@@ -76,6 +90,8 @@ impl FilenameTemplate {
           InvalidOptionType::InvalidFilenameSubstitution {
             name: name.to_string(),
             pattern_name: pattern_name.to_string(),
+            facade_module_id: context.facade_module_id.map(str::to_string),
+            module_ids: context.module_ids.iter().map(ToString::to_string).collect(),
           },
         ));
       }
@@ -126,8 +142,9 @@ mod tests {
     let hash_replacer =
       filename_template.has_hash_pattern().then_some(|_| Ok(hash_iter.next().unwrap()));
 
-    let filename =
-      filename_template.render(Some("hello"), None, None, hash_replacer).expect("should render");
+    let filename = filename_template
+      .render(Some("hello"), None, None, hash_replacer, FilenameSubstitutionContext::default())
+      .expect("should render");
 
     assert_eq!(filename, "hello-abc-def.js");
   }
@@ -154,7 +171,13 @@ mod tests {
   #[test]
   fn test_invalid_pattern() {
     let template = FilenameTemplate::new("/absolute/path/[name].js".to_string(), "entryFileNames");
-    let result = template.render(Some("test"), None, None, None::<&str>);
+    let result = template.render(
+      Some("test"),
+      None,
+      None,
+      None::<&str>,
+      FilenameSubstitutionContext::default(),
+    );
     assert!(result.is_err());
     assert!(
       result.unwrap_err().to_string().contains("patterns can be neither absolute nor relative")
@@ -164,7 +187,13 @@ mod tests {
   #[test]
   fn test_invalid_name_substitution() {
     let template = FilenameTemplate::new("[name].js".to_string(), "entryFileNames");
-    let result = template.render(Some("/absolute/name"), None, None, None::<&str>);
+    let result = template.render(
+      Some("/absolute/name"),
+      None,
+      None,
+      None::<&str>,
+      FilenameSubstitutionContext::default(),
+    );
     assert!(result.is_err());
     assert!(
       result
@@ -175,9 +204,32 @@ mod tests {
   }
 
   #[test]
+  fn invalid_name_substitution_reports_chunk_context() {
+    let template = FilenameTemplate::new("[name].js".to_string(), "chunkFileNames");
+    let facade: ModuleId = "/project/node_modules/dep/index.js".into();
+    let modules: Vec<ModuleId> = vec![facade.clone(), "/project/node_modules/dep/util.js".into()];
+    let context =
+      FilenameSubstitutionContext { facade_module_id: Some(facade.as_str()), module_ids: &modules };
+    let result =
+      template.render(Some("../node_modules/dep/index"), None, None, None::<&str>, context);
+    let err = result.unwrap_err().to_string();
+    // The bare substitution error is still present...
+    assert!(err.contains("Invalid substitution \"../node_modules/dep/index\""));
+    // ...plus the chunk context that points users at the source module.
+    assert!(err.contains("derived from module: /project/node_modules/dep/index.js"));
+    assert!(err.contains("This chunk contains modules:"));
+  }
+
+  #[test]
   fn test_valid_subdirectory() {
     let template = FilenameTemplate::new("dist/[name].js".to_string(), "entryFileNames");
-    let result = template.render(Some("test"), None, None, None::<&str>);
+    let result = template.render(
+      Some("test"),
+      None,
+      None,
+      None::<&str>,
+      FilenameSubstitutionContext::default(),
+    );
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "dist/test.js");
   }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -37,7 +37,7 @@ pub mod bundler_options {
       experimental_options::{
         ChunkOptimizationOption, ChunkOptimizationOptions, ExperimentalOptions,
       },
-      filename_template::{FilenameTemplate, is_path_fragment},
+      filename_template::{FilenameSubstitutionContext, FilenameTemplate, is_path_fragment},
       generated_code_options::GeneratedCodeOptions,
       hash_characters::HashCharacters,
       inject_import::InjectImport,

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use super::BuildEvent;
 use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::EventKind};
 
@@ -13,14 +15,36 @@ pub enum InvalidOptionType {
   InvalidContext(String),
   IncludeDependenciesRecursivelyWithConflictPreserveEntrySignatures(String),
   IncludeDependenciesRecursivelyWithImplicitPreserveEntrySignatures,
-  InvalidFilenamePattern { pattern: String, pattern_name: String },
-  InvalidFilenameSubstitution { name: String, pattern_name: String },
+  InvalidFilenamePattern {
+    pattern: String,
+    pattern_name: String,
+  },
+  InvalidFilenameSubstitution {
+    name: String,
+    pattern_name: String,
+    /// Facade (entry) module of the offending chunk, if any. Used to point users at the source
+    /// of an invalid `[name]` substitution.
+    facade_module_id: Option<String>,
+    /// Module ids contained in the offending chunk, used to help locate where the name came from.
+    module_ids: Vec<String>,
+  },
   CodeSplittingDisabledWithMultipleInputs,
   CodeSplittingDisabledWithPreserveModules,
-  HashLengthTooLong { pattern_name: String, received: usize, max: usize },
-  HashLengthTooShort { pattern_name: String, received: usize, min: usize, chunk_count: u32 },
+  HashLengthTooLong {
+    pattern_name: String,
+    received: usize,
+    max: usize,
+  },
+  HashLengthTooShort {
+    pattern_name: String,
+    received: usize,
+    min: usize,
+    chunk_count: u32,
+  },
   InvalidEmittedFileName(String),
-  NulByteInFilename { pattern_name: String },
+  NulByteInFilename {
+    pattern_name: String,
+  },
 }
 
 #[derive(Debug)]
@@ -31,6 +55,26 @@ pub struct InvalidOption {
 impl BuildEvent for InvalidOption {
   fn kind(&self) -> EventKind {
     EventKind::InvalidOptionError
+  }
+
+  fn id(&self) -> Option<String> {
+    match &self.invalid_option_type {
+      InvalidOptionType::InvalidFilenameSubstitution { facade_module_id, module_ids, .. } => {
+        facade_module_id.clone().or_else(|| module_ids.first().cloned())
+      }
+      _ => None,
+    }
+  }
+
+  fn ids(&self) -> Option<Vec<String>> {
+    match &self.invalid_option_type {
+      InvalidOptionType::InvalidFilenameSubstitution { module_ids, .. }
+        if !module_ids.is_empty() =>
+      {
+        Some(module_ids.clone())
+      }
+      _ => None,
+    }
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
@@ -84,11 +128,33 @@ impl BuildEvent for InvalidOption {
              slash like this: subdirectory/pattern."
           )
         }
-        InvalidOptionType::InvalidFilenameSubstitution { name, pattern_name } => {
-          format!(
+        InvalidOptionType::InvalidFilenameSubstitution { name, pattern_name, facade_module_id, module_ids } => {
+          let mut msg = format!(
             "Invalid substitution \"{name}\" for placeholder \"[name]\" in \"{pattern_name}\" pattern, \
              can be neither absolute nor relative paths."
-          )
+          );
+          if let Some(source) =
+            facade_module_id.as_deref().or_else(|| module_ids.first().map(String::as_str))
+          {
+            let _ = write!(msg, "\nThe \"[name]\" was derived from module: {source}");
+          }
+          if module_ids.len() > 1 {
+            const MAX_PREVIEW: usize = 5;
+            let preview = module_ids.iter().take(MAX_PREVIEW).cloned().collect::<Vec<_>>().join(", ");
+            let suffix = if module_ids.len() > MAX_PREVIEW {
+              format!(", ... ({} modules total)", module_ids.len())
+            } else {
+              String::new()
+            };
+            let _ = write!(msg, "\nThis chunk contains modules: {preview}{suffix}");
+          }
+          msg.push_str(
+            "\nThis usually happens when an emitted or dynamically imported chunk maps to a module \
+             outside the input base (for example inside node_modules), producing a relative \"../\" \
+             name. Check the \"name\" passed to this.emitFile({ type: 'chunk', ... }) or your \
+             \"output.chunkFileNames\"/\"output.entryFileNames\" option.",
+          );
+          msg
         }
         InvalidOptionType::CodeSplittingDisabledWithMultipleInputs => {
           "Invalid value \"false\" for option \"output.codeSplitting\" - multiple inputs are not supported when \"output.codeSplitting\" is false.".to_string()

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3019,6 +3019,8 @@ export interface NativeError {
   id?: string
   /** The exporter associated with the error (for import/export errors) */
   exporter?: string
+  /** Related module ids (e.g. the modules of the chunk that produced an invalid filename) */
+  ids?: Array<string>
   /** Location information (line, column, file) */
   loc?: BindingLogLocation
   /** Position in the source file in UTF-16 code units */

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -35,6 +35,7 @@ export function normalizeBindingError(e: BindingError): Error {
         message: e.field0.message,
         id: e.field0.id,
         exporter: e.field0.exporter,
+        ids: e.field0.ids,
         loc: e.field0.loc,
         pos: e.field0.pos,
         stack: undefined,

--- a/packages/rolldown/tests/invalid-filename-substitution.test.ts
+++ b/packages/rolldown/tests/invalid-filename-substitution.test.ts
@@ -1,0 +1,64 @@
+import type { Plugin } from 'rolldown';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+// oxlint-disable-next-line no-control-regex
+const removeAnsiColors = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, '');
+
+const virtual = (files: Record<string, string>): Plugin => ({
+  name: 'virtual',
+  resolveId(id) {
+    const key = id.replace(/^\.\//, '');
+    if (key in files) return key;
+  },
+  load(id) {
+    return files[id];
+  },
+});
+
+// #9994: an emitted chunk whose module resolves outside the input base produces a relative `../`
+// `[name]`, which rolldown rejects with INVALID_OPTION. The error used to expose only the offending
+// string, so users could not tell which module/plugin caused it. It should now name the source
+// module both in the message and via `error.id`/`error.ids`.
+test('invalid [name] substitution reports the offending chunk module (#9994)', async () => {
+  let caught: any;
+  try {
+    const bundle = await rolldown({
+      input: 'entry.js',
+      plugins: [
+        virtual({
+          'entry.js': `export const x = 1`,
+          'extra.js': `export const y = 2`,
+        }),
+        {
+          name: 'emit-chunk',
+          buildStart() {
+            this.emitFile({
+              type: 'chunk',
+              id: 'extra.js',
+              name: '../node_modules/some-dep/index.mjs_entry_Foo',
+            });
+          },
+        },
+      ],
+    });
+    await bundle.generate({ dir: 'dist' });
+  } catch (e) {
+    caught = e;
+  }
+
+  expect(caught, 'build should fail with an INVALID_OPTION error').toBeDefined();
+  const err = caught.errors?.[0] ?? caught;
+  const message = removeAnsiColors(err.message);
+
+  // The original substitution error is preserved...
+  expect(err.code).toBe('INVALID_OPTION');
+  expect(message).toContain('Invalid substitution "../node_modules/some-dep/index.mjs_entry_Foo"');
+  // ...and is now enriched with the source module + an actionable hint.
+  expect(message).toContain('derived from module: extra.js');
+  expect(message).toContain('this.emitFile');
+
+  // Programmatic locators that were previously `undefined`.
+  expect(err.id).toBe('extra.js');
+  expect(err.ids).toContain('extra.js');
+});

--- a/packages/rollup-tests/test/utils.js
+++ b/packages/rollup-tests/test/utils.js
@@ -88,6 +88,12 @@ function normalizeError(error, locExpected) {
 		// `logSourcemapBroken` is emitted at chunk-collapse time and carries no id.
 		delete clone.id;
 	}
+	if (clone.code === 'INVALID_OPTION') {
+		// Rolldown attaches the offending chunk's module id(s) to invalid-filename
+		// diagnostics (#9994) to help locate the source; Rollup carries no such ids.
+		delete clone.id;
+		delete clone.ids;
+	}
 	for (const key in clone) {
 		if (clone[key] === undefined) {
 			delete clone[key];


### PR DESCRIPTION
## Summary

Fixes #9994.

A build (e.g. a Qwik app) can fail with:

```
[INVALID_OPTION] Invalid substitution "../node_modules/@builder.io/qwik-city/lib/index.qwik.mjs_entry_ErrorBoundary" for placeholder "[name]" in "chunkFileNames" pattern, can be neither absolute nor relative paths.
```

The error exposed only the offending string — no hint about which module/chunk/plugin produced it, which is exactly the issue's complaint (*"the error doesn't indicate where the problem originates"*).

## Root cause

An emitted or dynamically-imported chunk whose module resolves **outside the input base** (e.g. inside `node_modules`) gets a derived `[name]` like `../node_modules/...` (`generate_stage`'s `p.relative(input_base)`), which `FilenameTemplate::render` then rejects via `is_path_fragment`. The diagnostic dropped all the chunk context the call site already had.

## Changes

- Thread the chunk's facade module id + module ids (already available as `RollupPreRenderedChunk`) into `FilenameTemplate::render` via a borrowed `FilenameSubstitutionContext` — only materialized on the error path, so the common (successful) path stays allocation-free.
- The `INVALID_OPTION` message now:
  - names the source module — `The "[name]" was derived from module: …`
  - lists the chunk's modules
  - adds an actionable hint pointing at `emitFile`'s `name` / `chunkFileNames`
- Populate `error.id` / `error.ids` (RollupLog interface) so the offending module is programmatically accessible. This also fixes an inconsistency where **warnings** exposed `ids` but **errors** did not.

## Before / After

| issue question | before | after |
| --- | --- | --- |
| which file caused it? | unknown | message + `error.id` |
| which modules are in the chunk? | — | `error.ids` + message |
| config / plugin / internal? | no hint | actionable hint |

## Tests

- Rust unit test in `filename_template.rs` covering the enriched message + chunk context.
- JS integration test (`tests/invalid-filename-substitution.test.ts`) asserting `errors[0].id` / `errors[0].ids` and the message, via a virtual-module reproduction.

---

*Disclosure: this PR was prepared with the assistance of Claude Code (AI). The author reviewed, built, and verified all changes locally (clippy, rustfmt, Rust unit tests, and the JS integration test all pass).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
