### PR TITLE
refactor: seal used_symbol_refs by construction after its last writer

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -264,13 +264,13 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     is_write: bool,
   ) -> BuildResult<BundleOutput> {
     let start = self.plugin_driver.start_timing();
-    let (mut link_stage_output, ast_table) =
+    let (mut link_stage_output, ast_table, used_symbol_refs) =
       LinkStage::new(scan_stage_output, &self.options).link();
     self.plugin_driver.set_link_stage_time(start);
 
     let bundle_output =
       GenerateStage::new(&mut link_stage_output, ast_table, &self.options, &self.plugin_driver)
-        .generate()
+        .generate(used_symbol_refs)
         .await; // Notice we don't use `?` to break the control flow here.
 
     // `create_output`/`make_copy` strip symbol-table scoping from the cache for

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -386,7 +386,7 @@ where
       let is_used = if ctx.link_output.module_table[canonical_ref.owner].is_external() {
         ctx.link_output.used_external_symbols.contains(&canonical_ref)
       } else {
-        ctx.link_output.used_symbol_refs.contains(&canonical_ref)
+        ctx.used_symbol_refs.contains(&canonical_ref)
       };
       if !is_used {
         return None;

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -7,7 +7,7 @@ use rolldown_common::{
   Chunk, ChunkDebugInfo, ChunkIdx, ChunkKind, ChunkMeta, ChunkReasonType,
   FacadeChunkEliminationReason, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTable,
   NormalModule, PostChunkOptimizationOperation, PreserveEntrySignatures, RuntimeHelper, StmtInfos,
-  WrapKind,
+  UsedSymbolRefsBuilder, WrapKind,
 };
 use rolldown_utils::{BitSet, IndexBitSet, indexmap::FxIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -974,6 +974,7 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
     module_is_assigned: &mut IndexBitSet<ModuleIdx>,
     temp_chunk_opt_graph: &ChunkOptimizationGraph,
+    used_symbol_refs: &mut UsedSymbolRefsBuilder,
   ) {
     // Find empty dynamic entry chunks that should be merged with their target common chunks
     let (mut facade_eliminations, common_chunk_merges, emitted_chunk_groups) =
@@ -1012,8 +1013,7 @@ impl GenerateStage<'_> {
           .retain(|item| match item {
             rolldown_common::SymbolOrMemberExprRef::Symbol(symbol_ref) => {
               // module namespace symbol requires `__exportAll` runtime helper
-              self.link_output.used_symbol_refs.contains(symbol_ref)
-                || symbol_ref.owner == runtime_module_idx
+              used_symbol_refs.contains(symbol_ref) || symbol_ref.owner == runtime_module_idx
             }
             rolldown_common::SymbolOrMemberExprRef::MemberExpr(_member_expr_ref) => true,
           });
@@ -1044,7 +1044,7 @@ impl GenerateStage<'_> {
       tree_shaking: self.options.treeshake.is_some(),
       runtime_idx: self.link_output.runtime.id(),
       metas: &self.link_output.metas,
-      used_symbol_refs: &mut self.link_output.used_symbol_refs,
+      used_symbol_refs,
       used_external_symbols: &mut self.link_output.used_external_symbols,
       constant_symbol_map: &self.link_output.global_constant_symbol_map,
       options: self.options,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -13,7 +13,7 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
   ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
   ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
-  RetainedExportSymbols, SymbolRef, WrapKind,
+  RetainedExportSymbols, SymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{
@@ -39,7 +39,11 @@ pub type IndexSplittingInfo = IndexVec<ModuleIdx, SplittingInfo>;
 
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate_chunks(&mut self) -> BuildResult<ChunkGraph> {
+  #[expect(clippy::too_many_lines)]
+  pub async fn generate_chunks(
+    &mut self,
+    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+  ) -> BuildResult<ChunkGraph> {
     // Count total entry points (not unique modules) to handle duplicates correctly
     let entries_len: u32 = self
       .link_output
@@ -149,7 +153,13 @@ impl GenerateStage<'_> {
       self.init_entry_point(&mut chunk_graph, &mut bits_to_chunk, entries_len, &input_base);
 
       self
-        .split_chunks(&mut index_splitting_info, &mut chunk_graph, &mut bits_to_chunk, &input_base)
+        .split_chunks(
+          &mut index_splitting_info,
+          &mut chunk_graph,
+          &mut bits_to_chunk,
+          &input_base,
+          used_symbol_refs,
+        )
         .await?;
     }
     // Merge external import namespaces at chunk level.
@@ -168,9 +178,7 @@ impl GenerateStage<'_> {
           continue;
         }
         group.sort_unstable_by_key(|item| self.link_output.module_table[item.owner].exec_order());
-        let Some(idx) =
-          group.iter().position(|item| self.link_output.used_symbol_refs.contains(item))
-        else {
+        let Some(idx) = group.iter().position(|item| used_symbol_refs.contains(item)) else {
           continue;
         };
         // In the extreme case, idx would eq to group.len() - 1, which means the first symbol is the only one that is used.
@@ -560,20 +568,11 @@ impl GenerateStage<'_> {
         } else {
           false
         };
-        Some((module_idx, m.namespace_object_ref, is_namespace_referenced))
+        Some((module_idx, is_namespace_referenced))
       })
       .collect_vec();
-    for (module_idx, namespace_ref, flag) in to_eliminate {
+    for (module_idx, flag) in to_eliminate {
       self.link_output.metas[module_idx].namespace_included = flag;
-      // Mirror the decision into `used_symbol_refs` because generic symbol-usage queries can
-      // receive a namespace ref (e.g. a `resolved_export.symbol_ref` produced by
-      // `export * as ns from '...'`). Dedicated namespace readers consult
-      // `meta.namespace_included` instead of the set.
-      if flag {
-        self.link_output.used_symbol_refs.insert(namespace_ref);
-      } else {
-        self.link_output.used_symbol_refs.remove(&namespace_ref);
-      }
     }
   }
 
@@ -581,15 +580,27 @@ impl GenerateStage<'_> {
   /// record the export's symbol ref and its canonical form when used. Must run after
   /// [`Self::finalized_module_namespace_ref_usage`] so the namespace decision is folded in
   /// (an `export * as ns` export resolves to a namespace ref).
-  pub fn compute_retained_export_symbols(&mut self) {
+  pub fn compute_retained_export_symbols(&mut self, used_symbol_refs: &UsedSymbolRefs) {
+    let link_output = &self.link_output;
+    // A normal module's namespace ref answers to the namespace decision, not to the
+    // inclusion fixpoint (see `finalized_module_namespace_ref_usage`).
+    let is_used = |symbol_ref: SymbolRef| {
+      if let Some(m) = link_output.module_table[symbol_ref.owner].as_normal()
+        && m.namespace_object_ref == symbol_ref
+      {
+        link_output.metas[symbol_ref.owner].namespace_included
+      } else {
+        used_symbol_refs.contains(&symbol_ref)
+      }
+    };
     let mut retained = RetainedExportSymbols::default();
-    for meta in &self.link_output.metas {
+    for meta in &link_output.metas {
       for export in meta.resolved_exports.values() {
-        if self.link_output.used_symbol_refs.contains(&export.symbol_ref) {
+        if is_used(export.symbol_ref) {
           retained.insert(export.symbol_ref);
         }
-        let canonical_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);
-        if self.link_output.used_symbol_refs.contains(&canonical_ref) {
+        let canonical_ref = link_output.symbol_db.canonical_ref_for(export.symbol_ref);
+        if is_used(canonical_ref) {
           retained.insert(canonical_ref);
         }
       }
@@ -844,6 +855,7 @@ impl GenerateStage<'_> {
     chunk_graph: &mut ChunkGraph,
     bits_to_chunk: &mut FxHashMap<BitSet, ChunkIdx>,
     input_base: &ArcStr,
+    used_symbol_refs: &mut UsedSymbolRefsBuilder,
   ) -> BuildResult<()> {
     // Determine which modules belong to which chunk. A module could belong to multiple chunks.
     let tag_registry = ModuleTagRegistry::new();
@@ -988,6 +1000,7 @@ impl GenerateStage<'_> {
         input_base,
         &mut module_is_assigned,
         &temp_chunk_graph,
+        used_symbol_refs,
       );
     }
 

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -9,7 +9,7 @@ use oxc_str::CompactStr;
 use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, CrossChunkImportItem, EntryPointKind, ExportsKind, ImportKind,
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PostChunkOptimizationOperation,
-  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, SymbolRef, WrapKind,
+  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, SymbolRef, UsedSymbolRefs, WrapKind,
 };
 use rolldown_utils::index_vec_ext::IndexVecRefExt as _;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -28,7 +28,11 @@ type IndexImportsFromOtherChunks =
 
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn compute_cross_chunk_links(&mut self, chunk_graph: &mut ChunkGraph) {
+  pub fn compute_cross_chunk_links(
+    &mut self,
+    chunk_graph: &mut ChunkGraph,
+    used_symbol_refs: &UsedSymbolRefs,
+  ) {
     let mut index_chunk_depended_symbols: IndexChunkDependedSymbols =
       index_vec![FxIndexSet::<SymbolRef>::default(); chunk_graph.chunk_table.len()];
     let mut index_chunk_exported_symbols: IndexChunkExportedSymbols =
@@ -59,8 +63,9 @@ impl GenerateStage<'_> {
       &mut index_cross_chunk_imports,
       &mut index_imports_from_other_chunks,
       &mut index_chunk_indirect_imports_from_external_modules,
+      used_symbol_refs,
     );
-    self.deconflict_exported_names(chunk_graph, &index_chunk_exported_symbols);
+    self.deconflict_exported_names(chunk_graph, &index_chunk_exported_symbols, used_symbol_refs);
 
     let index_sorted_cross_chunk_imports = index_cross_chunk_imports
       .par_iter_enumerated()
@@ -348,6 +353,7 @@ impl GenerateStage<'_> {
     index_cross_chunk_imports: &mut IndexCrossChunkImports,
     index_imports_from_other_chunks: &mut IndexImportsFromOtherChunks,
     index_chunk_indirect_imports_from_external_modules: &mut IndexChunkAllImportsFromExternalModules,
+    used_symbol_refs: &UsedSymbolRefs,
   ) {
     // For each module that has been absorbed as a facade namespace, we need to know
     // which other modules dynamically import it so we can tell whether the absorbed
@@ -525,11 +531,19 @@ impl GenerateStage<'_> {
 
         let chunk_meta_imports = &index_chunk_depended_symbols[chunk_id];
         for import_ref in chunk_meta_imports.iter().copied() {
-          // Depended symbols are over-collected; this drops refs the inclusion fixpoint
-          // never marked live: constants that get inlined (never inserted — constants kept
-          // as bindings, e.g. entry exports, stay in the set), namespace objects the
-          // generate stage eliminated, and dead collected refs.
-          if !self.link_output.used_symbol_refs.contains(&import_ref) {
+          // Depended symbols are over-collected; drop refs that are not live. A normal
+          // module's namespace ref answers to the namespace decision; everything else to
+          // the inclusion fixpoint (whose dead refs here are constants that got inlined —
+          // constants kept as bindings, e.g. entry exports, stay live — and over-collected
+          // refs).
+          let is_live = if let Some(m) = self.link_output.module_table[import_ref.owner].as_normal()
+            && m.namespace_object_ref == import_ref
+          {
+            self.link_output.metas[import_ref.owner].namespace_included
+          } else {
+            used_symbol_refs.contains(&import_ref)
+          };
+          if !is_live {
             continue;
           }
           // If the symbol from external module and the format is commonjs, we might need to insert runtime
@@ -677,6 +691,7 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &mut ChunkGraph,
     index_chunk_exported_symbols: &IndexChunkExportedSymbols,
+    used_symbol_refs: &UsedSymbolRefs,
   ) {
     let is_preserve_modules_enabled = self.options.preserve_modules;
     let allow_to_minify_internal_exports =
@@ -777,10 +792,16 @@ impl GenerateStage<'_> {
           )
         })
       {
-        // Same filter as the cross-chunk import loop above: exported-symbol candidates
-        // include inlined constants, eliminated namespace objects (dynamic entries register
-        // their namespace refs here), and refs the inclusion fixpoint left dead.
-        if !self.link_output.used_symbol_refs.contains(chunk_export) {
+        // Same liveness rule as the cross-chunk import loop above (dynamic entries
+        // register their namespace refs among the exported-symbol candidates).
+        let is_live = if let Some(m) = self.link_output.module_table[chunk_export.owner].as_normal()
+          && m.namespace_object_ref == *chunk_export
+        {
+          self.link_output.metas[chunk_export.owner].namespace_included
+        } else {
+          used_symbol_refs.contains(chunk_export)
+        };
+        if !is_live {
           continue;
         }
         let original_name: CompactStr = match predefined_names.as_slice() {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -6,6 +6,7 @@ use oxc_index::IndexVec;
 use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames;
 use rolldown_common::{
   ChunkIdx, ChunkKind, InstantiationKind, OutputExports, PackageJson, PathsOutputOption,
+  UsedSymbolRefs, UsedSymbolRefsBuilder,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -135,9 +136,16 @@ impl<'a> GenerateStage<'a> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
+  pub async fn generate(
+    &mut self,
+    mut used_symbol_refs: UsedSymbolRefsBuilder,
+  ) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
-    let mut chunk_graph = self.generate_chunks().await?;
+    let mut chunk_graph = self.generate_chunks(&mut used_symbol_refs).await?;
+
+    // The chunk optimizer's re-run of the inclusion pass (inside `generate_chunks`) was the
+    // last writer; sealing consumes the builder, so nothing downstream can mutate the set.
+    let used_symbol_refs = used_symbol_refs.seal();
 
     // Count only live chunks. Chunks merged away during chunk optimization (e.g.
     // the standalone runtime chunk folded back into its host) stay in
@@ -153,9 +161,9 @@ impl<'a> GenerateStage<'a> {
 
     self.finalized_module_namespace_ref_usage();
 
-    self.compute_retained_export_symbols();
+    self.compute_retained_export_symbols(&used_symbol_refs);
 
-    self.compute_cross_chunk_links(&mut chunk_graph);
+    self.compute_cross_chunk_links(&mut chunk_graph, &used_symbol_refs);
 
     self.ensure_lazy_module_initialization_order(&mut chunk_graph);
 
@@ -167,7 +175,7 @@ impl<'a> GenerateStage<'a> {
     self.trace_action_chunks_infos(&chunk_graph);
 
     let mut warnings = vec![];
-    self.compute_chunk_output_exports(&mut chunk_graph, &mut warnings)?;
+    self.compute_chunk_output_exports(&mut chunk_graph, &mut warnings, &used_symbol_refs)?;
     if !warnings.is_empty() {
       self.link_output.warnings.extend(warnings);
     }
@@ -203,7 +211,7 @@ impl<'a> GenerateStage<'a> {
     self.compute_wrapped_esm_init_metadata(&ast_table, &chunk_graph);
     self.finalize_modules(&mut chunk_graph, &mut ast_table);
     self.detect_ineffective_dynamic_imports(&chunk_graph);
-    self.render_chunk_to_assets(&chunk_graph, ast_table).await
+    self.render_chunk_to_assets(&chunk_graph, ast_table, &used_symbol_refs).await
   }
 
   /// Notices:
@@ -389,6 +397,7 @@ impl<'a> GenerateStage<'a> {
     &self,
     chunk_graph: &mut ChunkGraph,
     warnings: &mut Vec<BuildDiagnostic>,
+    used_symbol_refs: &UsedSymbolRefs,
   ) -> BuildResult<()> {
     // Collect all the chunk data we need first
     let mut chunk_export_data = Vec::new();
@@ -407,6 +416,7 @@ impl<'a> GenerateStage<'a> {
           chunk: &chunk_graph.chunk_table[chunk_idx],
           options: self.options,
           link_output: self.link_output,
+          used_symbol_refs,
           chunk_graph,
           plugin_driver: self.plugin_driver,
           module_id_to_codegen_ret: Vec::new(),

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -6,7 +6,7 @@ use oxc_str::CompactStr;
 use rolldown_common::{
   Asset, ChunkIdx, ConcatenateWrappedModuleKind, EmittedChunkInfo, InstantiationKind,
   ModuleRenderArgs, ModuleRenderOutput, Output, OutputAsset, OutputChunk, SharedFileEmitter,
-  SymbolRef,
+  SymbolRef, UsedSymbolRefs,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult};
@@ -43,6 +43,7 @@ impl GenerateStage<'_> {
     &mut self,
     chunk_graph: &ChunkGraph,
     ast_table: IndexEcmaAst,
+    used_symbol_refs: &UsedSymbolRefs,
   ) -> BuildResult<BundleOutput> {
     let mut errors = std::mem::take(&mut self.link_output.errors);
     let mut warnings = std::mem::take(&mut self.link_output.warnings);
@@ -50,8 +51,9 @@ impl GenerateStage<'_> {
     // (the last reader), where it is dropped at scope exit by the compiler —
     // releasing the per-module bumpalo arenas before `minify_chunks` and
     // `finalize_assets` allocate.
-    let (mut instantiated_chunks, index_chunk_to_instances) =
-      self.instantiate_chunks(chunk_graph, ast_table, &mut errors, &mut warnings).await?;
+    let (mut instantiated_chunks, index_chunk_to_instances) = self
+      .instantiate_chunks(chunk_graph, ast_table, &mut errors, &mut warnings, used_symbol_refs)
+      .await?;
 
     self.trace_action_package_graph_ready(chunk_graph, &instantiated_chunks);
 
@@ -146,6 +148,7 @@ impl GenerateStage<'_> {
     ast_table: IndexEcmaAst,
     errors: &mut Vec<BuildDiagnostic>,
     warnings: &mut Vec<BuildDiagnostic>,
+    used_symbol_refs: &UsedSymbolRefs,
   ) -> BuildResult<(IndexInstantiatedChunks, IndexChunkToInstances)> {
     let mut index_chunk_to_instances: IndexChunkToInstances =
       index_vec![FxIndexSet::default(); chunk_graph.chunk_table.len()];
@@ -186,6 +189,7 @@ impl GenerateStage<'_> {
               chunk,
               options: self.options,
               link_output: self.link_output,
+              used_symbol_refs,
               chunk_graph,
               plugin_driver: self.plugin_driver,
               module_id_to_codegen_ret,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -7,7 +7,7 @@ use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
   ConstExportMeta, DependedRuntimeHelperMap, EntryPoint, EntryPointKind, FlatOptions, ImportKind,
   ModuleIdx, ModuleTable, PreserveEntrySignatures, RetainedExportSymbols, RuntimeModuleBrief,
-  SymbolRef, SymbolRefDb, UsedExternalSymbols, UsedSymbolRefs,
+  SymbolRef, SymbolRefDb, UsedExternalSymbols, UsedSymbolRefsBuilder,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
@@ -66,7 +66,6 @@ pub struct LinkStageOutput {
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
-  pub used_symbol_refs: UsedSymbolRefs,
   pub used_external_symbols: UsedExternalSymbols,
   /// See [`RetainedExportSymbols`]; empty until the generate stage projects it.
   pub retained_export_symbols: RetainedExportSymbols,
@@ -108,7 +107,7 @@ pub struct LinkStage<'a> {
   pub errors: Vec<BuildDiagnostic>,
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
-  pub used_symbol_refs: UsedSymbolRefs,
+  pub used_symbol_refs: UsedSymbolRefsBuilder,
   pub used_external_symbols: UsedExternalSymbols,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
@@ -212,7 +211,7 @@ impl<'a> LinkStage<'a> {
       ast_table: scan_stage_output.index_ecma_ast,
       dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
       options,
-      used_symbol_refs: UsedSymbolRefs::default(),
+      used_symbol_refs: UsedSymbolRefsBuilder::default(),
       used_external_symbols: UsedExternalSymbols::default(),
       safely_merge_cjs_ns_map: FxHashMap::default(),
       normal_symbol_exports_chain_map: FxHashMap::default(),
@@ -229,7 +228,7 @@ impl<'a> LinkStage<'a> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn link(mut self) -> (LinkStageOutput, IndexEcmaAst) {
+  pub fn link(mut self) -> (LinkStageOutput, IndexEcmaAst, UsedSymbolRefsBuilder) {
     self.sort_modules();
     self.compute_tla();
     self.determine_module_exports_kind();
@@ -257,7 +256,6 @@ impl<'a> LinkStage<'a> {
         runtime: self.runtime,
         warnings: self.warnings,
         errors: self.errors,
-        used_symbol_refs: self.used_symbol_refs,
         used_external_symbols: self.used_external_symbols,
         retained_export_symbols: RetainedExportSymbols::default(),
         dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
@@ -271,6 +269,7 @@ impl<'a> LinkStage<'a> {
         has_enum_inlining: self.has_enum_inlining,
       },
       self.ast_table,
+      self.used_symbol_refs,
     )
   }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   IndexModules, MemberExprRef, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleType,
   NormalModule, NormalizedBundlerOptions, RUNTIME_MODULE_ID, RuntimeHelper, StmtEvalFlags,
   StmtInfo, StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
-  UsedExternalSymbols, UsedSymbolRefs, WrapKind, side_effects::DeterminedSideEffects,
+  UsedExternalSymbols, UsedSymbolRefsBuilder, WrapKind, side_effects::DeterminedSideEffects,
 };
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
@@ -71,7 +71,7 @@ pub struct IncludeContext<'a> {
   pub inline_const_smart: bool,
   pub runtime_idx: ModuleIdx,
   pub metas: &'a LinkingMetadataVec,
-  pub used_symbol_refs: &'a mut UsedSymbolRefs,
+  pub used_symbol_refs: &'a mut UsedSymbolRefsBuilder,
   pub used_external_symbols: &'a mut UsedExternalSymbols,
   pub constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
   pub options: &'a NormalizedBundlerOptions,
@@ -112,7 +112,7 @@ impl<'a> IncludeContext<'a> {
     is_module_included_vec: &'a mut ModuleInclusionVec,
     runtime_idx: ModuleIdx,
     metas: &'a LinkingMetadataVec,
-    used_symbol_refs: &'a mut UsedSymbolRefs,
+    used_symbol_refs: &'a mut UsedSymbolRefsBuilder,
     used_external_symbols: &'a mut UsedExternalSymbols,
     constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
     options: &'a NormalizedBundlerOptions,
@@ -255,7 +255,7 @@ impl LinkStage<'_> {
         m.as_normal().map_or(IndexBitSet::default(), |_| IndexBitSet::new(stmt_infos.len()))
       })
       .collect::<IndexVec<ModuleIdx, _>>();
-    let mut used_symbol_refs = UsedSymbolRefs::default();
+    let mut used_symbol_refs = UsedSymbolRefsBuilder::default();
     let mut used_external_symbols = UsedExternalSymbols::default();
     let mut is_module_included_vec: ModuleInclusionVec =
       IndexBitSet::new(self.module_table.modules.len());

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -2,7 +2,7 @@ use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_common::{
   Chunk, ChunkIdx, InstantiatedChunk, ModuleRenderOutput, NormalizedBundlerOptions, OutputExports,
-  PathsOutputOption, SymbolRef,
+  PathsOutputOption, SymbolRef, UsedSymbolRefs,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
@@ -16,6 +16,8 @@ pub struct GenerateContext<'a> {
   pub chunk: &'a Chunk,
   pub options: &'a NormalizedBundlerOptions,
   pub link_output: &'a LinkStageOutput,
+  /// Sealed record of inclusion-fixpoint liveness; see [`UsedSymbolRefs`].
+  pub used_symbol_refs: &'a UsedSymbolRefs,
   pub chunk_graph: &'a ChunkGraph,
   pub plugin_driver: &'a SharedPluginDriver,
   pub module_id_to_codegen_ret: Vec<Option<ModuleRenderOutput>>,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -219,7 +219,7 @@ pub use crate::{
     GetLocalDb, GetLocalDbMut, SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags,
   },
   types::used_external_symbols::UsedExternalSymbols,
-  types::used_symbol_refs::UsedSymbolRefs,
+  types::used_symbol_refs::{UsedSymbolRefs, UsedSymbolRefsBuilder},
   types::watch::WatcherChangeKind,
   types::wrap_kind::WrapKind,
 };

--- a/crates/rolldown_common/src/types/used_symbol_refs.rs
+++ b/crates/rolldown_common/src/types/used_symbol_refs.rs
@@ -2,28 +2,43 @@ use rustc_hash::FxHashSet;
 
 use super::symbol_ref::SymbolRef;
 
-/// Symbols the inclusion fixpoint decided are needed as bindings: refs referenced
-/// by included statements (inserted in both their original and canonical forms)
-/// plus interface-policy retentions (entry exports, CJS bailout, eval-kept
-/// imports). Constants that get inlined are deliberately absent (never inserted —
-/// their use sites are replaced with the value; constants that must stay bindings,
-/// e.g. entry exports, are present), and module namespace refs are inserted/removed
-/// once more by the generate stage's namespace decision.
+/// The sealed record of inclusion-fixpoint liveness: symbols the inclusion machinery
+/// decided are needed as bindings — refs referenced by included statements (in both
+/// their original and canonical forms) plus interface-policy retentions (entry exports,
+/// CJS bailout, eval-kept imports). Constants that get inlined are deliberately absent
+/// (never inserted — their use sites are replaced with the value; constants that must
+/// stay bindings, e.g. entry exports, are present), and a normal module's namespace ref
+/// is not authoritative here — the generate stage decides namespace retention
+/// separately, on `LinkingMetadata::namespace_included`.
 ///
-/// Writers: `include_symbol` during the inclusion pass, the chunk optimizer's
-/// facade-elimination re-run of that pass, and the namespace-decision mirror in
-/// `finalized_module_namespace_ref_usage`. Nothing else may mutate this.
+/// Read-only by construction: produced by [`UsedSymbolRefsBuilder::seal`] once the last
+/// writer (the chunk optimizer's facade-elimination re-run of the inclusion pass) has
+/// finished. There is no way to mutate it afterwards.
 ///
 /// Purpose-specific views exist for common questions — prefer them:
 /// `LinkingMetadata::namespace_included` for namespace retention,
 /// `UsedExternalSymbols` for external bindings, and `RetainedExportSymbols` for
 /// a module's retained export interface.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct UsedSymbolRefs {
   inner: FxHashSet<SymbolRef>,
 }
 
 impl UsedSymbolRefs {
+  #[inline]
+  pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.contains(symbol_ref)
+  }
+}
+
+/// The mutable phase of [`UsedSymbolRefs`], held only by the inclusion machinery
+/// (the link-stage fixpoint and the chunk optimizer's re-run of it).
+#[derive(Debug, Default)]
+pub struct UsedSymbolRefsBuilder {
+  inner: FxHashSet<SymbolRef>,
+}
+
+impl UsedSymbolRefsBuilder {
   #[inline]
   pub fn insert(&mut self, symbol_ref: SymbolRef) {
     self.inner.insert(symbol_ref);
@@ -34,8 +49,7 @@ impl UsedSymbolRefs {
     self.inner.contains(symbol_ref)
   }
 
-  #[inline]
-  pub fn remove(&mut self, symbol_ref: &SymbolRef) -> bool {
-    self.inner.remove(symbol_ref)
+  pub fn seal(self) -> UsedSymbolRefs {
+    UsedSymbolRefs { inner: self.inner }
   }
 }


### PR DESCRIPTION
### Description

Part 5 (follow-up to the review discussion) of the `used_symbol_refs` decomposition stack (stacked on #10090).

#10090 documented by convention that `used_symbol_refs` must not change after the inclusion machinery finishes. This PR enforces it at the type level instead:

- The mutable phase is a separate `UsedSymbolRefsBuilder` (`insert`/`contains`), held by the link-stage fixpoint and threaded explicitly through `generate_chunks` into the chunk optimizer's facade-elimination re-run — the last writer. `remove()` no longer exists at all.
- `seal()` consumes the builder and yields `UsedSymbolRefs`, which only exposes `contains()`. Downstream passes (retained-export projection, cross-chunk linking, chunk output exports, chunk rendering) receive the sealed value. Mutating after the seal point is a compile error, not a runtime check.
- The set no longer lives on `LinkStageOutput`; the ESM generator reads it through a dedicated `GenerateContext` field.

This also deletes the namespace-decision mirror left by #10087: `finalized_module_namespace_ref_usage` now only writes `meta.namespace_included`, and the three places whose answers previously depended on the mirrored set membership for namespace refs — the two cross-chunk liveness filters and the retained-export projection — consult the flag explicitly.

`UsedExternalSymbols` and `RetainedExportSymbols` could get the same builder/sealed split as a follow-up.

No behavior change; snapshots are untouched.

Stack: #10087 → #10088 → #10089 → #10090 → #10091