### PR TITLE
chore: remove the dead inline_entry_chunk_wrapping scaffolding

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -1,8 +1,7 @@
 use std::collections::VecDeque;
 
 use rolldown_common::{
-  Chunk, ChunkKind, ConcatenateWrappedModuleKind, EcmaViewMeta, ImportKind, ModuleGroup, ModuleIdx,
-  WrapKind,
+  Chunk, ChunkKind, ConcatenateWrappedModuleKind, ModuleGroup, ModuleIdx, WrapKind,
 };
 use rolldown_utils::rustc_hash::FxHashMapExt;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -24,114 +23,9 @@ impl GenerateStage<'_> {
     }
     for chunk in chunk_graph.chunk_table.iter_mut() {
       if matches!(chunk.kind, ChunkKind::EntryPoint { .. }) {
-        // self.inline_entry_chunk_wrapping(chunk);
         self.concatenate_wrapping_modules(chunk);
-        // Needs to investigate how to merge these two optimization
       }
     }
-  }
-
-  /// Use https://repl.rolldown.rs/#eNptkcFugzAMhl/FyoVWYhndZVKqHneutDOHBjAVEyQohI0J8e6zoaFirYREEv+2P/8eRSnUKCpT4CC/Oj4boe73WOR8bVrrPIyltROUzjYQyVdN8Sg1qcmt6WyNsrbX3aWxhSSZgksM9N+zIDU4zAVY6UHDCQ5JkhypOgrlXY9TLJyt68L+GEmisrpKv8I8iWyw/G+LMMLnTXZufUV9IJCG9AgC7AxCldRDzgnG1AAQLrqqQeN1rZYngM67KvcfA+Y9i8+uQKeA6Tk+pYa+ddICS93XoZGg+diuMNF83lqr78ZmwdhbrbI3OXdkP3f7Bceh751hG4/bxqs40+6fWC9ShuEWAWY+LzDP1kRJ2xVHhBHRXsVEhb4p6yATmbxk6LV8exfTH7g7ybo=
-  /// as an example.
-  /// A entry chunk always has pattern like when strict_execution_order_is_enabled:
-  /// ```js
-  /// // ...snip dependencies wrapping
-  /// var init_entry_module = function() {
-  ///   init_other();
-  /// };
-  /// init_entry_module();
-  /// ```
-  /// We could inline all reachable modules of the entry chunk, except module is a boundary module.
-  /// Here is the definition of boundary module:
-  /// - A module that has symbol used by other chunk, we can't safely eager eval it.
-  /// - A module imported side effects module that has WrapKind::Cjs
-  /// - A commonjs module, a commonjs module can't not be safely eager eval.
-  /// - A es module required by other module
-  /// - All reachable modules of a boundary module in current chunk.
-  // NOTE: Using #[allow] because these methods are conditionally used
-  #[allow(clippy::allow_attributes)]
-  #[allow(dead_code)]
-  fn inline_entry_chunk_wrapping(&mut self, chunk: &Chunk) {
-    // All modules in entry chunk must be reachable from a entry module.
-    let mut boundary_module = chunk
-      .exports_to_other_chunks
-      .keys()
-      .map(|symbol_ref| self.link_output.symbol_db.canonical_ref_for(*symbol_ref).owner)
-      .collect::<FxHashSet<_>>();
-
-    let chunk_modules_set = chunk.modules.iter().copied().collect::<FxHashSet<_>>();
-    for idx in &chunk.modules {
-      let Some(normal_module) = self.link_output.module_table[*idx].as_normal() else {
-        continue;
-      };
-      if normal_module.exports_kind.is_commonjs() {
-        boundary_module.insert(*idx);
-      }
-      let mut bailout_importer = false;
-      normal_module
-        .import_records
-        .iter()
-        .filter_map(|rec| rec.resolved_module.map(|module_idx| (rec, module_idx)))
-        .for_each(|(rec, module_idx)| {
-          if chunk_modules_set.contains(&module_idx) {
-            // 1. `import('./esm.js')` when `code_splitting` is disabled
-            // 2. `require('./esm.js')`
-            if rec.kind == ImportKind::Require || rec.kind == ImportKind::DynamicImport {
-              boundary_module.insert(module_idx);
-            }
-          }
-          let Some(normal) = self.link_output.module_table[module_idx].as_normal() else {
-            return;
-          };
-          if self.link_output.metas[normal.idx].wrap_kind() == WrapKind::Cjs
-            && normal.meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
-          {
-            bailout_importer = true;
-          }
-        });
-
-      if bailout_importer {
-        boundary_module.insert(*idx);
-      }
-    }
-
-    self.expand_boundary(&mut boundary_module, &chunk_modules_set);
-    for module_idx in &chunk.modules {
-      if boundary_module.contains(module_idx) {
-        // If the module is a boundary module, we can't inline it.
-        continue;
-      }
-      if self.link_output.metas[*module_idx].wrap_kind() == WrapKind::Esm {
-        self.link_output.metas[*module_idx].update_wrap_kind(WrapKind::None);
-      }
-    }
-  }
-
-  // NOTE: Using #[allow] because these methods are conditionally used
-  #[allow(clippy::allow_attributes)]
-  #[allow(dead_code)]
-  fn expand_boundary(
-    &self,
-    boundary_modules: &mut FxHashSet<ModuleIdx>,
-    chunk_modules: &FxHashSet<ModuleIdx>,
-  ) {
-    let mut visited = FxHashSet::default();
-    let mut q = std::mem::take(boundary_modules).into_iter().collect::<VecDeque<_>>();
-    while let Some(module_idx) = q.pop_front() {
-      if visited.contains(&module_idx) {
-        continue;
-      }
-      visited.insert(module_idx);
-      let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
-        continue;
-      };
-      module.import_records.iter().filter_map(|rec| rec.resolved_module).for_each(|importee_idx| {
-        if chunk_modules.contains(&importee_idx) {
-          q.push_back(importee_idx);
-        }
-      });
-    }
-    *boundary_modules = visited;
   }
 
   fn concatenate_wrapping_modules(&mut self, chunk: &mut Chunk) {


### PR DESCRIPTION
### What this solves

`inline_entry_chunk_wrapping` and `expand_boundary` in `on_demand_wrapping.rs` are never executed: the only call site is commented out, the active entry path uses `concatenate_wrapping_modules`, and both functions are annotated `#[allow(dead_code)]`. They were kept as scaffolding for an alternative on-demand-wrapping optimization that was never wired up.

### The change

Remove both functions (and their doc block), the commented-out call and its stale "needs to investigate" note in `on_demand_wrapping`, and the imports (`EcmaViewMeta`, `ImportKind`) that only they used. The live `concatenate_wrapping_modules` path is untouched: clippy is clean and the full integration suite passes with zero snapshot drift.
