### PR TITLE
perf: disable preserve_parens across all parse paths

### DIFF
--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -324,7 +324,11 @@ pub fn enhanced_transform(
 
   let allocator = Allocator::default();
   let parse_ret = Parser::new(&allocator, &source, source_type)
-    .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
+    .with_options(ParseOptions {
+      allow_return_outside_function: true,
+      preserve_parens: false,
+      ..Default::default()
+    })
     .parse();
   if parse_ret.panicked || !parse_ret.diagnostics.is_empty() {
     append_oxc_diagnostics(parse_ret.diagnostics, &source, filename, &mut warnings, &mut errors);

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -29,6 +29,7 @@ impl EcmaCompiler {
       ProgramCell::try_new(ProgramCellOwner { source: source.clone(), allocator }, |owner| {
         let parser = Parser::new(&owner.allocator, &owner.source, ty).with_options(ParseOptions {
           allow_return_outside_function: true,
+          preserve_parens: false,
           ..ParseOptions::default()
         });
         let ret = parser.parse();
@@ -57,7 +58,8 @@ impl EcmaCompiler {
     let inner =
       ProgramCell::try_new(ProgramCellOwner { source: source.clone(), allocator }, |owner| {
         let builder = AstBuilder::new(&owner.allocator);
-        let parser = Parser::new(&owner.allocator, &owner.source, ty);
+        let parser = Parser::new(&owner.allocator, &owner.source, ty)
+          .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() });
         let ret = parser.parse_expression();
         match ret {
           Ok(expr) => {
@@ -116,7 +118,10 @@ impl EcmaCompiler {
     minify_options: MinifierOptions,
     codegen_options: CodegenOptions,
   ) -> (String, Option<SourceMap<'static>>) {
-    let mut program = Parser::new(allocator, source_text, source_type).parse().program;
+    let mut program = Parser::new(allocator, source_text, source_type)
+      .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+      .parse()
+      .program;
     let minifier = Minifier::new(minify_options);
     let ret = if compress {
       minifier.minify(allocator, &mut program)

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -80,7 +80,12 @@ impl Plugin for ViteDynamicImportVarsPlugin {
         ModuleType::Tsx => oxc::span::SourceType::tsx(),
         _ => unreachable!(),
       };
-      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
+      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type)
+        .with_options(oxc::parser::ParseOptions {
+          preserve_parens: false,
+          ..oxc::parser::ParseOptions::default()
+        })
+        .parse();
       if parser_ret.panicked
         && let Some(err) =
           parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -41,7 +41,12 @@ impl Plugin for ViteImportGlobPlugin {
         ModuleType::Tsx => oxc::span::SourceType::tsx(),
         _ => unreachable!(),
       };
-      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
+      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type)
+        .with_options(oxc::parser::ParseOptions {
+          preserve_parens: false,
+          ..oxc::parser::ParseOptions::default()
+        })
+        .parse();
       if parser_ret.panicked
         && let Some(err) =
           parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
-use oxc::parser::Parser;
+use oxc::parser::{ParseOptions, Parser};
 use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
 use rolldown_ecmascript::semantic_builder_for_transform;
@@ -59,7 +59,9 @@ impl Plugin for ViteTransformPlugin {
       self.get_modified_transform_options(&ctx, args.id, &cwd, extension, args.code)?;
 
     let allocator = oxc::allocator::Allocator::default();
-    let ret = Parser::new(&allocator, args.code, source_type).parse();
+    let ret = Parser::new(&allocator, args.code, source_type)
+      .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+      .parse();
     if ret.panicked || !ret.diagnostics.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.diagnostics,


### PR DESCRIPTION
### What

Sets `preserve_parens: false` on every parser rolldown controls, so the oxc parser no longer emits a `ParenthesizedExpression` wrapper node for each `(expr)` in source:

- `EcmaCompiler::parse` — the primary JS/TS module parse
- `EcmaCompiler::parse_expr_as_program` — text / base64 / data-url modules
- `EcmaCompiler::dce_or_minify` — DCE / minify input (DCE already strips these, so this is a micro-opt that avoids allocating nodes that get removed anyway)
- `enhanced_transform` — the oxc transform path
- the vite `transform`, `import-glob`, and `dynamic-import-vars` plugins

Test-only and benchmark parsers (`cjs_export_analyzer` tests, sourcemap tests, side-effect-detector tests) are intentionally left untouched.

### Why

The wrapper nodes carry nothing codegen needs. In oxc, `GenExpr for ParenthesizedExpression` just delegates to the inner expression and re-derives parentheses from operator precedence:

```rust
impl GenExpr for ParenthesizedExpression<'_> {
    fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
        self.expression.print_expr(p, precedence, ctx);
    }
}
```

So emitted code is identical whether or not the wrappers exist — the flag only affects the in-memory AST shape. Dropping them means fewer AST nodes to allocate and traverse in every scanner / finalizer / visitor pass, and removes an AST-shape inconsistency (DCE already stripped these nodes when tree-shaking ran, so the parsed AST previously differed depending on whether tree-shaking was enabled).

### Note

The existing paren-peeling helpers (`ast_scanner`, `generate_lazy_export`, the vite build-import-analysis plugin, `side_effect_detector::get_inner_expression`) are kept: paren nodes can still enter the AST via plugin `transform_ast` hooks that parse with their own options, and via internal synthesis in `rolldown_ecmascript_utils/src/ast_factory.rs`. `get_inner_expression` also peels TS `as` / `satisfies` / `!` wrappers, so it is needed regardless.

### Test

- Rust integration suite (`cargo test -p rolldown --test integration`, 1778 fixtures) with snapshots on: all pass with **zero** snapshot changes — output is byte-for-byte identical.
- Node fixtures for the three vite plugins (`import-glob`, `dynamic-import-vars`, `transform` / `ecma-transform`) and the transform paths all pass.