### PR TITLE
test: add regression test for #10099 (lazyBarrel drops default-import binding but keeps its property reads)

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/10099/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10099/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/10099 - the barrel `index.js` default-imports `defaults.js` and reads `defaults_default.install`/`.version` at the top level, while re-exporting an EXTERNAL module's default (`extdep`, real-world `dayjs` in element-plus). The entry imports ONLY that external passthrough, which force-includes the barrel (an external default re-export is not resolvable from sub-modules). Under `experimental.lazyBarrel` + `moduleSideEffects: false`, tree-shaking dropped the `defaults_default` import AND its definition in `defaults.js`, yet kept the `defaults_default.install/.version` property-read statements -> `ReferenceError: defaults_default is not defined` when the compiled entry runs. Fixed by #10080 (gate a declared-pure module's side-effect statements on body demand); executing the entry must not throw.",
+  "config": {
+    "external": ["extdep"],
+    "experimental": {
+      "lazyBarrel": true
+    },
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/10099/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10099/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import external_default from "extdep";
+//#region main.js
+if (!external_default || external_default.name !== "extdep-default") throw new Error("external passthrough did not resolve");
+console.log("ok:", external_default.name);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10099/defaults.js
+++ b/crates/rolldown/tests/rolldown/issues/10099/defaults.js
@@ -1,0 +1,8 @@
+// Mirrors element-plus/es/defaults.mjs. Under `moduleSideEffects: false` this
+// `defaults_default` definition is prunable, so tree-shaking may drop it -- and
+// then must also drop every statement that reads `defaults_default`.
+import { makeInstaller } from './make-installer.js';
+
+var defaults_default = makeInstaller([]);
+
+export { defaults_default as default };

--- a/crates/rolldown/tests/rolldown/issues/10099/index.js
+++ b/crates/rolldown/tests/rolldown/issues/10099/index.js
@@ -1,0 +1,13 @@
+// Mirrors element-plus/es/index.mjs (the barrel). It default-imports `defaults.js`
+// and reads properties off it at the top level, AND re-exports an EXTERNAL
+// module's default (`external_default`, real-world `dayjs`) as a passthrough.
+import defaults_default from './defaults.js';
+import external_default from 'extdep';
+
+const install = defaults_default.install;
+const version = defaults_default.version;
+var barrel_default = defaults_default;
+
+// `extdep` is the only export the entry uses; it is a passthrough of an external
+// module's default, which is what forces this barrel to be included.
+export { external_default as extdep, install, version, barrel_default as default };

--- a/crates/rolldown/tests/rolldown/issues/10099/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10099/main.js
@@ -1,0 +1,13 @@
+// Consumer imports ONLY the external passthrough re-export (real-world:
+// `import { dayjs } from 'element-plus'`). Because `extdep`'s canonical is an
+// external module's default that is re-exported by the barrel, resolving it
+// force-includes the barrel `index.js` -- whose unrelated top-level
+// `defaults_default.install/.version` reads must NOT be retained once
+// `defaults_default`'s import and definition are tree-shaken away (#10099).
+import { extdep } from './index.js';
+
+if (!extdep || extdep.name !== 'extdep-default') {
+  throw new Error('external passthrough did not resolve');
+}
+
+console.log('ok:', extdep.name);

--- a/crates/rolldown/tests/rolldown/issues/10099/make-installer.js
+++ b/crates/rolldown/tests/rolldown/issues/10099/make-installer.js
@@ -1,0 +1,7 @@
+// Mirrors element-plus/es/make-installer.mjs: returns a plain object.
+export const makeInstaller = (components = []) => {
+  const install = (app) => {
+    components.forEach((c) => app.use(c));
+  };
+  return { version: '1.0.0', install };
+};

--- a/crates/rolldown/tests/rolldown/issues/10099/node_modules/extdep/index.js
+++ b/crates/rolldown/tests/rolldown/issues/10099/node_modules/extdep/index.js
@@ -1,0 +1,4 @@
+// Stub for the external module whose default is re-exported through the barrel
+// (real-world: `dayjs`). It only needs to resolve at runtime so the compiled
+// entry can read the passthrough value.
+export default { name: 'extdep-default' };

--- a/crates/rolldown/tests/rolldown/issues/10099/node_modules/extdep/package.json
+++ b/crates/rolldown/tests/rolldown/issues/10099/node_modules/extdep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "extdep",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}


### PR DESCRIPTION
## What

Adds a Rust integration-test fixture at `crates/rolldown/tests/rolldown/issues/10099/` closes #10099.

## Why

#10099: importing only `dayjs` from `element-plus` emitted a bundle that threw `ReferenceError: defaults_default is not defined`. The `sideEffects:false` barrel (`index.mjs`) re-exports an **external** module's default (`dayjs`) as a passthrough while reading `defaults_default.install`/`.version` at the top level. Importing only that passthrough force-includes the barrel; under `experimental.lazyBarrel` the tree-shaker dropped the `defaults_default` import **and** its definition but kept the property reads → dangling reference.

Fixed by #10080 (gate `sideEffects:false` modules' side effects on body demand). This PR adds the regression test for the specific element-plus shape, which none of #10080's fixtures cover: here the inclusion driver is an **external-default passthrough** (the sibling fixtures use local passthroughs or dynamic-import wrapping).

## The fixture

- `_config.json`: `external:["extdep"]`, `experimental.lazyBarrel:true`, `treeshake.moduleSideEffects:false`
- barrel `index.js` default-imports `defaults.js`, reads `.install`/`.version`, and re-exports the external default as `extdep`
- entry `main.js` imports only `{ extdep }` and asserts it resolves
- `node_modules/extdep/` stub so the external passthrough resolves at runtime

`experimental.lazyBarrel: true` is load-bearing: the bug is lazyBarrel-gated and lazyBarrel is default-off since #10071, so without it the test would pass on both the base and the fix.

## Verification

- **Green** on current `main` (fix present): the harness executes the compiled entry (`expectExecuted` default) and the snapshot is clean — no `defaults_default`.
- **Red** on the pre-fix base: the exact fixture source + config through published `rolldown@1.1.3` throws `ReferenceError: defaults_default is not defined`.

Test-only; no source changes.
