### PR TITLE
refactor: track used external symbols separately from used_symbol_refs

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -133,7 +133,7 @@ fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
         "\")"
       );
 
-      if ctx.link_output.used_symbol_refs.contains(&importee.namespace_ref) {
+      if ctx.link_output.used_external_symbols.contains(&importee.namespace_ref) {
         let external_module_symbol_name = ctx
           .link_output
           .symbol_db

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -374,7 +374,15 @@ where
   let specifiers = named_imports
     .filter_map(|(_importer, named_import)| {
       let canonical_ref = ctx.link_output.symbol_db.canonical_ref_for(named_import.imported_as);
-      if !ctx.link_output.used_symbol_refs.contains(&canonical_ref) {
+      // A named import that is itself re-exported skips the external binding merger
+      // (`bind_imports_and_exports`), so its canonical ref stays importer-local; its usage
+      // is still answered by `used_symbol_refs` until exports get their own tracking.
+      let is_used = if ctx.link_output.module_table[canonical_ref.owner].is_external() {
+        ctx.link_output.used_external_symbols.contains(&canonical_ref)
+      } else {
+        ctx.link_output.used_symbol_refs.contains(&canonical_ref)
+      };
+      if !is_used {
         return None;
       }
       let alias = ctx

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -66,7 +66,7 @@ pub fn render_chunk_external_imports<'a>(
         .symbol_db
         .canonical_name_for_or_original(importee.namespace_ref, &ctx.chunk.canonical_names);
 
-      if ctx.link_output.used_symbol_refs.contains(&importee.namespace_ref) {
+      if ctx.link_output.used_external_symbols.contains(&importee.namespace_ref) {
         // Check if this import needs __toESM
         let needs_interop = external_import_needs_interop(named_imports);
         if needs_interop {

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1045,6 +1045,7 @@ impl GenerateStage<'_> {
       runtime_idx: self.link_output.runtime.id(),
       metas: &self.link_output.metas,
       used_symbol_refs: &mut self.link_output.used_symbol_refs,
+      used_external_symbols: &mut self.link_output.used_external_symbols,
       constant_symbol_map: &self.link_output.global_constant_symbol_map,
       options: self.options,
       normal_symbol_exports_chain_map: &self.link_output.normal_symbol_exports_chain_map,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -7,7 +7,7 @@ use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
   ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
-  UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  UsedExternalSymbols, UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
 #[cfg(target_family = "wasm")]
@@ -69,6 +69,7 @@ pub struct LinkStageOutput {
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
   pub used_symbol_refs: UsedSymbolRefs,
+  pub used_external_symbols: UsedExternalSymbols,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
@@ -108,6 +109,7 @@ pub struct LinkStage<'a> {
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
   pub used_symbol_refs: UsedSymbolRefs,
+  pub used_external_symbols: UsedExternalSymbols,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -211,6 +213,7 @@ impl<'a> LinkStage<'a> {
       dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
       options,
       used_symbol_refs: UsedSymbolRefs::default(),
+      used_external_symbols: UsedExternalSymbols::default(),
       safely_merge_cjs_ns_map: FxHashMap::default(),
       normal_symbol_exports_chain_map: FxHashMap::default(),
       external_import_namespace_merger: FxHashMap::default(),
@@ -255,6 +258,7 @@ impl<'a> LinkStage<'a> {
         warnings: self.warnings,
         errors: self.errors,
         used_symbol_refs: self.used_symbol_refs,
+        used_external_symbols: self.used_external_symbols,
         dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
         safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
         external_import_namespace_merger: self.external_import_namespace_merger,

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -10,7 +10,7 @@ use rolldown_common::{
   ModuleNamespaceIncludedReason, ModuleType, NormalModule, NormalizedBundlerOptions,
   RUNTIME_HELPER_NAMES, RUNTIME_MODULE_ID, RuntimeHelper, RuntimeModuleBrief, StmtEvalFlags,
   StmtInfo, StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
-  UsedSymbolRefs, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
+  UsedExternalSymbols, UsedSymbolRefs, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
   side_effects::DeterminedSideEffects,
 };
 #[cfg(not(target_family = "wasm"))]
@@ -67,6 +67,7 @@ pub struct IncludeContext<'a> {
   pub runtime_idx: ModuleIdx,
   pub metas: &'a LinkingMetadataVec,
   pub used_symbol_refs: &'a mut UsedSymbolRefs,
+  pub used_external_symbols: &'a mut UsedExternalSymbols,
   pub constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
   pub options: &'a NormalizedBundlerOptions,
   pub normal_symbol_exports_chain_map: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -100,6 +101,7 @@ impl<'a> IncludeContext<'a> {
     runtime_idx: ModuleIdx,
     metas: &'a LinkingMetadataVec,
     used_symbol_refs: &'a mut UsedSymbolRefs,
+    used_external_symbols: &'a mut UsedExternalSymbols,
     constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
     options: &'a NormalizedBundlerOptions,
     normal_symbol_exports_chain_map: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -118,6 +120,7 @@ impl<'a> IncludeContext<'a> {
       runtime_idx,
       metas,
       used_symbol_refs,
+      used_external_symbols,
       constant_symbol_map,
       options,
       normal_symbol_exports_chain_map,
@@ -340,6 +343,7 @@ impl LinkStage<'_> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
+  #[expect(clippy::too_many_lines)]
   pub fn include_statements(
     &mut self,
     unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
@@ -354,6 +358,7 @@ impl LinkStage<'_> {
       })
       .collect::<IndexVec<ModuleIdx, _>>();
     let mut used_symbol_refs = UsedSymbolRefs::default();
+    let mut used_external_symbols = UsedExternalSymbols::default();
     let mut is_module_included_vec: ModuleInclusionVec =
       IndexBitSet::new(self.module_table.modules.len());
     let mut module_namespace_included_reason: ModuleNamespaceReasonVec =
@@ -380,6 +385,7 @@ impl LinkStage<'_> {
       self.runtime.id(),
       &self.metas,
       &mut used_symbol_refs,
+      &mut used_external_symbols,
       &self.global_constant_symbol_map,
       self.options,
       &self.normal_symbol_exports_chain_map,
@@ -538,6 +544,7 @@ impl LinkStage<'_> {
       self.runtime.id(),
       &self.metas,
       &mut used_symbol_refs,
+      &mut used_external_symbols,
       &self.global_constant_symbol_map,
       self.options,
       &self.normal_symbol_exports_chain_map,
@@ -548,6 +555,7 @@ impl LinkStage<'_> {
     include_runtime_symbol(context, &self.runtime, depended_runtime_helper);
 
     self.used_symbol_refs = used_symbol_refs;
+    self.used_external_symbols = used_external_symbols;
     // Store the final statement inclusion results back to metas.
     is_stmt_info_included_vec.into_iter_enumerated().for_each(|(module_idx, stmt_included_vec)| {
       self.metas[module_idx].stmt_info_included = stmt_included_vec;
@@ -983,6 +991,9 @@ pub fn include_symbol(
 
   // Also include the symbol that points to the canonical ref.
   ctx.used_symbol_refs.insert(symbol_ref);
+  if ctx.modules[symbol_ref.owner].is_external() {
+    ctx.used_external_symbols.insert(symbol_ref);
+  }
 
   // CJS bailout checks are handled by `include_symbol_and_check_cjs_bailout`
   // at most call sites. This keeps `include_symbol` focused on inclusion only.
@@ -1028,6 +1039,9 @@ pub fn include_symbol(
   };
 
   ctx.used_symbol_refs.insert(canonical_ref);
+  if ctx.modules[canonical_ref.owner].is_external() {
+    ctx.used_external_symbols.insert(canonical_ref);
+  }
   if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
     let wrapper_ref = {
       let meta = &ctx.metas[canonical_ref.owner];

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -83,7 +83,7 @@ pub fn deconflict_chunk_symbols(
       let db = link_output.symbol_db.local_db(*module);
       db.classic_data.iter_enumerated().for_each(|(symbol, _)| {
         let symbol_ref = (*module, symbol).into();
-        if link_output.used_symbol_refs.contains(&symbol_ref) {
+        if link_output.used_external_symbols.contains(&symbol_ref) {
           renamer.add_symbol_in_root_scope(symbol_ref, true);
         }
       });

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -217,6 +217,7 @@ pub use crate::{
   types::symbol_ref_db::{
     GetLocalDb, GetLocalDbMut, SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags,
   },
+  types::used_external_symbols::UsedExternalSymbols,
   types::used_symbol_refs::UsedSymbolRefs,
   types::watch::WatcherChangeKind,
   types::wrap_kind::WrapKind,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -59,6 +59,7 @@ pub mod str_or_bytes;
 pub mod symbol_or_member_expr_ref;
 pub mod symbol_ref;
 pub mod symbol_ref_db;
+pub mod used_external_symbols;
 pub mod used_symbol_refs;
 pub mod watch;
 pub mod wrap_kind;

--- a/crates/rolldown_common/src/types/used_external_symbols.rs
+++ b/crates/rolldown_common/src/types/used_external_symbols.rs
@@ -1,0 +1,29 @@
+use rustc_hash::FxHashSet;
+
+use super::symbol_ref::SymbolRef;
+
+/// Symbols owned by external modules that are used by included code.
+///
+/// Keys are refs whose `owner` is an external module: an external module's
+/// `namespace_ref`, or the per-name facade symbols created by the external
+/// import binding merger. Importer-local bindings that link to them are not
+/// recorded — query with the canonical (linked) ref.
+///
+/// Written only by the inclusion pass (`include_symbol`); read by output
+/// formats and chunk-level deconflicting.
+#[derive(Debug, Default)]
+pub struct UsedExternalSymbols {
+  inner: FxHashSet<SymbolRef>,
+}
+
+impl UsedExternalSymbols {
+  #[inline]
+  pub fn insert(&mut self, symbol_ref: SymbolRef) {
+    self.inner.insert(symbol_ref);
+  }
+
+  #[inline]
+  pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.contains(symbol_ref)
+  }
+}


### PR DESCRIPTION
### Description

Part 2 of the `used_symbol_refs` decomposition stack (stacked on #10087).

Symbols owned by external modules — an external module's `namespace_ref`, and the per-name facade symbols created by the external import binding merger in `bind_imports_and_exports` — have no statements, so their usage can only ever be tracked symbol-level. This PR gives them a dedicated `UsedExternalSymbols` set, written by `include_symbol` alongside `used_symbol_refs` whenever the inserted ref's owner is an external module, and switches the external-only consumers to it:

- ESM import specifier rendering (`format/esm.rs`)
- CJS/ESM external interop checks (`format/cjs.rs`, `format/utils/mod.rs`)
- chunk-level deconflicting (`deconflict_chunk_symbols.rs`)

The ESM named-import path keeps a `used_symbol_refs` fallback for canonical refs that stay importer-local: a named import that is itself re-exported skips the binding merger, so its canonical ref is not external-owned. (Part 3 initially tried to move that fallback to the export projection; it turned out to also cover eval-kept imports and platform-import cases that are no module's export, so it stays on the set — see the description there.)

No behavior change; snapshots are untouched.

Stack: #10087 → #10088 → #10089 → #10090 → #10091