### PR TITLE
test: failing test for default-import of re-exported external in cjs (#10069)

### DIFF
--- a/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/_config.json
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "external": ["node:https"],
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/_test.mjs
@@ -1,0 +1,6 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
+const assert = require('assert');
+const https = require('node:https');
+const { getAgentCtor } = require('./dist/main.js');
+
+assert.strictEqual(getAgentCtor(), https.Agent);

--- a/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/main.js
@@ -1,0 +1,5 @@
+import { node_https } from './reexport.js';
+
+export function getAgentCtor() {
+	return node_https.Agent;
+}

--- a/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/main.js
@@ -1,5 +1,5 @@
 import { node_https } from './reexport.js';
 
 export function getAgentCtor() {
-	return node_https.Agent;
+  return node_https.Agent;
 }

--- a/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/reexport.js
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_default_import_of_external_cjs/reexport.js
@@ -1,0 +1,3 @@
+import node_https from 'node:https';
+
+export { node_https };


### PR DESCRIPTION
Adds a failing integration test for #10069. Reproduces on current `main` (1.1.3).