### PR TITLE
chore: remove commented-out re_export_all_names field

### DIFF
--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -49,7 +49,6 @@ pub struct LinkingMetadata {
   wrap_kind: WrapKind,
   // Store the export info for each module, including export named declaration and export star declaration.
   pub resolved_exports: FxHashMap<CompactStr, ResolvedExport>,
-  // pub re_export_all_names: FxHashSet<CompactStr>,
   /// Store the names of exclude ambiguous resolved exports.
   /// It will be used to generate chunk exports and module namespace binding.
   /// The second element means if the export is came from commonjs module.


### PR DESCRIPTION
### What

Removes the commented-out `// pub re_export_all_names: FxHashSet<CompactStr>,` field from `LinkingMetadata`.

### Why

The field is fully commented out and has no other references anywhere in the workspace, so it is dead. Removing the stale line keeps the struct definition clean. `FxHashSet` is still imported and used by another field, so the import is untouched.