### PR TITLE
fix: emit async wrapper for TLA modules under onDemandWrapping

### DIFF
--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -193,6 +193,12 @@ fn render_chunk_content<'code>(
       .as_ref()
       .unwrap();
 
+    // The concatenated closure holds the bodies of every module in the group. If the group's
+    // entry is TLA-tainted (has top-level `await`, or awaits a TLA importee's `init` call), those
+    // `await`s land inside this closure, so it must be `async`. This mirrors the flag threaded
+    // into `make_esm_wrapper_stmt` for the non-concatenated wrapper.
+    let is_async = ctx.link_output.metas[group.entry].is_tla_or_contains_tla_dependency;
+
     source_joiner.append_source(hoisted_fns);
     if !hoisted_vars.is_empty() {
       source_joiner.append_source(concat_string!("var ", hoisted_vars, ";"));
@@ -210,7 +216,7 @@ fn render_chunk_content<'code>(
         String::new()
       },
       if is_pife_for_module_wrappers_enabled { "(" } else { "" },
-      "() => {"
+      if is_async { "async () => {" } else { "() => {" }
     ));
     // we render each module in the group by exec order.
     group.modules.iter().for_each(|module_idx| {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
@@ -8,5 +8,6 @@
     ],
     "strictExecutionOrder": true
   },
+  "configVariants": [{ "onDemandWrapping": true }],
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -13,3 +13,18 @@ await __esmMin((async () => {
 }))();
 
 ```
+
+# Variant: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+	//#region main.js
+	console.log(123);
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9083/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9083/_config.json
@@ -2,6 +2,7 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
-    }
+    },
+    { "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -71,3 +71,42 @@ await __esmMin((async () => {
 export { manager };
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function setup() {
+	manager.ready = true;
+}
+var value, manager;
+var init_middle = __esmMin((async () => {
+	//#region deep.js
+	await sleep(100);
+	value = "hello";
+	//#endregion
+	//#region middle.js
+	manager = {
+		value,
+		ready: false
+	};
+	//#endregion
+}));
+await __esmMin((async () => {
+	//#region barrel.js
+	await init_middle();
+	//#endregion
+	//#region main.js
+	setup();
+	//#endregion
+}))();
+export { manager };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/_config.json
@@ -2,6 +2,7 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
-    }
+    },
+    { "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
@@ -58,3 +58,35 @@ await __esmMin((async () => {
 export { value as normalLibValue, value$1 as tlaLibValue };
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region normal-lib.js
+var value;
+var init_normal_lib = __esmMin((() => {
+	value = "normal-dep+normal-lib";
+}));
+//#endregion
+var value$2, value$1;
+var init_tla_lib = __esmMin((async () => {
+	//#region tla-dep.js
+	value$2 = await Promise.resolve("tla-dep");
+	//#endregion
+	//#region tla-lib.js
+	value$1 = value$2 + "+tla-lib";
+	//#endregion
+}));
+//#endregion
+await __esmMin((async () => {
+	init_normal_lib();
+	await init_tla_lib();
+}))();
+export { value as normalLibValue, value$1 as tlaLibValue };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/_config.json
@@ -2,6 +2,7 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
-    }
+    },
+    { "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -41,3 +41,28 @@ await __esmMin((async () => {
 export { value };
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+var value$1, value;
+var init_lib = __esmMin((async () => {
+	//#region tla.js
+	value$1 = await Promise.resolve("tla");
+	//#endregion
+	//#region lib.js
+	value = value$1 + "+lib";
+	//#endregion
+}));
+//#endregion
+await __esmMin((async () => {
+	await init_lib();
+}))();
+export { value };
+
+```


### PR DESCRIPTION
### What this PR solves

Under `experimental.onDemandWrapping`, the concatenated module-group wrapper — the single `__esm` closure holding the bodies of every module in a merged group — was always emitted as a sync arrow. When the group's entry is TLA-tainted (has top-level `await`, or awaits a TLA importee's `init` call), those `await`s land inside that closure, producing a chunk with `await` in a non-async function: a SyntaxError at load.

```js
// before
var init_entry = __esm(() => {
  ...
  await init_dep();  // SyntaxError: await outside async function
});

// after
var init_entry = __esm(async () => {
  ...
  await init_dep();
});
```

### How

One render change in `render_chunk_content` (`crates/rolldown/src/ecmascript/format/esm.rs`): emit `async () => {` when `metas[group.entry].is_tla_or_contains_tla_dependency`. This mirrors the `is_async` flag already threaded into `make_esm_wrapper_stmt` for the non-concatenated (single-module) wrapper path — the concatenated group path just never received it.

### Tests

Added `{ "strictExecutionOrder": true, "onDemandWrapping": true }` config variants to the TLA fixtures so the emitted syntax is pinned by snapshots (and executed):

- `issues/9083`
- `topics/tla/on_demand_await_call`
- `topics/tla/transitive_dep`
- `function/experimental/on_demand_wrapping/top_level_await_syntax`

Each fails on main with the sync closure and passes with this change.
