### PR TITLE
fix(dev): prune dynamic import entry points when their imports are removed

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_testing.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_testing.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use rolldown_common::{Module, ModuleIdx, ModuleTable};
+use rolldown_common::{EntryPointKind, Module, ModuleIdx, ModuleTable};
 
 use super::Bundler;
 
@@ -144,11 +144,44 @@ impl Bundler {
         (format!("{:?}", entry.kind), module_id_at(&incremental.module_table, entry.idx))
       })
       .collect::<BTreeSet<_>>();
-    for entry in &fresh_snapshot.entry_points {
-      let entry =
-        (format!("{:?}", entry.kind), module_id_at(&fresh_snapshot.module_table, entry.idx));
-      if !incremental_entries.contains(&entry) {
+    let fresh_entries = fresh_snapshot
+      .entry_points
+      .iter()
+      .map(|entry| {
+        (format!("{:?}", entry.kind), module_id_at(&fresh_snapshot.module_table, entry.idx))
+      })
+      .collect::<BTreeSet<_>>();
+    for entry in &fresh_entries {
+      if !incremental_entries.contains(entry) {
         diffs.push(format!("entry point {entry:?} is missing in the incremental state"));
+      }
+    }
+    // Dynamic import entries must match exactly while a live module imports
+    // them. An entry kept only by orphans' dynamic import records is
+    // tolerated: the cache keeps the rows so re-adding an import can revive
+    // the entry, and `create_output` filters it from the build output. Other
+    // kinds allow extras on the incremental side, e.g. entries of modules
+    // that are no longer reachable (issue #7416, orphan cleanup).
+    for entry in &incremental.entry_points {
+      if entry.kind == EntryPointKind::DynamicImport {
+        let key = (format!("{:?}", entry.kind), module_id_at(&incremental.module_table, entry.idx));
+        if !fresh_entries.contains(&key) {
+          let has_live_dynamic_importer = incremental
+            .module_table
+            .modules
+            .get(entry.idx)
+            .and_then(Module::as_normal)
+            .is_some_and(|module| {
+              module
+                .dynamic_importers
+                .iter()
+                .any(|importer| fresh_module_ids.contains(&importer.to_string()))
+            });
+          if has_live_dynamic_importer {
+            diffs
+              .push(format!("dynamic import entry {key:?} only exists in the incremental state"));
+          }
+        }
       }
     }
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -568,6 +568,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             }
 
             let is_external = resolved_id.external.is_external();
+            // `user_defined_entry_ids` only covers entries seen by this scan;
+            // in partial mode it is empty, so cached entries need the lookup.
+            let is_cached_user_entry = self.cache.user_defined_entry.contains(&resolved_id.id);
             let idx = self.try_spawn_new_task(
               resolved_id,
               Some(ModuleTaskOwner::new(normal_module, raw_rec.span)),
@@ -606,6 +609,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             if matches!(raw_rec.kind, ImportKind::DynamicImport)
               && !is_external
               && !user_defined_entry_ids.contains(&idx)
+              && !is_cached_user_entry
             {
               match dynamic_import_entry_ids.entry(idx) {
                 Entry::Vacant(vac) => match raw_rec.dynamic_import_expr_info.as_ref() {

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -4,8 +4,8 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  BarrelState, EcmaModuleAstUsage, GetLocalDbMut, ImporterRecord, Module, ModuleId, ModuleIdx,
-  ResolvedId, StableModuleId,
+  BarrelState, EcmaModuleAstUsage, EntryPointKind, GetLocalDbMut, ImporterRecord, Module, ModuleId,
+  ModuleIdx, ResolvedId, StableModuleId,
 };
 use rolldown_error::BuildResult;
 use rolldown_plugin::PluginDriver;
@@ -143,8 +143,10 @@ impl ScanStageCache {
       }
     };
     // merge module_table, index_ast_scope, index_ecma_ast
+    let mut scanned_idxs = FxHashSet::default();
     for (new_idx, new_module) in modules {
       let idx = self.module_id_to_idx[new_module.id()].idx();
+      scanned_idxs.insert(idx);
 
       // Update `module_idx_by_abs_path`
       if let rolldown_common::Module::Normal(normal_module) = &new_module {
@@ -222,28 +224,40 @@ impl ScanStageCache {
       module.ecma_view.rebuild_importer_sets(&self.importers[*idx]);
     }
 
-    // merge entries
+    // merge entries. Drop the rows of re-scanned modules first: the incoming
+    // entry only carries the records that still exist, so a re-scanned
+    // importer that removed its dynamic import would otherwise leave stale
+    // rows behind.
+    for old_entry_point in &mut cache.entry_points {
+      if old_entry_point.kind == EntryPointKind::DynamicImport {
+        old_entry_point
+          .related_stmt_infos
+          .retain(|(module_idx, _, _, _)| !scanned_idxs.contains(module_idx));
+      }
+    }
     for entry_point in scan_stage_output.entry_points {
       if let Some(old_entry_point) = cache
         .entry_points
         .iter_mut()
         .find(|old_entry| old_entry.kind == entry_point.kind && old_entry.idx == entry_point.idx)
       {
-        let removed_module_idxs = entry_point
-          .related_stmt_infos
-          .iter()
-          .map(|(module_idx, _, _, _)| *module_idx)
-          .collect::<FxHashSet<_>>();
-        _ = old_entry_point
-          .related_stmt_infos
-          .extract_if(.., |(module_idx, _stmt_info_idx, _node_id, _)| {
-            removed_module_idxs.contains(module_idx)
-          });
         old_entry_point.related_stmt_infos.extend(entry_point.related_stmt_infos);
       } else {
         cache.entry_points.push(entry_point);
       }
     }
+
+    // A dynamic import entry whose last dynamic importer record disappeared
+    // must not keep producing a chunk. Records of orphaned importers survive
+    // here on purpose (re-adding an import revives the entry without a
+    // re-scan); [`Self::create_output`] filters those entries by reachability.
+    cache.entry_points.retain(|entry| {
+      entry.kind != EntryPointKind::DynamicImport
+        || self
+          .importers
+          .get(entry.idx)
+          .is_some_and(|records| records.iter().any(|record| record.kind.is_dynamic()))
+    });
 
     // Update barrel module resolved import records
     let resolved_barrel_modules = std::mem::take(&mut self.barrel_state.resolved_barrel_modules);
@@ -309,9 +323,64 @@ impl ScanStageCache {
     }
   }
 
+  /// Modules reachable from the real (non-dynamic) entries and the runtime
+  /// module. Orphans stay in the snapshot (issue #7416), so liveness has to
+  /// be derived, not assumed.
+  ///
+  /// # Panic
+  /// - if the snapshot is unset
+  fn compute_live_modules(&self) -> FxHashSet<ModuleIdx> {
+    let snapshot = self.get_snapshot();
+    let mut live = FxHashSet::default();
+    let mut queue = snapshot
+      .entry_points
+      .iter()
+      .filter(|entry| entry.kind != EntryPointKind::DynamicImport)
+      .map(|entry| entry.idx)
+      .collect::<Vec<_>>();
+    queue.push(snapshot.runtime.id());
+    while let Some(idx) = queue.pop() {
+      if !live.insert(idx) {
+        continue;
+      }
+      let Some(module) = snapshot.module_table.modules.get(idx).and_then(Module::as_normal) else {
+        continue;
+      };
+      for record in &module.ecma_view.import_records {
+        if let Some(dep_idx) = record.resolved_module
+          && !live.contains(&dep_idx)
+        {
+          queue.push(dep_idx);
+        }
+      }
+    }
+    live
+  }
+
   /// # Panic
   /// the function will panic if cache is unset
   pub fn create_output(&mut self) -> NormalizedScanStageOutput {
+    // The cache keeps a dynamic import entry while ANY importer record for it
+    // exists, including records of orphaned modules, so a re-added import can
+    // revive the entry without re-scanning the orphan. Only entries a live
+    // module dynamically imports may produce chunks though; a fresh build of
+    // the same files has no others.
+    let live_modules = self.compute_live_modules();
+    let entry_points = self
+      .get_snapshot()
+      .entry_points
+      .iter()
+      .filter(|entry| {
+        entry.kind != EntryPointKind::DynamicImport
+          || self.importers.get(entry.idx).is_some_and(|records| {
+            records
+              .iter()
+              .any(|record| record.kind.is_dynamic() && live_modules.contains(&record.importer_idx))
+          })
+      })
+      .cloned()
+      .collect();
+
     let cache = self.snapshot.as_mut().unwrap();
     // Only clone the mutated part of symbol_ref_db
     let symbol_ref_db_partial = cache.symbol_ref_db.clone_without_scoping();
@@ -332,7 +401,7 @@ impl ScanStageCache {
       stmt_infos: cache.stmt_infos.clone(),
 
       // Since `AstScope` is immutable in following phase, move it to avoid clone
-      entry_points: cache.entry_points.clone(),
+      entry_points,
       symbol_ref_db,
       runtime: cache.runtime.clone(),
       // TODO: cache warning

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/artifacts.snap
@@ -1,0 +1,274 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## lazy.js
+
+```js
+import { t as __exportAll } from "./main.js";
+//#region lazy.js
+var lazy_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("lazy.js");
+__rolldown_runtime__.registerModule("lazy.js", { exports: lazy_exports });
+const value = "lazy";
+//#endregion
+export { value };
+
+```
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ loadFromB: () => loadFromB });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+async function loadFromB() {
+	await import("./lazy.js").then(console.log);
+}
+b_hot.accept();
+//#endregion
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ loadFromC: () => loadFromC });
+const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
+__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+async function loadFromC() {
+	await import("./lazy.js").then(console.log);
+}
+c_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+export { __exportAll as t };
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region b.js
+var init_b_0 = __rolldown_runtime__.createEsmInitializer("b.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ loadFromB: () => loadFromB });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_b = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		async function loadFromB() {
+			console.log("b no longer loads lazy");
+		}
+		hot_b.accept();
+	} finally {}
+}));
+
+//#endregion
+init_b_0()
+__rolldown_runtime__.applyUpdates([['b.js', 'b.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: b.js, accepted_via: b.js
+
+## Build Output
+
+### Assets
+
+#### lazy.js
+
+```js
+import { t as __exportAll } from "./main.js";
+//#region lazy.js
+var lazy_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("lazy.js");
+__rolldown_runtime__.registerModule("lazy.js", { exports: lazy_exports });
+const value = "lazy";
+//#endregion
+export { value };
+
+```
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ loadFromB: () => loadFromB });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+async function loadFromB() {
+	console.log("b no longer loads lazy");
+}
+b_hot.accept();
+//#endregion
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ loadFromC: () => loadFromC });
+const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
+__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+async function loadFromC() {
+	await import("./lazy.js").then(console.log);
+}
+c_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+export { __exportAll as t };
+
+```
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region c.js
+var init_c_0 = __rolldown_runtime__.createEsmInitializer("c.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ loadFromC: () => loadFromC });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_c = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		async function loadFromC() {
+			console.log("c no longer loads lazy");
+		}
+		hot_c.accept();
+	} finally {}
+}));
+
+//#endregion
+init_c_0()
+__rolldown_runtime__.applyUpdates([['c.js', 'c.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: c.js, accepted_via: c.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ loadFromB: () => loadFromB });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+async function loadFromB() {
+	console.log("b no longer loads lazy");
+}
+b_hot.accept();
+//#endregion
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ loadFromC: () => loadFromC });
+const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
+__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+async function loadFromC() {
+	console.log("c no longer loads lazy");
+}
+c_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 2
+
+## Code
+
+```js
+//#region b.js
+var init_b_0 = __rolldown_runtime__.createEsmInitializer("b.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ loadFromB: () => loadFromB });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_b = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		async function loadFromB() {
+			await Promise.resolve().then(() => __rolldown_runtime__.loadExports("lazy.js")).then(console.log);
+		}
+		hot_b.accept();
+	} finally {}
+}));
+
+//#endregion
+init_b_0()
+__rolldown_runtime__.applyUpdates([['b.js', 'b.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: b.js, accepted_via: b.js
+
+## Build Output
+
+### Assets
+
+#### lazy.js
+
+```js
+import { t as __exportAll } from "./main.js";
+//#region lazy.js
+var lazy_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("lazy.js");
+__rolldown_runtime__.registerModule("lazy.js", { exports: lazy_exports });
+const value = "lazy";
+//#endregion
+export { value };
+
+```
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ loadFromB: () => loadFromB });
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+async function loadFromB() {
+	await import("./lazy.js").then(console.log);
+}
+b_hot.accept();
+//#endregion
+//#region c.js
+var c_exports = /* @__PURE__ */ __exportAll({ loadFromC: () => loadFromC });
+const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
+__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+async function loadFromC() {
+	console.log("c no longer loads lazy");
+}
+c_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+export { __exportAll as t };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.hmr-0.js
@@ -1,0 +1,5 @@
+export async function loadFromB() {
+  console.log('b no longer loads lazy');
+}
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.hmr-2.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.hmr-2.js
@@ -1,0 +1,5 @@
+export async function loadFromB() {
+  await import('./lazy.js').then(console.log);
+}
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/b.js
@@ -1,0 +1,5 @@
+export async function loadFromB() {
+  await import('./lazy.js').then(console.log);
+}
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/c.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/c.hmr-1.js
@@ -1,0 +1,5 @@
+export async function loadFromC() {
+  console.log('c no longer loads lazy');
+}
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/c.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/c.js
@@ -1,0 +1,5 @@
+export async function loadFromC() {
+  await import('./lazy.js').then(console.log);
+}
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/lazy.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/lazy.js
@@ -1,0 +1,1 @@
+export const value = 'lazy';

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_dynamic_import_entry/main.js
@@ -1,0 +1,2 @@
+import './b.js';
+import './c.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/artifacts.snap
@@ -1,0 +1,152 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## lazy.js
+
+```js
+import { t as __exportAll } from "./main.js";
+//#region lazy.js
+var lazy_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("lazy.js");
+__rolldown_runtime__.registerModule("lazy.js", { exports: lazy_exports });
+const value = "lazy";
+//#endregion
+export { value };
+
+```
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region hub.js
+var hub_exports = /* @__PURE__ */ __exportAll({ load: () => load });
+__rolldown_runtime__.createModuleHotContext("hub.js");
+__rolldown_runtime__.registerModule("hub.js", { exports: hub_exports });
+function load() {
+	return import("./lazy.js");
+}
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+main_hot.accept();
+//#endregion
+export { __exportAll as t };
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region main.js
+var init_main_0 = __rolldown_runtime__.createEsmInitializer("main.js", (function(__rolldown_module_id__) {
+	try {
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		const hot_main = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		hot_main.accept();
+	} finally {}
+}));
+
+//#endregion
+init_main_0()
+__rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: main.js, accepted_via: main.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", {});
+main_hot.accept();
+//#endregion
+
+```
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region main.js
+var init_main_0 = __rolldown_runtime__.createEsmInitializer("main.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_main = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_hub_00 = __rolldown_runtime__.loadExports("hub.js");
+		hot_main.accept();
+	} finally {}
+}));
+
+//#endregion
+init_main_0()
+__rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: main.js, accepted_via: main.js
+
+## Build Output
+
+### Assets
+
+#### lazy.js
+
+```js
+import { t as __exportAll } from "./main.js";
+//#region lazy.js
+var lazy_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("lazy.js");
+__rolldown_runtime__.registerModule("lazy.js", { exports: lazy_exports });
+const value = "lazy";
+//#endregion
+export { value };
+
+```
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region hub.js
+var hub_exports = /* @__PURE__ */ __exportAll({ load: () => load });
+__rolldown_runtime__.createModuleHotContext("hub.js");
+__rolldown_runtime__.registerModule("hub.js", { exports: hub_exports });
+function load() {
+	return import("./lazy.js");
+}
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+main_hot.accept();
+//#endregion
+export { __exportAll as t };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/hub.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/hub.js
@@ -1,0 +1,3 @@
+export function load() {
+  return import('./lazy.js');
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/lazy.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/lazy.js
@@ -1,0 +1,1 @@
+export const value = 'lazy';

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.hmr-0.js
@@ -1,0 +1,1 @@
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.hmr-1.js
@@ -1,0 +1,3 @@
+import './hub.js';
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/remove_transitive_dynamic_import_entry/main.js
@@ -1,0 +1,3 @@
+import './hub.js';
+
+import.meta.hot.accept();

--- a/internal-docs/cache/implementation.md
+++ b/internal-docs/cache/implementation.md
@@ -340,9 +340,18 @@ arm is `unreachable!()`.
    `EcmaView::rebuild_importer_sets`. The scan does this only for modules it
    produced; a cached module whose importer added/removed/re-kinded an import
    of it is refreshed here (issue #7416).
-5. **Merge entry points** — for a matching existing entry
-   point, drop `related_stmt_infos` for re-scanned modules and extend with the
-   new ones; otherwise push the new entry point.
+5. **Merge entry points** — drop the `related_stmt_infos` rows of every
+   re-scanned module from the cached dynamic import entries (the incoming
+   entry only carries records that still exist), extend matching entries with
+   the incoming rows or push new ones, then prune dynamic import entries that
+   no longer have any dynamic edge in `importers`. Edges of orphaned (no
+   longer reachable) importers survive in `importers` on purpose, so an
+   entry only they point at stays in the cache: re-adding an import of the
+   orphan revives the entry without a re-scan. `create_output` compensates
+   by filtering dynamic import entries against reachability
+   (`compute_live_modules`, a BFS from the non-dynamic entries), so only
+   entries a live module dynamically imports produce chunks — matching a
+   fresh build.
 6. **Patch barrel modules** — drain
    `barrel_state.resolved_barrel_modules` and write the resolved import records
    back into the cached modules.


### PR DESCRIPTION
### Description

Part of #7416. Stacked on #10115. This makes `ScanStageCache::merge` clean up dynamic import entry points when the dynamic imports behind them go away. Until now the entry list only ever grew.

#### Problem

Two related gaps in the entry point handling of `merge`:

1. Stale `related_stmt_infos` rows. The old code removed a re-scanned importer's rows only when the scan output contained a matching entry point, keyed by the incoming rows. When a re-scanned module removed its dynamic import entirely, the scan output had no entry for the target at all, so the importer's old rows stayed behind and kept pointing at statement and node ids of a module version that no longer exists.
2. Zombie entries. When the last dynamic importer of a module disappeared, the `DynamicImport` entry point stayed in the cache forever. Every incremental rebuild kept emitting a chunk for a module nothing imports dynamically anymore, which a fresh full build of the same files would not produce.

#### Fix

- Before merging the incoming entry points, drop the rows of every re-scanned module from the cached dynamic import entries. The incoming entries then re-add exactly the rows that still exist. This subsumes the old incoming-keyed `extract_if`, which is removed.
- After merging, prune every `DynamicImport` entry whose module no longer has any dynamic edge in the `importers` edge list. The edge list is reliable at merge time since #10107 and #10110. Other entry kinds are untouched.
- The prune is intentionally not transitive on the cache: edges of orphaned importers survive in the edge list, so an entry only they point at stays cached, and re-adding an import of the orphan revives the entry without a re-scan. `ScanStageCache::create_output` compensates by filtering `DynamicImport` entries against module reachability (`compute_live_modules`, a BFS from the non dynamic entries), so only entries a live module dynamically imports produce chunks, matching a fresh build. This covers the transitive case: `main` imports `hub`, `hub` dynamically imports `lazy`, and dropping the `hub` import from `main` must also stop emitting the `lazy` chunk even though `hub` is never re-scanned.
- Partial scans no longer create a `DynamicImport` entry for a module that is a configured user entry. The scan local `user_defined_entry_ids` set is empty in partial mode, so the existing full scan filter never matched there, and a dynamic import of the entry module produced a second entry row (and a second chunk) for it.

#### Tests

- New fixture `hmr/remove_transitive_dynamic_import_entry`: `main` statically imports `hub`, `hub` dynamically imports `lazy`. Dropping the `hub` import from `main` removes the `lazy` chunk from the build output without re-scanning `hub`; re-adding it revives the chunk.
- New fixture `hmr/remove_dynamic_import_entry`: two modules dynamically import `lazy.js` and drop it one by one. After the first drop the entry survives through the remaining importer. After the second drop the `lazy.js` chunk disappears from the build output. Re-adding the import brings the entry and the chunk back.
- The state parity check from #10115 is tightened for this: `DynamicImport` entries now must match a fresh full build exactly while a live module imports them; an entry kept in the cache only by orphans' dynamic import records is tolerated, since `create_output` filters it from the output and it exists precisely to make revival cheap (other kinds still allow extras on the incremental side until orphan cleanup lands). Reintroducing the bug locally makes the parity check fail on the new fixture with "dynamic import entry only exists in the incremental state", so the whole HMR suite now guards this behavior.

#### Docs

The entry point step of the `merge` algorithm in `internal-docs/cache/implementation.md` is updated.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->


