### PR TITLE
fix(dev): update importer relationships of cached modules in incremental build

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -253,7 +253,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
       return Ok(output);
     }
 
-    self.cache.merge(output)?;
+    self.cache.merge(output, &self.plugin_driver)?;
     self.cache.update_defer_sync_data(&self.options).await?;
     Ok(self.cache.create_output())
   }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -281,7 +281,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
           .collect::<Vec<_>>(),
       );
 
-      self.cache.merge(module_loader_output.into())?;
+      let plugin_driver = Arc::clone(&self.plugin_driver);
+      self.cache.merge(module_loader_output.into(), &plugin_driver)?;
 
       let options = Arc::clone(&self.options);
       self.cache.update_defer_sync_data(&options).await?;
@@ -374,7 +375,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     let module_loader_output = module_loader.fetch_modules(fetch_mode).await?;
     drop(module_loader);
 
-    self.cache.merge(module_loader_output.into()).map_err(|e| vec![anyhow::anyhow!(e).into()])?;
+    let plugin_driver = Arc::clone(&self.plugin_driver);
+    self
+      .cache
+      .merge(module_loader_output.into(), &plugin_driver)
+      .map_err(|e| vec![anyhow::anyhow!(e).into()])?;
 
     let options = Arc::clone(&self.options);
     self.cache.update_defer_sync_data(&options).await?;

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -217,6 +217,16 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     })
   }
 
+  /// Marks `idx` for importer-set re-derivation in `ScanStageCache::merge`;
+  /// call it next to every mutation of `intermediate_normal_modules.importers`.
+  /// Writes straight to the cache so marks survive a failed scan. No-op in
+  /// full scan mode, which rebuilds every module's sets anyway.
+  fn mark_module_importers_changed(&mut self, idx: ModuleIdx) {
+    if !self.is_full_scan {
+      self.cache.modules_with_changed_importers.insert(idx);
+    }
+  }
+
   /// Lazy barrel must not skip any of an entry's re-exports — an entry has to
   /// preserve all of its exports. Request `All` from it: if it has already been
   /// loaded as a barrel, load its remaining (deferred) records now; otherwise
@@ -425,11 +435,15 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             && let Some(previous_module) =
               self.cache.get_snapshot().module_table.modules.get(module_idx)
           {
-            let resolved_deps =
-              previous_module.import_records().into_iter().filter_map(|r| r.resolved_module);
+            let resolved_deps = previous_module
+              .import_records()
+              .into_iter()
+              .filter_map(|r| r.resolved_module)
+              .collect::<Vec<_>>();
             for dep_idx in resolved_deps {
               self.intermediate_normal_modules.importers[dep_idx]
                 .retain(|v| v.importer_idx != module_idx);
+              self.mark_module_importers_changed(dep_idx);
             }
           }
 
@@ -505,6 +519,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               importer_path: module.id().clone(),
               importer_idx: module_idx,
             });
+            self.mark_module_importers_changed(idx);
 
             // Defer usage merging - with only one consumer, keep fetch actions simple
             if let Some(usage) = dynamic_import_rec_exports_usage.remove(&rec_idx) {
@@ -617,6 +632,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               importer_path: module.id.clone(),
               importer_idx: module.idx,
             });
+            self.mark_module_importers_changed(idx);
             import_records.push(raw_rec.into_resolved(Some(idx)));
           }
           module.import_records = import_records;
@@ -730,14 +746,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
           // Note: (Compat to rollup)
           // The `dynamic_importers/importers` should be added after `module_parsed` hook.
           let importers = &self.intermediate_normal_modules.importers[idx];
-          for importer in importers {
-            if importer.kind.is_static() {
-              module.importers.insert(importer.importer_path.clone());
-              module.importers_idx.insert(importer.importer_idx);
-            } else {
-              module.dynamic_importers.insert(importer.importer_path.clone());
-            }
-          }
+          module.ecma_view.rebuild_importer_sets(importers);
           if !importers.is_empty() {
             idx_of_module_info_need_update.push(idx);
           }
@@ -1024,6 +1033,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               user_defined_entries,
             );
             self.intermediate_normal_modules.importers[new_idx].push(importer_record);
+            self.mark_module_importers_changed(new_idx);
             // Update resolved module in either cache snapshot or intermediate modules
             if is_module_from_cache_snapshot {
               self

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::IndexVec;
@@ -6,6 +8,7 @@ use rolldown_common::{
   StableModuleId,
 };
 use rolldown_error::BuildResult;
+use rolldown_plugin::PluginDriver;
 use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use sugar_path::SugarPath;
@@ -22,6 +25,10 @@ pub struct ScanStageCache {
   pub barrel_state: BarrelState,
   pub module_id_to_idx: FxHashMap<ModuleId, VisitState>,
   pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
+  /// Modules whose `importers` records were mutated by a partial scan.
+  /// [`Self::merge`] re-derives their materialized importer sets, which the
+  /// scan does only for re-scanned modules.
+  pub modules_with_changed_importers: FxHashSet<ModuleIdx>,
   pub user_defined_entry: FxHashSet<ModuleId>,
   // Usage: Map file path emitted by watcher to corresponding module index
   pub module_idx_by_abs_path: FxHashMap<ArcStr, ModuleIdx>,
@@ -67,7 +74,11 @@ impl ScanStageCache {
     self.snapshot.as_ref().unwrap()
   }
 
-  pub fn merge(&mut self, mut scan_stage_output: ScanStageOutput) -> BuildResult<()> {
+  pub fn merge(
+    &mut self,
+    mut scan_stage_output: ScanStageOutput,
+    plugin_driver: &PluginDriver,
+  ) -> BuildResult<()> {
     fn module_has_tla(module: &Module) -> bool {
       module.as_normal().is_some_and(|normal_module| {
         normal_module.ast_usage.contains(EcmaModuleAstUsage::TopLevelAwait)
@@ -157,6 +168,19 @@ impl ScanStageCache {
       );
     }
 
+    // The scan rebuilds the materialized importer sets only for the modules
+    // it re-scanned. Re-derive them for cached modules whose incoming edges
+    // changed. See internal-docs/cache/implementation.md.
+    let modules_with_changed_importers = std::mem::take(&mut self.modules_with_changed_importers);
+    for idx in &modules_with_changed_importers {
+      // The idx may belong to a module from a scan that failed before merging.
+      let Some(module) = cache.module_table.modules.get_mut(*idx).and_then(Module::as_normal_mut)
+      else {
+        continue;
+      };
+      module.ecma_view.rebuild_importer_sets(&self.importers[*idx]);
+    }
+
     // merge entries
     for entry_point in scan_stage_output.entry_points {
       if let Some(old_entry_point) = cache
@@ -205,7 +229,27 @@ impl ScanStageCache {
         user_defined_entry_modules.insert(idx);
       }
     }
+    // Entries emitted via `emitFile(type: 'chunk')` are only discovered by
+    // full scans (partial scans skip `buildStart`); their rows persist in
+    // `entry_points`, so keep their modules flagged as entries too.
+    for entry in &cache.entry_points {
+      if matches!(entry.kind, rolldown_common::EntryPointKind::EmittedUserDefined) {
+        user_defined_entry_modules.insert(entry.idx);
+      }
+    }
     cache.user_defined_entry_modules = user_defined_entry_modules;
+
+    // Keep the plugin-facing `ModuleInfo.importers` of those modules in
+    // sync as well; the scan refreshes it only for re-scanned modules.
+    for idx in modules_with_changed_importers {
+      let Some(module) = cache.module_table.modules.get(idx).and_then(Module::as_normal) else {
+        continue;
+      };
+      plugin_driver.set_module_info(
+        &module.id,
+        Arc::new(module.to_module_info(None, cache.user_defined_entry_modules.contains(&idx))),
+      );
+    }
 
     Ok(())
   }

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -82,51 +82,41 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 # HMR Step 2
 
-## Code
-
-```js
-//#region child.js
-var init_child_0 = __rolldown_runtime__.createEsmInitializer("child.js", (function(__rolldown_module_id__) {
-	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
-		const value = "child";
-	} finally {}
-}));
-
-//#endregion
-//#region parent.js
-var init_parent_1 = __rolldown_runtime__.createEsmInitializer("parent.js", (function(__rolldown_module_id__) {
-	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
-			childValue: () => childValue,
-			parentValue: () => parentValue
-		});
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
-		const childValue = "not-child";
-		const parentValue = "parent";
-		hot_parent.accept((newMod) => {
-			const { childValue, parentValue } = newMod;
-			assert.strictEqual(parentValue, "parent");
-			assert.strictEqual(childValue, "not-child");
-		});
-	} finally {}
-}));
-
-//#endregion
-init_parent_1()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
-```
-
 ## Meta
 
-- update type: patch
+- update type: full-reload
+- reason: no hmr boundary found for module `child.js`
 
-### Hmr Boundaries
+## Build Output
 
-- boundary: parent.js, accepted_via: parent.js
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region parent.js
+var parent_exports = /* @__PURE__ */ __exportAll({
+	childValue: () => childValue,
+	parentValue: () => parentValue
+});
+const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
+__rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
+const childValue = "not-child";
+const parentValue = "parent";
+parent_hot.accept((newMod) => {
+	const { childValue, parentValue } = newMod;
+	assert.strictEqual(parentValue, "parent");
+	assert.strictEqual(childValue, "not-child");
+});
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
 
 # HMR Step 3
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/_config.json
@@ -3,6 +3,5 @@
     "experimental": {
       "devMode": {}
     }
-  },
-  "expectExecuted": false
+  }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/accepter.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/accepter.js
@@ -1,0 +1,5 @@
+import { value } from './lib.js';
+
+export const read = () => value;
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/adder.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/adder.hmr-0.js
@@ -1,0 +1,5 @@
+import { value } from './lib.js';
+
+export const tag = `adder-${value}`;
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/adder.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/adder.js
@@ -1,0 +1,3 @@
+export const tag = 'adder';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/artifacts.snap
@@ -1,0 +1,123 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ value: () => "lib" });
+__rolldown_runtime__.createModuleHotContext("lib.js");
+__rolldown_runtime__.registerModule("lib.js", { exports: lib_exports });
+//#endregion
+//#region accepter.js
+var accepter_exports = /* @__PURE__ */ __exportAll({ read: () => read });
+const accepter_hot = __rolldown_runtime__.createModuleHotContext("accepter.js");
+__rolldown_runtime__.registerModule("accepter.js", { exports: accepter_exports });
+const read = () => "lib";
+accepter_hot.accept();
+//#endregion
+//#region adder.js
+var adder_exports = /* @__PURE__ */ __exportAll({ tag: () => tag });
+const adder_hot = __rolldown_runtime__.createModuleHotContext("adder.js");
+__rolldown_runtime__.registerModule("adder.js", { exports: adder_exports });
+const tag = "adder";
+adder_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region adder.js
+var init_adder_0 = __rolldown_runtime__.createEsmInitializer("adder.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ tag: () => tag });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_adder = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_lib_00 = __rolldown_runtime__.loadExports("lib.js");
+		const tag = `adder-${import_lib_00.value}`;
+		hot_adder.accept();
+	} finally {}
+}));
+
+//#endregion
+init_adder_0()
+__rolldown_runtime__.applyUpdates([['adder.js', 'adder.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: adder.js, accepted_via: adder.js
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region accepter.js
+var init_accepter_0 = __rolldown_runtime__.createEsmInitializer("accepter.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ read: () => read });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		init_lib_2();
+		const hot_accepter = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_lib_00 = __rolldown_runtime__.loadExports("lib.js");
+		const read = () => import_lib_00.value;
+		hot_accepter.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region adder.js
+var init_adder_1 = __rolldown_runtime__.createEsmInitializer("adder.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ tag: () => tag });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		init_lib_2();
+		const hot_adder = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_lib_10 = __rolldown_runtime__.loadExports("lib.js");
+		const tag = `adder-${import_lib_10.value}`;
+		hot_adder.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region lib.js
+var init_lib_2 = __rolldown_runtime__.createEsmInitializer("lib.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_lib = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "lib-edited";
+	} finally {}
+}));
+
+//#endregion
+init_accepter_0()
+init_adder_1()
+__rolldown_runtime__.applyUpdates([['accepter.js', 'accepter.js'],['adder.js', 'adder.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: accepter.js, accepted_via: accepter.js
+- boundary: adder.js, accepted_via: adder.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/lib.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/lib.hmr-1.js
@@ -1,0 +1,1 @@
+export const value = 'lib-edited';

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/lib.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/lib.js
@@ -1,0 +1,1 @@
+export const value = 'lib';

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_added_to_cached_module/main.js
@@ -1,0 +1,2 @@
+import './accepter.js';
+import './adder.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/_config.json
@@ -3,6 +3,5 @@
     "experimental": {
       "devMode": {}
     }
-  },
-  "expectExecuted": false
+  }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/accepter.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/accepter.js
@@ -1,0 +1,5 @@
+import { value } from './lib.js';
+
+export const read = () => value;
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/artifacts.snap
@@ -1,0 +1,106 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ value: () => "lib" });
+__rolldown_runtime__.createModuleHotContext("lib.js");
+__rolldown_runtime__.registerModule("lib.js", { exports: lib_exports });
+//#endregion
+//#region accepter.js
+var accepter_exports = /* @__PURE__ */ __exportAll({ read: () => read });
+const accepter_hot = __rolldown_runtime__.createModuleHotContext("accepter.js");
+__rolldown_runtime__.registerModule("accepter.js", { exports: accepter_exports });
+const read = () => "lib";
+accepter_hot.accept();
+//#endregion
+//#region dropper.js
+var dropper_exports = /* @__PURE__ */ __exportAll({ tag: () => tag });
+const dropper_hot = __rolldown_runtime__.createModuleHotContext("dropper.js");
+__rolldown_runtime__.registerModule("dropper.js", { exports: dropper_exports });
+const tag = `dropper-lib`;
+dropper_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region dropper.js
+var init_dropper_0 = __rolldown_runtime__.createEsmInitializer("dropper.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ tag: () => tag });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dropper = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const tag = "dropper";
+		hot_dropper.accept();
+	} finally {}
+}));
+
+//#endregion
+init_dropper_0()
+__rolldown_runtime__.applyUpdates([['dropper.js', 'dropper.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dropper.js, accepted_via: dropper.js
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region accepter.js
+var init_accepter_0 = __rolldown_runtime__.createEsmInitializer("accepter.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ read: () => read });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		init_lib_1();
+		const hot_accepter = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_lib_00 = __rolldown_runtime__.loadExports("lib.js");
+		const read = () => import_lib_00.value;
+		hot_accepter.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region lib.js
+var init_lib_1 = __rolldown_runtime__.createEsmInitializer("lib.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_lib = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "lib-edited";
+	} finally {}
+}));
+
+//#endregion
+init_accepter_0()
+__rolldown_runtime__.applyUpdates([['accepter.js', 'accepter.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: accepter.js, accepted_via: accepter.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/dropper.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/dropper.hmr-0.js
@@ -1,0 +1,3 @@
+export const tag = 'dropper';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/dropper.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/dropper.js
@@ -1,0 +1,5 @@
+import { value } from './lib.js';
+
+export const tag = `dropper-${value}`;
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/lib.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/lib.hmr-1.js
@@ -1,0 +1,1 @@
+export const value = 'lib-edited';

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/lib.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/lib.js
@@ -1,0 +1,1 @@
+export const value = 'lib';

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_removed_from_cached_module/main.js
@@ -1,0 +1,2 @@
+import './accepter.js';
+import './dropper.js';

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -11,8 +11,8 @@ use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId, ModuleIdx,
-  NamedImport, ResolvedImportRecord, SourceMutation, SymbolRef,
+  ExportsKind, HmrInfo, ImportRecordIdx, ImporterRecord, LocalExport, ModuleDefFormat, ModuleId,
+  ModuleIdx, NamedImport, ResolvedImportRecord, SourceMutation, SymbolRef,
   side_effects::DeterminedSideEffects, types::source_mutation::ArcSourceMutation,
 };
 
@@ -144,6 +144,23 @@ pub struct EcmaView {
   pub json_module_none_self_reference_included_symbol: Option<Box<FxHashSet<SymbolRef>>>,
   /// Import record indices for `module.exports = require(...)` patterns.
   pub cjs_reexport_import_record_ids: Vec<ImportRecordIdx>,
+}
+
+impl EcmaView {
+  /// Re-derives the importer sets from this module's `ImporterRecord`s.
+  pub fn rebuild_importer_sets(&mut self, records: &[ImporterRecord]) {
+    self.importers.clear();
+    self.importers_idx.clear();
+    self.dynamic_importers.clear();
+    for record in records {
+      if record.kind.is_static() {
+        self.importers.insert(record.importer_path.clone());
+        self.importers_idx.insert(record.importer_idx);
+      } else {
+        self.dynamic_importers.insert(record.importer_path.clone());
+      }
+    }
+  }
 }
 
 bitflags! {

--- a/internal-docs/bundler-data-lifecycle/implementation.md
+++ b/internal-docs/bundler-data-lifecycle/implementation.md
@@ -24,6 +24,7 @@ Bundler (long-lived)
   │     ├── snapshot (NormalizedScanStageOutput)
   │     ├── module_id_to_idx
   │     ├── importers
+  │     ├── modules_with_changed_importers
   │     ├── barrel_state
   │     ├── module_idx_by_abs_path
   │     └── module_idx_by_stable_id
@@ -76,14 +77,15 @@ Data created fresh for each build and discarded (or consumed) when the build com
 Bundler.cache (ScanStageCache) ──(move)──> Bundle.cache (temporary holder) ──(build)──> Bundle.cache ──(move)──> Bundler.cache
 ```
 
-| `ScanStageCache` field    | Purpose                                             |
-| ------------------------- | --------------------------------------------------- |
-| `snapshot`                | Full module graph (modules, ASTs, symbols, entries) |
-| `module_id_to_idx`        | Module ID to index lookup                           |
-| `importers`               | Reverse dependency graph                            |
-| `barrel_state`            | Barrel export optimization state                    |
-| `module_idx_by_abs_path`  | Path-based lookup for watcher                       |
-| `module_idx_by_stable_id` | Stable ID lookup for HMR                            |
+| `ScanStageCache` field           | Purpose                                                                      |
+| -------------------------------- | ---------------------------------------------------------------------------- |
+| `snapshot`                       | Full module graph (modules, ASTs, symbols, entries)                          |
+| `module_id_to_idx`               | Module ID to index lookup                                                    |
+| `importers`                      | Reverse dependency graph                                                     |
+| `modules_with_changed_importers` | Modules whose `importers` records a partial scan mutated; drained by `merge` |
+| `barrel_state`                   | Barrel export optimization state                                             |
+| `module_idx_by_abs_path`         | Path-based lookup for watcher                                                |
+| `module_idx_by_stable_id`        | Stable ID lookup for HMR                                                     |
 
 ### Cache integrity on a failed build
 

--- a/internal-docs/cache/implementation.md
+++ b/internal-docs/cache/implementation.md
@@ -25,7 +25,7 @@ Counting types literally named `*Cache`, there are 14. Grouped by purpose:
 
 | Type             | Location                                           | Stores                                                                   |
 | ---------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
-| `ScanStageCache` | `crates/rolldown/src/types/scan_stage_cache.rs:20` | The module-graph snapshot + module index maps. See the rest of this doc. |
+| `ScanStageCache` | `crates/rolldown/src/types/scan_stage_cache.rs:23` | The module-graph snapshot + module index maps. See the rest of this doc. |
 
 ### 2. Cross-build invalidation state
 
@@ -102,7 +102,7 @@ on a failed build.
 
 ### The struct
 
-`crates/rolldown/src/types/scan_stage_cache.rs:20`:
+`crates/rolldown/src/types/scan_stage_cache.rs:23`:
 
 ```rust
 pub struct ScanStageCache {
@@ -110,35 +110,37 @@ pub struct ScanStageCache {
   pub barrel_state: BarrelState,
   pub module_id_to_idx: FxHashMap<ModuleId, VisitState>,
   pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
+  pub modules_with_changed_importers: FxHashSet<ModuleIdx>,
   pub user_defined_entry: FxHashSet<ModuleId>,
   pub module_idx_by_abs_path: FxHashMap<ArcStr, ModuleIdx>,
   pub module_idx_by_stable_id: FxHashMap<StableModuleId, ModuleIdx>,
 }
 ```
 
-| Field                     | Purpose                                                                                                                |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `snapshot`                | The full module graph. `None` is a legal transient state; it is `private` and accessed only through the methods below. |
-| `barrel_state`            | Barrel re-export resolution state (`BarrelState`).                                                                     |
-| `module_id_to_idx`        | The `ModuleId` → `ModuleIdx` registry/allocator (see "Module identity model").                                         |
-| `importers`               | Reverse dependency graph: per module, who imports it.                                                                  |
-| `user_defined_entry`      | The set of configured root entry `ModuleId`s.                                                                          |
-| `module_idx_by_abs_path`  | Absolute-path → `ModuleIdx`, used by the watcher. Paths are slash-normalized.                                          |
-| `module_idx_by_stable_id` | `StableModuleId` → `ModuleIdx`, used by HMR.                                                                           |
+| Field                            | Purpose                                                                                                                                        |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshot`                       | The full module graph. `None` is a legal transient state; it is `private` and accessed only through the methods below.                         |
+| `barrel_state`                   | Barrel re-export resolution state (`BarrelState`).                                                                                             |
+| `module_id_to_idx`               | The `ModuleId` → `ModuleIdx` registry/allocator (see "Module identity model").                                                                 |
+| `importers`                      | Reverse dependency graph: per module, who imports it.                                                                                          |
+| `modules_with_changed_importers` | Modules whose `importers` records were mutated by a partial scan; `merge` drains it to re-derive their materialized importer sets (see below). |
+| `user_defined_entry`             | The set of configured root entry `ModuleId`s.                                                                                                  |
+| `module_idx_by_abs_path`         | Absolute-path → `ModuleIdx`, used by the watcher. Paths are slash-normalized.                                                                  |
+| `module_idx_by_stable_id`        | `StableModuleId` → `ModuleIdx`, used by HMR.                                                                                                   |
 
 `module_idx_by_abs_path` and `module_idx_by_stable_id` are **derived** —
-`build_module_index_maps` (`scan_stage_cache.rs:213`) clears and rebuilds both
+`build_module_index_maps` (`scan_stage_cache.rs:297`) clears and rebuilds both
 from the snapshot whenever `set_snapshot` runs.
 
 Snapshot accessors (`scan_stage_cache.rs`):
 
-- `set_snapshot` (`:34`) — installs a snapshot and rebuilds the index maps.
-- `get_snapshot` (`:66`) — `&NormalizedScanStageOutput`; **panics if `snapshot` is `None`**.
-- `get_snapshot_mut` (`:41`) — `&mut`; **panics if `None`**.
-- `take_snapshot` (`:46`) — moves the snapshot out, leaving `None`.
-- `update_defer_sync_data` (`:50`) — takes the snapshot, runs `defer_sync_scan_data`, restores it on every outcome, then propagates any error.
-- `merge` (`:70`) — splices a scan output into the snapshot (see below).
-- `create_output` (`:229`) — produces a `NormalizedScanStageOutput` for the build to consume.
+- `set_snapshot` (`:44`) — installs a snapshot and rebuilds the index maps.
+- `get_snapshot` (`:76`) — `&NormalizedScanStageOutput`; **panics if `snapshot` is `None`**.
+- `get_snapshot_mut` (`:51`) — `&mut`; **panics if `None`**.
+- `take_snapshot` (`:56`) — moves the snapshot out, leaving `None`.
+- `update_defer_sync_data` (`:60`) — takes the snapshot, runs `defer_sync_scan_data`, restores it on every outcome, then propagates any error.
+- `merge` (`:80`) — splices a scan output into the snapshot (see below).
+- `create_output` (`:313`) — produces a `NormalizedScanStageOutput` for the build to consume.
 
 ### `BundleMode`
 
@@ -293,7 +295,7 @@ Consequence: every module present in a scan output was registered in
 
 ## `ScanStageCache::merge` — the write path
 
-`scan_stage_cache.rs:70`. Signature: `merge(&mut self, scan_stage_output: ScanStageOutput) -> BuildResult<()>`.
+`scan_stage_cache.rs:80`. Signature: `merge(&mut self, scan_stage_output: ScanStageOutput, plugin_driver: &PluginDriver) -> BuildResult<()>`.
 
 ### Callers
 
@@ -308,14 +310,14 @@ arm is `unreachable!()`.
 
 ### Algorithm
 
-1. **First-build escape hatch** (`:77`–`:82`) — if `snapshot` is `None`,
+1. **First-build escape hatch** (`:91`–`:96`) — if `snapshot` is `None`,
    convert the whole output via `try_into` and return.
-2. **Extract `modules`** (`:83`–`:92`) — the `module_table` is matched: the
+2. **Extract `modules`** (`:97`–`:106`) — the `module_table` is matched: the
    `IndexVec` arm is `unreachable!()`; the `Map` arm is collected into a `Vec`
    and **sorted by idx**. The sort places existing modules (idx < cache length)
    before new ones (idx ≥ cache length), and orders new modules ascending so
    that `push` lands each at its allocated slot.
-3. **Per-module loop** (`:94`–`:158`):
+3. **Per-module loop** (`:108`–`:172`):
    - `new_idx` is the `Map` key (indexes the scan output); `idx` is
      `module_id_to_idx[new_module.id()].idx()` (indexes the cache). By
      invariant 6 they are equal.
@@ -328,16 +330,28 @@ arm is `unreachable!()`.
      count by the old↔new delta; replace or remove the TLA span.
    - All payload is moved (`mem::take` / `take` / `mem::replace` / `mem::swap`)
      out of the scan output — never cloned.
-4. **Merge entry points** (`:161`–`:181`) — for a matching existing entry
+4. **Re-derive importer sets of affected cached modules** (`:171`–`:182`) —
+   drain `modules_with_changed_importers` (filled by
+   `ModuleLoader::mark_module_importers_changed` next to every mutation of the
+   `importers` edge list) and rebuild each listed module's materialized
+   `importers`/`importers_idx`/`dynamic_importers` sets from the edge list via
+   `EcmaView::rebuild_importer_sets`. The scan does this only for modules it
+   produced; a cached module whose importer added/removed/re-kinded an import
+   of it is refreshed here (issue #7416).
+5. **Merge entry points** — for a matching existing entry
    point, drop `related_stmt_infos` for re-scanned modules and extend with the
    new ones; otherwise push the new entry point.
-5. **Patch barrel modules** (`:184`–`:192`) — drain
+6. **Patch barrel modules** — drain
    `barrel_state.resolved_barrel_modules` and write the resolved import records
    back into the cached modules.
-6. **Recompute user-defined entries** (`:194`–`:208`) — start from the scan
+7. **Recompute user-defined entries** — start from the scan
    output's set, add back persistent configured roots
    (`self.user_defined_entry`) that still resolve to a live module. This
    rebuilds the set each build rather than extending it monotonically.
+8. **Refresh plugin-facing `ModuleInfo`** — for the modules re-derived in
+   step 4, re-run `to_module_info` and `plugin_driver.set_module_info` so
+   `this.getModuleInfo(id).importers` matches the merged graph (the scan
+   refreshes it only for modules it produced).
 
 `merge` has two panic surfaces: the `module_id_to_idx[new_module.id()]` index
 expression (panics on a missing key — reachable only if invariant 6 is
@@ -350,16 +364,16 @@ as the `module_id_to_idx` lookup and is infallible.
 
 ### Writers of `ScanStageCache`
 
-| Writer                                                   | Location                                                                                | What it writes                                                                                                                                     |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ScanStage::scan(scan_mode, &mut self.cache)`            | called at `bundle.rs:104`                                                               | Non-snapshot fields via the loader.                                                                                                                |
-| `ModuleLoader` (`cache: &'a mut ScanStageCache`)         | `module_loader.rs:117` and methods                                                      | `module_id_to_idx`, `barrel_state` (e.g. removes `barrel_infos` on invalidate), `importers`, `user_defined_entry` (full incremental scan).         |
-| `ScanStageCache::merge`                                  | `scan_stage_cache.rs:70`; called at `bundle.rs:256`, `hmr_stage.rs:286/379/621`         | `snapshot`, `module_idx_by_abs_path`, `module_idx_by_stable_id`, `barrel_state.resolved_barrel_modules` (drained), `tla_*` fields in the snapshot. |
-| `ScanStageCache::set_snapshot`                           | `scan_stage_cache.rs:34`; called at `bundle.rs:250` and inside `update_defer_sync_data` | `snapshot` + rebuilds `module_idx_by_abs_path` / `module_idx_by_stable_id`.                                                                        |
-| `ScanStageCache::update_defer_sync_data`                 | `scan_stage_cache.rs:50`; called at `bundle.rs:257`, `hmr_stage.rs:289/382/623`         | Takes and restores `snapshot`; `defer_sync_scan_data` mutates per-module `side_effects` inside it.                                                 |
-| `ScanStageCache::create_output`                          | `scan_stage_cache.rs:229`; called at `bundle.rs:258`                                    | Mutates `snapshot.symbol_ref_db` (clones it without scoping, swaps); returns a `NormalizedScanStageOutput`.                                        |
-| `merge_immutable_fields_for_cache`                       | `bundle.rs:315`, called at `bundle.rs:279`                                              | `get_snapshot_mut()`; reinstates symbol-table scoping after the link stage.                                                                        |
-| `with_cached_bundle` / `with_cached_bundle_experimental` | `impl_bundler_incremental_build.rs:9` / `:27`                                           | Moves the whole `ScanStageCache` between `Bundler` and `Bundle`.                                                                                   |
+| Writer                                                   | Location                                                                                | What it writes                                                                                                                                                                                                                                         |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ScanStage::scan(scan_mode, &mut self.cache)`            | called at `bundle.rs:104`                                                               | Non-snapshot fields via the loader.                                                                                                                                                                                                                    |
+| `ModuleLoader` (`cache: &'a mut ScanStageCache`)         | `module_loader.rs:117` and methods                                                      | `module_id_to_idx`, `barrel_state` (e.g. removes `barrel_infos` on invalidate), `importers`, `modules_with_changed_importers`, `user_defined_entry` (full incremental scan).                                                                           |
+| `ScanStageCache::merge`                                  | `scan_stage_cache.rs:80`; called at `bundle.rs:256`, `hmr_stage.rs:284/377`             | `snapshot`, `module_idx_by_abs_path`, `module_idx_by_stable_id`, `barrel_state.resolved_barrel_modules` (drained), `modules_with_changed_importers` (drained), `tla_*` fields in the snapshot; refreshes plugin `module_infos` for re-derived modules. |
+| `ScanStageCache::set_snapshot`                           | `scan_stage_cache.rs:44`; called at `bundle.rs:250` and inside `update_defer_sync_data` | `snapshot` + rebuilds `module_idx_by_abs_path` / `module_idx_by_stable_id`.                                                                                                                                                                            |
+| `ScanStageCache::update_defer_sync_data`                 | `scan_stage_cache.rs:60`; called at `bundle.rs:257`, `hmr_stage.rs:289/382/623`         | Takes and restores `snapshot`; `defer_sync_scan_data` mutates per-module `side_effects` inside it.                                                                                                                                                     |
+| `ScanStageCache::create_output`                          | `scan_stage_cache.rs:313`; called at `bundle.rs:258`                                    | Mutates `snapshot.symbol_ref_db` (clones it without scoping, swaps); returns a `NormalizedScanStageOutput`.                                                                                                                                            |
+| `merge_immutable_fields_for_cache`                       | `bundle.rs:315`, called at `bundle.rs:279`                                              | `get_snapshot_mut()`; reinstates symbol-table scoping after the link stage.                                                                                                                                                                            |
+| `with_cached_bundle` / `with_cached_bundle_experimental` | `impl_bundler_incremental_build.rs:9` / `:27`                                           | Moves the whole `ScanStageCache` between `Bundler` and `Bundle`.                                                                                                                                                                                       |
 
 ### Readers of `ScanStageCache`
 
@@ -368,7 +382,7 @@ as the `module_id_to_idx` lookup and is infallible.
 | `HmrStage`             | `hmr_stage.rs:48`, `:52`              | `get_snapshot().module_table`, `get_snapshot().index_ecma_ast`; also uses the module index maps. HMR is also a writer (it calls `merge` / `update_defer_sync_data`). |
 | `ModuleLoader`         | `module_loader.rs:410`, `:983`        | `get_snapshot()` (e.g. `module_table.modules.get(..)`). Also reads `module_id_to_idx` (`:229`, `:869`), `barrel_state`, `user_defined_entry`.                        |
 | `defer_sync_scan_data` | `module_loader/deferred_scan_data.rs` | Reads `module_id_to_idx` (passed as `&FxHashMap<ModuleId, VisitState>`); mutates the snapshot's per-module side effects.                                             |
-| `merge`                | `scan_stage_cache.rs:70`              | Reads `module_id_to_idx` and `user_defined_entry`.                                                                                                                   |
+| `merge`                | `scan_stage_cache.rs:80`              | Reads `module_id_to_idx`, `user_defined_entry`, and `importers` (re-derives importer sets).                                                                          |
 
 ---
 


### PR DESCRIPTION
### Description

Part of #7416. This PR fixes the importer relationship item. The remaining items are listed at the end.

#### Problem

Importer relationships live in two layers:

1. The `importers` edge list on `ScanStageCache`. It is the authoritative reverse dependency graph, and #7348 already keeps it up to date during partial scans.
2. The materialized `importers`, `importers_idx` and `dynamic_importers` sets on each `NormalModule`, which are derived from that edge list.

A partial scan rebuilds the second layer only for the modules it rescans. When editing module A adds or removes an import of module B, or changes it between static and dynamic, the change lands on the sets of B. But B is usually served from cache and never rescanned, so its sets stay stale indefinitely.

The stale sets are consumed by:

- HMR boundary propagation (`importers_idx`). A patch can miss a newly added importer, whose module instance on the client then silently keeps the old dependency. A patch can also run modules that no longer import the edited file.
- `import.meta.hot.invalidate()`, which reads `caller.importers_idx` directly without any rescan.
- The link and generate stages on incremental rebuilds (`code_splitting`, `chunk_optimizer`, `on_demand_wrapping`, `create_exports_for_ecma_modules`).
- `this.getModuleInfo(id).importers` and `.dynamicImporters`.

#### Fix

The edge list is already correct, so this PR rebuilds the second layer from it for exactly the affected modules:

- `ScanStageCache` gains `modules_with_changed_importers`. `ModuleLoader::mark_module_importers_changed` records the target module next to every mutation of the `importers` edge list during a partial scan. The marks are written straight to the cache so they survive a failed scan.
- `ScanStageCache::merge` drains the set and rebuilds the sets of each listed module from the edge list through the new `EcmaView::rebuild_importer_sets`, the same helper the loader uses for rescanned modules.
- `merge` also refreshes the `ModuleInfo` exposed to plugins for those modules, because the scan refreshes it only for modules it produced. This keeps `ctx.getModuleInfo(id)` in `advancedChunks` name callbacks and plugin queries consistent with the merged graph. `merge` now takes `&PluginDriver` for this.
- The `user_defined_entry_modules` recompute in `merge` now also keeps the modules of `EmittedUserDefined` entry rows. Partial scans do not re-run `buildStart`, so entries emitted via `emitFile(type: 'chunk')` are absent from the scan output's set; without this, the refreshed `ModuleInfo` of such a module would report `isEntry: false` after any partial merge that touches its importers.

#### Behavior change in an existing snapshot

`delete_file_not_used_anymore` step 2 changes from a patch to a full reload. That step edits an orphaned module whose only importer dropped the import in step 0. The old patch came from walking the stale phantom edge. It ran a module that no longer imports the edited file and shipped dead code to the client. A full reload is the honest answer while orphaned modules remain in the graph state. The ideal result is a noop, because a fresh build would not contain the module at all, but that requires the orphan cleanup tracked in #7416. The test harness forbids executing output in fixtures that hit a full reload, which is why the fixture now sets `"expectExecuted": false`.

#### Tests

- `hmr/import_added_to_cached_module`: a module adds an import of a cached module. A later edit of the cached module must reach the new importer. Without the fix the patch misses that boundary.
- `hmr/import_removed_from_cached_module`: the mirror case. A later edit of the cached module must not run the old importer again. Without the fix the patch still contains it.

#### Docs

`internal-docs/cache/implementation.md` and `internal-docs/bundler-data-lifecycle/implementation.md` are updated for the new field and the new merge steps.

#### Remaining items of #7416

- The state still holds removed modules. Editing an orphaned module therefore triggers a full reload instead of a noop, and its module and AST stay in memory.
- There is no general check yet that an incremental build and a full build produce the same states. The new fixtures cover the importer sets only.
- There is no recovery story for a failed partial scan. A failed scan leaves `module_id_to_idx` marked as seen for modules whose results never reached the snapshot, so the edge list and the snapshot can drift apart until the affected files change again.
- Dynamic import entry points are never removed from the cached entry list when the dynamic import goes away.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->


