### PR TITLE
fix: preserve included external import declarations

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -319,7 +319,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     rec_idx: ImportRecordIdx,
   ) -> bool {
     let rec = &self.ctx.module.import_records[rec_idx];
-    let Some(resolved_module_idx) = rec.resolved_module else { return true };
+    let Some(resolved_module_idx) = rec.resolved_module else {
+      return !stmt.is_import_declaration();
+    };
     let Module::Normal(importee) = &self.ctx.modules[resolved_module_idx] else {
       return true;
     };

--- a/packages/rolldown/tests/behaviors/strict-execution-order.test.ts
+++ b/packages/rolldown/tests/behaviors/strict-execution-order.test.ts
@@ -1,0 +1,50 @@
+import type { OutputChunk, Plugin } from 'rolldown';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+test('keeps live external imports in shared strict entries', async () => {
+  const modules: Record<string, string> = {
+    'entry-a': `import { value } from 'first'; console.log(value); export { read } from 'first';`,
+    'entry-b': `import { value } from 'second'; console.log(value); export { read } from 'second';`,
+    first: `export { value, read } from 'shared';`,
+    second: `export { value, read } from 'shared';`,
+    shared: `export { value, read } from 'leaf';`,
+    leaf: `import { first, second } from 'dep'; export const value = first(second); export function read() { return value; }`,
+  };
+
+  const plugin: Plugin = {
+    name: 'virtual',
+    resolveId(id) {
+      if (id in modules) return id;
+    },
+    load(id) {
+      return modules[id];
+    },
+  };
+
+  const bundle = await rolldown({
+    input: {
+      a: 'entry-a',
+      b: 'entry-b',
+    },
+    external: ['dep'],
+    platform: 'browser',
+    plugins: [plugin],
+    treeshake: {
+      moduleSideEffects: false,
+    },
+  });
+  const result = await bundle.generate({
+    format: 'es',
+    strictExecutionOrder: true,
+    minify: false,
+  });
+  await bundle.close();
+
+  const shared = result.output.find(
+    (chunk): chunk is OutputChunk => chunk.type === 'chunk' && chunk.code.includes('first(second)'),
+  );
+
+  expect(shared).toBeDefined();
+  expect(shared!.code).toContain('import { first, second } from "dep";');
+});


### PR DESCRIPTION
This PR aims to fix a case where the finalizer removed an included external import declaration.

The finalizer handles both `import` declarations and `export ... from` declarations. 
Previously, when an import record did not resolve to an internal module, the finalizer removed the statement. That is not safe for an included external import declaration: the imported bindings may still be referenced by code that survived tree-shaking.

This showed up with `strictExecutionOrder` because module bodies can be moved into `__esmMin` wrappers. The wrapper body could still contain code like:

```js
value = first(second);
```

while the corresponding top-level import had been removed:

```js
import { first, second } from "dep";
```

This keeps included unresolved/external `ImportDeclaration`s in the output, while leaving unresolved `export ... from` handling unchanged.
