### PR TITLE
chore: remove the unused From<String>/Display impls for BindingLogLevel

### DIFF
--- a/crates/rolldown_binding/src/types/binding_log_level.rs
+++ b/crates/rolldown_binding/src/types/binding_log_level.rs
@@ -1,5 +1,4 @@
 use napi_derive::napi;
-use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 #[napi]
@@ -9,29 +8,6 @@ pub enum BindingLogLevel {
   #[default]
   Info,
   Debug,
-}
-
-impl From<String> for BindingLogLevel {
-  fn from(value: String) -> Self {
-    match value.as_str() {
-      "silent" => Self::Silent,
-      "warn" => Self::Warn,
-      "info" => Self::Info,
-      "debug" => Self::Debug,
-      _ => panic!("Invalid log level: {value}"),
-    }
-  }
-}
-
-impl Display for BindingLogLevel {
-  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    match self {
-      Self::Silent => write!(f, "silent"),
-      Self::Warn => write!(f, "warn"),
-      Self::Info => write!(f, "info"),
-      Self::Debug => write!(f, "debug"),
-    }
-  }
 }
 
 impl From<BindingLogLevel> for rolldown_common::LogLevel {


### PR DESCRIPTION
### What this solves

`BindingLogLevel` is a `#[napi]` enum that JS passes by its discriminant, so the `From<String>` impl (string to enum) is never called, yet it carried a `panic!("Invalid log level")` on the catch-all arm. The `Display` impl is likewise unused (nothing formats a `BindingLogLevel`). Only the enum itself and `From<BindingLogLevel> for rolldown_common::LogLevel` (used by `normalize_binding_options`) are live.

### The change

Remove the dead `From<String>` and `Display` impls and the now-unused `std::fmt` import, keeping the enum and the `From<BindingLogLevel> for LogLevel` conversion. The napi enum is untouched, so the generated bindings are unchanged and the crate builds clean under `clippy --deny warnings`.