### PR TITLE
refactor: project the retained export interface out of used_symbol_refs

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -85,7 +85,7 @@ impl Generator for EcmaGenerator {
           .resolved_exports
           .iter()
           .filter_map(|(key, export)| {
-            if ctx.link_output.used_symbol_refs.contains(&export.symbol_ref) {
+            if ctx.link_output.retained_export_symbols.contains(&export.symbol_ref) {
               Some(key.clone())
             } else {
               None

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
-  ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts, RuntimeModuleBrief,
-  SharedFileEmitter, StmtInfos, SymbolRef, SymbolRefDb, UsedSymbolRefs,
+  ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts,
+  RetainedExportSymbols, RuntimeModuleBrief, SharedFileEmitter, StmtInfos, SymbolRef, SymbolRefDb,
 };
 
 pub type FinalizerMutableFields = (
@@ -41,7 +41,7 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub file_emitter: &'me SharedFileEmitter,
   pub constant_value_map: &'me FxHashMap<SymbolRef, ConstExportMeta>,
   pub safely_merge_cjs_ns_map: &'me FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
-  pub used_symbol_refs: &'me UsedSymbolRefs,
+  pub retained_export_symbols: &'me RetainedExportSymbols,
   /// Pre-resolved paths for external modules (always a `FxHashMap` variant).
   pub resolved_paths: Option<&'me PathsOutputOption>,
   /// True if any module in the bundle has enum member values to inline.

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -807,7 +807,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .constant_value_map
           .get(&self.ctx.symbol_db.canonical_ref_for(resolved_export.symbol_ref))
           .is_some_and(|meta| !meta.commonjs_export);
-        if !self.ctx.used_symbol_refs.contains(&resolved_export.symbol_ref)
+        if !self.ctx.retained_export_symbols.contains(&resolved_export.symbol_ref)
           && !is_inlinable_constant
         {
           return None;

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -13,7 +13,7 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
   ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
   ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
-  SymbolRef, WrapKind,
+  RetainedExportSymbols, SymbolRef, WrapKind,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{
@@ -575,6 +575,26 @@ impl GenerateStage<'_> {
         self.link_output.used_symbol_refs.remove(&namespace_ref);
       }
     }
+  }
+
+  /// Projects `used_symbol_refs` onto the export domain: for every module's resolved export,
+  /// record the export's symbol ref and its canonical form when used. Must run after
+  /// [`Self::finalized_module_namespace_ref_usage`] so the namespace decision is folded in
+  /// (an `export * as ns` export resolves to a namespace ref).
+  pub fn compute_retained_export_symbols(&mut self) {
+    let mut retained = RetainedExportSymbols::default();
+    for meta in &self.link_output.metas {
+      for export in meta.resolved_exports.values() {
+        if self.link_output.used_symbol_refs.contains(&export.symbol_ref) {
+          retained.insert(export.symbol_ref);
+        }
+        let canonical_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);
+        if self.link_output.used_symbol_refs.contains(&canonical_ref) {
+          retained.insert(canonical_ref);
+        }
+      }
+    }
+    self.link_output.retained_export_symbols = retained;
   }
 
   /// Find all entry level external modules, and re propagate `has_dynamic_exports` for affected modules.

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -696,7 +696,7 @@ impl GenerateStage<'_> {
           entry_module.canonical_exports(false).for_each(|(name, export)| {
             let export_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);
             if !exported_chunk_symbols.contains_key(&export.symbol_ref)
-              || !self.link_output.used_symbol_refs.contains(&export.symbol_ref)
+              || !self.link_output.retained_export_symbols.contains(&export.symbol_ref)
             {
               // Rolldown supports tree-shaking on dynamic entries, so not all exports are used.
               return;
@@ -715,7 +715,7 @@ impl GenerateStage<'_> {
               let export_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);
               // Use canonical ref for lookup since that's the key in exported_chunk_symbols
               if !exported_chunk_symbols.contains_key(&export_ref)
-                || !self.link_output.used_symbol_refs.contains(&export_ref)
+                || !self.link_output.retained_export_symbols.contains(&export_ref)
               {
                 return;
               }

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -52,7 +52,7 @@ impl GenerateStage<'_> {
             file_emitter: &self.plugin_driver.file_emitter,
             constant_value_map: &self.link_output.global_constant_symbol_map,
             safely_merge_cjs_ns_map: &self.link_output.safely_merge_cjs_ns_map,
-            used_symbol_refs: &self.link_output.used_symbol_refs,
+            retained_export_symbols: &self.link_output.retained_export_symbols,
             resolved_paths: self.resolved_paths.as_ref(),
             has_enum_inlining,
           };

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -153,6 +153,8 @@ impl<'a> GenerateStage<'a> {
 
     self.finalized_module_namespace_ref_usage();
 
+    self.compute_retained_export_symbols();
+
     self.compute_cross_chunk_links(&mut chunk_graph);
 
     self.ensure_lazy_module_initialization_order(&mut chunk_graph);

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,8 +6,9 @@ use oxc_index::IndexVec;
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
-  ModuleIdx, ModuleTable, PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
-  UsedExternalSymbols, UsedSymbolRefs, dynamic_import_usage::DynamicImportExportsUsage,
+  ModuleIdx, ModuleTable, PreserveEntrySignatures, RetainedExportSymbols, RuntimeModuleBrief,
+  SymbolRef, SymbolRefDb, UsedExternalSymbols, UsedSymbolRefs,
+  dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
 #[cfg(target_family = "wasm")]
@@ -70,6 +71,8 @@ pub struct LinkStageOutput {
   pub errors: Vec<BuildDiagnostic>,
   pub used_symbol_refs: UsedSymbolRefs,
   pub used_external_symbols: UsedExternalSymbols,
+  /// See [`RetainedExportSymbols`]; empty until the generate stage projects it.
+  pub retained_export_symbols: RetainedExportSymbols,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
@@ -259,6 +262,7 @@ impl<'a> LinkStage<'a> {
         errors: self.errors,
         used_symbol_refs: self.used_symbol_refs,
         used_external_symbols: self.used_external_symbols,
+        retained_export_symbols: RetainedExportSymbols::default(),
         dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
         safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
         external_import_namespace_merger: self.external_import_namespace_merger,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -199,6 +199,7 @@ pub use crate::{
   types::rendered_module::RenderedModule,
   types::resolved_export::ResolvedExport,
   types::resolved_id::{ResolvedExternal, ResolvedId},
+  types::retained_export_symbols::RetainedExportSymbols,
   types::rollup_pre_rendered_asset::RollupPreRenderedAsset,
   types::rollup_pre_rendered_chunk::RollupPreRenderedChunk,
   types::rollup_rendered_chunk::RollupRenderedChunk,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -45,6 +45,7 @@ pub mod plugin_idx;
 pub mod rendered_module;
 pub mod resolved_export;
 pub mod resolved_id;
+pub mod retained_export_symbols;
 pub mod rollup_pre_rendered_asset;
 pub mod rollup_pre_rendered_chunk;
 pub mod rollup_rendered_chunk;

--- a/crates/rolldown_common/src/types/retained_export_symbols.rs
+++ b/crates/rolldown_common/src/types/retained_export_symbols.rs
@@ -1,0 +1,32 @@
+use rustc_hash::FxHashSet;
+
+use super::symbol_ref::SymbolRef;
+
+/// The retained export interface: symbols of resolved exports that survived
+/// tree-shaking (either genuinely referenced or kept by interface policy —
+/// entry exports, CJS bailout, eval).
+///
+/// Membership is tracked per ref form, mirroring `used_symbol_refs`: for every
+/// module's `resolved_exports` entry, the recorded `symbol_ref` is present iff
+/// that exact ref was marked used, and its canonical form iff the canonical
+/// value was marked used (possibly through another alias). The two answer
+/// different questions, so query with the same form the call site previously
+/// used against `used_symbol_refs`. Projected by the generate stage right
+/// after the module-namespace decision (`finalized_module_namespace_ref_usage`)
+/// and read-only afterwards.
+#[derive(Debug, Default)]
+pub struct RetainedExportSymbols {
+  inner: FxHashSet<SymbolRef>,
+}
+
+impl RetainedExportSymbols {
+  #[inline]
+  pub fn insert(&mut self, symbol_ref: SymbolRef) {
+    self.inner.insert(symbol_ref);
+  }
+
+  #[inline]
+  pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.contains(symbol_ref)
+  }
+}


### PR DESCRIPTION
### Description

Part 3 of the `used_symbol_refs` decomposition stack (stacked on #10088).

Consumers that iterate a module's resolved exports were answering "is this export retained" by querying `used_symbol_refs` directly. This PR projects that answer into a dedicated `RetainedExportSymbols` set — for every module's `resolved_exports` entry whose usage survived, the export's `symbol_ref` as recorded plus its canonical form — computed right after the module-namespace decision so `export * as ns` exports reflect it. Switched consumers:

- rendered-module export lists (`ecma_generator.rs`)
- the namespace object property list in the finalizer
- entry-chunk export naming and AllowExtension emitted-chunk exports (`compute_cross_chunk_links`)

With both this and #10087 in place, the finalizer context's `used_symbol_refs` field had no readers left, so it is removed here.

Note: the ESM external-import fallback from #10088 deliberately does NOT move to this projection. An instrumented attempt changed 20 snapshots: the non-external canonical refs it sees include imports kept alive by `eval` and platform-import cases, which are no module's export, so the export projection cannot answer them.

No behavior change; snapshots are untouched.

Stack: #10087 → #10088 → #10089 → #10090 → #10091