### PR TITLE
chore: remove dead Diagnostic::with_kind method

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -186,12 +186,6 @@ impl Diagnostic {
     self.convert_to_string(true)
   }
 
-  #[must_use]
-  pub fn with_kind(mut self, kind: String) -> Self {
-    self.kind = kind;
-    self
-  }
-
   /// Get the primary location information from the first label if available
   /// Returns (file_path, line, column, utf16_position)
   pub fn get_primary_location(&self) -> Option<(String, usize, usize, usize)> {


### PR DESCRIPTION
### What

Removes the `Diagnostic::with_kind` builder method from `rolldown_error`.

### Why

The method has no callers anywhere in the workspace. `rolldown_error` is an internal crate, so this dead `pub fn` is just unused surface. Removing it keeps the `Diagnostic` API to what is actually used.