### PR TITLE
fix(watch): re-read tsconfig files on each rebuild

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_getter.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_getter.rs
@@ -15,6 +15,12 @@ impl Bundler {
     self.bundle_factory.resolver.clear_cache();
   }
 
+  /// Clear cached tsconfig contents and their merged transform options so
+  /// the next build re-reads tsconfig files.
+  pub fn clear_tsconfig_cache(&self) {
+    self.bundle_factory.options.transform_options.clear_tsconfig_cache();
+  }
+
   pub fn watch_files(&self) -> &Arc<FxDashSet<ArcStr>> {
     static EMPTY_SET: LazyLock<Arc<FxDashSet<ArcStr>>> =
       LazyLock::new(|| Arc::new(FxDashSet::default()));

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -357,31 +357,20 @@ pub fn prepare_build_context(
     }
 
     // Create TransformOptions based on tsconfig mode:
-    // - Auto: Create Raw mode (will resolve tsconfig per file)
-    // - None/Manual: Create Normal mode (resolve tsconfig once now)
+    // - Auto/Manual: Raw mode, resolves tsconfig per file so watch rebuilds
+    //   pick up tsconfig edits once the caches are cleared
+    // - None: Normal mode
     match tsconfig {
       ref v @ TsConfig::Manual(ref path) => {
-        // Manual mode: Resolve tsconfig now and create Normal mode
-        let resolved_tsconfig = resolver
+        // Validate the tsconfig eagerly so a broken one still fails at startup
+        resolver
           .resolve_tsconfig(&path)
           .map_err(|err| BuildDiagnostic::tsconfig_error(path.display().to_string(), err))?;
-        Box::new(if resolved_tsconfig.references_resolved.is_empty() {
-          TransformOptions::new(
-            merge_transform_options_with_tsconfig(
-              raw_transform_options,
-              Some(&resolved_tsconfig),
-              &mut warnings,
-            )?,
-            target,
-            jsx_preset,
-          )
-        } else {
-          TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v.clone(), yarn_pnp),
-            target,
-            jsx_preset,
-          )
-        })
+        Box::new(TransformOptions::new_raw(
+          RawTransformOptions::new(raw_transform_options, v.clone(), yarn_pnp),
+          target,
+          jsx_preset,
+        ))
       }
       v @ TsConfig::Auto(is_auto) => {
         Box::new(if is_auto {

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -93,9 +93,11 @@ impl WatchTask {
         last_bundle_handle.plugin_driver().clear();
       }
 
-      // Always clear resolver cache before each rebuild in watch mode to avoid
-      // stale resolution results from modified package.json/tsconfig/export maps.
+      // Always clear the resolver and tsconfig caches before each rebuild in
+      // watch mode to avoid stale resolution and transform results from
+      // modified package.json/tsconfig/export maps.
       bundler.clear_resolver_cache();
+      bundler.clear_tsconfig_cache();
 
       // Use with_cached_bundle_experimental to register FS watches between scan and write phases.
       // This ensures changes made during render hooks (e.g. renderStart modifying a file)


### PR DESCRIPTION
Even when a watch rebuild was triggered, it kept using stale tsconfig data, because tsconfig-derived state lives as long as the bundler:

- Auto-discovery mode: `RawTransformOptions` holds a private resolver and a merged-options cache that were never cleared.
- Manual tsconfig without references: options were merged once at bundler construction and never re-read.

Fix, in two parts:

- Manual mode now always uses Raw mode (per-file resolution). This is the mode that auto-discovery and manual-with-references already use. The eager `resolve_tsconfig` call is kept so a broken tsconfig still fails at startup.
- The watch task clears the tsconfig caches next to the existing resolver cache clearing before every rebuild.

Side effect worth knowing: tsconfig merge-conflict warnings now show up during the build instead of at startup.

Part of #9598.
