### PR TITLE
chore: remove the unused ScheduledBuild napi struct

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 use rolldown_dev::{
-  BundleState, BundlingFuture, OnAdditionalAssetsCallback, OnHmrUpdatesCallback, OnOutputCallback,
+  BundleState, OnAdditionalAssetsCallback, OnHmrUpdatesCallback, OnOutputCallback,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -263,26 +263,6 @@ impl BindingDevEngine {
       .compile_lazy_entry(module_id, client_id)
       .await
       .map_err(|e| napi::Error::from_reason(format!("Failed to compile lazy entry: {e:#?}")))
-  }
-}
-
-#[napi]
-pub struct ScheduledBuild {
-  future: BundlingFuture,
-  already_scheduled: bool,
-}
-
-#[napi]
-impl ScheduledBuild {
-  #[napi]
-  pub async fn wait(&self) -> napi::Result<()> {
-    self.future.clone().await;
-    Ok(())
-  }
-
-  #[napi]
-  pub fn already_scheduled(&self) -> bool {
-    self.already_scheduled
   }
 }
 

--- a/packages/rolldown/src/binding.cjs
+++ b/packages/rolldown/src/binding.cjs
@@ -634,7 +634,6 @@ module.exports.BindingWatcherBundler = nativeBinding.BindingWatcherBundler
 module.exports.BindingWatcherChangeData = nativeBinding.BindingWatcherChangeData
 module.exports.BindingWatcherEvent = nativeBinding.BindingWatcherEvent
 module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
-module.exports.ScheduledBuild = nativeBinding.ScheduledBuild
 module.exports.TraceSubscriberGuard = nativeBinding.TraceSubscriberGuard
 module.exports.TsconfigCache = nativeBinding.TsconfigCache
 module.exports.BindingAttachDebugInfo = nativeBinding.BindingAttachDebugInfo

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1842,11 +1842,6 @@ export declare class ParallelJsPluginRegistry {
   constructor(workerCount: number)
 }
 
-export declare class ScheduledBuild {
-  wait(): Promise<void>
-  alreadyScheduled(): boolean
-}
-
 export declare class TraceSubscriberGuard {
   close(): void
 }

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -116,7 +116,6 @@ export const BindingWatcherBundler = __napiModule.exports.BindingWatcherBundler
 export const BindingWatcherChangeData = __napiModule.exports.BindingWatcherChangeData
 export const BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
-export const ScheduledBuild = __napiModule.exports.ScheduledBuild
 export const TraceSubscriberGuard = __napiModule.exports.TraceSubscriberGuard
 export const TsconfigCache = __napiModule.exports.TsconfigCache
 export const BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -155,7 +155,6 @@ module.exports.BindingWatcherBundler = __napiModule.exports.BindingWatcherBundle
 module.exports.BindingWatcherChangeData = __napiModule.exports.BindingWatcherChangeData
 module.exports.BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
-module.exports.ScheduledBuild = __napiModule.exports.ScheduledBuild
 module.exports.TraceSubscriberGuard = __napiModule.exports.TraceSubscriberGuard
 module.exports.TsconfigCache = __napiModule.exports.TsconfigCache
 module.exports.BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo


### PR DESCRIPTION
### What this solves

`ScheduledBuild` (a `#[napi]` struct with `wait` / `already_scheduled`) is never constructed: no Rust code builds or returns it, and it has no `#[napi(constructor)]`, so JS cannot instantiate it either. napi-rs does not even emit it into the generated bindings because it never appears in the public API surface, so it is unreachable dead code.

### The change

Remove the struct and its impl, and drop the `BundlingFuture` import that it was the only user of. Rebuilding leaves the generated bindings unchanged and `tsc` still passes, confirming there was no JS-side surface to break.