### PR TITLE
chore(rolldown_utils): remove unused time module

### DIFF
--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -28,7 +28,6 @@ pub mod make_unique_name;
 pub mod pattern_filter;
 pub mod replace_all_placeholder;
 pub mod stabilize_id;
-pub mod time;
 pub mod unique_arc;
 pub mod url;
 pub mod uuid;

--- a/crates/rolldown_utils/src/time.rs
+++ b/crates/rolldown_utils/src/time.rs
@@ -1,5 +1,0 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
-pub fn current_utc_timestamp_ms() -> String {
-  SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis().to_string()
-}


### PR DESCRIPTION
### What

Deletes `crates/rolldown_utils/src/time.rs` (its only item, `current_utc_timestamp_ms`) and drops `pub mod time;` from the crate root.

### Why

`rolldown_utils::time::current_utc_timestamp_ms` has no callers anywhere in the workspace. The only place that uses a function by that name is `rolldown_devtools`, which defines its own local `current_utc_timestamp_ms` (returning `u128`) and calls that, not this `String`-returning one. There is no qualified use of `rolldown_utils::time` and no re-export, so the module is dead.
