### PR TITLE
chore: remove unused ExpressionExt methods

### DIFF
--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/expression_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/expression_ext.rs
@@ -3,14 +3,10 @@ use oxc::ast::ast::Str;
 
 pub trait ExpressionExt<'ast> {
   fn as_call_expression(&self) -> Option<&ast::CallExpression<'ast>>;
-  fn as_call_expression_mut(&mut self) -> Option<&mut ast::CallExpression<'ast>>;
 
   fn as_identifier(&self) -> Option<&ast::IdentifierReference<'ast>>;
   fn as_identifier_mut(&mut self) -> Option<&mut ast::IdentifierReference<'ast>>;
-  fn as_unary_expression(&self) -> Option<&ast::UnaryExpression<'ast>>;
   fn as_string_literal(&self) -> Option<&ast::StringLiteral<'ast>>;
-  fn as_binary_expression(&self) -> Option<&ast::BinaryExpression<'ast>>;
-  fn as_static_member_expr_mut(&mut self) -> Option<&mut ast::StaticMemberExpression<'ast>>;
   fn as_static_module_request(&self) -> Option<Str<'ast>>;
 
   fn is_import_meta(&self) -> bool;
@@ -24,23 +20,12 @@ impl<'ast> ExpressionExt<'ast> for ast::Expression<'ast> {
     if let ast::Expression::CallExpression(call_expr) = self { Some(call_expr) } else { None }
   }
 
-  fn as_call_expression_mut(&mut self) -> Option<&mut ast::CallExpression<'ast>> {
-    if let ast::Expression::CallExpression(call_expr) = self { Some(call_expr) } else { None }
-  }
-
   fn as_identifier(&self) -> Option<&ast::IdentifierReference<'ast>> {
     if let ast::Expression::Identifier(ident) = self { Some(ident) } else { None }
   }
 
   fn as_identifier_mut(&mut self) -> Option<&mut ast::IdentifierReference<'ast>> {
     if let ast::Expression::Identifier(ident) = self { Some(ident) } else { None }
-  }
-
-  fn as_unary_expression(&self) -> Option<&ast::UnaryExpression<'ast>> {
-    let ast::Expression::UnaryExpression(expr) = self else {
-      return None;
-    };
-    Some(expr)
   }
 
   fn as_string_literal(&self) -> Option<&ast::StringLiteral<'ast>> {
@@ -56,13 +41,6 @@ impl<'ast> ExpressionExt<'ast> for ast::Expression<'ast> {
       ast::Expression::TemplateLiteral(request) => request.single_quasi(),
       _ => None,
     }
-  }
-
-  fn as_binary_expression(&self) -> Option<&ast::BinaryExpression<'ast>> {
-    let ast::Expression::BinaryExpression(expr) = self else {
-      return None;
-    };
-    Some(expr)
   }
 
   /// // Check if the expression is `import.meta`
@@ -87,13 +65,5 @@ impl<'ast> ExpressionExt<'ast> for ast::Expression<'ast> {
   fn is_import_meta_hot_accept(&self) -> bool {
     matches!(self, ast::Expression::StaticMemberExpression(member_expr)
     if member_expr.property.name == "accept" && member_expr.object.is_import_meta_hot())
-  }
-
-  fn as_static_member_expr_mut(&mut self) -> Option<&mut ast::StaticMemberExpression<'ast>> {
-    if let ast::Expression::StaticMemberExpression(member_expr) = self {
-      Some(member_expr)
-    } else {
-      None
-    }
   }
 }


### PR DESCRIPTION
### What

Removes four methods from the `ExpressionExt` trait (declaration plus impl) in `rolldown_ecmascript_utils`:

- `as_call_expression_mut`
- `as_unary_expression`
- `as_binary_expression`
- `as_static_member_expr_mut`

### Why

None of these four methods have any callers anywhere in the workspace. `ExpressionExt` is an internal utility trait, so the unused entries are dead code. The remaining methods (`as_call_expression`, `as_identifier`, `as_string_literal`, `as_static_module_request`, the `is_import_meta*` checks, and so on) are still used, so the trait and its imports stay. The crate and its main consumer both compile cleanly after the removal.