### PR TITLE
docs: write down the used_symbol_refs contract

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -525,6 +525,10 @@ impl GenerateStage<'_> {
 
         let chunk_meta_imports = &index_chunk_depended_symbols[chunk_id];
         for import_ref in chunk_meta_imports.iter().copied() {
+          // Depended symbols are over-collected; this drops refs the inclusion fixpoint
+          // never marked live: constants that get inlined (never inserted — constants kept
+          // as bindings, e.g. entry exports, stay in the set), namespace objects the
+          // generate stage eliminated, and dead collected refs.
           if !self.link_output.used_symbol_refs.contains(&import_ref) {
             continue;
           }
@@ -773,6 +777,9 @@ impl GenerateStage<'_> {
           )
         })
       {
+        // Same filter as the cross-chunk import loop above: exported-symbol candidates
+        // include inlined constants, eliminated namespace objects (dynamic entries register
+        // their namespace refs here), and refs the inclusion fixpoint left dead.
         if !self.link_output.used_symbol_refs.contains(chunk_export) {
           continue;
         }

--- a/crates/rolldown_common/src/types/used_symbol_refs.rs
+++ b/crates/rolldown_common/src/types/used_symbol_refs.rs
@@ -2,6 +2,22 @@ use rustc_hash::FxHashSet;
 
 use super::symbol_ref::SymbolRef;
 
+/// Symbols the inclusion fixpoint decided are needed as bindings: refs referenced
+/// by included statements (inserted in both their original and canonical forms)
+/// plus interface-policy retentions (entry exports, CJS bailout, eval-kept
+/// imports). Constants that get inlined are deliberately absent (never inserted —
+/// their use sites are replaced with the value; constants that must stay bindings,
+/// e.g. entry exports, are present), and module namespace refs are inserted/removed
+/// once more by the generate stage's namespace decision.
+///
+/// Writers: `include_symbol` during the inclusion pass, the chunk optimizer's
+/// facade-elimination re-run of that pass, and the namespace-decision mirror in
+/// `finalized_module_namespace_ref_usage`. Nothing else may mutate this.
+///
+/// Purpose-specific views exist for common questions — prefer them:
+/// `LinkingMetadata::namespace_included` for namespace retention,
+/// `UsedExternalSymbols` for external bindings, and `RetainedExportSymbols` for
+/// a module's retained export interface.
 #[derive(Debug, Default)]
 pub struct UsedSymbolRefs {
   inner: FxHashSet<SymbolRef>,

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -22,6 +22,9 @@ impl Plugin for TestPlugin {
     _ctx: SharedTransformPluginContext,
     args: &HookTransformArgs<'_>,
   ) -> HookTransformReturn {
+    if !args.id.ends_with("input.ts") {
+      return Ok(None);
+    }
     let mut code = self.0.lock().unwrap();
     *code = Some(args.code.to_string());
     Ok(None)


### PR DESCRIPTION
### Description

Part 4 (last) of the `used_symbol_refs` decomposition stack (stacked on #10089).

The original endgame was to delete `UsedSymbolRefs` entirely once every consumer had a purpose-specific home. An instrumented run over the whole test corpus rejected that: the cross-chunk filters (`compute_cross_chunk_links`) drop three populations of refs —

- ~1.3k inlinable constants (absent from the set by design: their use sites hold the value)
- ~0.7k namespace objects eliminated by the generate stage
- **~1.3k over-collected depended refs that neither constants nor namespaces explain** — refs only the inclusion fixpoint's own record can rule dead

The last population is not answerable by statement-inclusion bits (one bit per statement cannot distinguish which of a statement's bindings is referenced), nor by any of the new views. So the set stays — as the single record of fixpoint liveness. This PR writes that contract on the type: what membership means, the three sanctioned writers (the inclusion pass, the chunk optimizer's facade-elimination re-run, and the namespace-decision mirror), and pointers to the purpose-specific views (`LinkingMetadata::namespace_included`, `UsedExternalSymbols`, `RetainedExportSymbols`) that answer the common questions.

The over-collected population also suggests `collect_depended_symbols` collects more than needed; that is left as a separate investigation.

Docs/comments only; no behavior change.

Stack: #10087 → #10088 → #10089 → #10090 → #10091