### PR TITLE
fix(dev): ignore watcher events after close

### DIFF
--- a/crates/rolldown_dev/src/watcher_event_handler.rs
+++ b/crates/rolldown_dev/src/watcher_event_handler.rs
@@ -7,8 +7,10 @@ pub struct WatcherEventHandler {
 }
 impl FsEventHandler for WatcherEventHandler {
   fn handle_event(&mut self, event: rolldown_fs_watcher::FsEventResult) {
-    self.coordinator_tx.send(CoordinatorMsg::WatchEvent(event)).expect(
-      "Coordinator channel closed while sending file change event - coordinator terminated unexpectedly"
-    );
+    if self.coordinator_tx.send(CoordinatorMsg::WatchEvent(event)).is_err() {
+      tracing::debug!(
+        "[WatcherEventHandler] coordinator channel closed while sending file change event"
+      );
+    }
   }
 }


### PR DESCRIPTION
### Summary

Ignore file watcher events that arrive after the dev coordinator channel has already closed.

### Root cause

The debounced notify watcher can deliver a late event while the dev engine is closing. At that point the coordinator receiver may already be dropped, so sending `CoordinatorMsg::WatchEvent` returns `SendError`. There is no coordinator left to handle the event, so panicking from the watcher callback only crashes the host process.

### Impact

This avoids a spurious Rolldown panic during dev-server teardown, seen in Vite's Windows `test-serve` job as a `notify-rs debouncer loop` panic from `watcher_event_handler.rs`.

### Validation

- `cargo fmt --check`
- `cargo test -p rolldown_dev --lib`
- `git diff --check`