### PR TITLE
fix(dev): revert cache mutations when a partial scan fails

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -57,6 +57,10 @@ impl Bundler {
     is_write: bool,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<BundleOutput> {
+    // No snapshot, no graph to build on: scan fully. Deciding before the
+    // `BundleMode` choice applies the `IncrementalFullBuild` reset rules to
+    // the plugin driver state.
+    let scan_mode = if self.cache.has_snapshot() { scan_mode } else { ScanMode::Full };
     let bundle_mode = match scan_mode {
       ScanMode::Full => BundleMode::IncrementalFullBuild,
       ScanMode::Partial(_) => BundleMode::IncrementalBuild,

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -92,12 +92,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       first_invalidated_by,
     );
     // Look up by stable_id (matches what client sends from createModuleHotContext)
-    let module_idx = self
-      .cache
-      .module_idx_by_stable_id
-      .get(invalidate_caller.as_str())
-      .copied()
-      .unwrap_or_else(|| panic!("Not found modules for file: {invalidate_caller}"));
+    let Some(module_idx) =
+      self.cache.module_idx_by_stable_id.get(invalidate_caller.as_str()).copied()
+    else {
+      // The client references a module the current graph does not know,
+      // e.g. its bundle predates a failed full build that reset the cache.
+      return Ok(HmrUpdate::FullReload { reason: format!("unknown module `{invalidate_caller}`") });
+    };
 
     let caller = self.module_table().modules[module_idx].as_normal().unwrap();
 
@@ -216,11 +217,24 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     first_invalidated_by: Option<String>,
     clients: &[ClientHmrInput<'_>],
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
+    // Files re-queued by an earlier failed scan (`pending_rescans`) get
+    // re-fetched and merged by this update as well. Treat them as changed so
+    // their recovered content reaches the clients' patches; otherwise only
+    // the server-side graph would learn about their edits.
+    let mut stale_modules = stale_modules.clone();
+    let mut changed_modules = changed_modules.clone();
+    for resolved_id in &self.cache.pending_rescans {
+      if let Some(state) = self.cache.module_id_to_idx.get(&resolved_id.id) {
+        stale_modules.insert(state.idx());
+        changed_modules.insert(state.idx());
+      }
+    }
+
     // 1. Compute prerequisites for each client
     let mut clients_prerequisites = Vec::with_capacity(clients.len());
     for client in clients {
       let prerequisites =
-        self.compute_out_hmr_prerequisites(stale_modules, first_invalidated_by.as_deref(), client);
+        self.compute_out_hmr_prerequisites(&stale_modules, first_invalidated_by.as_deref(), client);
 
       tracing::trace!(
         "[HmrStage] computed prerequisites for client {}\n - require_full_reload: {}\n - boundaries: {:#?}",
@@ -339,6 +353,21 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     // module_id is the proxy module ID (e.g., "/abs/path/async-entry-a.js?rolldown-lazy=1")
     // The proxy has been marked as fetched, so the lazy compilation plugin's load hook
     // will return the fetched template which imports the real module.
+
+    // A failed full build leaves `module_id_to_idx` repopulated but the
+    // snapshot unset; `module_table()` would panic. Surface an error the
+    // client can handle instead.
+    if !self.cache.has_snapshot() {
+      return Err(
+        vec![
+          anyhow::anyhow!(
+            "Cannot compile lazy entry `{module_id}`: the last full build failed, so there is no module graph to compile against."
+          )
+          .into(),
+        ]
+        .into(),
+      );
+    }
 
     // 1. Get the originative resolved_id from the cached module
     // The proxy module should already be in the cache from the initial build.

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -114,6 +114,9 @@ pub struct ModuleLoader<'a, Fs: FileSystem + Clone + 'static> {
   symbol_ref_db: SymbolRefDb,
   is_full_scan: bool,
   new_added_modules_from_partial_scan: FxIndexSet<ModuleIdx>,
+  /// Ids inserted into `module_id_to_idx` by this partial scan;
+  /// `revert_partial_scan` removes them again on failure.
+  new_module_ids: Vec<ModuleId>,
   cache: &'a mut ScanStageCache,
   pub flat_options: FlatOptions,
   pub magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
@@ -210,6 +213,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       symbol_ref_db,
       intermediate_normal_modules,
       new_added_modules_from_partial_scan: FxIndexSet::default(),
+      new_module_ids: Vec::new(),
       flat_options,
       magic_string_tx,
       tla_module_count: 0,
@@ -217,10 +221,64 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     })
   }
 
+  /// Restores the cache to its pre-scan state so the next build can stay
+  /// incremental. The snapshot is never touched by a scan; everything else
+  /// is re-derived from it or reset. Existing `module_id_to_idx` entries are
+  /// self-healing (`Seen` -> `Invalidate` -> `Seen`), so only new keys need
+  /// removal. A failed full scan needs nothing: its cache reset already
+  /// forces a full retry.
+  /// See internal-docs/bundler-data-lifecycle/implementation.md ("Cache integrity on a failed build").
+  fn revert_partial_scan(
+    &mut self,
+    scanned_resolved_ids: Vec<ResolvedId>,
+    barrel_state_backup: Option<rolldown_common::BarrelState>,
+  ) {
+    if self.is_full_scan {
+      return;
+    }
+    for module_id in std::mem::take(&mut self.new_module_ids) {
+      self.cache.module_id_to_idx.remove(&module_id);
+    }
+    // New indices are freed for reuse above; drop the `ModuleIdx`-keyed
+    // transform dependencies recorded for them, or a later module reusing the
+    // index would inherit them.
+    for idx in &self.new_added_modules_from_partial_scan {
+      self.shared_context.plugin_driver.transform_dependencies.remove(idx);
+    }
+    // Retry only files the graph still needs: entries, or files something
+    // still imports (judged on the freshest edge state, where modules
+    // re-scanned by this failed scan already updated their edges). A broken
+    // file whose last import was removed must not fail every later build;
+    // a fresh build of the same tree would succeed without it.
+    let pending_rescans = scanned_resolved_ids
+      .into_iter()
+      .filter(|resolved_id| {
+        if self.cache.user_defined_entry.contains(&resolved_id.id) {
+          return true;
+        }
+        let Some(state) = self.cache.module_id_to_idx.get(&resolved_id.id) else {
+          return false;
+        };
+        let idx = state.idx();
+        self.cache.get_snapshot().user_defined_entry_modules.contains(&idx)
+          || self
+            .intermediate_normal_modules
+            .importers
+            .get(idx)
+            .is_some_and(|records| !records.is_empty())
+      })
+      .collect();
+    self.intermediate_normal_modules.importers = self.cache.derive_importers_from_snapshot();
+    self.cache.modules_with_changed_importers.clear();
+    if let Some(backup) = barrel_state_backup {
+      self.cache.barrel_state = backup;
+    }
+    self.cache.pending_rescans = pending_rescans;
+  }
+
   /// Marks `idx` for importer-set re-derivation in `ScanStageCache::merge`;
   /// call it next to every mutation of `intermediate_normal_modules.importers`.
-  /// Writes straight to the cache so marks survive a failed scan. No-op in
-  /// full scan mode, which rebuilds every module's sets anyway.
+  /// No-op in full scan mode, which rebuilds every module's sets anyway.
   fn mark_module_importers_changed(&mut self, idx: ModuleIdx) {
     if !self.is_full_scan {
       self.cache.modules_with_changed_importers.insert(idx);
@@ -277,6 +335,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
         let len = self.cache.module_id_to_idx.len();
         let idx = self.intermediate_normal_modules.alloc_ecma_module_idx_sparse(len.into());
         self.new_added_modules_from_partial_scan.insert(idx);
+        self.new_module_ids.push(resolved_id.id.clone());
         self.cache.module_id_to_idx.insert(resolved_id.id.clone(), VisitState::Seen(idx));
         idx
       }
@@ -326,6 +385,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     let mut errors = vec![];
     let mut all_warnings = vec![];
 
+    // Barrel state is accumulated demand, not derivable from the snapshot;
+    // back it up for `revert_partial_scan`. Disabled means empty and untouched.
+    let barrel_state_backup = (!self.is_full_scan && self.flat_options.is_lazy_barrel_enabled())
+      .then(|| self.cache.barrel_state.clone());
+
     // Initialize runtime module task if not yet started
     if let Entry::Vacant(e) = self.cache.module_id_to_idx.entry(RUNTIME_MODULE_ID) {
       let idx = self.intermediate_normal_modules.alloc_ecma_module_idx();
@@ -368,8 +432,18 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     }
 
     // If it is in partial scan mode, we need to invalidate the changed modules
-    // and re-fetch them, do nothing in full scan mode
-    for resolved_id in fetch_mode.iter().cloned() {
+    // and re-fetch them, do nothing in full scan mode. Files re-queued by a
+    // previous aborted scan (`pending_rescans`) are retried alongside.
+    let mut changed_resolved_ids = Vec::new();
+    let mut seen_changed_ids = FxHashSet::default();
+    for resolved_id in
+      fetch_mode.iter().cloned().chain(std::mem::take(&mut self.cache.pending_rescans))
+    {
+      if seen_changed_ids.insert(resolved_id.id.clone()) {
+        changed_resolved_ids.push(resolved_id);
+      }
+    }
+    for resolved_id in changed_resolved_ids.iter().cloned() {
       self.shared_context.plugin_driver.invalidate_context_load_module(&resolved_id.id);
       if let Entry::Occupied(mut occ) = self.cache.module_id_to_idx.entry(resolved_id.id.clone()) {
         let idx = occ.get().idx();
@@ -699,7 +773,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     }
 
     if !errors.is_empty() {
-      // Enrich UNRESOLVED_IMPORT errors with import chain
+      // Enrich UNRESOLVED_IMPORT errors with import chain. Must run before
+      // the revert below, which erases the failed scan's modules from the
+      // lookup structures the trace walks.
       for error in &mut errors {
         if let Some(resolve_error) = error.downcast_mut::<DiagnosableResolveError>() {
           let chain = self
@@ -709,6 +785,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
           }
         }
       }
+
+      self.revert_partial_scan(changed_resolved_ids, barrel_state_backup);
 
       let errors = consolidate_diagnostics(errors);
       return Err(errors.into());

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
   BarrelState, EcmaModuleAstUsage, GetLocalDbMut, ImporterRecord, Module, ModuleId, ModuleIdx,
-  StableModuleId,
+  ResolvedId, StableModuleId,
 };
 use rolldown_error::BuildResult;
 use rolldown_plugin::PluginDriver;
@@ -29,6 +29,11 @@ pub struct ScanStageCache {
   /// [`Self::merge`] re-derives their materialized importer sets, which the
   /// scan does only for re-scanned modules.
   pub modules_with_changed_importers: FxHashSet<ModuleIdx>,
+  /// Files of an aborted (and reverted) partial scan; the next partial scan
+  /// retries them, so their errors keep surfacing until the files are fixed.
+  /// Only files the graph still needs are queued; see
+  /// [`ModuleLoader::revert_partial_scan`](crate::module_loader::module_loader::ModuleLoader).
+  pub pending_rescans: Vec<ResolvedId>,
   pub user_defined_entry: FxHashSet<ModuleId>,
   // Usage: Map file path emitted by watcher to corresponding module index
   pub module_idx_by_abs_path: FxHashMap<ArcStr, ModuleIdx>,
@@ -72,6 +77,42 @@ impl ScanStageCache {
   /// - if the snapshot is unset
   pub fn get_snapshot(&self) -> &NormalizedScanStageOutput {
     self.snapshot.as_ref().unwrap()
+  }
+
+  /// Between builds the cache is either empty (no snapshot: only a full scan
+  /// is possible) or a valid graph any partial scan can build on. A failed
+  /// partial scan keeps the latter true by reverting its mutations
+  /// (`ModuleLoader::revert_partial_scan`).
+  pub fn has_snapshot(&self) -> bool {
+    self.snapshot.is_some()
+  }
+
+  /// Re-derives the `importers` edge list (one record per resolved import
+  /// record, keyed by the imported module) from the snapshot. Restores the
+  /// pre-scan list up to slot order; consumers treat slots as sets.
+  ///
+  /// # Panic
+  /// - if the snapshot is unset
+  pub fn derive_importers_from_snapshot(&self) -> IndexVec<ModuleIdx, Vec<ImporterRecord>> {
+    let snapshot = self.get_snapshot();
+    let mut importers = IndexVec::from_vec(
+      std::iter::repeat_with(Vec::new).take(snapshot.module_table.modules.len()).collect(),
+    );
+    for module in &snapshot.module_table.modules {
+      let Some(module) = module.as_normal() else {
+        continue;
+      };
+      for record in &module.ecma_view.import_records {
+        if let Some(dep_idx) = record.resolved_module {
+          importers[dep_idx].push(ImporterRecord {
+            importer_path: module.id.clone(),
+            importer_idx: module.idx,
+            kind: record.kind,
+          });
+        }
+      }
+    }
+    importers
   }
 
   pub fn merge(

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.hmr-1.js
@@ -1,0 +1,3 @@
+export const a = 'a-edited';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.hmr-3.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.hmr-3.js
@@ -1,0 +1,3 @@
+export const a = 'a-edited-again';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/a.js
@@ -1,0 +1,3 @@
+export const a = 'a';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/artifacts.snap
@@ -1,0 +1,159 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => "a" });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+a_hot.accept();
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => "b" });
+__rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 1
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 2
+
+## Meta
+
+- update type: full-reload
+- reason: no hmr boundary found for module `main.js`
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a = "a-edited";
+a_hot.accept();
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+__rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b = "b-fixed";
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 3
+
+## Code
+
+```js
+//#region a.js
+var init_a_0 = __rolldown_runtime__.createEsmInitializer("a.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ a: () => a });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_a = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = "a-edited-again";
+		hot_a.accept();
+	} finally {}
+}));
+
+//#endregion
+init_a_0()
+__rolldown_runtime__.applyUpdates([['a.js', 'a.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: a.js, accepted_via: a.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a = "a-edited-again";
+a_hot.accept();
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+__rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b = "b-fixed";
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.hmr-0.js
@@ -1,0 +1,1 @@
+invalid syntax

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.hmr-2.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.hmr-2.js
@@ -1,0 +1,1 @@
+export const b = 'b-fixed';

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/edit_other_file_while_broken/main.js
@@ -1,0 +1,2 @@
+import './a.js';
+import './b.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/a.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/a.hmr-1.js
@@ -1,0 +1,3 @@
+export const a = 'a-edited-while-b-broken';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/a.js
@@ -1,0 +1,3 @@
+export const a = 'a';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/artifacts.snap
@@ -1,0 +1,139 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => "a" });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+a_hot.accept();
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => "b" });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+b_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 1
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 2
+
+## Code
+
+```js
+//#region a.js
+var init_a_0 = __rolldown_runtime__.createEsmInitializer("a.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ a: () => a });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_a = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = "a-edited-while-b-broken";
+		hot_a.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region b.js
+var init_b_1 = __rolldown_runtime__.createEsmInitializer("b.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ b: () => b });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_b = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const b = "b-fixed";
+		hot_b.accept();
+	} finally {}
+}));
+
+//#endregion
+init_b_1()
+init_a_0()
+__rolldown_runtime__.applyUpdates([['b.js', 'b.js'],['a.js', 'a.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: b.js, accepted_via: b.js
+- boundary: a.js, accepted_via: a.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a = "a-edited-while-b-broken";
+a_hot.accept();
+//#endregion
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b = "b-fixed";
+b_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.hmr-0.js
@@ -1,0 +1,1 @@
+invalid syntax

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.hmr-2.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.hmr-2.js
@@ -1,0 +1,3 @@
+export const b = 'b-fixed';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/b.js
@@ -1,0 +1,3 @@
+export const b = 'b';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_delivers_other_edits/main.js
@@ -1,0 +1,2 @@
+import './a.js';
+import './b.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.hmr-1.js
@@ -1,0 +1,3 @@
+export const a = 'a-no-longer-imports-b';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.hmr-2.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.hmr-2.js
@@ -1,0 +1,3 @@
+export const a = 'a-edited-after-recovery';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/a.js
@@ -1,0 +1,5 @@
+import './b.js';
+
+export const a = 'a';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/artifacts.snap
@@ -1,0 +1,117 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => "b" });
+__rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+//#endregion
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => "a" });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+a_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 1
+
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ b.js:1:8 ]
+   │
+ 1 │ invalid syntax
+   │        │ 
+   │        ╰─ 
+   │ 
+   │ Help: Try inserting a semicolon here
+───╯
+
+```
+
+# HMR Step 2
+
+## Code
+
+```js
+//#region a.js
+var init_a_0 = __rolldown_runtime__.createEsmInitializer("a.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ a: () => a });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_a = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = "a-edited-after-recovery";
+		hot_a.accept();
+	} finally {}
+}));
+
+//#endregion
+init_a_0()
+__rolldown_runtime__.applyUpdates([['a.js', 'a.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: a.js, accepted_via: a.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a = "a-edited-after-recovery";
+a_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/b.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/b.hmr-0.js
@@ -1,0 +1,1 @@
+invalid syntax

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/remove_import_of_broken_file/main.js
@@ -1,0 +1,1 @@
+import './a.js';

--- a/crates/rolldown_common/src/types/lazy_barrel.rs
+++ b/crates/rolldown_common/src/types/lazy_barrel.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// State for lazy barrel optimization
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BarrelState {
   pub barrel_infos: FxHashMap<ModuleIdx, Option<LazyBarrelInfo>>,
   pub requested_exports: FxHashMap<ModuleIdx, ImportedExports>,
@@ -122,7 +122,7 @@ impl ImportedExports {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExportSource {
   imported: Specifier,
   record_idx: ImportRecordIdx,
@@ -131,7 +131,7 @@ pub struct ExportSource {
   is_direct_reexport: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BarrelInfo {
   /// `export const a = 1`
   pub local: Vec<CompactStr>,
@@ -272,7 +272,7 @@ impl BarrelInfo {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LazyBarrelInfo {
   pub info: BarrelInfo,
   pub remaining_imported_specifiers: FxHashMap<ImportRecordIdx, ImportedExports>,

--- a/internal-docs/bundler-data-lifecycle/implementation.md
+++ b/internal-docs/bundler-data-lifecycle/implementation.md
@@ -25,6 +25,7 @@ Bundler (long-lived)
   │     ├── module_id_to_idx
   │     ├── importers
   │     ├── modules_with_changed_importers
+  │     ├── pending_rescans
   │     ├── barrel_state
   │     ├── module_idx_by_abs_path
   │     └── module_idx_by_stable_id
@@ -77,15 +78,16 @@ Data created fresh for each build and discarded (or consumed) when the build com
 Bundler.cache (ScanStageCache) ──(move)──> Bundle.cache (temporary holder) ──(build)──> Bundle.cache ──(move)──> Bundler.cache
 ```
 
-| `ScanStageCache` field           | Purpose                                                                      |
-| -------------------------------- | ---------------------------------------------------------------------------- |
-| `snapshot`                       | Full module graph (modules, ASTs, symbols, entries)                          |
-| `module_id_to_idx`               | Module ID to index lookup                                                    |
-| `importers`                      | Reverse dependency graph                                                     |
-| `modules_with_changed_importers` | Modules whose `importers` records a partial scan mutated; drained by `merge` |
-| `barrel_state`                   | Barrel export optimization state                                             |
-| `module_idx_by_abs_path`         | Path-based lookup for watcher                                                |
-| `module_idx_by_stable_id`        | Stable ID lookup for HMR                                                     |
+| `ScanStageCache` field           | Purpose                                                                                       |
+| -------------------------------- | --------------------------------------------------------------------------------------------- |
+| `snapshot`                       | Full module graph (modules, ASTs, symbols, entries)                                           |
+| `module_id_to_idx`               | Module ID to index lookup                                                                     |
+| `importers`                      | Reverse dependency graph                                                                      |
+| `modules_with_changed_importers` | Modules whose `importers` records a partial scan mutated; drained by `merge`                  |
+| `pending_rescans`                | Work queue: files of an aborted (and reverted) partial scan; retried by the next partial scan |
+| `barrel_state`                   | Barrel export optimization state                                                              |
+| `module_idx_by_abs_path`         | Path-based lookup for watcher                                                                 |
+| `module_idx_by_stable_id`        | Stable ID lookup for HMR                                                                      |
 
 ### Cache integrity on a failed build
 
@@ -112,8 +114,53 @@ Each repair therefore runs **unconditionally**:
   `invalidate_js_side_cache` steps.
 - `update_defer_sync_data` restores the snapshot before propagating an error.
 
-A build that fails _before_ touching the cache (e.g. a scan-stage parse error)
-needs no repair — `scan_modules` returns early and the cache is untouched.
+A failed scan must also not leave the cache _out of sync_. Task results are
+applied as they arrive, so an aborted partial scan has already flipped
+re-scanned modules to `Seen` in `module_id_to_idx`, and may have mutated the
+`importers` edge list for completed tasks and allocated indices for newly
+discovered modules, while the snapshot never receives any of it (`merge` does
+not run on the error path). Splicing the next partial scan onto that state
+would serve stale module code silently and shift new module indices away from
+their snapshot positions.
+
+`ModuleLoader::revert_partial_scan` therefore restores the pre-scan state on
+every abort. The snapshot is never touched by a scan, so it acts as the clean
+master copy everything else is recovered from:
+
+- existing `module_id_to_idx` entries end the scan at their pre-scan values
+  (`Seen` -> `Invalidate` -> `Seen`); only the keys inserted for newly
+  discovered modules are removed;
+- the `importers` edge list is re-derived from the snapshot
+  (`ScanStageCache::derive_importers_from_snapshot`), since every edge is a
+  resolved import record of some module;
+- `modules_with_changed_importers` is cleared, `barrel_state` is restored
+  from an upfront clone (taken only when lazy barrel is enabled);
+- `transform_dependencies` entries of the newly allocated (and now freed)
+  module indices are dropped, so a later module reusing an index does not
+  inherit them;
+- the scanned files go into `ScanStageCache::pending_rescans`, a work queue
+  the next partial scan drains, so their errors keep surfacing until the
+  files are fixed. Only files the graph still needs are queued — entries, or
+  files something still imports on the freshest edge state. A broken file
+  whose last import was removed by this very scan is dropped, otherwise its
+  retry would fail every later build that a fresh build of the same tree
+  would pass.
+
+Two consumers depend on that queue's contents:
+
+- `HmrStage::compute_hmr_update` folds the pending files into its stale and
+  changed sets before computing client boundaries, so an edit that was rolled
+  back by a failed scan reaches the clients' patches once the retry succeeds
+  (not only the server-side graph);
+- error enrichment (`trace_import_chain_from_modules`) runs **before** the
+  revert, while the failed scan's modules still exist in `module_id_to_idx`
+  and the live edge list.
+
+The invariant this buys: **between builds the cache is either empty
+(`snapshot` is `None`: fresh bundler, or a failed full scan reset it) or a
+valid graph any partial scan can build on.** `Bundler::incremental_bundle`
+picks the scan mode from that property alone (`has_snapshot`), and no other
+consumer needs to reason about failed builds.
 
 **Why keep a cache from a failed build at all?** Committing a _torn_ cache is
 worse than dropping it: an empty snapshot panics the next `get_snapshot()`, and

--- a/internal-docs/cache/implementation.md
+++ b/internal-docs/cache/implementation.md
@@ -111,22 +111,24 @@ pub struct ScanStageCache {
   pub module_id_to_idx: FxHashMap<ModuleId, VisitState>,
   pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
   pub modules_with_changed_importers: FxHashSet<ModuleIdx>,
+  pub pending_rescans: Vec<ResolvedId>,
   pub user_defined_entry: FxHashSet<ModuleId>,
   pub module_idx_by_abs_path: FxHashMap<ArcStr, ModuleIdx>,
   pub module_idx_by_stable_id: FxHashMap<StableModuleId, ModuleIdx>,
 }
 ```
 
-| Field                            | Purpose                                                                                                                                        |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `snapshot`                       | The full module graph. `None` is a legal transient state; it is `private` and accessed only through the methods below.                         |
-| `barrel_state`                   | Barrel re-export resolution state (`BarrelState`).                                                                                             |
-| `module_id_to_idx`               | The `ModuleId` → `ModuleIdx` registry/allocator (see "Module identity model").                                                                 |
-| `importers`                      | Reverse dependency graph: per module, who imports it.                                                                                          |
-| `modules_with_changed_importers` | Modules whose `importers` records were mutated by a partial scan; `merge` drains it to re-derive their materialized importer sets (see below). |
-| `user_defined_entry`             | The set of configured root entry `ModuleId`s.                                                                                                  |
-| `module_idx_by_abs_path`         | Absolute-path → `ModuleIdx`, used by the watcher. Paths are slash-normalized.                                                                  |
-| `module_idx_by_stable_id`        | `StableModuleId` → `ModuleIdx`, used by HMR.                                                                                                   |
+| Field                            | Purpose                                                                                                                                                                               |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshot`                       | The full module graph. `None` is a legal transient state; it is `private` and accessed only through the methods below.                                                                |
+| `barrel_state`                   | Barrel re-export resolution state (`BarrelState`).                                                                                                                                    |
+| `module_id_to_idx`               | The `ModuleId` → `ModuleIdx` registry/allocator (see "Module identity model").                                                                                                        |
+| `importers`                      | Reverse dependency graph: per module, who imports it.                                                                                                                                 |
+| `modules_with_changed_importers` | Modules whose `importers` records were mutated by a partial scan; `merge` drains it to re-derive their materialized importer sets (see below).                                        |
+| `pending_rescans`                | Work queue: files of an aborted partial scan, whose mutations were reverted (`ModuleLoader::revert_partial_scan`); the next partial scan retries them so their errors keep surfacing. |
+| `user_defined_entry`             | The set of configured root entry `ModuleId`s.                                                                                                                                         |
+| `module_idx_by_abs_path`         | Absolute-path → `ModuleIdx`, used by the watcher. Paths are slash-normalized.                                                                                                         |
+| `module_idx_by_stable_id`        | `StableModuleId` → `ModuleIdx`, used by HMR.                                                                                                                                          |
 
 `module_idx_by_abs_path` and `module_idx_by_stable_id` are **derived** —
 `build_module_index_maps` (`scan_stage_cache.rs:297`) clears and rebuilds both
@@ -369,6 +371,7 @@ as the `module_id_to_idx` lookup and is infallible.
 | `ScanStage::scan(scan_mode, &mut self.cache)`            | called at `bundle.rs:104`                                                               | Non-snapshot fields via the loader.                                                                                                                                                                                                                    |
 | `ModuleLoader` (`cache: &'a mut ScanStageCache`)         | `module_loader.rs:117` and methods                                                      | `module_id_to_idx`, `barrel_state` (e.g. removes `barrel_infos` on invalidate), `importers`, `modules_with_changed_importers`, `user_defined_entry` (full incremental scan).                                                                           |
 | `ScanStageCache::merge`                                  | `scan_stage_cache.rs:80`; called at `bundle.rs:256`, `hmr_stage.rs:284/377`             | `snapshot`, `module_idx_by_abs_path`, `module_idx_by_stable_id`, `barrel_state.resolved_barrel_modules` (drained), `modules_with_changed_importers` (drained), `tla_*` fields in the snapshot; refreshes plugin `module_infos` for re-derived modules. |
+| `ModuleLoader::revert_partial_scan`                      | `module_loader.rs` scan error exit                                                      | Restores `module_id_to_idx` / `importers` / `barrel_state` / importer marks to their pre-scan state and fills `pending_rescans`.                                                                                                                       |
 | `ScanStageCache::set_snapshot`                           | `scan_stage_cache.rs:44`; called at `bundle.rs:250` and inside `update_defer_sync_data` | `snapshot` + rebuilds `module_idx_by_abs_path` / `module_idx_by_stable_id`.                                                                                                                                                                            |
 | `ScanStageCache::update_defer_sync_data`                 | `scan_stage_cache.rs:60`; called at `bundle.rs:257`, `hmr_stage.rs:289/382/623`         | Takes and restores `snapshot`; `defer_sync_scan_data` mutates per-module `side_effects` inside it.                                                                                                                                                     |
 | `ScanStageCache::create_output`                          | `scan_stage_cache.rs:313`; called at `bundle.rs:258`                                    | Mutates `snapshot.symbol_ref_db` (clones it without scoping, swaps); returns a `NormalizedScanStageOutput`.                                                                                                                                            |


### PR DESCRIPTION
### Description

Part of #7416. Stacked on #10107. This PR makes a failed scan harmless to the incremental cache. The remaining items of #7416 are listed at the end.

#### Problem

A partial scan applies task results as they arrive. When the scan aborts (the typical case is a syntax error in an edited file), the cache is left half updated while the snapshot receives nothing, because `merge` never runs on the error path:

1. Re-scanned modules were flipped to `Seen` in `module_id_to_idx`, so they are treated as fresh even though their new content never landed. The next build silently serves their old code and the error disappears.
2. Completed tasks already rewrote parts of the `importers` edge list, which then disagrees with the snapshot.
3. Newly discovered modules got an index and a `module_id_to_idx` entry, but no slot in the snapshot table. Since new indexes are allocated from the map length and `merge` appends at the table length, a leftover entry shifts every later module by one slot and corrupts all index based lookups.

Concrete reproduction (the new fixture): break `b.js`, then edit `a.js`. The rebuild reports success, ships the pre-break `b.js`, and the error overlay is gone.

#### Fix

A failed partial scan now reverts its cache mutations, so the cache holds a single invariant: between builds it is either empty (no snapshot, only a full scan is possible) or a valid graph any partial scan can build on. There is no third "poisoned" state and no consumer has to reason about failed builds.

`ModuleLoader::revert_partial_scan` runs at the scan error exit. The snapshot is never touched by a scan, so it acts as the clean master copy everything else is recovered from:

- `importers` is re-derived from the snapshot (`ScanStageCache::derive_importers_from_snapshot`), since every edge is a resolved import record of some module. Slot order is not preserved, and consumers treat slots as sets. The rebuild cost is paid only on failure, the happy path pays nothing.
- Existing `module_id_to_idx` entries end the scan at their pre-scan values (`Seen` to `Invalidate` back to `Seen` with the same index), so only the keys inserted for newly discovered modules need removal. The loader records them in `new_module_ids`.
- `modules_with_changed_importers` is cleared, matching the reverted edge list.
- `barrel_state` is restored from an upfront clone, taken only when lazy barrel is enabled. When disabled the state is empty and never mutated.
- The scanned files go into `ScanStageCache::pending_rescans`, a work queue the next partial scan drains. Reverting alone would lose the knowledge that these files changed, and the next build would silently serve their old content. The queue keeps their errors surfacing until the files are fixed. Only files the graph still needs are queued: configured or emitted entries, and files something still imports on the freshest edge state. A broken file whose last import was removed by the very scan that failed is dropped; otherwise its retry would fail every later partial build that a fresh build of the same tree would pass, wedging the session until a restart (new fixture `hmr/error_recovery/remove_import_of_broken_file`).
- `transform_dependencies` entries of the newly allocated (and now freed) module indices are dropped, so a later module reusing an index does not inherit them.

`Bundler::incremental_bundle` now picks the scan mode from `has_snapshot()` alone. A failed full scan needs no revert, its cache reset already leaves the empty state that forces a full retry.

One adjacent panic became reachable and is now handled: a client calling `import.meta.hot.invalidate()` for a module the current graph does not know (for example after a failed full build reset the cache) gets a full reload instead of a server panic. The same applies to `compile_lazy_entry`: a lazy chunk request arriving after a failed full build now returns an error instead of panicking on the missing snapshot.

Two consumers of the retry queue needed matching fixes:

- `HmrStage::compute_hmr_update` folds the queued files into its stale and changed sets before computing client boundaries. Without this, an edit rolled back by a failed scan reached the server graph on the successful retry but never a client patch, leaving connected clients silently running the old module. The new fixture `hmr/error_recovery/fix_broken_file_delivers_other_edits` asserts the recovery patch contains both the fixed file and the edit made while broken.
- The import chain enrichment of unresolved import errors now runs before the revert, while the failed scan's modules still exist in the lookup structures the trace walks. Running it after erased the chain from dev mode diagnostics.

Plugin side state (`module_infos`, JS side caches) is not reverted. Hooks that ran during the aborted scan already updated them. This residue is informational, keyed by module id, and overwritten by the next successful scan. The exception is `transform_dependencies`, which is keyed by module index: the entries of indices freed by the revert are dropped, as described above.

#### Behavior

- The existing error recovery fixtures are unchanged. Breaking a file and fixing the same file still recovers with a plain HMR patch.
- New fixture `hmr/error_recovery/remove_import_of_broken_file`: break `b.js`, then remove the `import './b.js'` from `a.js`. That build still surfaces the queued error once, then drops `b.js` from the queue since nothing imports it anymore, and the following edit builds normally again.
- New fixture `hmr/error_recovery/edit_other_file_while_broken`: break `b.js`, edit `a.js` (the error surfaces again instead of a fake success with stale code), fix `b.js` (builds succeed again, the queued edit of `a.js` lands in the same scan), edit `a.js` once more (a normal patch, proving the cache stayed incremental through the whole episode).

#### Docs

The "Cache integrity on a failed build" section of `internal-docs/bundler-data-lifecycle/implementation.md` now documents the revert and the two state invariant. `internal-docs/cache/implementation.md` is updated for the new field and methods.

#### Remaining items of #7416

- The state still holds removed modules. Editing an orphaned module triggers a full reload instead of a noop, and its module and AST stay in memory.
- There is no general check yet that an incremental build and a full build produce the same states. A dedicated comparison in the test harness would also guard the revert introduced here.
- Dynamic import entry points are never removed from the cached entry list when the dynamic import goes away.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->


