### PR TITLE
refactor: make module namespace inclusion an explicit linking metadata field

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -59,8 +59,7 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
     ast.program.with_mut(move |fields| {
       let (oxc_program, alloc) = (fields.program, fields.allocator);
 
-      let module_namespace_included =
-        self.used_symbol_refs.contains(&self.module.namespace_object_ref);
+      let module_namespace_included = self.linking_info.namespace_included;
 
       let need_inline_json_prop = matches!(self.module.module_type, ModuleType::Json)
         && !self.module.exports_kind.is_commonjs()

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -560,10 +560,15 @@ impl GenerateStage<'_> {
         } else {
           false
         };
-        Some((m.namespace_object_ref, is_namespace_referenced))
+        Some((module_idx, m.namespace_object_ref, is_namespace_referenced))
       })
       .collect_vec();
-    for (namespace_ref, flag) in to_eliminate {
+    for (module_idx, namespace_ref, flag) in to_eliminate {
+      self.link_output.metas[module_idx].namespace_included = flag;
+      // Mirror the decision into `used_symbol_refs` because generic symbol-usage queries can
+      // receive a namespace ref (e.g. a `resolved_export.symbol_ref` produced by
+      // `export * as ns from '...'`). Dedicated namespace readers consult
+      // `meta.namespace_included` instead of the set.
       if flag {
         self.link_output.used_symbol_refs.insert(namespace_ref);
       } else {

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -456,7 +456,7 @@ impl GenerateStage<'_> {
                 && let Some(none_self_referenced) =
                   normal_module.json_module_none_self_reference_included_symbol.as_deref()
                 && !normal_module.exports_kind.is_commonjs()
-                && !self.link_output.used_symbol_refs.contains(&normal_module.namespace_object_ref)
+                && !self.link_output.metas[module_idx].namespace_included
                 && !none_self_referenced
                   .contains(&self.link_output.symbol_db.canonical_ref_for(symbol))
               {

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -85,6 +85,11 @@ pub struct LinkingMetadata {
   /// Set when the runtime module has side effects (e.g. dev/HMR mode).
   pub has_side_effectful_runtime_dep: bool,
   pub module_namespace_included_reason: ModuleNamespaceIncludedReason,
+  /// Final decision on whether this module's namespace object is retained in the output.
+  /// Computed by [`crate::stages::generate_stage`]'s `finalized_module_namespace_ref_usage`
+  /// from `module_namespace_included_reason` together with the module's `exports_kind` and
+  /// `has_dynamic_exports`; only meaningful for passes that run after it.
+  pub namespace_included: bool,
   /// Tracks which statements in this module are included after tree-shaking.
   /// Each entry corresponds to a statement in the module's `stmt_infos`.
   pub stmt_info_included: IndexBitSet<StmtInfoIdx>,


### PR DESCRIPTION
### Description

Part 1 of a 4-PR stack that gives "is this symbol used" a single authority per question, by splitting purpose-specific views out of `used_symbol_refs`.

Whether a module's namespace object is retained was previously communicated to downstream passes by inserting/removing the module's `namespace_object_ref` in `used_symbol_refs` (#7002). That made the set a mutable side channel after tree-shaking had settled: from that point on the set and the statement-inclusion bits could disagree, and each reader picked one of them ad hoc.

This PR records the decision on a dedicated field, `LinkingMetadata::namespace_included`, computed in `finalized_module_namespace_ref_usage` from `module_namespace_included_reason`, and switches the dedicated readers over:

- the finalizer's namespace-declaration gate (`finalizer_context.rs`)
- the JSON export-interface check in `compute_cross_chunk_links`

The set insert/remove remains as a mirror derived from the flag, because generic symbol-usage queries can still receive namespace refs (e.g. a `resolved_export.symbol_ref` produced by `export * as ns from '...'`).

No behavior change; snapshots are untouched.

Stack: #10087 → #10088 → #10089 → #10090 → #10091