### PR TITLE
refactor(treeshake): single-source the own-export classification shared with the lazy-barrel loader

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/on_demand.rs
@@ -2,8 +2,8 @@
 //! side-effect-free modules. See [`side_effects_included_on_demand`] for the model.
 
 use rolldown_common::{
-  ExportsKind, IndexModules, Module, ModuleIdx, NormalModule, StmtInfo, SymbolRef, SymbolRefDb,
-  side_effects::DeterminedSideEffects,
+  ExportOrigin, ExportsKind, IndexModules, Module, ModuleIdx, NormalModule, StmtInfo, SymbolRef,
+  SymbolRefDb, side_effects::DeterminedSideEffects,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -93,7 +93,7 @@ pub fn compute_body_demand_keys(
     let body_demand_keys = module
       .named_exports
       .values()
-      .filter(|local_export| !module.named_imports.contains_key(&local_export.referenced))
+      .filter(|local_export| matches!(module.classify_export(local_export), ExportOrigin::Own))
       .map(|local_export| symbols.canonical_ref_for(local_export.referenced))
       .chain(std::iter::once(module.namespace_object_ref));
     for key in body_demand_keys {

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -62,6 +62,37 @@ impl EcmaViewMeta {
   }
 }
 
+/// Where a named export's value comes from: the module's own declaration, or a re-export of an
+/// import.
+///
+/// This classification is the contract between the lazy-barrel loader and tree shaking's
+/// body-demand gating, and the two sides MUST agree: the loader loads every plain import record
+/// of a barrel as soon as one of its *own* exports is requested (`BarrelInfo::local` in
+/// `take_needed_records`), and tree shaking includes the module's gated side-effect statements as
+/// soon as one of its *own* exports is used (`compute_body_demand_keys`). If they classified an
+/// export differently, a retained statement could reference an import record that was never
+/// loaded — a free identifier at runtime (the #9806 bug family). Keeping the classification in
+/// one place makes that agreement hold by construction.
+pub enum ExportOrigin<'a> {
+  /// Declared by the module itself: `export const a = ...`, `export function f() {}`, or a plain
+  /// `export { local }` of a local binding.
+  Own,
+  /// Re-exports an import: `export { a } from './x'`, `export * as ns from './x'`, or
+  /// `import { a } from './x'; export { a }`.
+  ReExport(&'a NamedImport),
+}
+
+impl EcmaView {
+  /// Classify a named export as the module's own declaration or a re-export of an import.
+  /// See [`ExportOrigin`] for why this must stay the single source of truth.
+  pub fn classify_export(&self, local_export: &LocalExport) -> ExportOrigin<'_> {
+    match self.named_imports.get(&local_export.referenced) {
+      Some(named_import) => ExportOrigin::ReExport(named_import),
+      None => ExportOrigin::Own,
+    }
+  }
+}
+
 #[derive(Debug, Clone)]
 pub struct EcmaView {
   pub dummy_record_set: FxHashSet<NodeId>,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -118,8 +118,8 @@ pub use crate::{
     dynamic_import_usage,
     ecma_asset_meta::EcmaAssetMeta,
     ecma_view::{
-      EcmaModuleAstUsage, EcmaView, EcmaViewMeta, PrependRenderedImport, ThisExprReplaceKind,
-      generate_replace_this_expr_map,
+      EcmaModuleAstUsage, EcmaView, EcmaViewMeta, ExportOrigin, PrependRenderedImport,
+      ThisExprReplaceKind, generate_replace_this_expr_map,
     },
     json_to_program::{json_value_to_ecma_ast, json_value_to_expression},
     module_idx::ModuleIdx,

--- a/crates/rolldown_common/src/types/lazy_barrel.rs
+++ b/crates/rolldown_common/src/types/lazy_barrel.rs
@@ -6,8 +6,9 @@ use rolldown_utils::rustc_hash::{FxHashMapExt as _, FxHashSetExt as _};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  EcmaView, ImportKind, ImportRecordIdx, ImportRecordMeta, ImportRecordStateInit, ModuleIdx,
-  NormalModule, RawImportRecord, ResolvedId, Specifier, side_effects::DeterminedSideEffects,
+  EcmaView, ExportOrigin, ImportKind, ImportRecordIdx, ImportRecordMeta, ImportRecordStateInit,
+  ModuleIdx, NormalModule, RawImportRecord, ResolvedId, Specifier,
+  side_effects::DeterminedSideEffects,
 };
 
 /// State for lazy barrel optimization
@@ -302,22 +303,28 @@ pub fn try_extract_lazy_barrel_info(
   // Categorize exports into named re-exports and local (own) exports
   // - Re-exports: `export * as ns from './x'` or `export { c as d } from './x'`
   // - Local exports: `export const a = 1` or `export function foo() {}`
+  //
+  // This classification is shared with tree shaking's body-demand gating
+  // (`ExportOrigin`); the loader's `local` case and the shaker's body-demand keys
+  // must agree, or a retained statement could reference a never-loaded record.
   for (export_name, local_export) in &ecma_view.named_exports {
-    if let Some(named_import) = ecma_view.named_imports.get(&local_export.referenced) {
-      // Re-export: the export references an import
-      let is_direct_reexport =
-        raw_import_records[named_import.record_idx].meta.contains(ImportRecordMeta::IsReExportOnly);
-      barrel_info.named.insert(
-        export_name.clone(),
-        ExportSource {
-          record_idx: named_import.record_idx,
-          imported: named_import.imported.clone(),
-          is_direct_reexport,
-        },
-      );
-    } else {
-      // Local export: the export is defined in this module
-      barrel_info.local.push(export_name.clone());
+    match ecma_view.classify_export(local_export) {
+      ExportOrigin::ReExport(named_import) => {
+        let is_direct_reexport = raw_import_records[named_import.record_idx]
+          .meta
+          .contains(ImportRecordMeta::IsReExportOnly);
+        barrel_info.named.insert(
+          export_name.clone(),
+          ExportSource {
+            record_idx: named_import.record_idx,
+            imported: named_import.imported.clone(),
+            is_direct_reexport,
+          },
+        );
+      }
+      ExportOrigin::Own => {
+        barrel_info.local.push(export_name.clone());
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Part 4 of the tree-shaking inclusion refactor stack (stacked on #10097).

The lazy-barrel loader and tree shaking each hand-rolled the same "is this export the module's own declaration or a re-export of an import?" lookup:

- loader: `try_extract_lazy_barrel_info` builds `BarrelInfo::local` from it, and `take_needed_records` loads every plain import record of a barrel as soon as one of its **own** exports is requested
- shaker: `compute_body_demand_keys` builds the body-demand keys from it, and a module's gated side-effect statements join as soon as one of its **own** exports is used

Those two sides must agree: if they classified an export differently, a retained statement could reference an import record that was never loaded — a free identifier at runtime. That disagreement class is exactly the #9806 bug family (#9691, #9806, #9961, #9964, #10013, #10048).

The classification now lives in one place — `EcmaView::classify_export → ExportOrigin { Own, ReExport(&NamedImport) }` in `rolldown_common` — consumed by both sides, so the agreement holds by construction and the invariant is documented at the definition site instead of in two mirror comments.

Scope note: the demand *semantics* (`take_needed_records` on the loader side vs body-demand sweeping on the shaker side) remain parallel implementations documented against each other; unifying those is future work.

No behavior change: byte-identical output across the integration suite, zero snapshot diffs.

Stack: #10095 → #10096 → #10097 → #10098
