### PR TITLE
fix: check finalize_other_specifiers in its own Debug attribute

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -38,7 +38,7 @@ pub struct BindingViteResolvePluginConfig {
   )]
   pub finalize_bare_specifier:
     Option<JsCallback<FnArgs<(String, String, Option<String>)>, Option<String>>>,
-  #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
+  #[debug("{}", if finalize_other_specifiers.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
   #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
   pub finalize_other_specifiers: Option<JsCallback<FnArgs<(String, String)>, Option<String>>>,
   #[debug("Some(<resolve_subpath_imports>)")]


### PR DESCRIPTION
### What this solves

The `#[debug(...)]` attribute on `BindingViteResolvePluginConfig::finalize_other_specifiers` tested `finalize_bare_specifier.is_some()` (the previous field, copy-pasted) instead of `finalize_other_specifiers.is_some()`. So when the config is `Debug`-formatted (logging/tracing), the `finalize_other_specifiers` field reflects whether the *bare-specifier* callback is set, not its own: it prints `Some(<finalize_other_specifiers>)` while actually being `None`, and `None` while actually being set.

### The fix

Reference `finalize_other_specifiers` in its own debug condition, matching the sibling `finalize_bare_specifier` field.