### PR TITLE
feat: re-enable `experimental.lazyBarrel` by default

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -123,6 +123,6 @@ impl ExperimentalOptions {
   }
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
-    self.lazy_barrel.unwrap_or(false)
+    self.lazy_barrel.unwrap_or(true)
   }
 }

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -244,13 +244,13 @@ If the loaded modules (`a.js`, `b.js`, etc.) are also barrel modules, lazy barre
 
 ## Configuration
 
-Lazy barrel optimization is currently disabled by default. You can enable it in your Rolldown configuration:
+Lazy barrel optimization is enabled by default. You can temporarily disable it in your Rolldown configuration:
 
 ```js
 // rolldown.config.js
 export default {
   experimental: {
-    lazyBarrel: true,
+    lazyBarrel: false,
   },
 };
 ```

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -715,7 +715,7 @@ export interface InputOptions {
      * describing your use case so we can address it before the option is gone.
      *
      * @see {@link https://rolldown.rs/in-depth/lazy-barrel-optimization | Lazy Barrel Documentation}
-     * @default false
+     * @default true
      */
     lazyBarrel?: boolean;
   };


### PR DESCRIPTION
## Description

#10071 temporarily disabled `experimental.lazyBarrel` by default (back to opt-in). The only reason was one remaining `strictExecutionOrder` tree-shaking issue, which was the root cause of the lazy barrel runtime `ReferenceError`.

That root cause has since been fixed by #10080 (`fix: gate sideEffects:false modules' side effects on body demand`), which closed the whole family of related issues: #9691, #9806, #9961, #9964, #10013, #10048.

Now that the root cause is resolved, this PR flips the default back to `true`, re-enabling lazy barrel optimization by default. It is the exact reverse of #10071. The option itself is unchanged, only its default value goes from `false` back to `true`.

Users who want to opt out can still disable it explicitly:

```js
// rolldown.config.js
export default {
  experimental: {
    lazyBarrel: false,
  },
};
```

## Changes

- Default `experimental.lazyBarrel` to `true` in `is_lazy_barrel_enabled`.
- Update the `@default` JSDoc tag on the `lazyBarrel` option back to `true`.
- Update the lazy barrel docs to reflect that it is enabled by default again.