### PR TITLE
fix(cli): parse codeSplitting boolean strings

### DIFF
--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -90,6 +90,16 @@ function camelizeNestedKeys(value: Record<string, any>): Record<string, any> {
   return result;
 }
 
+function coerceStringBoolean(value: unknown): unknown {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return value;
+}
+
 export function parseCliArguments(): NormalizedCliOptions & {
   rawArgs: Record<string, any>;
 } {
@@ -212,6 +222,14 @@ export function parseCliArguments(): NormalizedCliOptions & {
     } else if (type === 'array' && typeof value === 'string') {
       parsedOptions[key] = [value];
     }
+  }
+
+  // `codeSplitting` accepts either a boolean or an object. Since it is registered
+  // with cac as a value-taking option, `--codeSplitting false` and
+  // `--codeSplitting=false` arrive as strings and need the same boolean coercion
+  // as boolean-only CLI flags before validation.
+  if ('codeSplitting' in parsedOptions) {
+    parsedOptions.codeSplitting = coerceStringBoolean(parsedOptions.codeSplitting);
   }
 
   // Object option parsing — parse "key:val,key:val" strings (Rollup-compatible)

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -194,6 +194,25 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
+  it('should parse codeSplitting boolean string values', async () => {
+    const cwd = cliFixturesDir('cli-code-splitting-false');
+    const distDir = path.join(cwd, 'dist');
+
+    fs.rmSync(distDir, { recursive: true, force: true });
+    const spaceSeparated = await $({
+      cwd,
+    })`rolldown index.js --codeSplitting false --format esm --platform node --file dist/space.js`;
+    expect(spaceSeparated.exitCode).toBe(0);
+    expect(fs.readdirSync(distDir).filter((file) => file.endsWith('.js'))).toEqual(['space.js']);
+
+    fs.rmSync(distDir, { recursive: true, force: true });
+    const equalsSeparated = await $({
+      cwd,
+    })`rolldown index.js --codeSplitting=false --format esm --platform node --file dist/equals.js`;
+    expect(equalsSeparated.exitCode).toBe(0);
+    expect(fs.readdirSync(distDir).filter((file) => file.endsWith('.js'))).toEqual(['equals.js']);
+  });
+
   it('should handle pass `-s` options in any position', async () => {
     const cwd = cliFixturesDir('cli-option-sourcemap');
     const status = await $({ cwd })`rolldown index.ts -s -d dist`;

--- a/packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/dep.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/dep.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/index.js
@@ -1,0 +1,3 @@
+export async function load() {
+  return import('./dep.js');
+}


### PR DESCRIPTION
Fixes #10125.

### Summary

- Coerce `--codeSplitting true/false` string values from the CLI into booleans before validation.
- Add a CLI e2e fixture covering both `--codeSplitting false` and `--codeSplitting=false` with dynamic imports.

### Tests

- `vp fmt --check packages/rolldown/src/cli/arguments/index.ts packages/rolldown/tests/cli/cli-e2e.test.ts packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/index.js packages/rolldown/tests/cli/fixtures/cli-code-splitting-false/dep.js`
- `vp run --filter rolldown-tests test:cli -t 'codeSplitting boolean string values'`

### AI disclosure

I used an AI assistant to help prepare this change, and I reviewed and tested the result.
