### PR TITLE
docs(cli): clarify disabling boolean/object flags like codeSplitting

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -122,6 +122,18 @@ export default defineConfig({
 
 Flags can be passed as `--foo`, `--foo <value>`, or `--foo=<value>`. Boolean flags like `--minify` don't need a value, while key-value options like `--transform.define` use comma-separated syntax: `--transform.define key:value,key2:value2`. Many flags have short aliases (e.g., `-m` for `--minify`, `-f` for `--format`).
 
+::: warning Disabling boolean flags
+
+To turn a boolean flag _off_, prefix it with `--no-`, e.g. `--no-minify` or `--no-codeSplitting`. Passing `false` as a value—`--minify false` or `--codeSplitting=false`—is **not** supported and will error, because the value is read as the string `"false"` rather than a boolean. This matches [Rollup's CLI behavior](https://rollupjs.org/command-line-interface/) (`--no-treeshake`, etc.).
+
+Some flags accept either a boolean or an object (e.g. `codeSplitting`). For those you can:
+
+- enable with defaults: `--codeSplitting`
+- disable: `--no-codeSplitting`
+- set nested fields with dot-notation: `--codeSplitting.minSize 30000`
+
+:::
+
 ::: info Integration into other tools
 
 Note that your shell interprets arguments before Rolldown sees them—quotes and wildcards may behave unexpectedly. For advanced build processes or integration into other tools, consider using the [JavaScript API](/apis/bundler-api) instead. Key differences when switching from config files to the API:

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -1055,7 +1055,9 @@ const OutputCliOverrideSchema = v.strictObject({
         }),
       ]),
     ),
-    v.description('Code splitting options (true, false, or object)'),
+    v.description(
+      'Code splitting options. Enabled by default; use `--no-codeSplitting` to disable, or `--codeSplitting.minSize` / `--codeSplitting.minShareCount` to configure',
+    ),
   ),
   advancedChunks: v.pipe(
     v.optional(

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -49,7 +49,7 @@ OPTIONS
   --checks.unsupportedTsconfigOption Whether to emit warnings when a tsconfig option or combination of options is not supported.
   --chunkFileNames <name>     Name pattern for emitted secondary chunks.
   --cleanDir                  Clean output directory before emitting output.
-  --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
+  --codeSplitting <codeSplitting>Code splitting options. Enabled by default; use \`--no-codeSplitting\` to disable, or \`--codeSplitting.minSize\` / \`--codeSplitting.minShareCount\` to configure.
   --comments <comments>       Control comments in the output.
   --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
@@ -197,7 +197,7 @@ OPTIONS
   --checks.unsupportedTsconfigOption Whether to emit warnings when a tsconfig option or combination of options is not supported.
   --chunkFileNames <name>     Name pattern for emitted secondary chunks.
   --cleanDir                  Clean output directory before emitting output.
-  --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
+  --codeSplitting <codeSplitting>Code splitting options. Enabled by default; use \`--no-codeSplitting\` to disable, or \`--codeSplitting.minSize\` / \`--codeSplitting.minShareCount\` to configure.
   --comments <comments>       Control comments in the output.
   --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
@@ -345,7 +345,7 @@ OPTIONS
   --checks.unsupportedTsconfigOption Whether to emit warnings when a tsconfig option or combination of options is not supported.
   --chunkFileNames <name>     Name pattern for emitted secondary chunks.
   --cleanDir                  Clean output directory before emitting output.
-  --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
+  --codeSplitting <codeSplitting>Code splitting options. Enabled by default; use \`--no-codeSplitting\` to disable, or \`--codeSplitting.minSize\` / \`--codeSplitting.minShareCount\` to configure.
   --comments <comments>       Control comments in the output.
   --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.
@@ -493,7 +493,7 @@ OPTIONS
   --checks.unsupportedTsconfigOption Whether to emit warnings when a tsconfig option or combination of options is not supported.
   --chunkFileNames <name>     Name pattern for emitted secondary chunks.
   --cleanDir                  Clean output directory before emitting output.
-  --codeSplitting <codeSplitting>Code splitting options (true, false, or object).
+  --codeSplitting <codeSplitting>Code splitting options. Enabled by default; use \`--no-codeSplitting\` to disable, or \`--codeSplitting.minSize\` / \`--codeSplitting.minShareCount\` to configure.
   --comments <comments>       Control comments in the output.
   --configLoader <loader>     How to load the config file (bundle, native).
   --context <context>         The entity top-level \`this\` represents.


### PR DESCRIPTION
### Summary

Closes #10125.

`rolldown --codeSplitting false` (and `--codeSplitting=false`) fails with:

```
[error] Invalid value for option codeSplitting: Invalid type: Expected (boolean | Object) but received "false".
```

This is **working as intended** and matches Rollup. The CLI parser reads the value after `--codeSplitting` as the string `"false"`, not a boolean, and a `boolean | object` flag with no string presets has nothing to match it against. Rollup behaves identically — `rollup --treeshake false` errors the same way, and `--no-treeshake` is the supported "off" switch. It never coerces `true`/`false` strings on the CLI; boolean toggles always go through `--flag` / `--no-flag`.

The real problem is that our help text promised something that never worked:

> `--codeSplitting <codeSplitting>  Code splitting options (true, false, or object).`

The `false` there is a JS/config-file value, not a CLI value. The CLI way to disable code splitting is **`--no-codeSplitting`** (the modern equivalent of the deprecated `--inlineDynamicImports`), which already works today.

Per maintainer guidance on the issue (align with Rollup + clarify the docs), this PR is docs-only — no behavior change.

### Changes

- **`packages/rolldown/src/utils/validator.ts`** — reword the `codeSplitting` CLI description so it no longer implies `false` is a valid value, and instead points at `--no-codeSplitting` (disable) and `--codeSplitting.minSize` / `--codeSplitting.minShareCount` (object). Mirrors the existing `esModule` description, which already documents `--no-esModule`.
- **`docs/apis/cli.md`** — add a "Disabling boolean flags" callout under *Command Line Flags* explaining the general convention: use `--no-<flag>` to disable, why `--flag false` errors, that it matches Rollup, and how boolean-or-object flags (`codeSplitting`) work.
- **`packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap`** — refresh the `--help` snapshot for the new description.

### Behavior (unchanged, verified)

| CLI input | Result |
| --- | --- |
| `--codeSplitting` | ✅ `true` (enabled) |
| `--no-codeSplitting` | ✅ `false` — disables splitting (verified: 2 chunks → 1) |
| `--codeSplitting.minSize 30000` | ✅ object via dot-notation |
| `--codeSplitting false` / `=false` | ❌ errors (same as Rollup's `--treeshake false`) |

### Verification

- `pnpm build-node`; `rolldown --help` shows the new description.
- CLI e2e suite: 57 passed / 5 skipped, 4 snapshots updated.

### Possible follow-up (not in this PR)

Make the runtime error message for a `boolean | …` union flag nudge toward `--no-<flag>` when it receives the string `"false"`/`"true"`. Left out to keep this change docs-focused.
