### PR TITLE
docs(dev/lazy): update design and implementation

### DIFF
--- a/internal-docs/lazy-compilation/design.md
+++ b/internal-docs/lazy-compilation/design.md
@@ -4,17 +4,17 @@
 
 ## Key Notes (TL;DR)
 
-1. **Transparent UX** - `import('./module')` just works, no user code changes (future goal)
-2. **Dynamic imports only** - static imports always compiled immediately
-3. **`rolldown:exports` contract** - proxy modules export this; POC uses `lazyMagic` helper, later Rolldown runtime will unwrap automatically
-4. **Compilation granularity** - lazy module + all sync deps; nested `import()` become new lazy boundaries
-5. **Dev server returns JS directly** - `/lazy` request returns compiled code, browser loads it as an ES module
-6. **Module IDs** - use **absolute paths** (`module.id`) consistently throughout the runtime
+1. **Transparent UX** - `import('./module')` just works; the plugin rewrites dynamic imports and unwraps proxy exports automatically
+2. **Dynamic imports only** - static imports always compiled immediately. Boundary creation is module-type-blind (see Scope)
+3. **`rolldown:exports` contract** - proxy modules export this named export; the plugin's `transform_ast` chains `.then(__unwrap_lazy_compilation_entry)` onto every dynamic import in non-proxy modules
+4. **Compilation granularity** - lazy module + the sync deps the requesting client has not yet executed; nested `import()` become new lazy boundaries
+5. **Dev server returns JS directly** - `/@vite/lazy` returns the compiled code as a single JS string; the browser loads it as an ES module (only inline sourcemaps survive — see implementation.md)
+6. **Module IDs** - runtime module-map lookups use **stable IDs** (cwd-relative); absolute paths appear only in the `/@vite/lazy?id=` param and the fetched template's `import($MODULE_ID)`
 7. **Proxy module states** - proxies have two states: **not fetched** (stub template) and **fetched** (imports real module)
-8. **Build output refresh** - after lazy compilation, dev engine triggers rebuild to update build output
-9. **Caching** - AST cached internally; duplicate execution across entries is acceptable for POC
-10. **Error handling** - `Err` or panic is fine for POC
-11. **ClientId** - tracks multiple browser tabs/clients
+8. **Build output refresh** - after lazy compilation, the dev engine triggers a background rebuild to update build output; the rebuild is silent to connected clients
+9. **Dedup** - the server prunes modules the client already executed from the lazy patch, and lazy-chunk initializers carry a runtime dedup flag — a shared module never executes twice
+10. **Error handling** - unknown module ids are rejected (security gate, #9969); init errors in lazy modules reject the consumer's `await import()` catchably (#9981)
+11. **ClientId** - browser-generated UUID per tab; selects the per-client `executed_modules` set used to prune the lazy patch
 
 ## What is Lazy Compilation?
 
@@ -26,16 +26,37 @@ Lazy compilation is a **development optimization** that defers compilation of dy
 2. **On-demand compilation** - Code behind `import()` is compiled just-in-time when the browser executes it
 3. **Transparent to users** - No code changes required; `import('./foo')` should just work
 
+## Enabling
+
+Lazy compilation is opt-in, nested inside dev mode:
+
+```js
+export default {
+  experimental: {
+    devMode: { lazy: true },
+  },
+};
+```
+
+- `devMode` alone enables the dev/HMR machinery (`HmrPlugin`); `lazy: true` additionally prepends `LazyCompilationPlugin` before user plugins (`crates/rolldown/src/utils/apply_inner_plugins.rs`).
+- The plugin's `context()` exposes the shared `lazy_entries` / `fetched_entries` sets as a `LazyCompilationContext`, which is handed to the `DevEngine` so it can call `mark_as_fetched` before each lazy compile.
+- rolldown-vite's bundled dev mode enables `lazy: true` by default.
+
 ## Scope
 
 - **Dynamic imports only** (`import()`) - static imports are always compiled
-- **Standalone feature** - Reuses the HMR runtime/rendering path for module output, but does not emit HMR updates
+- **Standalone feature** - Reuses the HMR runtime/rendering path for module output. The `/@vite/lazy` request itself emits no HMR update — but once fetched, the lazy module is an ordinary watched graph module, and later edits to it flow through the normal per-client HMR pipeline (see implementation.md "Editing a fetched lazy module")
+- **Module-type-blind boundary** - `resolve_id` proxies _every_ dynamic import, with no extension or module-type filter, so the real target is not loaded until the first `/@vite/lazy` request. Everything in the compiled unit must render as an ECMAScript AST:
+  - **CSS** - unsupported in rolldown (removed, #4271); lazy compilation _defers_ the hard error from server startup to the first `/lazy` request (HTTP 500, catchable rejection at the consumer's `await import()`)
+  - **JSON / text / base64 / dataurl** - currently broken inside lazy chunks: their exports are synthesized at link time, which the lazy render path skips, so they register empty exports until a rebuild + page refresh (see implementation.md Known Limitations)
+  - **Binary assets** - work only when a plugin converts them to JS in its `load` hook (e.g. the dev server's Vite-style asset plugin); emitted bytes are delivered via `onAdditionalAssets` (#9815)
+- The compiled unit includes all static deps of the lazy module, and `new URL(...)` references count as static
 
 ## Compilation Granularity
 
 When a lazy module is requested:
 
-- Compile **that module + all its synchronous dependencies**
+- Compile **that module + its synchronous dependencies** — minus any module the requesting client has already executed (per-client pruning via `executed_modules`)
 - Nested dynamic imports (`import()` within the lazy module) are **not** compiled - they become their own lazy boundaries
 - This creates a natural "lazy boundary" at each dynamic import
 
@@ -49,6 +70,8 @@ Entry
     └── import('./lazy-b')  ← another lazy boundary (NOT compiled yet)
 ```
 
+Inside a rendered lazy chunk (or HMR patch), a nested `import()` of another lazy proxy is rewritten by the HMR finalizer to fetch `/@vite/lazy?...` and then read the proxy's registered exports via `loadExports(stableProxyId)` — partial bundles have no separately bundled proxy chunk, so the proxy's top-level export would otherwise be lost (see implementation.md "Lazy chunk rendering").
+
 ## Key Design Decisions
 
 ### 1. Transparent User Experience
@@ -57,30 +80,19 @@ Users should not need to change their code. `import('./module')` just works.
 
 ### 2. The `rolldown:exports` Contract
 
-Proxy modules export a special named export `'rolldown:exports'`:
+Proxy modules export a special named export `'rolldown:exports'` — a promise that resolves to the real module's exports (and **rejects** if the real module throws during initialization, which is what makes init errors catchable at the consumer's `await import()`, #9981).
+
+Rolldown's `transform_ast` hook automatically wraps dynamic imports with an unwrapping helper:
 
 ```js
-// Proxy module for lazy ./foo.js (NOT EXECUTED state)
-const lazyExports = (async () => {
-  await import(`/@vite/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=...`);
-  return __rolldown_runtime__.loadExports($MODULE_ID);
-})();
+// User code (unchanged)
+const mod = await import('./lazy.js');
 
-export { lazyExports as 'rolldown:exports' };
+// Transformed by lazy compilation plugin
+const mod = await import('./lazy.js').then(__unwrap_lazy_compilation_entry);
 ```
 
-- `'rolldown:exports'` is a promise that resolves to the real module's exports
-- Rolldown's `transform_ast` hook automatically wraps all dynamic imports with an unwrapping helper:
-
-  ```js
-  // User code (unchanged)
-  const mod = await import('./lazy.js');
-
-  // Transformed by lazy compilation plugin
-  const mod = await import('./lazy.js').then(__unwrap_lazy_compilation_entry);
-  ```
-
-- The helper is injected into each module that has dynamic imports:
+- The helper is injected (after any directive prologues) into each module where at least one dynamic import was wrapped:
 
   ```js
   function __unwrap_lazy_compilation_entry(m) {
@@ -89,41 +101,54 @@ export { lazyExports as 'rolldown:exports' };
   }
   ```
 
-- This is safe for ALL dynamic imports: lazy modules return the promise, non-lazy modules pass through unchanged
+- This is safe for ALL dynamic imports: lazy proxies return the promise, non-lazy modules pass through unchanged
+- Proxy modules themselves (ids containing `?rolldown-lazy=1`) are **exempt**: `transform_ast` skips them, so the stub's `import('/@vite/lazy?...')` and the fetched template's `import($MODULE_ID)` are never wrapped
 
 ### 3. Proxy Module States
 
 A proxy module has two states that determine what content the `LazyCompilationPlugin` returns:
 
-#### Not Executed (Initial State)
+#### Not Fetched (Initial State)
 
-Returns the **stub template** that fetches via `/lazy` endpoint:
+Returns the **stub template** (`proxy-module-template.js`), which fetches via the `/@vite/lazy` endpoint:
 
 ```js
-// proxy-module-template.js
 const lazyExports = (async () => {
+  // Remove the cache of the current module from the runtime's module map.
+  // This module with key $STABLE_PROXY_MODULE_ID is swapped in the lazy loaded chunk again with the real module.
+  delete __rolldown_runtime__.modules[$STABLE_PROXY_MODULE_ID];
+  // Dev server will intercept this import and serve the actual module code.
+  // We send the proxy module ID (with ?rolldown-lazy=1) so the server can mark it as fetched.
   await import(
-    `/@vite/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
+    /* @vite-ignore */ `/@vite/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
   );
-  return __rolldown_runtime__.loadExports($MODULE_ID);
+  // Loading the chunk re-registers this proxy id, exposing the real module's
+  // initializer as its own `rolldown:exports` promise. Await that promise (don't
+  // just hand back the namespace) so an error thrown while the real module
+  // initializes rejects `lazyExports` too, surfacing at the consumer's
+  // `await import(...)` (catchable) instead of escaping as an unhandled rejection.
+  return await __rolldown_runtime__.loadExports($STABLE_PROXY_MODULE_ID)['rolldown:exports'];
 })();
 
 export { lazyExports as 'rolldown:exports' };
 ```
+
+Three steps: (1) evict the proxy's stale runtime registration so the lazy chunk can re-register the same stable proxy id with the real initializer; (2) fetch the lazy chunk; (3) resolve through the **re-registered proxy's own `'rolldown:exports'` promise** — a two-level promise chain whose rejection semantics make init errors catchable.
 
 #### Fetched (After First Request)
 
-Returns the **fetched template** that directly imports the real module:
+Returns the **fetched template** (`proxy-module-template-fetched.js`), which imports the real module:
 
 ```js
-// proxy-module-template-fetched.js
 const lazyExports = (async () => {
-  const mod = await import($MODULE_ID);
-  return mod;
+  await import($MODULE_ID);
+  return __rolldown_runtime__.loadExports($STABLE_MODULE_ID);
 })();
 
 export { lazyExports as 'rolldown:exports' };
 ```
+
+The import result (namespace) is deliberately discarded: exports are read from the runtime registry by stable id, because chunk-level renaming can minify export names when a shared lazy module lands in a common chunk (#9132). `$MODULE_ID` is the absolute path (used for resolution only); `$STABLE_MODULE_ID` is the cwd-relative stable id.
 
 The state transition is managed by `LazyCompilationContext.mark_as_fetched()`.
 
@@ -131,13 +156,14 @@ The state transition is managed by `LazyCompilationContext.mark_as_fetched()`.
 
 The dev server handles `/@vite/lazy?id=...&clientId=...` requests:
 
-1. Receive request with **proxy module ID** (e.g., `/abs/path/foo.js?rolldown-lazy=1`)
-2. Call `DevEngine.compile_lazy_entry(proxyModuleId, clientId)` (Rust) / `DevEngine.compileEntry(moduleId, clientId)` (TS)
-3. DevEngine marks the proxy as fetched
-4. Partial scan from proxy module - plugin returns fetched template
-5. Fetched template's `import($MODULE_ID)` triggers compilation of actual module
-6. **Return compiled JS directly** - browser loads it as an ES module
-7. **Notify coordinator** - trigger rebuild to update build output for future page loads
+1. Receive request with the **proxy module ID** (absolute path with `?rolldown-lazy=1`) and the client's UUID
+2. Call `DevEngine.compileEntry(moduleId, clientId)` (TS) / `DevEngine::compile_lazy_entry` (Rust)
+3. DevEngine looks up that client's `executed_modules` and marks the proxy as fetched
+4. **Security gate**: the id is only a lookup key into the build cache — an id not already in the module graph is rejected with `Lazy entry module not found in cache` (never resolved from the filesystem, so a malicious request cannot bundle arbitrary files; analogous to Vite's `server.fs.strict`, pinned by test, #9969)
+5. Partial scan from the proxy module - plugin returns the fetched template, whose `import($MODULE_ID)` triggers compilation of the actual module
+6. Assets emitted during the compile are delivered via the `onAdditionalAssets` callback **before** the code is returned, so they are servable when the chunk executes (#9815)
+7. **Return compiled JS directly** (`Content-Type: application/javascript`) - the browser loads it as an ES module; compile failures answer HTTP 500
+8. **Notify coordinator** - trigger a background rebuild so future page loads get the fetched template without a `/lazy` request
 
 ## Related
 

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -15,13 +15,13 @@ Lazy compilation involves data at two scopes:
 
 Data shared across all connected browser tabs:
 
-| Data              | Description                                                     |
-| ----------------- | --------------------------------------------------------------- |
-| Module Graph      | All resolved and compiled modules                               |
-| `lazy_entries`    | Set of proxy module IDs discovered during resolution            |
-| `fetched_entries` | Set of proxy modules that have been fetched via `/lazy` request |
-| Build Output      | Bundled JS files on disk/memory                                 |
-| Watched Files     | Files monitored for changes                                     |
+| Data              | Description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| Module Graph      | All resolved and compiled modules                                       |
+| `lazy_entries`    | Set of proxy module IDs discovered during resolution                    |
+| `fetched_entries` | Set of proxy modules that have been fetched via a `/@vite/lazy` request |
+| Build Output      | Bundled JS files on disk/memory                                         |
+| Watched Files     | Files monitored for changes                                             |
 
 **Key behavior**: Once a lazy module is fetched by any client, all subsequent clients receive the fetched template (which imports the real module directly). The build output is refreshed after lazy compilation, so future page loads get the fetched template without needing a `/lazy` request.
 
@@ -29,10 +29,18 @@ Data shared across all connected browser tabs:
 
 Data specific to each browser tab:
 
-| Data               | Description                                                                   |
-| ------------------ | ----------------------------------------------------------------------------- |
-| `clientId`         | Unique identifier for the browser tab                                         |
-| `executed_modules` | Modules the browser has actually executed (used for HMR boundary computation) |
+| Data               | Description                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `clientId`         | Unique identifier for the browser tab                                                                |
+| `executed_modules` | Modules the browser has actually executed (used for HMR boundary computation and lazy-patch pruning) |
+
+Session lifecycle:
+
+- A client session is exactly `clientId → ClientSession { executed_modules }` in `SharedClients` on the `DevEngine`
+- Created **implicitly** on the first `hmr:module-registered` message for that `clientId` (dev server → `registerModules` → napi `register_modules`); removed via `removeClient` when the client's websocket disconnects
+- `executed_modules` is a **grow-only** set of **stable ids** — and it includes proxy ids like `src/foo.js?rolldown-lazy=1`, since the lazy chunk re-registers the proxy under its stable id
+- On the runtime side, `registerModule` feeds a debounced batcher that coalesces ids into one `hmr:module-registered` message; the messenger queues messages until the websocket opens
+- The special client id `"rolldown-tests"` is treated as having executed everything (Rust-level tests bypass per-client gating; only the browser E2E playgrounds exercise the `executed_modules` path)
 
 ### Fetched vs Executed
 
@@ -40,24 +48,33 @@ These are distinct concepts at different scopes:
 
 - **Fetched** (session-level): The browser sent a `/lazy` request for this proxy module. The server has compiled the actual module and its dependencies. All clients now receive the fetched template.
 
-- **Executed** (client-level): The browser has actually run the module's code. Used for HMR to determine which modules need updates for a specific client.
+- **Executed** (client-level): The browser has actually run the module's code. Used to prune the lazy patch for a specific client and to gate HMR propagation.
 
 A module can be fetched but not executed by a particular client (e.g., Client A fetched it, Client B hasn't navigated to that route yet).
+
+Per-client outcomes when a fetched lazy module is later edited (see "Editing a fetched lazy module"):
+
+- Client that executed it → a real `Patch`, or `FullReload` if no HMR boundary accepts the change
+- Client that never executed it → an effectively-empty `Patch` whose code is just `__rolldown_runtime__.applyUpdates([]);` (**not** `Noop` — `Noop` is produced only when the changed file maps to no graph module at all, e.g. an unfetched lazy file)
 
 ### Build Output Refresh
 
 After successful lazy compilation:
 
-1. `DevEngine` notifies the coordinator via `ModuleChanged` message
-2. Coordinator queues a `Rebuild` task and marks output as stale
-3. Rebuild updates build output with fetched template
-4. Future page loads get fetched template directly (no `/lazy` request needed)
+1. `DevEngine` notifies the coordinator via `ModuleChanged` (carrying the **raw proxy id**, `?rolldown-lazy=1` included)
+2. Coordinator first calls `update_watch_paths()` — watch files discovered during the lazy compile would otherwise be dropped when the rebuild task starts; this step is what makes later edits to the lazy module trigger rebuilds at all
+3. Coordinator queues a `Rebuild` task with the proxy id as the changed file and marks output as stale
+4. The rebuild swaps the stub for the fetched template in the build output; future page loads get it directly (no `/lazy` request needed)
 
-### Known Limitations
+The raw proxy id is deliberately **not** normalized: during the partial rebuild it resolves back to itself (the resolver preserves the query), string-matches the proxy module's key in the incremental cache, and forces the proxy's `load` hook to re-run — which now returns the fetched template. Normalizing to the real module id would invalidate the wrong module and leave the cached stub proxy in place.
 
-#### Race Condition in Shared Module Deduplication
+A successful background rebuild is **silent** to connected clients: output is swapped in place and no websocket message is sent (the running page keeps the code it got from `/lazy`). A reload fires only if a `FullReload` was already pending or the server is recovering from a previously-broadcast build error. `Rebuild` tasks never generate HMR updates and merge only with other `Rebuild`s, so the `?rolldown-lazy=1` pseudo-path can never leak into HMR-update computation — though plugins do observe it once through the `watch_change` hook.
 
-When multiple lazy entries share common dependencies, the server filters out modules the client has already executed using `executed_modules` (populated via `hmr:module-registered` messages from the browser).
+## Known Limitations
+
+### Shared-Module Deduplication
+
+When multiple lazy entries share common dependencies, two cooperating layers prevent duplicate execution:
 
 ```
 Entry
@@ -67,108 +84,156 @@ Entry
     └── shared.js (sync dep)
 ```
 
-**Normal flow (works correctly):**
+1. **Server-side pruning**: when collecting the sync deps for a lazy patch, the server skips modules whose stable id is in the requesting client's `executed_modules` (populated via `hmr:module-registered`)
+2. **Runtime dedup flag**: lazy chunks are rendered with `dedup_module_initializer: true`, which appends a truthy third argument to every module wrapper — `__rolldown_runtime__.createEsmInitializer(stableId, factory, 1)` / `createCjsInitializer(...)` — and the runtime skips the factory when the id is already registered
 
-1. Browser requests `/@vite/lazy?id=lazy-a` → Server returns patch with `lazy-a` + `shared.js`
-2. Browser executes patch → `shared.js` runs, sends `hmr:module-registered`
-3. Server updates `executed_modules` with `shared.js`
-4. Browser requests `/@vite/lazy?id=lazy-b` → Server filters out `shared.js`
-5. Server returns patch with `lazy-b` only → No duplicate execution ✓
+The server-side race window still exists (two `/lazy` requests in rapid succession, before the first patch's `hmr:module-registered` arrives, produce overlapping chunks — TODO in `hmr_stage.rs`), but the runtime dedup flag makes it harmless: `shared.js` appears in both chunks yet executes once.
 
-**Race condition (edge case):**
+**HMR patches deliberately omit the dedup flag** (`dedup_module_initializer: false`): a patch's whole point is to re-execute the module body and publish new exports, so deduping would silently drop updates. Code comments mark the flag as a workaround pending a runtime dispose/re-execute API.
 
-If the browser sends two `/@vite/lazy` requests in rapid succession (before the `hmr:module-registered` message from the first patch arrives), the server may not know about executed modules yet:
+### Link-Stage-Synthesized Exports (JSON, text, base64, dataurl)
 
-1. Browser requests `/@vite/lazy?id=lazy-a`
-2. Browser immediately requests `/@vite/lazy?id=lazy-b` (before `lazy-a` patch executes)
-3. Server returns both patches with `shared.js` included
-4. Browser executes both → `shared.js` runs twice ✗
+Modules whose exports are synthesized at link time are **broken inside lazy chunks** (and HMR patches): JSON/text/base64/dataurl modules are scanned as a bare expression statement with `ExportsKind::None`, and the `export default` is materialized only by the link stage's `generate_lazy_export` — which the lazy/HMR render path never runs (it renders pristine scan-time AST clones). The lazy chunk registers them as `registerModule(id, {})`, so importers see **empty exports on first lazy load**; after the background rebuild + a page refresh the full build applies the transform and the same import works. No playground fixture covers this yet.
 
-**Potential future enhancement:** Add a runtime guard in generated init functions to check if a module is already registered before executing:
+### CSS
 
-```javascript
-function init_shared_0() {
-  // Guard: skip if already initialized
-  if (__rolldown_runtime__.modules['shared.js']) {
-    return;
-  }
-  // ... module code
-}
-```
+CSS bundling was removed from rolldown (#4271), and the lazy boundary is created without loading the target — so `import('./style.css')` builds fine and the hard error (`Bundling CSS is no longer supported`) is **deferred to the first `/lazy` request**: HTTP 500, catchable rejection at the consumer's `await import()`.
 
-This would provide defense-in-depth against the race condition.
+### Assets
+
+Rolldown core has no built-in asset handling: an extension outside the default `module_types` map is read as UTF-8 and parsed as JS, so a binary file statically imported in a lazy subtree fails the lazy compile at request time. Asset imports inside a lazy subtree work only when a plugin converts them to JS in its `load` hook (as the dev server's ported `vite:asset` plugin does — see "Emitted assets").
+
+### Sourcemaps
+
+Only `sourcemap: 'inline'` works for lazy chunks. The `/lazy` payload is a plain `String` through the whole chain (`HmrStage` → `DevEngine` → napi → middleware), with no field for a separate map file: with `'file'`/`true`, the code gains a `//# sourceMappingURL=lazy_compile_{n}.js.map` comment but the map asset is discarded server-side (the comment dangles); `'hidden'` drops the map silently. HMR patches, by contrast, carry their map through `HmrPatch { sourcemap, sourcemap_filename }` and the dev server serves both patch and map from the in-memory file store — so an identical `sourcemap: 'file'` config works for HMR edits and silently breaks for lazy chunks. This path currently has no test coverage.
 
 ## Implementation Details
 
 ### Module ID Format
 
-**IMPORTANT**: All runtime module lookups use **stable IDs** (`stable_id`), which are relative paths from the cwd (e.g., `src/module.js`).
+**IMPORTANT**: All runtime module lookups use **stable IDs** (`stable_id`), relative paths from the cwd (e.g., `src/module.js`), computed via `ModuleId::new(id).stabilize(cwd)` with the cwd captured in the `build_start` hook.
 
 This ensures consistency between:
 
-- Proxy module's `loadExports("src/module.js")` call
-- Compiled module's `registerModule("src/module.js", ...)` call
-- `createModuleHotContext("src/module.js")` call
+- The stub's `delete __rolldown_runtime__.modules[stableProxyId]` / `loadExports(stableProxyId)` calls
+- Compiled module wrappers: `createEsmInitializer("src/module.js", ...)` (inside the wrapper body, `registerModule` / `createModuleHotContext` receive the id via the `__rolldown_module_id__` parameter)
 - `import.meta.hot.accept("src/dep.js", ...)` specifiers
 - `applyUpdates([["src/boundary.js", "src/acceptedVia.js"]])` boundaries
 
-The lazy compilation plugin computes the stable ID in-place using the `cwd` obtained from the `build_start` hook.
+Absolute paths survive in exactly two places: the `/@vite/lazy?id=` query value (the proxy id) and the fetched template's `import($MODULE_ID)` (used for resolution).
 
-Note: The proxy module's `/@vite/lazy?id=...` request still uses the absolute path (with `?rolldown-lazy=1`), and the fetched template's `import($MODULE_ID)` also uses the absolute path for module resolution.
+The templates are rendered with **four placeholders**, each substituted as a serde_json-quoted JS string literal (so the templates contain bare `$PLACEHOLDER` tokens and Windows backslash paths are escaped correctly, #9102):
+
+| Placeholder               | Value                              | Used by                                    |
+| ------------------------- | ---------------------------------- | ------------------------------------------ |
+| `$PROXY_MODULE_ID`        | absolute path + `?rolldown-lazy=1` | stub — the `/@vite/lazy?id=` request       |
+| `$STABLE_PROXY_MODULE_ID` | stable id + `?rolldown-lazy=1`     | stub — module-map delete + `loadExports`   |
+| `$MODULE_ID`              | absolute path (query stripped)     | fetched — `import($MODULE_ID)`             |
+| `$STABLE_MODULE_ID`       | stable id                          | fetched — `loadExports($STABLE_MODULE_ID)` |
+
+`render_proxy_template` replaces `$MODULE_ID` **last**, because the other three placeholder names contain `MODULE_ID` as a substring.
 
 ### Fetched State Tracking
 
-The `LazyCompilationPlugin` maintains two sets in `LazyCompilationContext`:
+The `LazyCompilationPlugin` maintains two sets in `LazyCompilationContext` (shared with the `DevEngine` via `plugin.context()`):
 
 - `lazy_entries` - All proxy module IDs created during resolution
 - `fetched_entries` - Proxy module IDs that have been fetched (requested at runtime via `/lazy`)
 
 When `resolve_id` is called for a dynamic import:
 
-1. If importer is a **fetched proxy** → return `None` (skip proxy creation, resolve to actual module)
-2. Otherwise → create proxy module ID and add to `lazy_entries`
+1. If the importer is a **fetched proxy** (`?rolldown-lazy=1` + in `fetched_entries`) → return `None` (skip proxy creation, resolve to actual module)
+2. Otherwise → resolve the specifier via `ctx.resolve` (`skip_self: true`, forwarding `args.custom`) and append `?rolldown-lazy=1`. The append is **idempotent** (#9439): `ctx.resolve` can re-enter other plugins' resolve hooks (e.g. an alias plugin), so if the resolved id already ends with the marker it is reused — a doubled suffix would desync the proxy id from the runtime invalidation key in the stub template (regression vitejs/vite#22454, pinned by the aliased-import spec)
 
 When `load` is called for a proxy module:
 
-1. If in `fetched_entries` → return fetched template
-2. Otherwise → return stub template
+1. Only ids present in `lazy_entries` are served at all — any other `?rolldown-lazy=1` id falls through to `Ok(None)`
+2. If in `fetched_entries` → return fetched template; otherwise → return stub template
+
+**Security gate — unknown module rejection (#9969)**: the id passed to `compileEntry` / `compile_lazy_entry` is treated purely as a lookup key into the build cache, never resolved as a filesystem path. An id not present from a prior build is rejected in `HmrStage::compile_lazy_entry` with `Lazy entry module not found in cache` — so a malicious `/@vite/lazy` request cannot bundle an arbitrary file (analogous to Vite's `server.fs.strict`; pinned by `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`). Note the ordering: `DevEngine::compile_lazy_entry` calls `mark_as_fetched` unconditionally **before** this validation, so an unknown id still lands in `fetched_entries` (harmless, but worth knowing when debugging).
+
+### Lazy Chunk Rendering
+
+`Bundler::compile_lazy_entry(module_id, client_id, executed_modules, next_patch_id)` → `HmrStage::compile_lazy_entry` (the `client_id` param is unused at this layer — per-client tailoring comes solely from `executed_modules`):
+
+1. Look the proxy up in the module cache (the #9969 gate), then run `ScanMode::Partial([proxy's resolved id])`
+2. `collect_sync_dependencies_for_client` walks the proxy's static deps plus the proxy's own dynamic import, **stopping** at any module whose stable id is in the client's `executed_modules`; external modules are dropped and the rest sorted by id
+3. Each module is rendered by `HmrAstFinalizer` into an initializer wrapper:
+
+   ```js
+   var init_foo = __rolldown_runtime__.createEsmInitializer(
+     'src/foo.js',
+     function (__rolldown_module_id__) {
+       try {
+         // registerModule/createModuleHotContext use __rolldown_module_id__;
+         // ESM exports are published as:
+         // var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ ... })
+       } finally {
+       }
+     },
+     1,
+   ); // trailing `1` = dedup flag, lazy chunks only
+   ```
+
+   (CJS modules use `createCjsInitializer` with `__rolldown_exports__` / `__rolldown_module__` params.)
+
+4. Dynamic imports inside the rendered modules are rewritten:
+   - importee id contains `?rolldown-lazy=1` (a nested lazy proxy) → ``import(`/@vite/lazy?id=${encodeURIComponent(absProxyId)}&clientId=${__rolldown_runtime__.clientId}`).then(() => __rolldown_runtime__.loadExports("<stableProxyId>"))`` — partial bundles have no separately bundled proxy chunk, so the proxy's top-level `'rolldown:exports'` export would be lost inside the init wrapper; reading it back via `loadExports` preserves the surface `__unwrap_lazy_compilation_entry` expects (pinned by the nested-dynamic-import spec)
+   - ordinary `import()` → `Promise.resolve().then(() => __rolldown_runtime__.loadExports("<stableId>"))`, prefixed with the importee's `init_x()` call when it is in the same patch
+5. The chunk ends with the proxy entry's `init_xxx()` call (this re-registers the proxy id with the real initializer — what the stub's step 3 awaits)
+6. The result is post-processed under a synthetic name `lazy_compile_{n}.js` (n from the dev engine's `next_invalidate_patch_id` counter, shared with `hmr.invalidate` patches — **not** the coordinator's `hmr_patch_{n}.js` counter) and returned as a plain JS string
+
+### Emitted Assets (#9815)
+
+Lazy compiles (like HMR patches) never run the generate stage, so assets emitted during the compile have no `onOutput` path. Instead, on success `DevEngine::compile_lazy_entry` drains `file_emitter.add_additional_files` into a `BundleOutput` and fires the `onAdditionalAssets` dev callback **before** returning the code — so the consumer can register/serve the assets (test-dev-server puts them in `memoryFiles`) before the browser requests them (fixes vitejs/vite#22596, pinned by the emitted-asset spec).
+
+Design constraint for consumers: asset URLs must be resolved **eagerly at `load`** (`emitFile` + `getFileName`, as the dev server's Vite-style asset plugin does) — a `renderChunk`-time placeholder scheme would leak, because the lazy render path never runs `renderChunk`.
 
 ### Build Output Refresh
 
-After successful lazy compilation, the dev engine notifies the coordinator:
+After successful lazy compilation, the dev engine's success branch does two things, in order:
 
 ```rust
 // In DevEngine::compile_lazy_entry
 if result.is_ok() {
+  // 1. deliver assets emitted during the compile (before the code returns)
+  if let Some(on_additional_assets) = ... { ... }
+  // 2. queue the background rebuild
   self.notify_module_changed(proxy_module_id);
 }
 ```
 
 The coordinator handles `ModuleChanged`:
 
-1. Queue a `TaskInput::Rebuild` with the module as changed
-2. Set `has_stale_bundle_output = true`
-3. Schedule build if stale
+1. Call `update_watch_paths()` first (see "Data Lifecycle → Build Output Refresh" for why)
+2. Queue a `TaskInput::Rebuild` with the raw proxy id as the changed file
+3. Set `has_stale_bundle_output = true`
+4. Schedule build if stale (runs immediately only when the coordinator is Idle/Failed; otherwise waits in the queue)
 
-This ensures future page loads get the fetched template directly (no `/lazy` request needed).
-Note: the current implementation notifies with the proxy module ID (includes `?rolldown-lazy=1`), so the rebuild path should resolve or normalize it to a real module ID.
-
-### Caching Strategy
-
-- AST and compilation results are cached internally - that's sufficient for now
-- **Known limitation (POC)**: Two different entries importing the same module may cause it to execute twice
-- This is acceptable for the initial implementation
+On **failure**, neither step runs: a failed lazy compile queues no rebuild and the stub template stays in the build output (but the proxy remains marked fetched). If the background rebuild itself fails, the consumer caches the error, broadcasts an error overlay to every client, and cancels any pending full reload so the page never reloads onto a broken bundle (#9903); the coordinator enters `Failed { Rebuild }` with stale output, recovered by the next file change or page access.
 
 ### Error Handling
 
-- Compilation errors: Return `Err` or panic - fine for POC
-- No graceful error recovery needed initially
+The error contract (no longer "POC — Err or panic is fine"):
+
+- **Unknown module id** → `Err("Lazy entry module not found in cache. module_id=...")` in `HmrStage::compile_lazy_entry`; the napi binding surfaces it as a rejected promise prefixed `Failed to compile lazy entry: ...`; the dev-server middleware answers HTTP 500 (missing `id`/`clientId` params fall through to `next()`; success sets `Content-Type: application/javascript`)
+- **Init errors are catchable (#9981)**: an error thrown while the lazy module initializes rejects the re-registered proxy's `'rolldown:exports'` promise, hence the stub's `lazyExports`, hence the consumer's `await import(...)` — try/catch works, and without a handler exactly one `unhandledrejection` fires. Pinned on both the **cold** path (first `/lazy` compile) and the **warm** path (fetched proxy after rebuild + reload) by the lazy-init-error specs (#9975 added the original failing spec; #9981 rewrote and split it)
+- **Runtime `loadExports` miss** does not throw — it warns and returns `{}`
+- The one remaining panic: calling `compile_lazy_entry` before any bundle has been built
 
 ### ClientId
 
-- Used to track multiple browser tabs/clients
-- Each browser tab gets a unique `clientId`
-- Dev server uses this to route compiled modules to the correct client
+- Generated by the HMR runtime at init via `crypto.randomUUID()` (before any lazy import can run), appended to the websocket URL (`?clientId=...` — the dev server closes clientId-less sockets with code 1008) and interpolated into every `/@vite/lazy` request via `__rolldown_runtime__.clientId`
+- Its only role in lazy compilation is **per-client patch pruning**: the engine looks up that client's `executed_modules` so the returned chunk omits modules the client already ran. Nothing is "routed" — the compiled code returns synchronously in the HTTP response
+- An unknown `clientId` silently degrades to an empty executed set (the full dependency closure is returned)
+
+### Editing a Fetched Lazy Module
+
+After `/lazy`, the real module and its sync deps are ordinary watched graph modules (thanks to the `update_watch_paths()` step), and an edit flows through the standard watch → per-client HMR path:
+
+- The fetched proxy participates as a plain **non-accepting** importer (`hmr_info.deps` comes only from `import.meta.hot.accept`, never from dynamic imports). Editing a non-self-accepting lazy module therefore propagates proxy → dynamic importer → `NoBoundary` → `FullReload` for every client that executed it; the dev task auto-upgrades to `HmrRebuild`, and the dev server defers the reload until the rebuild output lands (canceling it if the rebuild errors, #9903). Pinned by the shared-module spec's watch/auto-reload test
+- If the lazy module self-accepts (`import.meta.hot.accept()`), executed clients get a normal per-client `Patch` instead
+- Clients that never executed the module get the effectively-empty `applyUpdates([])` patch (see "Fetched vs Executed")
 
 ## End-to-End Flow
 
@@ -179,15 +244,16 @@ Note: the current implementation notifies with the proxy module ID (includes `?r
 │  - Entry + sync dependencies compiled normally                          │
 │  - Dynamic imports (import()) → replaced with proxy modules             │
 │  - Proxy module ID: /abs/path/module.js?rolldown-lazy=1                 │
-│  - Proxy contains STUB template (fetches via /lazy endpoint)            │
+│  - Proxy contains STUB template (fetches via /@vite/lazy endpoint)      │
 │  - Proxy exports 'rolldown:exports' promise                             │
 └─────────────────────────────────────────────────────────────────────────┘
                                     ↓
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ 2. BROWSER LOADS INITIAL BUNDLE                                         │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  - Runtime initializes                                                  │
-│  - Proxy module registers: registerModule("/abs/.../mod.js?rolldown-lazy=1")
+│  - Runtime initializes; clientId = crypto.randomUUID()                  │
+│  - Proxy registers under its STABLE id:                                 │
+│      registerModule("src/module.js?rolldown-lazy=1", { exports })       │
 │  - Stub template is ready to fetch on demand                            │
 └─────────────────────────────────────────────────────────────────────────┘
                                     ↓
@@ -195,6 +261,7 @@ Note: the current implementation notifies with the proxy module ID (includes `?r
 │ 3. USER CODE HITS: import('./lazy-module')                              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  - Proxy module executes (stub template)                                │
+│  - Deletes its own runtime registration (so the chunk can re-register)  │
 │  - Fetches: /@vite/lazy?id=/abs/path/lazy-module.js?rolldown-lazy=1&clientId=xxx
 │  - Browser waits on the promise                                         │
 └─────────────────────────────────────────────────────────────────────────┘
@@ -202,43 +269,44 @@ Note: the current implementation notifies with the proxy module ID (includes `?r
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ 4. DEV SERVER RECEIVES /lazy REQUEST                                    │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  - Receives proxyModuleId = "/abs/path/lazy-module.js?rolldown-lazy=1"  │
-│  - Calls DevEngine.compile_lazy_entry(proxyModuleId, clientId)          │
-│  - DevEngine marks proxy as FETCHED in LazyCompilationContext           │
+│  - Calls DevEngine.compileEntry(proxyModuleId, clientId)                │
+│  - Engine looks up the client's executed_modules                        │
+│  - Marks proxy as FETCHED in LazyCompilationContext                     │
+│  - Rejects ids not in the module cache (security gate, #9969)           │
 └─────────────────────────────────────────────────────────────────────────┘
                                     ↓
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ 5. PARTIAL SCAN FROM PROXY MODULE                                       │
+│ 5. PARTIAL SCAN + RENDER                                                │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  - ScanMode::Partial([proxyModuleId])                                   │
 │  - Plugin's load hook sees proxy is fetched → returns FETCHED template  │
 │  - Fetched template: import("/abs/path/lazy-module.js")                 │
-│  - Plugin's resolve_id sees importer is fetched proxy → returns None    │
-│  - Dynamic import resolves to ACTUAL module (no new proxy)              │
-│  - Actual module + sync dependencies are compiled                       │
+│  - resolve_id sees importer is a fetched proxy → returns None           │
+│  - Actual module + sync deps compiled — minus the client's              │
+│    already-executed modules                                             │
+│  - Modules rendered as createEsm/CjsInitializer(stableId, fn, 1)        │
+│    (dedup flag); chunk ends with the proxy entry's init call            │
 └─────────────────────────────────────────────────────────────────────────┘
                                     ↓
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ 6. RETURN COMPILED JS TO BROWSER                                        │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  - Response contains:                                                   │
-│    - Proxy module (with fetched template)                               │
-│    - Actual module (/abs/path/lazy-module.js)                           │
-│    - All sync dependencies of actual module                             │
-│  - Browser loads the code as an ES module                               │
-│  - registerModule() called for each module                              │
-│  - loadExports() finds actual module → returns real exports             │
-│  - Original import() promise resolves                                   │
+│  - Assets emitted during the compile already delivered via              │
+│    onAdditionalAssets (#9815)                                           │
+│  - Response is a single JS string (code only — no sourcemap channel)    │
+│  - Browser loads it as an ES module; initializers register each module  │
+│  - Entry init call re-registers the proxy id with the real initializer  │
+│  - Stub resolves: loadExports(stableProxyId)['rolldown:exports']        │
+│  - Original import() promise resolves (or rejects catchably, #9981)     │
 └─────────────────────────────────────────────────────────────────────────┘
                                     ↓
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ 7. BUILD OUTPUT REFRESH (Background)                                    │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  - DevEngine sends CoordinatorMsg::ModuleChanged { proxyModuleId }      │
-│  - Coordinator queues TaskInput::Rebuild                                │
-│  - has_stale_bundle_output = true                                       │
+│  - Coordinator: update_watch_paths() → queue Rebuild → mark stale       │
 │  - Rebuild updates build output with fetched template                   │
-│  - Future page loads get fetched template directly (no /lazy needed)    │
+│  - Silent to connected clients; future page loads skip /lazy            │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -250,9 +318,8 @@ Note: the current implementation notifies with the proxy module ID (includes `?r
 
 **Solution**: Use **stable IDs** (`stable_id`, relative paths from cwd) consistently in the runtime:
 
-- `registerModule(stableId, exports)`
+- `createEsmInitializer(stableId, factory[, dedup])` / `createCjsInitializer(...)` — inside the wrapper, `registerModule(__rolldown_module_id__, { exports })` and `createModuleHotContext(__rolldown_module_id__)` receive the id via the wrapper parameter (the main-bundle path still emits stable-id string literals)
 - `loadExports(stableId)`
-- `createModuleHotContext(stableId)`
 - `import.meta.hot.accept(stableId, callback)`
 - `applyUpdates([[boundaryStableId, acceptedViaStableId]])`
 
@@ -301,21 +368,17 @@ This allows the fetched template's dynamic import to resolve to the actual modul
 
 **Problem**: After the first lazy load, the build output on disk still had the stub template. Page refresh would show the stub again, requiring another `/lazy` request.
 
-**Solution**: Notify the coordinator to trigger a rebuild after successful lazy compilation (ideally with a real module ID):
+**Solution**: Notify the coordinator to trigger a rebuild after successful lazy compilation:
 
 ```rust
 // In DevEngine::compile_lazy_entry
 if result.is_ok() {
+  // (assets delivered via on_additional_assets first — see "Emitted Assets")
   self.notify_module_changed(proxy_module_id);
 }
-
-// notify_module_changed sends:
-CoordinatorMsg::ModuleChanged { module_id }
-
-// Coordinator handles it:
-self.queued_tasks.push_back(TaskInput::Rebuild { changed_files });
-self.has_stale_bundle_output = true;
 ```
+
+The notification deliberately carries the raw proxy id (`?rolldown-lazy=1` included) — it is the correct incremental-cache invalidation key, since the module whose content changed is the _proxy_ (stub → fetched template), not the real module. See "Build Output Refresh".
 
 ### Issue 5: Non-Identifier Export Names Need Computed Property Syntax
 
@@ -323,21 +386,21 @@ self.has_stale_bundle_output = true;
 
 ```js
 // INVALID - colon in identifier
-var exports = __rolldown_runtime__.__export({ rolldown:exports: () => lazyExports });
+var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ rolldown:exports: () => lazyExports });
 ```
 
 **Solution**: Use `is_validate_identifier_name()` to detect non-identifier export names and use computed property syntax:
 
 ```rust
 let computed = !is_validate_identifier_name(exported.as_str());
-self.snippet.object_property_kind_object_property(exported, expr, computed)
+self.ast_factory.make_lazy_export_property(exported, expr, computed)
 ```
 
 This generates valid JavaScript:
 
 ```js
 // VALID - computed property
-var exports = __rolldown_runtime__.__export({
+var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
   ['rolldown:exports']: () => lazyExports,
 });
 ```
@@ -357,8 +420,8 @@ Only updating one left the other using `stable_id`.
 
 The lazy compilation plugin creates two distinct module IDs:
 
-- **Proxy module**: `/abs/path/module.js?rolldown-lazy=1` (loaded initially, contains stub/fetched code)
-- **Actual module**: `/abs/path/module.js` (compiled on-demand, contains real code)
+- **Proxy module**: `/abs/path/module.js?rolldown-lazy=1` (loaded initially, contains stub/fetched code; registers at runtime under its stable id `src/module.js?rolldown-lazy=1`)
+- **Actual module**: `/abs/path/module.js` (compiled on-demand, contains real code; registers under `src/module.js`)
 
 The flow is:
 
@@ -367,8 +430,26 @@ The flow is:
 3. DevEngine marks proxy as fetched
 4. Partial scan from proxy → plugin returns fetched template
 5. Fetched template imports actual module → triggers compilation
-6. Both proxy (fetched) and actual module are in the output
-7. `loadExports("/abs/path/module.js")` finds and returns the exports
+6. The lazy chunk re-registers the proxy id with the real initializer, and the stub resolves via `loadExports("src/module.js?rolldown-lazy=1")['rolldown:exports']`
+7. After the background rebuild, both proxy (fetched) and actual module are in the output
+
+### Issue 8: Proxy-ID Creation Must Be Idempotent (#9439)
+
+**Problem**: With an alias plugin present, `ctx.resolve` re-entered the lazy plugin's `resolve_id`, appending `?rolldown-lazy=1` twice. The doubled suffix desynced the proxy id from the stub template's `delete modules[$STABLE_PROXY_MODULE_ID]` invalidation key, so the real module's exports never registered (`mod.foo` came back undefined — regression vitejs/vite#22454).
+
+**Solution**: Before appending the marker, check whether the resolved id already ends with `?rolldown-lazy=1` and reuse it. Pinned by the aliased-import spec.
+
+### Issue 9: Fetched Template Must Read Exports From the Registry (#9132)
+
+**Problem**: The fetched template originally returned the dynamic import's namespace object. When a shared lazy module landed in a common chunk, chunk-level renaming minified the export names and the namespace lookup yielded `undefined`.
+
+**Solution**: `await import($MODULE_ID)` for side effects only, then `return __rolldown_runtime__.loadExports($STABLE_MODULE_ID)` — the runtime registry preserves original export names. Pinned by the shared-module spec.
+
+### Issue 10: Init Errors Must Reject the Consumer's Promise (#9981)
+
+**Problem**: An error thrown while a lazily-compiled module initialized escaped as an unhandled rejection instead of surfacing at the consumer's `await import(...)`.
+
+**Solution**: The stub template awaits the **re-registered proxy's own `'rolldown:exports'` promise** (`return await loadExports($STABLE_PROXY_MODULE_ID)['rolldown:exports']`) rather than handing back a namespace — so a rejection anywhere in the chain rejects `lazyExports` and the consumer's import promise. Pinned by the two lazy-init-error specs (cold and warm paths).
 
 ## Implementation Notes
 
@@ -378,7 +459,23 @@ The lazy compilation plugin injects helper functions with double-underscore pref
 
 ### Directive Prologue Handling
 
-The injected helper function is inserted **after** any directive prologues (e.g., `"use strict"`) to preserve their semantics. The plugin counts leading string literal expression statements and inserts the helper after them.
+The injected helper function is inserted **after** any directive prologues (e.g., `"use strict"`) to preserve their semantics. The plugin counts leading string literal expression statements and inserts the helper after them. The helper is only injected when at least one dynamic import in the module was actually wrapped.
+
+## Test Coverage
+
+E2E playground: `packages/test-dev-server/tests/playground/lazy-compilation/` (one dev server config with `experimental.devMode.lazy: true` + an alias plugin):
+
+| Spec                        | Pins                                                                              |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| `basic`                     | lazy module arrives as two separate JS requests (proxy chunk + real chunk)        |
+| `aliased-import`            | idempotent proxy-id creation under alias re-entrancy (vite#22454)                 |
+| `emitted-asset`             | assets emitted during lazy compile are servable on first load (vite#22596)        |
+| `lazy-init-error`           | init errors catchable with try/catch — cold and warm paths (#9975/#9981)          |
+| `lazy-init-error-unhandled` | exactly one `unhandledrejection` without a handler — cold and warm paths          |
+| `nested-dynamic-import`     | nested lazy `import()` inside a lazy chunk resolves on first click                |
+| `shared-module`             | export-name preservation in shared chunks (#9132) + watch/auto-reload after fetch |
+
+Several specs use `retry: 0` because the bugs only reproduce on the first interaction with a fresh server. Unit test: `packages/rolldown/tests/dev/dev-lazy-compile.test.ts` pins the unknown-id rejection (#9969).
 
 ## Files Changed (Reference)
 
@@ -386,26 +483,36 @@ For future debugging, these files handle lazy compilation:
 
 ### Core Plugin
 
-1. **`crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs`** - Plugin with `resolve_id`, `load`, and `transform_ast` hooks, `LazyCompilationContext` with fetched state tracking
-2. **`crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs`** - AST visitor for transforming dynamic imports and helper function generation
+1. **`crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs`** - Plugin with `resolve_id`, `load`, and `transform_ast` hooks; `LazyCompilationContext` with fetched-state tracking; `render_proxy_template`
+2. **`crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs`** - AST visitor for wrapping dynamic imports and generating `__unwrap_lazy_compilation_entry`
 3. **`crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js`** - Stub template (not fetched)
 4. **`crates/rolldown_plugin_lazy_compilation/src/proxy-module-template-fetched.js`** - Fetched template
+5. **`crates/rolldown/src/utils/apply_inner_plugins.rs`** - registers the plugin when `experimental.dev_mode.lazy == true`
 
 ### Dev Engine
 
-5. **`crates/rolldown_dev/src/dev_engine.rs`** - `compile_lazy_entry()`, `notify_module_changed()`
-6. **`crates/rolldown_dev/src/types/coordinator_msg.rs`** - `ModuleChanged` message variant
-7. **`crates/rolldown_dev/src/bundle_coordinator.rs`** - Handles `ModuleChanged`, triggers rebuild
+6. **`crates/rolldown_dev/src/dev_engine.rs`** - `compile_lazy_entry()` (executed_modules lookup, mark-as-fetched, asset delivery, `notify_module_changed()`), client sessions
+7. **`crates/rolldown_dev/src/types/coordinator_msg.rs`** - `ModuleChanged` message variant
+8. **`crates/rolldown_dev/src/bundle_coordinator.rs`** - Handles `ModuleChanged` (`update_watch_paths` + rebuild), state machine
+9. **`crates/rolldown_binding/src/binding_dev_engine.rs`** - napi surface (`compile_entry`, `register_modules`, `remove_client`)
 
 ### HMR/Build
 
-8. **`crates/rolldown/src/hmr/hmr_stage.rs`** - `compile_lazy_entry()` partial scan logic
-9. **`crates/rolldown/src/hmr/hmr_ast_finalizer.rs`** - Export generation with computed property support
-10. **`crates/rolldown/src/hmr/utils.rs`** - `create_register_module_stmt()`, `create_module_hot_context_initializer_stmt()`
+10. **`crates/rolldown/src/hmr/hmr_stage.rs`** - `compile_lazy_entry()`: cache gate, partial scan, per-client dep collection, chunk rendering
+11. **`crates/rolldown/src/hmr/hmr_ast_finalizer.rs`** + **`impl_traverse_for_hmr_ast_finalizer.rs`** - initializer wrappers, dedup flag, dynamic-import rewrites (incl. the `/@vite/lazy` rewrite), computed-property exports
+12. **`crates/rolldown/src/hmr/utils.rs`** - register-module / hot-context statement builders (`__rolldown_module_id__` param)
+13. **`crates/rolldown/src/bundler/impl_bundler_hmr.rs`** - `Bundler::compile_lazy_entry` entry point
+14. **`crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js`** - browser runtime: `createEsm/CjsInitializer` (dedup gate), `registerModule`, `loadExports`, module-registered batching
+
+### Reference Dev Server (TS)
+
+15. **`packages/test-dev-server/src/middlewares/trigger-lazy-bundling.ts`** - the `/@vite/lazy` middleware (500 on error, `application/javascript` on success)
+16. **`packages/test-dev-server/src/environments/full-bundle-dev-environment.ts`** - `triggerLazyBundling`, `#onAdditionalAssets`, rebuild/reload handling
+17. **`packages/test-dev-server/src/utils/create-asset-plugin.ts`** - Vite-style eager asset resolution at `load`
 
 ## References
 
 - [design.md](./design.md) — goals, scope, and key design decisions
 - Current implementation: `crates/rolldown_plugin_lazy_compilation/`
-- Dev engine: `crates/rolldown_dev/`
+- Dev engine: `crates/rolldown_dev/` (see also `internal-docs/dev-engine/`)
 - Example: `examples/lazy-compilation/`


### PR DESCRIPTION
### Description

Rewrites `internal-docs/lazy-compilation/{design,implementation}.md` to match the current implementation. The docs dated back to the initial POC (split out in #9826) and had drifted from the code in several load-bearing places. Every claim was re-verified against current `main` (file/line spot-checks, cross-checked with the playground specs).

#### Corrections to stale / wrong content

- **Proxy templates**: both inline code blocks are now the real `proxy-module-template{,-fetched}.js` verbatim. The stub evicts its runtime cache entry and ends with `return await loadExports($STABLE_PROXY_MODULE_ID)['rolldown:exports']` — the two-level promise chain from #9981 that makes init errors catchable at the consumer's `await import()`. The fetched template returns `loadExports($STABLE_MODULE_ID)` instead of the import namespace (export-name preservation in shared chunks, #9132).
- **Module IDs**: design.md's TL;DR claimed absolute paths are used "consistently throughout the runtime" — runtime lookups actually use stable (cwd-relative) ids; absolute paths survive only in the `/@vite/lazy?id=` param and the fetched template's `import($MODULE_ID)`. Also documents the four template placeholders and their JSON-quoted rendering (#9102).
- **Error handling**: replaced "`Err` or panic is fine for POC" with the actual contract — unknown ids are rejected as a cache-key-only security gate (#9969), napi surfaces `Failed to compile lazy entry:` → HTTP 500, and init errors are catchable on both cold and warm paths (#9975/#9981).
- **Dedup**: the race-condition section's "potential future enhancement" runtime guard is long implemented — lazy chunks render `createEsm/CjsInitializer(stableId, factory, 1)` with a dedup flag (HMR patches deliberately omit it so updates re-execute). Rewrote the section around the two-layer dedup: per-client `executed_modules` pruning + the runtime flag.
- **Rebuild id normalization**: the old note said the `ModuleChanged` rebuild "should resolve or normalize" the proxy id to a real module id — the raw proxy id is deliberately correct (it is the incremental-cache invalidation key for the proxy whose content changed; normalizing would leave the stale stub cached). Note removed and the actual mechanism documented.
- Misc: `lazyMagic` helper (never existed), `__export` → `__exportAll`, `snippet` → `ast_factory` in the Lessons Learned snippets, `registerModule(stableId, { exports })` shape.

#### New coverage

- **Enabling / wiring**: `experimental.devMode.lazy: true`, inner-plugin registration, the shared `LazyCompilationContext` handed to the `DevEngine`
- **Lazy chunk rendering**: initializer wrappers + `__rolldown_module_id__` param, the nested-lazy `import()` → `/@vite/lazy` rewrite, entry init call, `lazy_compile_{n}.js` naming
- **Emitted assets**: delivered via `onAdditionalAssets` before the code returns (#9815)
- **Build output refresh**: `update_watch_paths()` runs first (what makes post-fetch edits watchable at all), silent output swap for connected clients, failure paths (#9903)
- **Editing a fetched lazy module**: per-client HMR outcomes; a non-accepting proxy escalates to FullReload → HmrRebuild with a deferred reload
- **Client sessions**: implicit creation on `hmr:module-registered`, removal on ws disconnect, the `"rolldown-tests"` escape hatch; clientId prunes the patch — nothing is "routed"
- **Known limitations**: link-stage-synthesized exports (JSON/text/base64/dataurl register `{}` inside lazy chunks until rebuild + refresh), CSS error deferral, assets require load-hook plugins, sourcemaps (inline-only for lazy chunks — the map asset is discarded on the lazy path, unlike `HmrPatch`)
- **Test coverage table**: the 7 playground specs + `dev-lazy-compile.test.ts` and what each pins

Docs only — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
