### PR TITLE
fix(sourcemap_filenames): hash emitted map contents, relative URLs

### DIFF
--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -746,6 +746,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         None,
       )
       .await?
+      .1
     } else {
       None
     };

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
   Asset, HashCharacters, InsChunkIdx, InstantiationKind, NormalizedBundlerOptions,
-  PathsOutputOption, SourceMapType, StrOrBytes,
+  PathsOutputOption, StrOrBytes,
 };
 use rolldown_error::BuildResult;
 #[cfg(not(target_family = "wasm"))]
@@ -25,7 +25,6 @@ use rolldown_utils::{
   xxhash::{encode_hash_with_base, xxhash_base64_url},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use sugar_path::SugarPath;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
@@ -122,12 +121,6 @@ pub async fn finalize_assets(
     })
     .collect::<Vec<_>>()
     .into();
-  // Inline sourcemaps also resolve `[hash]`: the name is still reported on the output chunk
-  // even though no `.map` asset is written (Rollup parity). With sourcemaps disabled no
-  // preliminary sourcemap filenames exist, so this yields nothing.
-  let sourcemap_final_hashes =
-    generate_sourcemap_hashes_by_idx(&index_instantiated_chunks, hash_base);
-
   deconflict_filenames(&index_instantiated_chunks, &mut index_final_hashes, hash_base);
 
   let final_hashes_by_placeholder = index_final_hashes
@@ -138,7 +131,6 @@ pub async fn finalize_assets(
       })
     })
     .flatten()
-    .chain(get_sourcemap_hashes_by_placeholder(&sourcemap_final_hashes, &index_instantiated_chunks))
     .collect::<FxHashMap<_, _>>();
 
   let mut assets: AssetVec = index_instantiated_chunks
@@ -155,7 +147,9 @@ pub async fn finalize_assets(
       .into();
 
       // Only chunks that actually produced a map report a sourcemap filename; Rollup reports
-      // `sourcemapFileName: null` otherwise.
+      // `sourcemapFileName: null` otherwise. `[chunkhash]` resolves here via the chunk
+      // placeholders; the sourcemap's own `[hash]` stays as a placeholder until
+      // `process_code_and_sourcemap` derives it from the emitted map contents.
       let preliminary_filename_str = if instantiated_chunk.map.is_some() {
         instantiated_chunk.preliminary_sourcemap_filename.as_ref().map(|f| f.as_str())
       } else {
@@ -227,7 +221,7 @@ pub async fn finalize_assets(
         let asset_code = mem::take(&mut asset.content);
         let mut code = asset_code.try_into_string()?;
         if let Some(map) = asset.map.as_mut() {
-          if let Some(sourcemap_asset) = process_code_and_sourcemap(
+          let (resolved_sourcemap_filename, sourcemap_asset) = process_code_and_sourcemap(
             options,
             &mut code,
             map,
@@ -235,10 +229,11 @@ pub async fn finalize_assets(
             asset.filename.as_str(),
             ecma_meta.debug_id,
             /*is_css*/ false,
-            ecma_meta.sourcemap_filename.clone(),
+            ecma_meta.sourcemap_filename.take(),
           )
-          .await?
-          {
+          .await?;
+          ecma_meta.sourcemap_filename = resolved_sourcemap_filename;
+          if let Some(sourcemap_asset) = sourcemap_asset {
             derived_asset = Ok(Some(Asset {
               originate_from: None,
               content: sourcemap_asset.source,
@@ -249,15 +244,6 @@ pub async fn finalize_assets(
                 original_file_names: sourcemap_asset.original_file_names,
               })),
             }));
-            if ecma_meta.sourcemap_filename.is_none() {
-              let sourcemap_filename =
-                if matches!(options.sourcemap, Some(SourceMapType::Inline) | None) {
-                  None
-                } else {
-                  Some(sourcemap_asset.filename.to_string())
-                };
-              ecma_meta.sourcemap_filename = sourcemap_filename;
-            }
           }
         }
         asset.content = code.into();
@@ -271,63 +257,6 @@ pub async fn finalize_assets(
   assets.extend(derived_assets.into_iter().flatten());
 
   Ok(assets)
-}
-
-fn generate_sourcemap_hashes_by_idx(
-  index_instantiated_chunks: &IndexInstantiatedChunks,
-  hash_base: u8,
-) -> Vec<(InsChunkIdx, String)> {
-  index_instantiated_chunks
-    .par_iter()
-    .enumerate()
-    .filter_map(|(idx, chunk)| {
-      let (Some(map), Some(preliminary_sourcemap_filename)) =
-        (&chunk.map, &chunk.preliminary_sourcemap_filename)
-      else {
-        return None;
-      };
-      // Only patterns containing `[hash]` need a resolved sourcemap hash.
-      preliminary_sourcemap_filename.hash_placeholder()?;
-      let InstantiationKind::Ecma(ecma_meta) = &chunk.kind else {
-        return None;
-      };
-      // Hash only machine-independent content: `sources` still hold absolute module paths here
-      // (they are only relativized later in `process_code_and_sourcemap`), and the preliminary
-      // filename embeds a transient placeholder index. Feeding either into the hash would
-      // rename sourcemaps across machines or on unrelated graph changes — the same invariant
-      // the placeholder normalization above maintains for chunk content hashes.
-      let mut content_only = map.clone();
-      content_only.set_sources(
-        map
-          .get_sources()
-          .map(|source| {
-            source.as_path().relative(&ecma_meta.file_dir).to_slash_lossy().into_owned()
-          })
-          .collect::<Vec<String>>(),
-      );
-      let mut hasher = Xxh3::default();
-      hasher.update(content_only.to_json_string().as_bytes());
-      let hash = encode_hash_with_base(&hasher.digest128().to_le_bytes(), hash_base);
-      Some((InsChunkIdx::from(idx), hash))
-    })
-    .collect()
-}
-fn get_sourcemap_hashes_by_placeholder<'a>(
-  sourcemap_final_hashes: &'a [(InsChunkIdx, String)],
-  index_instantiated_chunks: &IndexInstantiatedChunks,
-) -> impl Iterator<Item = (String, &'a str)> {
-  sourcemap_final_hashes
-    .iter()
-    .filter_map(|(idx, hash)| {
-      index_instantiated_chunks[*idx]
-        .preliminary_sourcemap_filename
-        .as_ref()
-        .and_then(|filename| filename.hash_placeholder())
-        .map(|placeholders| {
-          placeholders.iter().map(|placeholder| (placeholder.clone(), &hash[..placeholder.len()]))
-        })
-    })
-    .flatten()
 }
 
 fn collect_transitive_dependencies(

--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -5,11 +5,26 @@ use oxc::ast::CommentKind;
 use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
 use rolldown_error::{BuildResult, ResultExt};
 use rolldown_sourcemap::SourceMap;
+use rolldown_utils::{
+  hash_placeholder::{
+    HASH_PLACEHOLDER_LEFT_FINDER, extract_hash_placeholders, replace_placeholder_with_hash,
+  },
+  xxhash::encode_hash_with_base,
+};
+use rustc_hash::FxHashMap;
 use sugar_path::SugarPath;
 use url::Url;
+use xxhash_rust::xxh3::Xxh3;
 
 use super::uuid::uuid_v4_string_from_u128;
 
+/// Returns `(sourcemap_filename, sourcemap_asset)`:
+/// - `sourcemap_filename` is the final name reported on the output chunk. Any `[hash]`
+///   placeholder left in `sourcemap_filename` (from `output.sourcemapFileNames`) is resolved
+///   here from the exact serialized map being emitted, so the name is a faithful cache key
+///   for the file's final contents (after `sourcemapPathTransform`, `sourcemapIgnoreList`,
+///   `sourcemapExcludeSources`, debug ids, ...).
+/// - `sourcemap_asset` is the `.map` file to emit (`sourcemap: true | 'hidden'` only).
 #[expect(clippy::too_many_arguments)]
 pub async fn process_code_and_sourcemap(
   options: &NormalizedBundlerOptions,
@@ -20,7 +35,7 @@ pub async fn process_code_and_sourcemap(
   debug_id: u128,
   is_css: bool,
   sourcemap_filename: Option<String>,
-) -> BuildResult<Option<OutputAsset>> {
+) -> BuildResult<(Option<String>, Option<OutputAsset>)> {
   let source_map_link_comment_kind =
     if is_css { CommentKind::SingleLineBlock } else { CommentKind::Line };
   let file_base_name = Path::new(filename).file_name().expect("should have file name");
@@ -30,8 +45,12 @@ pub async fn process_code_and_sourcemap(
     map.set_source_contents(vec![]);
   }
 
-  let map_filename = sourcemap_filename.unwrap_or_else(|| format!("{filename}.map"));
-  let map_path = file_dir.join(&map_filename);
+  let has_custom_map_filename = sourcemap_filename.is_some();
+  let mut map_filename = sourcemap_filename.unwrap_or_else(|| format!("{filename}.map"));
+  // Rollup always hands `sourcemapIgnoreList`/`sourcemapPathTransform` the default
+  // `<chunk>.map` path, independent of `sourcemapFileNames` — which may still contain an
+  // unresolved `[hash]` here, since that hash derives from the transformed map content.
+  let map_path = file_dir.join(format!("{filename}.map"));
 
   if let Some(source_map_ignore_list) = &options.sourcemap_ignore_list {
     let mut x_google_ignore_list = vec![];
@@ -115,6 +134,11 @@ pub async fn process_code_and_sourcemap(
     match sourcemap {
       SourceMapType::File | SourceMapType::Hidden => {
         let source = map.to_json_string();
+        resolve_sourcemap_hash_placeholders(
+          &mut map_filename,
+          &source,
+          options.hash_characters.base(),
+        );
         if matches!(sourcemap, SourceMapType::File) {
           process_sourcemap_related_reference(
             code,
@@ -129,12 +153,12 @@ pub async fn process_code_and_sourcemap(
                   source.push_str(url.as_str());
                 }
                 None => {
-                  source.push_str(
-                    &Path::new(&map_filename)
-                      .file_name()
-                      .ok_or(anyhow::anyhow!("should have filename"))?
-                      .to_string_lossy(),
-                  );
+                  // Emit a URL that resolves from the chunk's location to the map file: the
+                  // plain basename for default sibling maps, a relative path when
+                  // `sourcemapFileNames` places maps in another directory. (Rollup emits the
+                  // bare basename even then, which cannot resolve — a known upstream quirk.)
+                  let chunk_dir = Path::new(filename).parent().unwrap_or_else(|| Path::new(""));
+                  source.push_str(&Path::new(&map_filename).relative(chunk_dir).to_slash_lossy());
                 }
               }
               Ok(())
@@ -142,14 +166,26 @@ pub async fn process_code_and_sourcemap(
             source_map_link_comment_kind,
           )?;
         }
-        return Ok(Some(OutputAsset {
-          filename: map_filename.as_str().into(),
-          source: source.into(),
-          original_file_names: vec![],
-          names: vec![],
-        }));
+        return Ok((
+          Some(map_filename.clone()),
+          Some(OutputAsset {
+            filename: map_filename.as_str().into(),
+            source: source.into(),
+            original_file_names: vec![],
+            names: vec![],
+          }),
+        ));
       }
       SourceMapType::Inline => {
+        if has_custom_map_filename {
+          // No `.map` file is written, but the resolved name is still reported on the
+          // output chunk (Rollup parity).
+          resolve_sourcemap_hash_placeholders(
+            &mut map_filename,
+            &map.to_json_string(),
+            options.hash_characters.base(),
+          );
+        }
         let data_url = map.to_data_url();
         process_sourcemap_related_reference(
           code,
@@ -160,11 +196,33 @@ pub async fn process_code_and_sourcemap(
           },
           source_map_link_comment_kind,
         )?;
+        return Ok((has_custom_map_filename.then_some(map_filename), None));
       }
     }
   }
 
-  Ok(None)
+  Ok((None, None))
+}
+
+fn resolve_sourcemap_hash_placeholders(map_filename: &mut String, map_json: &str, hash_base: u8) {
+  let placeholders = extract_hash_placeholders(map_filename, &HASH_PLACEHOLDER_LEFT_FINDER);
+  if placeholders.is_empty() {
+    return;
+  }
+  let mut hasher = Xxh3::default();
+  hasher.update(map_json.as_bytes());
+  let hash = encode_hash_with_base(&hasher.digest128().to_le_bytes(), hash_base);
+  let hashes_by_placeholder = placeholders
+    .iter()
+    .map(|placeholder| ((*placeholder).to_string(), &hash[..placeholder.len()]))
+    .collect::<FxHashMap<_, _>>();
+  let resolved = replace_placeholder_with_hash(
+    map_filename,
+    &hashes_by_placeholder,
+    &HASH_PLACEHOLDER_LEFT_FINDER,
+  )
+  .into_owned();
+  *map_filename = resolved;
 }
 
 fn process_sourcemap_related_reference(

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/_config.ts
@@ -1,0 +1,29 @@
+import type { OutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { getOutputSourcemapFilenames } from 'rolldown-tests/utils';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: ['main.js', 'nested.js'],
+    output: {
+      sourcemap: true,
+      entryFileNames: (chunk) => (chunk.name === 'nested' ? 'entries/[name].js' : '[name].js'),
+      sourcemapFileNames: 'maps/[name].js.map',
+    },
+  },
+  afterTest: (output) => {
+    expect(getOutputSourcemapFilenames(output)).toStrictEqual([
+      'maps/main.js.map',
+      'maps/nested.js.map',
+    ]);
+
+    const urlOf = (code: string) => /\/\/# sourceMappingURL=(\S+)/.exec(code)?.[1];
+    const chunk = (fileName: string) =>
+      output.output.find((o) => o.type === 'chunk' && o.fileName === fileName) as OutputChunk;
+
+    // The sourceMappingURL comment must resolve from the chunk's location to the emitted map.
+    expect(urlOf(chunk('main.js').code)).toBe('maps/main.js.map');
+    expect(urlOf(chunk('entries/nested.js').code)).toBe('../maps/nested.js.map');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/main.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/nested.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/subdirectory/nested.js
@@ -1,0 +1,1 @@
+console.log('nested');

--- a/packages/rolldown/tests/sourcemap/main.js
+++ b/packages/rolldown/tests/sourcemap/main.js
@@ -1,0 +1,1 @@
+console.log('sourcemap filenames hash input');

--- a/packages/rolldown/tests/sourcemap/sourcemap-filenames-hash.test.ts
+++ b/packages/rolldown/tests/sourcemap/sourcemap-filenames-hash.test.ts
@@ -1,0 +1,29 @@
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+async function generateMapName(
+  sourcemapPathTransform?: (source: string, sourcemapPath: string) => string,
+): Promise<string> {
+  const bundle = await rolldown({ input: './main.js', cwd: import.meta.dirname });
+  const { output } = await bundle.generate({
+    sourcemap: true,
+    sourcemapFileNames: '[name]-[hash].js.map',
+    sourcemapPathTransform,
+  });
+  await bundle.close();
+  const map = output.find((o) => o.type === 'asset' && o.fileName.endsWith('.map'));
+  expect(map).toBeDefined();
+  return map!.fileName;
+}
+
+test('sourcemap-filenames [hash] derives from the emitted map contents', async () => {
+  // `sourcemapPathTransform` changes the emitted map's `sources`, so it must change `[hash]` —
+  // the hash is a cache key for the bytes actually written to disk.
+  const plain = await generateMapName();
+  const transformedA = await generateMapName((source) => `transformed-a/${source}`);
+  const transformedB = await generateMapName((source) => `transformed-b/${source}`);
+  expect(transformedA).not.toBe(plain);
+  expect(transformedA).not.toBe(transformedB);
+  // Identical configuration must stay deterministic.
+  expect(await generateMapName((source) => `transformed-a/${source}`)).toBe(transformedA);
+});


### PR DESCRIPTION
### Description

Follow-up to #9271 (`output.sourcemapFileNames`, closes review findings from that PR).

**1. `sourceMappingURL` now resolves from the chunk to the map**

With a directory pattern like `sourcemapFileNames: 'maps/[name].js.map'`, the comment previously contained only the basename (`main.js.map`) while the file was emitted at `maps/main.js.map`, so browsers/tooling could not resolve it. The comment now emits the path relative to the chunk (`maps/main.js.map`, or `../maps/nested.js.map` from a chunk in a subdirectory). Default sibling maps produce byte-identical output to before (relative == basename).

> Note: Rollup itself emits the bare basename here (`renderChunks.ts` uses `basename(fileName)`), so this deliberately improves on upstream behavior. Rollup''s own `sourcemap-file-names` tests use flat patterns, so no compat expectations change.

**2. `[hash]` derives from the exact emitted map**

`[hash]` was computed from a pre-transform snapshot of the map, so `sourcemapPathTransform` / `sourcemapIgnoreList` / `sourcemapExcludeSources` could change the emitted `.map` contents without changing its filename — a stale cache key. The hash is now computed in `process_code_and_sourcemap` from the serialized map that is actually written (inline maps included), and the finalize-stage pre-hash pass is deleted entirely. Consequences:

- the ignore-list/path-transform callbacks receive the default `<chunk>.map` path, matching Rollup (they cannot receive the custom name — its `[hash]` depends on their output),
- the option is now zero-cost when unused: no per-chunk pass, no extra map serialization or clone.

### Tests

Both regression tests fail on `main` and pass with this change:

- `fixtures/output/sourcemap-filenames/subdirectory` — on main: `expected 'main.js.map' to be 'maps/main.js.map'`
- `tests/sourcemap/sourcemap-filenames-hash.test.ts` — on main: identical `[hash]` filenames across different `sourcemapPathTransform`s

Local validation: full JS suite 775/0, Rust integration 1798/0, workspace clippy `--deny warnings`, `cargo fmt`.