### PR TITLE
test(dev): add hot API test cases

### DIFF
--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/__tests__/hmr-accept-exports.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/__tests__/hmr-accept-exports.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `hmr` acceptExports behavior. On the client `acceptExports(names, cb)` is a
+// self-accept (export-name filtering is a server-side concern), so editing the module should
+// run the callback with the fresh module rather than full-reloading.
+
+describe('hmr-accept-exports', () => {
+  test('renders the initial value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('exports-v1');
+  });
+
+  // KNOWN GAP: rolldown's scanner recognizes `import.meta.hot.accept(...)` as self-accepting
+  // but not `acceptExports(...)`, so the module's compile-side `HmrSelfAccept` flag is unset.
+  // The server-side propagation walk (`crates/rolldown/src/hmr/hmr_stage.rs` —
+  // `is_hmr_self_accepting_module`) then treats the edit as having no boundary and sends a
+  // full reload, even though the client already registered the self-accept at runtime.
+  // Verified: this currently full-reloads. Unskip once the compiler recognizes acceptExports.
+  test.skip('acceptExports hot-updates via its callback', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+
+    editFile('app.js', (code) => code.replace("'exports-v1'", "'exports-v2'"));
+    await expect.poll(() => page.textContent('.value')).toBe('exports-v2');
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/app.js
@@ -1,0 +1,9 @@
+// `acceptExports(names, cb)` — on the client this behaves as a self-accept (the export
+// names are a server-side concern). Editing this module runs the callback with the fresh
+// module instead of full-reloading.
+export const value = 'exports-v1';
+document.querySelector('.value').textContent = value;
+
+import.meta.hot?.acceptExports(['value'], (mod) => {
+  document.querySelector('.value').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/index.html
@@ -1,0 +1,3 @@
+<h1>HMR acceptExports</h1>
+<div class="value"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/main.js
@@ -1,0 +1,1 @@
+import './app.js';

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-accept-exports",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-before-full-reload/__tests__/hmr-before-full-reload.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-before-full-reload/__tests__/hmr-before-full-reload.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `vite:beforeFullReload` hot event to the client-decided reload: the FBM
+// client walks its own graph, decides the reload, and must still announce it through the
+// hot event channel first.
+
+describe('hmr-before-full-reload', () => {
+  // Skipped together with the gap test below: with every test in the file skipped,
+  // vitest never runs the per-file browser + dev-server boot, and this smoke only
+  // guards an initial render that every active suite already exercises.
+  test.skip('renders the initial value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('reload-v1');
+    await page.evaluate(() => sessionStorage.removeItem('sawBeforeFullReload'));
+  });
+
+  // KNOWN FBM GAP: the client-decided reload path does not announce itself through the
+  // hot event channel. Verified against the paired vite (d07220fa): the page reloads and
+  // fresh content lands, but the `vite:beforeFullReload` listener never fires (the
+  // sessionStorage flag stays null). The pre-refactor server-decided reload path
+  // (f5d4fa67) did emit it, so this is a regression surface of the client-side-reload
+  // move. Unskip once the FBM client emits the event before reloading itself.
+  test.skip('vite:beforeFullReload fires before the client-decided reload', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    editFile('main.js', (code) => code.replace("'reload-v1'", "'reload-v2'"));
+    await expect.poll(() => page.textContent('.value')).toBe('reload-v2');
+
+    // The page really reloaded (marker wiped), and the event fired before it.
+    expect(await readReloadMarker()).toBe(null);
+    expect(
+      await page.evaluate(() => sessionStorage.getItem('sawBeforeFullReload')),
+    ).toBe('1');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-before-full-reload/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-before-full-reload/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-before-full-reload/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-before-full-reload/index.html
@@ -1,0 +1,3 @@
+<h1>HMR vite:beforeFullReload</h1>
+<div class="value"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-before-full-reload/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-before-full-reload/main.js
@@ -1,0 +1,9 @@
+export const value = 'reload-v1';
+document.querySelector('.value').textContent = value;
+
+// No accept anywhere: editing this module makes the client walk find no boundary and
+// reload the page itself. The event must fire before that reload; sessionStorage
+// survives it where window state does not.
+import.meta.hot?.on('vite:beforeFullReload', () => {
+  sessionStorage.setItem('sawBeforeFullReload', '1');
+});

--- a/packages/test-dev-server/tests/playground/hmr-before-full-reload/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-before-full-reload/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-before-full-reload",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/__tests__/hmr-circular-accept-outside.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/__tests__/hmr-circular-accept-outside.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `circular/` case: mod-a -> mod-b -> mod-c -> mod-a form a circle with no
+// acceptance inside it; the self-accepting entry OUTSIDE the circle is the boundary.
+// Editing inside the circle must hot-update through it — no reload, no infinite walk.
+
+describe('hmr-circular-accept-outside', () => {
+  // Skipped together with the gap test below: with every test in the file skipped,
+  // vitest never runs the per-file browser + dev-server boot. Circular-import rendering
+  // itself is covered by the active `hmr-circular-self-accept` suite.
+  test.skip('renders the chain through the circle', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.circular')).toContain('mod-a -> mod-b -> mod-c ->');
+  });
+
+  // KNOWN FBM GAP: the client walk treats ANY circular import chain as a reload reason
+  // (`fbmHmrClient.ts` bubble() returns "circular import chain" when it re-meets an
+  // ancestor) instead of deduping visited nodes through the cycle and continuing to the
+  // accepting boundary outside it, the way Vite's `propagateUpdate` does. Verified: the
+  // edited content still lands, but through a full page reload (the marker is wiped).
+  // Unskip once the walk crosses circles to an outside boundary.
+  test.skip('editing inside the circle hot-updates via the boundary outside it', async () => {
+    await plantReloadMarker();
+
+    editFile('mod-b.js', (code) => code.replace('`mod-b ->', '`mod-b (edited) ->'));
+    await expect.poll(() => page.textContent('.circular')).toContain('mod-b (edited) ->');
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/index.html
@@ -1,0 +1,3 @@
+<h1>HMR circular imports, boundary outside the circle</h1>
+<div class="circular"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/main.js
@@ -1,0 +1,7 @@
+import { msg } from './mod-a.js';
+
+document.querySelector('.circular').textContent = msg;
+
+import.meta.hot?.accept((mod) => {
+  document.querySelector('.circular').textContent = mod.msg;
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-a.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-a.js
@@ -1,0 +1,5 @@
+export const value = 'mod-a';
+
+import { value as _value } from './mod-b.js';
+
+export const msg = `mod-a -> ${_value}`;

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-b.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-b.js
@@ -1,0 +1,3 @@
+import { value as _value } from './mod-c.js';
+
+export const value = `mod-b -> ${_value}`;

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-c.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/mod-c.js
@@ -1,0 +1,13 @@
+import { value as _value } from './mod-a.js';
+
+// Reading `_value` here may throw (TDZ) or read a placeholder depending on how the
+// bundle evaluates the cycle; the assertion only cares that the chain renders and that
+// an edit to mod-b flows through the circle to the accepting boundary in main.js.
+let __value;
+try {
+  __value = `${_value}`;
+} catch {
+  __value = 'mod-a (cycle placeholder)';
+}
+
+export const value = `mod-c -> ${__value}`;

--- a/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-circular-accept-outside/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-circular-accept-outside",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/__tests__/hmr-circular-self-accept.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/__tests__/hmr-circular-self-accept.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+// Ports Vite's #2255 case: a module that self-accepts while sitting inside a circular
+// import group (c imports b, b imports c) must still receive its hot update. Vite only
+// asserts the new content lands (its own client may error and refresh); this asserts the
+// same end state.
+
+describe('hmr-circular-self-accept', () => {
+  test('renders the value from inside the circle', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.self-accept-within-circular')).toBe('c');
+  });
+
+  test('self-accepted module within the circle receives the update', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    editFile('c.js', (code) => code.replace("export const c = 'c'", "export const c = 'cc'"));
+    await expect.poll(() => page.textContent('.self-accept-within-circular')).toBe('cc');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/a.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/a.js
@@ -1,0 +1,5 @@
+import { b } from './b.js';
+
+export const a = {
+  b,
+};

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/b.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/b.js
@@ -1,0 +1,7 @@
+import { c } from './c.js';
+
+const b = {
+  c,
+};
+
+export { b };

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/c.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/c.js
@@ -1,0 +1,12 @@
+import './b.js';
+
+export const c = 'c';
+
+function render(content) {
+  document.querySelector('.self-accept-within-circular').textContent = content;
+}
+render(c);
+
+import.meta.hot?.accept((nextExports) => {
+  render(nextExports.c);
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/index.html
@@ -1,0 +1,3 @@
+<h1>HMR self-accept within circular imports</h1>
+<div class="self-accept-within-circular"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/main.js
@@ -1,0 +1,3 @@
+import { a } from './a.js';
+
+console.log(a);

--- a/packages/test-dev-server/tests/playground/hmr-circular-self-accept/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-circular-self-accept/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-circular-self-accept",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/__tests__/hmr-dispose-data.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/__tests__/hmr-dispose-data.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `hmr` dispose + `import.meta.hot.data` behavior: `dispose` runs before the
+// module is replaced and stashes state on `data`, which persists across the update and is
+// read back by the re-executed module.
+
+describe('hmr-dispose-data', () => {
+  test('first load has no persisted data', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('dispose-v1');
+    await expect.poll(() => page.textContent('.prev')).toBe('none');
+  });
+
+  test('dispose stashes state on `data`, read back after the update', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    // The dispose callback saves the CURRENT value; the re-run reads it as `prev`.
+    editFile('counter.js', (code) => code.replace("'dispose-v1'", "'dispose-v2'"));
+    await expect.poll(() => page.textContent('.value')).toBe('dispose-v2');
+    await expect.poll(() => page.textContent('.prev')).toBe('dispose-v1');
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/counter.js
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/counter.js
@@ -1,0 +1,12 @@
+// `dispose` runs before this module is replaced and stashes state on `import.meta.hot.data`,
+// which persists across updates; the re-executed module reads it back.
+const prev = import.meta.hot?.data?.saved ?? 'none';
+
+export const value = 'dispose-v1';
+document.querySelector('.value').textContent = value;
+document.querySelector('.prev').textContent = prev;
+
+import.meta.hot?.accept();
+import.meta.hot?.dispose((data) => {
+  data.saved = value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/index.html
@@ -1,0 +1,4 @@
+<h1>HMR dispose + data</h1>
+<div class="value"></div>
+<div class="prev"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/main.js
@@ -1,0 +1,1 @@
+import './counter.js';

--- a/packages/test-dev-server/tests/playground/hmr-dispose-data/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-dispose-data/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-dispose-data",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/__tests__/hmr-hot-events.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/__tests__/hmr-hot-events.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `hmr` "hot events" case: `import.meta.hot.on('vite:beforeUpdate' | 'vite:afterUpdate')`
+// fire around a js-update. `listener.js` records them into `.events`; editing the self-accepting
+// `target.js` triggers the update.
+
+describe('hmr-hot-events', () => {
+  test('renders initial state with no events yet', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('target-v1');
+    await expect.poll(() => page.textContent('.events')).toBe('');
+  });
+
+  test('vite:beforeUpdate / vite:afterUpdate fire on a hot update', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    editFile('target.js', (code) => code.replace("'target-v1'", "'target-v2'"));
+    await expect.poll(() => page.textContent('.value')).toBe('target-v2');
+
+    // Both built-in update events fired, in order, without a full reload.
+    await expect.poll(() => page.textContent('.events')).toBe('before,after');
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/index.html
@@ -1,0 +1,4 @@
+<h1>HMR hot events</h1>
+<div class="value"></div>
+<div class="events"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/listener.js
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/listener.js
@@ -1,0 +1,16 @@
+// Registers `import.meta.hot.on(...)` for the built-in HMR events. This module is never
+// edited, so its listeners persist across updates to `target.js`.
+const log = [];
+const render = () => {
+  document.querySelector('.events').textContent = log.join(',');
+};
+render();
+
+import.meta.hot?.on('vite:beforeUpdate', () => {
+  log.push('before');
+  render();
+});
+import.meta.hot?.on('vite:afterUpdate', () => {
+  log.push('after');
+  render();
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/main.js
@@ -1,0 +1,2 @@
+import './listener.js';
+import './target.js';

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-hot-events",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-hot-events/target.js
+++ b/packages/test-dev-server/tests/playground/hmr-hot-events/target.js
@@ -1,0 +1,8 @@
+// Self-accepts, so editing it triggers a js-update — which fires the `vite:beforeUpdate`
+// and `vite:afterUpdate` events registered in `listener.js`.
+export const value = 'target-v1';
+document.querySelector('.value').textContent = value;
+
+import.meta.hot?.accept((mod) => {
+  document.querySelector('.value').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/__tests__/hmr-hot-off.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/__tests__/hmr-hot-off.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `hot.off` coverage: a listener removed with `off` must not fire, while a
+// listener that stays registered does. Vite tests `off` with plugin custom events; FBM has
+// no plugin channel, so the built-in `vite:beforeUpdate` event exercises the same machinery.
+
+describe('hmr-hot-off', () => {
+  test('renders the initial value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('off-v1');
+  });
+
+  test('off-removed listener stays silent; kept listener fires', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    editFile('target.js', (code) => code.replace("'off-v1'", "'off-v2'"));
+    await expect.poll(() => page.textContent('.value')).toBe('off-v2');
+
+    const calls = await page.evaluate(() => ({
+      removed: (window as any).__removedCalls ?? 0,
+      kept: (window as any).__keptCalls ?? 0,
+    }));
+    expect(calls.kept).toBeGreaterThanOrEqual(1);
+    expect(calls.removed).toBe(0);
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/index.html
@@ -1,0 +1,3 @@
+<h1>HMR hot.off</h1>
+<div class="value"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/main.js
@@ -1,0 +1,16 @@
+import './target.js';
+
+// Ports Vite's `hot.off` behavior (Vite tests it via plugin custom events; FBM has no
+// upstream channel, so the built-in `vite:beforeUpdate` event exercises the same
+// listener add/remove machinery).
+const w = /** @type {any} */ (window);
+const removed = () => {
+  w.__removedCalls = (w.__removedCalls ?? 0) + 1;
+};
+import.meta.hot?.on('vite:beforeUpdate', removed);
+import.meta.hot?.off('vite:beforeUpdate', removed);
+
+const kept = () => {
+  w.__keptCalls = (w.__keptCalls ?? 0) + 1;
+};
+import.meta.hot?.on('vite:beforeUpdate', kept);

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-hot-off",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-hot-off/target.js
+++ b/packages/test-dev-server/tests/playground/hmr-hot-off/target.js
@@ -1,0 +1,6 @@
+export const value = 'off-v1';
+document.querySelector('.value').textContent = value;
+
+import.meta.hot?.accept((mod) => {
+  document.querySelector('.value').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/__tests__/hmr-invalidate-circular.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/__tests__/hmr-invalidate-circular.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+// Ports Vite's `invalidation-circular-deps` cases. Both sub-graphs are circles
+// (child imports parent, parent imports child) whose child accepts and then
+// immediately invalidates:
+// - circular-invalidate: the parent ALSO accept-then-invalidates, so nothing can handle
+//   the edit; the client must settle on a clean reload with fresh content instead of
+//   looping the invalidation forever.
+// - invalidate-handled-in-circle: the parent self-accepts for real, so the invalidation
+//   bubbles one level, the parent re-runs, and fresh content lands without a reload.
+
+describe('hmr-invalidate-circular', () => {
+  test('renders both circles', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.invalidation-circular-deps')).toBe('child');
+    await expect.poll(() => page.textContent('.invalidation-circular-deps-handled')).toBe('child');
+  });
+
+  test('unhandled invalidate in a circle settles on fresh content, no infinite HMR', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    editFile('circular-invalidate/child.js', (code) =>
+      code.replace("'child'", "'child updated'"));
+    await expect
+      .poll(() => page.textContent('.invalidation-circular-deps'), { timeout: 15_000 })
+      .toBe('child updated');
+    await waitForBuildStable();
+  });
+
+  test('invalidate handled one level up in the circle hot-updates', async () => {
+    editFile('invalidate-handled-in-circle/child.js', (code) =>
+      code.replace("'child'", "'child updated'"));
+    await expect
+      .poll(() => page.textContent('.invalidation-circular-deps-handled'), { timeout: 15_000 })
+      .toBe('child updated');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/circular-invalidate/child.js
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/circular-invalidate/child.js
@@ -1,0 +1,9 @@
+import './parent.js';
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value = 'child';

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/circular-invalidate/parent.js
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/circular-invalidate/parent.js
@@ -1,0 +1,11 @@
+import { value } from './child.js';
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    import.meta.hot.invalidate();
+  });
+}
+
+setTimeout(() => {
+  document.querySelector('.invalidation-circular-deps').textContent = value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/index.html
@@ -1,0 +1,4 @@
+<h1>HMR invalidate in circular deps</h1>
+<div class="invalidation-circular-deps"></div>
+<div class="invalidation-circular-deps-handled"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/invalidate-handled-in-circle/child.js
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/invalidate-handled-in-circle/child.js
@@ -1,0 +1,9 @@
+import './parent.js';
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value = 'child';

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/invalidate-handled-in-circle/parent.js
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/invalidate-handled-in-circle/parent.js
@@ -1,0 +1,9 @@
+import { value } from './child.js';
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {});
+}
+
+setTimeout(() => {
+  document.querySelector('.invalidation-circular-deps-handled').textContent = value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/main.js
@@ -1,0 +1,2 @@
+import './circular-invalidate/parent.js';
+import './invalidate-handled-in-circle/parent.js';

--- a/packages/test-dev-server/tests/playground/hmr-invalidate-circular/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-invalidate-circular/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-invalidate-circular",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/__tests__/hmr-lazy-dynamic-import-accept-dep.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/__tests__/hmr-lazy-dynamic-import-accept-dep.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Same as `hmr-dynamic-import-accept-dep`, but with `devMode.lazy: true`. Under lazy
+// compilation `foo` compiles on demand behind a `?rolldown-lazy=1` proxy, so the importer
+// walk sees the proxy chain instead of the real `app -> foo` dynamic edge and can't reach
+// `app`'s accept-dep boundary — the edit full-reloads.
+
+describe('hmr-lazy-dynamic-import-accept-dep', () => {
+  // Skipped together with the gap test below: with every test in the file skipped,
+  // vitest never runs the per-file browser + dev-server boot. The initial lazy render
+  // is already covered by `lazy-compilation/__tests__/basic.spec.ts`.
+  test.skip('renders the dynamically-imported value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.foo')).toBe('foo-v1');
+  });
+
+  // KNOWN LAZY GAP: lazy dynamic-import HMR bubbling is not implemented — a lazy dynamic
+  // edge full-reloads today (`crates/rolldown_common/src/ecmascript/ecma_view.rs` excludes
+  // `?rolldown-lazy=1` importers from the walkable set). Verified: this currently wipes the
+  // marker (full reload). Unskip once lazy dynamic-import HMR lands.
+  test.skip('editing the dynamically-imported dep hot-updates via the importer accept-dep', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+
+    editFile('foo.js', (code) => code.replace("'foo-v1'", "'foo-v2'"));
+    await expect.poll(() => page.textContent('.foo')).toBe('foo-v2');
+
+    // No full reload happened: the boundary walk crossed the lazy dynamic edge to `app`.
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/app.js
@@ -1,0 +1,10 @@
+// `app` reaches `foo` ONLY through a dynamic import() and accepts it as a dep. Editing
+// `foo` must bubble across the dynamic edge and stop at this edge boundary (app re-runs
+// nothing; the accept callback fires with the fresh `foo`), not full-reload.
+import('./foo.js').then((mod) => {
+  document.querySelector('.foo').textContent = mod.value;
+});
+
+import.meta.hot.accept('./foo.js', (mod) => {
+  document.querySelector('.foo').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/dev.config.mjs
@@ -1,0 +1,17 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      // Lazy: dynamic import() targets compile on demand behind a `?rolldown-lazy=1`
+      // proxy, so the importer walk sees the proxy chain, not the real dynamic edge.
+      devMode: { lazy: true },
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/foo.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/foo.js
@@ -1,0 +1,1 @@
+export const value = 'foo-v1';

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/index.html
@@ -1,0 +1,5 @@
+<h1>HMR dynamic import — importer accepts dep</h1>
+
+<div class="foo"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/main.js
@@ -1,0 +1,1 @@
+import './app.js';

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-lazy-dynamic-import-accept-dep",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/__tests__/hmr-lazy-dynamic-import-self-accept.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/__tests__/hmr-lazy-dynamic-import-self-accept.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Same as `hmr-dynamic-import-self-accept`, but with `devMode.lazy: true`. Under lazy
+// compilation the dynamically-imported `foo` compiles on demand behind a `?rolldown-lazy=1`
+// proxy, so the importer walk sees the proxy chain instead of the real `app -> foo` dynamic
+// edge and can't reach `app`'s self-accept boundary — the edit full-reloads.
+
+describe('hmr-lazy-dynamic-import-self-accept', () => {
+  // Skipped together with the gap test below: with every test in the file skipped,
+  // vitest never runs the per-file browser + dev-server boot. The initial lazy render
+  // is already covered by `lazy-compilation/__tests__/basic.spec.ts`.
+  test.skip('renders the dynamically-imported value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.foo')).toBe('foo-v1');
+  });
+
+  // KNOWN LAZY GAP: lazy dynamic-import HMR bubbling is not implemented — a lazy dynamic
+  // edge full-reloads today (`crates/rolldown_common/src/ecmascript/ecma_view.rs` excludes
+  // `?rolldown-lazy=1` importers from the walkable set). Verified: this currently wipes the
+  // marker (full reload). Unskip once lazy dynamic-import HMR lands.
+  test.skip('editing the dynamically-imported module hot-updates via the importer self-accept', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+
+    editFile('foo.js', (code) => code.replace("'foo-v1'", "'foo-v2'"));
+    await expect.poll(() => page.textContent('.foo')).toBe('foo-v2');
+
+    // No full reload happened: the boundary walk crossed the lazy dynamic edge to `app`.
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/app.js
@@ -1,0 +1,7 @@
+// `app` reaches `foo` ONLY through a dynamic import() and self-accepts. Editing `foo`
+// must bubble across the dynamic edge to this boundary and hot-update, not full-reload.
+import.meta.hot?.accept();
+
+import('./foo.js').then((mod) => {
+  document.querySelector('.foo').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/dev.config.mjs
@@ -1,0 +1,17 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      // Lazy: dynamic import() targets compile on demand behind a `?rolldown-lazy=1`
+      // proxy, so the importer walk sees the proxy chain, not the real dynamic edge.
+      devMode: { lazy: true },
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/foo.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/foo.js
@@ -1,0 +1,1 @@
+export const value = 'foo-v1';

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/index.html
@@ -1,0 +1,5 @@
+<h1>HMR dynamic import — importer self-accept</h1>
+
+<div class="foo"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/main.js
@@ -1,0 +1,1 @@
+import './app.js';

--- a/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-lazy-dynamic-import-self-accept",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/__tests__/hmr-nested-dep-accept.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/__tests__/hmr-nested-dep-accept.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's `hmr` "nested dep propagation" case: `app` accepts `./dep`, and `dep`
+// re-exports `./nested`. Editing the transitive `nested` must bubble nested -> dep -> app
+// to the accept-dep boundary and hot-update, not full-reload.
+
+describe('hmr-nested-dep-accept', () => {
+  test('renders the nested value', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.nested')).toBe('nested-v1');
+  });
+
+  test('editing a transitive dep bubbles up to the accept-dep boundary', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    editFile('nested.js', (code) => code.replace("'nested-v1'", "'nested-v2'"));
+    await expect.poll(() => page.textContent('.nested')).toBe('nested-v2');
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/app.js
@@ -1,0 +1,8 @@
+import { value } from './dep.js';
+document.querySelector('.nested').textContent = value;
+
+// Accept the direct dep. Editing the transitive `nested.js` bubbles up through `dep.js` to
+// this boundary; the callback gets the fresh `dep` (which re-exports the updated value).
+import.meta.hot?.accept('./dep.js', (mod) => {
+  document.querySelector('.nested').textContent = mod.value;
+});

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/dep.js
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/dep.js
@@ -1,0 +1,3 @@
+// Re-exports the nested module; `app` accepts THIS module, so editing `nested` must bubble
+// nested -> dep -> app to reach the accept-dep boundary.
+export { value } from './nested.js';

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/index.html
@@ -1,0 +1,3 @@
+<h1>HMR nested dep propagation</h1>
+<div class="nested"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/main.js
@@ -1,0 +1,1 @@
+import './app.js';

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/nested.js
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/nested.js
@@ -1,0 +1,1 @@
+export const value = 'nested-v1';

--- a/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-nested-dep-accept/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-nested-dep-accept",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/__tests__/hmr-not-loaded-dynamic-import.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/__tests__/hmr-not-loaded-dynamic-import.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import {
+  editFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  waitForBuildStable,
+} from '~utils';
+
+// Ports Vite's #7561 case: `dep.js` sits behind a dynamic import that never runs, so it
+// has an accept handler that never registered in this tab. Editing it must not disturb
+// the page; editing the entry (which nothing accepts) still reloads as usual.
+
+describe('hmr-not-loaded-dynamic-import', () => {
+  test('counter works before any edit', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('button')).toBe('Counter 0');
+    await page.click('button');
+    await expect.poll(() => page.textContent('button')).toBe('Counter 1');
+  });
+
+  test('editing the entry reloads the page (control)', async () => {
+    // No leading waitForBuildStable: the previous test already proved stability and
+    // nothing has been edited since; every call costs its full stability window.
+    await plantReloadMarker();
+
+    editFile('main.js', (code) => code + '\n');
+    // The reload resets the counter to its initial markup.
+    await expect.poll(() => readReloadMarker()).toBe(null);
+    await expect.poll(() => page.textContent('button')).toBe('Counter 0');
+    await page.click('button');
+    await expect.poll(() => page.textContent('button')).toBe('Counter 1');
+    await waitForBuildStable();
+  });
+
+  test('editing the never-loaded dynamic import does nothing', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+
+    editFile('dep.js', (code) => code + '\n');
+    // Wait out the rebuild, then prove the page was left alone: no reload, state intact.
+    await waitForBuildStable();
+    expect(await readReloadMarker()).toBe('alive');
+    await expect.poll(() => page.textContent('button')).toBe('Counter 1');
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/dep.js
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/dep.js
@@ -1,0 +1,6 @@
+// This file is never loaded.
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {});
+}
+
+export const value = 'dep';

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/index.html
@@ -1,0 +1,3 @@
+<h1>HMR not-loaded dynamic import</h1>
+<button type="button">Counter 0</button>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/main.js
@@ -1,0 +1,12 @@
+const btn = document.querySelector('button');
+let count = 0;
+btn.onclick = () => {
+  count++;
+  btn.textContent = `Counter ${count}`;
+};
+
+// Referenced so the bundler keeps the dynamic edge, but never called: `dep.js` never
+// executes in this tab.
+function neverCalled() {
+  import('./dep.js');
+}

--- a/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-not-loaded-dynamic-import",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-prune/__tests__/hmr-prune.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-prune/__tests__/hmr-prune.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+// Ports Vite's `hmr` prune behavior: when a module stops being imported, its
+// `import.meta.hot.prune(cb)` callback fires. Here, removing `app`'s import of
+// `prunable.js` should prune it.
+
+describe('hmr-prune', () => {
+  // Skipped together with the gap test below: with every test in the file skipped,
+  // vitest never runs the per-file browser + dev-server boot. On its own this smoke
+  // guards almost nothing — `prunable.js` sets `.prunable` BEFORE calling
+  // `import.meta.hot?.prune(...)`, so it passes even if the hot API were missing.
+  test.skip('renders the prunable module', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.prunable')).toBe('present');
+  });
+
+  // KNOWN FBM GAP: the full-bundle-mode client never fires `prune` — prune was a
+  // server-sent `vite:beforePrune` message, and FBM computes everything client-side without
+  // that channel (see `packages/.../vite/src/client/fbmHmrClient.ts`, which handles boundaries
+  // and dispose but not prune). Verified: removing the import does not fire the callback.
+  // Unskip once FBM implements prune.
+  test.skip('removing an import fires the prune callback', async () => {
+    await waitForBuildStable();
+
+    editFile('app.js', (code) => code.replace("import './prunable.js';\n", ''));
+    await expect.poll(() => page.textContent('.prunable')).toBe('pruned');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-prune/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-prune/app.js
@@ -1,0 +1,4 @@
+import './prunable.js';
+
+export const x = 1;
+import.meta.hot?.accept();

--- a/packages/test-dev-server/tests/playground/hmr-prune/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-prune/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-prune/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-prune/index.html
@@ -1,0 +1,3 @@
+<h1>HMR prune</h1>
+<div class="prunable"></div>
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-prune/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-prune/main.js
@@ -1,0 +1,1 @@
+import './app.js';

--- a/packages/test-dev-server/tests/playground/hmr-prune/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-prune/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-prune",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-prune/prunable.js
+++ b/packages/test-dev-server/tests/playground/hmr-prune/prunable.js
@@ -1,0 +1,6 @@
+// When `app` stops importing this module, its `prune` callback should fire.
+document.querySelector('.prunable').textContent = 'present';
+
+import.meta.hot?.prune(() => {
+  document.querySelector('.prunable').textContent = 'pruned';
+});

--- a/packages/test-dev-server/tests/playground/test-utils.ts
+++ b/packages/test-dev-server/tests/playground/test-utils.ts
@@ -66,6 +66,20 @@ export async function errorOverlayText(): Promise<string> {
   );
 }
 
+// --- Full-reload detection ---------------------------------------------------
+// The standard "no full reload happened" assertion of this suite: plant a marker
+// on `window`, run the update, then check the marker survived.
+
+/** Plant a marker on `window`; any full page reload wipes it. */
+export function plantReloadMarker(): Promise<unknown> {
+  return page.evaluate(() => ((window as unknown as { __marker?: string }).__marker = 'alive'));
+}
+
+/** Read the marker back; `null` means the page reloaded since planting. */
+export function readReloadMarker(): Promise<string | null> {
+  return page.evaluate(() => (window as unknown as { __marker?: string }).__marker ?? null);
+}
+
 // --- `/_dev/status` helpers, defaulting to the current spec's server --------
 
 export function waitForNextBuild(currentBuildSeq: number, timeoutMs?: number): Promise<DevStatus> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,6 +758,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-accept-exports:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-accept-outside-circular:
     devDependencies:
       '@rolldown/test-dev-server':
@@ -770,7 +776,31 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-before-full-reload:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-circular-accept-outside:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-circular-self-accept:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-client-invalidate:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-dispose-data:
     devDependencies:
       '@rolldown/test-dev-server':
         specifier: workspace:*
@@ -800,7 +830,43 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-hot-events:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-hot-off:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-invalidate-circular:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-accept-dep:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-lazy-dynamic-import-self-accept:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-multiple-edits:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-nested-dep-accept:
     devDependencies:
       '@rolldown/test-dev-server':
         specifier: workspace:*
@@ -824,7 +890,19 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-not-loaded-dynamic-import:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-patch-dedup:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-prune:
     devDependencies:
       '@rolldown/test-dev-server':
         specifier: workspace:*


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

## Summary

For full design and principles, please refer to https://github.com/rolldown/rolldown/pull/10164#issue-4824909361.

## The playgrounds

Each playground is a small app (`index.html` + JS modules + `dev.config.mjs` + `package.json`) with a `__tests__/*.spec.ts` that edits a file and asserts on the running page. Several port behavior expectations from Vite's HMR tests (the `hmr-hot-off` fixture says so explicitly).

| Group | Playgrounds | What they exercise |
|---|---|---|
| Accept | `hmr-accept-exports`, `hmr-nested-dep-accept` | `hot.accept` receiving new exports; accepting a dep deeper in the graph |
| Circular graphs | `hmr-circular-accept-outside`, `hmr-circular-self-accept`, `hmr-invalidate-circular` | accept / self-accept / `hot.invalidate` when the edited module sits in an import cycle |
| Lifecycle / state | `hmr-dispose-data`, `hmr-prune` | `hot.dispose` passing state through `hot.data`; `hot.prune` when a module is no longer imported |
| Events | `hmr-hot-events`, `hmr-hot-off` | `hot.on` for built-in `vite:beforeUpdate` / `vite:afterUpdate`; `hot.off` removing one listener while another stays |
| Dynamic import + lazy compilation | `hmr-lazy-dynamic-import-accept-dep`, `hmr-lazy-dynamic-import-self-accept`, `hmr-not-loaded-dynamic-import` | updates to dynamically imported modules, including under lazy compilation and when the module was never loaded |
| Full reload | `hmr-before-full-reload` | behavior around an update that must fall back to a full page reload |
