### PR TITLE
fix(rolldown): keep entry facade when a shared chunk holds another entry's module

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -813,12 +813,33 @@ impl GenerateStage<'_> {
 
       if meta.intersects(ChunkMeta::UserDefinedEntry) {
         if matches!(target_chunk.kind, ChunkKind::Common) {
-          let can_merge = match chunk.preserve_entry_signature {
-            Some(PreserveEntrySignatures::Strict) => {
-              self.can_merge_without_changing_entry_signature(chunk, &target_chunk.modules)
-            }
-            _ => true,
-          };
+          // Execution-isolation guard (issue #9463).
+          //
+          // Folding the common chunk *into* this user-defined entry chunk makes the
+          // entry chunk eagerly run this entry's top-level (its `init_*` call)
+          // whenever the chunk is loaded. If the common chunk also holds *another*
+          // user-defined entry's module, that other entry would be forced to import
+          // this entry chunk just to reach its own module — and would then run this
+          // entry's side effects. e.g. loading entry `b` would trigger entry `a`'s
+          // side effects. This happens when manual code splitting (a `codeSplitting`
+          // group, possibly via `entriesAware` subgroup merging) lumps several
+          // entries' modules into one shared chunk.
+          //
+          // Keep the thin facade in that case, so each entry imports the (wrapped)
+          // shared chunk and runs only its own `init_*`. A shared chunk that holds
+          // just this entry's module (plus non-entry deps a sibling genuinely
+          // depends on) is still folded in, preserving the #5726 facade-elimination.
+          let holds_other_user_entry = target_chunk.modules.iter().any(|&module_idx| {
+            module_idx != module
+              && self.link_output.user_defined_entry_modules.contains(&module_idx)
+          });
+          let can_merge = !holds_other_user_entry
+            && match chunk.preserve_entry_signature {
+              Some(PreserveEntrySignatures::Strict) => {
+                self.can_merge_without_changing_entry_signature(chunk, &target_chunk.modules)
+              }
+              _ => true,
+            };
           if can_merge {
             // merge all common chunk modules into entry chunk
             // swap original from_chunk_idx and target_chunk_idx

--- a/crates/rolldown/tests/rolldown/issues/9463/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463/_config.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9463 - With `strictExecutionOrder`, a `codeSplitting` group (here `entriesAware` + a large `entriesAwareMergeThreshold`) lumps both entry modules and the shared module into one chunk. `chunkOptimization` then folded that chunk into entry `a`, so executing entry `b` (`import \"./a.js\"; init_b()`) eagerly ran `init_a()` and triggered entry `a`'s side effect. Each entry must run only its own `init_*`.",
+  "config": {
+    "input": [
+      { "name": "a", "import": "./a.js" },
+      { "name": "b", "import": "./b.js" }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "chunkOptimization": true
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "common",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9463/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9463/_test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+
+// Behavioral regression test for https://github.com/rolldown/rolldown/issues/9463.
+//
+// Each module records its top-level side effect in `globalThis.sideEffectLog`.
+// Executing entry `b` (which reaches `shared.js` only via a dynamic import) must
+// run ONLY b's own side effects — never entry `a`'s. Before the fix, entry `b`'s
+// chunk imported entry `a`'s chunk and eagerly ran `init_a()`, so loading `b`
+// pushed `'a'`.
+
+globalThis.sideEffectLog = [];
+
+// Load ONLY entry `b`.
+await import(new URL('./dist/b.js', import.meta.url));
+// Let the dynamic `import('./shared.js')` continuation settle.
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+assert.ok(
+  !globalThis.sideEffectLog.includes('a'),
+  `executing entry "b" must not trigger entry "a"'s side effect; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+assert.deepStrictEqual(
+  globalThis.sideEffectLog,
+  ['b', 'shared-foo'],
+  `entry "b" should run only its own side effect plus its dynamic import; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+
+// Sanity: entry `a`'s side effect is not dead — it runs when `a` itself is loaded.
+await import(new URL('./dist/a.js', import.meta.url));
+assert.ok(
+  globalThis.sideEffectLog.includes('a'),
+  `entry "a"'s side effect should run when entry "a" is executed; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);

--- a/crates/rolldown/tests/rolldown/issues/9463/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9463/a.js
@@ -1,0 +1,6 @@
+import { foo } from './shared.js';
+
+// Top-level side effect of entry `a` (an observable global mutation, like the
+// `addEventListener` in the original report). Executing entry `b` must NOT run it.
+(globalThis.sideEffectLog ??= []).push('a');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] shared.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+# Assets
+
+## a.js
+
+```js
+import { n as init_a } from "./common~a~b~shared.js";
+init_a();
+
+```
+
+## b.js
+
+```js
+import { t as init_b } from "./common~a~b~shared.js";
+init_b();
+
+```
+
+## common~a~b~shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+var init_shared = __esmMin((() => {}));
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	init_shared();
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("b");
+	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
+		foo();
+	});
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9463/b.js
@@ -1,0 +1,7 @@
+// Entry `b` reaches `shared.js` only through a dynamic import, so executing `b`
+// must not trigger entry `a`'s top-level side effect.
+(globalThis.sideEffectLog ??= []).push('b');
+
+import('./shared.js').then(({ foo }) => {
+  foo();
+});

--- a/crates/rolldown/tests/rolldown/issues/9463/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9463/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  (globalThis.sideEffectLog ??= []).push('shared-foo');
+}

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9463 — same execution-isolation guard must hold for a PLAIN (non-entriesAware) codeSplitting group, which unions the bits of every matched module (including both entry modules) into one chunk.",
+  "config": {
+    "input": [
+      { "name": "a", "import": "./a.js" },
+      { "name": "b", "import": "./b.js" }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": { "chunkOptimization": true },
+    "codeSplitting": { "groups": [{ "name": "common", "entriesAwareMergeThreshold": 10000 }] }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/_test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+
+// https://github.com/rolldown/rolldown/issues/9463 (plain-group variant).
+// Loading entry `b` must run only b's own side effects, never entry `a`'s.
+globalThis.sideEffectLog = [];
+await import(new URL('./dist/b.js', import.meta.url));
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+assert.ok(
+  !globalThis.sideEffectLog.includes('a'),
+  `executing entry "b" must not trigger entry "a"'s side effect; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+assert.deepStrictEqual(globalThis.sideEffectLog, ['b', 'shared-foo']);

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/a.js
@@ -1,0 +1,4 @@
+import { foo } from './shared.js';
+
+(globalThis.sideEffectLog ??= []).push('a');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] shared.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+# Assets
+
+## a.js
+
+```js
+import { n as init_a } from "./common.js";
+init_a();
+
+```
+
+## b.js
+
+```js
+import { t as init_b } from "./common.js";
+init_b();
+
+```
+
+## common.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+var init_shared = __esmMin((() => {}));
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	init_shared();
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("b");
+	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
+		foo();
+	});
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/b.js
@@ -1,0 +1,5 @@
+(globalThis.sideEffectLog ??= []).push('b');
+
+import('./shared.js').then(({ foo }) => {
+  foo();
+});

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  (globalThis.sideEffectLog ??= []).push('shared-foo');
+}

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9463 — execution isolation must hold with more than two entries: a catch-all entriesAware group merges all three entry modules into one chunk; loading any one entry must run only its own init.",
+  "config": {
+    "input": [
+      { "name": "a", "import": "./a.js" },
+      { "name": "b", "import": "./b.js" },
+      { "name": "c", "import": "./c.js" }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": { "chunkOptimization": true },
+    "codeSplitting": {
+      "groups": [{ "name": "common", "entriesAware": true, "entriesAwareMergeThreshold": 10000 }]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/_test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+
+// https://github.com/rolldown/rolldown/issues/9463 (three-entry variant).
+// Loading entry `b` must run only b's own side effects — not entry `a`'s or `c`'s.
+globalThis.sideEffectLog = [];
+await import(new URL('./dist/b.js', import.meta.url));
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+assert.ok(
+  !globalThis.sideEffectLog.includes('a') && !globalThis.sideEffectLog.includes('c'),
+  `executing entry "b" must not trigger other entries' side effects; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+assert.deepStrictEqual(globalThis.sideEffectLog, ['b', 'shared-foo']);

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/a.js
@@ -1,0 +1,4 @@
+import { foo } from './shared.js';
+
+(globalThis.sideEffectLog ??= []).push('a');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
@@ -1,0 +1,63 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { r as init_a } from "./common~a~b~c.js";
+init_a();
+
+```
+
+## b.js
+
+```js
+import { n as init_b } from "./common~a~b~c.js";
+init_b();
+
+```
+
+## c.js
+
+```js
+import { t as init_c } from "./common~a~b~c.js";
+init_c();
+
+```
+
+## common~a~b~c.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+var init_shared = __esmMin((() => {}));
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	init_shared();
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	init_shared();
+	(globalThis.sideEffectLog ??= []).push("b");
+	foo();
+}));
+//#endregion
+//#region c.js
+var init_c = __esmMin((() => {
+	init_shared();
+	(globalThis.sideEffectLog ??= []).push("c");
+	foo();
+}));
+//#endregion
+export { init_b as n, init_a as r, init_c as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/b.js
@@ -1,0 +1,4 @@
+import { foo } from './shared.js';
+
+(globalThis.sideEffectLog ??= []).push('b');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/c.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/c.js
@@ -1,0 +1,4 @@
+import { foo } from './shared.js';
+
+(globalThis.sideEffectLog ??= []).push('c');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  (globalThis.sideEffectLog ??= []).push('shared-foo');
+}

--- a/internal-docs/code-splitting/implementation.md
+++ b/internal-docs/code-splitting/implementation.md
@@ -158,6 +158,8 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
 
+A **user-defined** entry can likewise become an empty facade when manual code splitting (a `codeSplitting` group, possibly via `entriesAware` subgroup merging) places its module into a common chunk. Folding that common chunk back into the entry chunk is only safe when the chunk does not also hold **another user-defined entry's module**. Otherwise the sibling entry would be forced to import this entry chunk just to reach its own module, and loading it would eagerly run this entry's top-level `init_*` — leaking its side effects into the sibling (visible under `strictExecutionOrder`). In that case the facade is kept so each entry imports the shared (wrapped) chunk and runs only its own `init_*`. See [#9463](https://github.com/rolldown/rolldown/issues/9463).
+
 ### Runtime Module Placement
 
 When code splitting is enabled, the runtime module is assigned before manual and normal module chunking into a dedicated common chunk. This chunk uses normal chunk naming and is not registered in `bits_to_chunk`, so other modules with the same reachability bits cannot be grouped into it. Manual chunking also treats the runtime as already assigned, including during recursive dependency collection. The normal chunking and common-chunk merging passes therefore operate on user modules without carrying runtime-specific exceptions.


### PR DESCRIPTION
## Summary

Fixes the `strictExecutionOrder` execution-order corruption reported in #9463: with `experimental.chunkOptimization` and a `codeSplitting` group that captures multiple **user-defined entry** modules, executing one entry eagerly ran another entry's top-level side effects.

Reproduction (the issue's REPL, as `tests/rolldown/issues/9463/`): entry `a` statically imports `shared`, entry `b` dynamically imports it, with an `entriesAware` group + large `entriesAwareMergeThreshold` + `strictExecutionOrder`.

Before — loading `b` runs `a`'s side effects:
```js
// a.js  → init_a/init_b/init_shared live here; chunk top-level unconditionally calls:
init_a();
export { init_b as t };
// b.js
import { t as init_b } from "./a.js";   // importing a.js runs init_a() first
init_b();
```
After — each entry runs only its own `init_*`:
```js
// a.js → import { n as init_a } from "./common~a~b~shared.js"; init_a();
// b.js → import { t as init_b } from "./common~a~b~shared.js"; init_b();
```

## Root cause

Manual code splitting can place several user-defined entry modules into one shared `Common` chunk (the `entriesAware` `entriesAwareMergeThreshold` merges subgroups by bitset similarity and unions their bits; a plain group unions bits directly). `chunkOptimization`'s facade elimination (`find_facade_chunk_merge_ops`) then folds that shared chunk **into** one entry chunk, which makes that entry chunk eagerly run its own `init_*`. The other entry, whose module also lives in the shared chunk, is then forced to `import` the first entry chunk to reach its own module — and running that chunk eagerly executes the first entry's side effects.

The existing safety check only ran for `preserveEntrySignatures: 'strict'`. Entries with no exports resolve to `AllowExtension` and took the `_ => true` arm, so nothing blocked the fold.

## The fix

In the user-defined-entry branch of `find_facade_chunk_merge_ops`, only fold the common chunk into the entry chunk when that chunk does **not** also hold another user-defined entry's module. Otherwise the thin facade is kept, so each entry imports the (wrapped) shared chunk and runs only its own `init_*`.

A common chunk that holds just this entry's module (plus non-entry deps a sibling genuinely depends on) is still folded — preserving the #5726 facade elimination.

## Tests

Three fixtures with **behavioral** `_test.mjs` that execute the output and assert the actual semantics (not just chunk snapshots) — each module records its top-level side effect in a global; loading entry `b` must run only `b`'s side effects and must not contain another entry's:
- `tests/rolldown/issues/9463/` — the reported case (entriesAware group, dynamic shared dep).
- `tests/rolldown/issues/9463_plain_group/` — plain (non-`entriesAware`) group, to prove the guard is not entriesAware-specific.
- `tests/rolldown/issues/9463_three_entries/` — three entries, to prove it scales past two.

All three were confirmed to **fail on the pre-fix code** (e.g. `["a","shared-foo","b","shared-foo"]`) and pass with the fix.

I also audited the rest of the chunk-optimizer merge/fold/wrap sites for the same "eager cross-entry execution" family and verified (by running probes) that the **strict** path is otherwise closed: under `strictExecutionOrder` every side-effectful module is wrapped (including under `onDemandWrapping`, since an observable side effect makes a module execution-order-sensitive), so the only eager leak was the entry-chunk fold fixed here. Dynamic→group / dynamic→common / dynamic→user-entry / static-via-intermediate / plain-group shapes were all checked and are isolated under strict. Full `rolldown` integration suite: no snapshot regressions; `#5726` and `strict_execution_order/on_demand_wrapping` unchanged.

## Out of scope / follow-up

This addresses the `strictExecutionOrder` case from the issue. The same logical leak still exists **without** `strictExecutionOrder` when a manual code-splitting group co-locates modules of different entry reachability: there the shared chunk's modules are eager (unwrapped), so loading one entry runs the co-located code of another. For non-entry modules this is the pre-existing manual-group over-inclusion tradeoff (see `advanced_chunks/entries_aware_merge_shared_deps`); for entry modules it is a genuine isolation gap. The structural cause is manual code splitting producing chunks whose `bits` is a union across modules of different reachability. Tracked in #9998; a complete fix would make manual splitting respect reachability boundaries (or keep cross-entry modules wrapped in non-strict mode too).

Closes #9463
