### PR TITLE
fix(rolldown_plugin_vite_dynamic_import_vars): avoid duplicating a constant prefix in the runtime path

### DIFF
--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
@@ -95,13 +95,17 @@ impl<'ast> DynamicImportVarsVisit<'ast, '_> {
       };
 
       let raw = source.span.shrink(1).source_text(self.source_text);
-      let raw_pattern = if &glob[..index] == source.quasis[0].value.raw {
-        Cow::Borrowed(raw)
-      } else {
-        let mut s = String::with_capacity(index + source.quasis[0].value.raw.len());
+      let raw_pattern = if async_imports.is_some() {
+        // The resolver replaced the bare/alias prefix with `glob`, so splice the resolved
+        // prefix onto the source after that prefix.
+        let prefix = source.quasis[0].value.raw.len();
+        let mut s = String::with_capacity(index + raw.len() - prefix);
         s.push_str(&glob[..index]);
-        s.push_str(&raw[source.quasis[0].value.raw.len()..]);
+        s.push_str(&raw[prefix..]);
         Cow::Owned(s)
+      } else {
+        // A relative specifier's source reproduces the path at runtime as-is.
+        Cow::Borrowed(raw)
       };
 
       let base = self.importer.parent().unwrap_or(self.root);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/_config.ts
@@ -1,0 +1,11 @@
+import { defineTest } from 'rolldown-tests';
+import { viteDynamicImportVarsPlugin, viteImportGlobPlugin } from 'rolldown/experimental';
+
+export default defineTest({
+  config: {
+    plugins: [viteDynamicImportVarsPlugin(), viteImportGlobPlugin()],
+  },
+  async afterTest() {
+    await import('./assert.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/assert.mjs
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import assert from 'node:assert';
+import { f } from './dist/main';
+
+// A constant before the first variable must not be duplicated into the runtime path.
+const m = await f('foo');
+assert.strictEqual(m.default, 'foo-loaded');

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/main.js
@@ -1,0 +1,3 @@
+export function f(name) {
+  return import(`./${'sub'}/views/${name}.js`);
+}

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/sub/views/foo.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable/sub/views/foo.js
@@ -1,0 +1,1 @@
+export default 'foo-loaded';


### PR DESCRIPTION
Related to vitejs/vite#22806

### What this solves

The vite-dynamic-import-vars plugin rewrites a variable dynamic import such as `import(./views/${name}.js)` into an `import.meta.glob` call plus a runtime path template (emitted in backticks) that is evaluated at runtime to look up the glob map. When building that template it used the original source for the simple case, and otherwise spliced the resolved glob prefix (`glob[..index]`) onto the source after the first quasi. That `else` branch was meant for the resolver/alias case, but it also fired whenever a constant expression (a string literal, a no-substitution template, or a literal concatenation) preceded the first variable. In that case the resolved constant is already baked into `glob[..index]` while the source slice still contains its source, so the constant prefix is emitted twice. For `import(./${'sub'}/views/${name}.js)` the runtime path became `./sub/views/sub/views/${name}.js`, which matches no glob key, so the import rejects at runtime with "Unknown variable dynamic import".

### The fix

Distinguish the two cases by whether the import went through the resolver. For a resolver/alias import the leading specifier was replaced by `glob`, so the resolved prefix is still spliced onto the source after that specifier (the runtime cannot derive it from the original alias). For a relative import the original source already reproduces the path at runtime: its constant expressions evaluate to the same text baked into the glob, and the bundler constant-folds them anyway, so the source is used verbatim. This matches Vite, which derives the raw pattern from the source rather than prepending the resolved prefix, and removes the splice that caused the duplication.

### Tests

Added `packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/const-before-variable`, a runtime test where a `${'sub'}` constant precedes the variable; it imports the built output and asserts `f('foo')` resolves to the real module. It rejects with "Unknown variable dynamic import: ./sub/views/sub/views/foo.js" without the fix and resolves with it. The existing dynamic-import-vars fixtures and the plugin unit tests still pass.