### PR TITLE
fix(watch): rebuild when tsconfig files change

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -267,6 +267,16 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       // - Only add watch files for files read from disk.
       // - Add watch files as early as possible for we might be able to recover from build errors.
       self.ctx.plugin_driver.watch_files.insert(self.resolved_id.id.as_arc_str().clone());
+      // The tsconfig governing this module affects its transform and
+      // resolution results, so watch it as well (#9598).
+      if let Some(tsconfig_path) = self
+        .ctx
+        .options
+        .transform_options
+        .discover_tsconfig_file(std::path::Path::new(self.resolved_id.id.as_str()))
+      {
+        self.ctx.plugin_driver.watch_files.insert(tsconfig_path.to_string_lossy().as_ref().into());
+      }
     }
     let (source, mut module_type) = result.map_err(|err| {
       downcast_napi_error_diagnostics(err).unwrap_or_else(|e| {

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1426,6 +1426,97 @@ async function waitBuildFinished(watcher: RolldownWatcher, updateFn?: () => void
   });
 }
 
+// https://github.com/rolldown/rolldown/issues/9598
+test.concurrent(
+  'rebuild when tsconfig changes (auto-discovery)',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-tsconfig-auto', retryCount, {
+      'main.ts': 'export class Foo { bar = 1 }',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ESNext', useDefineForClassFields: false },
+      }),
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    const output = path.join(dir, 'dist', 'main.js');
+
+    const watcher = watch({
+      input: path.join(dir, 'main.ts'),
+      cwd: dir,
+      tsconfig: true,
+      output: { file: output },
+    });
+
+    try {
+      await waitBuildFinished(watcher);
+      // useDefineForClassFields: false compiles the field to a constructor assignment
+      expect(fs.readFileSync(output, 'utf-8')).toContain('this.bar = 1');
+
+      // Changing only the tsconfig must trigger a rebuild that uses the new options
+      await editFile(
+        path.join(dir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ESNext', useDefineForClassFields: true },
+        }),
+      );
+      // useDefineForClassFields: true keeps the field declaration in the class body
+      await expect.poll(() => fs.readFileSync(output, 'utf-8')).not.toContain('this.bar = 1');
+      expect(fs.readFileSync(output, 'utf-8')).toContain('bar = 1');
+    } finally {
+      await watcher.close();
+    }
+  },
+);
+
+// https://github.com/rolldown/rolldown/issues/9598
+test.concurrent(
+  'rebuild when tsconfig changes (manual path)',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-tsconfig-manual', retryCount, {
+      'main.ts': 'export class Foo { bar = 1 }',
+      'tsconfig.build.json': JSON.stringify({
+        compilerOptions: { target: 'ESNext', useDefineForClassFields: false },
+      }),
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    const output = path.join(dir, 'dist', 'main.js');
+
+    const watcher = watch({
+      input: path.join(dir, 'main.ts'),
+      cwd: dir,
+      tsconfig: './tsconfig.build.json',
+      output: { file: output },
+    });
+
+    try {
+      await waitBuildFinished(watcher);
+      expect(fs.readFileSync(output, 'utf-8')).toContain('this.bar = 1');
+
+      await editFile(
+        path.join(dir, 'tsconfig.build.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ESNext', useDefineForClassFields: true },
+        }),
+      );
+      await expect.poll(() => fs.readFileSync(output, 'utf-8')).not.toContain('this.bar = 1');
+      expect(fs.readFileSync(output, 'utf-8')).toContain('bar = 1');
+    } finally {
+      await watcher.close();
+    }
+  },
+);
+
 // https://github.com/rolldown/rolldown/issues/8937
 test.concurrent(
   'watcher.close() should cancel an in-progress build',


### PR DESCRIPTION
tsconfig files were never registered as watch files, so editing them did not trigger a rebuild.

Every module read from disk now registers its governing tsconfig as a watch file. Plain JS modules register too because `compilerOptions.paths` also affects how their imports resolve. The extra `find_tsconfig` call is answered from oxc-resolver's cache after the first module in a directory.

Two watch tests (auto-discovery and manual path) flip `useDefineForClassFields` in the tsconfig and assert the rebuilt output. They cover this PR together with the cache clearing from the PR below.

Known limits, left as follow-ups:

- Files pulled in via `extends` are not watched yet. This needs oxc-resolver to report them (oxc-project/oxc-resolver#1011), planned on that side.
- Creating a brand-new tsconfig.json is not detected because the per-file watcher cannot watch missing paths.
- A solution-style root tsconfig that only routes to references is not watched, `find_tsconfig` returns the matched reference and does not report the root.

Fixes the watch-mode part of #9598.
