### PR TITLE
chore: remove dead BuildDiagnostic::downcast_ref method

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -118,11 +118,6 @@ impl BuildDiagnostic {
     self.inner.as_napi_error().ok_or(self)
   }
 
-  /// Attempt to downcast the inner event to a specific type.
-  pub fn downcast_ref<T: 'static + BuildEvent>(&self) -> Option<&T> {
-    self.inner.as_any().downcast_ref()
-  }
-
   /// Attempt to downcast the inner event to a specific type (mutable).
   pub fn downcast_mut<T: 'static + BuildEvent>(&mut self) -> Option<&mut T> {
     self.inner.as_any_mut().downcast_mut()


### PR DESCRIPTION
### What

Removes the `BuildDiagnostic::downcast_ref` method from `rolldown_error`.

### Why

The method has no callers anywhere in the workspace. The `downcast_ref` calls that do exist (in `napi_error.rs` and `plugin_error.rs`) are `anyhow::Error::downcast_ref`, downcasting an `anyhow::Error` into `napi::Error` or `BuildDiagnostic`, not this method. The sibling `downcast_mut` is still used (by the module loader) and stays.
