### PR TITLE
feat(linking): skip side-effect-free modules in per-entry reachability

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -1091,7 +1091,12 @@ impl GenerateStage<'_> {
       if is_user_defined_entry {
         index_splitting_info[module_idx].tags_bit_set.set_bit(ModuleTag::INITIAL_BIT);
       }
-      meta.dependencies.iter().copied().for_each(|dep_idx| {
+      // Walk only the dependencies this module actually loads at runtime (referenced-symbol
+      // owners and side-effect-full import targets). A side-effect-free module whose bindings
+      // resolve elsewhere — e.g. a pure barrel that only re-exports — must not be treated as
+      // reachable, otherwise it (and its subtree) is shared into this entry's chunk group even
+      // though the emitted code never imports it (#8920).
+      meta.load_dependencies.iter().copied().for_each(|dep_idx| {
         q.push_back(dep_idx);
       });
     }

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -1,5 +1,5 @@
 use rayon::iter::ParallelIterator;
-use rolldown_common::{Module, RuntimeHelper};
+use rolldown_common::{Module, ModuleIdx, RuntimeHelper};
 use rolldown_utils::{index_vec_ext::IndexVecRefExt, indexmap::FxIndexSet};
 
 use super::LinkStage;
@@ -20,6 +20,15 @@ impl LinkStage<'_> {
           |(symbol_ref, _came_from_cjs)| {
             let canonical_ref = self.symbols.canonical_ref_for(*symbol_ref);
             extended_dependencies.insert(canonical_ref.owner);
+            // An entry export may resolve to a facade binding whose value lives on a CJS
+            // module's namespace (e.g. re-exporting a name that a CJS module only provides
+            // dynamically). Inclusion follows that alias (`follow_cjs_namespace_alias`), so the
+            // aliased module is a real dependency of the entry, same as in the statement walk
+            // below.
+            let symbol = self.symbols.get(canonical_ref);
+            if let Some(ns) = &symbol.namespace_alias {
+              extended_dependencies.insert(ns.namespace_ref.owner);
+            }
           },
         );
 
@@ -108,13 +117,37 @@ impl LinkStage<'_> {
     // Currently, only the `toESM` helper needs to be transitively included.
     //
     //
+    let tree_shaking = self.options.treeshake.is_some();
     for (module_idx, extended_dependencies, runtime_helper) in processed_module_results {
+      // Symbol-derived dependencies always force their owner module to be loaded. Import-record
+      // targets (what `meta.dependencies` holds at this point) only do so when evaluating them
+      // has side effects — the same edge semantics `include_side_effectful_dependencies` uses
+      // during tree-shaking and `compute_cross_chunk_links` uses when emitting bare imports.
+      //
+      // Record edges into entry modules are kept even when side-effect-free: an entry's chunk
+      // exists regardless, and letting static importers participate in its bit pattern keeps
+      // shared code co-located with the entry chunk (Rollup collapses such code-less entry
+      // facades onto the chunk holding their exports — e.g. a statically imported re-export
+      // barrel that is also a dynamic entry must not push its re-export targets into a separate
+      // chunk, see rollup's `entry-without-code-dynamic`).
+      let load_dependencies: FxIndexSet<ModuleIdx> = extended_dependencies
+        .iter()
+        .copied()
+        .chain(self.metas[module_idx].dependencies.iter().copied().filter(|dep_idx| {
+          !tree_shaking
+            || self.entries.contains_key(dep_idx)
+            || self.module_table[*dep_idx].side_effects().has_side_effects()
+        }))
+        .collect();
+
       let meta = &mut self.metas[module_idx];
       meta.dependencies.extend(extended_dependencies);
+      meta.load_dependencies = load_dependencies;
       meta.depended_runtime_helper |= runtime_helper;
 
       if !runtime_helper.is_empty() {
         meta.dependencies.insert(self.runtime.id());
+        meta.load_dependencies.insert(self.runtime.id());
       }
     }
 
@@ -126,6 +159,7 @@ impl LinkStage<'_> {
         if runtime_module.side_effects.has_side_effects() {
           for &entry_module_idx in self.entries.keys() {
             self.metas[entry_module_idx].dependencies.insert(runtime_idx);
+            self.metas[entry_module_idx].load_dependencies.insert(runtime_idx);
             self.metas[entry_module_idx].has_side_effectful_runtime_dep = true;
           }
         }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -67,6 +67,22 @@ pub struct LinkingMetadata {
 
   /// The dependencies of the module. It means if you want include this module, you need to include these dependencies too.
   pub dependencies: FxIndexSet<ModuleIdx>,
+  /// The subset of module graph edges that force the target module to be loaded when this module
+  /// executes, used by code splitting to compute per-entry reachability
+  /// (`determine_reachable_modules_for_entry`):
+  ///
+  /// - modules owning the canonical symbols referenced by this module's included statements
+  ///   (these are what become cross-chunk symbol imports), and
+  /// - import-record targets whose evaluation has side effects, mirroring both
+  ///   `include_side_effectful_dependencies` in tree-shaking and the bare-import emission in
+  ///   `compute_cross_chunk_links`.
+  ///
+  /// Unlike [`Self::dependencies`], a side-effect-free module imported only for bindings that
+  /// canonically resolve elsewhere (e.g. a pure barrel re-exporting them) is *not* a load
+  /// dependency, so an entry that never uses the barrel's own code doesn't pull the barrel (or
+  /// its subtree) into its chunk group (#8920). Populated by `patch_module_dependencies`; with
+  /// tree-shaking disabled it equals [`Self::dependencies`].
+  pub load_dependencies: FxIndexSet<ModuleIdx>,
   // `None` the member expression resolve to a ambiguous export.
   pub resolved_member_expr_refs: MemberExprRefResolutionMap,
   pub star_exports_from_external_modules: Vec<ImportRecordIdx>,

--- a/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
@@ -18,33 +18,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
-import { n as setY2, t as setZ2 } from "./z.js";
-//#region c.js
-setY2();
-setZ2();
 //#endregion
-
-```
-
-## x.js
-
-```js
-//#region x.js
-function setX(v) {}
-//#endregion
-export { setX as t };
-
-```
-
-## z.js
-
-```js
-import "./x.js";
-function setY2(v) {}
-//#endregion
-//#region z.js
-function setZ2(v) {}
-//#endregion
-export { setY2 as n, setZ2 as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/_config.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Mirror of rollup's chunking-form/entry-without-code-dynamic: `dynamic.js` is a code-less re-export barrel that is both statically imported (main1) and a dynamic entry (main2). The static importer must keep participating in the dynamic entry's bit pattern so `foo.js` lands inside the dynamic entry chunk (3 chunks total) instead of splitting into a fourth shared chunk that leaves the dynamic chunk an empty facade.",
+  "config": {
+    "input": [
+      { "name": "main1", "import": "./main1.js" },
+      { "name": "main2", "import": "./main2.js" }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dynamic.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+const foo = "foo";
+//#endregion
+//#region dynamic.js
+var dynamic_exports = /* @__PURE__ */ __exportAll({ foo: () => "foo" });
+//#endregion
+export { foo as n, dynamic_exports as t };
+
+```
+
+## main1.js
+
+```js
+import "./dynamic.js";
+//#region main1.js
+console.log("foo");
+//#endregion
+
+```
+
+## main2.js
+
+```js
+//#region main2.js
+import("./dynamic.js").then((n) => n.t).then(console.log);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/dynamic.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/dynamic.js
@@ -1,0 +1,1 @@
+export { foo } from './foo.js';

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/foo.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/main1.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/main1.js
@@ -1,0 +1,3 @@
+import { foo } from './dynamic.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/main2.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/static_import_of_code_less_dynamic_entry/main2.js
@@ -1,0 +1,1 @@
+import('./dynamic.js').then(console.log);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -3,24 +3,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## common.js
-
-```js
-import { t as __esmMin } from "./rolldown-runtime.js";
-//#region common.js
-function foo() {
-	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
-}
-var common, _;
-var init_common = __esmMin((() => {
-	common = "common";
-	_ = /*#__PURE__*/ foo();
-}));
-//#endregion
-export { common as n, init_common as r, _ as t };
-
-```
-
 ## main.js
 
 ```js
@@ -37,8 +19,17 @@ await __esmMin((async () => {
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
-import { n as common, r as init_common, t as _ } from "./common.js";
 import nodeAssert from "node:assert";
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /*#__PURE__*/ foo();
+}));
+//#endregion
 //#region page-a.js
 function render() {
 	console.log(common, _);

--- a/crates/rolldown/tests/rolldown/issues/8920/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8920/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/8920 - two entries import different bindings from a side-effect-free barrel. `light` resolves through the barrel to `light.js`, so the light entry must not be considered to load the barrel (or `heavy.js`) at all: expect 2 chunks like Rollup ({entry-light, light} and {entry-heavy, barrel, heavy}) instead of a third shared chunk that makes the light entry load heavy code.",
+  "config": {
+    "input": [
+      { "name": "entry-light", "import": "./entry-light.js" },
+      { "name": "entry-heavy", "import": "./entry-heavy.js" }
+    ],
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8920/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-heavy.js
+
+```js
+//#region heavy.js
+var HeavyService = class {
+	run() {
+		return "heavy";
+	}
+};
+//#endregion
+//#region barrel.js
+const createService = () => new HeavyService();
+//#endregion
+//#region entry-heavy.js
+console.log(createService().run());
+//#endregion
+
+```
+
+## entry-light.js
+
+```js
+//#region light.js
+function light() {
+	return "light";
+}
+//#endregion
+//#region entry-light.js
+console.log(light());
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8920/barrel.js
+++ b/crates/rolldown/tests/rolldown/issues/8920/barrel.js
@@ -1,0 +1,5 @@
+import { HeavyService } from './heavy.js';
+
+export const createService = () => new HeavyService();
+
+export { light } from './light.js';

--- a/crates/rolldown/tests/rolldown/issues/8920/entry-heavy.js
+++ b/crates/rolldown/tests/rolldown/issues/8920/entry-heavy.js
@@ -1,0 +1,2 @@
+import { createService } from './barrel.js';
+console.log(createService().run());

--- a/crates/rolldown/tests/rolldown/issues/8920/entry-light.js
+++ b/crates/rolldown/tests/rolldown/issues/8920/entry-light.js
@@ -1,0 +1,2 @@
+import { light } from './barrel.js';
+console.log(light());

--- a/crates/rolldown/tests/rolldown/issues/8920/heavy.js
+++ b/crates/rolldown/tests/rolldown/issues/8920/heavy.js
@@ -1,0 +1,5 @@
+export class HeavyService {
+  run() {
+    return 'heavy';
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8920/light.js
+++ b/crates/rolldown/tests/rolldown/issues/8920/light.js
@@ -1,0 +1,3 @@
+export function light() {
+  return 'light';
+}

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_593/artifacts.snap
@@ -6,7 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## component.js
 
 ```js
-import { n as setInnerHtml, t as htmlEscape } from "./shared.js";
+import { n as SafeHtml, t as htmlEscape } from "./shared.js";
+//#region safe.js
+function setInnerHtml(elem, html) {
+	if (html instanceof SafeHtml) elem.innerHTML = html.unwrap();
+}
+//#endregion
 //#region component.js
 var Component = class {
 	constructor(name) {
@@ -24,7 +29,7 @@ export { Component };
 ## safehtml.js
 
 ```js
-import { r as SafeHtml } from "./shared.js";
+import { n as SafeHtml } from "./shared.js";
 export { SafeHtml };
 
 ```
@@ -48,11 +53,6 @@ var SafeHtml = class {
 	}
 };
 //#endregion
-//#region safe.js
-function setInnerHtml(elem, html) {
-	if (html instanceof SafeHtml) elem.innerHTML = html.unwrap();
-}
-//#endregion
 //#region shared.js
 function compareVersions(a, b) {
 	return a > b ? 1 : a < b ? -1 : 0;
@@ -61,6 +61,6 @@ function htmlEscape(str) {
 	return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
 }
 //#endregion
-export { setInnerHtml as n, SafeHtml as r, htmlEscape as t };
+export { SafeHtml as n, htmlEscape as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/artifacts.snap
@@ -6,23 +6,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## common-a.js
 
 ```js
-import { t as sharedB } from "./common-b.js";
+//#region common-b.js
+const sharedB = "shared-b";
+//#endregion
 //#region common-a.js
 function getSharedB() {
 	return sharedB;
 }
 //#endregion
 export { getSharedB as t };
-
-```
-
-## common-b.js
-
-```js
-//#region common-b.js
-const sharedB = "shared-b";
-//#endregion
-export { sharedB as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
@@ -6,10 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-import { t as fn } from "./shared.js";
-//#region entry-a.js
-const used = fn();
-console.log(used);
+//#region shared.js
+/* @__NO_SIDE_EFFECTS__ */
+function fn() {
+	console.log("fn side effect");
+}
+console.log(/* @__PURE__ */ fn());
 fn.call(null);
 //#endregion
 
@@ -18,18 +20,5 @@ fn.call(null);
 ## entry-b.js
 
 ```js
-
-```
-
-## shared.js
-
-```js
-//#region shared.js
-/* @__NO_SIDE_EFFECTS__ */
-function fn() {
-	console.log("fn side effect");
-}
-//#endregion
-export { fn as t };
 
 ```


### PR DESCRIPTION
### Description

Closes #8920. Minimal alternative to #9155 — no per-entry inclusion tracking; only the code-splitting reachability edges change.

#### Root cause

Rolldown already agrees in two places on what forces a module to be **loaded**:

- tree-shaking (`include_side_effectful_dependencies`) follows a static import-record edge only when the importee `side_effects().has_side_effects()`; used bindings pull in the module that canonically owns them (re-exports resolve *through* a barrel to the origin module), and
- `compute_cross_chunk_links` emits a bare `import "chunk.js"` for a record edge only when the importee has side effects; all other cross-chunk imports are symbol-driven.

The code-splitting BFS (`determine_reachable_modules_for_entry`) was the one place without that filter: it walks `meta.dependencies`, the union of **all** static record targets plus the symbol-owner dependencies merged in by `patch_module_dependencies`. So `entry-light → barrel` (a pure record edge whose imported binding canonically lives in `light.js`) still marked the barrel — and transitively `heavy.js` — as reachable from the light entry, producing a shared chunk that neither the inclusion semantics nor the emitted imports actually load:

```
# before: 3 chunks, entry-light loads HeavyService through the shared chunk
barrel.js   (heavy.js + light.js + barrel.js, bits {light,heavy})
entry-heavy.js
entry-light.js

# after: 2 chunks, same as Rollup
entry-heavy.js (heavy.js + barrel.js + entry-heavy.js)
entry-light.js (light.js + entry-light.js)
```

#### Fix

`patch_module_dependencies` now additionally records `meta.load_dependencies` — the edges that actually force a module to be loaded at runtime:

- modules owning the canonical symbols referenced by this module's included statements (incl. CJS namespace-alias owners, runtime-when-helpers, entry-chunk export owners), plus
- import-record targets whose evaluation has side effects (the exact `include_side_effectful_dependencies` rule; with tree-shaking disabled the set equals `dependencies`, so nothing changes there).

`determine_reachable_modules_for_entry` walks `load_dependencies`. Every other `meta.dependencies` consumer (chunk optimizer, manual code splitting, on-demand wrapping, dynamic-already-loaded) keeps the broad set, so their behavior is untouched.

One deliberate exception: record edges **into entry modules** are never pruned. An entry's chunk exists regardless, and letting static importers participate in its bit pattern keeps shared code co-located with the entry chunk — Rollup reaches the same topology by collapsing code-less entry facades onto the chunk holding their exports. Without this, a statically imported re-export barrel that is also a dynamic entry pushes its re-export targets into a separate shared chunk and leaves the dynamic chunk an empty facade (caught by rollup's `chunking-form/entry-without-code-dynamic` in CI: 4 chunks instead of 3; mirrored here as the `code_splitting/static_import_of_code_less_dynamic_entry` fixture).

Every included module stays reachable: a module only becomes included via a side-effect-full record edge or via a used symbol, and both edge kinds are present in `load_dependencies` (the existing `debug_assert` at the chunk-assignment site checks exactly this invariant across the whole suite). The suite surfaced one previously masked asymmetry — an entry export resolving to a facade binding with a CJS `namespace_alias` (`esbuild/importstar/export_other_nested_common_js`) contributed no dependency edge from the entry-chunk loop, unlike the statement walk; the entry-chunk loop now mirrors the same namespace-alias handling.

#### Snapshot changes (all audited)

Beyond the new `issues/8920` and `code_splitting/static_import_of_code_less_dynamic_entry` fixtures, 5 existing snapshots change, all in the same direction — a module that an entry never actually loads is no longer assigned to that entry's chunk group:

- `issues/rolldown_vite_593`, `chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry`, `tree_shaking/no_side_effects_namespace_cross_chunk_cases`: single-consumer modules move out of shared chunks into their only consumer; shared chunks keep only genuinely shared code.
- `strict_execution_order/strip_plain_chunk_imports`: the `common.js` chunk (reachable only through plain record edges — what this fixture is about) colocates with its one real consumer; the executed `node:assert` checks still pass.
- `esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive`: the pure `set*` helper chain colocates into the `c.js` entry, letting the default `dce-only` pass eliminate the provably dead chain entirely (its `a.js`/`b.js` outputs were already empty on main).

Fixtures involving record edges into dynamic entry modules (`issue_8809`, `dynamic_entry_shared_module_not_merged`, `9320_star`) keep today's output byte-for-byte thanks to the entry-edge exception above; slimming those dynamic-entry namespaces/facades is the existing proxy-chunk follow-up topic, not this PR.

Fixtures that execute their output all still pass; full integration suite is green (1756 passed, hmr/watcher skipped locally on Windows).
