### PR TITLE
fix(chunk-optimizer): follow entry facade edges in runtime placement cycle check

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1549,6 +1549,10 @@ impl GenerateStage<'_> {
   ///   post-optimization graph.
   /// - Self-edges (`target_chunk == current`) are skipped — an intra-chunk
   ///   import can't form an inter-chunk cycle.
+  /// - Besides module import records, an entry-point chunk whose entry module
+  ///   was captured into another chunk (e.g. by a `codeSplitting` group) gets a
+  ///   render-time static import of that module's wrapper/namespace from the
+  ///   capturing chunk, so that facade edge is followed too (#9993).
   fn chunk_reaches_via_static_import(
     from: ChunkIdx,
     to: ChunkIdx,
@@ -1563,6 +1567,14 @@ impl GenerateStage<'_> {
       }
       if current == to {
         return true;
+      }
+      if let ChunkKind::EntryPoint { module: entry_module_idx, .. } =
+        chunk_graph.chunk_table[current].kind
+        && let Some(entry_module_chunk) = chunk_graph.module_to_chunk[entry_module_idx]
+        && entry_module_chunk != current
+        && !chunk_graph.post_chunk_optimization_operations.contains_key(&entry_module_chunk)
+      {
+        queue.push_back(entry_module_chunk);
       }
       for &module_idx in &chunk_graph.chunk_table[current].modules {
         let Some(module) = module_table[module_idx].as_normal() else {

--- a/crates/rolldown/tests/rolldown/issues/9993/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9993/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "input": [
+      { "name": "entry-1", "import": "./node4.cjs" },
+      { "name": "entry-2", "import": "./node3.cjs" }
+    ],
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [{ "name": "v", "test": "node[0-4]" }]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9993/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9993/_test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+
+// Regression test for #9993 (a regression of #9224): the runtime module must
+// not be merged into a chunk that is part of a static import cycle with a
+// chunk calling runtime helpers (e.g. `__commonJSMin`) at top level. Before
+// the fix, the entry chunk of `entry-2` hosted the runtime while the group
+// chunk `v.js` both consumed `__commonJSMin` at top level and was statically
+// imported back by `entry-2.js` (entry-2's entry module was captured into the
+// group chunk), so evaluating `entry-2.js` threw
+// `TypeError: __commonJSMin is not a function`.
+//
+// Note: entry-2 must be imported first here. Loading `entry-1.js` as the
+// evaluation root still throws `require_node3 is not a function` because
+// entry-2's facade calls the group chunk's top-level `require_node3` binding
+// before that chunk's body runs. That cross-chunk evaluation-order defect is
+// NOT part of the #9993 regression window — rolldown 1.0.3 emits the same
+// entry-1-first crash for this input.
+const entry2 = await import('./dist/entry-2.js');
+assert.strictEqual(entry2.default.node_3, 3);
+const entry1 = await import('./dist/entry-1.js');
+assert.strictEqual(entry1.default.node_4, 4);
+assert.strictEqual(globalThis.__issue_9993_3, 1);
+assert.strictEqual(globalThis.__issue_9993_4, 1);
+assert.strictEqual(globalThis.__issue_9993_5, 1);

--- a/crates/rolldown/tests/rolldown/issues/9993/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9993/artifacts.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-1.js
+
+```js
+import { n as require_node4 } from "./v.js";
+export default require_node4();
+
+```
+
+## entry-2.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+import { t as require_node3 } from "./v.js";
+//#region node5.js
+var node5_exports = /* @__PURE__ */ __exportAll({ node_5: () => node_5 });
+var node_5;
+var init_node5 = __esmMin((() => {
+	globalThis.__issue_9993_5 = (globalThis.__issue_9993_5 || 0) + 1;
+	node_5 = {};
+	node_5.value = 5;
+}));
+//#endregion
+export default require_node3();
+export { node5_exports as n, init_node5 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## v.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_node5 } from "./entry-2.js";
+//#region node4.cjs
+var require_node4 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__issue_9993_4 = (globalThis.__issue_9993_4 || 0) + 1;
+	exports.node_4 = 4;
+}));
+//#endregion
+//#region node3.cjs
+var require_node3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__issue_9993_3 = (globalThis.__issue_9993_3 || 0) + 1;
+	init_node5();
+	exports.node_3 = 3;
+}));
+//#endregion
+export { require_node4 as n, require_node3 as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9993/node3.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9993/node3.cjs
@@ -1,0 +1,6 @@
+// CJS module that is also entry-2. It requires an ESM module (node5.js) that is
+// NOT captured by the chunk group, which pulls the runtime helper out of the
+// group chunk and into the sibling entry chunk.
+globalThis.__issue_9993_3 = (globalThis.__issue_9993_3 || 0) + 1;
+void require('./node5.js');
+exports.node_3 = 3;

--- a/crates/rolldown/tests/rolldown/issues/9993/node4.cjs
+++ b/crates/rolldown/tests/rolldown/issues/9993/node4.cjs
@@ -1,0 +1,3 @@
+// CJS module that is also entry-1. Wrapped by rolldown in `__commonJSMin`.
+globalThis.__issue_9993_4 = (globalThis.__issue_9993_4 || 0) + 1;
+exports.node_4 = 4;

--- a/crates/rolldown/tests/rolldown/issues/9993/node5.js
+++ b/crates/rolldown/tests/rolldown/issues/9993/node5.js
@@ -1,0 +1,5 @@
+// Plain ESM module, deliberately outside the chunk group's `test`.
+globalThis.__issue_9993_5 = (globalThis.__issue_9993_5 || 0) + 1;
+var node_5 = {};
+node_5.value = 5;
+export { node_5 };


### PR DESCRIPTION
### Description

This is also more like a workaround fix, I'm working on how to solve these issues in a row. It requires some structure changes, meanwhile let's fix it first since it's p1

---

Fixes #9993 (regression of #9224, introduced in 1.1.1 by #9419).

When a `codeSplitting` group captures an **entry module** into another chunk, the entry chunk gets a render-time static import of that module's wrapper/namespace symbol from the capturing chunk (via `collect_depended_symbols`). `chunk_reaches_via_static_import` only walked module **import records**, so the runtime-merge decision in `try_merge_runtime_chunk` could not see that back-edge:

- `runtime_target_would_create_static_cycle` reported "no cycle" for a target that does statically import a helper consumer back, and
- `find_consumer_dominator` treated that entry chunk as a downstream sink.

The runtime module was then merged into the entry chunk of `entry-2`, while the group chunk both called `__commonJSMin` at top level and was statically imported back by that entry chunk — so ESM evaluated the group chunk before the helper initialized: `TypeError: __commonJSMin is not a function`.

This PR makes the reachability BFS also follow the entry-module facade edge (EntryPoint chunk → chunk physically containing its entry module). With it, the merge is rejected for such graphs and the runtime stays in a dependency-free leaf chunk — the same layout rolldown 1.0.3 emitted. A spurious edge (e.g. for an unwrapped entry with no re-exported symbols) only makes the merge decision more conservative; worst case is one extra `rolldown-runtime` chunk, never a broken output. No existing test snapshot changes.

Verified against the reporter's standalone repro (https://github.com/thevuong/rolldown-9993-repro): `npm run repro` fails on 1.1.3 and current main, passes with this fix.

### Out of scope (pre-existing, not part of the 1.1.1 regression window)

The fixture's chunk graph still contains a benign-looking static cycle (`v.js` ↔ `entry-2.js`) where `entry-2`'s facade calls the group chunk's top-level `require_node3` binding. Loading `entry-2.js` first is fine, but loading `entry-1.js` as the evaluation root still throws `require_node3 is not a function` — and rolldown **1.0.3 emits the same entry-1-first crash** for this input, so that cross-chunk evaluation-order defect predates this regression (it matches the reporter's follow-up observation that patching only the helper's emit form is insufficient in general). The new test documents this and pins only the regression.