### PR TITLE
refactor(deconflict): extract collect_chunk_scope_captured_names

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -90,56 +90,8 @@ pub fn deconflict_chunk_symbols(
     });
   }
 
-  // Collect the canonical names of things that are emitted at the chunk's root scope and thus
-  // captured by every CJS-wrapped module's `__commonJS((exports, module) => { ... })` closure.
-  // A real-AST root-scope binding inside the closure whose name matches one of these would
-  // shadow the captured value at runtime (issues #9055, #9375). We track only rolldown-emitted
-  // names — iife/umd factory params and `require_xxx` wrapper facades — and intentionally
-  // exclude the names of import bindings that get rewritten away at codegen time. We use the
-  // symbols' *original* names here: wrapper symbols haven't been renamed yet at this point, and
-  // if any of them ends up renamed in the loop below, the conflict that triggered the rename
-  // would have been the user-source local — which is exactly the case we want to catch.
-  let mut chunk_scope_captured_names: FxHashSet<CompactStr> = FxHashSet::default();
-  if matches!(format, OutputFormat::Iife | OutputFormat::Umd) {
-    // Mirror the set rendered as factory params by `render_chunk_external_imports` +
-    // `render_factory_parameters`.
-    for (external_idx, _) in &chunk.direct_imports_from_external_modules {
-      let Some(external) = link_output.module_table[*external_idx].as_external() else {
-        continue;
-      };
-      if let Some(name) = renamer.get_canonical_name(external.namespace_ref) {
-        chunk_scope_captured_names.insert(name.clone());
-      }
-    }
-  }
-  // CJS wrapper facades (e.g. `require_foo`) are rendered at chunk scope and captured by every
-  // CJS-wrapped module's closure in this chunk.
-  for module_idx in chunk.modules.iter().copied() {
-    if let Some(wrapper_ref) = link_output.metas[module_idx].wrapper_ref {
-      let canonical_ref = link_output.symbol_db.canonical_ref_for(wrapper_ref);
-      chunk_scope_captured_names
-        .insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
-    }
-  }
-  if matches!(format, OutputFormat::Esm) {
-    // A CJS wrapper whose module lives in *another* chunk is hoisted here as a real root-scope
-    // import binding (`import { ... as require_foo } from "./other.js"`) and is likewise captured
-    // by every CJS-wrapped closure in this chunk. The in-chunk loop above can't see it because its
-    // owner module isn't in `chunk.modules`, so we recover it from the cross-chunk import list.
-    // Without this, an author-local of the same name inside a CJS closure shadows the imported
-    // wrapper, emitting the self-referential `var require_foo = require_foo()` (issue #9630).
-    for item in chunk.imports_from_other_chunks.values().flatten() {
-      let canonical_ref = link_output.symbol_db.canonical_ref_for(item.import_ref);
-      let is_cjs_wrapper =
-        link_output.metas[canonical_ref.owner].wrapper_ref.is_some_and(|wrapper_ref| {
-          link_output.symbol_db.canonical_ref_for(wrapper_ref) == canonical_ref
-        });
-      if is_cjs_wrapper {
-        chunk_scope_captured_names
-          .insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
-      }
-    }
-  }
+  let chunk_scope_captured_names =
+    collect_chunk_scope_captured_names(chunk, link_output, format, &renamer);
 
   // The renamer relies on `chunk.modules` being in ascending exec_order so that
   // `.rev()` yields entry-first / descending exec_order — the same priority as
@@ -275,6 +227,64 @@ pub fn deconflict_chunk_symbols(
   rename_shadowing_symbols_in_nested_scopes(chunk, link_output, format, &mut renamer);
 
   chunk.canonical_names = renamer.into_canonical_names();
+}
+
+/// Collect the canonical names of things that are emitted at the chunk's root scope and thus
+/// captured by every CJS-wrapped module's `__commonJS((exports, module) => { ... })` closure.
+/// A real-AST root-scope binding inside the closure whose name matches one of these would
+/// shadow the captured value at runtime (issues #9055, #9375, #9630). We track only
+/// rolldown-emitted names — iife/umd factory params and `require_xxx` wrapper facades — and
+/// intentionally exclude the names of import bindings that get rewritten away at codegen time.
+/// We use the symbols' *original* names here: wrapper symbols haven't been renamed yet at this
+/// point, and if any of them ends up renamed in the deconfliction loop, the conflict that
+/// triggered the rename would have been the user-source local — which is exactly the case we
+/// want to catch.
+fn collect_chunk_scope_captured_names(
+  chunk: &Chunk,
+  link_output: &LinkStageOutput,
+  format: OutputFormat,
+  renamer: &Renamer<'_>,
+) -> FxHashSet<CompactStr> {
+  let mut captured: FxHashSet<CompactStr> = FxHashSet::default();
+  if matches!(format, OutputFormat::Iife | OutputFormat::Umd) {
+    // Mirror the set rendered as factory params by `render_chunk_external_imports` +
+    // `render_factory_parameters`.
+    for (external_idx, _) in &chunk.direct_imports_from_external_modules {
+      let Some(external) = link_output.module_table[*external_idx].as_external() else {
+        continue;
+      };
+      if let Some(name) = renamer.get_canonical_name(external.namespace_ref) {
+        captured.insert(name.clone());
+      }
+    }
+  }
+  // CJS wrapper facades (e.g. `require_foo`) are rendered at chunk scope and captured by every
+  // CJS-wrapped module's closure in this chunk.
+  for module_idx in chunk.modules.iter().copied() {
+    if let Some(wrapper_ref) = link_output.metas[module_idx].wrapper_ref {
+      let canonical_ref = link_output.symbol_db.canonical_ref_for(wrapper_ref);
+      captured.insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
+    }
+  }
+  if matches!(format, OutputFormat::Esm) {
+    // A CJS wrapper whose module lives in *another* chunk is hoisted here as a real root-scope
+    // import binding (`import { ... as require_foo } from "./other.js"`) and is likewise captured
+    // by every CJS-wrapped closure in this chunk. The in-chunk loop above can't see it because its
+    // owner module isn't in `chunk.modules`, so we recover it from the cross-chunk import list.
+    // Without this, an author-local of the same name inside a CJS closure shadows the imported
+    // wrapper, emitting the self-referential `var require_foo = require_foo()` (issue #9630).
+    for item in chunk.imports_from_other_chunks.values().flatten() {
+      let canonical_ref = link_output.symbol_db.canonical_ref_for(item.import_ref);
+      let is_cjs_wrapper =
+        link_output.metas[canonical_ref.owner].wrapper_ref.is_some_and(|wrapper_ref| {
+          link_output.symbol_db.canonical_ref_for(wrapper_ref) == canonical_ref
+        });
+      if is_cjs_wrapper {
+        captured.insert(CompactStr::new(canonical_ref.name(&link_output.symbol_db)));
+      }
+    }
+  }
+  captured
 }
 
 /// Rename nested scope symbols that would shadow top-level symbols.


### PR DESCRIPTION
Pure no-op refactor, split out of the #9882 follow-up work — **stacked on #9921**.

Extracts the inline "chunk-scope captured names" collection block out of `deconflict_chunk_symbols` into a dedicated `collect_chunk_scope_captured_names` helper. No behavior change.

### Why

The follow-up fix #9970 adds wrapped-ESM namespace-object capture lines to this block, which pushes `deconflict_chunk_symbols` past clippy's `too_many_lines` (200) ceiling. Extracting the helper first keeps #9970 focused purely on the actual fix.

### Changes

- Move the captured-names collection into `collect_chunk_scope_captured_names(chunk, link_output, format, &renamer)` — verbatim logic, just relocated.

### Tests

No new behavior → no new fixtures. Verified as a no-op: all `topics/deconflict` + `issues/9882` snapshot tests pass unchanged.
