### PR TITLE
refactor: drop redundant program scope enter/leave in finalizer

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -9,7 +9,6 @@ use oxc::{
     match_member_expression,
   },
   ast_visit::{VisitMut, walk_mut},
-  semantic::ScopeFlags,
   span::{SPAN, Span},
 };
 use oxc_str::CompactStr;
@@ -143,18 +142,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       }
     });
 
-    self.enter_scope(
-      {
-        let mut flags = ScopeFlags::Top;
-        if program.source_type.is_strict() || program.has_use_strict_directive() {
-          flags |= ScopeFlags::StrictMode;
-        }
-        flags
-      },
-      &program.scope_id,
-    );
     walk_mut::walk_program(self, program);
-    self.leave_scope();
 
     // Insert keep_name statements for top-level declarations
     self.insert_keep_name_statements(&mut program.body);


### PR DESCRIPTION
### What

In `ScopeHoistingFinalizer::visit_program`, removes the manual `enter_scope` / `leave_scope` pair wrapped around `walk_mut::walk_program`, plus the now-unused `semantic::ScopeFlags` import.

### Why

`walk_mut::walk_program` already calls `enter_scope` and `leave_scope` internally, using the exact same scope-flag computation (`ScopeFlags::Top`, with `StrictMode` added when the program is strict or has a `"use strict"` directive) and the same `scope_id`. The manual wrapper duplicated that, so `enter_scope` / `leave_scope` ran twice per program.

The duplication was harmless because the finalizer's `enter_scope` / `leave_scope` only derive two boolean states (`TopLevel`, `IsRootLevel`) via `scope_stack.iter().rev().all(...)` predicates, and pushing the same `Top` flag twice does not change an `.all()` result. Nothing reads the stack depth or length. Removing the redundant wrapper keeps behavior identical while dropping dead nesting.