### PR TITLE
chore: remove dead CopyModulePlugin::is_active method

### DIFF
--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -31,10 +31,6 @@ impl CopyModulePlugin {
     }
     Self { copy_extensions }
   }
-
-  pub fn is_active(&self) -> bool {
-    !self.copy_extensions.is_empty()
-  }
 }
 
 impl Plugin for CopyModulePlugin {


### PR DESCRIPTION
### What

Removes the `CopyModulePlugin::is_active` method from `rolldown_plugin_copy_module`.

### Why

The method has no callers anywhere in the workspace. The plugin is registered unconditionally in `apply_inner_plugins`, and the `resolve_id` hook does its own inline `self.copy_extensions.is_empty()` check rather than going through `is_active`, so the method is dead.