### PR TITLE
perf(binding): box dev and watcher napi futures

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -7,32 +7,15 @@ use crate::{
     binding_outputs::{BindingOutputs, to_binding_error},
     error::{BindingError, BindingErrors, BindingResult},
   },
-  utils::{handle_result, handle_warnings, normalize_binding_options::normalize_binding_options},
+  utils::{
+    handle_result, handle_warnings, normalize_binding_options::normalize_binding_options,
+    spawn_boxed_future,
+  },
 };
-use napi::{
-  Env,
-  bindgen_prelude::{PromiseRaw, ToNapiValue},
-};
+use napi::{Env, bindgen_prelude::PromiseRaw};
 use napi_derive::napi;
 use rolldown::{BundleHandle, BundlerConfig};
-use std::{future::Future, pin::Pin, sync::Arc};
-
-/// Box a future before handing it to napi's [`Env::spawn_future`].
-///
-/// `Env::spawn_future` is monomorphized over the concrete future type, so every
-/// distinct async body re-instantiates the whole tokio task harness (`poll_future`,
-/// `Core<T, S>`, the scheduler dispatch, …). These `BindingBundler` entry points run
-/// once per build, so erasing the future to a single `Pin<Box<dyn Future>>` collapses
-/// that machinery to one instantiation per output type, at the cost of one
-/// (perf-irrelevant) heap allocation per call. Do NOT use this for per-module/per-hook
-/// futures, where the extra allocation would be on a hot path.
-fn spawn_boxed_future<T: 'static + Send + ToNapiValue>(
-  env: &Env,
-  fut: impl 'static + Send + Future<Output = napi::Result<T>>,
-) -> napi::Result<PromiseRaw<'_, T>> {
-  let fut: Pin<Box<dyn Future<Output = napi::Result<T>> + Send>> = Box::pin(fut);
-  env.spawn_future(fut)
-}
+use std::sync::Arc;
 
 #[napi]
 pub struct BindingBundler {

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -11,13 +11,16 @@ use crate::types::binding_client_hmr_update::BindingClientHmrUpdate;
 use crate::types::binding_error_stage::BindingErrorStage;
 use crate::types::binding_outputs::{BindingOutputs, to_binding_error};
 use crate::types::error::{BindingErrors, BindingResult};
-use crate::utils::create_bundler_config_from_binding_options::create_bundler_config_from_binding_options;
-use napi::bindgen_prelude::FnArgs;
+use crate::utils::{
+  create_bundler_config_from_binding_options::create_bundler_config_from_binding_options,
+  spawn_boxed_future,
+};
+use napi::bindgen_prelude::{FnArgs, PromiseRaw};
 use napi::{Either, Env, threadsafe_function::ThreadsafeFunctionCallMode};
 
 #[napi]
 pub struct BindingDevEngine {
-  inner: rolldown_dev::DevEngine,
+  inner: Arc<rolldown_dev::DevEngine>,
   cwd: Arc<Path>,
   _session_id: Arc<str>,
   _session: rolldown_devtools::Session,
@@ -161,47 +164,67 @@ impl BindingDevEngine {
     let inner = rolldown_dev::DevEngine::new(bundler_config, rolldown_dev_options)
       .map_err(|e| napi::Error::from_reason(format!("Fail to create dev engine: {e:#?}")))?;
 
-    Ok(Self { inner, cwd, _session_id: session_id, _session: session })
+    Ok(Self { inner: Arc::new(inner), cwd, _session_id: session_id, _session: session })
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn run<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.run().await.map_err(|_e| napi::Error::from_reason("Failed to run dev engine"))?;
+      Ok(())
+    })
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn ensure_current_build_finish<'env>(
+    &self,
+    env: &'env Env,
+  ) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner
+        .wait_for_ongoing_bundle()
+        .await
+        .map_err(|_e| napi::Error::from_reason("Failed to ensure current build finish"))?;
+      Ok(())
+    })
   }
 
   #[napi]
-  pub async fn run(&self) -> napi::Result<()> {
-    self.inner.run().await.map_err(|_e| napi::Error::from_reason("Failed to run dev engine"))?;
-    Ok(())
+  pub fn get_bundle_state<'env>(
+    &self,
+    env: &'env Env,
+  ) -> napi::Result<PromiseRaw<'env, BindingBundleState>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner
+        .get_bundle_state()
+        .await
+        .map(Into::into)
+        .map_err(|_e| napi::Error::from_reason("Failed to get bundle state"))
+    })
   }
 
   #[napi]
-  pub async fn ensure_current_build_finish(&self) -> napi::Result<()> {
-    self
-      .inner
-      .wait_for_ongoing_bundle()
-      .await
-      .map_err(|_e| napi::Error::from_reason("Failed to ensure current build finish"))?;
-    Ok(())
-  }
-
-  #[napi]
-  pub async fn get_bundle_state(&self) -> napi::Result<BindingBundleState> {
-    self
-      .inner
-      .get_bundle_state()
-      .await
-      .map(Into::into)
-      .map_err(|_e| napi::Error::from_reason("Failed to get bundle state"))
-  }
-
-  #[napi]
-  pub async fn ensure_latest_build_output(&self) -> napi::Result<BindingResult<()>> {
-    match self.inner.ensure_latest_bundle_output().await {
-      Ok(()) => Ok(Either::B(())),
-      Err(errors) => {
-        let binding_errors: Vec<_> = errors
-          .iter()
-          .map(|diagnostic| to_binding_error(diagnostic, self.cwd.to_path_buf()))
-          .collect();
-        Ok(Either::A(BindingErrors::new(binding_errors)))
+  pub fn ensure_latest_build_output<'env>(
+    &self,
+    env: &'env Env,
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<()>>> {
+    let inner = Arc::clone(&self.inner);
+    let cwd = Arc::clone(&self.cwd);
+    spawn_boxed_future(env, async move {
+      match inner.ensure_latest_bundle_output().await {
+        Ok(()) => Ok(Either::B(())),
+        Err(errors) => {
+          let binding_errors: Vec<_> = errors
+            .iter()
+            .map(|diagnostic| to_binding_error(diagnostic, cwd.to_path_buf()))
+            .collect();
+          Ok(Either::A(BindingErrors::new(binding_errors)))
+        }
       }
-    }
+    })
   }
 
   #[napi]
@@ -210,45 +233,66 @@ impl BindingDevEngine {
   }
 
   #[napi]
-  pub async fn invalidate(
+  pub fn invalidate<'env>(
     &self,
+    env: &'env Env,
     caller: String,
     first_invalidated_by: Option<String>,
-  ) -> napi::Result<BindingResult<Vec<BindingClientHmrUpdate>>> {
-    match self.inner.invalidate(caller, first_invalidated_by).await {
-      Ok(updates) => {
-        let binding_updates =
-          updates.into_iter().map(BindingClientHmrUpdate::from).collect::<Vec<_>>();
-        Ok(Either::B(binding_updates))
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<Vec<BindingClientHmrUpdate>>>> {
+    let inner = Arc::clone(&self.inner);
+    let cwd = Arc::clone(&self.cwd);
+    spawn_boxed_future(env, async move {
+      match inner.invalidate(caller, first_invalidated_by).await {
+        Ok(updates) => {
+          let binding_updates =
+            updates.into_iter().map(BindingClientHmrUpdate::from).collect::<Vec<_>>();
+          Ok(Either::B(binding_updates))
+        }
+        Err(errors) => {
+          let binding_errors: Vec<_> = errors
+            .iter()
+            .map(|diagnostic| to_binding_error(diagnostic, cwd.to_path_buf()))
+            .collect();
+          Ok(Either::A(BindingErrors::new(binding_errors)))
+        }
       }
-      Err(errors) => {
-        let binding_errors: Vec<_> = errors
-          .iter()
-          .map(|diagnostic| to_binding_error(diagnostic, self.cwd.to_path_buf()))
-          .collect();
-        Ok(Either::A(BindingErrors::new(binding_errors)))
-      }
-    }
+    })
   }
 
-  #[napi]
-  pub async fn register_modules(&self, client_id: String, modules: Vec<String>) {
-    self.inner.clients.lock().await.entry(client_id).or_default().executed_modules.extend(modules);
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn register_modules<'env>(
+    &self,
+    env: &'env Env,
+    client_id: String,
+    modules: Vec<String>,
+  ) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.clients.lock().await.entry(client_id).or_default().executed_modules.extend(modules);
+      Ok(())
+    })
   }
 
-  #[napi]
-  pub async fn remove_client(&self, client_id: String) {
-    self.inner.clients.lock().await.remove(&client_id);
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn remove_client<'env>(
+    &self,
+    env: &'env Env,
+    client_id: String,
+  ) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.clients.lock().await.remove(&client_id);
+      Ok(())
+    })
   }
 
-  #[napi]
-  pub async fn close(&self) -> napi::Result<()> {
-    self
-      .inner
-      .close()
-      .await
-      .map_err(|_e| napi::Error::from_reason("Failed to close dev engine"))?;
-    Ok(())
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.close().await.map_err(|_e| napi::Error::from_reason("Failed to close dev engine"))?;
+      Ok(())
+    })
   }
 
   /// Compile a lazy entry module and return HMR-style patch code.
@@ -257,12 +301,19 @@ impl BindingDevEngine {
   /// The module was previously stubbed with a proxy, and now we need to compile the
   /// actual module and its dependencies.
   #[napi]
-  pub async fn compile_entry(&self, module_id: String, client_id: String) -> napi::Result<String> {
-    self
-      .inner
-      .compile_lazy_entry(module_id, client_id)
-      .await
-      .map_err(|e| napi::Error::from_reason(format!("Failed to compile lazy entry: {e:#?}")))
+  pub fn compile_entry<'env>(
+    &self,
+    env: &'env Env,
+    module_id: String,
+    client_id: String,
+  ) -> napi::Result<PromiseRaw<'env, String>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner
+        .compile_lazy_entry(module_id, client_id)
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to compile lazy entry: {e:#?}")))
+    })
   }
 }
 

--- a/crates/rolldown_binding/src/binding_watcher_bundler.rs
+++ b/crates/rolldown_binding/src/binding_watcher_bundler.rs
@@ -1,5 +1,8 @@
+use napi::{Env, bindgen_prelude::PromiseRaw};
 use napi_derive::napi;
 use rolldown::BundleHandle;
+
+use crate::utils::spawn_boxed_future;
 
 /// Minimal wrapper around a `BundleHandle` for watcher events.
 /// This is returned from watcher event data to allow calling `result.close()`.
@@ -10,10 +13,13 @@ pub struct BindingWatcherBundler {
 
 #[napi]
 impl BindingWatcherBundler {
-  #[napi]
-  pub async fn close(&self) -> napi::Result<()> {
-    self.inner.close().await.map_err(|e| napi::Error::from_reason(e.to_string()))?;
-    Ok(())
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = self.inner.clone();
+    spawn_boxed_future(env, async move {
+      inner.close().await.map_err(|e| napi::Error::from_reason(e.to_string()))?;
+      Ok(())
+    })
   }
 }
 

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -7,7 +7,12 @@ pub mod napi_error;
 pub mod normalize_binding_options;
 
 use std::any::Any;
+use std::{future::Future, pin::Pin};
 
+use napi::{
+  Env,
+  bindgen_prelude::{PromiseRaw, ToNapiValue},
+};
 use napi_derive::napi;
 use rolldown::{LogLevel, NormalizedBundlerOptions};
 use rolldown_error::{
@@ -16,6 +21,23 @@ use rolldown_error::{
 use rolldown_tracing::try_init_tracing;
 
 pub use normalize_binding_transform_options::normalize_binding_transform_options;
+
+/// Box a future before handing it to napi's [`Env::spawn_future`].
+///
+/// `Env::spawn_future` is monomorphized over the concrete future type, so every
+/// distinct async body re-instantiates the tokio task harness (`poll_future`,
+/// `Core<T, S>`, the scheduler dispatch, ...). Binding entry points run once per
+/// operation, so erasing the future to a single `Pin<Box<dyn Future>>` collapses
+/// that machinery to one instantiation per output type, at the cost of one
+/// heap allocation per call. Do not use this for per-module/per-hook futures,
+/// where the extra allocation would be on a hot path.
+pub fn spawn_boxed_future<T: 'static + Send + ToNapiValue>(
+  env: &Env,
+  fut: impl 'static + Send + Future<Output = napi::Result<T>>,
+) -> napi::Result<PromiseRaw<'_, T>> {
+  let fut: Pin<Box<dyn Future<Output = napi::Result<T>> + Send>> = Box::pin(fut);
+  env.spawn_future(fut)
+}
 
 #[napi]
 pub struct TraceSubscriberGuard {

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -3,7 +3,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use napi::bindgen_prelude::FnArgs;
+use napi::{
+  Env,
+  bindgen_prelude::{FnArgs, PromiseRaw},
+};
 use napi_derive::napi;
 use rolldown_common::WatcherChangeKind;
 use rolldown_watcher::{WatchEvent, WatcherConfig, WatcherEventHandler};
@@ -11,7 +14,10 @@ use rolldown_watcher::{WatchEvent, WatcherConfig, WatcherEventHandler};
 use crate::types::binding_bundler_options::BindingBundlerOptions;
 use crate::types::binding_watcher_event::BindingWatcherEvent;
 use crate::types::js_callback::{MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt};
-use crate::utils::create_bundler_config_from_binding_options::create_bundler_config_from_binding_options;
+use crate::utils::{
+  create_bundler_config_from_binding_options::create_bundler_config_from_binding_options,
+  spawn_boxed_future,
+};
 
 /// Bridges watcher events from Rust to JS via a `ThreadsafeFunction`.
 struct NapiWatcherEventHandler {
@@ -50,7 +56,7 @@ impl WatcherEventHandler for NapiWatcherEventHandler {
 
 #[napi]
 pub struct BindingWatcher {
-  inner: rolldown_watcher::Watcher,
+  inner: Arc<rolldown_watcher::Watcher>,
 }
 
 #[napi]
@@ -88,32 +94,37 @@ impl BindingWatcher {
           errs.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
         )
       })?;
-    Ok(Self { inner })
+    Ok(Self { inner: Arc::new(inner) })
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  #[napi]
-  pub async fn run(&self) -> napi::Result<()> {
-    self.inner.run();
-    Ok(())
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn run<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.run();
+      Ok(())
+    })
   }
 
   /// Gives consumers a reliable way to await the watcher's completion.
   /// The Node.js layer relies on the pending Promise to keep the process from exiting.
   #[tracing::instrument(level = "debug", skip_all)]
-  #[napi]
-  pub async fn wait_for_close(&self) -> napi::Result<()> {
-    self.inner.wait_for_close().await;
-    Ok(())
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn wait_for_close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.wait_for_close().await;
+      Ok(())
+    })
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  #[napi]
-  pub async fn close(&self) -> napi::Result<()> {
-    self
-      .inner
-      .close()
-      .await
-      .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let inner = Arc::clone(&self.inner);
+    spawn_boxed_future(env, async move {
+      inner.close().await.map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))
+    })
   }
 }


### PR DESCRIPTION
Box dev-engine and watcher NAPI futures through the shared binding helper to reduce async monomorphization in cold exported entry points.

Binary size impact from the profile build:

```text
.text:                 ~11.4 MiB -> ~11.3 MiB
llvm-lines total:      1,891,214 / 51,330 copies -> 1,744,742 / 46,233 copies
tokio poll_future:     44,050 IR lines / 218 copies -> 27,890 / 138
tokio crate bucket:    226.1 KiB -> 183.6 KiB
napi crate bucket:     446.0 KiB -> 424.4 KiB
rolldown_binding:      782.4 KiB -> 765.6 KiB
```

Validated with `cargo fmt --package rolldown_binding`, `cargo check -p rolldown_binding --lib`, `cargo llvm-lines`, `cargo bloat`, `just lint-rust`, and `just build-rolldown`.