### PR TITLE
feat: add experimental persistent build cache (experimental.buildCache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ecmascript",
  "oxc_index",
+ "oxc_sourcemap",
  "oxc_str",
  "oxc_traverse",
  "petgraph",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -34,6 +34,7 @@ oxc = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
+oxc_sourcemap = { workspace = true }
 oxc_str = { workspace = true }
 oxc_traverse = { workspace = true }
 petgraph = { workspace = true }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -33,6 +33,7 @@ use tracing::Instrument;
 
 use crate::module_loader::module_task::ModuleTaskOwner;
 use crate::types::scan_stage_cache::ScanStageCache;
+use crate::utils::build_cache::BuildCache;
 use crate::utils::load_entry_module::load_entry_module;
 use crate::{SharedOptions, SharedResolver};
 
@@ -193,13 +194,19 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       },
     };
 
+    // The native magic-string path generates transform sourcemaps outside the
+    // module task, so cache entries could not capture them; bypass the cache.
+    let build_cache =
+      if magic_string_tx.is_none() { BuildCache::new(&options, &plugin_driver) } else { None };
+
     // Unbounded as defense in depth. If any sender ends up driven from a sync
     // napi binding through `block_on`, a bounded channel could deadlock: the
     // send future would wait on capacity that only the consumer can free, but
     // the consumer may need the JS thread — pinned by `block_on` — to run
     // plugin hooks first. Keeping the channel unbounded removes that edge.
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let shared_context = Arc::new(TaskContext { options, tx, resolver, fs, plugin_driver, meta });
+    let shared_context =
+      Arc::new(TaskContext { options, tx, resolver, fs, plugin_driver, meta, build_cache });
 
     let importers = std::mem::take(&mut cache.importers);
     let intermediate_normal_modules = IntermediateNormalModules::new(is_full_scan, importers);

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use arcstr::ArcStr;
@@ -108,11 +109,51 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
 
     let mut sourcemap_chain = vec![];
     let mut hook_side_effects = self.resolved_id.side_effects.take();
-    let (source, module_type) = self
-      .load_source(&mut sourcemap_chain, &mut hook_side_effects, self.magic_string_tx.clone())
-      .await?;
-
+    let side_effects_from_resolve = hook_side_effects;
     let stable_id = id.stabilize(&self.ctx.options.cwd);
+
+    // Persistent build cache, keyed on the module's on-disk content: a hit
+    // replays the plugin `load`/`transform` pipeline results plus the resolved
+    // dependencies without calling any hook or the resolver; parsing and
+    // scanning re-run natively on the cached code below.
+    // See internal-docs/build-cache/implementation.md.
+    let mut cached_deps = None;
+    let mut cache_write_key = None;
+    let mut cache_hit = None;
+    if let Some(cache) = &self.ctx.build_cache
+      && let Some(disk_source) = self.read_disk_source_for_cache_key().await
+    {
+      let key =
+        cache.cache_key(stable_id.as_arc_str(), self.asserted_module_type.as_ref(), &disk_source);
+      if let Some(hit) = cache.get(&key).await {
+        // Watch registration mirrors the read-from-disk path in `load_source`.
+        self.ctx.plugin_driver.watch_files.insert(id.as_arc_str().clone());
+        sourcemap_chain = hit.sourcemap_chain;
+        if hit.side_effects.is_some() {
+          hook_side_effects = hit.side_effects;
+        }
+        cached_deps = Some(hit.resolved_deps);
+        cache_hit = Some((StrOrBytes::Str(hit.code), hit.module_type));
+      } else {
+        cache_write_key = Some(key);
+      }
+    }
+
+    let (source, module_type) = match cache_hit {
+      Some(source_and_type) => source_and_type,
+      None => {
+        self
+          .load_source(&mut sourcemap_chain, &mut hook_side_effects, self.magic_string_tx.clone())
+          .await?
+      }
+    };
+
+    // Snapshot what a stored entry needs before `source` moves into the view;
+    // only string sources are cacheable, the pipeline never transforms bytes.
+    let code_to_cache = match (&cache_write_key, &source) {
+      (Some(_), StrOrBytes::Str(code)) => Some(code.clone()),
+      _ => None,
+    };
 
     if matches!(module_type, ModuleType::Css) {
       Err(BuildDiagnostic::unsupported_feature(
@@ -143,16 +184,50 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       )
       .await?;
 
-    let resolved_deps = resolve_dependencies(
-      &self.resolved_id,
-      &self.ctx.options,
-      &self.ctx.resolver,
-      &self.ctx.plugin_driver,
-      &raw_import_records,
-      ecma_view.source.clone(),
-      &mut warnings,
-    )
-    .await?;
+    let resolved_deps = match cached_deps.take() {
+      // Scanning the cached code deterministically reproduces the import
+      // records the stored resolutions are positionally aligned with; a length
+      // mismatch means a corrupt entry, so fall back to a fresh resolution.
+      Some(deps) if deps.len() == raw_import_records.len() => deps,
+      _ => {
+        let warnings_len_before_resolve = warnings.len();
+        let resolved_deps = resolve_dependencies(
+          &self.resolved_id,
+          &self.ctx.options,
+          &self.ctx.resolver,
+          &self.ctx.plugin_driver,
+          &raw_import_records,
+          ecma_view.source.clone(),
+          &mut warnings,
+        )
+        .await?;
+        if let Some(cache) = &self.ctx.build_cache
+          && let Some(key) = &cache_write_key
+          && let Some(code) = &code_to_cache
+          // Resolution warnings (e.g. unresolved imports treated as external)
+          // would not replay on a hit, so such modules are never stored.
+          && warnings.len() == warnings_len_before_resolve
+        {
+          // Side effects may already be set by resolution data outside the
+          // cache key, so only the load/transform pipeline's own override is
+          // stored; storing the pre-existing value would replay stale
+          // resolution data on later hits.
+          let side_effects_override =
+            if hook_side_effects == side_effects_from_resolve { None } else { hook_side_effects };
+          cache
+            .set(
+              key,
+              code,
+              &module_type,
+              side_effects_override,
+              &ecma_view.sourcemap_chain,
+              &resolved_deps,
+            )
+            .await;
+        }
+        resolved_deps
+      }
+    };
 
     for (record, info) in raw_import_records.iter().zip(&resolved_deps) {
       match record.kind {
@@ -310,5 +385,28 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       ))?;
     }
     Ok((source, module_type))
+  }
+
+  /// Reads the module's raw on-disk content, which keys its build cache
+  /// entry. Only absolute filesystem paths are cacheable: virtual modules,
+  /// data URLs, `rolldown:` ids and unreadable files bypass the cache.
+  async fn read_disk_source_for_cache_key(&self) -> Option<Vec<u8>> {
+    if !Path::new(self.resolved_id.id.as_str()).is_absolute() {
+      return None;
+    }
+    let fs = self.ctx.fs.clone();
+    #[cfg(not(target_family = "wasm"))]
+    {
+      let id = self.resolved_id.id.clone();
+      tokio::runtime::Handle::current()
+        .spawn_blocking(move || fs.read(Path::new(id.as_str())).ok())
+        .await
+        .ok()
+        .flatten()
+    }
+    #[cfg(target_family = "wasm")]
+    {
+      fs.read(Path::new(self.resolved_id.id.as_str())).ok()
+    }
   }
 }

--- a/crates/rolldown/src/module_loader/task_context.rs
+++ b/crates/rolldown/src/module_loader/task_context.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use oxc::transformer_plugins::ReplaceGlobalDefinesConfig;
 use rolldown_common::ModuleLoaderMsg;
 use rolldown_fs::FileSystem;
 use rolldown_plugin::SharedPluginDriver;
 
+use crate::utils::build_cache::BuildCache;
 use crate::{SharedOptions, SharedResolver};
 
 /// Used to store common data shared between all tasks.
@@ -13,6 +16,7 @@ pub struct TaskContext<Fs: FileSystem> {
   pub fs: Fs,
   pub plugin_driver: SharedPluginDriver,
   pub meta: TaskContextMeta,
+  pub build_cache: Option<Arc<BuildCache>>,
 }
 
 pub struct TaskContextMeta {

--- a/crates/rolldown/src/utils/build_cache.rs
+++ b/crates/rolldown/src/utils/build_cache.rs
@@ -14,7 +14,7 @@ use rolldown_common::{
   ResolvedExternal, ResolvedId, SourcemapChainElement,
   side_effects::{HookSideEffects, SideEffects},
 };
-use rolldown_plugin::PluginDriver;
+use rolldown_plugin::{HookUsage, PluginDriver};
 use rolldown_utils::{stabilize_id::stabilize_id, xxhash::xxhash_with_base};
 use sugar_path::SugarPath;
 
@@ -23,6 +23,12 @@ use sugar_path::SugarPath;
 const FORMAT_VERSION: u8 = 1;
 const MAGIC: [u8; 4] = *b"RDBC";
 const HEADER_LEN: usize = MAGIC.len() + 1 + 8;
+
+/// Rolldown's always-registered inner plugins (see `apply_inner_plugins`):
+/// their hooks are native early-return filters whose cost is far below the
+/// cache's own per-module overhead, so they don't count as cacheable work.
+const CHEAP_INNER_PLUGINS: [&str; 4] =
+  ["builtin:copy-module", "builtin:asset-module", "builtin:data-url", "builtin:oxc-runtime"];
 
 /// The portion of a module's scan state produced by the plugin `load` and
 /// `transform` pipelines plus dependency resolution. On a cache hit this is
@@ -57,6 +63,24 @@ impl BuildCache {
     plugin_driver: &PluginDriver,
   ) -> Option<Arc<Self>> {
     let cache_options = options.experimental.build_cache_options()?;
+
+    // The cache can only save `resolveId`/`load`/`transform` hook work plus
+    // the dependency resolution it replays. When no plugin (beyond the cheap
+    // inner ones) registers any of those hooks there is nothing expensive to
+    // skip and the cache would only add fs reads and entry decoding to every
+    // module, so it disables itself.
+    let cached_hooks = HookUsage::ResolveId
+      | HookUsage::ResolveDynamicImport
+      | HookUsage::Load
+      | HookUsage::Transform;
+    let has_cacheable_work = plugin_driver.plugins().iter().any(|plugin| {
+      plugin.call_hook_usage().intersects(cached_hooks)
+        && !CHEAP_INNER_PLUGINS.contains(&plugin.call_name().as_ref())
+    });
+    if !has_cacheable_work {
+      return None;
+    }
+
     let dir = options
       .cwd
       .join(cache_options.dir.as_deref().unwrap_or("node_modules/.cache/rolldown"))

--- a/crates/rolldown/src/utils/build_cache.rs
+++ b/crates/rolldown/src/utils/build_cache.rs
@@ -1,0 +1,555 @@
+//! Persistent (filesystem) cache for per-module build pipeline results:
+//! `load` hooks, `transform` hooks and dependency resolution.
+//!
+//! See `internal-docs/build-cache/design.md` for the rationale and
+//! `internal-docs/build-cache/implementation.md` for the data flow.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arcstr::ArcStr;
+use oxc_index::IndexVec;
+use rolldown_common::{
+  ImportRecordIdx, ModuleDefFormat, ModuleType, NormalizedBundlerOptions, PackageJson, PluginIdx,
+  ResolvedExternal, ResolvedId, SourcemapChainElement,
+  side_effects::{HookSideEffects, SideEffects},
+};
+use rolldown_plugin::PluginDriver;
+use rolldown_utils::{stabilize_id::stabilize_id, xxhash::xxhash_with_base};
+use sugar_path::SugarPath;
+
+/// Bump whenever the on-disk entry layout changes. Mixed into the cache salt,
+/// so old entries simply stop matching instead of failing to decode.
+const FORMAT_VERSION: u8 = 1;
+const MAGIC: [u8; 4] = *b"RDBC";
+const HEADER_LEN: usize = MAGIC.len() + 1 + 8;
+
+/// The portion of a module's scan state produced by the plugin `load` and
+/// `transform` pipelines plus dependency resolution. On a cache hit this is
+/// everything needed to skip all three for the module; parsing and scanning
+/// re-run natively on `code` and deterministically reproduce the import
+/// records `resolved_deps` is positionally aligned with.
+pub struct CachedModule {
+  pub code: String,
+  pub module_type: ModuleType,
+  /// `Some` only when a load or transform hook overrode the side effects, so
+  /// a hit never clobbers side effects derived from resolution data that sits
+  /// outside the cache key.
+  pub side_effects: Option<HookSideEffects>,
+  pub sourcemap_chain: Vec<SourcemapChainElement>,
+  pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
+}
+
+/// A content-addressed store of [`CachedModule`] entries: one file per entry
+/// at `<dir>/<key[0..2]>/<key>`, where the key is a hash covering the cache
+/// salt and the module's identity plus on-disk content. The layout is
+/// deliberately dumb so external tooling can sync it to and from remote
+/// storage without understanding the entry format.
+pub struct BuildCache {
+  dir: PathBuf,
+  salt: String,
+  cwd: PathBuf,
+}
+
+impl BuildCache {
+  pub fn new(
+    options: &NormalizedBundlerOptions,
+    plugin_driver: &PluginDriver,
+  ) -> Option<Arc<Self>> {
+    let cache_options = options.experimental.build_cache_options()?;
+    let dir = options
+      .cwd
+      .join(cache_options.dir.as_deref().unwrap_or("node_modules/.cache/rolldown"))
+      .join("build-v1");
+
+    // Everything that invalidates the whole cache goes into the salt. Plugin
+    // configurations and implementations are invisible here; callers fold
+    // those into `key` (see `BuildCacheOptions::key`).
+    let mut salt_input = vec![FORMAT_VERSION];
+    salt_input.extend_from_slice(env!("CARGO_PKG_VERSION").as_bytes());
+    salt_input.push(0);
+    salt_input.extend_from_slice(cache_options.key.as_deref().unwrap_or_default().as_bytes());
+    salt_input.push(0);
+    salt_input.extend_from_slice(format!("{:?}", options.platform).as_bytes());
+    // `moduleTypes` decides module types before the cached seam; sorted for a
+    // deterministic hash across processes.
+    let mut module_types: Vec<_> = options.module_types.iter().collect();
+    module_types.sort_by_key(|(a, _)| *a);
+    for (extension, module_type) in module_types {
+      salt_input.push(0);
+      salt_input.extend_from_slice(extension.as_bytes());
+      salt_input.push(0);
+      salt_input.extend_from_slice(module_type.to_string().as_bytes());
+    }
+    for plugin in plugin_driver.plugins() {
+      salt_input.push(0);
+      salt_input.extend_from_slice(plugin.call_name().as_bytes());
+    }
+    let salt = xxhash_with_base(&salt_input, 16);
+
+    Some(Arc::new(Self { dir, salt, cwd: options.cwd.clone() }))
+  }
+
+  pub fn cache_key(
+    &self,
+    stable_id: &str,
+    asserted_module_type: Option<&ModuleType>,
+    source: &[u8],
+  ) -> String {
+    // Hash the (potentially large) source separately so the combined input
+    // stays small; `stable_id` keeps keys portable across machines.
+    let source_hash = xxhash_with_base(source, 16);
+    let asserted = asserted_module_type.map(ToString::to_string).unwrap_or_default();
+    let mut input = Vec::with_capacity(
+      self.salt.len() + stable_id.len() + asserted.len() + source_hash.len() + 16,
+    );
+    input.extend_from_slice(self.salt.as_bytes());
+    input.push(0);
+    input.extend_from_slice(stable_id.as_bytes());
+    input.push(0);
+    input.extend_from_slice(asserted.as_bytes());
+    input.push(0);
+    input.extend_from_slice(source_hash.as_bytes());
+    xxhash_with_base(&input, 16)
+  }
+
+  pub async fn get(&self, key: &str) -> Option<CachedModule> {
+    let path = self.entry_path(key);
+    let cwd = self.cwd.clone();
+    #[cfg(not(target_family = "wasm"))]
+    {
+      tokio::runtime::Handle::current()
+        .spawn_blocking(move || read_entry(&path, &cwd))
+        .await
+        .ok()
+        .flatten()
+    }
+    #[cfg(target_family = "wasm")]
+    {
+      read_entry(&path, &cwd)
+    }
+  }
+
+  pub async fn set(
+    &self,
+    key: &str,
+    code: &str,
+    module_type: &ModuleType,
+    side_effects: Option<HookSideEffects>,
+    sourcemap_chain: &[SourcemapChainElement],
+    resolved_deps: &IndexVec<ImportRecordIdx, ResolvedId>,
+  ) {
+    let Some(bytes) =
+      encode_entry(code, module_type, side_effects, sourcemap_chain, resolved_deps, &self.cwd)
+    else {
+      return;
+    };
+    let path = self.entry_path(key);
+    #[cfg(not(target_family = "wasm"))]
+    {
+      let _ =
+        tokio::runtime::Handle::current().spawn_blocking(move || write_entry(&path, &bytes)).await;
+    }
+    #[cfg(target_family = "wasm")]
+    {
+      write_entry(&path, &bytes);
+    }
+  }
+
+  fn entry_path(&self, key: &str) -> PathBuf {
+    self.dir.join(&key[0..2]).join(key)
+  }
+}
+
+fn hook_side_effects_to_u8(side_effects: HookSideEffects) -> u8 {
+  match side_effects {
+    HookSideEffects::True => 0,
+    HookSideEffects::False => 1,
+    HookSideEffects::NoTreeshake => 2,
+  }
+}
+
+fn hook_side_effects_from_u64(value: u64) -> Option<HookSideEffects> {
+  match value {
+    0 => Some(HookSideEffects::True),
+    1 => Some(HookSideEffects::False),
+    2 => Some(HookSideEffects::NoTreeshake),
+    _ => None,
+  }
+}
+
+fn module_def_format_to_u8(format: ModuleDefFormat) -> u8 {
+  match format {
+    ModuleDefFormat::Unknown => 0,
+    ModuleDefFormat::Cjs => 1,
+    ModuleDefFormat::Cts => 2,
+    ModuleDefFormat::CjsPackageJson => 3,
+    ModuleDefFormat::EsmMjs => 4,
+    ModuleDefFormat::EsmMts => 5,
+    ModuleDefFormat::EsmPackageJson => 6,
+  }
+}
+
+fn module_def_format_from_u64(value: u64) -> Option<ModuleDefFormat> {
+  match value {
+    0 => Some(ModuleDefFormat::Unknown),
+    1 => Some(ModuleDefFormat::Cjs),
+    2 => Some(ModuleDefFormat::Cts),
+    3 => Some(ModuleDefFormat::CjsPackageJson),
+    4 => Some(ModuleDefFormat::EsmMjs),
+    5 => Some(ModuleDefFormat::EsmMts),
+    6 => Some(ModuleDefFormat::EsmPackageJson),
+    _ => None,
+  }
+}
+
+fn resolved_external_to_u8(external: ResolvedExternal) -> u8 {
+  match external {
+    ResolvedExternal::Bool(false) => 0,
+    ResolvedExternal::Bool(true) => 1,
+    ResolvedExternal::Absolute => 2,
+    ResolvedExternal::Relative => 3,
+  }
+}
+
+fn resolved_external_from_u64(value: u64) -> Option<ResolvedExternal> {
+  match value {
+    0 => Some(ResolvedExternal::Bool(false)),
+    1 => Some(ResolvedExternal::Bool(true)),
+    2 => Some(ResolvedExternal::Absolute),
+    3 => Some(ResolvedExternal::Relative),
+    _ => None,
+  }
+}
+
+/// Absolute paths are stored relative to `cwd` (marked with `abs`) so entries
+/// stay portable across machines sharing the cache.
+fn encode_path(path: &str, cwd: &Path) -> serde_json::Value {
+  let is_absolute = Path::new(path).is_absolute();
+  serde_json::json!({
+    "p": if is_absolute { stabilize_id(path, cwd) } else { path.to_string() },
+    "abs": is_absolute,
+  })
+}
+
+fn decode_path(value: &serde_json::Value, cwd: &Path) -> Option<String> {
+  let stored = value.get("p")?.as_str()?;
+  if value.get("abs")?.as_bool()? {
+    Some(stored.as_path().absolutize_with(cwd).to_str()?.to_string())
+  } else {
+    Some(stored.to_string())
+  }
+}
+
+fn encode_side_effects(side_effects: &SideEffects) -> serde_json::Value {
+  match side_effects {
+    SideEffects::Bool(value) => serde_json::json!({ "b": value }),
+    SideEffects::String(value) => serde_json::json!({ "s": value }),
+    SideEffects::Array(values) => serde_json::json!({ "a": values }),
+  }
+}
+
+fn decode_side_effects(value: &serde_json::Value) -> Option<SideEffects> {
+  if let Some(b) = value.get("b") {
+    Some(SideEffects::Bool(b.as_bool()?))
+  } else if let Some(s) = value.get("s") {
+    Some(SideEffects::String(s.as_str()?.to_string()))
+  } else {
+    let values = value.get("a")?.as_array()?;
+    Some(SideEffects::Array(
+      values.iter().map(|v| v.as_str().map(str::to_string)).collect::<Option<Vec<_>>>()?,
+    ))
+  }
+}
+
+fn encode_resolved_dep(dep: &ResolvedId, cwd: &Path) -> serde_json::Value {
+  serde_json::json!({
+    "id": encode_path(dep.id.as_str(), cwd),
+    "format": module_def_format_to_u8(dep.module_def_format),
+    "external": resolved_external_to_u8(dep.external),
+    "normalizeExternalId": dep.normalize_external_id,
+    "sideEffects": dep.side_effects.map(hook_side_effects_to_u8),
+    "noSideEffects": dep.is_external_without_side_effects,
+    "packageJson": dep.package_json.as_ref().map(|package_json| {
+      serde_json::json!({
+        "name": package_json.name(),
+        "version": package_json.version(),
+        "type": package_json.r#type(),
+        "sideEffects": package_json.side_effects.as_ref().map(encode_side_effects),
+        "realpath": encode_path(&package_json.realpath().to_string_lossy(), cwd),
+      })
+    }),
+  })
+}
+
+fn decode_resolved_dep(value: &serde_json::Value, cwd: &Path) -> Option<ResolvedId> {
+  let package_json = match value.get("packageJson")? {
+    serde_json::Value::Null => None,
+    package_json => {
+      let r#type = match package_json.get("type")? {
+        serde_json::Value::Null => None,
+        value => Some(match value.as_str()? {
+          "commonjs" => "commonjs",
+          "module" => "module",
+          _ => return None,
+        }),
+      };
+      let side_effects = match package_json.get("sideEffects")? {
+        serde_json::Value::Null => None,
+        value => Some(decode_side_effects(value)?),
+      };
+      Some(Arc::new(PackageJson::from_parts(
+        package_json.get("name")?.as_str().map(ArcStr::from),
+        package_json.get("version")?.as_str().map(ArcStr::from),
+        r#type,
+        side_effects,
+        PathBuf::from(decode_path(package_json.get("realpath")?, cwd)?),
+      )))
+    }
+  };
+  Some(ResolvedId {
+    id: decode_path(value.get("id")?, cwd)?.into(),
+    module_def_format: module_def_format_from_u64(value.get("format")?.as_u64()?)?,
+    external: resolved_external_from_u64(value.get("external")?.as_u64()?)?,
+    normalize_external_id: match value.get("normalizeExternalId")? {
+      serde_json::Value::Null => None,
+      value => Some(value.as_bool()?),
+    },
+    package_json,
+    side_effects: match value.get("sideEffects")? {
+      serde_json::Value::Null => None,
+      value => Some(hook_side_effects_from_u64(value.as_u64()?)?),
+    },
+    is_external_without_side_effects: value.get("noSideEffects")?.as_bool()?,
+  })
+}
+
+/// Entry layout: `MAGIC`, format version byte, `u64` LE metadata length, the
+/// metadata JSON, then the raw transformed code bytes. Keeping the code out of
+/// the JSON avoids escaping the biggest blob.
+fn encode_entry(
+  code: &str,
+  module_type: &ModuleType,
+  side_effects: Option<HookSideEffects>,
+  sourcemap_chain: &[SourcemapChainElement],
+  resolved_deps: &IndexVec<ImportRecordIdx, ResolvedId>,
+  cwd: &Path,
+) -> Option<Vec<u8>> {
+  let mut chain = Vec::with_capacity(sourcemap_chain.len());
+  for element in sourcemap_chain {
+    let value = match element {
+      SourcemapChainElement::Load(map) => serde_json::json!({
+        "t": "load",
+        "m": map.to_json_string(),
+      }),
+      SourcemapChainElement::Transform((plugin_idx, map)) => serde_json::json!({
+        "t": "map",
+        "p": plugin_idx.raw(),
+        "m": map.to_json_string(),
+      }),
+      SourcemapChainElement::Omitted { plugin_idx, plugin_name } => serde_json::json!({
+        "t": "omitted",
+        "p": plugin_idx.raw(),
+        "n": plugin_name.as_str(),
+      }),
+      SourcemapChainElement::Null { plugin_idx, original_content } => serde_json::json!({
+        "t": "null",
+        "p": plugin_idx.raw(),
+        "c": original_content.as_str(),
+      }),
+    };
+    chain.push(value);
+  }
+  let meta = serde_json::json!({
+    "moduleType": module_type.to_string(),
+    "sideEffects": side_effects.map(hook_side_effects_to_u8),
+    "chain": chain,
+    "deps": resolved_deps.iter().map(|dep| encode_resolved_dep(dep, cwd)).collect::<Vec<_>>(),
+  });
+  let meta_bytes = serde_json::to_vec(&meta).ok()?;
+
+  let mut bytes = Vec::with_capacity(HEADER_LEN + meta_bytes.len() + code.len());
+  bytes.extend_from_slice(&MAGIC);
+  bytes.push(FORMAT_VERSION);
+  bytes.extend_from_slice(&(meta_bytes.len() as u64).to_le_bytes());
+  bytes.extend_from_slice(&meta_bytes);
+  bytes.extend_from_slice(code.as_bytes());
+  Some(bytes)
+}
+
+/// Any malformed or unreadable entry is treated as a miss; the build then
+/// recomputes and rewrites it. An entry whose resolved dependencies no longer
+/// exist on disk is also a miss, so deleted or moved files fall back to a
+/// fresh resolution instead of replaying a stale one.
+fn read_entry(path: &Path, cwd: &Path) -> Option<CachedModule> {
+  let bytes = std::fs::read(path).ok()?;
+  let entry = decode_entry(&bytes, cwd)?;
+  let deps_exist = entry.resolved_deps.iter().all(|dep| {
+    let path = Path::new(dep.id.as_str());
+    dep.external.is_external() || !path.is_absolute() || std::fs::metadata(path).is_ok()
+  });
+  deps_exist.then_some(entry)
+}
+
+fn decode_entry(bytes: &[u8], cwd: &Path) -> Option<CachedModule> {
+  if bytes.len() < HEADER_LEN || bytes[0..4] != MAGIC || bytes[4] != FORMAT_VERSION {
+    return None;
+  }
+  let meta_len = usize::try_from(u64::from_le_bytes(bytes[5..13].try_into().ok()?)).ok()?;
+  let code_offset = HEADER_LEN.checked_add(meta_len)?;
+  if bytes.len() < code_offset {
+    return None;
+  }
+  let meta: serde_json::Value = serde_json::from_slice(&bytes[HEADER_LEN..code_offset]).ok()?;
+  let code = String::from_utf8(bytes[code_offset..].to_vec()).ok()?;
+
+  let module_type_str = meta.get("moduleType")?.as_str()?;
+  let module_type = ModuleType::from_known_str(module_type_str)
+    .unwrap_or_else(|_| ModuleType::Custom(module_type_str.to_string()));
+  let side_effects = match meta.get("sideEffects")? {
+    serde_json::Value::Null => None,
+    value => Some(hook_side_effects_from_u64(value.as_u64()?)?),
+  };
+
+  let mut sourcemap_chain = vec![];
+  for element in meta.get("chain")?.as_array()? {
+    sourcemap_chain.push(match element.get("t")?.as_str()? {
+      // Parse through the lifetime-generic type; the stored chain needs the
+      // owned (`'static`) form.
+      "load" => SourcemapChainElement::Load(
+        oxc_sourcemap::SourceMap::from_json_string(element.get("m")?.as_str()?).ok()?.into_owned(),
+      ),
+      "map" => SourcemapChainElement::Transform((
+        decode_plugin_idx(element)?,
+        oxc_sourcemap::SourceMap::from_json_string(element.get("m")?.as_str()?).ok()?.into_owned(),
+      )),
+      "omitted" => SourcemapChainElement::Omitted {
+        plugin_idx: decode_plugin_idx(element)?,
+        plugin_name: ArcStr::from(element.get("n")?.as_str()?),
+      },
+      "null" => SourcemapChainElement::Null {
+        plugin_idx: decode_plugin_idx(element)?,
+        original_content: ArcStr::from(element.get("c")?.as_str()?),
+      },
+      _ => return None,
+    });
+  }
+
+  let mut resolved_deps = IndexVec::new();
+  for dep in meta.get("deps")?.as_array()? {
+    resolved_deps.push(decode_resolved_dep(dep, cwd)?);
+  }
+
+  Some(CachedModule { code, module_type, side_effects, sourcemap_chain, resolved_deps })
+}
+
+fn decode_plugin_idx(element: &serde_json::Value) -> Option<PluginIdx> {
+  Some(PluginIdx::from_raw(u32::try_from(element.get("p")?.as_u64()?).ok()?))
+}
+
+/// Writes go to a process-unique temp file first and are moved into place with
+/// a rename, so concurrent builds sharing a cache dir never observe partial
+/// entries. All errors are swallowed: the cache is an optimization and must
+/// never fail the build.
+fn write_entry(path: &Path, bytes: &[u8]) {
+  let Some(parent) = path.parent() else { return };
+  if let Err(error) = std::fs::create_dir_all(parent) {
+    tracing::debug!("failed to create build cache dir {}: {error}", parent.display());
+    return;
+  }
+  let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else { return };
+  let tmp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+  let result = std::fs::write(&tmp_path, bytes).and_then(|()| {
+    std::fs::rename(&tmp_path, path).inspect_err(|_| {
+      let _ = std::fs::remove_file(&tmp_path);
+    })
+  });
+  if let Err(error) = result {
+    tracing::debug!("failed to write build cache entry {}: {error}", path.display());
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn entry_roundtrip() {
+    let cwd = std::env::current_dir().unwrap();
+    let chain = vec![
+      SourcemapChainElement::Omitted {
+        plugin_idx: PluginIdx::from_raw(3),
+        plugin_name: "p".into(),
+      },
+      SourcemapChainElement::Null {
+        plugin_idx: PluginIdx::from_raw(4),
+        original_content: "const a = 1;".into(),
+      },
+    ];
+    let dep_path = cwd.join("dep.js");
+    let mut deps: IndexVec<ImportRecordIdx, ResolvedId> = IndexVec::new();
+    deps.push(ResolvedId {
+      id: dep_path.to_str().unwrap().into(),
+      module_def_format: ModuleDefFormat::EsmMjs,
+      external: ResolvedExternal::Bool(false),
+      normalize_external_id: None,
+      package_json: Some(Arc::new(PackageJson::from_parts(
+        Some("pkg".into()),
+        Some("1.0.0".into()),
+        Some("module"),
+        Some(SideEffects::Array(vec!["*.css".to_string()])),
+        cwd.join("package.json"),
+      ))),
+      side_effects: Some(HookSideEffects::False),
+      is_external_without_side_effects: false,
+    });
+    deps.push(ResolvedId::new_external_without_side_effects("react".into()));
+
+    let bytes = encode_entry(
+      "const a = 2;",
+      &ModuleType::Tsx,
+      Some(HookSideEffects::False),
+      &chain,
+      &deps,
+      &cwd,
+    )
+    .unwrap();
+    let entry = decode_entry(&bytes, &cwd).unwrap();
+    assert_eq!(entry.code, "const a = 2;");
+    assert_eq!(entry.module_type, ModuleType::Tsx);
+    assert_eq!(entry.side_effects, Some(HookSideEffects::False));
+    assert_eq!(entry.sourcemap_chain.len(), 2);
+    assert_eq!(entry.resolved_deps.len(), 2);
+
+    let dep = &entry.resolved_deps[ImportRecordIdx::from_raw(0)];
+    assert_eq!(dep.id.as_str(), dep_path.to_str().unwrap());
+    assert_eq!(dep.module_def_format, ModuleDefFormat::EsmMjs);
+    assert!(!dep.external.is_external());
+    assert_eq!(dep.side_effects, Some(HookSideEffects::False));
+    let package_json = dep.package_json.as_ref().unwrap();
+    assert_eq!(package_json.name(), Some("pkg"));
+    assert_eq!(package_json.r#type(), Some("module"));
+    assert_eq!(package_json.realpath(), cwd.join("package.json"));
+    assert_eq!(
+      package_json.check_side_effects_for("styles/app.css"),
+      Some(true),
+      "sideEffects globs must survive the roundtrip"
+    );
+
+    let external = &entry.resolved_deps[ImportRecordIdx::from_raw(1)];
+    assert_eq!(external.id.as_str(), "react");
+    assert!(external.external.is_external());
+    assert!(external.is_external_without_side_effects);
+  }
+
+  #[test]
+  fn rejects_unknown_version_and_garbage() {
+    let cwd = std::env::current_dir().unwrap();
+    let bytes = encode_entry("code", &ModuleType::Js, None, &[], &IndexVec::new(), &cwd).unwrap();
+    let mut wrong_version = bytes.clone();
+    wrong_version[4] = FORMAT_VERSION + 1;
+    assert!(decode_entry(&wrong_version, &cwd).is_none());
+    assert!(decode_entry(&bytes[0..HEADER_LEN - 1], &cwd).is_none());
+    assert!(decode_entry(b"not a cache entry", &cwd).is_none());
+  }
+}

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod apply_inner_plugins;
 pub mod augment_chunk_hash;
+pub mod build_cache;
 pub mod chunk;
 pub mod defer_drop;
 pub mod external_import_interop;

--- a/crates/rolldown/tests/rolldown/topics/build_cache/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/build_cache/mod.rs
@@ -1,0 +1,208 @@
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rolldown::{
+  BuildCacheOption, BuildCacheOptions, Bundler, BundlerOptions, ExperimentalOptions, InputItem,
+};
+use rolldown_common::Output;
+use rolldown_plugin::{HookTransformOutputMap, HookUsage, Plugin};
+
+/// Counts its `resolveId` (importer-driven only), `load` and `transform`
+/// invocations on fixture modules and rewrites the `__MARKER__` placeholder,
+/// so cache hits are observable both through the counters (the whole pipeline
+/// skipped) and the emitted chunk (cached code used).
+#[derive(Debug, Default)]
+struct CountingPlugin {
+  resolve_calls: Arc<AtomicUsize>,
+  load_calls: Arc<AtomicUsize>,
+  transform_calls: Arc<AtomicUsize>,
+}
+
+impl Plugin for CountingPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "counting".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::ResolveId | HookUsage::Load | HookUsage::Transform
+  }
+
+  async fn resolve_id(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookResolveIdArgs<'_>,
+  ) -> rolldown_plugin::HookResolveIdReturn {
+    // Entry points resolve on every build; only dependency resolution is
+    // covered by the cache.
+    if args.importer.is_some() {
+      self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+    }
+    Ok(None)
+  }
+
+  async fn load(
+    &self,
+    _ctx: rolldown_plugin::SharedLoadPluginContext,
+    args: &rolldown_plugin::HookLoadArgs<'_>,
+  ) -> rolldown_plugin::HookLoadReturn {
+    if is_fixture_module(args.id) {
+      self.load_calls.fetch_add(1, Ordering::SeqCst);
+    }
+    Ok(None)
+  }
+
+  async fn transform(
+    &self,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !is_fixture_module(args.id) {
+      return Ok(None);
+    }
+    self.transform_calls.fetch_add(1, Ordering::SeqCst);
+    Ok(Some(rolldown_plugin::HookTransformOutput {
+      code: Some(args.code.replace("__MARKER__", "transformed")),
+      map: HookTransformOutputMap::Null,
+      ..Default::default()
+    }))
+  }
+}
+
+/// The virtual runtime module (`\0rolldown/runtime.js`) runs its hooks on
+/// every build by design; only real fixture files are counted.
+fn is_fixture_module(id: &str) -> bool {
+  id.ends_with(".js") && !id.starts_with('\0')
+}
+
+struct BuildResult {
+  resolve_calls: usize,
+  load_calls: usize,
+  transform_calls: usize,
+  code: String,
+}
+
+/// Builds `entry.js` in `cwd` with the persistent build cache enabled and
+/// returns per-hook invocation counts plus the entry chunk's code.
+async fn build(cwd: &Path, cache_dir: &Path, key: Option<&str>) -> anyhow::Result<BuildResult> {
+  let plugin = Arc::new(CountingPlugin::default());
+  let (resolve_calls, load_calls, transform_calls) = (
+    Arc::clone(&plugin.resolve_calls),
+    Arc::clone(&plugin.load_calls),
+    Arc::clone(&plugin.transform_calls),
+  );
+  let mut bundler = Bundler::with_plugins(
+    BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "./entry.js".to_string(),
+      }]),
+      cwd: Some(cwd.to_path_buf()),
+      experimental: Some(ExperimentalOptions {
+        build_cache: Some(BuildCacheOption::Options(BuildCacheOptions {
+          dir: Some(cache_dir.to_string_lossy().into_owned()),
+          key: key.map(str::to_string),
+        })),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+    vec![plugin],
+  )?;
+
+  let output = bundler.generate().await?;
+  let code = output
+    .assets
+    .iter()
+    .find_map(|asset| match asset {
+      Output::Chunk(chunk) => Some(chunk.code.clone()),
+      Output::Asset(_) => None,
+    })
+    .expect("build should emit a chunk");
+  Ok(BuildResult {
+    resolve_calls: resolve_calls.load(Ordering::SeqCst),
+    load_calls: load_calls.load(Ordering::SeqCst),
+    transform_calls: transform_calls.load(Ordering::SeqCst),
+    code,
+  })
+}
+
+/// Creates a fresh two-module fixture (`entry.js` importing `dep.js`) plus an
+/// empty cache dir under the target tmpdir.
+fn fresh_fixture(name: &str) -> (PathBuf, PathBuf) {
+  let root = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("build_cache").join(name);
+  let _ = std::fs::remove_dir_all(&root);
+  let cwd = root.join("src");
+  std::fs::create_dir_all(&cwd).unwrap();
+  std::fs::write(
+    cwd.join("entry.js"),
+    "import { dep } from './dep.js';\nconsole.log('__MARKER__', dep);\n",
+  )
+  .unwrap();
+  std::fs::write(cwd.join("dep.js"), "export const dep = '__MARKER__ dep';\n").unwrap();
+  (cwd, root.join("cache"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn second_build_skips_resolve_load_and_transform_and_reuses_cached_output() {
+  let (cwd, cache_dir) = fresh_fixture("hit");
+
+  let first = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(first.resolve_calls, 1, "cold build must resolve the dependency");
+  assert_eq!(first.load_calls, 2, "cold build must load both modules");
+  assert_eq!(first.transform_calls, 2, "cold build must transform both modules");
+  assert!(first.code.contains("transformed"), "transform result must reach the chunk");
+
+  let second = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(second.resolve_calls, 0, "warm build must skip dependency resolution");
+  assert_eq!(second.load_calls, 0, "warm build must skip the load hooks");
+  assert_eq!(second.transform_calls, 0, "warm build must skip the transform hooks");
+  assert_eq!(second.code, first.code, "cached build must produce identical output");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn changing_cache_key_invalidates_entries() {
+  let (cwd, cache_dir) = fresh_fixture("key");
+
+  let first = Box::pin(build(&cwd, &cache_dir, Some("config-hash-a"))).await.unwrap();
+  assert_eq!(first.transform_calls, 2);
+
+  let same_key = Box::pin(build(&cwd, &cache_dir, Some("config-hash-a"))).await.unwrap();
+  assert_eq!(same_key.transform_calls, 0, "same key must hit the cache");
+
+  let new_key = Box::pin(build(&cwd, &cache_dir, Some("config-hash-b"))).await.unwrap();
+  assert_eq!(new_key.transform_calls, 2, "a new key must invalidate every entry");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn editing_a_module_reruns_only_its_own_pipeline() {
+  let (cwd, cache_dir) = fresh_fixture("edit");
+
+  let first = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(first.transform_calls, 2);
+
+  std::fs::write(cwd.join("dep.js"), "export const dep = '__MARKER__ dep edited';\n").unwrap();
+  let after_edit = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(after_edit.transform_calls, 1, "only the edited module must re-run its pipeline");
+  assert_eq!(after_edit.load_calls, 1, "the unchanged importer must stay cached");
+  assert!(after_edit.code.contains("dep edited"), "output must pick up the edit");
+
+  let warm_again = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(warm_again.transform_calls, 0, "the edited module must be cached again");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deleting_a_cached_dependency_falls_back_to_fresh_resolution() {
+  let (cwd, cache_dir) = fresh_fixture("delete");
+
+  let first = Box::pin(build(&cwd, &cache_dir, None)).await.unwrap();
+  assert_eq!(first.transform_calls, 2);
+
+  std::fs::remove_file(cwd.join("dep.js")).unwrap();
+  let result = Box::pin(build(&cwd, &cache_dir, None)).await;
+  assert!(
+    result.is_err(),
+    "a deleted dependency must fail like a cold build instead of replaying stale resolutions"
+  );
+}

--- a/crates/rolldown/tests/rolldown/topics/build_cache/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/build_cache/mod.rs
@@ -193,6 +193,34 @@ async fn editing_a_module_reruns_only_its_own_pipeline() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn cache_disables_itself_without_cacheable_plugin_hooks() {
+  let (cwd, cache_dir) = fresh_fixture("bypass");
+
+  // No plugin registers `resolveId`/`load`/`transform` (only rolldown's cheap
+  // inner plugins do), so there is nothing for the cache to skip and it must
+  // not pay its own overhead: no entries, not even the cache dir.
+  let mut bundler = Bundler::new(BundlerOptions {
+    input: Some(vec![InputItem {
+      name: Some("entry".to_string()),
+      import: "./entry.js".to_string(),
+    }]),
+    cwd: Some(cwd.clone()),
+    experimental: Some(ExperimentalOptions {
+      build_cache: Some(BuildCacheOption::Options(BuildCacheOptions {
+        dir: Some(cache_dir.to_string_lossy().into_owned()),
+        key: None,
+      })),
+      ..Default::default()
+    }),
+    ..Default::default()
+  })
+  .expect("failed to create bundler");
+  Box::pin(bundler.generate()).await.expect("build should succeed");
+
+  assert!(!cache_dir.exists(), "a build with no cacheable hooks must not touch the cache dir");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn deleting_a_cached_dependency_falls_back_to_fresh_resolution() {
   let (cwd, cache_dir) = fresh_fixture("delete");
 

--- a/crates/rolldown/tests/rolldown/topics/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/mod.rs
@@ -1,2 +1,3 @@
+mod build_cache;
 mod hmr;
 mod runtime;

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -14,6 +14,7 @@ pub struct BindingExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<Either<bool, BindingChunkOptimizationOptions>>,
   pub lazy_barrel: Option<bool>,
+  pub build_cache: Option<Either<bool, BindingBuildCacheOptions>>,
 }
 
 impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -38,7 +39,24 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
         Either::B(v) => rolldown_common::ChunkOptimizationOption::Options(v.into()),
       }),
       lazy_barrel: value.lazy_barrel,
+      build_cache: value.build_cache.map(|v| match v {
+        Either::A(v) => rolldown_common::BuildCacheOption::Bool(v),
+        Either::B(v) => rolldown_common::BuildCacheOption::Options(v.into()),
+      }),
     })
+  }
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug, Default)]
+pub struct BindingBuildCacheOptions {
+  pub dir: Option<String>,
+  pub key: Option<String>,
+}
+
+impl From<BindingBuildCacheOptions> for rolldown_common::BuildCacheOptions {
+  fn from(value: BindingBuildCacheOptions) -> Self {
+    Self { dir: value.dir, key: value.key }
   }
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -66,6 +66,37 @@ impl ChunkOptimizationOption {
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields, default)
+)]
+pub struct BuildCacheOptions {
+  /// Directory where cache entries are stored. Relative paths are resolved
+  /// against `cwd`. Defaults to `node_modules/.cache/rolldown`.
+  pub dir: Option<String>,
+  /// Extra cache invalidation key mixed into every entry's hash. The cache key
+  /// only captures the rolldown version, the ordered plugin names, each
+  /// module's id and on-disk content. Plugin *configuration* or
+  /// *implementation* changes and resolution inputs outside module files
+  /// (lockfile, `tsconfig.json` paths) are invisible to it, so callers must
+  /// fold anything that changes resolve/load/transform output (e.g. a hash of
+  /// the resolved config and lockfile) into this key.
+  pub key: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(untagged)
+)]
+pub enum BuildCacheOption {
+  Bool(bool),
+  Options(BuildCacheOptions),
+}
+
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 pub struct ExperimentalOptions {
@@ -80,6 +111,7 @@ pub struct ExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<ChunkOptimizationOption>,
   pub lazy_barrel: Option<bool>,
+  pub build_cache: Option<BuildCacheOption>,
 }
 
 impl ExperimentalOptions {
@@ -124,5 +156,13 @@ impl ExperimentalOptions {
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
     self.lazy_barrel.unwrap_or(false)
+  }
+
+  pub fn build_cache_options(&self) -> Option<BuildCacheOptions> {
+    match &self.build_cache {
+      Some(BuildCacheOption::Bool(true)) => Some(BuildCacheOptions::default()),
+      Some(BuildCacheOption::Options(options)) => Some(options.clone()),
+      Some(BuildCacheOption::Bool(false)) | None => None,
+    }
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -35,7 +35,8 @@ pub mod bundler_options {
       devtools_options::DevtoolsOptions,
       es_module_flag::EsModuleFlag,
       experimental_options::{
-        ChunkOptimizationOption, ChunkOptimizationOptions, ExperimentalOptions,
+        BuildCacheOption, BuildCacheOptions, ChunkOptimizationOption, ChunkOptimizationOptions,
+        ExperimentalOptions,
       },
       filename_template::{FilenameTemplate, is_path_fragment},
       generated_code_options::GeneratedCodeOptions,

--- a/crates/rolldown_common/src/types/module_def_format.rs
+++ b/crates/rolldown_common/src/types/module_def_format.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 /// Module Definition Format.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ModuleDefFormat {
   #[default]
   Unknown,

--- a/crates/rolldown_common/src/types/package_json.rs
+++ b/crates/rolldown_common/src/types/package_json.rs
@@ -15,6 +15,18 @@ pub struct PackageJson {
 }
 
 impl PackageJson {
+  /// Reconstructs a `PackageJson` from previously extracted fields, e.g. when
+  /// replaying a persistent build cache entry.
+  pub fn from_parts(
+    name: Option<ArcStr>,
+    version: Option<ArcStr>,
+    r#type: Option<&'static str>,
+    side_effects: Option<SideEffects>,
+    realpath: PathBuf,
+  ) -> Self {
+    Self { name, version, r#type, side_effects, realpath }
+  }
+
   pub fn from_oxc_pkg_json(oxc_pkg_json: &oxc_resolver::PackageJson) -> Self {
     Self {
       name: oxc_pkg_json.name().map(ArcStr::from),

--- a/crates/rolldown_common/src/types/side_effects.rs
+++ b/crates/rolldown_common/src/types/side_effects.rs
@@ -52,7 +52,7 @@ pub(crate) fn glob_match_with_normalized_pattern(pattern: &str, path: &str) -> b
   fast_glob::glob_match(&normalized_glob, path.trim_start_matches("./"))
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookSideEffects {
   True,
   False,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1033,6 +1033,16 @@
             "boolean",
             "null"
           ]
+        },
+        "buildCache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BuildCacheOption"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -1127,6 +1137,38 @@
         "avoidRedundantChunkLoads": {
           "type": "boolean",
           "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "BuildCacheOption": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/BuildCacheOptions"
+        }
+      ]
+    },
+    "BuildCacheOptions": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "description": "Directory where cache entries are stored. Relative paths are resolved\nagainst `cwd`. Defaults to `node_modules/.cache/rolldown`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "key": {
+          "description": "Extra cache invalidation key mixed into every entry's hash. The cache key\nonly captures the rolldown version, the ordered plugin names, each\nmodule's id and on-disk content. Plugin *configuration* or\n*implementation* changes and resolution inputs outside module files\n(lockfile, `tsconfig.json` paths) are invisible to it, so callers must\nfold anything that changes resolve/load/transform output (e.g. a hash of\nthe resolved config and lockfile) into this key.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       },
       "additionalProperties": false

--- a/internal-docs/build-cache/design.md
+++ b/internal-docs/build-cache/design.md
@@ -1,0 +1,130 @@
+# Persistent Build Cache - Design
+
+> The data flow and file pointers live in [implementation.md](./implementation.md).
+
+## Problem
+
+For most projects rolldown is fast enough that persistent caching is not worth
+its complexity (see the discussion in
+[#802](https://github.com/rolldown/rolldown/discussions/802)). Two situations
+break that assumption (tracked in
+[#6995](https://github.com/rolldown/rolldown/issues/6995)):
+
+- Slow JavaScript plugin hooks (framework compilers, legacy transpilers,
+  custom resolvers). Every call crosses the NAPI boundary and runs
+  single-threaded JS, so the `resolveId`/`load`/`transform` pipeline dominates
+  cold-build time.
+- Very large module graphs (100k+ modules in monorepos), where even cheap
+  per-module work adds up and CI machines rebuild the same unchanged modules
+  thousands of times a day.
+
+The existing `ScanStageCache` only helps rebuilds within one process (watch
+mode / HMR). Nothing survives a process restart, and nothing can be shared
+between machines.
+
+An earlier iteration ([#10137](https://github.com/rolldown/rolldown/pull/10137))
+cached only the `transform` stage. Review feedback was that rolldown targets
+caching for the whole bundler pipeline, not a single hook, so this design
+covers everything a module task does before the native parse: the `load`
+pipeline, the `transform` pipeline and dependency resolution (`resolveId`
+hooks plus the native resolver).
+
+## Goals
+
+- Opt-in, experimental persistent cache that skips every plugin hook and the
+  resolver for unchanged modules, across processes.
+- Never fail or corrupt a build: every cache error degrades to a miss, every
+  write is atomic.
+- Warm builds must produce byte-identical output to cold builds, including
+  sourcemaps and side-effect-driven tree shaking.
+- On-disk layout simple enough that external tooling can implement **remote
+  caching** on top (e.g. read-through from an HTTP mirror, CI writers
+  populating an object store) by syncing files, without understanding the
+  entry format. Cache keys and entry contents must therefore be
+  machine-portable (no absolute paths).
+- Smallest possible surface area inside rolldown; the cache touches exactly
+  one seam (`ModuleTask::run_inner`).
+
+## Non-goals
+
+- Caching parse, link or codegen results. The oxc AST is arena-allocated and
+  self-referential, so it cannot be serialized without a dedicated
+  representation; parsing and scanning are native and fast relative to JS
+  plugin hooks. Re-parsing the cached post-transform source reproduces the
+  scan state, including the import records the cached resolutions align with.
+- Automatic invalidation on plugin configuration or implementation changes.
+  Rolldown cannot observe either, so callers fold a config/lockfile hash into
+  `experimental.buildCache.key` (the same contract Metro's `getCacheKey` and
+  webpack's `cache.version` use).
+- Replacing `ScanStageCache`. The two compose: within a watch session the
+  in-memory cache avoids re-scanning entirely; the persistent cache
+  accelerates the scans that do happen.
+
+## Decisions and trade-offs
+
+- **Key on the module's raw on-disk content, not the post-`load` source.**
+  Keying on post-`load` source (as #10137 did) forces `load` hooks to run on
+  every build. Reading the file directly makes the key available before any
+  hook runs, so hits skip the whole pipeline. The cost: modules that do not
+  map to a real file (virtual modules, data URLs) bypass the cache entirely,
+  and `load`/`transform` hooks are assumed to be deterministic functions of
+  the module's id and content, the same determinism contract Metro and
+  webpack's filesystem cache rely on.
+- **Cache resolved dependencies positionally, not by specifier.** Scanning the
+  cached code is deterministic, so the import records of a warm build are
+  identical to the cold build's and a plain array lines up with them. A length
+  mismatch (corrupt entry) falls back to fresh resolution.
+- **Validate cached resolutions by stat-ing dep files on hits.** A deleted or
+  moved dependency turns the entry into a miss, so the importer re-resolves
+  and fails (or externalizes) exactly like a cold build. Newly added files
+  that would shadow an old resolution are NOT detected; that class of change
+  is folded into `key` (documented limitation, same as webpack's
+  `unsafeCache`).
+- **Serialize the full `ResolvedId`, including `package.json` data.** Side
+  effects derived from `package.json` `sideEffects` globs are evaluated in the
+  dependency's own task via `resolved_id.package_json`, so dropping it would
+  change tree shaking between cold and warm builds. `PackageJson` is five
+  small fields; paths inside entries are stored cwd-relative for portability.
+- **Modules whose resolution produced warnings are never stored.** Warnings
+  (e.g. "treating missing import as external") are emitted during resolution
+  and would silently disappear on hits; re-running the pipeline keeps them.
+- **One file per entry, content-addressed, atomic rename.** Rejected a single
+  store file / database: per-entry files need no locking across concurrent
+  builds, tolerate partial syncs, and are trivially mirrored to remote
+  storage. The 256-way `key[0..2]` sharding keeps directories small at
+  monorepo scale.
+- **Format: JSON metadata header + raw code bytes.** Rejected new
+  serialization dependencies (bincode/rkyv); `serde_json` is already a
+  dependency, and keeping the code blob out of JSON avoids escaping the
+  largest field. A format version byte plus the salt guard both decode
+  compatibility and semantic compatibility.
+- **Side effects are stored as a delta.** The pre-`load` value comes from
+  resolution data outside the cache key, so only a load/transform-hook
+  override is stored and replayed.
+
+## Known limitations
+
+- Hook side channels are not replayed on hits: `this.emitFile`,
+  `this.addWatchFile` and custom module meta written during `load` or
+  `transform` are lost for cached modules. Plugins relying on those must
+  currently not be used with the cache enabled. (The module's own watch-file
+  registration is preserved; it does not depend on hooks.)
+- Resolution inputs that live outside module files (lockfile changes that
+  move a package, `tsconfig.json` path mappings, new files shadowing an old
+  resolution) are invisible to the content-based key. Callers fold them into
+  `key`.
+- Incompatible with `experimental.nativeMagicString` + sourcemaps: that path
+  generates transform sourcemaps on a side channel outside the module task, so
+  the cache silently disables itself there.
+- No eviction. Entries are small and content-addressed; callers can wipe or
+  age out the directory externally. Revisit if this graduates from
+  experimental.
+
+## Open questions
+
+- Should the store become a trait (get/set) so embedders can plug remote
+  backends directly instead of syncing the directory? The current layout was
+  chosen so that this can be added later without changing the entry format.
+- Whether Vite should derive `key` automatically from its resolved config.
+- Whether entry-point resolution (`resolve_user_defined_entries`) is worth
+  caching too; it is a handful of resolutions per build.

--- a/internal-docs/build-cache/design.md
+++ b/internal-docs/build-cache/design.md
@@ -101,6 +101,13 @@ hooks plus the native resolver).
 - **Side effects are stored as a delta.** The pre-`load` value comes from
   resolution data outside the cache key, so only a load/transform-hook
   override is stored and replayed.
+- **The cache disables itself when no plugin registers a cacheable hook.**
+  With nothing to skip, the cache would only add per-module fs reads and
+  entry decoding (measured 1.8x slower warm, 5.7x slower cold on a 10k-module
+  plugin-free build). Rolldown's always-registered inner plugins
+  (`copy-module`, `asset-module`, `data-url`, `oxc-runtime`) are exempt from
+  the check: their hooks are native early-return filters cheaper than the
+  cache itself.
 
 ## Known limitations
 

--- a/internal-docs/build-cache/implementation.md
+++ b/internal-docs/build-cache/implementation.md
@@ -29,6 +29,9 @@ codegen) is unchanged.
    enabled, unless the native magic-string sourcemap channel is active (those
    sourcemaps are generated outside the module task and could not be
    captured; see `create_sourcemap_channel` in `scan_stage.rs`).
+   `BuildCache::new` also returns `None` when no plugin beyond rolldown's
+   cheap inner plugins registers a `resolveId`/`load`/`transform` hook; with
+   nothing to skip, the cache would be pure overhead.
 2. `ModuleTask::run_inner` reads the module's raw on-disk content
    (`read_disk_source_for_cache_key`) before running any hook. Ids that are
    not absolute filesystem paths (virtual modules, data URLs, `rolldown:`)

--- a/internal-docs/build-cache/implementation.md
+++ b/internal-docs/build-cache/implementation.md
@@ -1,0 +1,91 @@
+# Persistent Build Cache - Implementation
+
+> Rationale, trade-offs and limitations live in [design.md](./design.md).
+
+## Summary
+
+`experimental.buildCache` persists the result of a module task's plugin
+pipeline per module: the post-transform code, module type, sourcemap chain,
+side-effect override and the resolved dependencies. On a hit, `ModuleTask`
+restores all of it from disk and never calls a `resolveId`, `load` or
+`transform` hook, nor the native resolver, for that module. Parsing and
+scanning re-run natively on the cached code; everything downstream (link,
+codegen) is unchanged.
+
+## Components
+
+| Piece               | Location                                                                                        |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| Option types        | `crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs`                |
+| Store + entry codec | `crates/rolldown/src/utils/build_cache.rs`                                                      |
+| Construction        | `ModuleLoader::new` (`crates/rolldown/src/module_loader/module_loader.rs`)                      |
+| Read/write seam     | `ModuleTask::run_inner` (`crates/rolldown/src/module_loader/module_task.rs`)                    |
+| Binding             | `BindingBuildCacheOptions` (`crates/rolldown_binding/.../binding_experimental_options.rs`)      |
+| JS options          | `packages/rolldown/src/options/input-options.ts`, `validator.ts`, `bindingify-input-options.ts` |
+
+## Data flow
+
+1. `ModuleLoader::new` builds one `BuildCache` per build when the option is
+   enabled, unless the native magic-string sourcemap channel is active (those
+   sourcemaps are generated outside the module task and could not be
+   captured; see `create_sourcemap_channel` in `scan_stage.rs`).
+2. `ModuleTask::run_inner` reads the module's raw on-disk content
+   (`read_disk_source_for_cache_key`) before running any hook. Ids that are
+   not absolute filesystem paths (virtual modules, data URLs, `rolldown:`)
+   or cannot be read bypass the cache entirely.
+3. The key is
+   `xxh3(salt, stable_id, asserted_module_type, xxh3(disk_bytes))`, hex
+   encoded, where
+   `salt = xxh3(format_version, rolldown_version, options.key, platform, sorted moduleTypes, ordered plugin names)`.
+   `stable_id` (cwd-relative, forward slashes) keeps keys portable across
+   machines, which remote cache layers rely on.
+4. Hit (`BuildCache::get` decoded the entry and every cached non-external
+   dependency with an absolute path still exists on disk):
+   - the module id is registered as a watch file, mirroring the
+     read-from-disk path in `load_source`;
+   - the stored sourcemap chain (including `Load` elements) replaces the
+     empty chain, the side-effects override is applied if one was stored, and
+     the cached code + module type feed straight into `create_ecma_view`;
+   - after the native scan, the cached `ResolvedId`s are used instead of
+     calling `resolve_dependencies`. They are positionally aligned with the
+     scanned import records; a length mismatch falls back to fresh
+     resolution.
+5. Miss: the normal pipeline runs (`load_source` → `transform_source` →
+   `create_ecma_view` → `resolve_dependencies`). If the source was a string
+   and resolution emitted no warnings, the entry is stored: code, final
+   module type, side-effects delta (only if the load/transform pipeline
+   changed it), the full sourcemap chain (taken from
+   `ecma_view.sourcemap_chain`, which `create_ecma_view` moves verbatim) and
+   the resolved dependencies.
+
+## Entry format
+
+`<dir>/build-v1/<key[0..2]>/<key>`, written to a process-unique temp file and
+renamed into place. Layout:
+
+```text
+b"RDBC"  format_version:u8  meta_len:u64le  meta_json  raw code bytes
+```
+
+`meta_json` holds `moduleType`, the optional `sideEffects` override (0/1/2),
+the serialized chain elements (`Load`/`Transform` maps as sourcemap JSON,
+`Omitted`/`Null` with plugin index and payload) and `deps`, one object per
+import record: the resolved id, `ModuleDefFormat`, external kind,
+side-effect data and the dependency's `package.json` fields (name, version,
+type, `sideEffects`, realpath). Absolute paths inside entries are stored
+cwd-relative with an `abs` marker and re-absolutized against the reader's
+cwd. Any decode failure, size mismatch or unknown version is treated as a
+miss and the entry is rewritten.
+
+## Invariants
+
+- Cache failures never fail the build: reads degrade to misses, writes log at
+  `debug` level and are dropped.
+- `PluginIdx` values inside cached chains are only meaningful because the
+  ordered plugin name list is part of the salt; changing the plugin list
+  invalidates every entry.
+- Cached `resolved_deps` line up with the import records scanned from the
+  cached code because scanning is deterministic; the length check is the
+  corruption guard.
+- The runtime module task and emitted-entry virtual modules never touch the
+  cache (their ids are not absolute paths).

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1874,6 +1874,11 @@ export declare enum BindingAttachDebugInfo {
   Full = 2
 }
 
+export interface BindingBuildCacheOptions {
+  dir?: string
+  key?: string
+}
+
 export interface BindingBuiltinPlugin {
   __name: BindingBuiltinPluginName
   options?: unknown
@@ -2230,6 +2235,7 @@ export interface BindingExperimentalOptions {
   nativeMagicString?: boolean
   chunkOptimization?: boolean | BindingChunkOptimizationOptions
   lazyBarrel?: boolean
+  buildCache?: boolean | BindingBuildCacheOptions
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -657,6 +657,46 @@ export interface InputOptions {
      */
     incrementalBuild?: boolean;
     /**
+     * Persist per-module build pipeline results (plugin `load` and
+     * `transform` output plus dependency resolution) to disk and reuse them
+     * across builds and processes.
+     *
+     * Entries are keyed on each module's on-disk content: a hit skips every
+     * `resolveId`, `load` and `transform` hook for that module and replays
+     * the resolved dependencies, which mainly pays off for expensive
+     * JavaScript hooks (framework compilers, legacy transpilers) and very
+     * large module graphs. Parsing, scanning and all later build stages run
+     * unchanged. Virtual modules and data URLs always bypass the cache.
+     *
+     * The cache key covers the rolldown version, platform, the ordered
+     * plugin names, each module's id and file content, plus the `key`
+     * option. Plugin configuration or implementation changes and resolution
+     * inputs outside module files (lockfile, `tsconfig.json` paths, newly
+     * added files that shadow a previous resolution) are NOT detected
+     * automatically: fold anything that affects resolve/load/transform
+     * output (e.g. a hash of your resolved config and lockfile) into `key`.
+     *
+     * Hooks are assumed to be deterministic functions of the module's id and
+     * content. Side channels (`this.emitFile`, `this.addWatchFile`, custom
+     * module meta) are not replayed on cache hits, and the cache is not
+     * applied when `nativeMagicString` is enabled together with sourcemaps.
+     *
+     * @default false
+     */
+    buildCache?:
+      | boolean
+      | {
+          /**
+           * Directory where cache entries are stored, resolved against `cwd`.
+           * @default 'node_modules/.cache/rolldown'
+           */
+          dir?: string;
+          /**
+           * Extra cache invalidation key, hashed into every entry.
+           */
+          key?: string;
+        };
+    /**
      * Use native Rust implementation of MagicString for source map generation.
      *
      * [MagicString](https://github.com/rich-harris/magic-string) is a JavaScript library commonly used by bundlers

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -680,6 +680,8 @@ export interface InputOptions {
      * content. Side channels (`this.emitFile`, `this.addWatchFile`, custom
      * module meta) are not replayed on cache hits, and the cache is not
      * applied when `nativeMagicString` is enabled together with sourcemaps.
+     * When no plugin registers a `resolveId`, `load` or `transform` hook the
+     * cache disables itself, since there would be nothing to skip.
      *
      * @default false
      */

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -176,6 +176,7 @@ function bindingifyExperimental(
     chunkImportMap: experimental?.chunkImportMap,
     onDemandWrapping: experimental?.onDemandWrapping,
     incrementalBuild: experimental?.incrementalBuild,
+    buildCache: experimental?.buildCache,
     nativeMagicString: experimental?.nativeMagicString,
     chunkOptimization: experimental?.chunkOptimization,
     lazyBarrel: experimental?.lazyBarrel,

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -657,6 +657,15 @@ const InputOptionsSchema = v.strictObject({
       ),
       onDemandWrapping: v.optional(v.boolean()),
       incrementalBuild: v.optional(v.boolean()),
+      buildCache: v.optional(
+        v.union([
+          v.boolean(),
+          v.strictObject({
+            dir: v.optional(v.string()),
+            key: v.optional(v.string()),
+          }),
+        ]),
+      ),
       nativeMagicString: v.optional(v.boolean()),
       chunkOptimization: v.optional(
         v.union([

--- a/packages/rolldown/tests/behaviors/build-cache.test.ts
+++ b/packages/rolldown/tests/behaviors/build-cache.test.ts
@@ -1,9 +1,8 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rolldown } from 'rolldown';
 import { expect, test } from 'vitest';
-
-const root = join(import.meta.dirname, 'dist/build-cache');
 
 interface BuildResult {
   calls: { resolve: number; load: number; transform: number };
@@ -11,10 +10,12 @@ interface BuildResult {
   mappings: string;
 }
 
+// Fixtures live in an OS tempdir: other behaviors test files build into the
+// shared `dist/` directory concurrently and could wipe fixtures placed there.
 function setupFixture(name: string): { cwd: string; cacheDir: string } {
-  const cwd = join(root, name, 'src');
-  const cacheDir = join(root, name, 'cache');
-  if (existsSync(join(root, name))) rmSync(join(root, name), { recursive: true });
+  const root = mkdtempSync(join(tmpdir(), `rolldown-build-cache-${name}-`));
+  const cwd = join(root, 'src');
+  const cacheDir = join(root, 'cache');
   mkdirSync(cwd, { recursive: true });
   writeFileSync(
     join(cwd, 'entry.js'),

--- a/packages/rolldown/tests/behaviors/build-cache.test.ts
+++ b/packages/rolldown/tests/behaviors/build-cache.test.ts
@@ -1,0 +1,96 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+const root = join(import.meta.dirname, 'dist/build-cache');
+
+interface BuildResult {
+  calls: { resolve: number; load: number; transform: number };
+  code: string;
+  mappings: string;
+}
+
+function setupFixture(name: string): { cwd: string; cacheDir: string } {
+  const cwd = join(root, name, 'src');
+  const cacheDir = join(root, name, 'cache');
+  if (existsSync(join(root, name))) rmSync(join(root, name), { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  writeFileSync(
+    join(cwd, 'entry.js'),
+    `import { dep } from './dep.js';\nexport const out = '__MARKER__' + dep;\n`,
+  );
+  writeFileSync(join(cwd, 'dep.js'), `export const dep = '__MARKER__ dep';\n`);
+  return { cwd, cacheDir };
+}
+
+// Counts JS plugin hook invocations for fixture modules; the virtual runtime
+// module runs its hooks on every build and is excluded.
+async function build(cwd: string, cacheDir: string, key?: string): Promise<BuildResult> {
+  const calls = { resolve: 0, load: 0, transform: 0 };
+  const bundler = await rolldown({
+    input: join(cwd, 'entry.js'),
+    cwd,
+    experimental: { buildCache: { dir: cacheDir, key } },
+    plugins: [
+      {
+        name: 'counting',
+        resolveId(_source, importer) {
+          if (importer != null) calls.resolve++;
+          return null;
+        },
+        load(id) {
+          if (id.endsWith('.js') && !id.startsWith('\0')) calls.load++;
+          return null;
+        },
+        transform(code, id) {
+          if (!id.endsWith('.js') || id.startsWith('\0')) return null;
+          calls.transform++;
+          return { code: code.replace('__MARKER__', 'transformed'), map: null };
+        },
+      },
+    ],
+  });
+  const { output } = await bundler.generate({ sourcemap: true });
+  await bundler.close();
+  const chunk = output[0];
+  return { calls, code: chunk.code, mappings: chunk.map!.mappings };
+}
+
+test('warm build skips JS resolve/load/transform hooks and emits identical output', async () => {
+  const { cwd, cacheDir } = setupFixture('hit');
+
+  const cold = await build(cwd, cacheDir);
+  expect(cold.calls).toEqual({ resolve: 1, load: 2, transform: 2 });
+  expect(cold.code).toContain('transformed');
+
+  const warm = await build(cwd, cacheDir);
+  expect(warm.calls).toEqual({ resolve: 0, load: 0, transform: 0 });
+  expect(warm.code).toBe(cold.code);
+  expect(warm.mappings).toBe(cold.mappings);
+});
+
+test('changing the cache key re-runs the whole pipeline', async () => {
+  const { cwd, cacheDir } = setupFixture('key');
+
+  const cold = await build(cwd, cacheDir, 'config-a');
+  expect(cold.calls.transform).toBe(2);
+
+  const sameKey = await build(cwd, cacheDir, 'config-a');
+  expect(sameKey.calls.transform).toBe(0);
+
+  const newKey = await build(cwd, cacheDir, 'config-b');
+  expect(newKey.calls.transform).toBe(2);
+});
+
+test('editing a module re-runs only its own pipeline', async () => {
+  const { cwd, cacheDir } = setupFixture('edit');
+
+  const cold = await build(cwd, cacheDir);
+  expect(cold.calls.transform).toBe(2);
+
+  writeFileSync(join(cwd, 'dep.js'), `export const dep = '__MARKER__ dep edited';\n`);
+  const afterEdit = await build(cwd, cacheDir);
+  expect(afterEdit.calls.transform).toBe(1);
+  expect(afterEdit.code).toContain('dep edited');
+});


### PR DESCRIPTION
### Description

This is a follow-up to #10137 (persistent cache for the `transform` stage only), which was closed with the feedback that rolldown is [targeting caching for the whole bundler pipeline, not just `transform`](https://github.com/rolldown/rolldown/pull/10137#issuecomment-4889927322). This PR extends that work into a concrete, minimal implementation of a whole-module-pipeline persistent cache, and is opened as a **draft** to give the persistent cache design work (#6995, #802) something tangible to evaluate and benchmark against. If the team prefers to keep this in the design phase for now, closing it is completely fine; the design notes and benchmark data below may still be useful input.

It adds `experimental.buildCache`: an opt-in filesystem cache that persists, per module, everything a module task produces before the native parse: the plugin `load` pipeline output, the plugin `transform` pipeline output (code, module type, side-effect override, sourcemap chain) and the resolved dependencies (`resolveId` hooks plus the native resolver, including `package.json` side-effects data). On a cache hit **no plugin hook and no resolver call runs for that module**; parsing, scanning and all later stages run unchanged on the cached post-transform source.

```js
export default {
  experimental: {
    // or `buildCache: true` for the defaults
    buildCache: {
      dir: 'node_modules/.cache/rolldown', // default
      key: myConfigAndLockfileHash,        // extra invalidation key
    },
  },
};
```

### Benchmarks (10,000 modules, before/after)

Full methodology, raw runs and reproduction scripts: https://gist.github.com/christianvuerings/e43cdf8b2597cdf8565f99ca7e4b57a4. Every run is a fresh process, so warm numbers are cross-process. Release builds, Apple M3 Max.

| Scenario (10,001 modules) | no cache | warm cache | speedup |
| --- | ---: | ---: | ---: |
| babel in `transform` hook | 34,270 ms | 422 ms | 81x |
| babel in `transform` + no-op `resolveId`/`load` hooks | 33,594 ms | 428 ms | 78x |
| babel in `load` hook (SFC-compiler shape) | 34,395 ms | 433 ms | 79x |
| no JS plugins (native only) | 213 ms | 218 ms (cache self-disables) | ~none |

Two rows worth calling out:

- **babel in `load`**: a transform-only cache (#10137, measured on the same fixture) gives **zero** benefit here (34,838 ms warm) because its key is the post-`load` source, so `load` hooks must run on every build. Keying on raw file content lets this design skip the `load` pipeline too, which is where Vue SFC / Svelte-style compilers do their work.
- **no JS plugins**: with nothing expensive to skip, the cache would only add fs reads and entry decoding (measured 1.8x slower warm, 5.7x slower cold before this guard existed), so `BuildCache::new` returns `None` when no plugin beyond rolldown's cheap inner plugins registers a `resolveId`/`load`/`transform` hook; such builds never touch the cache directory.

Cold builds (cache being written) cost 1-2% on plugin-heavy builds. Warm output is byte-identical to an uncached build (`diff -rq` over the whole 10k-module output, both scenarios, and byte-identical sourcemap `mappings` in the JS tests).

### Design summary

- Cache seam is exactly one place: `ModuleTask::run_inner` tries the cache before `load_source` and stores after `resolve_dependencies`.
- Entry key: `xxh3(salt, stable_id, asserted_module_type, xxh3(raw file bytes))`, with `salt = xxh3(format_version, rolldown_version, options.key, platform, sorted moduleTypes, ordered plugin names)`. Keys and entry contents are machine-portable (cwd-relative paths), so external tooling can layer **remote caching** on top by syncing the directory (CI writers populate an object store, readers warm the local dir), without rolldown needing any network code.
- Resolved dependencies are stored positionally: re-scanning the cached code deterministically reproduces the import records they align with, so import records themselves never need serialization (and the arena-allocated oxc AST stays out of the cache entirely; re-parsing is the cheap, safe part).
- Correctness details:
  - On a hit every cached non-external dependency is stat-ed; a deleted or moved file turns the entry into a miss so the importer re-resolves and fails or externalizes exactly like a cold build.
  - The full `ResolvedId` is serialized including `package.json` `sideEffects` data, so tree shaking is identical cold vs warm.
  - Side effects are stored as a delta: only a load/transform-hook override is replayed, never side effects derived from resolution data outside the cache key.
  - Modules whose resolution produced warnings (e.g. missing import treated as external) are never stored, so warnings replay on every build.
  - The whole sourcemap chain (`Load`, `Transform`, `Omitted`, `Null` elements) is persisted and replayed.
  - Virtual modules, data URLs and `rolldown:` ids bypass the cache; the runtime module task is untouched. The cache silently disables itself when `experimental.nativeMagicString` + sourcemaps is active.
  - Every cache failure (corrupt entry, unreadable dir, write error) degrades to a miss or a dropped write; the cache can never fail a build.
  - The cache disables itself when no plugin registers a cacheable hook, so enabling it on a plugin-free config costs nothing.
- Entry format: magic + version byte + JSON metadata header + raw code bytes, one self-contained file per entry at `<dir>/build-v1/<hash[0..2]>/<hash>`, atomic rename writes. No new dependencies (`serde_json`, `xxhash` and `oxc_sourcemap` were already in the tree).
- `internal-docs/build-cache/{design,implementation}.md` cover the rationale, rejected alternatives and data flow in more detail.

### Known limitations (documented in the option's JSDoc and internal docs)

- `load`/`transform` hooks are assumed to be deterministic functions of the module's id and content; hook side channels (`this.emitFile`, `this.addWatchFile`, custom module meta) are not replayed on hits.
- Resolution inputs outside module files (lockfile changes, `tsconfig.json` paths, newly added files that shadow an old resolution) and plugin config changes are invisible to the key; callers fold a config/lockfile hash into `key`, the same contract as webpack's `cache.version` and Metro's `getCacheKey`.
- No eviction policy; entries are content-addressed and callers manage the directory lifecycle.

### Tests

- `crates/rolldown/tests/rolldown/topics/build_cache`: warm build runs zero `resolveId`/`load`/`transform` hooks with identical output; `key` invalidation; editing one module re-runs only that module's pipeline; deleting a cached dependency falls back to fresh resolution instead of replaying stale state; a build with no cacheable plugin hooks never creates the cache directory.
- Unit tests for the entry codec (roundtrip including resolved deps and `package.json` side-effects globs, version/garbage rejection).
- `packages/rolldown/tests/behaviors/build-cache.test.ts`: the same assertions through the JS plugin path, plus byte-identical sourcemap `mappings` cold vs warm.
- `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean; full `--test integration` suite passes (the only failure locally is `test262_module_code` from an uninitialized `test262` submodule); `vp check`, knip and the node type tests pass.

### AI usage disclosure

Per the [contribution guide's AI policy](https://rolldown.rs/contribution-guide/#ai-usage-policy): this PR was implemented with AI assistance (Claude Code). The design, code, tests and docs were reviewed, and all benchmark numbers come from real runs (methodology and scripts in the linked gist).
