### PR TITLE
fix(dev): don't panic when an HMR rebuild hits an unresolved import

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -986,14 +986,23 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       }
       visited.insert(idx);
 
-      let module_opt = self.intermediate_normal_modules.modules.get(idx);
-      if let Some(module) = module_opt {
-        if let Some(normal) = module.as_normal() {
-          chain.push(normal.id.to_string());
-        }
+      // A partial scan only holds re-scanned modules, so read unchanged ones
+      // from the last successful build's snapshot. An empty slot stays skipped
+      // to keep the failed module out of its own chain.
+      let module_opt = match self.intermediate_normal_modules.modules.try_get(idx) {
+        Some(slot) => slot.as_ref(),
+        None => self.cache.snapshot().and_then(|snapshot| snapshot.module_table.modules.get(idx)),
+      };
+      if let Some(normal) = module_opt.and_then(Module::as_normal) {
+        chain.push(normal.id.to_string());
       }
 
-      if user_defined_entry_ids.contains(&idx) {
+      if user_defined_entry_ids.contains(&idx)
+        || self
+          .cache
+          .snapshot()
+          .is_some_and(|snapshot| snapshot.user_defined_entry_modules.contains(&idx))
+      {
         break;
       }
 

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -79,6 +79,11 @@ impl ScanStageCache {
     self.snapshot.as_ref().unwrap()
   }
 
+  /// Non-panicking variant of [`Self::get_snapshot`].
+  pub fn snapshot(&self) -> Option<&NormalizedScanStageOutput> {
+    self.snapshot.as_ref()
+  }
+
   /// Between builds the cache is either empty (no snapshot: only a full scan
   /// is possible) or a valid graph any partial scan can build on. A failed
   /// partial scan keeps the latter true by reverting its mutations

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "dev": {
+    "ensureLatestBuildOutputForEachStep": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/artifacts.snap
@@ -1,0 +1,98 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => "dep" });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+if (dep_hot) dep_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+console.log("dep");
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Errors
+
+### UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Could not resolve './does-not-exist' in dep.js
+   ╭─[ dep.js:1:8 ]
+   │
+ 1 │ import './does-not-exist';
+   │        ─────────┬────────  
+   │                 ╰────────── Module not found.
+   │ 
+   │ Help: 'dep.js' is imported by the following path:
+   │         - dep.js
+   │         - main.js
+───╯
+
+```
+
+# HMR Step 1
+
+## Code
+
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer("dep.js", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "dep";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
+
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => "dep" });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+if (dep_hot) dep_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+console.log("dep");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.hmr-0.js
@@ -1,0 +1,7 @@
+import './does-not-exist';
+
+export const value = 'dep';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.hmr-1.js
@@ -1,0 +1,5 @@
+export const value = 'dep';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/dep.js
@@ -1,0 +1,5 @@
+export const value = 'dep';
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_unresolved_import/main.js
@@ -1,0 +1,2 @@
+import { value } from './dep'
+console.log(value)

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -66,6 +66,14 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
     }
   }
 
+  /// Non-panicking lookup. Absence is a normal outcome for the sparse `Map` variant.
+  pub fn try_get(&self, i: I) -> Option<&T> {
+    match self {
+      HybridIndexVec::IndexVec(index_vec) => index_vec.get(i),
+      HybridIndexVec::Map(map) => map.get(&i),
+    }
+  }
+
   /// # Panic
   /// Caller should ensure the index is exists in container.
   pub fn get(&self, i: I) -> &T {


### PR DESCRIPTION
### Description

Fixes #10136.

In a dev (FBM) session, editing a file so that one of its imports no longer resolves crashed the whole worker thread instead of reporting the error:

```
thread 'rolldown-worker' panicked at crates/rolldown_common/src/types/hybrid_index_vec.rs:76:28:
HybridIndexVec::Map missing idx 2 (len=1)
```

#### Root cause

When a rebuild fails with an unresolved import, `trace_import_chain_from_modules` enriches the error with the import chain (added in #7625). The walk follows `importers` edges, which cover the whole module graph. But in a partial scan, `intermediate_normal_modules.modules` is the sparse `HybridIndexVec::Map` and only holds the modules that were re-scanned. The first step from the changed module to its unchanged importer looks up an index that is not in the map, and `HybridIndexVec::get` panics on missing keys.

The existing error-recovery tests did not catch this because they use syntax errors. Only a `DiagnosableResolveError` triggers the chain tracing.

#### Fix

- Add a non-panicking `HybridIndexVec::try_get`. The panicking `get` is kept as is, so real indexing bugs still surface loudly.
- Add a non-panicking `ScanStageCache::snapshot()` accessor.
- In the chain walk, read modules that are missing from the sparse table out of the last successful build's snapshot. A slot that is present but empty (the module whose scan just failed) stays skipped, so the chain output matches full builds.
- Also stop the walk at entries recorded in the snapshot. The per-scan entry set is empty in a partial scan, so the old check never fired there.

With the fix, the rebuild reports a normal `UNRESOLVED_IMPORT` diagnostic with the full import chain, and the next edit recovers via a regular HMR patch.

#### Test

New fixture `topics/hmr/error_recovery/from_rebuild_unresolved_import`. Step 0 introduces an unresolvable import (this reproduced the panic before the fix), step 1 reverts it and verifies HMR recovers.
