### PR TITLE
chore: drop the redundant visited.insert in manual code splitting

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -859,8 +859,6 @@ fn add_module_and_dependencies_to_group_recursively(
     return;
   }
 
-  visited.insert(module_idx);
-
   module_group.add_module(module_idx, module_table);
   if recursively {
     for dep in &module_metas[module_idx].dependencies {


### PR DESCRIPTION
### What this solves

In `add_module_and_dependencies_to_group_recursively`, `module_idx` is already inserted into `visited` at the top (`let is_visited = !visited.insert(module_idx)`), and the early returns in between never remove it. The second `visited.insert(module_idx)` later in the function therefore always re-inserts an element that is already present, a no-op.

### The change

Remove the redundant insert. Behavior is unchanged: the crate builds clean under `clippy --deny warnings` and the full integration suite passes with zero snapshot drift.