### PR TITLE
test(dev): assert incremental scan state matches a fresh full build after each HMR step

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_testing.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_testing.rs
@@ -1,0 +1,161 @@
+use std::collections::BTreeSet;
+
+use rolldown_common::{Module, ModuleIdx, ModuleTable};
+
+use super::Bundler;
+
+impl Bundler {
+  /// Asserts the incremental scan state matches what a fresh full build of
+  /// the same inputs produced. Modules only present on the incremental side
+  /// are allowed: removed modules currently stay in the state (issue #7416).
+  /// Their outgoing importer records stay with them, so importer sets are
+  /// compared ignoring importers that do not exist in the fresh build; a
+  /// stale importer entry from a module the fresh build *does* have is still
+  /// a divergence.
+  ///
+  /// # Panics
+  /// - if the states diverge, listing every difference
+  pub fn assert_scan_state_parity_with(&self, fresh: &Bundler) {
+    fn module_id_at(table: &ModuleTable, idx: ModuleIdx) -> String {
+      table.modules.get(idx).map_or_else(|| format!("<unknown {idx:?}>"), |m| m.id().to_string())
+    }
+
+    if self.options().experimental.is_lazy_barrel_enabled() {
+      // Lazy barrel loads import records on demand, so the loaded subset
+      // depends on request history and legitimately differs per session.
+      return;
+    }
+
+    let incremental_cache = &self.cache;
+    let fresh_cache = &fresh.cache;
+    assert!(
+      incremental_cache.has_snapshot() && fresh_cache.has_snapshot(),
+      "state parity needs both bundlers to have completed a build with incremental build enabled"
+    );
+    let incremental = incremental_cache.get_snapshot();
+    let fresh_snapshot = fresh_cache.get_snapshot();
+
+    let mut diffs = Vec::new();
+
+    // Orphan modules keep their outgoing importer records (issue #7416);
+    // importer entries pointing at modules unknown to the fresh build are
+    // exactly those and get filtered out of the comparisons below.
+    let fresh_module_ids = fresh_snapshot
+      .module_table
+      .modules
+      .iter()
+      .map(|module| module.id().to_string())
+      .collect::<BTreeSet<_>>();
+
+    for fresh_module in &fresh_snapshot.module_table.modules {
+      let id = fresh_module.id();
+      let Some(state) = incremental_cache.module_id_to_idx.get(id) else {
+        diffs.push(format!("`{id}` is missing in the incremental state"));
+        continue;
+      };
+      let Some(incremental_module) = incremental.module_table.modules.get(state.idx()) else {
+        diffs.push(format!("`{id}` has an idx but no module in the incremental snapshot"));
+        continue;
+      };
+      match (fresh_module, incremental_module) {
+        (Module::Normal(fresh_module), Module::Normal(incremental_module)) => {
+          let fresh_importers =
+            fresh_module.importers.iter().map(ToString::to_string).collect::<BTreeSet<_>>();
+          let incremental_importers = incremental_module
+            .importers
+            .iter()
+            .map(ToString::to_string)
+            .filter(|importer| fresh_module_ids.contains(importer))
+            .collect::<BTreeSet<_>>();
+          if fresh_importers != incremental_importers {
+            diffs.push(format!(
+              "`{id}` importers differ: fresh {fresh_importers:?}, incremental {incremental_importers:?}"
+            ));
+          }
+
+          let fresh_dynamic_importers =
+            fresh_module.dynamic_importers.iter().map(ToString::to_string).collect::<BTreeSet<_>>();
+          let incremental_dynamic_importers = incremental_module
+            .dynamic_importers
+            .iter()
+            .map(ToString::to_string)
+            .filter(|importer| fresh_module_ids.contains(importer))
+            .collect::<BTreeSet<_>>();
+          if fresh_dynamic_importers != incremental_dynamic_importers {
+            diffs.push(format!(
+              "`{id}` dynamic importers differ: fresh {fresh_dynamic_importers:?}, incremental {incremental_dynamic_importers:?}"
+            ));
+          }
+
+          let fresh_importer_ids = fresh_module
+            .importers_idx
+            .iter()
+            .map(|idx| module_id_at(&fresh_snapshot.module_table, *idx))
+            .collect::<BTreeSet<_>>();
+          let incremental_importer_ids = incremental_module
+            .importers_idx
+            .iter()
+            .map(|idx| module_id_at(&incremental.module_table, *idx))
+            .filter(|importer| fresh_module_ids.contains(importer))
+            .collect::<BTreeSet<_>>();
+          if fresh_importer_ids != incremental_importer_ids {
+            diffs.push(format!(
+              "`{id}` importers_idx differ: fresh {fresh_importer_ids:?}, incremental {incremental_importer_ids:?}"
+            ));
+          }
+
+          if fresh_module.import_records.len() == incremental_module.import_records.len() {
+            for (index, (fresh_record, incremental_record)) in
+              fresh_module.import_records.iter().zip(&incremental_module.import_records).enumerate()
+            {
+              let fresh_target = fresh_record
+                .resolved_module
+                .map(|idx| module_id_at(&fresh_snapshot.module_table, idx));
+              let incremental_target = incremental_record
+                .resolved_module
+                .map(|idx| module_id_at(&incremental.module_table, idx));
+              if fresh_record.kind != incremental_record.kind || fresh_target != incremental_target
+              {
+                diffs.push(format!(
+                  "`{id}` import record {index} differs: fresh ({:?}, {fresh_target:?}), incremental ({:?}, {incremental_target:?})",
+                  fresh_record.kind, incremental_record.kind
+                ));
+              }
+            }
+          } else {
+            diffs.push(format!(
+              "`{id}` import record count differs: fresh {}, incremental {}",
+              fresh_module.import_records.len(),
+              incremental_module.import_records.len()
+            ));
+          }
+        }
+        (Module::External(_), Module::External(_)) => {}
+        _ => {
+          diffs.push(format!("`{id}` module kind differs between fresh and incremental state"));
+        }
+      }
+    }
+
+    let incremental_entries = incremental
+      .entry_points
+      .iter()
+      .map(|entry| {
+        (format!("{:?}", entry.kind), module_id_at(&incremental.module_table, entry.idx))
+      })
+      .collect::<BTreeSet<_>>();
+    for entry in &fresh_snapshot.entry_points {
+      let entry =
+        (format!("{:?}", entry.kind), module_id_at(&fresh_snapshot.module_table, entry.idx));
+      if !incremental_entries.contains(&entry) {
+        diffs.push(format!("entry point {entry:?} is missing in the incremental state"));
+      }
+    }
+
+    assert!(
+      diffs.is_empty(),
+      "incremental scan state diverges from a fresh full build:\n{}",
+      diffs.join("\n")
+    );
+  }
+}

--- a/crates/rolldown/src/bundler/mod.rs
+++ b/crates/rolldown/src/bundler/mod.rs
@@ -3,5 +3,7 @@ mod impl_bundler_build;
 mod impl_bundler_getter;
 mod impl_bundler_hmr;
 mod impl_bundler_incremental_build;
+#[cfg(feature = "testing")]
+mod impl_bundler_testing;
 
 pub use self::bundler::Bundler;

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -402,24 +402,32 @@ impl DevEngine {
     &self,
     changed_files: FxIndexMap<PathBuf, WatcherChangeKind>,
   ) {
-    for (path, event) in changed_files {
-      // Create a synthetic file change event to simulate real file system changes
-      let notify_event = notify::Event {
-        kind: if event == WatcherChangeKind::Delete {
-          notify::EventKind::Remove(notify::event::RemoveKind::Any)
-        } else {
-          notify::EventKind::Modify(notify::event::ModifyKind::Data(notify::event::DataChange::Any))
-        },
-        paths: vec![path],
-        attrs: notify::event::EventAttributes::default(),
-      };
+    // Create synthetic file change events to simulate real file system
+    // changes. The whole step goes into ONE batch: one event per message
+    // would spawn one build per file, while the future awaited below only
+    // covers the first, leaving the rest racing the caller's assertions.
+    let events = changed_files
+      .into_iter()
+      .map(|(path, event)| {
+        let notify_event = notify::Event {
+          kind: if event == WatcherChangeKind::Delete {
+            notify::EventKind::Remove(notify::event::RemoveKind::Any)
+          } else {
+            notify::EventKind::Modify(notify::event::ModifyKind::Data(
+              notify::event::DataChange::Any,
+            ))
+          },
+          paths: vec![path],
+          attrs: notify::event::EventAttributes::default(),
+        };
+        rolldown_fs_watcher::FsEvent { detail: notify_event, time: std::time::Instant::now() }
+      })
+      .collect::<Vec<_>>();
 
-      let event =
-        rolldown_fs_watcher::FsEvent { detail: notify_event, time: std::time::Instant::now() };
-
+    if !events.is_empty() {
       // Send WatchEvent message to coordinator (simulates real file change)
       // The coordinator will automatically schedule a build via handle_file_changes
-      let _ = self.coordinator_sender.send(CoordinatorMsg::WatchEvent(Ok(vec![event])));
+      let _ = self.coordinator_sender.send(CoordinatorMsg::WatchEvent(Ok(events)));
     }
 
     // Send ScheduleBuild to ensure WatchEvent is processed (FIFO),
@@ -431,6 +439,11 @@ impl DevEngine {
     if let Ok(Some(ret)) = reply_rx.await {
       ret.future.await;
     }
+  }
+
+  #[cfg(feature = "testing")]
+  pub fn bundler(&self) -> Arc<Mutex<Bundler>> {
+    Arc::clone(&self.bundler)
   }
 
   #[cfg(feature = "testing")]

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -2032,6 +2032,11 @@
           "description": "If `true`, the test will call `ensure_latest_build_output()` after each HMR step to wait for async builds.\nThis allows capturing all build outputs triggered by each step.\nDefault is `false` for backwards compatibility and performance.",
           "type": "boolean",
           "default": false
+        },
+        "checkStateParity": {
+          "description": "After each HMR step, run a fresh full build of the current file state\nand assert the incremental scan state matches it. Skipped automatically\nfor steps whose state does not build and for steps whose incremental\nbuild failed (a failed scan is reverted, so the state intentionally\nstays at the last good build). Default is `true`.",
+          "type": "boolean",
+          "default": true
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -11,8 +11,8 @@ use anyhow::Context;
 use oxc::parser::{ParseOptions, Parser};
 use oxc::span::SourceType;
 use rolldown::{
-  BundleOutput, Bundler, BundlerOptions, IsExternal, OutputFormat, Platform, SourceMapType,
-  plugin::__inner::SharedPluginable,
+  BundleOutput, Bundler, BundlerBuilder, BundlerOptions, IsExternal, OutputFormat, Platform,
+  SourceMapType, plugin::__inner::SharedPluginable,
 };
 use rolldown::{ChecksOptions, NormalizedBundlerOptions};
 use rolldown_common::Output;
@@ -268,6 +268,34 @@ impl IntegrationTest {
         // Optionally wait for async builds to complete
         if self.test_meta.dev.ensure_latest_build_output_for_each_step {
           dev_engine.ensure_latest_bundle_output().await.unwrap();
+        }
+
+        // Compare the incremental scan state with a fresh full build of the
+        // current file state. Running it per step catches divergences that a
+        // later rescan of the affected module would repair. Skipped when the
+        // current state does not build (e.g. a step introducing a syntax
+        // error), and when this step's incremental build failed: a failed
+        // scan is reverted, so the state intentionally stays at the last
+        // good build and cannot mirror the current files yet.
+        if self.test_meta.dev.check_state_parity {
+          let step_failed = {
+            let hmr_updates = hmr_updates_by_steps.lock().unwrap();
+            let build_results = build_results_by_steps.lock().unwrap();
+            hmr_updates.last().is_some_and(|step| step.iter().any(Result::is_err))
+              || build_results.last().is_some_and(|step| step.iter().any(Result::is_err))
+          };
+          if !step_failed {
+            let mut fresh_bundler = BundlerBuilder::default()
+              .with_options(named_options.options.clone())
+              .with_plugins(plugins.clone())
+              .build()
+              .expect("failed to build the state parity bundler");
+            if fresh_bundler.generate().await.is_ok() {
+              let incremental_bundler = dev_engine.bundler();
+              let incremental_bundler = incremental_bundler.lock().await;
+              incremental_bundler.assert_scan_state_parity_with(&fresh_bundler);
+            }
+          }
         }
       }
 

--- a/crates/rolldown_testing_config/src/dev_test_meta.rs
+++ b/crates/rolldown_testing_config/src/dev_test_meta.rs
@@ -2,6 +2,10 @@ use rolldown_dev_common::types::DevOptions;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+fn default_true() -> bool {
+  true
+}
+
 #[derive(Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DevTestMeta {
@@ -12,6 +16,13 @@ pub struct DevTestMeta {
   /// This allows capturing all build outputs triggered by each step.
   /// Default is `false` for backwards compatibility and performance.
   pub ensure_latest_build_output_for_each_step: bool,
+  #[serde(default = "default_true")]
+  /// After each HMR step, run a fresh full build of the current file state
+  /// and assert the incremental scan state matches it. Skipped automatically
+  /// for steps whose state does not build and for steps whose incremental
+  /// build failed (a failed scan is reverted, so the state intentionally
+  /// stays at the last good build). Default is `true`.
+  pub check_state_parity: bool,
 }
 
 impl Default for DevTestMeta {


### PR DESCRIPTION
### Description

Part of #7416. Stacked on #10112. This adds the test #7416 asks for: one that ensures an incremental build and a full build produce the same states.

#### What it does

After each HMR step of a dev fixture, the test harness now builds a fresh bundler with the same options and plugins against the current file state and runs a full build. The fresh bundler has no history, so its scan state is by definition the correct answer for the files on disk. The harness then asserts the incremental state matches it:

- `importers` and `dynamic_importers` of every module, compared as sets of module ids. Importer entries pointing at modules the fresh build does not know are ignored: those are the outgoing records of orphaned modules, which stay in the state by design (issue #7416). A stale importer entry from a module the fresh build *does* have is still reported.
- `importers_idx`, mapped back to module ids since the two sides use different index spaces, with the same orphan filter.
- Every import record's kind and resolved target.
- Entry points, where the fresh set must be a subset of the incremental set. Extras on the incremental side are allowed for now, because removed modules and stale dynamic import entries are separate open items of #7416.

Any difference fails the test with a per module, per field report.

#### Why per step instead of once at the end

An end of run comparison has a blind spot: a divergence on a cached module is silently repaired as soon as a later step happens to rescan that module, so only the intermediate state is wrong, which is exactly when HMR reads it. This was verified by temporarily reintroducing the bug fixed in #10107 (a cached module keeping a stale importer set). The end of run check passed, the per step check caught it immediately and reported the exact missing importer.

#### When it is skipped

- Steps whose file state does not build, e.g. the error recovery fixtures while their syntax error is in place. A state that cannot be built has no full build to compare against.
- Steps whose incremental build failed. A failed scan is reverted, so the state intentionally stays at the last good build and cannot mirror the current files until a later scan retries them.
- Fixtures with lazy barrel enabled. It loads import records on demand, so the loaded subset depends on request history and legitimately differs between a session and a fresh build.

#### Opting out

`dev.checkStateParity` defaults to `true`, so every existing and future dev fixture gets the check for free (all 38 current HMR fixtures pass with it enabled). A fixture that intentionally documents a known divergence can set it to `false`, and the flag in its config then serves as a visible marker of the known gap until the underlying fix lands.

#### Implementation notes

- The comparison lives inside the `rolldown` crate behind the existing `testing` feature (`Bundler::assert_scan_state_parity_with`), so it can read the private cache directly and no new public API surface is added.
- `DevEngine` gains a `testing` gated `bundler()` accessor, following the existing `get_watched_files` pattern.
- `ensure_task_with_changed_files` now sends the whole step as one watch event batch. One event per message spawned one build per file while the awaited future only covered the first, so a multi file step could race the assertion.
- The config schema is regenerated by the existing build script.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->


