### PR TITLE
feat: add experimental persistent transform cache (experimental.transformCache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ecmascript",
  "oxc_index",
+ "oxc_sourcemap",
  "oxc_str",
  "oxc_traverse",
  "petgraph",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -34,6 +34,7 @@ oxc = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
+oxc_sourcemap = { workspace = true }
 oxc_str = { workspace = true }
 oxc_traverse = { workspace = true }
 petgraph = { workspace = true }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -34,6 +34,7 @@ use tracing::Instrument;
 use crate::module_loader::module_task::ModuleTaskOwner;
 use crate::types::scan_stage_cache::ScanStageCache;
 use crate::utils::load_entry_module::load_entry_module;
+use crate::utils::transform_cache::TransformCache;
 use crate::{SharedOptions, SharedResolver};
 
 use super::external_module_task::ExternalModuleTask;
@@ -190,13 +191,19 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       },
     };
 
+    // The native magic-string path generates transform sourcemaps outside the
+    // module task, so cache entries could not capture them; bypass the cache.
+    let transform_cache =
+      if magic_string_tx.is_none() { TransformCache::new(&options, &plugin_driver) } else { None };
+
     // Unbounded as defense in depth. If any sender ends up driven from a sync
     // napi binding through `block_on`, a bounded channel could deadlock: the
     // send future would wait on capacity that only the consumer can free, but
     // the consumer may need the JS thread — pinned by `block_on` — to run
     // plugin hooks first. Keeping the channel unbounded removes that edge.
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let shared_context = Arc::new(TaskContext { options, tx, resolver, fs, plugin_driver, meta });
+    let shared_context =
+      Arc::new(TaskContext { options, tx, resolver, fs, plugin_driver, meta, transform_cache });
 
     let importers = std::mem::take(&mut cache.importers);
     let intermediate_normal_modules = IntermediateNormalModules::new(is_full_scan, importers);

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -6,7 +6,7 @@ use oxc::span::Span;
 use rolldown_common::{
   ExportsKind, FlatOptions, ImportKind, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ModuleType,
   NormalModule, NormalModuleTaskResult, ResolvedId, SourceMapGenMsg, SourcemapChainElement,
-  StrOrBytes, try_extract_lazy_barrel_info,
+  StrOrBytes, side_effects::HookSideEffects, try_extract_lazy_barrel_info,
 };
 use rolldown_error::{
   BuildDiagnostic, BuildResult, DiagnosticOptions, EventKindSwitcher, UnloadableDependencyContext,
@@ -19,7 +19,9 @@ use rolldown_fs::FileSystem;
 use crate::{
   ecmascript::ecma_module_view_factory::{CreateEcmaViewReturn, create_ecma_view},
   types::module_factory::{CreateModuleContext, CreateModuleViewArgs},
-  utils::{load_source::load_source, transform_source::transform_source},
+  utils::{
+    load_source::load_source, transform_cache::TransformCache, transform_source::transform_source,
+  },
 };
 
 use super::{resolve_utils::resolve_dependencies, task_context::TaskContext};
@@ -284,18 +286,32 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     let source = match source {
       _ if self.resolved_id.id.starts_with("rolldown:") => source,
       StrOrBytes::Str(source) => {
-        // Run plugin transform.
-        let source = transform_source(
-          &self.ctx.plugin_driver,
-          &self.resolved_id,
-          self.module_idx,
-          source,
-          sourcemap_chain,
-          hook_side_effects,
-          &mut module_type,
-          magic_string_tx,
-        )
-        .await?;
+        // Run plugin transform, backed by the persistent transform cache when
+        // `experimental.transformCache` is enabled.
+        let source = if let Some(cache) = &self.ctx.transform_cache {
+          self
+            .transform_source_with_cache(
+              cache,
+              source,
+              sourcemap_chain,
+              hook_side_effects,
+              &mut module_type,
+              magic_string_tx,
+            )
+            .await?
+        } else {
+          transform_source(
+            &self.ctx.plugin_driver,
+            &self.resolved_id,
+            self.module_idx,
+            source,
+            sourcemap_chain,
+            hook_side_effects,
+            &mut module_type,
+            magic_string_tx,
+          )
+          .await?
+        };
         source.into()
       }
       StrOrBytes::Bytes(_) => source,
@@ -310,5 +326,64 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       ))?;
     }
     Ok((source, module_type))
+  }
+
+  /// Runs the plugin transform pipeline through the persistent transform
+  /// cache: a hit restores the transformed code, module type, side effects and
+  /// transform sourcemap chain without calling any transform hook; a miss runs
+  /// the pipeline and stores its result.
+  /// See internal-docs/transform-cache/implementation.md.
+  #[expect(clippy::too_many_arguments)]
+  async fn transform_source_with_cache(
+    &self,
+    cache: &TransformCache,
+    source: String,
+    sourcemap_chain: &mut Vec<SourcemapChainElement>,
+    hook_side_effects: &mut Option<HookSideEffects>,
+    module_type: &mut ModuleType,
+    magic_string_tx: Option<std::sync::mpsc::Sender<SourceMapGenMsg>>,
+  ) -> anyhow::Result<String> {
+    let stable_id = self.resolved_id.id.stabilize(&self.ctx.options.cwd);
+    let key = cache.cache_key(stable_id.as_arc_str(), module_type, &source);
+
+    if let Some(hit) = cache.get(&key).await {
+      sourcemap_chain.extend(hit.sourcemap_chain);
+      if hit.side_effects.is_some() {
+        *hook_side_effects = hit.side_effects;
+      }
+      *module_type = hit.module_type;
+      return Ok(hit.code);
+    }
+
+    let chain_len_before_transform = sourcemap_chain.len();
+    let side_effects_before_transform = *hook_side_effects;
+    let transformed = transform_source(
+      &self.ctx.plugin_driver,
+      &self.resolved_id,
+      self.module_idx,
+      source,
+      sourcemap_chain,
+      hook_side_effects,
+      module_type,
+      magic_string_tx,
+    )
+    .await?;
+
+    // Side effects may already be set before the transform pipeline (from
+    // resolution data outside the cache key), so only the transform's own
+    // override is stored; storing the pre-existing value would replay stale
+    // resolution data on later hits.
+    let side_effects_override =
+      if *hook_side_effects == side_effects_before_transform { None } else { *hook_side_effects };
+    cache
+      .set(
+        &key,
+        &transformed,
+        module_type,
+        side_effects_override,
+        &sourcemap_chain[chain_len_before_transform..],
+      )
+      .await;
+    Ok(transformed)
   }
 }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -333,7 +333,6 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
   /// transform sourcemap chain without calling any transform hook; a miss runs
   /// the pipeline and stores its result.
   /// See internal-docs/transform-cache/implementation.md.
-  #[expect(clippy::too_many_arguments)]
   async fn transform_source_with_cache(
     &self,
     cache: &TransformCache,

--- a/crates/rolldown/src/module_loader/task_context.rs
+++ b/crates/rolldown/src/module_loader/task_context.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use oxc::transformer_plugins::ReplaceGlobalDefinesConfig;
 use rolldown_common::ModuleLoaderMsg;
 use rolldown_fs::FileSystem;
 use rolldown_plugin::SharedPluginDriver;
 
+use crate::utils::transform_cache::TransformCache;
 use crate::{SharedOptions, SharedResolver};
 
 /// Used to store common data shared between all tasks.
@@ -13,6 +16,7 @@ pub struct TaskContext<Fs: FileSystem> {
   pub fs: Fs,
   pub plugin_driver: SharedPluginDriver,
   pub meta: TaskContextMeta,
+  pub transform_cache: Option<Arc<TransformCache>>,
 }
 
 pub struct TaskContextMeta {

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub mod render_chunks;
 pub mod render_ecma_module;
 pub mod resolve_id;
 pub mod shebang;
+pub mod transform_cache;
 pub mod transform_source;
 pub mod tweak_ast_for_scanning;
 pub mod uuid;

--- a/crates/rolldown/src/utils/transform_cache.rs
+++ b/crates/rolldown/src/utils/transform_cache.rs
@@ -1,0 +1,305 @@
+//! Persistent (filesystem) cache for per-module transform results.
+//!
+//! See `internal-docs/transform-cache/design.md` for the rationale and
+//! `internal-docs/transform-cache/implementation.md` for the data flow.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arcstr::ArcStr;
+use rolldown_common::{
+  ModuleType, NormalizedBundlerOptions, PluginIdx, SourcemapChainElement,
+  side_effects::HookSideEffects,
+};
+use rolldown_plugin::PluginDriver;
+use rolldown_utils::xxhash::xxhash_with_base;
+
+/// Bump whenever the on-disk entry layout changes. Mixed into the cache salt,
+/// so old entries simply stop matching instead of failing to decode.
+const FORMAT_VERSION: u8 = 1;
+const MAGIC: [u8; 4] = *b"RDTC";
+const HEADER_LEN: usize = MAGIC.len() + 1 + 8;
+
+/// The portion of a module's scan state produced by the plugin `transform`
+/// pipeline. On a cache hit this is everything needed to skip
+/// [`crate::utils::transform_source::transform_source`] entirely.
+pub struct CachedTransform {
+  pub code: String,
+  pub module_type: ModuleType,
+  /// `Some` only when a transform hook overrode the side effects, so a hit
+  /// never clobbers side effects derived from resolution or the load hook.
+  pub side_effects: Option<HookSideEffects>,
+  pub sourcemap_chain: Vec<SourcemapChainElement>,
+}
+
+/// A content-addressed store of [`CachedTransform`] entries: one file per
+/// entry at `<dir>/<key[0..2]>/<key>`, where the key is a hash covering the
+/// cache salt and the module's identity plus post-`load` source. The layout is
+/// deliberately dumb so external tooling can sync it to and from remote
+/// storage without understanding the entry format.
+pub struct TransformCache {
+  dir: PathBuf,
+  salt: String,
+}
+
+impl TransformCache {
+  pub fn new(
+    options: &NormalizedBundlerOptions,
+    plugin_driver: &PluginDriver,
+  ) -> Option<Arc<Self>> {
+    let cache_options = options.experimental.transform_cache_options()?;
+    let dir = options
+      .cwd
+      .join(cache_options.dir.as_deref().unwrap_or("node_modules/.cache/rolldown"))
+      .join("transform-v1");
+
+    // Everything that invalidates the whole cache goes into the salt. Plugin
+    // configurations and implementations are invisible here; callers fold
+    // those into `key` (see `TransformCacheOptions::key`).
+    let mut salt_input = vec![FORMAT_VERSION];
+    salt_input.extend_from_slice(env!("CARGO_PKG_VERSION").as_bytes());
+    salt_input.push(0);
+    salt_input.extend_from_slice(cache_options.key.as_deref().unwrap_or_default().as_bytes());
+    for plugin in plugin_driver.plugins() {
+      salt_input.push(0);
+      salt_input.extend_from_slice(plugin.call_name().as_bytes());
+    }
+    let salt = xxhash_with_base(&salt_input, 16);
+
+    Some(Arc::new(Self { dir, salt }))
+  }
+
+  pub fn cache_key(&self, stable_id: &str, module_type: &ModuleType, source: &str) -> String {
+    // Hash the (potentially large) source separately so the combined input
+    // stays small; `stable_id` keeps keys portable across machines.
+    let source_hash = xxhash_with_base(source.as_bytes(), 16);
+    let mut input = Vec::with_capacity(self.salt.len() + stable_id.len() + source_hash.len() + 16);
+    input.extend_from_slice(self.salt.as_bytes());
+    input.push(0);
+    input.extend_from_slice(stable_id.as_bytes());
+    input.push(0);
+    input.extend_from_slice(module_type.to_string().as_bytes());
+    input.push(0);
+    input.extend_from_slice(source_hash.as_bytes());
+    xxhash_with_base(&input, 16)
+  }
+
+  pub async fn get(&self, key: &str) -> Option<CachedTransform> {
+    let path = self.entry_path(key);
+    #[cfg(not(target_family = "wasm"))]
+    {
+      tokio::runtime::Handle::current()
+        .spawn_blocking(move || read_entry(&path))
+        .await
+        .ok()
+        .flatten()
+    }
+    #[cfg(target_family = "wasm")]
+    {
+      read_entry(&path)
+    }
+  }
+
+  pub async fn set(
+    &self,
+    key: &str,
+    code: &str,
+    module_type: &ModuleType,
+    side_effects: Option<HookSideEffects>,
+    transform_chain: &[SourcemapChainElement],
+  ) {
+    let Some(bytes) = encode_entry(code, module_type, side_effects, transform_chain) else {
+      return;
+    };
+    let path = self.entry_path(key);
+    #[cfg(not(target_family = "wasm"))]
+    {
+      let _ =
+        tokio::runtime::Handle::current().spawn_blocking(move || write_entry(&path, &bytes)).await;
+    }
+    #[cfg(target_family = "wasm")]
+    {
+      write_entry(&path, &bytes);
+    }
+  }
+
+  fn entry_path(&self, key: &str) -> PathBuf {
+    self.dir.join(&key[0..2]).join(key)
+  }
+}
+
+fn side_effects_to_u8(side_effects: HookSideEffects) -> u8 {
+  match side_effects {
+    HookSideEffects::True => 0,
+    HookSideEffects::False => 1,
+    HookSideEffects::NoTreeshake => 2,
+  }
+}
+
+fn side_effects_from_u8(value: u64) -> Option<HookSideEffects> {
+  match value {
+    0 => Some(HookSideEffects::True),
+    1 => Some(HookSideEffects::False),
+    2 => Some(HookSideEffects::NoTreeshake),
+    _ => None,
+  }
+}
+
+/// Entry layout: `MAGIC`, format version byte, `u64` LE metadata length, the
+/// metadata JSON, then the raw transformed code bytes. Keeping the code out of
+/// the JSON avoids escaping the biggest blob.
+fn encode_entry(
+  code: &str,
+  module_type: &ModuleType,
+  side_effects: Option<HookSideEffects>,
+  transform_chain: &[SourcemapChainElement],
+) -> Option<Vec<u8>> {
+  let mut chain = Vec::with_capacity(transform_chain.len());
+  for element in transform_chain {
+    let value = match element {
+      SourcemapChainElement::Transform((plugin_idx, map)) => serde_json::json!({
+        "t": "map",
+        "p": plugin_idx.raw(),
+        "m": map.to_json_string(),
+      }),
+      SourcemapChainElement::Omitted { plugin_idx, plugin_name } => serde_json::json!({
+        "t": "omitted",
+        "p": plugin_idx.raw(),
+        "n": plugin_name.as_str(),
+      }),
+      SourcemapChainElement::Null { plugin_idx, original_content } => serde_json::json!({
+        "t": "null",
+        "p": plugin_idx.raw(),
+        "c": original_content.as_str(),
+      }),
+      // `Load` elements are produced before the transform pipeline; one showing
+      // up here means the caller sliced the chain wrong. Don't cache garbage.
+      SourcemapChainElement::Load(_) => return None,
+    };
+    chain.push(value);
+  }
+  let meta = serde_json::json!({
+    "moduleType": module_type.to_string(),
+    "sideEffects": side_effects.map(side_effects_to_u8),
+    "chain": chain,
+  });
+  let meta_bytes = serde_json::to_vec(&meta).ok()?;
+
+  let mut bytes = Vec::with_capacity(HEADER_LEN + meta_bytes.len() + code.len());
+  bytes.extend_from_slice(&MAGIC);
+  bytes.push(FORMAT_VERSION);
+  bytes.extend_from_slice(&(meta_bytes.len() as u64).to_le_bytes());
+  bytes.extend_from_slice(&meta_bytes);
+  bytes.extend_from_slice(code.as_bytes());
+  Some(bytes)
+}
+
+/// Any malformed or unreadable entry is treated as a miss; the build then
+/// recomputes and rewrites it.
+fn read_entry(path: &Path) -> Option<CachedTransform> {
+  let bytes = std::fs::read(path).ok()?;
+  decode_entry(&bytes)
+}
+
+fn decode_entry(bytes: &[u8]) -> Option<CachedTransform> {
+  if bytes.len() < HEADER_LEN || bytes[0..4] != MAGIC || bytes[4] != FORMAT_VERSION {
+    return None;
+  }
+  let meta_len = usize::try_from(u64::from_le_bytes(bytes[5..13].try_into().ok()?)).ok()?;
+  let code_offset = HEADER_LEN.checked_add(meta_len)?;
+  if bytes.len() < code_offset {
+    return None;
+  }
+  let meta: serde_json::Value = serde_json::from_slice(&bytes[HEADER_LEN..code_offset]).ok()?;
+  let code = String::from_utf8(bytes[code_offset..].to_vec()).ok()?;
+
+  let module_type_str = meta.get("moduleType")?.as_str()?;
+  let module_type = ModuleType::from_known_str(module_type_str)
+    .unwrap_or_else(|_| ModuleType::Custom(module_type_str.to_string()));
+  let side_effects = match meta.get("sideEffects")? {
+    serde_json::Value::Null => None,
+    value => Some(side_effects_from_u8(value.as_u64()?)?),
+  };
+
+  let mut sourcemap_chain = vec![];
+  for element in meta.get("chain")?.as_array()? {
+    let plugin_idx = PluginIdx::from_raw(u32::try_from(element.get("p")?.as_u64()?).ok()?);
+    sourcemap_chain.push(match element.get("t")?.as_str()? {
+      "map" => SourcemapChainElement::Transform((
+        plugin_idx,
+        // Parse through the lifetime-generic type; the stored chain needs the
+        // owned (`'static`) form.
+        oxc_sourcemap::SourceMap::from_json_string(element.get("m")?.as_str()?).ok()?.into_owned(),
+      )),
+      "omitted" => SourcemapChainElement::Omitted {
+        plugin_idx,
+        plugin_name: ArcStr::from(element.get("n")?.as_str()?),
+      },
+      "null" => SourcemapChainElement::Null {
+        plugin_idx,
+        original_content: ArcStr::from(element.get("c")?.as_str()?),
+      },
+      _ => return None,
+    });
+  }
+
+  Some(CachedTransform { code, module_type, side_effects, sourcemap_chain })
+}
+
+/// Writes go to a process-unique temp file first and are moved into place with
+/// a rename, so concurrent builds sharing a cache dir never observe partial
+/// entries. All errors are swallowed: the cache is an optimization and must
+/// never fail the build.
+fn write_entry(path: &Path, bytes: &[u8]) {
+  let Some(parent) = path.parent() else { return };
+  if let Err(error) = std::fs::create_dir_all(parent) {
+    tracing::debug!("failed to create transform cache dir {}: {error}", parent.display());
+    return;
+  }
+  let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else { return };
+  let tmp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+  let result = std::fs::write(&tmp_path, bytes).and_then(|()| {
+    std::fs::rename(&tmp_path, path).inspect_err(|_| {
+      let _ = std::fs::remove_file(&tmp_path);
+    })
+  });
+  if let Err(error) = result {
+    tracing::debug!("failed to write transform cache entry {}: {error}", path.display());
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn entry_roundtrip() {
+    let chain = vec![
+      SourcemapChainElement::Omitted {
+        plugin_idx: PluginIdx::from_raw(3),
+        plugin_name: "p".into(),
+      },
+      SourcemapChainElement::Null {
+        plugin_idx: PluginIdx::from_raw(4),
+        original_content: "const a = 1;".into(),
+      },
+    ];
+    let bytes =
+      encode_entry("const a = 2;", &ModuleType::Tsx, Some(HookSideEffects::False), &chain).unwrap();
+    let entry = decode_entry(&bytes).unwrap();
+    assert_eq!(entry.code, "const a = 2;");
+    assert_eq!(entry.module_type, ModuleType::Tsx);
+    assert_eq!(entry.side_effects, Some(HookSideEffects::False));
+    assert_eq!(entry.sourcemap_chain.len(), 2);
+  }
+
+  #[test]
+  fn rejects_unknown_version_and_garbage() {
+    let bytes = encode_entry("code", &ModuleType::Js, None, &[]).unwrap();
+    let mut wrong_version = bytes.clone();
+    wrong_version[4] = FORMAT_VERSION + 1;
+    assert!(decode_entry(&wrong_version).is_none());
+    assert!(decode_entry(&bytes[0..HEADER_LEN - 1]).is_none());
+    assert!(decode_entry(b"not a cache entry").is_none());
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/mod.rs
@@ -1,2 +1,3 @@
 mod hmr;
 mod runtime;
+mod transform_cache;

--- a/crates/rolldown/tests/rolldown/topics/transform_cache/entry.js
+++ b/crates/rolldown/tests/rolldown/topics/transform_cache/entry.js
@@ -1,0 +1,2 @@
+export const value = '__MARKER__';
+console.log(value);

--- a/crates/rolldown/tests/rolldown/topics/transform_cache/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/transform_cache/mod.rs
@@ -1,0 +1,118 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rolldown::{
+  Bundler, BundlerOptions, ExperimentalOptions, InputItem, TransformCacheOption,
+  TransformCacheOptions,
+};
+use rolldown_common::Output;
+use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin};
+
+/// Counts its `transform` invocations on the entry module and rewrites the
+/// `__MARKER__` placeholder, so cache hits are observable both through the
+/// counter (hooks skipped) and the emitted chunk (cached code used).
+#[derive(Debug)]
+struct CountingTransformPlugin {
+  calls: Arc<AtomicUsize>,
+}
+
+impl Plugin for CountingTransformPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "counting-transform".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform
+  }
+
+  async fn transform(
+    &self,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !args.id.ends_with("entry.js") {
+      return Ok(None);
+    }
+    self.calls.fetch_add(1, Ordering::SeqCst);
+    Ok(Some(rolldown_plugin::HookTransformOutput {
+      code: Some(args.code.replace("__MARKER__", "transformed")),
+      map: HookTransformOutputMap::Null,
+      ..Default::default()
+    }))
+  }
+}
+
+fn fixture_cwd() -> PathBuf {
+  concat!(env!("CARGO_MANIFEST_DIR"), "/tests/rolldown/topics/transform_cache").into()
+}
+
+/// Builds the fixture with the persistent transform cache enabled and returns
+/// how often the transform hook ran plus the entry chunk's code.
+async fn build(cache_dir: &std::path::Path, key: Option<&str>) -> (usize, String) {
+  let calls = Arc::new(AtomicUsize::new(0));
+  let mut bundler = Bundler::with_plugins(
+    BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "./entry.js".to_string(),
+      }]),
+      cwd: Some(fixture_cwd()),
+      experimental: Some(ExperimentalOptions {
+        transform_cache: Some(TransformCacheOption::Options(TransformCacheOptions {
+          dir: Some(cache_dir.to_string_lossy().into_owned()),
+          key: key.map(str::to_string),
+        })),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+    vec![Arc::new(CountingTransformPlugin { calls: Arc::clone(&calls) })],
+  )
+  .expect("failed to create bundler");
+
+  let output = bundler.generate().await.expect("build should succeed");
+  let code = output
+    .assets
+    .iter()
+    .find_map(|asset| match asset {
+      Output::Chunk(chunk) => Some(chunk.code.clone()),
+      Output::Asset(_) => None,
+    })
+    .expect("build should emit a chunk");
+  (calls.load(Ordering::SeqCst), code)
+}
+
+fn fresh_cache_dir(name: &str) -> PathBuf {
+  let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("transform_cache").join(name);
+  let _ = std::fs::remove_dir_all(&dir);
+  dir
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn second_build_skips_transform_hooks_and_reuses_cached_output() {
+  let cache_dir = fresh_cache_dir("hit");
+
+  let (first_calls, first_code) = Box::pin(build(&cache_dir, None)).await;
+  assert_eq!(first_calls, 1, "cold build must run the transform hook");
+  assert!(first_code.contains("transformed"), "transform result must reach the chunk");
+
+  let (second_calls, second_code) = Box::pin(build(&cache_dir, None)).await;
+  assert_eq!(second_calls, 0, "warm build must skip the transform hook entirely");
+  assert_eq!(second_code, first_code, "cached build must produce identical output");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn changing_cache_key_invalidates_entries() {
+  let cache_dir = fresh_cache_dir("key");
+
+  let (first_calls, _) = Box::pin(build(&cache_dir, Some("config-hash-a"))).await;
+  assert_eq!(first_calls, 1);
+
+  let (same_key_calls, _) = Box::pin(build(&cache_dir, Some("config-hash-a"))).await;
+  assert_eq!(same_key_calls, 0, "same key must hit the cache");
+
+  let (new_key_calls, _) = Box::pin(build(&cache_dir, Some("config-hash-b"))).await;
+  assert_eq!(new_key_calls, 1, "a new key must invalidate every entry");
+}

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -14,6 +14,7 @@ pub struct BindingExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<Either<bool, BindingChunkOptimizationOptions>>,
   pub lazy_barrel: Option<bool>,
+  pub transform_cache: Option<Either<bool, BindingTransformCacheOptions>>,
 }
 
 impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -38,7 +39,24 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
         Either::B(v) => rolldown_common::ChunkOptimizationOption::Options(v.into()),
       }),
       lazy_barrel: value.lazy_barrel,
+      transform_cache: value.transform_cache.map(|v| match v {
+        Either::A(v) => rolldown_common::TransformCacheOption::Bool(v),
+        Either::B(v) => rolldown_common::TransformCacheOption::Options(v.into()),
+      }),
     })
+  }
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug, Default)]
+pub struct BindingTransformCacheOptions {
+  pub dir: Option<String>,
+  pub key: Option<String>,
+}
+
+impl From<BindingTransformCacheOptions> for rolldown_common::TransformCacheOptions {
+  fn from(value: BindingTransformCacheOptions) -> Self {
+    Self { dir: value.dir, key: value.key }
   }
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -66,6 +66,36 @@ impl ChunkOptimizationOption {
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields, default)
+)]
+pub struct TransformCacheOptions {
+  /// Directory where cache entries are stored. Relative paths are resolved
+  /// against `cwd`. Defaults to `node_modules/.cache/rolldown`.
+  pub dir: Option<String>,
+  /// Extra cache invalidation key mixed into every entry's hash. The cache key
+  /// only captures the rolldown version, the ordered plugin names, each
+  /// module's id, module type and post-`load` source. Plugin *configuration*
+  /// or *implementation* changes are invisible to it, so callers must fold
+  /// anything that changes transform output (e.g. a hash of the resolved
+  /// config and lockfile) into this key.
+  pub key: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(untagged)
+)]
+pub enum TransformCacheOption {
+  Bool(bool),
+  Options(TransformCacheOptions),
+}
+
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 pub struct ExperimentalOptions {
@@ -80,6 +110,7 @@ pub struct ExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<ChunkOptimizationOption>,
   pub lazy_barrel: Option<bool>,
+  pub transform_cache: Option<TransformCacheOption>,
 }
 
 impl ExperimentalOptions {
@@ -124,5 +155,13 @@ impl ExperimentalOptions {
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
     self.lazy_barrel.unwrap_or(false)
+  }
+
+  pub fn transform_cache_options(&self) -> Option<TransformCacheOptions> {
+    match &self.transform_cache {
+      Some(TransformCacheOption::Bool(true)) => Some(TransformCacheOptions::default()),
+      Some(TransformCacheOption::Options(options)) => Some(options.clone()),
+      Some(TransformCacheOption::Bool(false)) | None => None,
+    }
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -36,6 +36,7 @@ pub mod bundler_options {
       es_module_flag::EsModuleFlag,
       experimental_options::{
         ChunkOptimizationOption, ChunkOptimizationOptions, ExperimentalOptions,
+        TransformCacheOption, TransformCacheOptions,
       },
       filename_template::{FilenameTemplate, is_path_fragment},
       generated_code_options::GeneratedCodeOptions,

--- a/crates/rolldown_common/src/types/side_effects.rs
+++ b/crates/rolldown_common/src/types/side_effects.rs
@@ -52,7 +52,7 @@ pub(crate) fn glob_match_with_normalized_pattern(pattern: &str, path: &str) -> b
   fast_glob::glob_match(&normalized_glob, path.trim_start_matches("./"))
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookSideEffects {
   True,
   False,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1033,6 +1033,16 @@
             "boolean",
             "null"
           ]
+        },
+        "transformCache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TransformCacheOption"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -1127,6 +1137,38 @@
         "avoidRedundantChunkLoads": {
           "type": "boolean",
           "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "TransformCacheOption": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/TransformCacheOptions"
+        }
+      ]
+    },
+    "TransformCacheOptions": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "description": "Directory where cache entries are stored. Relative paths are resolved\nagainst `cwd`. Defaults to `node_modules/.cache/rolldown`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "key": {
+          "description": "Extra cache invalidation key mixed into every entry's hash. The cache key\nonly captures the rolldown version, the ordered plugin names, each\nmodule's id, module type and post-`load` source. Plugin *configuration*\nor *implementation* changes are invisible to it, so callers must fold\nanything that changes transform output (e.g. a hash of the resolved\nconfig and lockfile) into this key.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       },
       "additionalProperties": false

--- a/internal-docs/transform-cache/design.md
+++ b/internal-docs/transform-cache/design.md
@@ -1,0 +1,92 @@
+# Persistent Transform Cache - Design
+
+> The data flow and file pointers live in [implementation.md](./implementation.md).
+
+## Problem
+
+For most projects rolldown is fast enough that persistent caching is not worth
+its complexity (see the discussion in
+[#802](https://github.com/rolldown/rolldown/discussions/802)). Two situations
+break that assumption (tracked in
+[#6995](https://github.com/rolldown/rolldown/issues/6995)):
+
+- Slow JavaScript `transform` plugins (framework compilers, legacy
+  transpilers). Every call crosses the NAPI boundary and runs single-threaded
+  JS, so the transform pipeline dominates cold-build time.
+- Very large module graphs (100k+ modules in monorepos), where even cheap
+  per-module work adds up and CI machines rebuild the same unchanged modules
+  thousands of times a day.
+
+The existing `ScanStageCache` only helps rebuilds within one process (watch
+mode / HMR). Nothing survives a process restart, and nothing can be shared
+between machines.
+
+## Goals
+
+- Opt-in, experimental persistent cache that skips the plugin `transform`
+  pipeline for unchanged modules, across processes.
+- Never fail or corrupt a build: every cache error degrades to a miss, every
+  write is atomic.
+- On-disk layout simple enough that external tooling can implement **remote
+  caching** on top (e.g. read-through from an HTTP mirror, CI writers
+  populating an object store) by syncing files, without understanding the
+  entry format. Cache keys must therefore be machine-portable (no absolute
+  paths).
+- Smallest possible surface area inside rolldown; the cache touches exactly
+  one seam (around `transform_source`).
+
+## Non-goals
+
+- Caching parse, link or codegen results. The oxc AST is arena-allocated and
+  self-referential, so it cannot be serialized without a dedicated
+  representation; parsing is also cheap relative to JS transform hooks.
+- Automatic invalidation on plugin configuration or implementation changes.
+  Rolldown cannot observe either, so callers fold a config/lockfile hash into
+  `experimental.transformCache.key` (the same contract Metro's
+  `getCacheKey` and webpack's `cache.version` use).
+- Replacing `ScanStageCache`. The two compose: within a watch session the
+  in-memory cache avoids re-scanning entirely; the persistent cache
+  accelerates the scans that do happen.
+
+## Decisions and trade-offs
+
+- **Cache the post-transform source, not scan output.** Deserializing symbols,
+  scopes and statement info would require serializable mirrors of large
+  internal types for modest wins; re-parsing with oxc is fast. Skipping the
+  transform pipeline captures most of the win at a fraction of the surface.
+- **Key on the post-`load` source.** `load` hooks still run on hits (they are
+  the source of truth for virtual modules and cheap for disk files), which
+  makes the key well-defined for every module kind.
+- **One file per entry, content-addressed, atomic rename.** Rejected a single
+  store file / database: per-entry files need no locking across concurrent
+  builds, tolerate partial syncs, and are trivially mirrored to remote
+  storage. The 256-way `key[0..2]` sharding keeps directories small at
+  monorepo scale.
+- **Format: JSON metadata header + raw code bytes.** Rejected new
+  serialization dependencies (bincode/rkyv); `serde_json` is already a
+  dependency, and keeping the code blob out of JSON avoids escaping the
+  largest field. A format version byte plus the salt guard both decode
+  compatibility and semantic compatibility.
+- **Side effects are stored as a delta.** The pre-transform value can come
+  from resolution data outside the cache key (`package.json` `sideEffects`),
+  so only a transform-hook override is stored and replayed.
+
+## Known limitations
+
+- Transform-hook side channels are not replayed on hits: `this.emitFile`,
+  `this.addWatchFile` and custom module meta written during `transform` are
+  lost for cached modules. Plugins relying on those must currently not be used
+  with the cache enabled.
+- Incompatible with `experimental.nativeMagicString` + sourcemaps: that path
+  generates transform sourcemaps on a side channel outside the module task, so
+  the cache silently disables itself there.
+- No eviction. Entries are small and content-addressed; callers can wipe or
+  age out the directory externally. Revisit if this graduates from
+  experimental.
+
+## Open questions
+
+- Should the store become a trait (get/set) so embedders can plug remote
+  backends directly instead of syncing the directory? The current layout was
+  chosen so that this can be added later without changing the entry format.
+- Whether Vite should derive `key` automatically from its resolved config.

--- a/internal-docs/transform-cache/implementation.md
+++ b/internal-docs/transform-cache/implementation.md
@@ -1,0 +1,68 @@
+# Persistent Transform Cache - Implementation
+
+> Rationale, trade-offs and limitations live in [design.md](./design.md).
+
+## Summary
+
+`experimental.transformCache` persists the result of the plugin `transform`
+pipeline per module. On a hit, `ModuleTask` restores the transformed code,
+module type, transform sourcemap chain and side-effect override from disk and
+never calls a `transform` hook. Everything downstream (parse, scan, link,
+codegen) is unchanged.
+
+## Components
+
+| Piece               | Location                                                                                        |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| Option types        | `crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs`                |
+| Store + entry codec | `crates/rolldown/src/utils/transform_cache.rs`                                                  |
+| Construction        | `ModuleLoader::new` (`crates/rolldown/src/module_loader/module_loader.rs`)                      |
+| Read/write seam     | `ModuleTask::transform_source_with_cache` (`crates/rolldown/src/module_loader/module_task.rs`)  |
+| Binding             | `BindingTransformCacheOptions` (`crates/rolldown_binding/.../binding_experimental_options.rs`)  |
+| JS options          | `packages/rolldown/src/options/input-options.ts`, `validator.ts`, `bindingify-input-options.ts` |
+
+## Data flow
+
+1. `ModuleLoader::new` builds one `TransformCache` per build when the option
+   is enabled, unless the native magic-string sourcemap channel is active
+   (those sourcemaps are generated outside the module task and could not be
+   captured; see `create_sourcemap_channel` in `scan_stage.rs`).
+2. `ModuleTask::load_source` runs the `load` pipeline normally, then routes
+   string sources through `transform_source_with_cache` instead of
+   `transform_source`.
+3. The key is
+   `xxh3(salt, stable_id, module_type, xxh3(source))`, hex encoded, where
+   `salt = xxh3(format_version, rolldown_version, options.key, ordered plugin names)`.
+   `stable_id` (cwd-relative, forward slashes) keeps keys portable across
+   machines, which remote cache layers rely on.
+4. Hit: extend `sourcemap_chain` with the stored transform elements, restore
+   `module_type`, apply the side-effects override if one was stored, return
+   the cached code.
+5. Miss: run `transform_source`, then store the code, the final module type,
+   the side-effects delta (only if the pipeline changed it) and exactly the
+   chain elements appended by the transform pipeline
+   (`sourcemap_chain[len_before..]`).
+
+## Entry format
+
+`<dir>/transform-v1/<key[0..2]>/<key>`, written to a process-unique temp file
+and renamed into place. Layout:
+
+```text
+b"RDTC"  format_version:u8  meta_len:u64le  meta_json  raw code bytes
+```
+
+`meta_json` holds `moduleType`, the optional `sideEffects` override (0/1/2)
+and the serialized chain elements (`Transform` maps as sourcemap JSON,
+`Omitted`/`Null` with plugin index and payload). Any decode failure, size
+mismatch or unknown version is treated as a miss and the entry is rewritten.
+
+## Invariants
+
+- A `SourcemapChainElement::Load` must never be cached; `encode_entry` refuses
+  the whole entry if the caller sliced the chain wrong.
+- Cache failures never fail the build: reads degrade to misses, writes log at
+  `debug` level and are dropped.
+- `PluginIdx` values inside cached chains are only meaningful because the
+  ordered plugin name list is part of the salt; changing the plugin list
+  invalidates every entry.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2230,6 +2230,7 @@ export interface BindingExperimentalOptions {
   nativeMagicString?: boolean
   chunkOptimization?: boolean | BindingChunkOptimizationOptions
   lazyBarrel?: boolean
+  transformCache?: boolean | BindingTransformCacheOptions
 }
 
 export interface BindingFilterToken {
@@ -2727,6 +2728,11 @@ export interface BindingSourceMapOptions {
    * - "boundary": high-resolution only at word boundaries
    */
   hires?: boolean | string
+}
+
+export interface BindingTransformCacheOptions {
+  dir?: string
+  key?: string
 }
 
 export interface BindingTransformHookExtraArgs {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -1,3 +1,7 @@
+// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
+import type { RolldownBuild } from '../api/rolldown/rolldown-build';
+// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
+import type { watch } from '../api/watch/index';
 import type {
   LogLevel,
   LogLevelOption,
@@ -5,17 +9,12 @@ import type {
   RolldownLog,
   RolldownLogWithString,
 } from '../log/logging';
-import type { RolldownPluginOption } from '../plugin';
+// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
+import type { Plugin, RolldownPluginOption } from '../plugin';
 import type { TreeshakingOptions } from '../types/module-side-effects';
 import type { NullValue, StringOrRegExp } from '../types/utils';
 import type { ChecksOptions } from './generated/checks-options';
 import type { TransformOptions } from './transform-options';
-// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
-import type { watch } from '../api/watch/index';
-// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
-import type { Plugin } from '../plugin';
-// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
-import type { RolldownBuild } from '../api/rolldown/rolldown-build';
 
 /**
  * @inline
@@ -656,6 +655,40 @@ export interface InputOptions {
      * @default false
      */
     incrementalBuild?: boolean;
+    /**
+     * Persist per-module transform results to disk and reuse them across
+     * builds and processes.
+     *
+     * On a cache hit the whole plugin `transform` pipeline is skipped for that
+     * module, which mainly pays off for expensive JavaScript transform hooks
+     * (framework compilers, legacy transpilers) and very large module graphs.
+     * Parsing and later build stages still run normally.
+     *
+     * The cache key covers the rolldown version, the ordered plugin names,
+     * each module's id, module type and post-`load` source, plus the `key`
+     * option. Plugin configuration or implementation changes are NOT detected
+     * automatically: fold anything that affects transform output (e.g. a hash
+     * of your resolved config and lockfile) into `key`.
+     *
+     * Not applied when `nativeMagicString` is enabled together with
+     * sourcemaps, and transform-hook side channels (`this.emitFile`,
+     * `this.addWatchFile`) are not replayed on cache hits.
+     *
+     * @default false
+     */
+    transformCache?:
+      | boolean
+      | {
+          /**
+           * Directory where cache entries are stored, resolved against `cwd`.
+           * @default 'node_modules/.cache/rolldown'
+           */
+          dir?: string;
+          /**
+           * Extra cache invalidation key, hashed into every entry.
+           */
+          key?: string;
+        };
     /**
      * Use native Rust implementation of MagicString for source map generation.
      *

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -1,10 +1,3 @@
-import {
-  BindingAttachDebugInfo,
-  BindingChunkModuleOrderBy,
-  BindingLogLevel,
-  BindingPropertyReadSideEffects,
-  BindingPropertyWriteSideEffects,
-} from '../binding.cjs';
 import type {
   BindingDeferSyncScanData,
   BindingExperimentalOptions,
@@ -12,8 +5,18 @@ import type {
   BindingInjectImportNamespace,
   BindingInputOptions,
 } from '../binding.cjs';
-import { bindingifyManifestPlugin, BuiltinPlugin } from '../builtin-plugin/utils';
-import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
+import {
+  BindingAttachDebugInfo,
+  BindingChunkModuleOrderBy,
+  BindingLogLevel,
+  BindingPropertyReadSideEffects,
+  BindingPropertyWriteSideEffects,
+} from '../binding.cjs';
+import {
+  BuiltinPlugin,
+  bindingifyBuiltInPlugin,
+  bindingifyManifestPlugin,
+} from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import type { LogLevelOption } from '../log/logging';
 import type { AttachDebugOptions, DevModeOptions, InputOptions } from '../options/input-options';
@@ -176,6 +179,7 @@ function bindingifyExperimental(
     chunkImportMap: experimental?.chunkImportMap,
     onDemandWrapping: experimental?.onDemandWrapping,
     incrementalBuild: experimental?.incrementalBuild,
+    transformCache: experimental?.transformCache,
     nativeMagicString: experimental?.nativeMagicString,
     chunkOptimization: experimental?.chunkOptimization,
     lazyBarrel: experimental?.lazyBarrel,

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -1,4 +1,14 @@
 import * as v from 'valibot';
+
+import type {
+  ChecksOptions,
+  InputOption,
+  ModuleTypes,
+  RollupLogWithString,
+  TransformOptions,
+  TreeshakingOptions,
+  WatcherOptions,
+} from '..';
 import type {
   CodegenOptions,
   CompressOptions,
@@ -24,21 +34,21 @@ import type {
 } from '../options/input-options';
 import type {
   AddonFunction,
-  CodeSplittingNameFunction,
-  CodeSplittingTestFunction,
   AssetFileNamesFunction,
   ChunkFileNamesFunction,
+  CodeSplittingNameFunction,
+  CodeSplittingOptions,
+  CodeSplittingTestFunction,
+  GeneratedCodeOptions,
+  GeneratedCodePreset,
   GlobalsFunction,
   ManualChunksFunction,
+  MinifyOptions,
+  ModuleFormat,
   OutputOptions,
   PathsFunction,
   PreRenderedAsset,
   SanitizeFileNameFunction,
-  MinifyOptions,
-  ModuleFormat,
-  CodeSplittingOptions,
-  GeneratedCodePreset,
-  GeneratedCodeOptions,
 } from '../options/output-options';
 import type { RolldownOutputPluginOption, RolldownPluginOption } from '../plugin';
 import type { SourcemapIgnoreListOption, SourcemapPathTransformOption } from '../types/misc';
@@ -46,15 +56,6 @@ import type { RenderedChunk } from '../types/rolldown-output';
 import type { AnyFn, StringOrRegExp } from '../types/utils';
 import { flattenValibotSchema } from './flatten-valibot-schema';
 import { styleText } from './style-text';
-import type {
-  ChecksOptions,
-  InputOption,
-  ModuleTypes,
-  RollupLogWithString,
-  TransformOptions,
-  TreeshakingOptions,
-  WatcherOptions,
-} from '..';
 
 type IsSchemaSubType<
   SubTypeSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
@@ -657,6 +658,15 @@ const InputOptionsSchema = v.strictObject({
       ),
       onDemandWrapping: v.optional(v.boolean()),
       incrementalBuild: v.optional(v.boolean()),
+      transformCache: v.optional(
+        v.union([
+          v.boolean(),
+          v.strictObject({
+            dir: v.optional(v.string()),
+            key: v.optional(v.string()),
+          }),
+        ]),
+      ),
       nativeMagicString: v.optional(v.boolean()),
       chunkOptimization: v.optional(
         v.union([


### PR DESCRIPTION
### Description

This PR is a concrete, minimal implementation proposal for the filesystem build cache tracked in #6995, following the direction discussed in #802. Since new features should be agreed on first, this is opened as a **draft** to give that discussion something tangible to evaluate; happy to iterate on any part of it or split it up.

It adds `experimental.transformCache`: an opt-in filesystem cache that persists per-module plugin `transform` pipeline results (code, module type, side-effect override, transform sourcemap chain) across builds and processes. On a cache hit the entire transform pipeline is skipped for that module; `load` hooks, parsing and all later stages run unchanged.

```js
export default {
  experimental: {
    // or `transformCache: true` for the defaults
    transformCache: {
      dir: 'node_modules/.cache/rolldown', // default
      key: myConfigAndLockfileHash,        // extra invalidation key
    },
  },
};
```

### Motivation

We are migrating a very large monorepo (100k+ modules, CI fleets building overlapping module graphs all day) at our large company from a legacy bundler to Rolldown. Rolldown itself is fast, but as #6995 notes, two things still dominate cold builds: slow JavaScript `transform` plugins (every call crosses the NAPI boundary and runs single-threaded JS) and sheer module count. A persistent transform cache removes the dominant cost for unchanged modules, which is almost all of them on a typical CI build.

The on-disk layout is deliberately simple and content-addressed (`<dir>/transform-v1/<hash[0..2]>/<hash>`, one self-contained file per entry, atomic rename writes, machine-portable keys built from cwd-relative module ids) so that **remote caching** can be layered on top externally: CI writers populate an object store, developers and CI readers warm the local directory from an HTTP mirror. That is the same architecture we run today on our legacy bundler (memory, then disk, then HTTP/S3), and this PR is the building block that makes it possible with Rolldown without Rolldown itself needing any network code.

### Design summary

- Cache seam is exactly one place: `ModuleTask::load_source` routes string sources through `transform_source_with_cache` instead of `transform_source` when enabled.
- Entry key: `xxh3(salt, stable_id, module_type, xxh3(post_load_source))`, with `salt = xxh3(format_version, rolldown_version, options.key, ordered plugin names)`.
- Entry format: magic + version byte + JSON metadata header + raw code bytes (keeps the biggest blob unescaped; no new dependencies, `serde_json` and `xxhash` were already in the tree).
- Correctness details:
  - Side effects are stored as a delta: only a transform-hook override is replayed, so hits never clobber side effects derived from resolution data (`package.json` `sideEffects`) that sits outside the cache key.
  - The transform sourcemap chain (including `Omitted`/`Null` markers used for `SOURCEMAP_BROKEN` warnings) is persisted and replayed; warm builds produce byte-identical chunks and sourcemaps.
  - The cache silently disables itself when `experimental.nativeMagicString` + sourcemaps is active, because that path generates transform maps outside the module task.
  - Every cache failure (corrupt entry, unreadable dir, write error) degrades to a miss or a dropped write; the cache can never fail a build.
- Cache reads/writes go through `spawn_blocking`, mirroring how `load_source` does file IO.

`internal-docs/transform-cache/{design,implementation}.md` in this PR cover the rationale, rejected alternatives and data flow in more detail.

### Alternatives explored

- Persisting scan results (AST, symbols, scopes), as originally benchmarked in #802. The oxc AST is arena-allocated and self-referential, so this requires serializable mirrors of large internal types. The transform pipeline is where the expensive JS work lives, so caching at that seam captures most of the win at a small fraction of the surface area and risk.
- Automatic invalidation on plugin config changes. Rolldown cannot observe plugin configuration or implementations, so this follows the established contract of webpack's `cache.version` and Metro's `getCacheKey`: callers fold a config/lockfile hash into `key`. Ordered plugin names are part of the salt, so adding/removing/reordering plugins invalidates automatically.
- A pluggable get/set store trait for remote backends inside Rolldown. Deliberately deferred; the dumb directory layout supports external sync tooling today and a trait can be added later without changing the entry format.

### Known limitations (documented in the option's JSDoc and internal docs)

- Transform-hook side channels (`this.emitFile`, `this.addWatchFile`, custom module meta written during `transform`) are not replayed on hits.
- No eviction policy; entries are content-addressed and callers manage the directory lifecycle.

### Tests

- `crates/rolldown/tests/rolldown/topics/transform_cache`: warm build runs zero transform hooks and produces identical output; changing `key` invalidates all entries.
- Unit tests for the entry codec (roundtrip, version/garbage rejection).
- Verified through the JS API with the built binding: a JS transform plugin is called once cold and zero times warm across processes, `map` mappings are byte-identical cold vs warm, and a changed `key` re-runs transforms.
- `cargo clippy --workspace --all-targets` clean; full `--test integration` suite passes (the only failure locally is `test262_module_code` from an uninitialized `test262` submodule).
