### PR TITLE
fix(dev): full rebuild and client full-reload when a tsconfig changes

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.ts"
+      }
+    ],
+    "tsconfig": true,
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/artifacts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ Foo: () => Foo });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+var Foo = class {
+	constructor() {
+		this.bar = 1;
+	}
+};
+//#endregion
+export { Foo };
+
+```
+
+# HMR Step 0
+
+## Meta
+
+- update type: full-reload
+- reason: tsconfig change
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ Foo: () => Foo });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+var Foo = class {
+	bar = 1;
+};
+//#endregion
+export { Foo };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/main.ts
@@ -1,0 +1,3 @@
+export class Foo {
+  bar = 1;
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.hmr-0.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.hmr-0.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.ts"
+      }
+    ],
+    "tsconfig": true,
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/a.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/a.ts
@@ -1,0 +1,1 @@
+export const value = 'from-a';

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/artifacts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.ts
+var a_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("a.ts");
+__rolldown_runtime__.registerModule("a.ts", { exports: a_exports });
+const value = "from-a";
+//#endregion
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ result: () => result });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+const result = value;
+//#endregion
+export { result };
+
+```
+
+# HMR Step 0
+
+## Meta
+
+- update type: full-reload
+- reason: tsconfig change
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.ts
+var b_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("b.ts");
+__rolldown_runtime__.registerModule("b.ts", { exports: b_exports });
+const value = "from-b";
+//#endregion
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ result: () => result });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+const result = value;
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/b.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/b.ts
@@ -1,0 +1,1 @@
+export const value = 'from-b';

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/main.ts
@@ -1,0 +1,3 @@
+import { value } from '@dep';
+
+export const result = value;

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.hmr-0.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.hmr-0.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dep": ["./b.ts"]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dep": ["./a.ts"]
+    }
+  }
+}

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -3,7 +3,7 @@ use std::{
   sync::{Arc, atomic::AtomicU32},
 };
 
-use rolldown_common::{ClientHmrInput, ScanMode};
+use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrUpdate, ScanMode};
 use rolldown_utils::indexmap::FxIndexMap;
 use tokio::sync::Mutex;
 
@@ -112,6 +112,44 @@ impl BundlingTask {
           }
         }
       }
+    }
+
+    // A tsconfig edit affects every module the tsconfig governs, which HMR
+    // patches and partial scans cannot represent. Clear the caches, tell
+    // clients to fully reload, and fall back to a full rebuild.
+    let changed_tsconfig = {
+      let bundler = self.bundler.lock().await;
+      let changed_tsconfig = self
+        .input
+        .changed_files()
+        .keys()
+        .any(|path| bundler.options().transform_options.is_known_tsconfig(path));
+      if changed_tsconfig {
+        bundler.clear_resolver_cache();
+        bundler.clear_tsconfig_cache();
+      }
+      changed_tsconfig
+    };
+    if changed_tsconfig {
+      tracing::trace!("[BundlingTask] detects a tsconfig change, upgrading to a full rebuild");
+      if let Some(on_hmr_updates) = self.dev_context.options.on_hmr_updates.as_ref() {
+        let changed_files = self
+          .input
+          .changed_files()
+          .keys()
+          .map(|path| path.to_string_lossy().to_string())
+          .collect::<Vec<_>>();
+        let clients = self.dev_context.clients.lock().await;
+        let updates = clients
+          .keys()
+          .map(|client_id| ClientHmrUpdate {
+            client_id: client_id.clone(),
+            update: HmrUpdate::FullReload { reason: "tsconfig change".to_owned() },
+          })
+          .collect();
+        on_hmr_updates(Ok((updates, changed_files)));
+      }
+      self.input = TaskInput::FullBuild;
     }
 
     let mut has_full_reload_update = false;


### PR DESCRIPTION
In the dev engine, a tsconfig edit cannot be handled as an HMR patch or a partial scan: it changes transform and resolution results for every module the tsconfig governs.

When a changed file is a known tsconfig, the bundling task now:

1. clears the resolver and tsconfig caches
2. sends a `FullReload` update to all clients
3. upgrades itself to a full rebuild (`TaskInput::FullBuild`)

Review notes:

- Detection lives in `BundlingTask`, not the coordinator, because the coordinator must not lock the bundler while a running build holds the lock.
- The upgrade happens after the `watchChange` hooks so they still see the changed files.
- The coordinator reads `requires_full_rebuild()` only at scheduling time, so a task that upgrades itself mid-run completes through the normal `InProgress` path.

Two HMR fixtures cover the transform side (`useDefineForClassFields`) and the resolver side (`paths` remapping an import to another file). The harness additionally asserts that the changed tsconfig is in the watched files and that the incremental scan state matches a fresh full build after each step.

Part of #9598.
