### PR TITLE
chore: remove dead LazyCompilationContext::is_lazy_module method

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -23,11 +23,6 @@ pub struct LazyCompilationContext {
 }
 
 impl LazyCompilationContext {
-  /// Check if a module is a lazy module
-  pub fn is_lazy_module(&self, module_id: &str) -> bool {
-    self.lazy_entries.contains(module_id)
-  }
-
   /// Mark a proxy module as fetched. This changes the content returned by the load hook
   /// from a stub (fetches via /lazy endpoint) to actual code that imports the real module.
   pub fn mark_as_fetched(&self, proxy_module_id: &str) {


### PR DESCRIPTION
### What

Removes the `LazyCompilationContext::is_lazy_module` method from `rolldown_plugin_lazy_compilation`.

### Why

The method has no callers anywhere in the workspace. It is a dead `pub fn` on the context shared between the plugin and the dev engine. The sibling `mark_as_fetched` on the same impl is still used and stays.