### PR TITLE
perf: return impl ExactSizeIterator from slice-backed accessors

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -50,7 +50,7 @@ impl ChunkGraph {
   }
 
   #[expect(unused)]
-  pub fn sorted_chunks(&self) -> impl Iterator<Item = &Chunk> {
+  pub fn sorted_chunks(&self) -> impl ExactSizeIterator<Item = &Chunk> {
     self.sorted_chunk_idx_vec.iter().map(move |&id| &self.chunk_table.chunks[id])
   }
 

--- a/crates/rolldown_common/src/generated/runtime_helper.rs
+++ b/crates/rolldown_common/src/generated/runtime_helper.rs
@@ -52,7 +52,7 @@ impl DependedRuntimeHelperMap {
   }
 
   /// Iterate over `(single-bit helper, &statements)` pairs for each defined `RuntimeHelper` bit.
-  pub fn iter(&self) -> impl Iterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
+  pub fn iter(&self) -> impl ExactSizeIterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
     self.0.iter().enumerate().map(|(i, v)| {
       // `i` is always within `0..RUNTIME_HELPER_NAMES.len()`, matching a defined single-bit flag.
       (RuntimeHelper::from_bits_truncate(1 << i), v)

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -93,7 +93,7 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
     }
   }
 
-  pub fn iter(&self) -> impl Iterator<Item = &T> {
+  pub fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
     match self {
       HybridIndexVec::IndexVec(index_vec) => itertools::Either::Left(index_vec.iter()),
       HybridIndexVec::Map(hash_map) => itertools::Either::Right(hash_map.values()),

--- a/crates/rolldown_common/src/types/scan_mode.rs
+++ b/crates/rolldown_common/src/types/scan_mode.rs
@@ -16,7 +16,7 @@ impl<T> ScanMode<T> {
     matches!(self, Self::Full)
   }
 
-  pub fn iter(&self) -> impl Iterator<Item = &T> {
+  pub fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
     match self {
       ScanMode::Full => Either::Left(std::iter::empty()),
       ScanMode::Partial(ids) => Either::Right(ids.iter()),

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -93,7 +93,7 @@ impl StmtInfos {
 
   pub fn iter_enumerated_without_namespace_stmt(
     &self,
-  ) -> impl Iterator<Item = (StmtInfoIdx, &StmtInfo)> {
+  ) -> impl ExactSizeIterator<Item = (StmtInfoIdx, &StmtInfo)> {
     self.infos.iter_enumerated().skip(1)
   }
 

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -87,7 +87,8 @@ impl PluginDriver {
   pub fn iter_plugin_with_context_by_order<'me>(
     &'me self,
     ordered_plugins: &'me [PluginIdx],
-  ) -> impl Iterator<Item = (PluginIdx, &'me SharedPluginable, &'me PluginContext)> + 'me {
+  ) -> impl ExactSizeIterator<Item = (PluginIdx, &'me SharedPluginable, &'me PluginContext)> + 'me
+  {
     ordered_plugins.iter().copied().map(move |idx| {
       let plugin = &self.plugins[idx];
       let context = &self.contexts[idx];

--- a/tasks/generator/src/generators/runtime_helper.rs
+++ b/tasks/generator/src/generators/runtime_helper.rs
@@ -98,7 +98,7 @@ impl DependedRuntimeHelperMap {
   }
 
   /// Iterate over `(single-bit helper, &statements)` pairs for each defined `RuntimeHelper` bit.
-  pub fn iter(&self) -> impl Iterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
+  pub fn iter(&self) -> impl ExactSizeIterator<Item = (RuntimeHelper, &Vec<StmtInfoIdx>)> {
     self.0.iter().enumerate().map(|(i, v)| {
       // `i` is always within `0..RUNTIME_HELPER_NAMES.len()`, matching a defined single-bit flag.
       (RuntimeHelper::from_bits_truncate(1 << i), v)


### PR DESCRIPTION
These accessors are already `ExactSizeIterator` internally — the `impl Iterator` return type just erased it. Widening to `impl ExactSizeIterator` lets callers pre-size collections from the known length (`Vec::with_capacity(iter.len())`) instead of growing through reallocs, and lets them call `.len()` directly. Backward-compatible: `ExactSizeIterator: Iterator`, so existing callers are unaffected.

| accessor | backing |
|---|---|
| `ChunkGraph::sorted_chunks` | `Vec<ChunkIdx>::iter().map(..)` |
| `PluginDriver::iter_plugin_with_context_by_order` | `&[PluginIdx]::iter().copied().map(..)` |
| `StmtInfos::iter_enumerated_without_namespace_stmt` | `IndexVec::iter_enumerated().skip(1)` (`Skip` preserves the exact len) |
| `HybridIndexVec::iter` | `Either<IndexVec::iter(), FxHashMap::values()>` (both arms `ExactSizeIterator`) |
| `ScanMode::iter` | `Either<iter::empty(), slice::iter()>` (both arms `ExactSizeIterator`) |
| `DependedRuntimeHelperMap::iter` | `[Vec<_>; N]::iter().enumerate().map(..)` |

The rest of the crate's `impl Iterator` accessors are correctly left alone — they use `filter_map` / `flat_map` / custom iterators that erase the length.

Same idea as oxc-project/oxc#24144.
