### PR TITLE
refactor(clippy): ban std HashMap/HashSet in favour of FxHashMap/FxHashSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "heck",
  "ignore",
  "rolldown_workspace",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -9,6 +9,11 @@ disallowed-methods = [
   { path = "std::collections::HashSet::new", reason = "prefer FxHashSet", replacement = "rustc_hash::FxHashSet::default" },
 ]
 
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "Use `rustc_hash::FxHashMap` instead, which is typically faster." },
+  { path = "std::collections::HashSet", reason = "Use `rustc_hash::FxHashSet` instead, which is typically faster." },
+]
+
 ### await-holding-invalid-types
 ## we can remove these if https://github.com/xacrimon/dashmap/issues/348 lands
 

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -1,6 +1,5 @@
 #![expect(clippy::print_stderr)]
 
-use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -13,7 +12,7 @@ use rolldown::BundlerOptions;
 use rolldown_error::{BuildDiagnostic, DiagnosticOptions, EventKind};
 use rolldown_testing::integration_test::IntegrationTest;
 use rolldown_testing::test_config::TestMeta;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use sugar_path::SugarPath;
 use walkdir::WalkDir;
@@ -63,7 +62,7 @@ struct Test262FailureMetadata {
   issue: Option<String>,
 }
 
-static KNOWN_FAILURES: LazyLock<HashMap<String, Test262FailureMetadata>> = LazyLock::new(|| {
+static KNOWN_FAILURES: LazyLock<FxHashMap<String, Test262FailureMetadata>> = LazyLock::new(|| {
   let json_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/test262_failures.json");
   let json_content =
     std::fs::read_to_string(json_path).expect("Failed to read test262_failures.json");
@@ -539,8 +538,7 @@ fn validate_no_stale_pass_metadata(results: &[TestResult]) {
 
 /// Validates that all KNOWN_FAILURES entries correspond to actual test files
 fn validate_known_failures(results: &[TestResult]) {
-  let all_test_paths: std::collections::HashSet<String> =
-    results.iter().map(TestResult::get_clean_path).collect();
+  let all_test_paths: FxHashSet<String> = results.iter().map(TestResult::get_clean_path).collect();
 
   let unknown_failures: Vec<String> =
     KNOWN_FAILURES.keys().filter(|key| !all_test_paths.contains(key.as_str())).cloned().collect();

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -13,6 +13,10 @@
 // }),
 // Looks redundant
 #![allow(clippy::missing_transmute_annotations)]
+// NAPI-RS requires `std::collections::HashMap`/`HashSet` to generate the TypeScript definitions,
+// so the whole binding crate opts out of the `FxHashMap`/`FxHashSet` type ban (the hasher is
+// already `FxBuildHasher` at every use site).
+#![allow(clippy::disallowed_types)]
 
 #[cfg(all(target_family = "wasm", tokio_unstable))]
 use std::sync::{

--- a/crates/rolldown_common/src/types/idx_ext.rs
+++ b/crates/rolldown_common/src/types/idx_ext.rs
@@ -1,8 +1,5 @@
 use crate::{ChunkIdx, ChunkTable, ModuleIdx, ModuleTable};
-use std::{
-  collections::{HashMap, HashSet},
-  hash::BuildHasher,
-};
+use std::hash::BuildHasher;
 
 pub trait IdxDebugExt {
   fn debug(&self, module_table: &ModuleTable, chunk_table: &ChunkTable) -> String;
@@ -36,7 +33,11 @@ impl<T: IdxDebugExt> IdxDebugExt for Vec<T> {
   }
 }
 
-impl<T: IdxDebugExt, S: BuildHasher> IdxDebugExt for HashSet<T, S> {
+#[expect(
+  clippy::disallowed_types,
+  reason = "blanket impl generic over the hasher `S`; `FxHashSet` is an alias and can't express this"
+)]
+impl<T: IdxDebugExt, S: BuildHasher> IdxDebugExt for std::collections::HashSet<T, S> {
   fn debug(&self, module_table: &ModuleTable, chunk_table: &ChunkTable) -> String {
     let items: Vec<String> =
       self.iter().map(|item| item.debug(module_table, chunk_table)).collect();
@@ -44,7 +45,13 @@ impl<T: IdxDebugExt, S: BuildHasher> IdxDebugExt for HashSet<T, S> {
   }
 }
 
-impl<K: IdxDebugExt, V: IdxDebugExt, S: BuildHasher> IdxDebugExt for HashMap<K, V, S> {
+#[expect(
+  clippy::disallowed_types,
+  reason = "blanket impl generic over the hasher `S`; `FxHashMap` is an alias and can't express this"
+)]
+impl<K: IdxDebugExt, V: IdxDebugExt, S: BuildHasher> IdxDebugExt
+  for std::collections::HashMap<K, V, S>
+{
   fn debug(&self, module_table: &ModuleTable, chunk_table: &ChunkTable) -> String {
     let items: Vec<String> = self
       .iter()

--- a/tasks/ls_lint/Cargo.toml
+++ b/tasks/ls_lint/Cargo.toml
@@ -12,6 +12,7 @@ globset = "0.4"
 heck = { workspace = true }
 ignore = "0.4"
 rolldown_workspace = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/tasks/ls_lint/src/main.rs
+++ b/tasks/ls_lint/src/main.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::print_stderr)]
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use anyhow::Result;
 use globset::{Glob, GlobMatcher, GlobSetBuilder};
@@ -20,8 +20,8 @@ enum Case {
 #[derive(Deserialize, Debug)]
 struct LsLintConfig {
   ignore: Vec<String>,
-  file: HashMap<String, Case>,
-  directory: HashMap<String, Case>,
+  file: FxHashMap<String, Case>,
+  directory: FxHashMap<String, Case>,
 }
 
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Ports oxc's `disallowed-types` guard-rail into rolldown's `clippy.toml`: bans `std::collections::HashMap`/`HashSet` in favour of `rustc_hash::FxHashMap`/`FxHashSet`.

(rolldown already had `avoid-breaking-exported-api` and the `HashMap::new`/`HashSet::new` constructor bans; this adds the type-level ban.)

### Changes

- **Converted** the 6 genuine default-SipHash sites to `Fx*` (`test262.rs`, `tasks/ls_lint`).
- **Suppressed** the unavoidable sites narrowly (they *cannot* become `FxHashMap`):
  - `rolldown_binding` → crate-root `#![allow(clippy::disallowed_types)]`, since the whole crate needs `std::collections::HashMap` for napi's TypeScript type generation (already hashed with `FxBuildHasher`);
  - `rolldown_common::types::idx_ext` → `#[expect(clippy::disallowed_types)]` on the two blanket impls, which are generic over the hasher `S` and so must name the std type.

### Not included

- The `disallowed-methods` cow_utils bans (reverted from this PR).
- `ignore-interior-mutability` — oxc-linter-specific type with no rolldown equivalent.

## Verification

`cargo clippy --workspace --all-targets -- -D clippy::disallowed_types` passes.
