### PR TITLE
fix(rolldown_plugin_vite_resolve): return empty object for `browser: false` mapped modules

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -416,6 +416,9 @@ impl Resolver {
         }
         Ok(None)
       }
+      // A module mapped to `false` in the `browser` field. It resolves to a bare
+      // `__vite-browser-external` id (no `:name` suffix, unlike externalized `node:*` builtins),
+      // which the load hook turns into an empty module per the browser field spec.
       Err(oxc_resolver::ResolveError::Ignored(_)) => Ok(Some(HookResolveIdOutput {
         id: arcstr::literal!(BROWSER_EXTERNAL_ID),
         ..Default::default()

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -497,8 +497,13 @@ impl Plugin for ViteResolvePlugin {
     args: &HookLoadArgs<'_>,
   ) -> HookLoadReturn {
     if let Some(id_without_prefix) = args.id.strip_prefix(BROWSER_EXTERNAL_ID) {
+      // A bare `__vite-browser-external` (no `:name` suffix) is a `browser` field `false`
+      // mapping. Per the browser field spec it must resolve to an empty module, not the proxy
+      // that throws on property access.
+      let is_browser_field_false = id_without_prefix.is_empty();
+
       if self.resolve_options.is_build {
-        if self.resolve_options.is_production {
+        if self.resolve_options.is_production || is_browser_field_false {
           // rolldown treats missing export as an error, and will break build.
           // So use cjs to avoid it.
           return Ok(Some(HookLoadOutput {
@@ -507,18 +512,12 @@ impl Plugin for ViteResolvePlugin {
           }));
         } else {
           return Ok(Some(HookLoadOutput {
-            code: get_development_build_browser_external_module_code(
-              // trim leading `:` if it's not empty
-              if id_without_prefix.is_empty() {
-                id_without_prefix
-              } else {
-                &id_without_prefix[1..]
-              },
-            ),
+            // trim leading `:`
+            code: get_development_build_browser_external_module_code(&id_without_prefix[1..]),
             ..Default::default()
           }));
         }
-      } else if self.resolve_options.is_production {
+      } else if self.resolve_options.is_production || is_browser_field_false {
         // in dev, needs to return esm
         return Ok(Some(HookLoadOutput {
           code: arcstr::literal!("export default {}"),
@@ -526,10 +525,8 @@ impl Plugin for ViteResolvePlugin {
         }));
       } else {
         return Ok(Some(HookLoadOutput {
-          code: get_development_dev_browser_external_module_code(
-            // trim leading `:` if it's not empty
-            if id_without_prefix.is_empty() { id_without_prefix } else { &id_without_prefix[1..] },
-          ),
+          // trim leading `:`
+          code: get_development_dev_browser_external_module_code(&id_without_prefix[1..]),
           ..Default::default()
         }));
       }


### PR DESCRIPTION
Modules mapped to `false` in a package's browser field are supposed to resolve to an empty module ("ignore a module" (https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module)). The plugin was instead resolving them to the same `__vite-browser-external` proxy used for externalized `node:*` builtins, which throws on any property access in a dev build.

That breaks packages that intentionally probe optional exports of a `browser: false` module. The canonical case is object-inspect (https://github.com/inspect-js/object-inspect), whose `package.json` has `"browser": { "./util.inspect.js": false }` and whose entry does, at module-init time:

```javascript
var utilInspect = require('./util.inspect'); // browser: false
var inspectCustom = utilInspect.custom;      // property access -> throws
```

In a dev build (`NODE_ENV=development vite build`) the `.custom` access hits the throwing proxy and crashes the whole bundle at startup. Production builds (which return `module.exports = {}`) work fine, so it only reproduces in dev.

fixes https://github.com/vitejs/vite/issues/22022