### PR TITLE
fix(generate): keep JSON namespace interface under preserveModules

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -438,18 +438,25 @@ impl GenerateStage<'_> {
               .map(|(name, export)| (name, export.symbol_ref))
             {
               // `preserveModules` emits a module's complete declared interface (#9934). A JSON
-              // module synthesizes a named export per top-level key, but a key that is reached
-              // only through its own default-export object has its `var` binding folded into that
-              // object by the finalizer's `try_inline_json_module_prop`, leaving no standalone
-              // declaration. Listing such a key here produces an `export { key }` with no binding
-              // -> `SyntaxError: Export 'x' is not defined in module` (#10020).
+              // module synthesizes a named export per top-level key, but the finalizer
+              // (`try_inline_json_module_prop`) may fold a key's `var` binding into the
+              // self-contained default-export object, leaving no standalone declaration. Listing
+              // such a key here produces an `export { key }` with no binding ->
+              // `SyntaxError: Export 'x' is not defined in module` (#10020).
               //
-              // `json_module_none_self_reference_included_symbol` holds the JSON keys included for
-              // a non-self-reference reason (named import, entry export) — the keys the finalizer
-              // keeps materialized. Skip any key absent from it.
+              // Drop a key iff the finalizer inlines it away. That decision is gated on
+              // `need_inline_json_prop` (see `finalizer_context.rs`): JSON, ESM exports, and the
+              // module namespace object NOT included; and within that, a key is inlined iff it is
+              // absent from `json_module_none_self_reference_included_symbol` (i.e. not reached by
+              // a named import, entry export, or — keeping every key materialized — a namespace
+              // import). Mirror that full condition so the export interface never lists an
+              // inlined-away key, while a namespace-imported JSON chunk still exports its complete
+              // interface (every key keeps its binding).
               if let Module::Normal(normal_module) = &self.link_output.module_table[module_idx]
                 && let Some(none_self_referenced) =
                   normal_module.json_module_none_self_reference_included_symbol.as_deref()
+                && !normal_module.exports_kind.is_commonjs()
+                && !self.link_output.used_symbol_refs.contains(&normal_module.namespace_object_ref)
                 && !none_self_referenced
                   .contains(&self.link_output.symbol_db.canonical_ref_for(symbol))
               {

--- a/crates/rolldown/tests/rolldown/issues/10020/index.js
+++ b/crates/rolldown/tests/rolldown/issues/10020/index.js
@@ -1,7 +1,7 @@
 // Default-import a JSON module and read keys dynamically.
 // Mirrors vinext's packages/vinext/src/build/google-fonts/fallback-metrics.ts:
 //   import rawFallbackMetrics from "./fallback-metrics-data.json" with { type: "json" };
-import metrics from "./data.json" with { type: "json" };
+import metrics from './data.json' with { type: 'json' };
 
 export function get(name) {
   return metrics[name];

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Regression coverage for preserveModules + JSON namespace imports. When a JSON module is used opaquely as a namespace, the JSON finalizer keeps the key/default declarations materialized; the preserved JSON chunk must still export default and top-level keys from data.js.",
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "./index.js"
+      }
+    ],
+    "preserveModules": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_test.mjs
@@ -17,7 +17,7 @@ assert.equal(namespace.answer, 42);
 assert.deepEqual(namespace.nested, { ok: true });
 assert.deepEqual(namespace.default, expectedDefault);
 
-console.log(`data.dataModule: `, dataModule)
+console.log(`data.dataModule: `, dataModule);
 assert.equal(dataModule.answer, 42);
 assert.deepEqual(dataModule.nested, { ok: true });
 assert.deepEqual(dataModule.default, expectedDefault);

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/_test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+
+import { namespace, namespaceKeys } from './dist/index.js';
+
+const dataModule = await import('./dist/data.js');
+const expectedDefault = {
+  answer: 42,
+  nested: {
+    ok: true,
+  },
+};
+const expectedKeys = ['answer', 'default', 'nested'];
+
+assert.deepEqual(namespaceKeys, expectedKeys);
+assert.deepEqual(Object.keys(namespace).sort(), expectedKeys);
+assert.equal(namespace.answer, 42);
+assert.deepEqual(namespace.nested, { ok: true });
+assert.deepEqual(namespace.default, expectedDefault);
+
+console.log(`data.dataModule: `, dataModule)
+assert.equal(dataModule.answer, 42);
+assert.deepEqual(dataModule.nested, { ok: true });
+assert.deepEqual(dataModule.default, expectedDefault);

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/artifacts.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/_rolldown/runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll };
+
+```
+
+## data.js
+
+```js
+import { __exportAll } from "./_virtual/_rolldown/runtime.js";
+//#region data.json
+var data_exports = /* @__PURE__ */ __exportAll({
+	answer: () => answer,
+	default: () => data_default,
+	nested: () => nested
+});
+var answer = 42;
+var nested = { "ok": true };
+var data_default = {
+	answer,
+	nested
+};
+//#endregion
+export { answer, data_exports, data_default as default, nested };
+
+```
+
+## index.js
+
+```js
+import { data_exports } from "./data.js";
+//#region index.js
+const namespace = data_exports;
+const namespaceKeys = Object.keys(data_exports).sort();
+console.log(data_exports);
+//#endregion
+export { namespace, namespaceKeys };
+
+```

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/data.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/data.json
@@ -1,0 +1,6 @@
+{
+  "answer": 42,
+  "nested": {
+    "ok": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/index.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports/index.js
@@ -1,0 +1,6 @@
+import * as data from './data.json' with { type: 'json' };
+
+export const namespace = data;
+export const namespaceKeys = Object.keys(data).sort();
+
+console.log(data);


### PR DESCRIPTION
### What

Builds on the parent PR (#10020). A JSON module imported as a namespace (`import * as ns from './x.json'`) keeps every top-level key materialized — the finalizer only inlines JSON keys when the module namespace object is **not** included (`need_inline_json_prop`, see `finalizer_context.rs`).

> **This is pre-existing behavior, not a regression.** On `main` a namespace-imported JSON chunk under `preserveModules` already exports its full interface correctly — `import('./dist/data.js')` exposes every top-level key. Unlike #10020 (which *is* a #9934 regression), there is no namespace bug on `main`. I verified the guard test passes on `main`.

The reason this PR exists is purely to keep the stack consistent: the parent PR's #10020 narrowing (skip keys absent from `json_module_none_self_reference_included_symbol`) is too coarse for the namespace case — those keys are absent from that set yet still materialized, so the **parent PR alone** would drop them:

```js
// parent PR (#10020) alone: only the namespace object survives
export { data_exports };
// with this PR: pre-existing full interface preserved
export { answer, data_exports, data_default as default, nested };
```

### Fix

Mirror the finalizer's **full** inlining condition rather than the key-set alone: only drop a key when JSON property inlining is actually active — JSON, ESM exports, and the namespace object **not** included. The stack's net behavior then matches `main` for the namespace case.

### Test

`crates/rolldown/tests/rolldown/misc/preserve_modules/json_namespace_preserves_exports`: `import * as` a JSON module under preserveModules and assert (via `_test.mjs`) that `import('./dist/data.js')` re-exposes every top-level key plus `default`. Verified: passes on `main`, fails on the parent PR alone, passes here.

---

> Stacked on the #10020 fix.
