### PR TITLE
chore: remove never-constructed MatchImportKind::_Ignore variant

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -66,26 +66,16 @@ impl PartialEq for MatchImportKindNormal {
 #[derive(Debug, PartialEq, Eq)]
 #[expect(clippy::box_collection)]
 pub enum MatchImportKind {
-  /// The import is either external or not defined.
-  _Ignore,
   // "sourceIndex" and "ref" are in use
   Normal(MatchImportKindNormal),
   // "namespaceRef" and "alias" are in use
-  Namespace {
-    namespace_ref: SymbolRef,
-  },
+  Namespace { namespace_ref: SymbolRef },
   // Both "matchImportNormal" and "matchImportNamespace"
-  NormalAndNamespace {
-    namespace_ref: SymbolRef,
-    alias: CompactStr,
-  },
+  NormalAndNamespace { namespace_ref: SymbolRef, alias: CompactStr },
   // The import could not be evaluated due to a cycle
   Cycle,
   // The import resolved to multiple symbols via "export * from"
-  Ambiguous {
-    symbol_ref: SymbolRef,
-    potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>>,
-  },
+  Ambiguous { symbol_ref: SymbolRef, potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>> },
   NoMatch,
 }
 
@@ -928,7 +918,7 @@ impl BindImportsAndExportsContext<'_> {
       );
       tracing::trace!("Got match result {:?}", ret);
       match ret {
-        MatchImportKind::_Ignore | MatchImportKind::Cycle => {}
+        MatchImportKind::Cycle => {}
         MatchImportKind::Ambiguous { symbol_ref, potentially_ambiguous_symbol_refs } => {
           let importee = self.index_modules[resolved_module_idx].stable_id().to_string();
 


### PR DESCRIPTION
### What

Removes the `MatchImportKind::_Ignore` enum variant from `bind_imports_and_exports.rs` and drops it from the only match arm that referenced it (`MatchImportKind::_Ignore | MatchImportKind::Cycle => {}` becomes `MatchImportKind::Cycle => {}`).

### Why

The `_Ignore` variant was never constructed anywhere in the codebase. Its only two occurrences were the definition itself and a single match arm, so that arm could never be reached. Removing it deletes genuinely dead code and slightly simplifies the match.

Note: `_Ignore` carried the only doc comment in the enum, which is what kept rustfmt formatting every struct-like variant in the expanded multi-line style. With it gone, rustfmt collapses `Namespace`, `NormalAndNamespace`, and `Ambiguous` onto single lines. That reformatting is an unavoidable consequence of the removal under the repo's rustfmt config, not a deliberate style change.
