### PR TITLE
fix(dev): disable lazy barrel in dev mode

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -272,9 +272,14 @@ pub fn prepare_build_context(
       .unwrap_or_default(),
   );
 
+  let mut raw_treeshake = raw_options.treeshake;
   let mut experimental = raw_options.experimental.unwrap_or_default();
   if experimental.dev_mode.is_some() {
     experimental.incremental_build = Some(true);
+    // Dev mode requires treeshaking to be disabled, and lazy barrel relies on
+    // treeshaking, so it must be disabled as well.
+    raw_treeshake = TreeshakeOptions::Boolean(false);
+    experimental.lazy_barrel = Some(false);
   }
 
   if experimental.attach_debug_info.is_none() {
@@ -299,12 +304,6 @@ pub fn prepare_build_context(
   );
   let cwd =
     raw_options.cwd.unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
-
-  let mut raw_treeshake = raw_options.treeshake;
-  if experimental.dev_mode.is_some() {
-    // Dev mode requires treeshaking to be disabled
-    raw_treeshake = TreeshakeOptions::Boolean(false);
-  }
 
   let tsconfig = raw_options.tsconfig.map(|tsconfig| tsconfig.with_base(&cwd)).unwrap_or_default();
   let yarn_pnp = raw_resolve.yarn_pnp.unwrap_or(false);


### PR DESCRIPTION
## What is this PR solving?

Dev mode (`experimental.devMode`) requires treeshaking to be disabled. We already force `treeshake` off when `experimental.dev_mode.is_some()` in `prepare_build_context`.

The `lazy_barrel` optimization is a form of treeshaking for barrel (re-export) files: it lazily tracks and prunes re-exports based on what is actually used. It is enabled by default (`is_lazy_barrel_enabled()` returns `true` when the option is `None`). This means that in dev mode, treeshaking is off but lazy barrel is still on, which is inconsistent and can lead to incorrect behavior.

This PR forces `lazy_barrel` off whenever dev mode is enabled. While doing so, the two separate `experimental.dev_mode.is_some()` checks (one forcing `incremental_build` on, the other forcing `treeshake` off) are merged into a single block, so all dev-mode overrides live in one place.

## Changes

`crates/rolldown/src/utils/prepare_build_context.rs`:

```rust
let mut raw_treeshake = raw_options.treeshake;
let mut experimental = raw_options.experimental.unwrap_or_default();
if experimental.dev_mode.is_some() {
  experimental.incremental_build = Some(true);
  // Dev mode requires treeshaking to be disabled, and lazy barrel relies on
  // treeshaking, so it must be disabled as well.
  raw_treeshake = TreeshakeOptions::Boolean(false);
  experimental.lazy_barrel = Some(false);
}
```

Because `is_lazy_barrel_enabled()` reads `self.lazy_barrel.unwrap_or(true)`, setting it to `Some(false)` forces the feature off, overriding the default-on behavior. All downstream call sites (`module_task`, `module_loader`, `flat_options`) go through `is_lazy_barrel_enabled()`, so this single override turns the feature off everywhere for dev mode.

## Why do it here?

This block already normalizes dev-mode-specific overrides, and it runs before `flat_options` and the module loader read the flag, so the override takes effect for the whole build. Keeping the `treeshake`, `incremental_build`, and `lazy_barrel` decisions in one obvious block makes the shared reason explicit. `raw_treeshake` is declared just above the block (it only depends on `raw_options.treeshake`), so pulling it up to merge the two checks is safe.