### PR TITLE
refactor(treeshake): make body demand a second module bit instead of a stmt multimap

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -15,8 +15,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
   chunk_graph::ChunkGraph,
   stages::link_stage::{
-    IncludeContext, SymbolIncludeReason, compute_on_demand_side_effect_stmts,
-    include_runtime_symbol, include_symbol,
+    IncludeContext, SymbolIncludeReason, compute_body_demand_keys, include_runtime_symbol,
+    include_symbol,
   },
   types::linking_metadata::{
     LinkingMetadata, LinkingMetadataVec, included_info_to_linking_metadata_vec,
@@ -1026,7 +1026,7 @@ impl GenerateStage<'_> {
     // Replay the link-stage inclusion semantics: side-effectful statements of
     // user-declared side-effect-free modules join only through body demand.
     // Already-included statements make the replayed edges no-ops.
-    let mut on_demand_side_effect_stmts = compute_on_demand_side_effect_stmts(
+    let body_demand_keys = compute_body_demand_keys(
       &self.link_output.module_table.modules,
       &self.link_output.stmt_infos,
       &self.link_output.symbol_db,
@@ -1055,7 +1055,8 @@ impl GenerateStage<'_> {
       inline_const_smart: self.options.optimization.is_inline_const_smart_mode(),
       json_module_none_self_reference_included_symbol: FxHashMap::default(),
       entry_module_idxs: &self.link_output.user_defined_entry_modules,
-      on_demand_side_effect_stmts: &mut on_demand_side_effect_stmts,
+      body_demand_keys: &body_demand_keys,
+      body_demand_swept: FxHashSet::default(),
       pending: Vec::new(),
     };
 

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -41,7 +41,7 @@ mod tree_shaking;
 
 pub use tree_shaking::{
   IncludeContext, ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec,
-  SymbolIncludeReason, compute_on_demand_side_effect_stmts, include_runtime_symbol, include_symbol,
+  SymbolIncludeReason, compute_body_demand_keys, include_runtime_symbol, include_symbol,
 };
 mod wrapping;
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
   on_demand::{
-    compute_on_demand_side_effect_stmts, is_gated_side_effect_stmt, side_effects_included_on_demand,
+    compute_body_demand_keys, is_gated_side_effect_stmt, side_effects_included_on_demand,
   },
   passes::{
     collect_depended_runtime_helpers, include_cjs_bailout_exports, include_runtime_symbol,
@@ -88,11 +88,16 @@ pub struct IncludeContext<'a> {
   /// on-demand side-effect inclusion: they are the requested program. Dynamic
   /// entries join through namespace/own-export body demand instead.
   pub entry_module_idxs: &'a FxHashSet<ModuleIdx>,
-  /// Body-demand key (a module's own export or namespace object) -> the gated
-  /// side-effect statements of that module (see
-  /// [`side_effects_included_on_demand`]). Entries are drained by
-  /// [`include_symbol`] as their key becomes used.
-  pub on_demand_side_effect_stmts: &'a mut FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>>,
+  /// Body-demand key (a module's own export or namespace object) -> the module whose gated
+  /// side-effect statements using that key demands (see
+  /// [`side_effects_included_on_demand`]). Consulted by [`include_symbol`] as symbols become
+  /// used.
+  pub body_demand_keys: &'a FxHashMap<SymbolRef, ModuleIdx>,
+  /// The second module-inclusion bit: modules whose *gated* side-effect statements have joined
+  /// because their body was demanded. Distinct from `is_module_included_vec` (structural
+  /// inclusion), which deliberately skips those statements for
+  /// [`side_effects_included_on_demand`] modules.
+  pub body_demand_swept: FxHashSet<ModuleIdx>,
   /// Work queue of the inclusion engine (see [`drain_work_items`]). Edge producers push typed
   /// work items here instead of recursing; the public `include_*` entry points drain it to
   /// empty before returning. Invariant (debug-asserted at every public entry point): empty
@@ -119,7 +124,7 @@ impl<'a> IncludeContext<'a> {
     normal_symbol_exports_chain_map: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
     module_namespace_included_reason: &'a mut ModuleNamespaceReasonVec,
     entry_module_idxs: &'a FxHashSet<ModuleIdx>,
-    on_demand_side_effect_stmts: &'a mut FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>>,
+    body_demand_keys: &'a FxHashMap<SymbolRef, ModuleIdx>,
   ) -> Self {
     Self {
       modules,
@@ -141,7 +146,8 @@ impl<'a> IncludeContext<'a> {
       module_namespace_included_reason,
       json_module_none_self_reference_included_symbol: FxHashMap::default(),
       entry_module_idxs,
-      on_demand_side_effect_stmts,
+      body_demand_keys,
+      body_demand_swept: FxHashSet::default(),
       pending: Vec::new(),
     }
   }
@@ -267,7 +273,7 @@ impl LinkStage<'_> {
       .iter()
       .any(|m| m.as_normal().is_some_and(|n| !n.ecma_view.enum_member_value_map.is_empty()));
     let entry_module_idxs = self.user_defined_entry_module_idxs();
-    let mut on_demand_side_effect_stmts = compute_on_demand_side_effect_stmts(
+    let body_demand_keys = compute_body_demand_keys(
       &self.module_table.modules,
       &self.stmt_infos,
       &self.symbols,
@@ -289,7 +295,7 @@ impl LinkStage<'_> {
       &self.normal_symbol_exports_chain_map,
       &mut module_namespace_included_reason,
       &entry_module_idxs,
-      &mut on_demand_side_effect_stmts,
+      &body_demand_keys,
     );
 
     let (user_defined_entries, mut dynamic_entries): (Vec<_>, Vec<_>) =
@@ -442,7 +448,7 @@ impl LinkStage<'_> {
       &self.normal_symbol_exports_chain_map,
       &mut module_namespace_included_reason,
       &entry_module_idxs,
-      &mut on_demand_side_effect_stmts,
+      &body_demand_keys,
     );
     include_runtime_symbol(context, &self.runtime, depended_runtime_helper);
 
@@ -709,14 +715,22 @@ fn is_bypassed_inlined_constant(
 /// statements join now (e.g. `foo.bar = 1` once `foo` is demanded); see
 /// `side_effects_included_on_demand`. Must sit after the inlined-constant
 /// bypass: demand satisfied by inlining doesn't include the module today.
-/// `remove` keeps each key processed at most once.
+/// The `body_demand_swept` bit keeps each module swept at most once.
 fn drain_body_demand_stmts(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
-  if let Some(stmts) = ctx.on_demand_side_effect_stmts.remove(&canonical_ref) {
-    for (module_idx, stmt_info_idx) in stmts {
-      if let Module::Normal(_) = &ctx.modules[module_idx] {
-        ctx.pending.push(WorkItem::Statement(module_idx, stmt_info_idx));
-      }
-    }
+  let Some(&module_idx) = ctx.body_demand_keys.get(&canonical_ref) else {
+    return;
+  };
+  if !ctx.body_demand_swept.insert(module_idx) {
+    return;
+  }
+  if let Module::Normal(_) = &ctx.modules[module_idx] {
+    ctx.stmt_infos[module_idx].iter_enumerated_without_namespace_stmt().for_each(
+      |(stmt_info_idx, stmt_info)| {
+        if is_gated_side_effect_stmt(stmt_info) {
+          ctx.pending.push(WorkItem::Statement(module_idx, stmt_info_idx));
+        }
+      },
+    );
   }
 }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/mod.rs
@@ -8,5 +8,5 @@ pub use include_statements::{
   IncludeContext, ModuleInclusionVec, ModuleNamespaceReasonVec, StmtInclusionVec,
   SymbolIncludeReason, include_symbol,
 };
-pub use on_demand::compute_on_demand_side_effect_stmts;
+pub use on_demand::compute_body_demand_keys;
 pub use passes::include_runtime_symbol;

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
@@ -2,8 +2,8 @@
 //! side-effect-free modules. See [`side_effects_included_on_demand`] for the model.
 
 use rolldown_common::{
-  ExportsKind, IndexModules, Module, ModuleIdx, NormalModule, StmtInfo, StmtInfoIdx, SymbolRef,
-  SymbolRefDb, side_effects::DeterminedSideEffects,
+  ExportsKind, IndexModules, Module, ModuleIdx, NormalModule, StmtInfo, SymbolRef, SymbolRefDb,
+  side_effects::DeterminedSideEffects,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -28,7 +28,7 @@ use crate::{stages::link_stage::LinkStage, type_alias::IndexStmtInfos};
 ///
 /// Instead such statements join when the module's *body* is demanded: one of
 /// its own (non-re-export) exports or its namespace object becomes used (via
-/// `on_demand_side_effect_stmts`) — e.g. `foo.bar = 1` stays once `foo` is
+/// `body_demand_keys`) — e.g. `foo.bar = 1` stays once `foo` is
 /// demanded, `#7597`'s top-level asserts stay because the entry imports the
 /// module's own `Modal`. This mirrors the lazy-barrel loader exactly: body
 /// demand is its `has_local_export`/`All` case, in which it loads every plain
@@ -56,21 +56,27 @@ pub(super) fn side_effects_included_on_demand(
 
 /// Build the demand edges for modules whose side-effectful statements are
 /// included on demand (see [`side_effects_included_on_demand`]): body-demand
-/// key -> the module's gated side-effect statements.
+/// key -> the module whose gated side-effect statements it demands.
 ///
 /// A module's body counts as demanded when one of its *own* exports (an export
 /// that doesn't re-export an import) or its namespace object becomes used —
 /// mirroring the lazy-barrel loader's `local` classification, which loads every
 /// plain import record of the module exactly in those cases. Demand through
 /// pure re-exports leaves the body dropped.
-pub fn compute_on_demand_side_effect_stmts(
+///
+/// The gated statements themselves are enumerated at demand time (they are a pure
+/// function of the immutable `stmt_infos`); this map only answers "whose body does
+/// using this symbol demand?". Every key's canonical is owned by the module itself
+/// (own exports and namespace refs never link across modules), so the map is
+/// one-to-one per module.
+pub fn compute_body_demand_keys(
   modules: &IndexModules,
   stmt_infos: &IndexStmtInfos,
   symbols: &SymbolRefDb,
   treeshake_enabled: bool,
   entry_module_idxs: &FxHashSet<ModuleIdx>,
-) -> FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> {
-  let mut map: FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>> = FxHashMap::default();
+) -> FxHashMap<SymbolRef, ModuleIdx> {
+  let mut map: FxHashMap<SymbolRef, ModuleIdx> = FxHashMap::default();
   if !treeshake_enabled {
     return map;
   }
@@ -78,12 +84,10 @@ pub fn compute_on_demand_side_effect_stmts(
     if !side_effects_included_on_demand(module, entry_module_idxs) {
       continue;
     }
-    let gated: Vec<(ModuleIdx, StmtInfoIdx)> = stmt_infos[module.idx]
+    let has_gated_stmts = stmt_infos[module.idx]
       .iter_enumerated_without_namespace_stmt()
-      .filter(|(_, stmt_info)| is_gated_side_effect_stmt(stmt_info))
-      .map(|(stmt_idx, _)| (module.idx, stmt_idx))
-      .collect();
-    if gated.is_empty() {
+      .any(|(_, stmt_info)| is_gated_side_effect_stmt(stmt_info));
+    if !has_gated_stmts {
       continue;
     }
     let body_demand_keys = module
@@ -93,7 +97,11 @@ pub fn compute_on_demand_side_effect_stmts(
       .map(|local_export| symbols.canonical_ref_for(local_export.referenced))
       .chain(std::iter::once(module.namespace_object_ref));
     for key in body_demand_keys {
-      map.entry(key).or_default().extend(gated.iter().copied());
+      let previous = map.insert(key, module.idx);
+      debug_assert!(
+        previous.is_none_or(|prev| prev == module.idx),
+        "a body-demand key must belong to exactly one module"
+      );
     }
   }
   map


### PR DESCRIPTION
### Description

Part 3 of the tree-shaking inclusion refactor stack (stacked on #10096).

#### Before

The body-demand machinery stored, for **every** body-demand key of a module, a full copy of that module's gated side-effect statement list (`FxHashMap<SymbolRef, Vec<(ModuleIdx, StmtInfoIdx)>>`), drained by map removal. That one mutable map entangled three different things: the **demand edge** (key → module), the **gate predicate** (which statements are gated), and the **progress state** (encoded as entry presence/absence). A module with N own exports carried N copies of the same statement list, and "has this module's body already joined?" was emergent from which keys happened to have been removed.

#### After

The rule being implemented — *a `sideEffects: false` module's gated statements join once its body is demanded* — is a boolean event on a **module**, and the state now says exactly that. Module inclusion is two explicit bits:

- `is_module_included_vec` — structural inclusion (wrapper/interop resolvable, side-effectful deps evaluated); unchanged
- `body_demand_swept` — the module's gated side-effect statements have joined because one of its own exports / its namespace object was actually used

and each of the three entangled concerns lives where it belongs:

- **Demand edge** — `body_demand_keys: FxHashMap<SymbolRef, ModuleIdx>` ("whose body does using this symbol demand?"), immutable and shared across both `IncludeContext` constructions (link stage and chunk-optimizer replay); no more `&mut` threading. Every key's canonical is owned by the module itself (own exports and namespace refs never link across modules). Before, `entry(key).or_default().extend(..)` would have silently merged two modules' statements if that invariant ever broke; now it's an explicit `debug_assert!` exercised by the whole suite.
- **Gate predicate** — the gated statements are enumerated at demand time from the immutable `stmt_infos`, via the same `is_gated_side_effect_stmt` used when building the key map. One source of truth; no O(keys × gated stmts) materialized copies.
- **Progress** — `body_demand_swept: FxHashSet<ModuleIdx>`, owned per run. `insert()` returning `false` short-circuits, so the sweep happens exactly once per **module**. Before, `remove(&key)` only guaranteed once per *key*: demanding a second export of the same module re-enqueued all its statements (harmless only because `include_statement` is idempotent — you had to know that to trust it). The generate-stage replay gets shared edges plus a fresh swept set: graph-scoped facts vs run-scoped progress.

#### Why `FxHashMap`/`FxHashSet` rather than `IndexBitSet`

`is_module_included_vec` is already an `IndexBitSet` — dense domain, touched for essentially every module on the hot path. The two body-demand structures sit on the other side of that line: they are sparse, usually **empty**. A module contributes keys only if it is user-declared side-effect-free, ESM, non-entry, without `eval`, **and** has a top-level side-effecting statement that reads module-level bindings — the rare #9806-family pattern.

- `body_demand_keys` can't be dense-indexed at all: `SymbolRef` is a two-dimensional key (`owner` × `SymbolId`), so a dense encoding would cost O(total symbols in the graph). The map *is* probed once per symbol in `include_symbol`, but a `get` on an empty `FxHashMap` is a few instructions — the common case stays effectively free.
- `body_demand_swept` is constructed fresh per `IncludeContext` (twice in the link stage, again in the chunk-optimizer replay). `IndexBitSet::new(modules.len())` would allocate and zero the full module range each time to record what is almost always nothing; `FxHashSet::default()` allocates nothing until the first insert, and it is only touched after a `body_demand_keys` hit. Its cardinality is bounded by the number of gated modules, so both structures are zero-cost together in the common case.
- Neither structure is ever iterated (membership test / probe only), so hash iteration order cannot leak into output.

#### Explored and rejected

Deriving `is_module_included` from the statement bits. The `SymbolIncludeReason::SimulatedFacadeChunk` path (chunk optimizer) deliberately includes statements **without** structurally including the module, so a derived bit is a behavior change, not a refactor.

No behavior change: byte-identical output across the integration suite, zero snapshot diffs.

Stack: #10095 → #10096 → #10097 → #10098
