### PR TITLE
fix(rolldown_plugin_vite_import_glob): support tsconfig paths with `import.meta.glob`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
@@ -205,12 +205,14 @@ impl From<BindingHookJsResolveIdOptions> for Arc<CustomField> {
   fn from(value: BindingHookJsResolveIdOptions) -> Self {
     let mut map = CustomField::default();
     map.insert(ResolveIdOptionsScan, value.scan.unwrap_or(false));
-    if let Some(is_sub_imports_pattern) =
-      value.custom.and_then(|v| v.vite_import_glob.and_then(|v| v.is_sub_imports_pattern))
-    {
+    if let Some(vite_plugin_custom) = value.custom {
+      let is_sub_imports_pattern =
+        vite_plugin_custom.vite_import_glob.and_then(|meta| meta.is_sub_imports_pattern);
       map.insert(
         rolldown_plugin_utils::constants::ViteImportGlob,
-        rolldown_plugin_utils::constants::ViteImportGlobValue(is_sub_imports_pattern),
+        rolldown_plugin_utils::constants::ViteImportGlobValue(
+          is_sub_imports_pattern.unwrap_or(false),
+        ),
       );
     }
     Arc::new(map)

--- a/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
@@ -36,11 +36,11 @@ impl TryFrom<BindingPluginContextResolveOptions> for PluginContextResolveOptions
     if let Some(js_custom_id) = value.custom {
       custom.insert(JsPluginContextResolveCustomArgId, js_custom_id);
     }
-    if let Some(is_sub_imports_pattern) = value
-      .vite_plugin_custom
-      .and_then(|v| v.vite_import_glob.and_then(|v| v.is_sub_imports_pattern))
-    {
-      custom.insert(ViteImportGlob, ViteImportGlobValue(is_sub_imports_pattern));
+    if let Some(vite_import_glob) = value.vite_plugin_custom.and_then(|c| c.vite_import_glob) {
+      custom.insert(
+        ViteImportGlob,
+        ViteImportGlobValue(vite_import_glob.is_sub_imports_pattern.unwrap_or(false)),
+      );
     }
     Ok(Self {
       import_kind: value.import_kind.as_deref().unwrap_or("import-statement").try_into()?,

--- a/crates/rolldown_plugin_utils/src/constants.rs
+++ b/crates/rolldown_plugin_utils/src/constants.rs
@@ -4,8 +4,11 @@ use rolldown_plugin::typedmap::TypedMapKey;
 // https://v8.dev/blog/cost-of-javascript-2019#json
 pub const THRESHOLD_SIZE: usize = 10 * 1000;
 
+/// Marks an `import.meta.glob` pattern resolve so the resolver can apply glob-aware
+/// handling. The value additionally flags subpath-import (`#`) patterns.
 #[derive(Hash, PartialEq, Eq)]
 pub struct ViteImportGlob;
+
 pub struct ViteImportGlobValue(pub bool);
 
 impl ViteImportGlobValue {

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -292,16 +292,14 @@ impl GlobImportVisit<'_> {
       path_posix::join(&[&dir, glob])
     } else {
       let is_sub_imports_pattern = glob.starts_with('#') && glob.contains('*');
+      let mut custom = rolldown_plugin::CustomField::new();
+      custom.insert(ViteImportGlob, ViteImportGlobValue(is_sub_imports_pattern));
       let future = self.ctx.resolve(
         glob,
         Some(self.id),
-        is_sub_imports_pattern.then(|| {
-          let mut custom = rolldown_plugin::CustomField::new();
-          custom.insert(ViteImportGlob, ViteImportGlobValue(true));
-          rolldown_plugin::PluginContextResolveOptions {
-            custom: Arc::new(custom),
-            ..Default::default()
-          }
+        Some(rolldown_plugin::PluginContextResolveOptions {
+          custom: Arc::new(custom),
+          ..Default::default()
         }),
       );
 

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -1,4 +1,5 @@
 use std::{
+  borrow::Cow,
   ffi::OsString,
   fs,
   path::{self, Path, PathBuf},
@@ -337,6 +338,33 @@ impl Resolver {
     } else {
       inner_resolver.resolve(&self.root, &path_with_prefix)
     }
+  }
+
+  /// Apply the tsconfig `paths`/`baseUrl` alias mapping to `specifier` without checking whether the mapped target exists
+  /// on disk. Used to resolve `import.meta.glob` specifiers, where the mapped path does not point at a real file.
+  pub fn resolve_tsconfig_path_alias(
+    &self,
+    importer: &str,
+    specifier: &str,
+  ) -> Result<Vec<String>, oxc_resolver::ResolveError> {
+    let _guard = self.lock.lock_for_update();
+
+    // check if `is_absolute` to avoid extra `join` overhead
+    let importer_path = if Path::new(importer).is_absolute() {
+      Cow::Borrowed(Path::new(importer))
+    } else {
+      Cow::Owned(self.root.join(importer))
+    };
+    let Some(tsconfig) = self.inner.find_tsconfig(importer_path.as_ref())? else {
+      return Ok(Vec::new());
+    };
+    Ok(
+      tsconfig
+        .resolve_path_alias_or_base_url(specifier)
+        .into_iter()
+        .map(|p| normalize_path(&p.to_string_lossy()).into_owned())
+        .collect(),
+    )
   }
 
   pub fn normalize_oxc_resolver_result(

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -342,6 +342,38 @@ impl Plugin for ViteResolvePlugin {
     );
     let resolver = self.resolvers.get(additional_options);
 
+    let specifier = normalize_leading_slashes(&id);
+
+    // tsconfig `paths` mapping for `import.meta.glob`.
+    // The specifier is a glob pattern so we need to apply the mapping here,
+    // otherwise the mapping will be ignored as the mapped path does not point at a
+    // real file.
+    if self.resolve_options.tsconfig_paths
+      && args.custom.get(&rolldown_plugin_utils::constants::ViteImportGlob).is_some()
+      && let Some(importer) = args.importer
+    {
+      let mut candidates = resolver.resolve_tsconfig_path_alias(importer, specifier)?;
+      if candidates.len() > 1 {
+        self
+          .warn(
+            ctx,
+            format!(
+              "The glob \"{specifier}\" matches a tsconfig `paths` entry with multiple targets. \
+               Currently, multiple target `paths` is not supported for glob resolution. The first (\"{}\") is used unconditionally.",
+              candidates[0]
+            ),
+          )
+          .await?;
+      }
+      if !candidates.is_empty() {
+        let mapped = candidates.swap_remove(0);
+        self
+          .debug_log(|| format!("[glob-tsconfig-paths] {} -> {}", id.cyan(), mapped.dimmed()))
+          .await?;
+        return Ok(Some(HookResolveIdOutput { id: mapped.into(), ..Default::default() }));
+      }
+    }
+
     if is_bare_import(&id) {
       let external = self.resolve_options.is_build
         && self.environment_consumer == "server"
@@ -459,7 +491,6 @@ impl Plugin for ViteResolvePlugin {
       }
     }
 
-    let specifier = normalize_leading_slashes(&id);
     let resolved = resolver.normalize_oxc_resolver_result(
       specifier,
       args.importer,

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/_config.ts
@@ -1,0 +1,53 @@
+import { defineTest } from 'rolldown-tests';
+import { viteImportGlobPlugin, viteResolvePlugin } from 'rolldown/experimental';
+import { expect, vi } from 'vitest';
+
+// `@x/*` maps to multiple targets (`./a/*` and `./b/*`).
+// Only the first (`./a/*`) is used for the glob, and a warning is emitted about the ignored targets.
+const onMultipleTargetsWarn = vi.fn();
+
+export default defineTest({
+  config: {
+    input: './src/main.ts',
+    onLog(level, log) {
+      if (level === 'warn' && log.message.includes('multiple targets')) {
+        expect(log.message).toContain('@x/dir/**/*');
+        onMultipleTargetsWarn();
+      }
+    },
+    plugins: [
+      viteResolvePlugin({
+        resolveOptions: {
+          isBuild: true,
+          isProduction: true,
+          asSrc: false,
+          preferRelative: false,
+          root: import.meta.dirname,
+          scan: false,
+          mainFields: ['main'],
+          conditions: [],
+          externalConditions: [],
+          extensions: ['.js'],
+          tryIndex: false,
+          preserveSymlinks: false,
+          tsconfigPaths: true,
+        },
+        environmentConsumer: 'client',
+        environmentName: 'test',
+        builtins: [],
+        external: [],
+        noExternal: [],
+        dedupe: [],
+        legacyInconsistentCjsInterop: false,
+        resolveSubpathImports() {
+          throw new Error('Not implemented');
+        },
+      }),
+      viteImportGlobPlugin({ root: import.meta.dirname }),
+    ],
+  },
+  async afterTest() {
+    expect(onMultipleTargetsWarn).toHaveBeenCalledTimes(1);
+    await import('./assert.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/assert.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { modules } from './dist/main.js';
+
+// The first target (`./src/a/*`) is used, so files come from `./src/a/dir`.
+assert.deepStrictEqual(Object.keys(modules), ['/src/a/dir/a.js']);
+assert.strictEqual(modules['/src/a/dir/a.js'].default, 'from-a');

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/src/a/dir/a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/src/a/dir/a.js
@@ -1,0 +1,1 @@
+export default 'from-a';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/src/main.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/src/main.ts
@@ -1,0 +1,1 @@
+export const modules = import.meta.glob('@x/dir/**/*', { eager: true });

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/tsconfig.json
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths-multiple-targets/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@x/*": ["./src/a/*", "./src/b/*"]
+    }
+  }
+}

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/_config.ts
@@ -1,0 +1,42 @@
+import { defineTest } from 'rolldown-tests';
+import { viteImportGlobPlugin, viteResolvePlugin } from 'rolldown/experimental';
+
+// `import.meta.glob('@/dir/**/*')` must resolve the `@/*` -> `./src/*` tsconfig paths mapping
+export default defineTest({
+  config: {
+    input: './src/main.ts',
+    plugins: [
+      viteResolvePlugin({
+        resolveOptions: {
+          isBuild: true,
+          isProduction: true,
+          asSrc: false,
+          preferRelative: false,
+          root: import.meta.dirname,
+          scan: false,
+          mainFields: ['main'],
+          conditions: [],
+          externalConditions: [],
+          extensions: ['.js'],
+          tryIndex: false,
+          preserveSymlinks: false,
+          tsconfigPaths: true,
+        },
+        environmentConsumer: 'client',
+        environmentName: 'test',
+        builtins: [],
+        external: [],
+        noExternal: [],
+        dedupe: [],
+        legacyInconsistentCjsInterop: false,
+        resolveSubpathImports() {
+          throw new Error('Not implemented');
+        },
+      }),
+      viteImportGlobPlugin({ root: import.meta.dirname }),
+    ],
+  },
+  async afterTest() {
+    await import('./assert.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/assert.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { modules } from './dist/main.js';
+
+assert.deepStrictEqual(Object.keys(modules).sort(), ['/src/dir/a.js', '/src/dir/b.js']);
+assert.strictEqual(modules['/src/dir/a.js'].default, 'a');
+assert.strictEqual(modules['/src/dir/b.js'].default, 'b');

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/dir/a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/dir/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/dir/b.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/dir/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/main.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/src/main.ts
@@ -1,0 +1,1 @@
+export const modules = import.meta.glob('@/dir/**/*', { eager: true });

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/tsconfig.json
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/tsconfig-paths/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Implements tsconfig paths support for `import.meta.glob` in a similar way to how subpath imports support is implemented.

This PR does not support the case when the `paths` has multiple items in the array. Doing so requires the resolution to happen in the `rolldown_plugin_vite_import_glob` plugin because the candidates cannot be returned from `this.resolve`. But that could break plugins that resolves in between these plugins.

An alternative approach is to make oxc-resolver possible to resolve globs. But this requires a huge change and I think it's not worth at this point.

implements https://github.com/vitejs/vite/issues/22881
requires https://github.com/oxc-project/oxc-resolver/pull/1282