### PR TITLE
refactor(treeshake): split include_statements.rs into focused modules

### DIFF
--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -40,11 +40,8 @@ mod sort_modules;
 mod tree_shaking;
 
 pub use tree_shaking::{
-  ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec,
-  include_statements::{
-    IncludeContext, SymbolIncludeReason, compute_on_demand_side_effect_stmts,
-    include_runtime_symbol, include_symbol,
-  },
+  IncludeContext, ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec,
+  SymbolIncludeReason, compute_on_demand_side_effect_stmts, include_runtime_symbol, include_symbol,
 };
 mod wrapping;
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/dynamic_entries.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/dynamic_entries.rs
@@ -1,0 +1,218 @@
+//! Dynamic-entry handling for the inclusion fixpoint: topological ordering of dynamic
+//! entries (so ancestors include before descendants), aliveness determination (a dead
+//! pure dynamic import must not retain its entry), and per-iteration processing.
+
+use std::cmp::Reverse;
+
+use oxc::semantic::NodeId;
+use petgraph::prelude::DiGraphMap;
+use rolldown_common::{
+  EntryPoint, EntryPointKind, ImportKind, ImportRecordIdx, ImportRecordMeta, Module, ModuleIdx,
+  dynamic_import_usage::DynamicImportExportsUsage,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::stages::link_stage::LinkStage;
+
+use super::include_statements::{
+  IncludeContext, StmtInclusionVec, SymbolIncludeReason, include_declaring_statements,
+  include_module, include_symbol_and_check_cjs_bailout,
+};
+
+impl LinkStage<'_> {
+  /// Process a dynamic entry and determine if it should be retained.
+  /// Returns `true` if the entry should be kept, `false` if it should be filtered out.
+  pub(super) fn process_and_retain_dynamic_entry(
+    &self,
+    entry: &EntryPoint,
+    cycled_idx: &FxHashSet<ModuleIdx>,
+    context: &mut IncludeContext,
+    unused_record_idxs: &mut Vec<(ModuleIdx, ImportRecordIdx)>,
+    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
+  ) -> bool {
+    if !cycled_idx.contains(&entry.idx) {
+      if let Some(item) = self.is_dynamic_entry_alive(
+        entry,
+        context.is_included_vec,
+        unreachable_import_expression_node_ids,
+      ) {
+        unused_record_idxs.extend(item);
+        return false;
+      }
+    }
+    let module = match &self.module_table[entry.idx] {
+      Module::Normal(module) => module,
+      Module::External(_module) => {
+        // Case: import('external').
+        return true;
+      }
+    };
+    let meta = &self.metas[entry.idx];
+    meta.referenced_symbols_by_entry_point_chunk.iter().for_each(|(symbol_ref, _came_from_cjs)| {
+      if let Module::Normal(_) = &context.modules[symbol_ref.owner] {
+        include_declaring_statements(context, symbol_ref);
+        include_symbol_and_check_cjs_bailout(
+          context,
+          *symbol_ref,
+          SymbolIncludeReason::EntryExport,
+        );
+      }
+    });
+    include_module(context, module);
+    true
+  }
+
+  /// # Description
+  /// Some dynamic entries also reference another dynamic entry, we need to ensure each
+  /// dynamic entry is included before all its descendant dynamic entry.
+  /// ```js
+  /// // a.js
+  /// export default import('./b.js').then((mod) => {
+  ///   return mod;
+  /// })
+  ///
+  /// // b.js
+  /// export default import('./c.js').then((mod) => {
+  ///  return mod;
+  /// })
+  ///
+  /// // c.js
+  /// export default 1;
+  /// ```
+  /// after first round user defined entry are included, `default` of `b.js` are included, but
+  /// `default` of `c.js` is not included.
+  /// note: We can't use default entry point order, since they are sorted by stable_id.
+  ///
+  /// # Complexity
+  ///   - construct the dynamic entry relation graph: O(M), `M` the number of modules.
+  ///   - ref https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm#Complexity
+  ///     `O(|V|+|E|)`, for the most of the scenario the relation graph is sparsely connected, we
+  ///     could assume it is `O(N)`, `N` is the number of dynamic entries.
+  ///   - So overall, the complexity is `O(M)`.
+  pub(super) fn sort_dynamic_entries_by_topological_order(
+    &self,
+    dynamic_entries: &mut [EntryPoint],
+  ) -> FxHashSet<ModuleIdx> {
+    let mut graph: DiGraphMap<ModuleIdx, ()> = DiGraphMap::new();
+
+    // TODO: Since we don't skip visited node, If a project has a lot of dynamic entries,
+    // and they are all connected, the performance may be impacted. But this seems rare in real world,
+    // we could optimize it later if needed.
+    for entry in dynamic_entries.iter() {
+      let mut entry_module_idx = entry.idx;
+      let cur = entry_module_idx;
+      let mut visited = FxHashSet::default();
+      self.construct_dynamic_entry_graph(&mut graph, &mut visited, &mut entry_module_idx, cur);
+    }
+    let mut cycled_dynamic_entries = FxHashSet::default();
+    // https://docs.rs/petgraph/latest/petgraph/algo/fn.tarjan_scc.html
+    // the order of struct connected component is sorted by reverse topological sort.
+    let idx_to_order_map = petgraph::algo::tarjan_scc(&graph)
+      .into_iter()
+      .enumerate()
+      .filter(|(_idx, scc)| {
+        if scc.len() > 1 {
+          cycled_dynamic_entries.extend(scc.iter().copied());
+          return false;
+        }
+        true
+      })
+      .map(|(idx, scc)| (scc[0], idx))
+      .collect::<FxHashMap<ModuleIdx, usize>>();
+    // We only need to ensure the relative order of those none cycled dynamic entries are correct, rest of them
+    // we just bailout them
+    dynamic_entries.sort_by_key(|item| {
+      idx_to_order_map.get(&item.idx).map_or(Reverse(usize::MAX), |&order| Reverse(order))
+    });
+    cycled_dynamic_entries
+  }
+
+  fn construct_dynamic_entry_graph(
+    &self,
+    g: &mut DiGraphMap<ModuleIdx, ()>,
+    visited: &mut FxHashSet<ModuleIdx>,
+    root_node: &mut ModuleIdx,
+    cur_node: ModuleIdx,
+  ) -> Option<()> {
+    if visited.contains(&cur_node) {
+      return Some(());
+    }
+    visited.insert(cur_node);
+    let module = self.module_table[cur_node].as_normal()?;
+    for rec in &module.import_records {
+      let Some(module_idx) = rec.resolved_module else {
+        continue;
+      };
+      if rec.kind == ImportKind::DynamicImport {
+        let seen = g.contains_node(module_idx);
+        if *root_node != module_idx {
+          g.add_edge(*root_node, module_idx, ());
+          // Even it is visited before, we still needs to connect the edge
+          if seen {
+            continue;
+          }
+        }
+        let previous = *root_node;
+        *root_node = module_idx;
+        self.construct_dynamic_entry_graph(g, visited, root_node, module_idx);
+        *root_node = previous;
+        continue;
+      }
+      // Can't put it at the beginning of the loop,
+      self.construct_dynamic_entry_graph(g, visited, root_node, module_idx);
+    }
+    Some(())
+  }
+
+  /// Note:
+  /// this function determine if a dynamic_entry is still alive, return the unused dynamic
+  /// import record idxs(due to limitation of rustc borrow checker) if it is unused.
+  fn is_dynamic_entry_alive(
+    &self,
+    entry_point: &EntryPoint,
+    is_stmt_included_vec: &StmtInclusionVec,
+    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
+  ) -> Option<Vec<(ModuleIdx, ImportRecordIdx)>> {
+    let mut ret = vec![];
+    let is_lived = match entry_point.kind {
+      EntryPointKind::UserDefined | EntryPointKind::EmittedUserDefined => true,
+      EntryPointKind::DynamicImport => {
+        let is_dynamic_imported_module_exports_unused =
+          self.dynamic_import_exports_usage_map.get(&entry_point.idx).is_some_and(
+            |item| matches!(item, DynamicImportExportsUsage::Partial(set) if set.is_empty()),
+          );
+
+        // Mark the dynamic entry as lived if at least one statement that create this entry is included
+        entry_point.related_stmt_infos.iter().any(
+          |(module_idx, stmt_idx, node_id, import_record_idx)| {
+            if unreachable_import_expression_node_ids.contains(&(*module_idx, *node_id)) {
+              return false;
+            }
+            let module =
+              &self.module_table[*module_idx].as_normal().expect("should be a normal module");
+            let all_dead_pure_dynamic_import = {
+              let import_record = &module.import_records[*import_record_idx];
+              let importee_side_effects = self.module_table[import_record.into_resolved_module()]
+                .side_effects()
+                .has_side_effects();
+
+              // Only consider it is unused if it is a top level pure dynamic import and the
+              // importee module has no side effects.
+              !importee_side_effects
+                && import_record.meta.contains(ImportRecordMeta::TopLevelPureDynamicImport)
+            };
+            let is_stmt_included = is_stmt_included_vec[*module_idx].has_bit(*stmt_idx);
+            let lived = is_stmt_included
+              && (!is_dynamic_imported_module_exports_unused || !all_dead_pure_dynamic_import);
+
+            if !lived && all_dead_pure_dynamic_import {
+              ret.push((*module_idx, *import_record_idx));
+            }
+            lived
+          },
+        )
+      }
+    };
+    (!is_lived).then_some(ret)
+  }
+}

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -1,17 +1,12 @@
-use std::cmp::Reverse;
-
 use itertools::Itertools;
 use oxc::semantic::NodeId;
 use oxc_index::IndexVec;
-use petgraph::prelude::DiGraphMap;
 use rolldown_common::{
-  ConstExportMeta, EcmaModuleAstUsage, EcmaViewMeta, EntryPoint, EntryPointKind, ExportsKind,
-  ImportKind, ImportRecordIdx, ImportRecordMeta, IndexModules, Module, ModuleIdx,
-  ModuleNamespaceIncludedReason, ModuleType, NormalModule, NormalizedBundlerOptions,
-  RUNTIME_HELPER_NAMES, RUNTIME_MODULE_ID, RuntimeHelper, RuntimeModuleBrief, StmtEvalFlags,
+  ConstExportMeta, EcmaModuleAstUsage, EcmaViewMeta, ExportsKind, ImportKind, ImportRecordMeta,
+  IndexModules, MemberExprRef, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleType,
+  NormalModule, NormalizedBundlerOptions, RUNTIME_MODULE_ID, RuntimeHelper, StmtEvalFlags,
   StmtInfo, StmtInfoIdx, StmtInfoMeta, StmtInfos, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
-  UsedExternalSymbols, UsedSymbolRefs, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
-  side_effects::DeterminedSideEffects,
+  UsedExternalSymbols, UsedSymbolRefs, WrapKind, side_effects::DeterminedSideEffects,
 };
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
@@ -26,6 +21,16 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
   stages::link_stage::LinkStage, type_alias::IndexStmtInfos,
   types::linking_metadata::LinkingMetadataVec,
+};
+
+use super::{
+  on_demand::{
+    compute_on_demand_side_effect_stmts, is_gated_side_effect_stmt, side_effects_included_on_demand,
+  },
+  passes::{
+    collect_depended_runtime_helpers, include_cjs_bailout_exports, include_runtime_symbol,
+    preserve_reexported_interfaces,
+  },
 };
 
 pub type StmtInclusionVec = IndexVec<ModuleIdx, IndexBitSet<StmtInfoIdx>>;
@@ -134,75 +139,12 @@ impl<'a> IncludeContext<'a> {
   }
 }
 
-/// Whether side-effectful statements of `module` that reference module-level
-/// symbols are included on demand instead of being swept in unconditionally by
-/// [`include_module`].
-///
-/// A module the user declared side-effect free (`"sideEffects": false` in
-/// package.json, `treeshake.moduleSideEffects: false`) must not have such
-/// statements retained merely because they *evaluate* effects. Without this,
-/// any force-inclusion of the module — the wrapper-ref edge under
-/// `strictExecutionOrder`, `require()` of ESM, or an inlined dynamic import
-/// under `codeSplitting: false` — resurrects side-effect statements that plain
-/// (unwrapped) tree-shaking provably drops, making inclusion inconsistent
-/// between `strictExecutionOrder: true` and `false`. It also breaks the lazy
-/// barrel loader's contract: the loader defers import records by requested
-/// exports, so a retained statement referencing a never-requested import ends up
-/// referencing a record that was correctly never loaded and crashes at runtime
-/// (#9691, #9806, #9961, #9964, #10013, #10048).
-///
-/// Instead such statements join when the module's *body* is demanded: one of
-/// its own (non-re-export) exports or its namespace object becomes used (via
-/// `on_demand_side_effect_stmts`) — e.g. `foo.bar = 1` stays once `foo` is
-/// demanded, `#7597`'s top-level asserts stay because the entry imports the
-/// module's own `Modal`. This mirrors the lazy-barrel loader exactly: body
-/// demand is its `has_local_export`/`All` case, in which it loads every plain
-/// import record of the module — so a kept statement can never reference an
-/// unloaded record, and a deferred record is only ever referenced by dropped
-/// statements.
-///
-/// Statements referencing no module-level symbol (a bare `console.log()`) and
-/// import/re-export statements (which drive wrapper init calls and side-effect
-/// imports) cannot dangle an import and keep the unconditional sweep.
-/// Exemptions: user-defined entry modules (the requested program keeps its
-/// body — dynamic entries instead join through namespace/own-export body
-/// demand, so a dead pure dynamic import can't resurrect a body), modules
-/// using `eval` (it can observe anything), and CommonJS modules (their exports
-/// are side-effect assignments that the demand edges don't model).
-fn side_effects_included_on_demand(
-  module: &NormalModule,
-  entry_module_idxs: &FxHashSet<ModuleIdx>,
-) -> bool {
-  matches!(module.side_effects, DeterminedSideEffects::UserDefined(false))
-    && matches!(module.exports_kind, ExportsKind::Esm)
-    && !module.meta.has_eval()
-    && !entry_module_idxs.contains(&module.idx)
-}
-
-fn include_cjs_bailout_exports(
-  context: &mut IncludeContext,
-  metas: &LinkingMetadataVec,
-  bailout_modules: impl IntoIterator<Item = ModuleIdx>,
-) {
-  for idx in bailout_modules {
-    metas[idx].resolved_exports.values().filter(|local| local.came_from_commonjs).for_each(
-      |local| {
-        include_symbol_and_check_cjs_bailout(
-          context,
-          local.symbol_ref,
-          SymbolIncludeReason::Normal,
-        );
-      },
-    );
-  }
-}
-
 /// Include a symbol and check for CJS tree-shaking bailout.
 ///
 /// Use this at most call sites. Only use bare [`include_symbol`] when you
 /// explicitly want to skip the bailout check (e.g., for partial CJS member-
 /// expression access or runtime symbols).
-fn include_symbol_and_check_cjs_bailout(
+pub(super) fn include_symbol_and_check_cjs_bailout(
   ctx: &mut IncludeContext,
   symbol_ref: SymbolRef,
   include_reason: SymbolIncludeReason,
@@ -246,104 +188,8 @@ fn check_cjs_bailout(ctx: &mut IncludeContext, symbol_ref: SymbolRef) {
   }
 }
 
-/// Collects all depended runtime helpers from included modules only.
-/// Eliminated modules may have runtime helpers set (for propagation to importers),
-/// but we should only include the runtime if an included module actually needs it.
-fn collect_depended_runtime_helpers(
-  modules: &IndexModules,
-  metas: &LinkingMetadataVec,
-  is_module_included_vec: &ModuleInclusionVec,
-) -> RuntimeHelper {
-  let iter = modules.par_iter().zip_eq(metas.par_iter()).filter_map(|(module, meta)| {
-    module
-      .as_normal()
-      .filter(|m| is_module_included_vec.has_bit(m.idx))
-      .map(|_| meta.depended_runtime_helper)
-  });
-
-  #[cfg(not(target_family = "wasm"))]
-  let depended_runtime_helper = iter.reduce(RuntimeHelper::default, |a, b| a | b);
-  #[cfg(target_family = "wasm")]
-  let depended_runtime_helper = iter.reduce(|a, b| a | b).unwrap_or_default();
-
-  depended_runtime_helper
-}
-
-/// Build the demand edges for modules whose side-effectful statements are
-/// included on demand (see [`side_effects_included_on_demand`]): body-demand
-/// key -> the module's gated side-effect statements.
-///
-/// A module's body counts as demanded when one of its *own* exports (an export
-/// that doesn't re-export an import) or its namespace object becomes used —
-/// mirroring the lazy-barrel loader's `local` classification, which loads every
-/// plain import record of the module exactly in those cases. Demand through
-/// pure re-exports leaves the body dropped.
-pub fn compute_on_demand_side_effect_stmts(
-  modules: &IndexModules,
-  stmt_infos: &IndexStmtInfos,
-  symbols: &SymbolRefDb,
-  treeshake_enabled: bool,
-  entry_module_idxs: &FxHashSet<ModuleIdx>,
-) -> FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> {
-  let mut map: FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> = FxHashMap::default();
-  if !treeshake_enabled {
-    return map;
-  }
-  for module in modules.iter().filter_map(Module::as_normal) {
-    if !side_effects_included_on_demand(module, entry_module_idxs) {
-      continue;
-    }
-    let gated: Vec<(ModuleIdx, StmtInfoIdx)> = stmt_infos[module.idx]
-      .iter_enumerated_without_namespace_stmt()
-      .filter(|(_, stmt_info)| is_gated_side_effect_stmt(stmt_info))
-      .map(|(stmt_idx, _)| (module.idx, stmt_idx))
-      .collect();
-    if gated.is_empty() {
-      continue;
-    }
-    let body_demand_keys = module
-      .named_exports
-      .values()
-      .filter(|local_export| !module.named_imports.contains_key(&local_export.referenced))
-      .map(|local_export| symbols.canonical_ref_for(local_export.referenced))
-      .chain(std::iter::once(module.namespace_object_ref));
-    for key in body_demand_keys {
-      map.entry(key).or_default().extend(gated.iter().copied());
-    }
-  }
-  map
-}
-
-/// A statement that joins through body demand rather than the unconditional
-/// sweep of [`include_module`]: it evaluates side effects *and* reads
-/// module-level bindings (so it can dangle a lazily-deferred import), and is not
-/// an import/re-export statement (those drive wrapper init calls and
-/// side-effect-import inclusion; `reference_needed_symbols` also pushes wrapper
-/// refs onto them, which must not count as user references).
-fn is_gated_side_effect_stmt(stmt_info: &StmtInfo) -> bool {
-  stmt_info.eval_flags.has_side_effect_for_tree_shaking()
-    && !stmt_info.referenced_symbols.is_empty()
-    && stmt_info.import_records.is_empty()
-}
-
 impl LinkStage<'_> {
-  /// User-defined (and emitted) entries — exempt from on-demand side-effect
-  /// gating: they are the requested program. A dynamic entry participates like
-  /// any module: an observed namespace or used export is body demand, while a
-  /// dead pure dynamic import must not resurrect the body its removal already
-  /// models as an empty namespace.
-  fn user_defined_entry_module_idxs(&self) -> FxHashSet<ModuleIdx> {
-    self
-      .entries
-      .values()
-      .flatten()
-      .filter(|entry| entry.kind.is_user_defined())
-      .map(|entry| entry.idx)
-      .collect()
-  }
-
   #[tracing::instrument(level = "debug", skip_all)]
-  #[expect(clippy::too_many_lines)]
   pub fn include_statements(
     &mut self,
     unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
@@ -411,14 +257,8 @@ impl LinkStage<'_> {
       let meta = &self.metas[entry.idx];
       meta.referenced_symbols_by_entry_point_chunk.iter().for_each(
         |(symbol_ref, _came_from_cjs)| {
-          if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
-            context.stmt_infos[symbol_ref.owner]
-              .declared_stmts_by_symbol(symbol_ref)
-              .iter()
-              .copied()
-              .for_each(|stmt_info_id| {
-                include_statement(context, module, stmt_info_id);
-              });
+          if let Module::Normal(_) = &context.modules[symbol_ref.owner] {
+            include_declaring_statements(context, symbol_ref);
             include_symbol_and_check_cjs_bailout(
               context,
               *symbol_ref,
@@ -580,279 +420,18 @@ impl LinkStage<'_> {
         .collect::<Vec<_>>()
     );
   }
-
-  /// Process a dynamic entry and determine if it should be retained.
-  /// Returns `true` if the entry should be kept, `false` if it should be filtered out.
-  fn process_and_retain_dynamic_entry(
-    &self,
-    entry: &EntryPoint,
-    cycled_idx: &FxHashSet<ModuleIdx>,
-    context: &mut IncludeContext,
-    unused_record_idxs: &mut Vec<(ModuleIdx, ImportRecordIdx)>,
-    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
-  ) -> bool {
-    if !cycled_idx.contains(&entry.idx) {
-      if let Some(item) = self.is_dynamic_entry_alive(
-        entry,
-        context.is_included_vec,
-        unreachable_import_expression_node_ids,
-      ) {
-        unused_record_idxs.extend(item);
-        return false;
-      }
-    }
-    let module = match &self.module_table[entry.idx] {
-      Module::Normal(module) => module,
-      Module::External(_module) => {
-        // Case: import('external').
-        return true;
-      }
-    };
-    let meta = &self.metas[entry.idx];
-    meta.referenced_symbols_by_entry_point_chunk.iter().for_each(|(symbol_ref, _came_from_cjs)| {
-      if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
-        context.stmt_infos[symbol_ref.owner]
-          .declared_stmts_by_symbol(symbol_ref)
-          .iter()
-          .copied()
-          .for_each(|stmt_info_id| {
-            include_statement(context, module, stmt_info_id);
-          });
-        include_symbol_and_check_cjs_bailout(
-          context,
-          *symbol_ref,
-          SymbolIncludeReason::EntryExport,
-        );
-      }
-    });
-    include_module(context, module);
-    true
-  }
-
-  /// # Description
-  /// Some dynamic entries also reference another dynamic entry, we need to ensure each
-  /// dynamic entry is included before all its descendant dynamic entry.
-  /// ```js
-  /// // a.js
-  /// export default import('./b.js').then((mod) => {
-  ///   return mod;
-  /// })
-  ///
-  /// // b.js
-  /// export default import('./c.js').then((mod) => {
-  ///  return mod;
-  /// })
-  ///
-  /// // c.js
-  /// export default 1;
-  /// ```
-  /// after first round user defined entry are included, `default` of `b.js` are included, but
-  /// `default` of `c.js` is not included.
-  /// note: We can't use default entry point order, since they are sorted by stable_id.
-  ///
-  /// # Complexity
-  ///   - construct the dynamic entry relation graph: O(M), `M` the number of modules.
-  ///   - ref https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm#Complexity
-  ///     `O(|V|+|E|)`, for the most of the scenario the relation graph is sparsely connected, we
-  ///     could assume it is `O(N)`, `N` is the number of dynamic entries.
-  ///   - So overall, the complexity is `O(M)`.
-  fn sort_dynamic_entries_by_topological_order(
-    &self,
-    dynamic_entries: &mut [EntryPoint],
-  ) -> FxHashSet<ModuleIdx> {
-    let mut graph: DiGraphMap<ModuleIdx, ()> = DiGraphMap::new();
-
-    // TODO: Since we don't skip visited node, If a project has a lot of dynamic entries,
-    // and they are all connected, the performance may be impacted. But this seems rare in real world,
-    // we could optimize it later if needed.
-    for entry in dynamic_entries.iter() {
-      let mut entry_module_idx = entry.idx;
-      let cur = entry_module_idx;
-      let mut visited = FxHashSet::default();
-      self.construct_dynamic_entry_graph(&mut graph, &mut visited, &mut entry_module_idx, cur);
-    }
-    let mut cycled_dynamic_entries = FxHashSet::default();
-    // https://docs.rs/petgraph/latest/petgraph/algo/fn.tarjan_scc.html
-    // the order of struct connected component is sorted by reverse topological sort.
-    let idx_to_order_map = petgraph::algo::tarjan_scc(&graph)
-      .into_iter()
-      .enumerate()
-      .filter(|(_idx, scc)| {
-        if scc.len() > 1 {
-          cycled_dynamic_entries.extend(scc.iter().copied());
-          return false;
-        }
-        true
-      })
-      .map(|(idx, scc)| (scc[0], idx))
-      .collect::<FxHashMap<ModuleIdx, usize>>();
-    // We only need to ensure the relative order of those none cycled dynamic entries are correct, rest of them
-    // we just bailout them
-    dynamic_entries.sort_by_key(|item| {
-      idx_to_order_map.get(&item.idx).map_or(Reverse(usize::MAX), |&order| Reverse(order))
-    });
-    cycled_dynamic_entries
-  }
-
-  fn construct_dynamic_entry_graph(
-    &self,
-    g: &mut DiGraphMap<ModuleIdx, ()>,
-    visited: &mut FxHashSet<ModuleIdx>,
-    root_node: &mut ModuleIdx,
-    cur_node: ModuleIdx,
-  ) -> Option<()> {
-    if visited.contains(&cur_node) {
-      return Some(());
-    }
-    visited.insert(cur_node);
-    let module = self.module_table[cur_node].as_normal()?;
-    for rec in &module.import_records {
-      let Some(module_idx) = rec.resolved_module else {
-        continue;
-      };
-      if rec.kind == ImportKind::DynamicImport {
-        let seen = g.contains_node(module_idx);
-        if *root_node != module_idx {
-          g.add_edge(*root_node, module_idx, ());
-          // Even it is visited before, we still needs to connect the edge
-          if seen {
-            continue;
-          }
-        }
-        let previous = *root_node;
-        *root_node = module_idx;
-        self.construct_dynamic_entry_graph(g, visited, root_node, module_idx);
-        *root_node = previous;
-        continue;
-      }
-      // Can't put it at the beginning of the loop,
-      self.construct_dynamic_entry_graph(g, visited, root_node, module_idx);
-    }
-    Some(())
-  }
-
-  /// Note:
-  /// this function determine if a dynamic_entry is still alive, return the unused dynamic
-  /// import record idxs(due to limitation of rustc borrow checker) if it is unused.
-  fn is_dynamic_entry_alive(
-    &self,
-    entry_point: &EntryPoint,
-    is_stmt_included_vec: &StmtInclusionVec,
-    unreachable_import_expression_node_ids: &FxHashSet<(ModuleIdx, NodeId)>,
-  ) -> Option<Vec<(ModuleIdx, ImportRecordIdx)>> {
-    let mut ret = vec![];
-    let is_lived = match entry_point.kind {
-      EntryPointKind::UserDefined | EntryPointKind::EmittedUserDefined => true,
-      EntryPointKind::DynamicImport => {
-        let is_dynamic_imported_module_exports_unused =
-          self.dynamic_import_exports_usage_map.get(&entry_point.idx).is_some_and(
-            |item| matches!(item, DynamicImportExportsUsage::Partial(set) if set.is_empty()),
-          );
-
-        // Mark the dynamic entry as lived if at least one statement that create this entry is included
-        entry_point.related_stmt_infos.iter().any(
-          |(module_idx, stmt_idx, node_id, import_record_idx)| {
-            if unreachable_import_expression_node_ids.contains(&(*module_idx, *node_id)) {
-              return false;
-            }
-            let module =
-              &self.module_table[*module_idx].as_normal().expect("should be a normal module");
-            let all_dead_pure_dynamic_import = {
-              let import_record = &module.import_records[*import_record_idx];
-              let importee_side_effects = self.module_table[import_record.into_resolved_module()]
-                .side_effects()
-                .has_side_effects();
-
-              // Only consider it is unused if it is a top level pure dynamic import and the
-              // importee module has no side effects.
-              !importee_side_effects
-                && import_record.meta.contains(ImportRecordMeta::TopLevelPureDynamicImport)
-            };
-            let is_stmt_included = is_stmt_included_vec[*module_idx].has_bit(*stmt_idx);
-            let lived = is_stmt_included
-              && (!is_dynamic_imported_module_exports_unused || !all_dead_pure_dynamic_import);
-
-            if !lived && all_dead_pure_dynamic_import {
-              ret.push((*module_idx, *import_record_idx));
-            }
-            lived
-          },
-        )
-      }
-    };
-    (!is_lived).then_some(ret)
-  }
 }
 
-pub fn include_runtime_symbol(
-  ctx: &mut IncludeContext,
-  runtime: &RuntimeModuleBrief,
-  depended_runtime_helper: RuntimeHelper,
-) {
-  let runtime_module = &ctx.modules[runtime.id()].as_normal().expect("runtime should be normal");
-
-  if depended_runtime_helper.is_empty() {
-    // No runtime helpers needed, but if the runtime has side effects (e.g. from
-    // a plugin transform), we still need to include it.
-    if runtime_module.side_effects.has_side_effects() {
-      include_module(ctx, runtime_module);
-    }
-    return;
-  }
-
-  for helper in depended_runtime_helper {
-    let index = helper.bits().trailing_zeros() as usize;
-    let name = RUNTIME_HELPER_NAMES[index];
-    include_symbol(ctx, runtime.resolve_symbol(name), SymbolIncludeReason::Normal);
-  }
-}
-
-/// if no export is used, and the module has no side effects, the module should not be included
-/// Preserve re-exported interfaces for `preserveModules`.
-///
-/// Every module maps 1:1 to an output file whose `export { ... }` must mirror the source module's
-/// interface. A re-export (`export { x } from './y'`) resolves to a *canonical* symbol owned by
-/// `./y`, and consumers bind that canonical directly, bypassing this module's facade binding — so
-/// the facade is tree-shaken out of this file's exports (issue #9122).
-///
-/// We re-mark a facade as used and include its re-export statement (so the cross-chunk import is
-/// generated) only when the facade is actually consumed *through* this module — i.e. it appears as
-/// an intermediate in the export chain of some used import, recorded in
-/// `normal_symbol_exports_chain_map`. This is chain-granular: a re-export nobody imports through
-/// this module stays tree-shaken, even when the same canonical is used via a different module path
-/// (e.g. a side-effect-only wrapper re-exporting `foo` while a consumer reaches `foo` straight from
-/// its source); a genuinely-unused export likewise stays tree-shaken because no used import reaches
-/// it. `#9122`'s `wrapper` keeps `StateCode`/`getX` because the entry imports them *through*
-/// `wrapper` (`export { … } from './wrapper.js'`). The synthetic runtime module is excluded.
-///
-/// Must run once, after the inclusion fixpoint has settled `used_symbol_refs`. It only includes
-/// re-export statements that reference already-retained canonicals, so it introduces no new
-/// reachable values and needs no further convergence.
-fn preserve_reexported_interfaces(ctx: &mut IncludeContext) {
-  if !ctx.options.preserve_modules {
-    return;
-  }
-  // Collect every intermediate re-export facade that lies on the export chain of a *used* imported
-  // symbol — these are the facades consumed through their own module.
-  let mut consumed_facades: FxHashSet<SymbolRef> = FxHashSet::default();
-  for (imported_as_ref, reexports) in ctx.normal_symbol_exports_chain_map {
-    if ctx.used_symbol_refs.contains(imported_as_ref) {
-      consumed_facades.extend(reexports.iter().copied());
-    }
-  }
-  for symbol_ref in consumed_facades {
-    let module_idx = symbol_ref.owner;
-    if module_idx == ctx.runtime_idx || !ctx.is_module_included_vec.has_bit(module_idx) {
-      continue;
-    }
-    let Module::Normal(module) = &ctx.modules[module_idx] else {
-      continue;
-    };
-    let declaring_stmts = ctx.stmt_infos[module_idx].declared_stmts_by_symbol(&symbol_ref).to_vec();
-    for stmt_info_id in declaring_stmts {
-      include_statement(ctx, module, stmt_info_id);
-    }
-    include_symbol_and_check_cjs_bailout(ctx, symbol_ref, SymbolIncludeReason::EntryExport);
+/// Include every statement that declares `symbol_ref` in its owner module (no-op for external
+/// owners). This is the "a used binding keeps its declaration" edge, applied at every reference
+/// site.
+pub(super) fn include_declaring_statements(ctx: &mut IncludeContext, symbol_ref: &SymbolRef) {
+  if let Module::Normal(module) = &ctx.modules[symbol_ref.owner] {
+    ctx.stmt_infos[symbol_ref.owner].declared_stmts_by_symbol(symbol_ref).iter().copied().for_each(
+      |stmt_info_id| {
+        include_statement(ctx, module, stmt_info_id);
+      },
+    );
   }
 }
 
@@ -869,52 +448,90 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
 
   let forced_no_treeshake = matches!(module.side_effects, DeterminedSideEffects::NoTreeshake);
   if ctx.tree_shaking && !forced_no_treeshake {
-    // Binding-reading side-effect statements of a user-declared
-    // side-effect-free module join only through body demand instead of this
-    // sweep; see `side_effects_included_on_demand`. Statements without symbol
-    // references (e.g. a bare `console.log()`) and import/re-export statements
-    // cannot dangle an import and keep today's behavior.
-    let on_demand_side_effects = side_effects_included_on_demand(module, ctx.entry_module_idxs);
-    ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
-      |(stmt_info_id, stmt_info)| {
-        // No need to handle the namespace statement specially, because it doesn't have side effects and will only be included if it is used.
-        let bail_eval = module.meta.has_eval()
-          && !stmt_info.declared_symbols.is_empty()
-          && stmt_info_id.index() != 0;
-        let has_side_effects = if module.meta.contains(EcmaViewMeta::SafelyTreeshakeCommonjs)
-          && ctx.options.treeshake.commonjs()
-        {
-          stmt_info.eval_flags.contains(StmtEvalFlags::UnknownSideEffect)
-        } else {
-          stmt_info.eval_flags.has_side_effect_for_tree_shaking()
-        };
-        if (has_side_effects && !(on_demand_side_effects && is_gated_side_effect_stmt(stmt_info)))
-          || bail_eval
-        {
-          include_statement(ctx, module, stmt_info_id);
-        }
-      },
-    );
+    sweep_side_effect_statements(ctx, module);
   } else {
-    // Skip the namespace statement. It should be included only if it is used no matter tree shaking is enabled or not.
-    ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
-      |(stmt_info_id, stmt_info)| {
-        if stmt_info.force_tree_shaking {
-          if stmt_info.eval_flags.has_side_effect_for_tree_shaking() {
-            // If `force_tree_shaking` is true, the statement should be included either by itself having side effects
-            // or by other statements referencing it.
-            include_statement(ctx, module, stmt_info_id);
-          }
-        } else {
-          include_statement(ctx, module, stmt_info_id);
-        }
-      },
-    );
+    include_statements_without_treeshaking(ctx, module);
   }
 
+  include_side_effectful_dependencies(ctx, module);
+
+  if module.meta.has_eval() && matches!(module.module_type, ModuleType::Js | ModuleType::Jsx) {
+    // `eval` can observe any module-level binding, so every import must survive.
+    module.named_imports.keys().for_each(|symbol| {
+      include_symbol_and_check_cjs_bailout(ctx, *symbol, SymbolIncludeReason::Normal);
+    });
+  }
+
+  ctx.metas[module.idx].included_commonjs_export_symbol.iter().for_each(|symbol_ref| {
+    include_symbol_and_check_cjs_bailout(ctx, *symbol_ref, SymbolIncludeReason::Normal);
+  });
+
+  // With enabling HMR, rolldown will register included esm module's namespace object to the runtime.
+  if ctx.options.is_dev_mode_enabled()
+    && module.idx != ctx.runtime_idx
+    && matches!(module.exports_kind, ExportsKind::Esm)
+  {
+    include_statement(ctx, module, StmtInfos::NAMESPACE_STMT_IDX);
+    ctx.module_namespace_included_reason[module.idx].insert(ModuleNamespaceIncludedReason::Unknown);
+  }
+}
+
+/// The unconditional side-effect sweep of an included module under tree shaking: force-include
+/// every top-level statement that evaluates side effects (plus `eval` bail statements).
+///
+/// Binding-reading side-effect statements of a user-declared side-effect-free module join only
+/// through body demand instead of this sweep; see `side_effects_included_on_demand`. Statements
+/// without symbol references (e.g. a bare `console.log()`) and import/re-export statements cannot
+/// dangle an import and keep today's behavior.
+fn sweep_side_effect_statements(ctx: &mut IncludeContext, module: &NormalModule) {
+  let on_demand_side_effects = side_effects_included_on_demand(module, ctx.entry_module_idxs);
+  ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
+    |(stmt_info_id, stmt_info)| {
+      // No need to handle the namespace statement specially, because it doesn't have side effects and will only be included if it is used.
+      let bail_eval = module.meta.has_eval()
+        && !stmt_info.declared_symbols.is_empty()
+        && stmt_info_id.index() != 0;
+      let has_side_effects = if module.meta.contains(EcmaViewMeta::SafelyTreeshakeCommonjs)
+        && ctx.options.treeshake.commonjs()
+      {
+        stmt_info.eval_flags.contains(StmtEvalFlags::UnknownSideEffect)
+      } else {
+        stmt_info.eval_flags.has_side_effect_for_tree_shaking()
+      };
+      if (has_side_effects && !(on_demand_side_effects && is_gated_side_effect_stmt(stmt_info)))
+        || bail_eval
+      {
+        include_statement(ctx, module, stmt_info_id);
+      }
+    },
+  );
+}
+
+/// With tree shaking disabled (or `moduleSideEffects: "no-treeshake"`), every statement of an
+/// included module is kept, except `force_tree_shaking` statements which still join only via side
+/// effects or references.
+fn include_statements_without_treeshaking(ctx: &mut IncludeContext, module: &NormalModule) {
+  // Skip the namespace statement. It should be included only if it is used no matter tree shaking is enabled or not.
+  ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
+    |(stmt_info_id, stmt_info)| {
+      if stmt_info.force_tree_shaking {
+        if stmt_info.eval_flags.has_side_effect_for_tree_shaking() {
+          // If `force_tree_shaking` is true, the statement should be included either by itself having side effects
+          // or by other statements referencing it.
+          include_statement(ctx, module, stmt_info_id);
+        }
+      } else {
+        include_statement(ctx, module, stmt_info_id);
+      }
+    },
+  );
+}
+
+/// Include imported modules for their side effects: an included module evaluates each dependency
+/// that has (or may have) side effects, even when none of its bindings are used.
+fn include_side_effectful_dependencies(ctx: &mut IncludeContext, module: &NormalModule) {
   let module_meta = &ctx.metas[module.idx];
 
-  // Include imported modules for its side effects
   module_meta.dependencies.iter().copied().for_each(|dependency_idx| {
     // Guard-hoist: skip already-included dependencies before paying the
     // `ctx.modules[idx]` match + `has_side_effects()` check. The authoritative
@@ -936,24 +553,6 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
     module.stable_id,
     module_meta.dependencies.iter().map(|idx| { ctx.modules[*idx].id().to_string() }).collect_vec()
   );
-  if module.meta.has_eval() && matches!(module.module_type, ModuleType::Js | ModuleType::Jsx) {
-    module.named_imports.keys().for_each(|symbol| {
-      include_symbol_and_check_cjs_bailout(ctx, *symbol, SymbolIncludeReason::Normal);
-    });
-  }
-
-  ctx.metas[module.idx].included_commonjs_export_symbol.iter().for_each(|symbol_ref| {
-    include_symbol_and_check_cjs_bailout(ctx, *symbol_ref, SymbolIncludeReason::Normal);
-  });
-
-  // With enabling HMR, rolldown will register included esm module's namespace object to the runtime.
-  if ctx.options.is_dev_mode_enabled()
-    && module.idx != ctx.runtime_idx
-    && matches!(module.exports_kind, ExportsKind::Esm)
-  {
-    include_statement(ctx, module, StmtInfos::NAMESPACE_STMT_IDX);
-    ctx.module_namespace_included_reason[module.idx].insert(ModuleNamespaceIncludedReason::Unknown);
-  }
 }
 
 pub fn include_symbol(
@@ -963,31 +562,11 @@ pub fn include_symbol(
 ) {
   let mut canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
 
-  if let Some(v) = ctx.constant_symbol_map.get(&canonical_ref)
-    && !include_reason.contains(SymbolIncludeReason::EntryExport)
-    && (!ctx.inline_const_smart || v.safe_to_inline)
-    && !v.commonjs_export
-  {
-    // If the symbol is a constant value and it is not a commonjs module export, we don't need to include it since it would be always inlined.
-    // In smart mode, we only skip if `safe_to_inline` is true (meaning it will be inlined regardless of context).
-    // We don't need to add any flag since if `inlineConst` is disabled, the test expr will always
-    // return `false`
+  if is_bypassed_inlined_constant(ctx, canonical_ref, include_reason) {
     return;
   }
 
-  // Demanding a user-declared side-effect-free module's own export (or its
-  // namespace) makes the module's body observable, so its gated side-effect
-  // statements join now (e.g. `foo.bar = 1` once `foo` is demanded); see
-  // `side_effects_included_on_demand`. Must sit after the inlined-constant
-  // bypass: demand satisfied by inlining doesn't include the module today.
-  // `remove` keeps each key processed at most once.
-  if let Some(stmts) = ctx.on_demand_side_effect_stmts.remove(&canonical_ref) {
-    for (module_idx, stmt_info_idx) in stmts {
-      if let Module::Normal(module) = &ctx.modules[module_idx] {
-        include_statement(ctx, module, stmt_info_idx);
-      }
-    }
-  }
+  drain_body_demand_stmts(ctx, canonical_ref);
 
   // Also include the symbol that points to the canonical ref.
   ctx.used_symbol_refs.insert(symbol_ref);
@@ -998,11 +577,74 @@ pub fn include_symbol(
   // CJS bailout checks are handled by `include_symbol_and_check_cjs_bailout`
   // at most call sites. This keeps `include_symbol` focused on inclusion only.
 
-  let canonical_ref_symbol = ctx.symbols.get(canonical_ref);
+  follow_cjs_namespace_alias(ctx, &mut canonical_ref);
+
+  let is_simulated_facade_chunk =
+    note_namespace_inclusion_reason(ctx, canonical_ref, include_reason);
+
+  ctx.used_symbol_refs.insert(canonical_ref);
+  if ctx.modules[canonical_ref.owner].is_external() {
+    ctx.used_external_symbols.insert(canonical_ref);
+  }
+  if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
+    demand_esm_init_wrapper(ctx, canonical_ref);
+    note_json_self_reference(ctx, module, canonical_ref, include_reason);
+    include_declaring_statements(ctx, &canonical_ref);
+    if !is_simulated_facade_chunk {
+      include_module(ctx, module);
+    }
+  }
+
+  include_property_write_referencing_stmts(ctx, symbol_ref);
+}
+
+/// Mirror of the finalizer's constant inlining: a constant value is always inlined at its
+/// reference sites, so the reference does not retain the declaration.
+///
+/// If the symbol is a constant value and it is not a commonjs module export, we don't need to
+/// include it since it would be always inlined. In smart mode, we only skip if `safe_to_inline`
+/// is true (meaning it will be inlined regardless of context). We don't need to add any flag
+/// since if `inlineConst` is disabled, the test expr will always return `false`.
+fn is_bypassed_inlined_constant(
+  ctx: &IncludeContext,
+  canonical_ref: SymbolRef,
+  include_reason: SymbolIncludeReason,
+) -> bool {
+  if let Some(v) = ctx.constant_symbol_map.get(&canonical_ref)
+    && !include_reason.contains(SymbolIncludeReason::EntryExport)
+    && (!ctx.inline_const_smart || v.safe_to_inline)
+    && !v.commonjs_export
+  {
+    return true;
+  }
+  false
+}
+
+/// Demanding a user-declared side-effect-free module's own export (or its
+/// namespace) makes the module's body observable, so its gated side-effect
+/// statements join now (e.g. `foo.bar = 1` once `foo` is demanded); see
+/// `side_effects_included_on_demand`. Must sit after the inlined-constant
+/// bypass: demand satisfied by inlining doesn't include the module today.
+/// `remove` keeps each key processed at most once.
+fn drain_body_demand_stmts(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
+  if let Some(stmts) = ctx.on_demand_side_effect_stmts.remove(&canonical_ref) {
+    for (module_idx, stmt_info_idx) in stmts {
+      if let Module::Normal(module) = &ctx.modules[module_idx] {
+        include_statement(ctx, module, stmt_info_idx);
+      }
+    }
+  }
+}
+
+/// Follow the CJS-interop alias: the canonical of `import { a } from './cjs.js'` points at the
+/// interop namespace binding (`import_cjs`) via `namespace_alias`. Rewrites `canonical_ref` to
+/// the alias target and includes the specific named export of the CJS module.
+fn follow_cjs_namespace_alias(ctx: &mut IncludeContext, canonical_ref: &mut SymbolRef) {
+  let canonical_ref_symbol = ctx.symbols.get(*canonical_ref);
   if let Some(namespace_alias) = &canonical_ref_symbol.namespace_alias {
-    canonical_ref = namespace_alias.namespace_ref;
+    *canonical_ref = namespace_alias.namespace_ref;
     if let Some(idx) =
-      ctx.metas[canonical_ref.owner].import_record_ns_to_cjs_module.get(&canonical_ref)
+      ctx.metas[canonical_ref.owner].import_record_ns_to_cjs_module.get(canonical_ref)
     {
       // Include specific named export from CJS module.
       // Default import bailout is handled by check_cjs_bailout at call sites.
@@ -1022,10 +664,20 @@ pub fn include_symbol(
       });
     }
   }
+}
 
+/// When the canonical is a module-namespace object, record *why* the namespace is included (the
+/// finalizer emits it differently per reason). Returns whether this inclusion originates from a
+/// simulated facade chunk, in which case the owner module itself must not be structurally
+/// included.
+fn note_namespace_inclusion_reason(
+  ctx: &mut IncludeContext,
+  canonical_ref: SymbolRef,
+  include_reason: SymbolIncludeReason,
+) -> bool {
   let is_module_namespace =
     ctx.modules[canonical_ref.owner].namespace_object_ref() == Some(canonical_ref);
-  let is_simulated_facade_chunk = if is_module_namespace {
+  if is_module_namespace {
     if include_reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::Unknown);
@@ -1036,44 +688,46 @@ pub fn include_symbol(
     include_reason.intersects(SymbolIncludeReason::SimulatedFacadeChunk)
   } else {
     false
+  }
+}
+
+/// Using any binding of a `WrapKind::Esm` module demands its `init_*` wrapper: the binding is
+/// only initialized once the wrapper runs.
+fn demand_esm_init_wrapper(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
+  let wrapper_ref = {
+    let meta = &ctx.metas[canonical_ref.owner];
+    matches!(meta.wrap_kind(), WrapKind::Esm)
+      .then_some(meta.wrapper_ref)
+      .flatten()
+      .filter(|wrapper_ref| *wrapper_ref != canonical_ref)
   };
-
-  ctx.used_symbol_refs.insert(canonical_ref);
-  if ctx.modules[canonical_ref.owner].is_external() {
-    ctx.used_external_symbols.insert(canonical_ref);
+  if let Some(wrapper_ref) = wrapper_ref {
+    include_symbol(ctx, wrapper_ref, SymbolIncludeReason::Normal);
   }
-  if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
-    let wrapper_ref = {
-      let meta = &ctx.metas[canonical_ref.owner];
-      matches!(meta.wrap_kind(), WrapKind::Esm)
-        .then_some(meta.wrapper_ref)
-        .flatten()
-        .filter(|wrapper_ref| *wrapper_ref != canonical_ref)
-    };
-    if let Some(wrapper_ref) = wrapper_ref {
-      include_symbol(ctx, wrapper_ref, SymbolIncludeReason::Normal);
-    }
+}
 
-    if !include_reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference)
-      && module.module_type == ModuleType::Json
-    {
-      ctx
-        .json_module_none_self_reference_included_symbol
-        .entry(module.idx)
-        .or_default()
-        .insert(canonical_ref);
-    }
-    ctx.stmt_infos[canonical_ref.owner]
-      .declared_stmts_by_symbol(&canonical_ref)
-      .iter()
-      .copied()
-      .for_each(|stmt_info_id| {
-        include_statement(ctx, module, stmt_info_id);
-      });
-    if !is_simulated_facade_chunk {
-      include_module(ctx, module);
-    }
+/// Track which of a JSON module's top-level properties are referenced from *outside* its own
+/// synthesized default export, so the finalizer knows which properties cannot be inlined.
+fn note_json_self_reference(
+  ctx: &mut IncludeContext,
+  module: &NormalModule,
+  canonical_ref: SymbolRef,
+  include_reason: SymbolIncludeReason,
+) {
+  if !include_reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference)
+    && module.module_type == ModuleType::Json
+  {
+    ctx
+      .json_module_none_self_reference_included_symbol
+      .entry(module.idx)
+      .or_default()
+      .insert(canonical_ref);
   }
+}
+
+/// With `propertyWriteSideEffects: false`, property-write statements are not side effects — but
+/// once the written-to symbol is included, its write statements must come along.
+fn include_property_write_referencing_stmts(ctx: &mut IncludeContext, symbol_ref: SymbolRef) {
   if matches!(
     ctx.options.treeshake.property_write_side_effects(),
     rolldown_common::PropertyWriteSideEffects::False
@@ -1106,11 +760,76 @@ pub fn include_statement(
 
   let stmt_info = ctx.stmt_infos[module.idx].get(stmt_info_idx);
 
-  // FIXME: bailout for require() import for now
-  // it is fine for now, since webpack did not support it either
-  // ```js
-  // const cjs = require('./cjs.js')
-  // ```
+  scan_import_records_for_cjs_bailout(ctx, module, stmt_info);
+  let mut include_kind = if stmt_info.meta.contains(StmtInfoMeta::ReExportDynamicExports) {
+    SymbolIncludeReason::ReExportDynamicExports
+  } else {
+    SymbolIncludeReason::Normal
+  };
+
+  let is_json_module = module.module_type == ModuleType::Json;
+
+  // For a transformed json module
+  if is_json_module && !stmt_info.referenced_symbols.is_empty() {
+    include_kind |= SymbolIncludeReason::JsonDefaultExportSelfReference;
+  }
+
+  stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
+    if let Some(member_expr_resolution) = match reference_ref {
+      SymbolOrMemberExprRef::Symbol(_) => None,
+      SymbolOrMemberExprRef::MemberExpr(member_expr_ref) => {
+        member_expr_ref.resolution(&ctx.metas[module.idx].resolved_member_expr_refs)
+      }
+    } {
+      // Caveat: If we can get the `MemberExprRefResolution` from the `resolved_member_expr_refs`,
+      // it means this member expr definitely contains module namespace ref.
+      if let Some(resolved_ref) = member_expr_resolution.resolved {
+        member_expr_resolution.depended_refs.iter().for_each(|sym_ref| {
+          include_declaring_statements(ctx, sym_ref);
+        });
+        include_symbol(ctx, resolved_ref, include_kind);
+        // When the member expression resolves to a specific CJS export property
+        // (e.g., `ns.x`), we skip the bailout check — we know the access is partial
+        // and CJS tree-shaking can work. Otherwise, the full namespace may be used
+        // opaquely, so we check for bailout.
+        if member_expr_resolution.target_commonjs_exported_symbol.is_none() {
+          check_cjs_bailout(ctx, resolved_ref);
+        }
+      } else {
+        // If it points to nothing, the expression will be rewritten as `void 0` and there's nothing we need to include
+      }
+    } else {
+      // For enum member accesses (e.g., `B.member`), check if the member will be inlined
+      // by the finalizer. If so, skip including the enum's declaration — it's dead code
+      // after inlining. This mirrors the `constant_symbol_map` bypass in `include_symbol`.
+      if let SymbolOrMemberExprRef::MemberExpr(member_expr_ref) = reference_ref {
+        if is_inlined_enum_member_access(ctx.modules, ctx.symbols, member_expr_ref) {
+          return;
+        }
+      }
+      let original_ref = reference_ref.symbol_ref();
+      std::iter::once(original_ref)
+        .chain(
+          ctx.normal_symbol_exports_chain_map.get(original_ref).map(Vec::as_slice).unwrap_or(&[]),
+        )
+        .for_each(|sym_ref| {
+          include_declaring_statements(ctx, sym_ref);
+        });
+      include_symbol_and_check_cjs_bailout(ctx, *original_ref, include_kind);
+    }
+  });
+}
+
+/// FIXME: bailout for require() import for now
+/// it is fine for now, since webpack did not support it either
+/// ```js
+/// const cjs = require('./cjs.js')
+/// ```
+fn scan_import_records_for_cjs_bailout(
+  ctx: &mut IncludeContext,
+  module: &NormalModule,
+  stmt_info: &StmtInfo,
+) {
   stmt_info
     .import_records
     .iter()
@@ -1149,97 +868,33 @@ pub fn include_statement(
         ctx.bailout_cjs_tree_shaking_modules.insert(module_idx);
       }
     });
-  let mut include_kind = if stmt_info.meta.contains(StmtInfoMeta::ReExportDynamicExports) {
-    SymbolIncludeReason::ReExportDynamicExports
-  } else {
-    SymbolIncludeReason::Normal
+}
+
+/// Whether a member access will be inlined as an enum member literal by the finalizer, in which
+/// case the enum declaration must not be retained by this reference.
+///
+/// This applies to both const and regular enums. The member access will be replaced
+/// by a literal, so the reference no longer needs the declaration. If the enum is
+/// also referenced as a bare symbol (e.g., `typeof E`, `console.log(E)`), that
+/// separate reference will independently include the declaration via `include_symbol`.
+/// Regular enum IIFEs are `@__PURE__`, so they'll be tree-shaken if truly unused.
+/// Enum inlining is unconditional (not gated by inlineConst mode) because it implements
+/// TypeScript's const enum semantics, which mandate replacement. Only simple member accesses
+/// (e.g. `E.member`) are inlined — not deep chains like `E.member.something`, and not writes.
+fn is_inlined_enum_member_access(
+  modules: &IndexModules,
+  symbols: &SymbolRefDb,
+  member_expr_ref: &MemberExprRef,
+) -> bool {
+  let canonical_ref = symbols.canonical_ref_for(member_expr_ref.object_ref);
+  let Some(Module::Normal(owner_module)) = modules.get(canonical_ref.owner) else {
+    return false;
   };
-
-  let is_json_module = module.module_type == ModuleType::Json;
-
-  // For a transformed json module
-  if is_json_module && !stmt_info.referenced_symbols.is_empty() {
-    include_kind |= SymbolIncludeReason::JsonDefaultExportSelfReference;
-  }
-
-  stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
-    if let Some(member_expr_resolution) = match reference_ref {
-      SymbolOrMemberExprRef::Symbol(_) => None,
-      SymbolOrMemberExprRef::MemberExpr(member_expr_ref) => {
-        member_expr_ref.resolution(&ctx.metas[module.idx].resolved_member_expr_refs)
-      }
-    } {
-      // Caveat: If we can get the `MemberExprRefResolution` from the `resolved_member_expr_refs`,
-      // it means this member expr definitely contains module namespace ref.
-      if let Some(resolved_ref) = member_expr_resolution.resolved {
-        member_expr_resolution.depended_refs.iter().for_each(|sym_ref| {
-          if let Module::Normal(module) = &ctx.modules[sym_ref.owner] {
-            ctx.stmt_infos[sym_ref.owner]
-              .declared_stmts_by_symbol(sym_ref)
-              .iter()
-              .copied()
-              .for_each(|stmt_info_id| {
-                include_statement(ctx, module, stmt_info_id);
-              });
-          }
-        });
-        include_symbol(ctx, resolved_ref, include_kind);
-        // When the member expression resolves to a specific CJS export property
-        // (e.g., `ns.x`), we skip the bailout check — we know the access is partial
-        // and CJS tree-shaking can work. Otherwise, the full namespace may be used
-        // opaquely, so we check for bailout.
-        if member_expr_resolution.target_commonjs_exported_symbol.is_none() {
-          check_cjs_bailout(ctx, resolved_ref);
-        }
-      } else {
-        // If it points to nothing, the expression will be rewritten as `void 0` and there's nothing we need to include
-      }
-    } else {
-      // For enum member accesses (e.g., `B.member`), check if the member will be inlined
-      // by the finalizer. If so, skip including the enum's declaration — it's dead code
-      // after inlining. This mirrors the `constant_symbol_map` bypass in `include_symbol`.
-      //
-      // This applies to both const and regular enums. The member access will be replaced
-      // by a literal, so the reference no longer needs the declaration. If the enum is
-      // also referenced as a bare symbol (e.g., `typeof E`, `console.log(E)`), that
-      // separate reference will independently include the declaration via `include_symbol`.
-      // Regular enum IIFEs are `@__PURE__`, so they'll be tree-shaken if truly unused.
-      if let SymbolOrMemberExprRef::MemberExpr(member_expr_ref) = reference_ref {
-        let canonical_ref = ctx.symbols.canonical_ref_for(member_expr_ref.object_ref);
-        if let Some(Module::Normal(owner_module)) = ctx.modules.get(canonical_ref.owner) {
-          let symbol_name = canonical_ref.name(ctx.symbols);
-          if let Some(members) = owner_module.ecma_view.enum_member_value_map.get(symbol_name) {
-            // Only bypass for simple member accesses (e.g., `E.member`), not deep chains
-            // like `E.member.something` which wouldn't be inlined.
-            if !member_expr_ref.is_write
-              && let [prop] = member_expr_ref.prop_and_span_list.as_slice()
-              && members.contains_key(prop.name.as_str())
-            {
-              // This member access will be inlined — don't include the enum declaration.
-              // Enum inlining is unconditional (not gated by inlineConst mode) because
-              // it implements TypeScript's const enum semantics, which mandate replacement.
-              return;
-            }
-          }
-        }
-      }
-      let original_ref = reference_ref.symbol_ref();
-      std::iter::once(original_ref)
-        .chain(
-          ctx.normal_symbol_exports_chain_map.get(original_ref).map(Vec::as_slice).unwrap_or(&[]),
-        )
-        .for_each(|sym_ref| {
-          if let Module::Normal(module) = &ctx.modules[sym_ref.owner] {
-            ctx.stmt_infos[sym_ref.owner]
-              .declared_stmts_by_symbol(sym_ref)
-              .iter()
-              .copied()
-              .for_each(|stmt_info_id| {
-                include_statement(ctx, module, stmt_info_id);
-              });
-          }
-        });
-      include_symbol_and_check_cjs_bailout(ctx, *original_ref, include_kind);
-    }
-  });
+  let symbol_name = canonical_ref.name(symbols);
+  let Some(members) = owner_module.ecma_view.enum_member_value_map.get(symbol_name) else {
+    return false;
+  };
+  !member_expr_ref.is_write
+    && matches!(member_expr_ref.prop_and_span_list.as_slice(),
+      [prop] if members.contains_key(prop.name.as_str()))
 }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
@@ -1,4 +1,12 @@
 pub(super) mod determine_side_effects;
+mod dynamic_entries;
 pub mod include_statements;
+mod on_demand;
+mod passes;
 
-pub use include_statements::{ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec};
+pub use include_statements::{
+  IncludeContext, ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec,
+  SymbolIncludeReason, include_symbol,
+};
+pub use on_demand::compute_on_demand_side_effect_stmts;
+pub use passes::include_runtime_symbol;

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
@@ -1,0 +1,129 @@
+//! On-demand (body-demand) inclusion of side-effect statements for user-declared
+//! side-effect-free modules. See [`side_effects_included_on_demand`] for the model.
+
+use rolldown_common::{
+  ExportsKind, IndexModules, Module, ModuleIdx, NormalModule, StmtInfo, StmtInfoIdx, SymbolRef,
+  SymbolRefDb, side_effects::DeterminedSideEffects,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{stages::link_stage::LinkStage, type_alias::IndexStmtInfos};
+
+/// Whether side-effectful statements of `module` that reference module-level
+/// symbols are included on demand instead of being swept in unconditionally by
+/// [`super::include_statements::include_module`].
+///
+/// A module the user declared side-effect free (`"sideEffects": false` in
+/// package.json, `treeshake.moduleSideEffects: false`) must not have such
+/// statements retained merely because they *evaluate* effects. Without this,
+/// any force-inclusion of the module — the wrapper-ref edge under
+/// `strictExecutionOrder`, `require()` of ESM, or an inlined dynamic import
+/// under `codeSplitting: false` — resurrects side-effect statements that plain
+/// (unwrapped) tree-shaking provably drops, making inclusion inconsistent
+/// between `strictExecutionOrder: true` and `false`. It also breaks the lazy
+/// barrel loader's contract: the loader defers import records by requested
+/// exports, so a retained statement referencing a never-requested import ends up
+/// referencing a record that was correctly never loaded and crashes at runtime
+/// (#9691, #9806, #9961, #9964, #10013, #10048).
+///
+/// Instead such statements join when the module's *body* is demanded: one of
+/// its own (non-re-export) exports or its namespace object becomes used (via
+/// `on_demand_side_effect_stmts`) — e.g. `foo.bar = 1` stays once `foo` is
+/// demanded, `#7597`'s top-level asserts stay because the entry imports the
+/// module's own `Modal`. This mirrors the lazy-barrel loader exactly: body
+/// demand is its `has_local_export`/`All` case, in which it loads every plain
+/// import record of the module — so a kept statement can never reference an
+/// unloaded record, and a deferred record is only ever referenced by dropped
+/// statements.
+///
+/// Statements referencing no module-level symbol (a bare `console.log()`) and
+/// import/re-export statements (which drive wrapper init calls and side-effect
+/// imports) cannot dangle an import and keep the unconditional sweep.
+/// Exemptions: user-defined entry modules (the requested program keeps its
+/// body — dynamic entries instead join through namespace/own-export body
+/// demand, so a dead pure dynamic import can't resurrect a body), modules
+/// using `eval` (it can observe anything), and CommonJS modules (their exports
+/// are side-effect assignments that the demand edges don't model).
+pub(super) fn side_effects_included_on_demand(
+  module: &NormalModule,
+  entry_module_idxs: &FxHashSet<ModuleIdx>,
+) -> bool {
+  matches!(module.side_effects, DeterminedSideEffects::UserDefined(false))
+    && matches!(module.exports_kind, ExportsKind::Esm)
+    && !module.meta.has_eval()
+    && !entry_module_idxs.contains(&module.idx)
+}
+
+/// Build the demand edges for modules whose side-effectful statements are
+/// included on demand (see [`side_effects_included_on_demand`]): body-demand
+/// key -> the module's gated side-effect statements.
+///
+/// A module's body counts as demanded when one of its *own* exports (an export
+/// that doesn't re-export an import) or its namespace object becomes used —
+/// mirroring the lazy-barrel loader's `local` classification, which loads every
+/// plain import record of the module exactly in those cases. Demand through
+/// pure re-exports leaves the body dropped.
+pub fn compute_on_demand_side_effect_stmts(
+  modules: &IndexModules,
+  stmt_infos: &IndexStmtInfos,
+  symbols: &SymbolRefDb,
+  treeshake_enabled: bool,
+  entry_module_idxs: &FxHashSet<ModuleIdx>,
+) -> FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> {
+  let mut map: FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> = FxHashMap::default();
+  if !treeshake_enabled {
+    return map;
+  }
+  for module in modules.iter().filter_map(Module::as_normal) {
+    if !side_effects_included_on_demand(module, entry_module_idxs) {
+      continue;
+    }
+    let gated: Vec<(ModuleIdx, StmtInfoIdx)> = stmt_infos[module.idx]
+      .iter_enumerated_without_namespace_stmt()
+      .filter(|(_, stmt_info)| is_gated_side_effect_stmt(stmt_info))
+      .map(|(stmt_idx, _)| (module.idx, stmt_idx))
+      .collect();
+    if gated.is_empty() {
+      continue;
+    }
+    let body_demand_keys = module
+      .named_exports
+      .values()
+      .filter(|local_export| !module.named_imports.contains_key(&local_export.referenced))
+      .map(|local_export| symbols.canonical_ref_for(local_export.referenced))
+      .chain(std::iter::once(module.namespace_object_ref));
+    for key in body_demand_keys {
+      map.entry(key).or_default().extend(gated.iter().copied());
+    }
+  }
+  map
+}
+
+/// A statement that joins through body demand rather than the unconditional
+/// sweep of [`super::include_statements::include_module`]: it evaluates side
+/// effects *and* reads module-level bindings (so it can dangle a lazily-deferred
+/// import), and is not an import/re-export statement (those drive wrapper init
+/// calls and side-effect-import inclusion; `reference_needed_symbols` also
+/// pushes wrapper refs onto them, which must not count as user references).
+pub(super) fn is_gated_side_effect_stmt(stmt_info: &StmtInfo) -> bool {
+  stmt_info.eval_flags.has_side_effect_for_tree_shaking()
+    && !stmt_info.referenced_symbols.is_empty()
+    && stmt_info.import_records.is_empty()
+}
+
+impl LinkStage<'_> {
+  /// User-defined (and emitted) entries — exempt from on-demand side-effect
+  /// gating: they are the requested program. A dynamic entry participates like
+  /// any module: an observed namespace or used export is body demand, while a
+  /// dead pure dynamic import must not resurrect the body its removal already
+  /// models as an empty namespace.
+  pub(super) fn user_defined_entry_module_idxs(&self) -> FxHashSet<ModuleIdx> {
+    self
+      .entries
+      .values()
+      .flatten()
+      .filter(|entry| entry.kind.is_user_defined())
+      .map(|entry| entry.idx)
+      .collect()
+  }
+}

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/passes.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/passes.rs
@@ -1,0 +1,137 @@
+//! Standalone passes that run around the inclusion fixpoint: CJS bailout export
+//! inclusion (per fixpoint iteration), runtime-helper collection/inclusion (after
+//! the fixpoint), and `preserveModules` re-export interface preservation (once,
+//! after convergence).
+
+use rolldown_common::{
+  IndexModules, Module, ModuleIdx, RUNTIME_HELPER_NAMES, RuntimeHelper, RuntimeModuleBrief,
+  SymbolRef,
+};
+// On wasm targets `rolldown_utils::rayon` shims `par_iter()` to a plain `Iterator`,
+// so `zip_eq` resolves via `Itertools` there and via `IndexedParallelIterator` natively.
+#[cfg(target_family = "wasm")]
+use itertools::Itertools as _;
+#[cfg(not(target_family = "wasm"))]
+use rolldown_utils::rayon::IndexedParallelIterator;
+use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
+use rustc_hash::FxHashSet;
+
+use crate::types::linking_metadata::LinkingMetadataVec;
+
+use super::include_statements::{
+  IncludeContext, ModuleInclusionVec, SymbolIncludeReason, include_module, include_statement,
+  include_symbol, include_symbol_and_check_cjs_bailout,
+};
+
+pub(super) fn include_cjs_bailout_exports(
+  context: &mut IncludeContext,
+  metas: &LinkingMetadataVec,
+  bailout_modules: impl IntoIterator<Item = ModuleIdx>,
+) {
+  for idx in bailout_modules {
+    metas[idx].resolved_exports.values().filter(|local| local.came_from_commonjs).for_each(
+      |local| {
+        include_symbol_and_check_cjs_bailout(
+          context,
+          local.symbol_ref,
+          SymbolIncludeReason::Normal,
+        );
+      },
+    );
+  }
+}
+
+/// Collects all depended runtime helpers from included modules only.
+/// Eliminated modules may have runtime helpers set (for propagation to importers),
+/// but we should only include the runtime if an included module actually needs it.
+pub(super) fn collect_depended_runtime_helpers(
+  modules: &IndexModules,
+  metas: &LinkingMetadataVec,
+  is_module_included_vec: &ModuleInclusionVec,
+) -> RuntimeHelper {
+  let iter = modules.par_iter().zip_eq(metas.par_iter()).filter_map(|(module, meta)| {
+    module
+      .as_normal()
+      .filter(|m| is_module_included_vec.has_bit(m.idx))
+      .map(|_| meta.depended_runtime_helper)
+  });
+
+  #[cfg(not(target_family = "wasm"))]
+  let depended_runtime_helper = iter.reduce(RuntimeHelper::default, |a, b| a | b);
+  #[cfg(target_family = "wasm")]
+  let depended_runtime_helper = iter.reduce(|a, b| a | b).unwrap_or_default();
+
+  depended_runtime_helper
+}
+
+pub fn include_runtime_symbol(
+  ctx: &mut IncludeContext,
+  runtime: &RuntimeModuleBrief,
+  depended_runtime_helper: RuntimeHelper,
+) {
+  let runtime_module = &ctx.modules[runtime.id()].as_normal().expect("runtime should be normal");
+
+  if depended_runtime_helper.is_empty() {
+    // No runtime helpers needed, but if the runtime has side effects (e.g. from
+    // a plugin transform), we still need to include it.
+    if runtime_module.side_effects.has_side_effects() {
+      include_module(ctx, runtime_module);
+    }
+    return;
+  }
+
+  for helper in depended_runtime_helper {
+    let index = helper.bits().trailing_zeros() as usize;
+    let name = RUNTIME_HELPER_NAMES[index];
+    include_symbol(ctx, runtime.resolve_symbol(name), SymbolIncludeReason::Normal);
+  }
+}
+
+/// if no export is used, and the module has no side effects, the module should not be included
+/// Preserve re-exported interfaces for `preserveModules`.
+///
+/// Every module maps 1:1 to an output file whose `export { ... }` must mirror the source module's
+/// interface. A re-export (`export { x } from './y'`) resolves to a *canonical* symbol owned by
+/// `./y`, and consumers bind that canonical directly, bypassing this module's facade binding — so
+/// the facade is tree-shaken out of this file's exports (issue #9122).
+///
+/// We re-mark a facade as used and include its re-export statement (so the cross-chunk import is
+/// generated) only when the facade is actually consumed *through* this module — i.e. it appears as
+/// an intermediate in the export chain of some used import, recorded in
+/// `normal_symbol_exports_chain_map`. This is chain-granular: a re-export nobody imports through
+/// this module stays tree-shaken, even when the same canonical is used via a different module path
+/// (e.g. a side-effect-only wrapper re-exporting `foo` while a consumer reaches `foo` straight from
+/// its source); a genuinely-unused export likewise stays tree-shaken because no used import reaches
+/// it. `#9122`'s `wrapper` keeps `StateCode`/`getX` because the entry imports them *through*
+/// `wrapper` (`export { … } from './wrapper.js'`). The synthetic runtime module is excluded.
+///
+/// Must run once, after the inclusion fixpoint has settled `used_symbol_refs`. It only includes
+/// re-export statements that reference already-retained canonicals, so it introduces no new
+/// reachable values and needs no further convergence.
+pub(super) fn preserve_reexported_interfaces(ctx: &mut IncludeContext) {
+  if !ctx.options.preserve_modules {
+    return;
+  }
+  // Collect every intermediate re-export facade that lies on the export chain of a *used* imported
+  // symbol — these are the facades consumed through their own module.
+  let mut consumed_facades: FxHashSet<SymbolRef> = FxHashSet::default();
+  for (imported_as_ref, reexports) in ctx.normal_symbol_exports_chain_map {
+    if ctx.used_symbol_refs.contains(imported_as_ref) {
+      consumed_facades.extend(reexports.iter().copied());
+    }
+  }
+  for symbol_ref in consumed_facades {
+    let module_idx = symbol_ref.owner;
+    if module_idx == ctx.runtime_idx || !ctx.is_module_included_vec.has_bit(module_idx) {
+      continue;
+    }
+    let Module::Normal(module) = &ctx.modules[module_idx] else {
+      continue;
+    };
+    let declaring_stmts = ctx.stmt_infos[module_idx].declared_stmts_by_symbol(&symbol_ref).to_vec();
+    for stmt_info_id in declaring_stmts {
+      include_statement(ctx, module, stmt_info_id);
+    }
+    include_symbol_and_check_cjs_bailout(ctx, symbol_ref, SymbolIncludeReason::EntryExport);
+  }
+}


### PR DESCRIPTION
### Description

Part 1 of the tree-shaking inclusion refactor stack.

`include_statements.rs` had grown to ~1200 lines interleaving the inclusion fixpoint driver, the three mutually recursive inclusion functions, dynamic-entry topological ordering, the body-demand gating model, and several standalone passes — with 10+ orthogonal policies (CJS bailouts, constant/enum inlining bypasses, JSON self-reference tracking, `eval` handling, HMR namespace registration, property-write retention) inlined directly into the recursion. Reviewing any change meant re-deriving which clause belonged to which concern; every bug fix added another inline branch.

Pure code motion, in three commits:

- **Split into focused modules**
  - `dynamic_entries.rs` — dynamic-entry topological ordering (tarjan), aliveness determination, per-iteration processing (~200 lines unrelated to inclusion mechanics)
  - `on_demand.rs` — the body-demand gating model (`side_effects_included_on_demand`, `compute_on_demand_side_effect_stmts`, `is_gated_side_effect_stmt`)
  - `passes.rs` — standalone passes around the fixpoint (CJS bailout export inclusion, runtime-helper collection/inclusion, `preserveModules` re-export interface preservation)
- **Extract named policies** — each inline block of `include_module` / `include_symbol` / `include_statement` becomes a named function with a doc contract (`sweep_side_effect_statements`, `include_side_effectful_dependencies`, `is_bypassed_inlined_constant`, `drain_body_demand_stmts`, `follow_cjs_namespace_alias`, `note_namespace_inclusion_reason`, `demand_esm_init_wrapper`, `note_json_self_reference`, `include_property_write_referencing_stmts`, `scan_import_records_for_cjs_bailout`, `is_inlined_enum_member_access`), so the three skeletons read as a sequence of policies. Also dedupes `include_declaring_statements`, which replaces five hand-rolled copies of the "a used binding keeps its declaring statements" loop.
- **wasm build fix** — the move dropped an incidental `itertools::Itertools` import that wasm targets need for `zip_eq` (`rolldown_utils::rayon` shims `par_iter()` to a plain `Iterator` there); caught by the browser/WASI CI jobs.

No behavior change: byte-identical output across the integration suite (zero snapshot diffs), clippy clean, `wasm32-wasip1-threads` checked.

Stack: #10095 → #10096 → #10097 → #10098
