### PR TITLE
docs: use GitHub-flavored alert for Etiquette note in contribution guide

### DIFF
--- a/docs/contribution-guide/index.md
+++ b/docs/contribution-guide/index.md
@@ -36,11 +36,8 @@ We welcome pull requests for bugs, fixes, improvements, and new features. Before
 
 For setting up the project's development environment, see [Project Setup](../development-guide/setup-the-project.md).
 
-:::info
-
-Please read the [Etiquette](https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette) chapter before submitting a pull request.
-
-:::
+> [!NOTE]
+> Please read the [Etiquette](https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette) chapter before submitting a pull request.
 
 ### Send a pull request directly
 


### PR DESCRIPTION
## Description

The Etiquette note in the contribution guide used a `:::info` VitePress container. That renders as a proper INFO callout on the docs site, but GitHub's blob view shows it as literal `:::info` / `:::` text:

The contribution guide is commonly read directly on GitHub, so this switches the block to a GitHub-flavored alert (`> [!NOTE]`), which renders as a callout on **both** GitHub and the VitePress docs site (`gfmAlerts` is enabled by default in the VitePress version we use).

## Before / After

```diff
-:::info
-
-Please read the [Etiquette](...) chapter before submitting a pull request.
-
-:::
+> [!NOTE]
+> Please read the [Etiquette](...) chapter before submitting a pull request.
```

No behavior change on the docs site — both forms render as a callout there. The only difference is GitHub now renders it correctly too.