### PR TITLE
refactor: drop redundant is_user_defined filter on partitioned entries

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -399,7 +399,7 @@ impl LinkStage<'_> {
         .into_values()
         .flatten()
         .partition(|item| item.kind.is_user_defined());
-    user_defined_entries.iter().filter(|entry| entry.kind.is_user_defined()).for_each(|entry| {
+    user_defined_entries.iter().for_each(|entry| {
       let module = match &self.module_table[entry.idx] {
         Module::Normal(module) => module,
         Module::External(_module) => {


### PR DESCRIPTION
### What

In `include_statements`, removes the `.filter(|entry| entry.kind.is_user_defined())` applied to `user_defined_entries`.

### Why

`user_defined_entries` is produced by `partition(|item| item.kind.is_user_defined())`, so every element in it already satisfies `is_user_defined()`. Filtering it again on the same predicate always passes everything through, making the call a no-op. The `partition` itself stays because `dynamic_entries` (the other half) is still used.