### PR TITLE
chore: remove unused StatementExt methods

### DIFF
--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/statement_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/statement_ext.rs
@@ -1,26 +1,17 @@
 use oxc::ast::ast;
 
 pub trait StatementExt<'me, 'ast> {
-  fn is_import_declaration(&self) -> bool;
   fn as_import_declaration(&'me self) -> Option<&'me ast::ImportDeclaration<'ast>>;
   fn as_export_default_declaration_mut(
     &'me mut self,
   ) -> Option<&'me mut ast::ExportDefaultDeclaration<'ast>>;
   fn as_export_all_declaration(&self) -> Option<&ast::ExportAllDeclaration<'ast>>;
-  fn as_export_named_declaration(&self) -> Option<&ast::ExportNamedDeclaration<'ast>>;
   fn as_export_named_declaration_mut(&mut self) -> Option<&mut ast::ExportNamedDeclaration<'ast>>;
-
-  fn is_function_declaration(&self) -> bool;
-  fn as_function_declaration(&self) -> Option<&ast::Function<'ast>>;
 
   fn is_module_declaration_with_source(&self) -> bool;
 }
 
 impl<'ast> StatementExt<'_, 'ast> for ast::Statement<'ast> {
-  fn is_import_declaration(&self) -> bool {
-    matches!(self, ast::Statement::ImportDeclaration(_))
-  }
-
   fn as_import_declaration(&self) -> Option<&ast::ImportDeclaration<'ast>> {
     if let ast::Statement::ImportDeclaration(import_decl) = self {
       return Some(&**import_decl);
@@ -44,26 +35,11 @@ impl<'ast> StatementExt<'_, 'ast> for ast::Statement<'ast> {
     None
   }
 
-  fn as_export_named_declaration(&self) -> Option<&ast::ExportNamedDeclaration<'ast>> {
-    if let ast::Statement::ExportNamedDeclaration(export_named_decl) = self {
-      return Some(&**export_named_decl);
-    }
-    None
-  }
-
   fn as_export_named_declaration_mut(&mut self) -> Option<&mut ast::ExportNamedDeclaration<'ast>> {
     if let ast::Statement::ExportNamedDeclaration(export_named_decl) = self {
       return Some(&mut **export_named_decl);
     }
     None
-  }
-
-  fn as_function_declaration(&self) -> Option<&ast::Function<'ast>> {
-    if let ast::Statement::FunctionDeclaration(func_decl) = self { Some(func_decl) } else { None }
-  }
-
-  fn is_function_declaration(&self) -> bool {
-    self.as_function_declaration().is_some()
   }
 
   /// Check if the statement is `[import|export] ... from ...` or `export ... from ...`


### PR DESCRIPTION
### What

Removes four methods from the `StatementExt` trait (declaration plus impl) in `rolldown_ecmascript_utils`:

- `is_import_declaration`
- `as_export_named_declaration`
- `as_function_declaration`
- `is_function_declaration`

### Why

None of these four methods have any callers in the workspace. `as_function_declaration` was only called by `is_function_declaration`, which itself is unused, so both go together. `StatementExt` is an internal utility trait, so the unused entries are dead code. The remaining methods (`as_import_declaration`, `as_export_default_declaration_mut`, `as_export_all_declaration`, `as_export_named_declaration_mut`, `is_module_declaration_with_source`) are still used, so the trait and its import stay. The crate and its main consumer both compile cleanly after the removal.
