### PR TITLE
chore: remove unused From impl for RolldownLabelSpan

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -26,12 +26,6 @@ impl From<ArcStr> for DiagnosticFileId {
 #[derive(Debug, Clone)]
 pub struct RolldownLabelSpan(DiagnosticFileId, Range<usize>);
 
-impl From<(DiagnosticFileId, Range<usize>)> for RolldownLabelSpan {
-  fn from((id, range): (DiagnosticFileId, Range<usize>)) -> Self {
-    Self(id, range)
-  }
-}
-
 impl ariadne::Span for RolldownLabelSpan {
   type SourceId = DiagnosticFileId;
 


### PR DESCRIPTION
### What

Removes the `From<(DiagnosticFileId, Range<usize>)>` impl for `RolldownLabelSpan` in `rolldown_error`.

### Why

The impl has no callers. Both construction sites for `RolldownLabelSpan` use the tuple-struct syntax `RolldownLabelSpan(id, range)` directly, and nothing in the workspace converts a `(DiagnosticFileId, Range<usize>)` tuple via `.into()` or `RolldownLabelSpan::from(..)`. The `Range` import is still used by the struct definition, so it stays.
