### PR TITLE
test: move string_wizard replace unit tests to the JS magic-string suite

### DIFF
--- a/crates/string_wizard/tests/magic_string_replace.rs
+++ b/crates/string_wizard/tests/magic_string_replace.rs
@@ -1,49 +1,10 @@
 use oxc_sourcemap::SourcemapVisualizer;
 use string_wizard::{MagicString, ReplaceOptions, SourceMapOptions};
 
-#[test]
-fn works_with_string_replace() {
-  let code = "1 2 1 2";
-  let mut s = MagicString::new(code);
-
-  s.replace("2", "3").unwrap();
-
-  assert_eq!(s.to_string(), "1 3 1 2");
-}
-
-#[test]
-fn should_not_search_back() {
-  let code = "122121";
-  let mut s = MagicString::new(code);
-
-  s.replace("12", "21").unwrap();
-
-  assert_eq!(s.to_string(), "212121");
-}
-
-mod replace_all {
-  use super::*;
-
-  #[test]
-  fn works_with_string_replace() {
-    let code = "1212";
-    let mut s = MagicString::new(code);
-
-    s.replace_all("2", "3").unwrap();
-
-    assert_eq!(s.to_string(), "1313");
-  }
-
-  #[test]
-  fn should_not_search_back() {
-    let code = "121212";
-    let mut s = MagicString::new(code);
-
-    s.replace_all("12", "21").unwrap();
-
-    assert_eq!(s.to_string(), "212121");
-  }
-}
+// NOTE: The plain `replace` / `replace_all` unit tests were moved to
+// `packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts` so they
+// exercise the JS binding's UTF-16 -> UTF-8 conversion. The sourcemap snapshot
+// tests below stay here because they rely on `insta` + `SourcemapVisualizer`.
 
 #[test]
 fn replace_sourcemap_with_chinese() {

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -5,6 +5,14 @@ import { describe, it } from 'vitest';
 /**
  * Hand-written tests for rolldown-specific BindingMagicString behaviour.
  * These are NOT auto-generated; do not delete or regenerate this file.
+ *
+ * The `string_wizard: replace` block near the bottom was ported from the plain
+ * `replace` / `replaceAll` unit tests in
+ * `crates/string_wizard/tests/magic_string_replace.rs`. Running them through the
+ * JS `RolldownMagicString` binding exercises the full pipeline — in particular
+ * the UTF-16 (JS string index) -> UTF-8 (byte offset) location conversion that
+ * only exists on the binding boundary. The rest of the string_wizard crate
+ * tests stay in Rust.
  */
 
 describe('offset', () => {
@@ -286,6 +294,42 @@ describe('lastLine', () => {
       s.prepend('pre');
       assert.strictEqual(s.toString(), 'prep\nqrx');
       assert.strictEqual(s.lastLine(), 'qrx');
+    });
+  });
+});
+
+// ===========================================================================
+// Ported from the plain `replace` / `replaceAll` unit tests in
+// `crates/string_wizard/tests/magic_string_replace.rs`. Running them through
+// the JS `RolldownMagicString` binding exercises the full pipeline — in
+// particular the UTF-16 (JS string index) -> UTF-8 (byte offset) location
+// conversion that only exists on the binding boundary.
+// ===========================================================================
+
+describe('string_wizard: replace', () => {
+  it('works with string replace', () => {
+    const s = new MagicString('1 2 1 2');
+    s.replace('2', '3');
+    assert.strictEqual(s.toString(), '1 3 1 2');
+  });
+
+  it('should not search back', () => {
+    const s = new MagicString('122121');
+    s.replace('12', '21');
+    assert.strictEqual(s.toString(), '212121');
+  });
+
+  describe('replaceAll', () => {
+    it('works with string replace', () => {
+      const s = new MagicString('1212');
+      s.replaceAll('2', '3');
+      assert.strictEqual(s.toString(), '1313');
+    });
+
+    it('should not search back', () => {
+      const s = new MagicString('121212');
+      s.replaceAll('12', '21');
+      assert.strictEqual(s.toString(), '212121');
     });
   });
 });


### PR DESCRIPTION
## What

Moves the plain `replace` / `replaceAll` unit tests out of the Rust crate test
`crates/string_wizard/tests/magic_string_replace.rs` and into
`packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts`.

## Why

Running these through the `RolldownMagicString` binding exercises the whole JS
usage pipeline — in particular the UTF-16 (JS string index) → UTF-8 (byte
offset) location conversion that only exists on the binding boundary.

## Scope

- Only the four plain `replace` / `replaceAll` unit tests are moved.
- The sourcemap **snapshot** tests (`replace_sourcemap`,
  `replace_sourcemap_with_chinese`) stay in Rust as-is — they rely on `insta` +
  `SourcemapVisualizer`, which have no JS equivalent.

## Verification

- `cargo test -p string_wizard` — green (the two sourcemap snapshot tests still run in Rust).
- `vitest run rolldown-magic-string.test.ts` — 40 passed (36 pre-existing + 4 moved).