### PR TITLE
fix: serialize the KeepAssign unused minify option as "keep_assign"

### DIFF
--- a/crates/rolldown_binding/src/utils/minify_options_conversion.rs
+++ b/crates/rolldown_binding/src/utils/minify_options_conversion.rs
@@ -26,7 +26,7 @@ pub fn compress_options_to_napi_compress_options(
     drop_labels: Some(compress.drop_labels.iter().cloned().collect()),
     unused: Some(match compress.unused {
       oxc::minifier::CompressOptionsUnused::Remove => napi::Either::A(true),
-      oxc::minifier::CompressOptionsUnused::KeepAssign => napi::Either::B("keep-assign".to_owned()),
+      oxc::minifier::CompressOptionsUnused::KeepAssign => napi::Either::B("keep_assign".to_owned()),
       oxc::minifier::CompressOptionsUnused::Keep => napi::Either::A(false),
     }),
     keep_names: {


### PR DESCRIPTION
### What this solves

`compress_options_to_napi_compress_options` (used to expose the normalized options back to JS) serialized `CompressOptionsUnused::KeepAssign` as the string `"keep-assign"`. But `oxc_minify_napi` parses the `unused` option as `"keep_assign"` and its TS type is `boolean | 'keep_assign'`, so the normalized options reported a hyphenated value that does not match the accepted input and is rejected with `Invalid unused option: "keep-assign"` if fed back.

### The fix

Serialize the variant as `"keep_assign"` to match the parser and the TS type. It is the only hyphenated occurrence of this option in the tree.