### PR TITLE
fix: reset the word-boundary state on newline in Hires::Boundary sourcemaps

### DIFF
--- a/crates/rolldown/tests/rolldown/function/module_types/copy/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/copy/basic/artifacts.snap
@@ -29,6 +29,7 @@ console.log(data, data2);
 
 ```
 - ../main.js
+(1:0) "const " --> (3:0) "const "
 (1:6) "data2 = require(" --> (3:6) "data2 = ("
 (1:6) "data2 = require(" --> (3:15) "/* @__PURE__ */ ((x) => typeof require !== \"undefined\" ? require : typeof Proxy !== \"undefined\" ? new Proxy(x, { get: (a, b) => (typeof require !== \"undefined\" ? require : a)[b] }) : x)(function(x) {\n"
 (1:6) "data2 = require(" --> (6:1) "))"

--- a/crates/rolldown/tests/rolldown/function/module_types/copy/nested_path/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/copy/nested_path/artifacts.snap
@@ -30,6 +30,7 @@ console.log(shallow, deep, shallowReq, deepReq);
 
 ```
 - ../../../main.js
+(2:0) "const " --> (9:0) "const "
 (2:6) "shallowReq = require(" --> (9:6) "shallowReq = "
 (2:6) "shallowReq = require(" --> (9:19) "__require("
 (2:27) "'./root.txt'" --> (9:29) "\"../../deep/assets/root-DcToKNib.txt\""

--- a/crates/string_wizard/src/source_map/sourcemap_builder.rs
+++ b/crates/string_wizard/src/source_map/sourcemap_builder.rs
@@ -76,6 +76,8 @@ impl<'a> SourcemapBuilder<'a> {
             loc.bump_line();
             self.bump_line();
             new_line = true;
+            // A newline ends the current word run.
+            char_in_hires_boundary = false;
           }
           _ => {
             if new_line || !matches!(self.hires, Hires::False) {

--- a/crates/string_wizard/tests/magic_string_source_map.rs
+++ b/crates/string_wizard/tests/magic_string_source_map.rs
@@ -61,3 +61,17 @@ function test() {
   insta::assert_snapshot!("hires_true", visualize(&s, Hires::True, &output));
   insta::assert_snapshot!("hires_boundary", visualize(&s, Hires::Boundary, &output));
 }
+
+#[test]
+fn hires_boundary_maps_word_at_start_of_next_line() {
+  // The first line ends with a word char and the second starts with one.
+  let s = MagicString::new("const a = 1\nconst b = 2");
+  let sm = s.source_map(SourceMapOptions { hires: Hires::Boundary, ..Default::default() });
+  assert!(
+    sm.get_tokens().any(|t| t.get_dst_line() == 1
+      && t.get_dst_col() == 0
+      && t.get_src_line() == 1
+      && t.get_src_col() == 0),
+    "the word starting the line after a word-ending line lost its source mapping"
+  );
+}


### PR DESCRIPTION
### What this solves

In `Hires::Boundary` mode the sourcemap builder tracks `char_in_hires_boundary` so that only the first character of each word run emits a mapping token. A `'\n'` is handled in its own match arm that bumps the line but never clears that flag. So when a source line ends with a word character (identifier, number, keyword), the flag stays set across the newline, the first word character of the next line takes the "already inside a word" branch and is skipped, and that line gets no start-of-line mapping. For example `const a = 1\nconst b = 2` left the second line's leading word unmapped.

`Hires::Boundary` is used widely (plugin transform sourcemaps, `generateMap({ hires: "boundary" })`, and the asset-module / copy-module / vite-dynamic-import-vars / vite-import-glob builtins), so this degrades sourcemaps for common no-semicolon and identifier-terminated lines. The reference magic-string runs `'\n'` through the same boundary logic, which resets the flag, so it does not lose the mapping.

### The fix

Reset `char_in_hires_boundary` to `false` in the `'\n'` arm so a newline ends the current word run and the first word character of the next line still emits its boundary token.

### Tests

Added `hires_boundary_maps_word_at_start_of_next_line` in `crates/string_wizard/tests/magic_string_source_map.rs`: for a source whose first line ends with a word char and whose second line starts with one, it asserts a token maps the start of the second generated line back to the second source line. It fails on the old code and passes with the fix. The existing `Hires::Boundary` snapshot is unchanged because its lines end with non-word characters.