### PR TITLE
feat: add `--configLoader=native` option

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -48,6 +48,18 @@ export default defineConfig((commandLineArgs) => {
 });
 ```
 
+### Config Loaders
+
+By default Rolldown loads a config file by bundling it with Rolldown first (`configLoader: 'bundle'`). This works on any supported runtime, including for TypeScript configs.
+
+If your runtime can import the config directly (Node.js 22.18+ (native TypeScript type stripping), Bun, Deno, or a loader registered via `--import` (e.g. `tsx`, `jiti`)), you can skip the bundling step with the `native` loader:
+
+```shell
+rolldown -c rolldown.config.ts --configLoader native
+```
+
+The `native` loader is more simple and is planned to be the default in the future.
+
 ### Config Intellisense
 
 Since Rolldown ships with TypeScript typings, you can leverage your IDE's intellisense with JSDoc type hints:
@@ -138,6 +150,13 @@ The flags listed below are only available via the command line interface.
 ### `-c, --config <filename>`
 
 Use the specified config file. If the argument is used but no filename is specified, Rolldown will look for a default config file. See [Configuration Files](#configuration-files) for more details.
+
+### `--configLoader <loader>`
+
+How to load the config file. One of:
+
+- `bundle` (default): bundle the config with Rolldown before importing it.
+- `native`: import the config directly, relying on the runtime for TypeScript and loader support. See [Config Loaders](#config-loaders).
 
 ### `-h` / `--help`
 

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -131,6 +131,7 @@
     "cac": "catalog:",
     "consola": "catalog:",
     "execa": "catalog:",
+    "fresh-import": "catalog:",
     "glob": "catalog:",
     "oxc-parser": "catalog:",
     "pathe": "catalog:",

--- a/packages/rolldown/src/cli/arguments/alias.ts
+++ b/packages/rolldown/src/cli/arguments/alias.ts
@@ -1,5 +1,6 @@
 import type { InputCliOptions } from '../../options/input-options';
 import type { OutputCliOptions } from '../../options/output-options';
+import type { ConfigLoader } from '../../utils/load-config';
 
 export interface CliOptions extends InputCliOptions, OutputCliOptions {
   config?: string | boolean;
@@ -7,6 +8,7 @@ export interface CliOptions extends InputCliOptions, OutputCliOptions {
   version?: boolean;
   watch?: boolean;
   environment?: string | string[];
+  configLoader?: ConfigLoader;
 }
 
 interface OptionConfig {
@@ -25,6 +27,9 @@ export const alias: Partial<Record<keyof CliOptions, OptionConfig>> = {
   config: {
     abbreviation: 'c',
     hint: 'filename',
+  },
+  configLoader: {
+    hint: 'loader',
   },
   help: {
     abbreviation: 'h',

--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -6,10 +6,11 @@ import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import { getInputCliKeys, getOutputCliKeys, validateCliOptions } from '../../utils/validator';
 import { logger } from '../logger';
+import type { ConfigLoader } from '../../utils/load-config';
 import type { CliOptions } from './alias';
 import { setNestedProperty } from './utils';
 
-const reservedKeys = new Set(['help', 'version', 'config', 'watch', 'environment']);
+const reservedKeys = new Set(['help', 'version', 'config', 'watch', 'environment', 'configLoader']);
 
 export interface NormalizedCliOptions {
   input: InputOptions;
@@ -19,6 +20,7 @@ export interface NormalizedCliOptions {
   version: boolean;
   watch: boolean;
   environment?: string | string[];
+  configLoader?: ConfigLoader;
 }
 
 export function normalizeCliOptions(
@@ -51,6 +53,10 @@ export function normalizeCliOptions(
 
   if (options.environment !== undefined) {
     result.environment = options.environment;
+  }
+
+  if (options.configLoader !== undefined) {
+    result.configLoader = options.configLoader;
   }
 
   const keysOfInput = new Set(getInputCliKeys());

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -22,7 +22,9 @@ export async function bundleWithConfig(
     process.env.ROLLDOWN_WATCH = 'true';
   }
 
-  const config = await loadConfig(configPath);
+  const config = await loadConfig(configPath, {
+    configLoader: cliOptions.configLoader,
+  });
   // If config is a function, call it with raw command line arguments
   const resolvedConfig = typeof config === 'function' ? await config(rawArgs) : config;
 

--- a/packages/rolldown/src/utils/load-config.ts
+++ b/packages/rolldown/src/utils/load-config.ts
@@ -126,18 +126,54 @@ function tryStatSync(file: string): fs.Stats | undefined {
   }
 }
 
+export type ConfigLoader = 'bundle' | 'native';
+
+export interface LoadConfigOptions {
+  /**
+   * How to load the config file.
+   * - `'bundle'` (default): bundle the config with Rolldown, then import it.
+   * - `'native'`: import the config directly, delegating TypeScript/loader
+   *   handling to the runtime. Faster, but requires runtime support.
+   *
+   * @default 'bundle'
+   */
+  configLoader?: ConfigLoader;
+}
+
+async function loadNativeConfig(resolvedPath: string): Promise<ConfigExport> {
+  const url = pathToFileURL(resolvedPath).href;
+  const { freshImport } = await import('fresh-import');
+  const freshImported = freshImport(url);
+  if (freshImported) {
+    const { result } = await freshImported;
+    return (result as { [Symbol.toStringTag]: 'Module'; default: ConfigExport }).default;
+  }
+  // Runtimes without Module-hook support (e.g. Bun/Deno)
+  const mod = await import(url + '?t=' + Date.now());
+  return mod.default;
+}
+
 /**
  * Load config from a file in a way that Rolldown does.
  *
  * @param configPath The path to the config file. If empty, it will look for `rolldown.config` with supported extensions in the current working directory.
+ * @param options Loading options. `configLoader` selects `'bundle'` (default) or `'native'`.
  * @returns The loaded config export
  *
  * @category Config
  */
-export async function loadConfig(configPath: string): Promise<ConfigExport> {
+export async function loadConfig(
+  configPath: string,
+  options: LoadConfigOptions = {},
+): Promise<ConfigExport> {
+  const configLoader = options.configLoader ?? 'bundle';
   const ext = path.extname((configPath = configPath || (await findConfigFileNameInCwd())));
 
   try {
+    if (configLoader === 'native') {
+      return await loadNativeConfig(path.resolve(configPath));
+    }
+
     if (
       SUPPORTED_JS_CONFIG_FORMATS.includes(ext) ||
       (process.env.NODE_OPTIONS?.includes('--import=tsx') &&
@@ -155,6 +191,18 @@ export async function loadConfig(configPath: string): Promise<ConfigExport> {
       );
     }
   } catch (err) {
+    if (configLoader === 'native') {
+      const isTsConfig = SUPPORTED_TS_CONFIG_FORMATS.includes(ext);
+      const tsHint =
+        isTsConfig && !process.features.typescript
+          ? ' This runtime does not natively support TypeScript config files.'
+          : '';
+      throw new Error(
+        `Failed to load the config file "${configPath}" using the "native" config loader.${tsHint} ` +
+          `Try "--configLoader bundle", or register a loader such as "--import tsx".`,
+        { cause: err },
+      );
+    }
     throw new Error('Error happened while loading config.', { cause: err });
   }
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -1097,6 +1097,10 @@ const CliOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Watch files in bundle and rebuild on changes'),
   ),
+  configLoader: v.pipe(
+    v.optional(v.union([v.literal('bundle'), v.literal('native')])),
+    v.description('How to load the config file (bundle, native)'),
+  ),
   ...InputCliOptionsSchema.entries,
   ...OutputCliOptionsSchema.entries,
 });

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -51,6 +51,7 @@ OPTIONS
   --cleanDir                  Clean output directory before emitting output.
   --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
   --comments <comments>       Control comments in the output.
+  --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
   --cwd <cwd>                 Current working directory.
   --devtools.sessionId <devtools.sessionId>Used to name the build.
@@ -198,6 +199,7 @@ OPTIONS
   --cleanDir                  Clean output directory before emitting output.
   --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
   --comments <comments>       Control comments in the output.
+  --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
   --cwd <cwd>                 Current working directory.
   --devtools.sessionId <devtools.sessionId>Used to name the build.
@@ -345,6 +347,7 @@ OPTIONS
   --cleanDir                  Clean output directory before emitting output.
   --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
   --comments <comments>       Control comments in the output.
+  --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
   --cwd <cwd>                 Current working directory.
   --devtools.sessionId <devtools.sessionId>Used to name the build.
@@ -492,6 +495,7 @@ OPTIONS
   --cleanDir                  Clean output directory before emitting output.
   --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
   --comments <comments>       Control comments in the output.
+  --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
   --cwd <cwd>                 Current working directory.
   --devtools.sessionId <devtools.sessionId>Used to name the build.
@@ -773,6 +777,18 @@ exports[`config > should allow multiply output 1`] = `
 
 exports[`config > should bundle in ext-js-syntax-cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
+
+"
+`;
+
+exports[`config > should load config with --configLoader native (mjs) 1`] = `
+"<DIR>/index.js  chunk │ size: 0.11 kB
+
+"
+`;
+
+exports[`config > should load ts config with --configLoader native 1`] = `
+"<DIR>/index.js  chunk │ size: 0.11 kB
 
 "
 `;

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -478,6 +478,27 @@ describe('config', () => {
     expect(content).not.toContain('export {');
   });
 
+  it('should load config with --configLoader native (mjs)', async () => {
+    const cwd = cliFixturesDir('ext-mjs');
+    const status = await $({
+      cwd,
+    })`rolldown -c rolldown.config.mjs --configLoader native`;
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+  });
+
+  it.runIf(process.features.typescript)(
+    'should load ts config with --configLoader native',
+    async () => {
+      const cwd = cliFixturesDir('ext-ts');
+      const status = await $({
+        cwd,
+      })`rolldown -c rolldown.config.ts --configLoader native`;
+      expect(status.exitCode).toBe(0);
+      expect(cleanStdout(status.stdout)).toMatchSnapshot();
+    },
+  );
+
   it('should handle `-c -w` without `-w` being consumed as config filename (#3248)', async () => {
     const cwd = cliFixturesDir('cli-config-with-watch');
     const controller = new AbortController();

--- a/packages/rolldown/tests/utils/fixtures/load-config/native.config.mjs
+++ b/packages/rolldown/tests/utils/fixtures/load-config/native.config.mjs
@@ -1,0 +1,1 @@
+export default { input: './entry.js' };

--- a/packages/rolldown/tests/utils/fixtures/load-config/throws.config.mjs
+++ b/packages/rolldown/tests/utils/fixtures/load-config/throws.config.mjs
@@ -1,0 +1,1 @@
+throw new Error('boom from config');

--- a/packages/rolldown/tests/utils/load-config.test.ts
+++ b/packages/rolldown/tests/utils/load-config.test.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import { loadConfig } from 'rolldown/config';
+import { describe, expect, it } from 'vitest';
+
+const fixtures = path.join(import.meta.dirname, 'fixtures', 'load-config');
+
+describe('loadConfig native configLoader', () => {
+  it('loads an mjs config via the native loader', async () => {
+    const config = await loadConfig(path.join(fixtures, 'native.config.mjs'), {
+      configLoader: 'native',
+    });
+    expect(config).toStrictEqual({ input: './entry.js' });
+  });
+
+  it('wraps native load failures with a helpful hint and preserves the cause', async () => {
+    await expect(
+      loadConfig(path.join(fixtures, 'throws.config.mjs'), {
+        configLoader: 'native',
+      }),
+    ).rejects.toThrow(/native.*config loader/i);
+
+    try {
+      await loadConfig(path.join(fixtures, 'throws.config.mjs'), {
+        configLoader: 'native',
+      });
+      expect.unreachable();
+    } catch (err) {
+      const cause = (err as { cause?: Error }).cause;
+      expect(cause?.message).toContain('boom from config');
+    }
+  });
+
+  it('defaults to the bundle loader when no option is passed', async () => {
+    const config = await loadConfig(path.join(fixtures, 'native.config.mjs'));
+    expect(config).toStrictEqual({ input: './entry.js' });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ catalogs:
     follow-redirects:
       specifier: ^1.15.6
       version: 1.16.0
+    fresh-import:
+      specifier: ^0.2.1
+      version: 0.2.1
     fs-extra:
       specifier: ^11.3.2
       version: 11.3.5
@@ -558,6 +561,9 @@ importers:
       execa:
         specifier: 'catalog:'
         version: 9.6.1
+      fresh-import:
+        specifier: 'catalog:'
+        version: 0.2.1
       glob:
         specifier: 'catalog:'
         version: 13.0.6
@@ -6208,6 +6214,10 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  fresh-import@0.2.1:
+    resolution: {integrity: sha512-fwvkgwvZ60xFe0FQ5nynh9mgayR5HY0e0rzPs2cDiGhrOo7N8ARyMHP0Ew7bUFe7QAaZmouphLnCoJKAe6dTog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -12720,6 +12730,8 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  fresh-import@0.2.1: {}
 
   fresh@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,7 @@ catalog:
   fast-glob: ^3.3.3
   fixturify: ^3.0.0
   follow-redirects: ^1.15.6
+  fresh-import: ^0.2.1
   fs-extra: ^11.3.2
   glob: ^13.0.0
   lodash-es: ^4.17.21


### PR DESCRIPTION
This PR introduces `--configLoader=native.`This feature is aligned with the `--configLoader=native` feature in Vite which is planned to be the default in the future.



close https://github.com/rolldown/rolldown/issues/8757