### PR TITLE
refactor: type construct_vite_preload_call to take an ObjectPattern

### DIFF
--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -61,7 +61,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       *await_expr = Expression::AwaitExpression(AwaitExpression::boxed(
         SPAN,
         self.construct_vite_preload_call(
-          BindingPattern::ObjectPattern(ObjectPattern::boxed(
+          ObjectPattern::boxed(
             SPAN,
             oxc::allocator::Vec::from_value_in(
               BindingProperty::new(
@@ -76,7 +76,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
             ),
             NONE,
             &self.ast_factory,
-          )),
+          ),
           await_expr.take_in(&self.ast_factory.allocator()),
         ),
         &self.ast_factory,
@@ -110,21 +110,21 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         Argument::FunctionExpression(func) => &func.params,
         _ => return None,
       };
-      let first_param = params.items.first()?;
-      if matches!(&first_param.pattern, BindingPattern::ObjectPattern(_)) {
-        Some(first_param.pattern.clone_in(self.ast_factory.allocator()))
-      } else {
-        None
+      match &params.items.first()?.pattern {
+        BindingPattern::ObjectPattern(object_pat) => {
+          Some(object_pat.clone_in(self.ast_factory.allocator()))
+        }
+        _ => None,
       }
     });
-    if let Some(binding_pat) = destructuring_pat {
+    if let Some(object_pat) = destructuring_pat {
       // For destructuring: replace only the import() in the callee with __vitePreload(...)
       // keeping the .then() call on the outside
       let Expression::StaticMemberExpression(callee) = &mut call_expr.callee else {
         unreachable!();
       };
       callee.object = self.construct_vite_preload_call(
-        binding_pat,
+        object_pat,
         Expression::new_await_expression(
           SPAN,
           callee.object.take_in(&self.ast_factory.allocator()),
@@ -155,16 +155,11 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
   pub fn construct_vite_preload_call(
     &self,
-    binding_pat: BindingPattern<'a>,
+    object_pat: oxc::allocator::Box<'a, ObjectPattern<'a>>,
     await_expr: Expression<'a>,
   ) -> Expression<'a> {
-    let argument = if let BindingPattern::BindingIdentifier(_) = binding_pat {
-      let Expression::AwaitExpression(expr) = await_expr else {
-        unreachable!("The `await_expr` must be `Expression::AwaitExpression`.")
-      };
-      self.ast_factory.make_arrow_returning(expr.unbox().argument)
-    } else {
-      Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
+    self.vite_preload_call(Argument::from(Expression::ArrowFunctionExpression(
+      ArrowFunctionExpression::boxed(
         SPAN,
         false,
         true,
@@ -190,7 +185,9 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
                   VariableDeclarator::new(
                     SPAN,
                     VariableDeclarationKind::Const,
-                    binding_pat.clone_in(self.ast_factory.allocator()),
+                    BindingPattern::ObjectPattern(
+                      object_pat.clone_in(self.ast_factory.allocator()),
+                    ),
                     NONE,
                     Some(await_expr),
                     false,
@@ -204,7 +201,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
             )));
             statements.push(Statement::ReturnStatement(ReturnStatement::boxed(
               SPAN,
-              Some(binding_pat.into_expression(&self.ast_factory)),
+              Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_factory)),
               &self.ast_factory,
             )));
             statements
@@ -212,9 +209,8 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           &self.ast_factory,
         ),
         &self.ast_factory,
-      ))
-    };
-    self.vite_preload_call(Argument::from(argument))
+      ),
+    )))
   }
 
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -79,7 +79,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_variable_declaration(&mut self, decl: &mut VariableDeclaration<'a>) {
     if self.insert_preload {
       for decl in &mut decl.declarations {
-        if matches!(decl.id, BindingPattern::ObjectPattern(_))
+        if let BindingPattern::ObjectPattern(object_pat) = &decl.id
           && matches!(
             &decl.init,
             Some(Expression::AwaitExpression(expr)) if matches!(expr.argument, Expression::ImportExpression(_))
@@ -88,7 +88,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
           decl.init = Some(Expression::new_await_expression(
             SPAN,
             self.construct_vite_preload_call(
-              decl.id.clone_in(self.ast_factory.allocator()),
+              object_pat.clone_in(self.ast_factory.allocator()),
               decl.init.take().unwrap(),
             ),
             &self.ast_factory,


### PR DESCRIPTION
### What

Changes `BuildImportAnalysisVisitor::construct_vite_preload_call` to take `Box<ObjectPattern>` instead of a generic `BindingPattern`, and updates its three callers to pass the `ObjectPattern` directly.

Inside the function, the value is wrapped back into `BindingPattern::ObjectPattern(..)` at the two spots that need a `BindingPattern` (the `const { .. } = await import()` declarator and the `return { .. }` expression).

### Why

`construct_vite_preload_call` had a `BindingPattern::BindingIdentifier` branch that was never reached. All three callers only ever pass an object pattern:

- `rewrite_member_expr` builds an `ObjectPattern` inline
- `rewrite_call_expr` only proceeds when the `.then()` callback's first parameter is an `ObjectPattern`
- `visit_variable_declaration` only proceeds when the declarator id is an `ObjectPattern`

Since `ast_utils` and `ast_visit` are private modules, the method is not reachable from outside the crate, so those three are the complete set of callers and the identifier branch was dead.

Rather than deleting the dead branch and keeping the loose `BindingPattern` parameter, encoding the `ObjectPattern` invariant in the signature removes the branch by construction and lets the callers drop their now-redundant `matches!` guards and whole-pattern clones.

### Verification

- `cargo check` / `cargo clippy --deny warnings` / `cargo fmt --all --check`
- `just build-rolldown` rebuilds the `.node` binding; `tsc` passes
- The `build-import-analysis` fixtures (destructuring, member access, nested import, complex syntax, and so on) all pass with zero snapshot drift, confirming the generated transform output is unchanged
