### PR TITLE
chore: remove dead CSS/HTML cache structs from plugin utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,9 +2933,7 @@ dependencies = [
  "regex",
  "rolldown_common",
  "rolldown_plugin",
- "rolldown_sourcemap",
  "rolldown_utils",
- "rustc-hash",
  "serde_json",
  "sugar_path",
 ]

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -29,8 +29,6 @@ percent-encoding = { workspace = true }
 regex = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_sourcemap = { workspace = true }
 rolldown_utils = { workspace = true }
-rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/constants.rs
+++ b/crates/rolldown_plugin_utils/src/constants.rs
@@ -2,10 +2,8 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 
-use rolldown_common::OutputChunk;
 use rolldown_plugin::typedmap::TypedMapKey;
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
-use rustc_hash::FxHashMap;
 
 // Use `10kB` as a threshold for 'auto'
 // https://v8.dev/blog/cost-of-javascript-2019#json
@@ -27,7 +25,6 @@ impl TypedMapKey for ViteImportGlob {
 
 #[derive(Debug, Default)]
 pub struct ChunkMetadata {
-  pub imported_css: FxDashSet<ArcStr>,
   pub imported_assets: FxDashSet<ArcStr>,
 }
 
@@ -40,62 +37,4 @@ impl ViteMetadata {
   pub fn get(&self, key: ArcStr) -> Arc<ChunkMetadata> {
     self.inner.entry(key).or_default().clone()
   }
-}
-
-#[derive(Debug, Default)]
-pub struct CSSEntriesCache {
-  pub inner: FxDashMap<ArcStr, ArcStr>,
-}
-
-#[derive(Debug, Default)]
-pub struct CSSModuleCache {
-  pub inner: FxDashMap<String, FxHashMap<String, String>>,
-}
-
-#[derive(Debug, Default)]
-pub struct HTMLProxyResult {
-  pub inner: FxDashMap<String, String>,
-}
-
-#[derive(Debug, Default)]
-pub struct HTMLProxyMapItem {
-  pub code: ArcStr,
-  pub map: Option<rolldown_sourcemap::SourceMap>,
-}
-
-#[derive(Debug, Default)]
-pub struct HTMLProxyMap {
-  pub inner: FxDashMap<String, FxDashMap<usize, HTMLProxyMapItem>>,
-}
-
-#[derive(Debug, Default)]
-pub struct CSSStyles {
-  pub inner: FxDashMap<String, String>,
-}
-
-#[derive(Debug, Default)]
-pub struct PureCSSChunks {
-  pub inner: FxDashSet<ArcStr>,
-}
-
-#[derive(Debug, Default)]
-pub struct CSSChunkCache {
-  pub inner: FxDashMap<ArcStr, String>,
-}
-
-#[derive(Debug, Default)]
-pub struct CSSBundleName(pub String);
-
-#[derive(Debug, Default)]
-pub struct RemovedPureCSSFilesCache {
-  pub inner: FxDashMap<ArcStr, Arc<OutputChunk>>,
-}
-
-#[derive(Debug, Default)]
-pub struct CSSUrlCache {
-  pub inner: FxDashMap<String, String>,
-}
-
-pub struct CSSScopeToMap {
-  pub inner: FxHashMap<String, (String, Option<String>)>,
 }


### PR DESCRIPTION
### What

Removes the leftover CSS/HTML cache structs from `rolldown_plugin_utils/src/constants.rs` and the unused `imported_css` field on `ChunkMetadata`:

- `CSSEntriesCache`, `CSSModuleCache`, `CSSStyles`, `PureCSSChunks`, `CSSChunkCache`, `CSSBundleName`, `RemovedPureCSSFilesCache`, `CSSUrlCache`, `CSSScopeToMap`
- `HTMLProxyResult`, `HTMLProxyMapItem`, `HTMLProxyMap`
- `ChunkMetadata::imported_css`

Also drops the now-orphaned `rolldown_common::OutputChunk` and `rustc_hash::FxHashMap` imports.

### Why

These structs and the `imported_css` field are leftovers from CSS bundling, which was dropped. None of them are referenced anywhere in the workspace. The sibling `imported_assets` field is still used (by `render_asset_url_in_js`), so `ChunkMetadata` stays, and `ViteMetadata` / `ViteImportGlob` / `THRESHOLD_SIZE` are untouched.
