### PR TITLE
perf: avoid redundant sourcemap string copies in collapse and minify paths

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
@@ -44,25 +44,35 @@ impl GenerateStage<'_> {
           };
 
           let allocator_guard = allocator_pool.get();
-          // TODO: Do we need to ensure `chunk.preliminary_filename` to be absolute path?
-          let (minified_content, new_map) = EcmaCompiler::dce_or_minify(
-            &allocator_guard,
-            chunk.content.try_as_inner_str()?,
-            options.format.source_type().with_jsx(true),
-            chunk.map.is_some(),
-            chunk.preliminary_filename.as_str(),
-            compress,
-            minify_option.clone(),
-            codegen_options,
-          );
+          // The minify map borrows the pre-minify `chunk.content` (as `sourcesContent`,
+          // which the collapse discards), so collapse before swapping in the minified
+          // content instead of paying an `into_owned` copy of the whole chunk text.
+          let (minified_content, collapsed_map) = {
+            // TODO: Do we need to ensure `chunk.preliminary_filename` to be absolute path?
+            let (minified_content, new_map) = EcmaCompiler::dce_or_minify(
+              &allocator_guard,
+              chunk.content.try_as_inner_str()?,
+              options.format.source_type().with_jsx(true),
+              chunk.map.is_some(),
+              chunk.preliminary_filename.as_str(),
+              compress,
+              minify_option.clone(),
+              codegen_options,
+            );
+            let collapsed_map = match (&chunk.map, &new_map) {
+              (Some(origin_map), Some(new_map)) => {
+                Some(collapse_sourcemaps(&[origin_map, new_map]))
+              }
+              _ => {
+                // TODO: Map is dirty. Should we reset the `chunk.map` to `None`?
+                None
+              }
+            };
+            (minified_content, collapsed_map)
+          };
           chunk.content = minified_content.into();
-          match (&chunk.map, &new_map) {
-            (Some(origin_map), Some(new_map)) => {
-              chunk.map = Some(collapse_sourcemaps(&[origin_map, new_map]));
-            }
-            _ => {
-              // TODO: Map is dirty. Should we reset the `chunk.map` to `None`?
-            }
+          if let Some(map) = collapsed_map {
+            chunk.map = Some(map);
           }
         }
         rolldown_common::InstantiationKind::None

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -242,9 +242,10 @@ impl NormalModule {
             hires: string_wizard::Hires::Boundary,
             ..Default::default()
           });
-          let map = render_output
-            .map
-            .map(|original| collapse_sourcemaps(&[&original.into_owned(), &mutated_map]));
+          // `original` borrows the module source; `collapse_sourcemaps` copies what it
+          // keeps from it, so no `into_owned` detach is needed.
+          let map =
+            render_output.map.map(|original| collapse_sourcemaps(&[&original, &mutated_map]));
           return ModuleRenderOutput { code, map };
         }
         ModuleRenderOutput {

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -424,9 +424,11 @@ pub fn enhanced_transform(
     })
     .build(&program);
 
-  let output_map = match (input_map, codegen_ret.map.map(oxc_sourcemap::SourceMap::into_owned)) {
+  let output_map = match (input_map, codegen_ret.map) {
+    // The collapse only keeps strings from `im`, so the borrowed codegen map can be
+    // used directly — detaching it first would copy the whole source for nothing.
     (Some(im), Some(om)) => Some(collapse_sourcemaps(&[&im, &om])),
-    (None, map) => map,
+    (None, map) => map.map(oxc_sourcemap::SourceMap::into_owned),
     (Some(_), None) => None,
   };
 

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -107,17 +107,20 @@ impl EcmaCompiler {
       .build(ast.program())
   }
 
+  /// The returned map borrows `source_text` (its `sourcesContent` and token names are slices
+  /// of it) — callers that keep it beyond the borrow must `into_owned` it; callers that only
+  /// feed it to `collapse_sourcemaps` can use it as-is and skip that copy.
   #[expect(clippy::too_many_arguments)]
-  pub fn dce_or_minify(
-    allocator: &Allocator,
-    source_text: &str,
+  pub fn dce_or_minify<'a>(
+    allocator: &'a Allocator,
+    source_text: &'a str,
     source_type: SourceType,
     enable_sourcemap: bool,
     filename: &str,
     compress: bool,
     minify_options: MinifierOptions,
     codegen_options: CodegenOptions,
-  ) -> (String, Option<SourceMap<'static>>) {
+  ) -> (String, Option<SourceMap<'a>>) {
     let mut program = Parser::new(allocator, source_text, source_type)
       .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
       .parse()
@@ -136,7 +139,7 @@ impl EcmaCompiler {
       .with_scoping(ret.scoping)
       .with_private_member_mappings(ret.class_private_mappings)
       .build(&program);
-    (ret.code, ret.map.map(SourceMap::into_owned))
+    (ret.code, ret.map)
   }
 }
 

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -17,35 +17,38 @@ pub use crate::source::{Source, SourceMapSource};
 /// Strips the first `lines` destination lines from the sourcemap, decrementing all remaining
 /// destination line numbers accordingly. Used to re-anchor a sourcemap after removing a
 /// prefix (e.g. a shebang line) from the generated code.
+///
+/// Reuses the map's existing allocations: strings are moved, and the token buffer is mutated
+/// in place unless tokens have to be dropped (only when some token maps into the stripped
+/// prefix, which rolldown's own maps never do — prepended text carries no tokens).
 pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap {
   if lines == 0 {
     return sourcemap;
   }
 
-  let tokens: Box<[Token]> = sourcemap
-    .get_tokens()
-    .filter(|t| t.get_dst_line() >= lines)
-    .map(|token| {
-      Token::new(
-        token.get_dst_line() - lines,
-        token.get_dst_col(),
-        token.get_src_line(),
-        token.get_src_col(),
-        token.get_source_id(),
-        token.get_name_id(),
-      )
-    })
-    .collect();
+  let shift = |token: &Token| {
+    Token::new(
+      token.get_dst_line() - lines,
+      token.get_dst_col(),
+      token.get_src_line(),
+      token.get_src_col(),
+      token.get_source_id(),
+      token.get_name_id(),
+    )
+  };
 
-  SourceMap::new(
-    sourcemap.get_file().map(|f| Cow::Owned(f.to_owned())),
-    sourcemap.get_names().map(|n| Cow::Owned(n.to_owned())).collect(),
-    sourcemap.get_source_root().map(|s| Cow::Owned(s.to_owned())),
-    sourcemap.get_sources().map(|s| Cow::Owned(s.to_owned())).collect(),
-    sourcemap.get_source_contents().map(|c| c.map(|s| Cow::Owned(s.to_owned()))).collect(),
-    tokens,
-    None,
-  )
+  let mut parts = sourcemap.into_parts();
+  if parts.tokens.iter().any(|t| t.get_dst_line() < lines) {
+    parts.tokens = parts.tokens.iter().filter(|t| t.get_dst_line() >= lines).map(shift).collect();
+  } else {
+    for token in &mut parts.tokens {
+      *token = shift(token);
+    }
+  }
+  // The chunk boundaries and VLQ baselines in `token_chunks` describe the pre-shift tokens.
+  parts.token_chunks = None;
+
+  SourceMap::from_parts(parts)
 }
 
 /// Builds an empty sourcemap with no tokens, sources, names, or contents.
@@ -54,11 +57,15 @@ pub fn empty_sourcemap() -> SourceMap {
 }
 
 // <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
-pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
+//
+// Input maps may borrow their strings (e.g. a codegen map borrowing the source it was
+// printed from) — the output is always owned, since it only copies from the first map.
+// This lets callers collapse a freshly generated map without `into_owned`-ing it first.
+pub fn collapse_sourcemaps(sourcemap_chain: &[&oxc_sourcemap::SourceMap<'_>]) -> SourceMap {
   debug_assert!(sourcemap_chain.len() > 1);
   if sourcemap_chain.len() == 1 {
     // If there's only one sourcemap, return it as is.
-    return sourcemap_chain[0].clone();
+    return sourcemap_chain[0].clone().into_owned();
   }
 
   let last_map = sourcemap_chain.last().expect("sourcemap_chain should not be empty");


### PR DESCRIPTION
### Description

`collapse_sourcemaps` only copies strings from the *first* map of the chain, yet its `&[&SourceMap<'static>]` signature forced callers to `into_owned()` freshly generated codegen maps before collapsing — deep-copying strings (including whole-chunk `sourcesContent`) that were immediately discarded.

- `rolldown_sourcemap::collapse_sourcemaps` now accepts `&[&SourceMap<'_>]`; existing callers compile unchanged via covariance, and the output stays owned since it only copies from the first map.
- `EcmaCompiler::dce_or_minify` returns the codegen map borrowing its input instead of detaching it to `'static`.
- `minify_chunks` collapses the minify map before swapping in the minified content, removing a full copy of the pre-minify chunk text + all mangled names per minified chunk.
- `NormalModule::render` (mutations path) and `enhanced_transform` drop the same immediately-discarded `into_owned` copies (one module-source copy per mutated module / per transform call with an input map).
- `adjust_sourcemap_dst_lines` moves the map through `into_parts()` instead of re-cloning every name/source/`sourcesContent` string, and shifts tokens in place when none fall inside the stripped prefix (always the case for rolldown-generated maps, since prepended text carries no tokens). Side effect: `file`/`sourceRoot`/`debugId`/ignore-list are now preserved instead of silently dropped.

Outputs are byte-identical on `three10x` with `minify: true` + `sourcemap: 'file'` (chunk and 19.6 MB map hash equal before/after); user CPU is unchanged and peak RSS drops ~15–40 MB on that fixture since the removed copies were transient.