### PR TITLE
refactor(tree-shaking): extract const/enum inline bypasses into a policy module

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -28,6 +28,8 @@ use crate::{
   types::linking_metadata::LinkingMetadataVec,
 };
 
+use super::policy::{member_is_inlined_enum, symbol_is_inlined_const};
+
 pub type StmtInclusionVec = IndexVec<ModuleIdx, IndexBitSet<StmtInfoIdx>>;
 pub type ModuleInclusionVec = IndexBitSet<ModuleIdx>;
 pub type ModuleNamespaceReasonVec = IndexVec<ModuleIdx, ModuleNamespaceIncludedReason>;
@@ -955,15 +957,9 @@ pub fn include_symbol(
 ) {
   let mut canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
 
-  if let Some(v) = ctx.constant_symbol_map.get(&canonical_ref)
-    && !include_reason.contains(SymbolIncludeReason::EntryExport)
-    && (!ctx.inline_const_smart || v.safe_to_inline)
-    && !v.commonjs_export
-  {
-    // If the symbol is a constant value and it is not a commonjs module export, we don't need to include it since it would be always inlined.
-    // In smart mode, we only skip if `safe_to_inline` is true (meaning it will be inlined regardless of context).
-    // We don't need to add any flag since if `inlineConst` is disabled, the test expr will always
-    // return `false`
+  // A symbol that will be inlined at its use sites (an inlinable constant) needs no
+  // declaration; see `policy::symbol_is_inlined_const`.
+  if symbol_is_inlined_const(ctx, canonical_ref, include_reason) {
     return;
   }
 
@@ -1181,33 +1177,12 @@ pub fn include_statement(
         // If it points to nothing, the expression will be rewritten as `void 0` and there's nothing we need to include
       }
     } else {
-      // For enum member accesses (e.g., `B.member`), check if the member will be inlined
-      // by the finalizer. If so, skip including the enum's declaration — it's dead code
-      // after inlining. This mirrors the `constant_symbol_map` bypass in `include_symbol`.
-      //
-      // This applies to both const and regular enums. The member access will be replaced
-      // by a literal, so the reference no longer needs the declaration. If the enum is
-      // also referenced as a bare symbol (e.g., `typeof E`, `console.log(E)`), that
-      // separate reference will independently include the declaration via `include_symbol`.
-      // Regular enum IIFEs are `@__PURE__`, so they'll be tree-shaken if truly unused.
-      if let SymbolOrMemberExprRef::MemberExpr(member_expr_ref) = reference_ref {
-        let canonical_ref = ctx.symbols.canonical_ref_for(member_expr_ref.object_ref);
-        if let Some(Module::Normal(owner_module)) = ctx.modules.get(canonical_ref.owner) {
-          let symbol_name = canonical_ref.name(ctx.symbols);
-          if let Some(members) = owner_module.ecma_view.enum_member_value_map.get(symbol_name) {
-            // Only bypass for simple member accesses (e.g., `E.member`), not deep chains
-            // like `E.member.something` which wouldn't be inlined.
-            if !member_expr_ref.is_write
-              && let [prop] = member_expr_ref.prop_and_span_list.as_slice()
-              && members.contains_key(prop.name.as_str())
-            {
-              // This member access will be inlined — don't include the enum declaration.
-              // Enum inlining is unconditional (not gated by inlineConst mode) because
-              // it implements TypeScript's const enum semantics, which mandate replacement.
-              return;
-            }
-          }
-        }
+      // An enum member access the finalizer will inline to a literal needs no enum
+      // declaration for this reference; see `policy::member_is_inlined_enum`.
+      if let SymbolOrMemberExprRef::MemberExpr(member_expr_ref) = reference_ref
+        && member_is_inlined_enum(ctx, member_expr_ref)
+      {
+        return;
       }
       let original_ref = reference_ref.symbol_ref();
       std::iter::once(original_ref)

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod determine_side_effects;
 pub mod include_statements;
+mod policy;
 
 pub use include_statements::{ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec};

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/policy.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/policy.rs
@@ -1,0 +1,54 @@
+//! Tree-shaking inclusion policy.
+//!
+//! The generic reachability walk in [`super::include_statements`]
+//! (`include_module` / `include_statement` / `include_symbol`) asks the questions
+//! here instead of encoding domain rules inline. Each function is a pure read over
+//! [`IncludeContext`]; keeping them together lets the walk read as a plain graph
+//! traversal and lets a rule change (or a new rule) live in one place.
+
+use rolldown_common::{MemberExprRef, Module, SymbolRef};
+
+use super::include_statements::{IncludeContext, SymbolIncludeReason};
+
+/// Whether `canonical_ref` is an inlinable constant that is substituted at every use
+/// site, so its declaration need not be included.
+///
+/// In smart mode we only skip when `safe_to_inline` (it will be inlined regardless of
+/// context). CommonJS module exports are never skipped. When `inlineConst` is disabled
+/// the map is empty, so this is always `false`.
+pub fn symbol_is_inlined_const(
+  ctx: &IncludeContext<'_>,
+  canonical_ref: SymbolRef,
+  include_reason: SymbolIncludeReason,
+) -> bool {
+  ctx.constant_symbol_map.get(&canonical_ref).is_some_and(|v| {
+    !include_reason.contains(SymbolIncludeReason::EntryExport)
+      && (!ctx.inline_const_smart || v.safe_to_inline)
+      && !v.commonjs_export
+  })
+}
+
+/// Whether `member_expr_ref` is an enum member access (`E.member`) that the finalizer
+/// will inline to a literal, so the enum declaration need not be included for this
+/// reference.
+///
+/// Only simple accesses qualify — not deep chains like `E.member.something`, which are
+/// not inlined. Enum inlining is unconditional (not gated by `inlineConst`) because it
+/// implements TypeScript's const-enum semantics, which mandate replacement. A bare
+/// reference to the enum elsewhere (`typeof E`, `console.log(E)`) still includes the
+/// declaration via its own `include_symbol`.
+pub fn member_is_inlined_enum(ctx: &IncludeContext<'_>, member_expr_ref: &MemberExprRef) -> bool {
+  let canonical_ref = ctx.symbols.canonical_ref_for(member_expr_ref.object_ref);
+  let Some(Module::Normal(owner_module)) = ctx.modules.get(canonical_ref.owner) else {
+    return false;
+  };
+  let symbol_name = canonical_ref.name(ctx.symbols);
+  let Some(members) = owner_module.ecma_view.enum_member_value_map.get(symbol_name) else {
+    return false;
+  };
+  !member_expr_ref.is_write
+    && matches!(
+      member_expr_ref.prop_and_span_list.as_slice(),
+      [prop] if members.contains_key(prop.name.as_str())
+    )
+}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
