### PR TITLE
feat: disable `experimental.lazyBarrel` by default

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -123,6 +123,6 @@ impl ExperimentalOptions {
   }
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
-    self.lazy_barrel.unwrap_or(true)
+    self.lazy_barrel.unwrap_or(false)
   }
 }

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -244,13 +244,13 @@ If the loaded modules (`a.js`, `b.js`, etc.) are also barrel modules, lazy barre
 
 ## Configuration
 
-Lazy barrel optimization is enabled by default. You can temporarily disable it in your Rolldown configuration:
+Lazy barrel optimization is currently disabled by default. You can enable it in your Rolldown configuration:
 
 ```js
 // rolldown.config.js
 export default {
   experimental: {
-    lazyBarrel: false,
+    lazyBarrel: true,
   },
 };
 ```

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -715,7 +715,7 @@ export interface InputOptions {
      * describing your use case so we can address it before the option is gone.
      *
      * @see {@link https://rolldown.rs/in-depth/lazy-barrel-optimization | Lazy Barrel Documentation}
-     * @default true
+     * @default false
      */
     lazyBarrel?: boolean;
   };


### PR DESCRIPTION
## Description

This PR temporarily disables `experimental.lazyBarrel` by default again (back to opt-in).

Only one unresolved issue is left: a `strictExecutionOrder` tree shaking issue, which is the root cause of the lazy barrel runtime error. Even though it could be fixed quickly, it doesn't hurt to turn the option off today and re-enable it by default in a future release once that issue is resolved. Users who want the optimization can still opt in explicitly.

This reverts the default flip introduced in #9632 (`feat: enable experimental.lazyBarrel by default`). The option itself is unchanged, only its default value goes from `true` back to `false`.

Users who still want lazy barrel optimization can enable it:

```js
export default {
  experimental: {
    lazyBarrel: true,
  },
};
```

## Changes

- Default `experimental.lazyBarrel` to `false` in `is_lazy_barrel_enabled`.
- Update the `@default` JSDoc tag on the `lazyBarrel` option to `false`.
- Update the lazy barrel docs to reflect that it is now disabled by default and document how to opt in.