### PR TITLE
perf: remap build-machine paths out of release binaries

### DIFF
--- a/packages/rolldown/build-binding.ts
+++ b/packages/rolldown/build-binding.ts
@@ -1,5 +1,7 @@
-import { rmSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { createBuildCommand, NapiCli } from '@napi-rs/cli';
@@ -14,8 +16,60 @@ const buildCommand = createBuildCommand(args);
 
 const argsOptions = buildCommand.getOptions();
 
+const isRelease = argsOptions.release === true || argsOptions.profile === 'release';
+
+// For published binaries, remap the absolute build-machine paths (cargo/rustup homes and
+// the workspace root) that rustc embeds into panic locations and tracing callsite metadata.
+// This shrinks the binary's string tables and keeps the build machine's filesystem layout
+// out of the shipped artifact. Release-only so local dev backtraces keep clickable paths.
+// Replace with cargo `-Ztrim-paths` once it stabilizes (rust-lang/cargo#12137).
+//
+// The flags are injected as a cargo `--config target.'cfg(all())'.rustflags=[…]` entry, NOT
+// via RUSTFLAGS/CARGO_BUILD_RUSTFLAGS: config-level target rustflags are joined with the
+// `.cargo/config.toml` target entries (windows crt-static, ucrt link-args), whereas the napi
+// CLI promotes CARGO_BUILD_RUSTFLAGS to RUSTFLAGS, which would suppress those entries
+// entirely (measured: it silently dropped crt-static from the windows binary).
+// Known gap: napi-cli always sets RUSTFLAGS for musl targets (`-C target-feature=-crt-static`),
+// which suppresses config-level rustflags there — musl artifacts keep unremapped paths.
+let remapConfig: string | undefined;
+if (isRelease) {
+  const cargoHome = process.env.CARGO_HOME ?? resolve(homedir(), '.cargo');
+  const rustupHome = process.env.RUSTUP_HOME ?? resolve(homedir(), '.rustup');
+  const workspaceRoot = resolve(__dirname, '../..');
+  const remaps = [
+    `--remap-path-prefix=${cargoHome}=/cargo`,
+    `--remap-path-prefix=${rustupHome}=/rustup`,
+    `--remap-path-prefix=${workspaceRoot}=/rolldown`,
+  ];
+  // Collapse the long per-registry hash directory (`registry/src/index.crates.io-<hash>`)
+  // too: rustc uses the last matching prefix, so these more-specific mappings go last.
+  // The registry extraction dirs only exist after dependencies are fetched, and this script
+  // runs before napi invokes cargo — on a cold CI runner the directory would be empty. Fetch
+  // first (cheap: the same download cargo would do anyway), then enumerate sorted so the
+  // resulting flag set is deterministic.
+  spawnSync(
+    'cargo',
+    ['fetch', '--locked', ...(argsOptions.target ? ['--target', argsOptions.target] : [])],
+    { cwd: workspaceRoot, stdio: 'inherit' },
+  );
+  const registrySrc = resolve(cargoHome, 'registry', 'src');
+  try {
+    for (const dir of readdirSync(registrySrc).sort()) {
+      remaps.push(`--remap-path-prefix=${resolve(registrySrc, dir)}=/deps`);
+    }
+  } catch {
+    // no registry dir (e.g. vendored deps) — nothing to collapse
+  }
+  // TOML literal strings cannot contain single quotes; such paths just skip the remap.
+  if (remaps.every((flag) => !flag.includes("'"))) {
+    remapConfig = `target.'cfg(all())'.rustflags=[${remaps.map((flag) => `'${flag}'`).join(',')}]`;
+  }
+}
+
 const napiArgs = {
   ...argsOptions,
+  // `getOptions()` doesn't surface CLI rest args, so this doesn't overwrite anything.
+  ...(remapConfig ? { cargoOptions: ['--config', remapConfig] } : {}),
   outputDir: './src',
   manifestPath: '../../crates/rolldown_binding/Cargo.toml',
   platform: true,


### PR DESCRIPTION
Remap the absolute build-machine paths that rustc embeds into shipped release binaries. Two benefits: the build machine's filesystem layout is kept out of published artifacts (12 of 14 targets), and every target's `.node` shrinks (−52 to −165 KiB, mean −110 KiB).

> **Scope:** this PR is now **path-remap only**. The separate "build std without the backtrace symbolizer" change (a larger, independent size win) has been split out to land on its own — it is not part of this diff.

## Size impact

Measured as a **matched same-day pair**: baseline branch `baseline-size-4b018b35` pinned at this PR's exact parent `4b018b35c`, [rebuilt today](https://github.com/rolldown/rolldown/actions/runs/29200051958) alongside [the PR build](https://github.com/rolldown/rolldown/actions/runs/29199314634) by the same workflow. **Drift is verified zero** — the same-day baseline is byte-identical to the original [2026-07-07 baseline](https://github.com/rolldown/rolldown/actions/runs/28874572401) on all 14 targets, so every delta below is attributable to exactly this diff. Sizes are the stripped release `.node` per target.

| platform | baseline (KiB) | this PR (KiB) | Δ | build-machine paths |
|---|---:|---:|---:|:---:|
| linux-x64-gnu | 18,657.6 | 18,509.6 | **−148.0 (−0.79%)** | removed |
| darwin-x64 | 16,725.4 | 16,573.7 | **−151.8 (−0.91%)** | removed |
| linux-arm64-gnu | 16,821.2 | 16,725.2 | **−96.0 (−0.57%)** | removed |
| darwin-arm64 | 15,928.9 | 15,864.4 | **−64.5 (−0.40%)** | removed |
| win32-x64-msvc | 20,007.5 | 19,842.5 | **−165.0 (−0.82%)** | removed |
| linux-x64-musl | 18,705.5 | 18,594.5 | **−111.0 (−0.59%)** | **kept (≈500)** |

<details><summary>All 14 targets — <b>1,539 KiB</b> saved total, <b>110 KiB</b>/target mean</summary>

| platform | baseline (KiB) | this PR (KiB) | Δ | build-machine paths |
|---|---:|---:|---:|:---:|
| win32-x64-msvc | 20,007.5 | 19,842.5 | **−165.0 (−0.82%)** | removed |
| darwin-x64 | 16,725.4 | 16,573.7 | **−151.8 (−0.91%)** | removed |
| linux-x64-gnu | 18,657.6 | 18,509.6 | **−148.0 (−0.79%)** | removed |
| freebsd-x64 | 18,654.4 | 18,510.3 | **−144.1 (−0.77%)** | removed |
| linux-ppc64-gnu | 21,213.7 | 21,085.7 | **−128.0 (−0.60%)** | removed |
| linux-s390x-gnu | 19,477.1 | 19,353.1 | **−124.0 (−0.64%)** | removed |
| win32-arm64-msvc | 17,310.5 | 17,188.5 | **−122.0 (−0.70%)** | removed |
| linux-x64-musl | 18,705.5 | 18,594.5 | **−111.0 (−0.59%)** | **kept (≈500)** |
| linux-arm64-gnu | 16,821.2 | 16,725.2 | **−96.0 (−0.57%)** | removed |
| openharmony-arm64 | 16,826.2 | 16,737.5 | **−88.7 (−0.53%)** | removed |
| android-arm64 | 16,833.9 | 16,745.9 | **−88.1 (−0.52%)** | removed |
| darwin-arm64 | 15,928.9 | 15,864.4 | **−64.5 (−0.40%)** | removed |
| linux-arm64-musl | 16,865.1 | 16,808.8 | **−56.2 (−0.33%)** | **kept (≈500)** |
| linux-arm-gnueabihf | 15,173.8 | 15,121.8 | **−52.0 (−0.34%)** | removed |

</details>

Only ~20–47% of each delta is the shorter path strings themselves (e.g. linux-x64-gnu: −69 KiB of strings within the −148 KiB total); the rest is the section-layout shift that adding `--remap-path-prefix` induces in rustc's symbol/metadata handling. That layout effect is also why the two musl targets still shrink even though their paths stay unremapped (see gaps).

## What changed

- `packages/rolldown/build-binding.ts` — on release builds, builds the `--remap-path-prefix` set (cargo home → `/cargo`, rustup home → `/rustup`, workspace root → `/rolldown`, each `registry/src/<hash>` dir → `/deps`) and injects it via a cargo `--config target.'cfg(all())'.rustflags=[…]` option.
- **No workflow or toolchain changes.** The remap needs no `rust-src`, no `-Z build-std`, no env flags; `.github/workflows/reusable-release-build.yml` is untouched.

## How it works

rustc embeds absolute paths (`/…/.cargo/registry/src/…`, rustup toolchain sources, the workspace root) into panic `Location`s and tracing callsite metadata. Release builds remap them, so panic messages read `/deps/oxc_transformer-0.139.0/src/…` and the build machine's filesystem layout stays out of shipped artifacts. Release-only, so local dev backtraces keep clickable absolute paths.

Deterministic: the per-registry `registry/src/<hash>` dirs only exist after a fetch, so the script runs `cargo fetch --locked --target` first, then enumerates them sorted — the flag set is a function of the lockfile, not of ambient cargo-home state on the runner.

Why `--config` instead of `RUSTFLAGS`/`CARGO_BUILD_RUSTFLAGS`: the napi CLI promotes `CARGO_BUILD_RUSTFLAGS` to `RUSTFLAGS`, which suppresses all target-level rustflags from `.cargo/config.toml` — an earlier revision of this PR silently dropped `crt-static` from the windows binary that way (its `.node` gained `VCRUNTIME140` imports). Config-level target rustflags are *joined* with the config.toml entries instead, so windows keeps `crt-static` and still gets remapped.

## Verification (from the PR artifacts)

- **Build-machine paths removed on 12/14 targets** — 0 `/home/runner`, `/Users/runner`, `runneradmin`, or `D:\a` strings (e.g. linux-x64-gnu 605 → 0, win32-x64-msvc 878 → 0).
- **windows `crt-static` intact** — 0 `VCRUNTIME140` imports; the `.node` stays statically linked to the CRT.
- **No linking change** — every ELF target stays dynamically linked / stripped, exactly as baseline.
- **Zero drift** — original 07-07 baseline ≡ same-day baseline, byte-for-byte, all 14 targets.

## Known gaps / follow-ups

- **musl keeps its registry paths** (`linux-x64-musl`, `linux-arm64-musl`): napi-cli unconditionally sets `RUSTFLAGS` for musl (`-C target-feature=-crt-static`), suppressing the config-level rustflags, so ~500 `/home/runner/.cargo/registry/…` strings remain — **no privacy benefit on musl** (the size still drops via the layout effect). Root cause is the CLI's `CARGO_BUILD_RUSTFLAGS`→`RUSTFLAGS` promotion; the durable fix is upstream in napi-rs.
- Migrate the remap block to cargo `-Ztrim-paths` when it stabilizes (rust-lang/cargo#12137).
- The build-std / backtrace-symbolizer removal (a separate, larger size win) lands on its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
