### PR TITLE
fix: trim an emptied chunk's outro/intro instead of skipping past it

### DIFF
--- a/crates/string_wizard/src/magic_string/trim.rs
+++ b/crates/string_wizard/src/magic_string/trim.rs
@@ -60,7 +60,11 @@ impl<'text> MagicString<'text> {
       let trimmed_content = trim_start_pattern(&content, pattern);
 
       if content.is_empty() {
-        // Content is empty (e.g., from a remove), continue to next chunk
+        // Content is empty (e.g. from a remove); the outro is next in output order, so trim
+        // it and abort if non-whitespace remains.
+        if trim_deque_start(&mut chunk.outro, pattern) {
+          return true;
+        }
         chunk_idx = next_idx;
         continue;
       }
@@ -122,7 +126,11 @@ impl<'text> MagicString<'text> {
       let trimmed_content = trim_end_pattern(&content, pattern);
 
       if content.is_empty() {
-        // Content is empty (e.g., from a remove), continue to prev chunk
+        // Content is empty (e.g. from a remove); the intro is next in reverse output order,
+        // so trim it and abort if non-whitespace remains.
+        if trim_deque_end(&mut chunk.intro, pattern) {
+          return true;
+        }
         chunk_idx = prev_idx;
         continue;
       }

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -438,3 +438,27 @@ mod misc {
     assert!(s.has_changed());
   }
 }
+
+mod trim {
+  use super::*;
+
+  #[test]
+  fn trim_start_aborts_at_an_emptied_chunks_outro() {
+    // chunk[0,1] is emptied but its outro "X" follows it; the space after is not leading.
+    let mut s = MagicString::new("A B");
+    s.remove(0, 1).unwrap();
+    s.append_left(1, "X");
+    s.trim_start(None);
+    assert_eq!(s.to_string(), "X B");
+  }
+
+  #[test]
+  fn trim_end_aborts_at_an_emptied_chunks_intro() {
+    // chunk[2,3] is emptied but its intro "X" precedes it; the space before is not trailing.
+    let mut s = MagicString::new("A B");
+    s.remove(2, 3).unwrap();
+    s.prepend_right(2, "X");
+    s.trim_end(None);
+    assert_eq!(s.to_string(), "A X");
+  }
+}


### PR DESCRIPTION
### What this solves

`trim_start` / `trim_end` walk the chunks and stop at the first non-whitespace. Each chunk's output order is intro, content, outro. When a chunk's content is already empty (for example after `remove()`), the start trimmer `continue`d to the next chunk without trimming or inspecting that chunk's outro (and the end trimmer symmetrically skipped the intro). The outro comes right after the empty content in output order, so if it holds non-whitespace the trim should abort there. Because it didn't, trimming proceeded into the following chunk and deleted whitespace that is not leading (resp. trailing). For example, `"A B"` with the first character removed and `"X"` appended into the emptied chunk's outro renders as `"X B"`, so `trim_start` should be a no-op, but it returned `"XB"`. The reference magic-string's `Chunk.trimStart` trims the outro and aborts when it is non-empty even if the content is empty.

### The fix

In the empty-content branch of `trim_start_aborted` (and symmetrically in `trim_end_aborted`), trim the chunk's outro (resp. intro) and abort if non-whitespace remains, mirroring the path already taken when the content is trimmed down to empty.

### Tests

Added a `trim` test module with two cases: an emptied chunk whose outro precedes following whitespace (`trim_start`) and whose intro follows preceding whitespace (`trim_end`); both assert the trim is a no-op. They fail on the old code (`"XB"` / `"AX"`) and pass with the fix, and the expected `"X B"` / `"A X"` outputs match magic-string.