### PR TITLE
revert: "fix(plugin): make lazy hook metadata enumerable (#9991)"

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -218,7 +218,6 @@ export function bindingifyTransform(
             magicStringInstance = new RolldownMagicString(code);
             return magicStringInstance;
           },
-          enumerable: true,
         },
         ast: {
           get() {
@@ -242,7 +241,6 @@ export function bindingifyTransform(
             });
             return astInstance;
           },
-          enumerable: true,
         },
       });
       const transformCtx = new TransformPluginContextImpl(

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -77,7 +77,6 @@ export function bindingifyRenderChunk(
             magicStringInstance = new RolldownMagicString(code);
             return magicStringInstance;
           },
-          enumerable: true,
           configurable: true,
         });
       }

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
@@ -22,13 +22,6 @@ export default defineTest({
             return null;
           }
 
-          expect(Object.keys(meta)).toEqual(
-            expect.arrayContaining(['moduleType', 'magicString', 'ast']),
-          );
-          const spreadMeta = { ...meta };
-          expect(spreadMeta.magicString).toBe(meta.magicString);
-          expect(spreadMeta.ast).toBe(meta.ast);
-
           // Test 1: Verify that multiple accesses return the same cached instance
           // The magicString getter caches the instance on first access
           meta.magicString.overwrite(0, code.length, 'replaced;');

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/native-magic-string/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/native-magic-string/_config.ts
@@ -18,11 +18,6 @@ export default defineTest({
             throw new Error('magicString should be available when nativeMagicString is enabled');
           }
 
-          expect(Object.keys(meta)).toEqual(expect.arrayContaining(['chunks', 'magicString']));
-          const spreadMeta = { ...meta };
-          expect(spreadMeta.chunks).toBe(meta.chunks);
-          expect(spreadMeta.magicString).toBe(meta.magicString);
-
           meta.magicString.replaceAll('name', 'userName');
           // Test 1: Verify that multiple accesses return the same cached instance
           const ref1 = meta.magicString;


### PR DESCRIPTION
Reverts #9991.

That PR made the lazy hook metadata getters (`magicString`, `ast`, `moduleType`, ...) `enumerable: true`. This breaks Vite tests because the now-enumerable getters get triggered/listed when the metadata object is spread or iterated with `Object.keys`, which has unintended side effects.

CI failure: https://github.com/rolldown/rolldown/actions/runs/28277946084/job/83788294448

Reverting to restore green CI; the original change can be reworked afterwards.
