### PR TITLE
chore(deps): bump oxc_resolver to 11.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "11.21.3"
+version = "11.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5400dea5053fe933683bcfc63cfd6025a9826748a9ecf2da37892d2993da57"
+checksum = "a73a86454f0d1c18deb29396e0eb2a932b552f710d13e42f6536321d1f1326d8"
 dependencies = [
  "cfg-if",
  "compact_str",
@@ -1897,6 +1897,7 @@ dependencies = [
  "fast-glob",
  "indexmap",
  "json-strip-comments",
+ "memchr",
  "nodejs-built-in-modules",
  "once_cell",
  "percent-encoding",
@@ -1915,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.21.3"
+version = "11.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3561cdc54c4a3c7391499cd9971fbcde281ca989e85f591fff5b3495605187"
+checksum = "0d8423812b86f08eb1f5cfbaa7bd04682f5e3e343788d8ed482d59397c2d9d44"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,10 +271,10 @@ oxc_index = { version = "5", features = [
   "rayon",
   "serde",
 ] } # https://github.com/oxc-project/oxc-index-vec
-oxc_resolver = { version = "11.21.3", features = [
+oxc_resolver = { version = "11.22.0", features = [
   "yarn_pnp",
 ] } # https://github.com/oxc-project/oxc-resolver
-oxc_resolver_napi = { version = "11.21.3", default-features = false, features = ["yarn_pnp"] }
+oxc_resolver_napi = { version = "11.22.0", default-features = false, features = ["yarn_pnp"] }
 oxc_sourcemap = { version = "8.0.1" } # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.dev]

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -37,7 +37,7 @@ pub struct Resolver<Fs: FileSystem = OsFileSystem> {
   package_json_cache: FxDashMap<PathBuf, Arc<PackageJson>>,
 }
 
-impl<Fs: FileSystem + Clone> Resolver<Fs> {
+impl<Fs: FileSystem + Clone + 'static> Resolver<Fs> {
   /// Creates a new resolver with the specified options.
   pub fn new(
     fs: Fs,


### PR DESCRIPTION
Bumps `oxc_resolver` and `oxc_resolver_napi` from `11.21.3` to `11.22.0`.

## Binary size

Release `.node` binding (`librolldown_binding.dylib`, fat-LTO + `strip = "symbols"` — the shipped artifact):

| version | size |
| --- | --- |
| 11.21.3 | 17,172,368 bytes |
| 11.22.0 | 16,327,728 bytes |
| **Δ** | **−844,640 bytes (−824.8 KiB, −4.92%)** |

The reduction comes from 11.22.0 type-erasing the filesystem into a non-generic `ResolverImpl` core (collapsing monomorphized resolver copies) plus its reduced tsconfig-paths code size. The size delta is cleanly attributable: the only lockfile change is the two resolver crates (`memchr` was already present transitively — it powers the new SIMD fast-reject — so no new crates are pulled in).

## Code change

The type-erasure requires `Fs: 'static` at resolver construction, so `Resolver::new` in `rolldown_resolver` gains a `'static` bound — matching the convention already used by every downstream consumer (`ScanStage`, `Bundle`, `ModuleLoader`, …):

```rust
-impl<Fs: FileSystem + Clone> Resolver<Fs> {
+impl<Fs: FileSystem + Clone + 'static> Resolver<Fs> {
```

## Performance

No measurable end-to-end change on the criterion bundle benches (threejs / rome_ts): the 11.22.0 resolver speedups (skipped UTF-8 validation on hot paths, SIMD fast-reject, fewer allocations) are micro-optimizations on the resolution hot path, which is a small fraction of total bundle time, so they sit below the bench noise floor.
