### PR TITLE
fix: preserve sourcemap mappings for indented lines when a CJS module shares the chunk

### DIFF
--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -69,11 +69,11 @@ assert.equal(import_cjs.a, void 0);
 (0:7) "exports = " --> (20:8) "exports = "
 (0:17) "1;\n" --> (20:18) "1;\n"
 - ../esm-import-cjs-require.js
-(3:0) "assert.equal(a, undefined);\n" --> (25:0) "assert."
-(3:0) "assert.equal(a, undefined);\n" --> (25:7) "equal("
-(3:0) "assert.equal(a, undefined);\n" --> (25:13) "import_cjs."
-(3:0) "assert.equal(a, undefined);\n" --> (25:24) "a, "
-(3:0) "assert.equal(a, undefined);\n" --> (25:27) "void "
-(3:0) "assert.equal(a, undefined);\n" --> (25:32) "0"
-(3:0) "assert.equal(a, undefined);\n" --> (25:33) ");\n"
+(3:0) "assert." --> (25:0) "assert."
+(3:7) "equal(" --> (25:7) "equal("
+(3:13) "a, " --> (25:13) "import_cjs."
+(3:13) "a, " --> (25:24) "a, "
+(3:16) "undefined" --> (25:27) "void "
+(3:16) "undefined" --> (25:32) "0"
+(3:25) ");\n" --> (25:33) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/_config.json
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/_config.json
@@ -1,0 +1,4 @@
+{
+  "visualizeSourcemap": true,
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/app.js
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/app.js
@@ -1,0 +1,4 @@
+export function app() {
+  globalThis.side = 1;
+  return 42;
+}

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/artifacts.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region app.js
+var import_dep = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports.hello = function() {
+		return "hi";
+	};
+})))();
+function app() {
+	globalThis.side = 1;
+	return 42;
+}
+//#endregion
+//#region main.js
+globalThis.h = import_dep.hello;
+globalThis.a = app;
+//#endregion
+
+//# sourceMappingURL=main.js.map
+```
+
+# Sourcemap Visualizer
+
+```
+- ../dep.cjs
+(0:0) "module." --> (5:1) "module."
+(0:7) "exports." --> (5:8) "exports."
+(0:15) "hello = " --> (5:16) "hello = "
+(0:23) "function () " --> (5:24) "function() "
+(0:35) "{\n" --> (5:35) "{\n"
+(1:2) "return " --> (6:2) "return "
+(1:9) "'hi';\n" --> (6:9) "\"hi\";\n"
+(2:0) "};\n" --> (7:1) "};\n"
+- ../app.js
+(0:0) "export function " --> (9:0) "function "
+(0:16) "app() " --> (9:9) "app() "
+(0:22) "{\n" --> (9:15) "{\n"
+(1:2) "globalThis." --> (10:1) "globalThis."
+(1:13) "side = " --> (10:12) "side = "
+(1:20) "1;\n" --> (10:19) "1;\n"
+(2:2) "return " --> (11:1) "return "
+(2:9) "42;\n" --> (11:8) "42;\n"
+(3:0) "}\n" --> (12:0) "}\n"
+- ../main.js
+(2:0) "globalThis." --> (15:0) "globalThis."
+(2:11) "h = " --> (15:11) "h = "
+(2:15) "hello;\n" --> (15:15) "import_dep."
+(2:15) "hello;\n" --> (15:26) "hello;\n"
+(3:0) "globalThis." --> (16:0) "globalThis."
+(3:11) "a = " --> (16:11) "a = "
+(3:15) "app;\n" --> (16:15) "app;\n"
+```

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/dep.cjs
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/dep.cjs
@@ -1,0 +1,3 @@
+module.exports.hello = function () {
+  return 'hi';
+};

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/main.js
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/main.js
@@ -1,0 +1,4 @@
+import { hello } from './dep.cjs';
+import { app } from './app.js';
+globalThis.h = hello;
+globalThis.a = app;

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -228,8 +228,12 @@ impl NormalModule {
             mutation.apply(&mut magic_string);
           }
           let code = magic_string.to_string();
+          // `collapse_sourcemaps` walks this map's tokens, so it must match the codegen map's
+          // granularity — the default `Hires::False` maps only each line's column 0 and drops
+          // indented lines' mappings (rolldown#10070).
           let mutated_map = magic_string.source_map(SourceMapOptions {
             source: Arc::clone(&original_code),
+            hires: string_wizard::Hires::Boundary,
             ..Default::default()
           });
           let map = render_output


### PR DESCRIPTION
Workaround fix for #10070

**Problem.** When a CJS module shares a chunk with concatenated ESM modules, the ESM modules lose sourcemap mappings for their indented lines (`globalThis.side = 1` / `return 42` in the repro) — only when the CJS file is present.

**Cause.** A CJS module's require-init is prepended into a concatenated ESM module as a MagicString mutation, and `NormalModule::render` built that mutation map with the default `Hires::False` (one token per line, at column 0). `collapse_sourcemaps` composes by walking the last map's tokens and looking each up in the codegen map per line; the lookup returns `None` (dropping the token) when the line has no token at column ≤ the query. For indented lines the codegen token sits after the indent, so the column-0 query misses.

**Fix.** Build the mutation map with `Hires::Boundary` (a token at every identifier/punctuation boundary — a superset of codegen's columns), so the collapse always finds a match.

**Not the root fix.** `Hires` only controls maps rolldown generates itself; the same drop still happens when `collapse_sourcemaps` walks a coarse map from a plugin's `renderChunk`/`transform` hook. The real fix belongs in `oxc_sourcemap`: approximate to the line's nearest token on a same-line miss instead of returning `None`, as Rollup's `traceSegment` already does.

**Testing.** Added `sourcemap/issue_10070`; app.js body lines now map correctly. Only other snapshot change is `cjs_compat/mix-cjs-esm` — coarse per-line positions become accurate columns (strict improvement).
