### PR TITLE
feat: detect top-level import-binding reads as execution-order sensitive

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -25,7 +25,7 @@ use crate::ast_scanner::cjs_export_analyzer::CommonJsAstType;
 
 use super::{
   AstScanner, UntranspiledSyntax, cjs_export_analyzer::CjsGlobalAssignmentType,
-  stmt_eval_analyzer::StmtEvalAnalyzer,
+  stmt_eval_analyzer::StmtEvalAnalyzer, top_level_import_read::TopLevelImportReadDetector,
 };
 
 impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
@@ -89,7 +89,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       }
 
       self.visit_statement(stmt);
-      if stmt_eval_facts.is_order_sensitive() {
+      // Tree-shaking side effects / global reads / pure annotations come from the analyzer.
+      // Top-level reads of imported bindings are detected by a separate uniform walk so the
+      // signal is complete by construction (no per-expression-form gaps).
+      if stmt_eval_facts.is_order_sensitive()
+        || TopLevelImportReadDetector::detect(&self.result.symbol_ref_db.ast_scopes, stmt)
+      {
         self.result.ecma_view_meta.insert(EcmaViewMeta::ExecutionOrderSensitive);
       }
       self.result.stmt_infos.add_stmt_info(std::mem::take(&mut self.current_stmt_info));

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -6,6 +6,7 @@ pub mod impl_visit;
 mod import_analyzer;
 mod new_url;
 pub mod stmt_eval_analyzer;
+mod top_level_import_read;
 
 use arcstr::ArcStr;
 use const_eval::{ConstEvalCtx, try_extract_const_literal};

--- a/crates/rolldown/src/ast_scanner/top_level_import_read.rs
+++ b/crates/rolldown/src/ast_scanner/top_level_import_read.rs
@@ -274,6 +274,16 @@ mod test {
   }
 
   #[test]
+  fn default_export_value_is_a_read() {
+    assert_eq!(detect("import { a } from './a'; export default a;"), vec![false, true]);
+  }
+
+  #[test]
+  fn instance_field_initializers_are_conservatively_flagged() {
+    assert_eq!(detect("import { x } from './state'; export class C { f = x; }"), vec![false, true]);
+  }
+
+  #[test]
   fn class_definition_time_reads_are_flagged() {
     // Static field initializers run at class-definition (module-eval) time.
     assert_eq!(

--- a/crates/rolldown/src/ast_scanner/top_level_import_read.rs
+++ b/crates/rolldown/src/ast_scanner/top_level_import_read.rs
@@ -1,0 +1,210 @@
+use oxc::ast::ast::{
+  ArrowFunctionExpression, ExportNamedDeclaration, Expression, Function, IdentifierReference,
+  Statement, TSType,
+};
+use oxc::ast_visit::{Visit, walk};
+use oxc::semantic::ScopeFlags;
+use rolldown_common::AstScopes;
+
+/// Does a top-level statement **read** an imported binding during its own
+/// module-evaluation-time execution?
+///
+/// This is the execution-order-sensitive signal for imported-binding reads. It is a deliberate
+/// **over-approximation** — sound for wrapping decisions, where the only dangerous mistake is
+/// under-reporting (a genuinely order-sensitive statement reported as `false` could be unwrapped
+/// and reordered across a mutation). When unsure we report `true`.
+///
+/// Why a dedicated uniform walk instead of threading the fact through the side-effect analyzer:
+/// completeness. The side-effect analyzer propagates facts per expression form, which is how gaps
+/// creep in (e.g. an imported binding buried in a mid-chain computed key such as `a[imp].y`, or a
+/// namespace aliased into a local). Here we simply visit **every** sub-node once, so no expression
+/// form can be missed, and any newly added syntax is covered by default.
+///
+/// What is skipped, and why it stays sound:
+/// - **Function / arrow bodies** (incl. class method bodies and parameter defaults) run at *call*
+///   time, not module-eval time. If such a body actually runs during module evaluation it does so
+///   through a call/`new`, which the side-effect / pure-annotation analysis independently reports
+///   as order-sensitive — so skipping bodies never hides a module-eval-time read.
+/// - **Import declarations and re-export specifiers** (`export { a }`, `export { a } from '...'`)
+///   forward bindings; they do not read a value. Only the `declaration` half of an export (e.g.
+///   `export const x = imp`) evaluates at module-eval time.
+/// - **Type annotations** are erased at runtime.
+///
+/// Deliberately conservative (reports `true` though the read is technically deferred):
+/// - **Instance class-field initializers** (`class C { f = imp }`) run at construction, not at
+///   class definition. They are treated as top-level reads for now; refining this is a pure
+///   precision gain and can come later.
+///
+/// Known limitation, inherent to any syntactic analysis: under
+/// `treeshake.propertyReadSideEffects: false`, a getter/`Proxy` trap that reads an imported binding
+/// is invisible here. That is the option's explicit "reads are side-effect-free" promise, not a gap
+/// this walk can close.
+pub struct TopLevelImportReadDetector<'scopes> {
+  scopes: &'scopes AstScopes,
+  reads_import: bool,
+}
+
+impl<'scopes> TopLevelImportReadDetector<'scopes> {
+  /// Returns `true` if evaluating `stmt` at module-eval time reads an imported binding.
+  pub fn detect(scopes: &'scopes AstScopes, stmt: &Statement) -> bool {
+    let mut detector = Self { scopes, reads_import: false };
+    detector.visit_statement(stmt);
+    detector.reads_import
+  }
+}
+
+impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
+  fn visit_identifier_reference(&mut self, it: &IdentifierReference<'ast>) {
+    if self.reads_import {
+      return;
+    }
+    let Some(reference_id) = it.reference_id.get() else {
+      return;
+    };
+    let Some(symbol_id) = self.scopes.symbol_id_for(reference_id) else {
+      return;
+    };
+    if self.scopes.scoping().symbol_flags(symbol_id).is_import() {
+      self.reads_import = true;
+    }
+  }
+
+  // Prune the rest of the walk once we've already found a read.
+  fn visit_expression(&mut self, it: &Expression<'ast>) {
+    if self.reads_import {
+      return;
+    }
+    walk::walk_expression(self, it);
+  }
+
+  // Bodies run at call time, not module-eval time — skip entirely (params/defaults included).
+  fn visit_function(&mut self, _it: &Function<'ast>, _flags: ScopeFlags) {}
+  fn visit_arrow_function_expression(&mut self, _it: &ArrowFunctionExpression<'ast>) {}
+
+  // `export { a }` / `export { a } from '...'` forward bindings without reading them. Only the
+  // declaration half of an export (`export const x = imp`) evaluates at module-eval time.
+  fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'ast>) {
+    if let Some(declaration) = &it.declaration {
+      self.visit_declaration(declaration);
+    }
+  }
+
+  // Types are erased at runtime; a type-only import reference is never a value read.
+  fn visit_ts_type(&mut self, _it: &TSType<'ast>) {}
+}
+
+#[cfg(test)]
+mod test {
+  use super::TopLevelImportReadDetector;
+  use oxc::span::SourceType;
+  use rolldown_common::AstScopes;
+  use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
+
+  /// One bool per top-level statement: does it read an imported binding at module-eval time?
+  fn detect(code: &str) -> Vec<bool> {
+    let source_type = SourceType::tsx();
+    let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
+    let semantic = EcmaAst::make_semantic(ast.program());
+    let scoping = semantic.into_scoping();
+    let ast_scopes = AstScopes::new(scoping);
+    ast
+      .program()
+      .body
+      .iter()
+      .map(|stmt| TopLevelImportReadDetector::detect(&ast_scopes, stmt))
+      .collect()
+  }
+
+  #[test]
+  fn direct_and_member_reads() {
+    // Import declaration itself reads nothing; the read is in `snap`.
+    assert_eq!(
+      detect("import { counter } from './state'; export const snap = counter;"),
+      vec![false, true]
+    );
+    // Member chain rooted at an import.
+    assert_eq!(
+      detect("import { obj } from './state'; export const snap = obj.value;"),
+      vec![false, true]
+    );
+    // Import read as a call argument at top level.
+    assert_eq!(detect("import { x } from './state'; sideEffect(x);"), vec![false, true]);
+    // Import read inside a compound expression.
+    assert_eq!(
+      detect("import { x } from './state'; export const o = { a: x };"),
+      vec![false, true]
+    );
+  }
+
+  #[test]
+  fn nested_computed_key_hole_is_closed() {
+    // `a[imp].y` — the import is a mid-chain computed key. This is exactly the gap the per-form
+    // analyzer missed; the uniform walk catches it unconditionally (no `propertyReadSideEffects`
+    // dependence).
+    assert_eq!(
+      detect("import { key } from './state'; const obj = {}; export const snap = obj[key].y;"),
+      vec![false, false, true]
+    );
+    assert_eq!(
+      detect("import { key } from './state'; const obj = {}; export const snap = obj[key][key];"),
+      vec![false, false, true]
+    );
+  }
+
+  #[test]
+  fn namespace_member_and_alias() {
+    // Namespace member read.
+    assert_eq!(
+      detect("import * as ns from './state'; export const snap = ns.foo;"),
+      vec![false, true]
+    );
+    // Namespace aliased into a local, then read through the alias. Flagging the bare `ns` read on
+    // the `const x = ns` statement is what makes the module order-sensitive — closing the alias
+    // gap conservatively.
+    assert_eq!(
+      detect("import * as ns from './state'; const x = ns; export const snap = x.foo;"),
+      vec![false, true, false]
+    );
+  }
+
+  #[test]
+  fn function_and_arrow_bodies_are_deferred() {
+    // Reading an import inside a function/arrow body is a call-time read, not module-eval time.
+    assert_eq!(
+      detect("import { counter } from './state'; export function read() { return counter; }"),
+      vec![false, false]
+    );
+    assert_eq!(
+      detect("import { counter } from './state'; export const read = () => counter;"),
+      vec![false, false]
+    );
+    // Class method bodies are deferred too.
+    assert_eq!(
+      detect("import { x } from './state'; export class C { m() { return x; } }"),
+      vec![false, false]
+    );
+  }
+
+  #[test]
+  fn reexports_and_non_imports_are_not_reads() {
+    // Pure re-export barrel forwards a binding without reading its value.
+    assert_eq!(detect("export { a } from './a';"), vec![false]);
+    assert_eq!(detect("import { a } from './a'; export { a };"), vec![false, false]);
+    // A local (non-import) binding read is not order-sensitive here.
+    assert_eq!(detect("const a = 1; export const b = a;"), vec![false, false]);
+  }
+
+  #[test]
+  fn class_definition_time_reads_are_flagged() {
+    // Static field initializers run at class-definition (module-eval) time.
+    assert_eq!(
+      detect("import { x } from './state'; export class C { static s = x; }"),
+      vec![false, true]
+    );
+    // A superclass expression is evaluated at class-definition time.
+    assert_eq!(
+      detect("import { Base } from './state'; export class C extends Base {}"),
+      vec![false, true]
+    );
+  }
+}

--- a/crates/rolldown/src/ast_scanner/top_level_import_read.rs
+++ b/crates/rolldown/src/ast_scanner/top_level_import_read.rs
@@ -66,6 +66,11 @@ impl<'scopes> TopLevelImportReadDetector<'scopes> {
         self.visit_formal_parameters(&arrow.params);
         self.visit_function_body(&arrow.body);
       }
+      Expression::SequenceExpression(sequence) => {
+        if let Some(last) = sequence.expressions.last() {
+          self.visit_immediately_invoked_function(last);
+        }
+      }
       _ => {}
     }
   }
@@ -229,6 +234,17 @@ mod test {
     assert_eq!(
       detect("import { value } from './state'; export const snapshot = ((x = value) => x)();"),
       vec![false, true]
+    );
+    // A sequence expression calls only its final expression.
+    assert_eq!(
+      detect("import { value } from './state'; export const snapshot = (0, (() => value))();"),
+      vec![false, true]
+    );
+    assert_eq!(
+      detect(
+        "import { value } from './state'; export const snapshot = ((() => value), (() => 0))();"
+      ),
+      vec![false, false]
     );
   }
 

--- a/crates/rolldown/src/ast_scanner/top_level_import_read.rs
+++ b/crates/rolldown/src/ast_scanner/top_level_import_read.rs
@@ -1,6 +1,6 @@
 use oxc::ast::ast::{
-  ArrowFunctionExpression, ExportNamedDeclaration, Expression, Function, IdentifierReference,
-  Statement, TSType,
+  ArrowFunctionExpression, CallExpression, ExportNamedDeclaration, Expression, Function,
+  IdentifierReference, Statement, TSType,
 };
 use oxc::ast_visit::{Visit, walk};
 use oxc::semantic::ScopeFlags;
@@ -21,10 +21,10 @@ use rolldown_common::AstScopes;
 /// form can be missed, and any newly added syntax is covered by default.
 ///
 /// What is skipped, and why it stays sound:
-/// - **Function / arrow bodies** (incl. class method bodies and parameter defaults) run at *call*
-///   time, not module-eval time. If such a body actually runs during module evaluation it does so
-///   through a call/`new`, which the side-effect / pure-annotation analysis independently reports
-///   as order-sensitive — so skipping bodies never hides a module-eval-time read.
+/// - **Function / arrow bodies** are skipped when the function is merely declared or stored because
+///   they run at call time. Directly invoked function literals are the exception: their parameter
+///   defaults run immediately, as do non-generator bodies, so `visit_call_expression` traverses
+///   those parts explicitly.
 /// - **Import declarations and re-export specifiers** (`export { a }`, `export { a } from '...'`)
 ///   forward bindings; they do not read a value. Only the `declaration` half of an export (e.g.
 ///   `export const x = imp`) evaluates at module-eval time.
@@ -50,6 +50,24 @@ impl<'scopes> TopLevelImportReadDetector<'scopes> {
     let mut detector = Self { scopes, reads_import: false };
     detector.visit_statement(stmt);
     detector.reads_import
+  }
+
+  fn visit_immediately_invoked_function(&mut self, callee: &Expression<'_>) {
+    match callee.get_inner_expression() {
+      Expression::FunctionExpression(function) => {
+        self.visit_formal_parameters(&function.params);
+        if !function.generator
+          && let Some(body) = &function.body
+        {
+          self.visit_function_body(body);
+        }
+      }
+      Expression::ArrowFunctionExpression(arrow) => {
+        self.visit_formal_parameters(&arrow.params);
+        self.visit_function_body(&arrow.body);
+      }
+      _ => {}
+    }
   }
 }
 
@@ -77,9 +95,19 @@ impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
     walk::walk_expression(self, it);
   }
 
-  // Bodies run at call time, not module-eval time — skip entirely (params/defaults included).
+  // Merely creating a function does not run its parameters or body.
   fn visit_function(&mut self, _it: &Function<'ast>, _flags: ScopeFlags) {}
   fn visit_arrow_function_expression(&mut self, _it: &ArrowFunctionExpression<'ast>) {}
+
+  fn visit_call_expression(&mut self, it: &CallExpression<'ast>) {
+    if self.reads_import {
+      return;
+    }
+    walk::walk_call_expression(self, it);
+    if !self.reads_import {
+      self.visit_immediately_invoked_function(&it.callee);
+    }
+  }
 
   // `export { a }` / `export { a } from '...'` forward bindings without reading them. Only the
   // declaration half of an export (`export const x = imp`) evaluates at module-eval time.
@@ -181,6 +209,41 @@ mod test {
     // Class method bodies are deferred too.
     assert_eq!(
       detect("import { x } from './state'; export class C { m() { return x; } }"),
+      vec![false, false]
+    );
+  }
+
+  #[test]
+  fn immediately_invoked_functions_run_during_module_evaluation() {
+    assert_eq!(
+      detect("import { value } from './state'; export const snapshot = (() => value)();"),
+      vec![false, true]
+    );
+    assert_eq!(
+      detect(
+        "import { value } from './state'; export const snapshot = (function () { return value })();"
+      ),
+      vec![false, true]
+    );
+    // Parameter defaults run when the function is called.
+    assert_eq!(
+      detect("import { value } from './state'; export const snapshot = ((x = value) => x)();"),
+      vec![false, true]
+    );
+  }
+
+  #[test]
+  fn immediately_invoked_generator_only_runs_parameter_initializers() {
+    assert_eq!(
+      detect(
+        "import { value } from './state'; export const iterator = (function* (x = value) {})();"
+      ),
+      vec![false, true]
+    );
+    assert_eq!(
+      detect(
+        "import { value } from './state'; export const iterator = (function* () { yield value })();"
+      ),
       vec![false, false]
     );
   }


### PR DESCRIPTION
Stacked on #10168.

### What

Adds `TopLevelImportReadDetector` — a dedicated, uniform AST walk that marks a top-level statement as execution-order sensitive when its module-evaluation-time execution reads an imported binding — and OR-es it into `EcmaViewMeta::ExecutionOrderSensitive`.

### Why

On-demand wrapping should eventually decide "wrap or not" from execution-order sensitivity alone, so that a module which imports dependencies but only uses them inside function/class bodies can stay unwrapped. For that, the order-sensitivity signal must be **complete**: it may never miss a top-level read of an imported binding, or such a module could be unwrapped and reordered across a mutation.

The earlier approach (#10169) threaded this fact through the per-expression-form side-effect analyzer, which is exactly how gaps slip in — e.g. an imported binding in a mid-chain computed key (`a[imp].y`) or a namespace aliased into a local (`const x = ns; x.foo`). This replaces that with a single uniform walk that visits every sub-node once, so no expression form can be missed and newly added syntax is covered by default. It is a deliberate over-approximation, which is the sound direction for wrapping (under-reporting is the only dangerous mistake).

Skipped, and why each stays sound:

- **Function / arrow bodies** (incl. class method bodies and parameter defaults) run at call time. If such a body runs during module evaluation it does so through a call / `new`, which the side-effect / pure-annotation analysis already reports as order-sensitive.
- **Import declarations and re-export specifiers** (`export { a }`, `export { a } from '...'`) forward bindings without reading a value, so pure barrels stay unmarked.
- **Type annotations** are erased at runtime.

Known limitation, inherent to any syntactic analysis: under `treeshake.propertyReadSideEffects: false`, a getter / `Proxy` trap that reads an imported binding is invisible here — that is the option's own "reads are side-effect-free" promise, not a gap this walk can close.

### Currently inert

Every unwrap / chunk-grouping consumer of `ExecutionOrderSensitive` is additionally gated by `import_records.is_empty()`, and a module that reads an import necessarily has an import record, so no wrap or chunk decision changes yet. This lands the detection ahead of the follow-up that drops the `import_records.is_empty()` gate and lets the flag decide unwrapping on its own.

### Tests

- `cargo test -p rolldown --lib top_level_import_read` — 6 new unit tests: direct / member / computed-key / compound reads; the `a[key].y` mid-chain computed-key and `const x = ns; x.foo` namespace-alias cases; function / arrow / method bodies skipped; re-export barrels and locals not flagged; static field initializer and `extends` clause.
- `cargo fmt --check` and `cargo clippy -p rolldown --lib --tests` clean.
- Full integration suite unchanged — the change is inert; the strict-execution-order / wrapping / on-demand fixtures are green.
