### PR TITLE
perf(treeshake): memoize symbol inclusion (experiment, do not review)

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1042,6 +1042,12 @@ impl GenerateStage<'_> {
       is_included_vec: &mut stmt_info_included_vec,
       is_module_included_vec: &mut module_included_vec,
       tree_shaking: self.options.treeshake.is_some(),
+      treeshake_commonjs: self.options.treeshake.commonjs(),
+      property_write_side_effects_disabled: matches!(
+        self.options.treeshake.property_write_side_effects(),
+        rolldown_common::PropertyWriteSideEffects::False
+      ),
+      dev_mode: self.options.is_dev_mode_enabled(),
       runtime_idx: self.link_output.runtime.id(),
       metas: &self.link_output.metas,
       used_symbol_refs,

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1035,37 +1035,23 @@ impl GenerateStage<'_> {
     );
 
     let runtime = &self.link_output.runtime;
-    let context = &mut IncludeContext {
-      modules: &self.link_output.module_table.modules,
-      stmt_infos: &self.link_output.stmt_infos,
-      symbols: &self.link_output.symbol_db,
-      is_included_vec: &mut stmt_info_included_vec,
-      is_module_included_vec: &mut module_included_vec,
-      tree_shaking: self.options.treeshake.is_some(),
-      treeshake_commonjs: self.options.treeshake.commonjs(),
-      property_write_side_effects_disabled: matches!(
-        self.options.treeshake.property_write_side_effects(),
-        rolldown_common::PropertyWriteSideEffects::False
-      ),
-      dev_mode: self.options.is_dev_mode_enabled(),
-      runtime_idx: self.link_output.runtime.id(),
-      metas: &self.link_output.metas,
+    let context = &mut IncludeContext::new(
+      &self.link_output.module_table.modules,
+      &self.link_output.stmt_infos,
+      &self.link_output.symbol_db,
+      &mut stmt_info_included_vec,
+      &mut module_included_vec,
+      self.link_output.runtime.id(),
+      &self.link_output.metas,
       used_symbol_refs,
-      used_external_symbols: &mut self.link_output.used_external_symbols,
-      constant_symbol_map: &self.link_output.global_constant_symbol_map,
-      options: self.options,
-      normal_symbol_exports_chain_map: &self.link_output.normal_symbol_exports_chain_map,
-      bailout_cjs_tree_shaking_modules: FxHashSet::default(),
-      module_inclusion_changed: false,
-      module_namespace_included_reason: &mut module_namespace_reason_vec,
-      inline_const_smart: self.options.optimization.is_inline_const_smart_mode(),
-      json_module_none_self_reference_included_symbol: FxHashMap::default(),
-      entry_module_idxs: &self.link_output.user_defined_entry_modules,
-      body_demand_keys: &body_demand_keys,
-      body_demand_swept: FxHashSet::default(),
-      pending: Vec::new(),
-      processed_symbol_masks: FxHashMap::default(),
-    };
+      &mut self.link_output.used_external_symbols,
+      &self.link_output.global_constant_symbol_map,
+      self.options,
+      &self.link_output.normal_symbol_exports_chain_map,
+      &mut module_namespace_reason_vec,
+      &self.link_output.user_defined_entry_modules,
+      &body_demand_keys,
+    );
 
     let mut runtime_dependent_chunks = FxHashSet::default();
 

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1058,6 +1058,7 @@ impl GenerateStage<'_> {
       body_demand_keys: &body_demand_keys,
       body_demand_swept: FxHashSet::default(),
       pending: Vec::new(),
+      processed_symbol_masks: FxHashMap::default(),
     };
 
     let mut runtime_dependent_chunks = FxHashSet::default();

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -217,7 +217,11 @@ pub(in crate::stages) enum WorkItem {
   /// side-effectful dependencies.
   Module(ModuleIdx),
   /// A symbol became used: retain its declaration, wrapper, and owner module.
-  Symbol(SymbolRef, SymbolIncludeReason),
+  /// `check_cjs_bailout` is set at sites where the symbol may stand for a full CJS namespace
+  /// used opaquely (see [`check_cjs_bailout`]); producers that know the access is partial (a
+  /// resolved member expression on a CJS namespace) or internal (wrapper refs, CJS-interop
+  /// named exports, runtime symbols) clear it to keep CJS tree-shaking working.
+  Symbol { symbol_ref: SymbolRef, reason: SymbolIncludeReason, check_cjs_bailout: bool },
   /// Include one statement and follow everything it references.
   Statement(ModuleIdx, StmtInfoIdx),
 }
@@ -229,7 +233,9 @@ fn drain_work_items(ctx: &mut IncludeContext) {
   while let Some(item) = ctx.pending.pop() {
     match item {
       WorkItem::Module(module_idx) => handle_include_module(ctx, module_idx),
-      WorkItem::Symbol(symbol_ref, reason) => handle_include_symbol(ctx, symbol_ref, reason),
+      WorkItem::Symbol { symbol_ref, reason, check_cjs_bailout } => {
+        handle_include_symbol(ctx, symbol_ref, reason, check_cjs_bailout);
+      }
       WorkItem::Statement(module_idx, stmt_info_idx) => {
         handle_include_statement(ctx, module_idx, stmt_info_idx);
       }
@@ -248,32 +254,22 @@ pub(super) fn include_symbol_and_check_cjs_bailout(
   include_reason: SymbolIncludeReason,
 ) {
   debug_assert!(ctx.pending.is_empty(), "engine queue must be empty between public entry points");
-  push_symbol_and_check_cjs_bailout(ctx, symbol_ref, include_reason);
+  ctx.pending.push(WorkItem::Symbol {
+    symbol_ref,
+    reason: include_reason,
+    check_cjs_bailout: true,
+  });
   drain_work_items(ctx);
   debug_assert!(ctx.pending.is_empty(), "public entry points must drain the queue to empty");
 }
 
-/// Engine-internal variant of [`include_symbol_and_check_cjs_bailout`]: enqueues the symbol and
-/// runs the (order-independent) bailout check immediately, without draining. Handlers and edge
-/// producers must use this — only the public entry points drain.
-fn push_symbol_and_check_cjs_bailout(
-  ctx: &mut IncludeContext,
-  symbol_ref: SymbolRef,
-  include_reason: SymbolIncludeReason,
-) {
-  ctx.pending.push(WorkItem::Symbol(symbol_ref, include_reason));
-  check_cjs_bailout(ctx, symbol_ref);
-}
-
 /// Check if including this symbol should trigger CJS tree-shaking bailout.
-/// This is called at `include_symbol` call sites where the symbol is NOT accessed
-/// via a resolved member expression on a CJS namespace (i.e., where the full namespace
-/// might be used opaquely). When we know only a specific property is accessed
-/// (member expression with `target_commonjs_exported_symbol`), we skip this check
-/// to allow CJS tree-shaking.
-fn check_cjs_bailout(ctx: &mut IncludeContext, symbol_ref: SymbolRef) {
-  let canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
-
+/// This runs for `WorkItem::Symbol`s pushed with `check_cjs_bailout` — sites where the symbol
+/// is NOT accessed via a resolved member expression on a CJS namespace (i.e., where the full
+/// namespace might be used opaquely). When we know only a specific property is accessed
+/// (member expression with `target_commonjs_exported_symbol`), the producer clears the flag
+/// to allow CJS tree-shaking. Takes the already-resolved canonical of the used symbol.
+fn check_cjs_bailout(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
   // If the symbol is a CJS namespace import ref, bail out the target CJS module.
   if let Some(idx) =
     ctx.metas[canonical_ref.owner].import_record_ns_to_cjs_module.get(&canonical_ref)
@@ -591,12 +587,20 @@ fn handle_include_module(ctx: &mut IncludeContext, module_idx: ModuleIdx) {
   if module.meta.has_eval() && matches!(module.module_type, ModuleType::Js | ModuleType::Jsx) {
     // `eval` can observe any module-level binding, so every import must survive.
     module.named_imports.keys().for_each(|symbol| {
-      push_symbol_and_check_cjs_bailout(ctx, *symbol, SymbolIncludeReason::Normal);
+      ctx.pending.push(WorkItem::Symbol {
+        symbol_ref: *symbol,
+        reason: SymbolIncludeReason::Normal,
+        check_cjs_bailout: true,
+      });
     });
   }
 
   ctx.metas[module.idx].included_commonjs_export_symbol.iter().for_each(|symbol_ref| {
-    push_symbol_and_check_cjs_bailout(ctx, *symbol_ref, SymbolIncludeReason::Normal);
+    ctx.pending.push(WorkItem::Symbol {
+      symbol_ref: *symbol_ref,
+      reason: SymbolIncludeReason::Normal,
+      check_cjs_bailout: true,
+    });
   });
 
   // With enabling HMR, rolldown will register included esm module's namespace object to the runtime.
@@ -694,7 +698,11 @@ pub fn include_symbol(
   include_reason: SymbolIncludeReason,
 ) {
   debug_assert!(ctx.pending.is_empty(), "engine queue must be empty between public entry points");
-  ctx.pending.push(WorkItem::Symbol(symbol_ref, include_reason));
+  ctx.pending.push(WorkItem::Symbol {
+    symbol_ref,
+    reason: include_reason,
+    check_cjs_bailout: false,
+  });
   drain_work_items(ctx);
   debug_assert!(ctx.pending.is_empty(), "public entry points must drain the queue to empty");
 }
@@ -703,8 +711,16 @@ fn handle_include_symbol(
   ctx: &mut IncludeContext,
   symbol_ref: SymbolRef,
   include_reason: SymbolIncludeReason,
+  should_check_cjs_bailout: bool,
 ) {
   let mut canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
+
+  // Before the constant bypass and the memo gate: the check ran unconditionally at push time
+  // when it lived there, and it is the one effect (writing into the per-fixpoint-iteration
+  // bailout set) the memo must not skip.
+  if should_check_cjs_bailout {
+    check_cjs_bailout(ctx, canonical_ref);
+  }
 
   if is_bypassed_inlined_constant(ctx, canonical_ref, include_reason) {
     return;
@@ -821,7 +837,11 @@ fn follow_cjs_namespace_alias(ctx: &mut IncludeContext, canonical_ref: &mut Symb
           return;
         };
         if namespace_alias.property_name.as_str() != "default" {
-          ctx.pending.push(WorkItem::Symbol(export_symbol.symbol_ref, SymbolIncludeReason::Normal));
+          ctx.pending.push(WorkItem::Symbol {
+            symbol_ref: export_symbol.symbol_ref,
+            reason: SymbolIncludeReason::Normal,
+            check_cjs_bailout: false,
+          });
         }
       });
     }
@@ -869,7 +889,11 @@ fn demand_esm_init_wrapper(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
       .filter(|wrapper_ref| *wrapper_ref != canonical_ref)
   };
   if let Some(wrapper_ref) = wrapper_ref {
-    ctx.pending.push(WorkItem::Symbol(wrapper_ref, SymbolIncludeReason::Normal));
+    ctx.pending.push(WorkItem::Symbol {
+      symbol_ref: wrapper_ref,
+      reason: SymbolIncludeReason::Normal,
+      check_cjs_bailout: false,
+    });
   }
 }
 
@@ -965,14 +989,15 @@ fn handle_include_statement(
         member_expr_resolution.depended_refs.iter().for_each(|sym_ref| {
           enqueue_declaring_statements(ctx, sym_ref);
         });
-        ctx.pending.push(WorkItem::Symbol(resolved_ref, include_kind));
         // When the member expression resolves to a specific CJS export property
         // (e.g., `ns.x`), we skip the bailout check — we know the access is partial
         // and CJS tree-shaking can work. Otherwise, the full namespace may be used
         // opaquely, so we check for bailout.
-        if member_expr_resolution.target_commonjs_exported_symbol.is_none() {
-          check_cjs_bailout(ctx, resolved_ref);
-        }
+        ctx.pending.push(WorkItem::Symbol {
+          symbol_ref: resolved_ref,
+          reason: include_kind,
+          check_cjs_bailout: member_expr_resolution.target_commonjs_exported_symbol.is_none(),
+        });
       } else {
         // If it points to nothing, the expression will be rewritten as `void 0` and there's nothing we need to include
       }
@@ -993,7 +1018,11 @@ fn handle_include_statement(
         .for_each(|sym_ref| {
           enqueue_declaring_statements(ctx, sym_ref);
         });
-      push_symbol_and_check_cjs_bailout(ctx, *original_ref, include_kind);
+      ctx.pending.push(WorkItem::Symbol {
+        symbol_ref: *original_ref,
+        reason: include_kind,
+        check_cjs_bailout: true,
+      });
     }
   });
 }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -111,12 +111,9 @@ pub struct IncludeContext<'a> {
   /// empty before returning. Invariant (debug-asserted at every public entry point): empty
   /// whenever control is outside the engine.
   pending: Vec<WorkItem>,
-  /// Exact-repeat memo for [`handle_include_symbol`]'s canonical-level tail: the tail is a
-  /// deterministic, monotone (insert/enqueue-only) function of `(canonical ref, include
-  /// reason)`, so a repeated pair adds nothing and is skipped — turning O(symbol references)
-  /// tail runs into O(unique (canonical, reason) pairs), in practice ~one per canonical.
-  /// Alias-keyed work (marking `symbol_ref` itself used, property-write retention) runs
-  /// before the memo check and is never skipped.
+  /// Memo for [`handle_include_symbol`]'s canonical-level tail — a deterministic, monotone
+  /// function of `(canonical ref, include reason)`, so exact repeats are skipped. Alias-keyed
+  /// work runs before the memo gate and is never skipped.
   processed_symbol_reasons: FxHashSet<(SymbolRef, SymbolIncludeReason)>,
 }
 
@@ -188,11 +185,8 @@ enum WorkItem {
   Statement(ModuleIdx, StmtInfoIdx),
 }
 
-/// Enqueue a symbol work item. `check_cjs_bailout` is set at sites where the symbol may stand
-/// for a full CJS namespace used opaquely (see [`check_cjs_bailout`]); producers that know the
-/// access is partial (a resolved member expression on a CJS namespace) or internal (wrapper
-/// refs, CJS-interop named exports, runtime symbols) pass `false` to keep CJS tree-shaking
-/// working.
+/// Enqueue a symbol work item. Pass `check_cjs_bailout: false` only when the access is known
+/// to be partial or engine-internal; see [`check_cjs_bailout`].
 fn push_symbol(
   ctx: &mut IncludeContext,
   symbol_ref: SymbolRef,
@@ -235,12 +229,10 @@ pub(super) fn include_symbol_and_check_cjs_bailout(
   debug_assert!(ctx.pending.is_empty(), "public entry points must drain the queue to empty");
 }
 
-/// Check if including this symbol should trigger CJS tree-shaking bailout.
-/// This runs for `WorkItem::Symbol`s pushed with `check_cjs_bailout` — sites where the symbol
-/// is NOT accessed via a resolved member expression on a CJS namespace (i.e., where the full
-/// namespace might be used opaquely). When we know only a specific property is accessed
-/// (member expression with `target_commonjs_exported_symbol`), the producer clears the flag
-/// to allow CJS tree-shaking. Takes the already-resolved canonical of the used symbol.
+/// Check if including this symbol should trigger CJS tree-shaking bailout. Runs for symbols
+/// pushed with `check_cjs_bailout`: sites where the full namespace might be used opaquely.
+/// Producers that resolve a specific property access (`target_commonjs_exported_symbol`)
+/// clear the flag so CJS tree-shaking can work. Takes the already-resolved canonical.
 fn check_cjs_bailout(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
   // If the symbol is a CJS namespace import ref, bail out the target CJS module.
   if let Some(idx) =
@@ -365,10 +357,8 @@ impl LinkStage<'_> {
       let bailout_modules = std::mem::take(&mut context.bailout_cjs_tree_shaking_modules);
       include_cjs_bailout_exports(context, &self.metas, bailout_modules);
 
-      // Only entries not yet included are rescanned: an included entry is settled (inclusion
-      // is monotone), so it leaves `pending_entry_indices` and later iterations shrink to the
-      // dead/undecided tail. An entry sharing its module with an already-included one is
-      // settled by that sibling (same skip the full rescan used to perform via the set).
+      // Included entries are settled (inclusion is monotone) and drop out, so later
+      // iterations rescan only the dead/undecided tail; siblings of an included idx drop too.
       pending_entry_indices.retain(|&entry_index| {
         let entry = &dynamic_entries[entry_index];
         if included_dynamic_entry.contains(&entry.idx) {
@@ -693,18 +683,15 @@ fn handle_include_symbol(
     return;
   }
 
-  // Alias-keyed work: the referencing symbol itself becomes used, and (under
-  // `propertyWriteSideEffects: false`) its property-write statements come along. Keyed by
-  // `symbol_ref`, not the canonical, so it runs for every distinct alias.
+  // Alias-keyed work — keyed by `symbol_ref`, not the canonical, so it must run for every
+  // reference and stays outside the memo gate.
   ctx.used_symbol_refs.insert(symbol_ref);
   if ctx.modules[symbol_ref.owner].is_external() {
     ctx.used_external_symbols.insert(symbol_ref);
   }
   include_property_write_referencing_stmts(ctx, symbol_ref);
 
-  // Everything below is the canonical-level tail: a deterministic, monotone function of
-  // (canonical ref, include reason), so an exact repeat adds nothing and is skipped (see
-  // `processed_symbol_reasons`).
+  // Canonical-level tail below: skip exact repeats (see `processed_symbol_reasons`).
   if !ctx.processed_symbol_reasons.insert((canonical_ref, include_reason)) {
     return;
   }
@@ -878,8 +865,7 @@ fn include_property_write_referencing_stmts(ctx: &mut IncludeContext, symbol_ref
       .unwrap_or(&[]);
     if ctx.modules[symbol_ref.owner].as_normal().is_some() {
       for stmt_info_id in stmt_ids.iter().copied() {
-        // Pure work-skip for repeat references; the authoritative dedup is still `set_bit`
-        // inside the statement handler.
+        // Work-skip only; the authoritative dedup is `set_bit` in the statement handler.
         if !ctx.is_included_vec[symbol_ref.owner].has_bit(stmt_info_id) {
           ctx.pending.push(WorkItem::Statement(symbol_ref.owner, stmt_info_id));
         }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -105,6 +105,7 @@ impl From<SymbolIncludeReason> for SymbolProcessMask {
   }
 }
 
+#[expect(clippy::struct_excessive_bools)] // Cached option flags; raw booleans read clearest.
 pub struct IncludeContext<'a> {
   pub modules: &'a IndexModules,
   /// Per-module statement-info table, detached from `EcmaView` and held on
@@ -115,6 +116,13 @@ pub struct IncludeContext<'a> {
   pub is_module_included_vec: &'a mut ModuleInclusionVec,
   pub tree_shaking: bool,
   pub inline_const_smart: bool,
+  /// `options.treeshake.commonjs()`, hoisted out of the per-statement sweep.
+  pub treeshake_commonjs: bool,
+  /// `options.treeshake.property_write_side_effects() == False`, hoisted out of the
+  /// per-reference symbol handling.
+  pub property_write_side_effects_disabled: bool,
+  /// `options.is_dev_mode_enabled()`, hoisted out of the per-module handling.
+  pub dev_mode: bool,
   pub runtime_idx: ModuleIdx,
   pub metas: &'a LinkingMetadataVec,
   pub used_symbol_refs: &'a mut UsedSymbolRefsBuilder,
@@ -187,6 +195,12 @@ impl<'a> IncludeContext<'a> {
       is_module_included_vec,
       tree_shaking: options.treeshake.is_some(),
       inline_const_smart: options.optimization.is_inline_const_smart_mode(),
+      treeshake_commonjs: options.treeshake.commonjs(),
+      property_write_side_effects_disabled: matches!(
+        options.treeshake.property_write_side_effects(),
+        rolldown_common::PropertyWriteSideEffects::False
+      ),
+      dev_mode: options.is_dev_mode_enabled(),
       runtime_idx,
       metas,
       used_symbol_refs,
@@ -612,7 +626,7 @@ fn handle_include_module(ctx: &mut IncludeContext, module_idx: ModuleIdx) {
   });
 
   // With enabling HMR, rolldown will register included esm module's namespace object to the runtime.
-  if ctx.options.is_dev_mode_enabled()
+  if ctx.dev_mode
     && module.idx != ctx.runtime_idx
     && matches!(module.exports_kind, ExportsKind::Esm)
   {
@@ -630,15 +644,15 @@ fn handle_include_module(ctx: &mut IncludeContext, module_idx: ModuleIdx) {
 /// dangle an import and keep today's behavior.
 fn sweep_side_effect_statements(ctx: &mut IncludeContext, module: &NormalModule) {
   let on_demand_side_effects = side_effects_included_on_demand(module, ctx.entry_module_idxs);
+  let has_eval = module.meta.has_eval();
+  let safely_treeshake_commonjs =
+    module.meta.contains(EcmaViewMeta::SafelyTreeshakeCommonjs) && ctx.treeshake_commonjs;
   ctx.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt().for_each(
     |(stmt_info_id, stmt_info)| {
       // No need to handle the namespace statement specially, because it doesn't have side effects and will only be included if it is used.
-      let bail_eval = module.meta.has_eval()
-        && !stmt_info.declared_symbols.is_empty()
-        && stmt_info_id.index() != 0;
-      let has_side_effects = if module.meta.contains(EcmaViewMeta::SafelyTreeshakeCommonjs)
-        && ctx.options.treeshake.commonjs()
-      {
+      let bail_eval =
+        has_eval && !stmt_info.declared_symbols.is_empty() && stmt_info_id.index() != 0;
+      let has_side_effects = if safely_treeshake_commonjs {
         stmt_info.eval_flags.contains(StmtEvalFlags::UnknownSideEffect)
       } else {
         stmt_info.eval_flags.has_side_effect_for_tree_shaking()
@@ -927,10 +941,7 @@ fn note_json_self_reference(
 /// With `propertyWriteSideEffects: false`, property-write statements are not side effects — but
 /// once the written-to symbol is included, its write statements must come along.
 fn include_property_write_referencing_stmts(ctx: &mut IncludeContext, symbol_ref: SymbolRef) {
-  if matches!(
-    ctx.options.treeshake.property_write_side_effects(),
-    rolldown_common::PropertyWriteSideEffects::False
-  ) {
+  if ctx.property_write_side_effects_disabled {
     let stmt_ids: &[StmtInfoIdx] = ctx.stmt_infos[symbol_ref.owner]
       .symbol_ref_to_referenced_stmt_idx()
       .get(&symbol_ref)

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -381,6 +381,8 @@ impl LinkStage<'_> {
     let mut unused_record_idxs = vec![];
     let cycled_idx = self.sort_dynamic_entries_by_topological_order(&mut dynamic_entries);
     let mut included_dynamic_entry = FxHashSet::default();
+    // Indices into `dynamic_entries` (in topological order) still awaiting inclusion.
+    let mut pending_entry_indices: Vec<usize> = (0..dynamic_entries.len()).collect();
     loop {
       context.module_inclusion_changed = false;
 
@@ -391,9 +393,14 @@ impl LinkStage<'_> {
       let bailout_modules = std::mem::take(&mut context.bailout_cjs_tree_shaking_modules);
       include_cjs_bailout_exports(context, &self.metas, bailout_modules);
 
-      dynamic_entries.iter().for_each(|entry| {
+      // Only entries not yet included are rescanned: an included entry is settled (inclusion
+      // is monotone), so it leaves `pending_entry_indices` and later iterations shrink to the
+      // dead/undecided tail. An entry sharing its module with an already-included one is
+      // settled by that sibling (same skip the full rescan used to perform via the set).
+      pending_entry_indices.retain(|&entry_index| {
+        let entry = &dynamic_entries[entry_index];
         if included_dynamic_entry.contains(&entry.idx) {
-          return;
+          return false;
         }
         let included = self.process_and_retain_dynamic_entry(
           entry,
@@ -405,6 +412,7 @@ impl LinkStage<'_> {
         if included {
           included_dynamic_entry.insert(entry.idx);
         }
+        !included
       });
 
       if !context.module_inclusion_changed {

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -59,6 +59,52 @@ bitflags::bitflags! {
     }
 }
 
+bitflags::bitflags! {
+  /// Memo key for the canonical-level tail of [`handle_include_symbol`], normalized from
+  /// [`SymbolIncludeReason`] so that every reason-dependent effect of the tail fires iff a
+  /// single mask bit is *present*:
+  /// - `Normal` and `EntryExport` behave identically in the tail, so both fold into
+  ///   [`Self::Structural`].
+  /// - Effects triggered by the *absence* of a reason bit become synthetic presence bits:
+  ///   [`note_json_self_reference`] fires when `JsonDefaultExportSelfReference` is absent, and
+  ///   the owner-module push fires (for namespace symbols) when `SimulatedFacadeChunk` is
+  ///   absent. The presence of those two reason bits triggers nothing, so it is dropped.
+  ///
+  /// This gives the skip rule its correctness argument: `seen` is a union of masks over
+  /// processed calls, each bit in it implies the corresponding effect already ran in whichever
+  /// call contributed it, so `seen ⊇ mask` means every effect of the incoming call has
+  /// happened and the (monotone) tail can be skipped.
+  #[derive(Debug, Clone, Copy)]
+  pub(in crate::stages) struct SymbolProcessMask: u8 {
+    /// `Normal` or `EntryExport` — the tail treats them identically.
+    const Structural = 1;
+    const ReExportDynamicExports = 1 << 1;
+    /// Synthetic: the reason lacked `JsonDefaultExportSelfReference`.
+    const NonJsonSelfReference = 1 << 2;
+    /// Synthetic: the reason lacked `SimulatedFacadeChunk`.
+    const NonSimulatedFacadeChunk = 1 << 3;
+  }
+}
+
+impl From<SymbolIncludeReason> for SymbolProcessMask {
+  fn from(reason: SymbolIncludeReason) -> Self {
+    let mut mask = Self::empty();
+    if reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
+      mask |= Self::Structural;
+    }
+    if reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
+      mask |= Self::ReExportDynamicExports;
+    }
+    if !reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference) {
+      mask |= Self::NonJsonSelfReference;
+    }
+    if !reason.contains(SymbolIncludeReason::SimulatedFacadeChunk) {
+      mask |= Self::NonSimulatedFacadeChunk;
+    }
+    mask
+  }
+}
+
 pub struct IncludeContext<'a> {
   pub modules: &'a IndexModules,
   /// Per-module statement-info table, detached from `EcmaView` and held on
@@ -105,6 +151,13 @@ pub struct IncludeContext<'a> {
   /// `chunk_optimizer` constructs `IncludeContext` with a struct literal; nothing outside this
   /// module should touch it.
   pub(in crate::stages) pending: Vec<WorkItem>,
+  /// Memo of [`handle_include_symbol`]'s canonical-level tail: canonical ref -> union of
+  /// [`SymbolProcessMask`]s already processed. The tail is deterministic in (canonical ref,
+  /// mask) and performs only monotone inserts/enqueues, so a repeat whose mask is covered by
+  /// `seen` is skipped — turning O(symbol references) full handlings into O(unique canonicals).
+  /// Alias-keyed work (marking `symbol_ref` itself used, property-write retention) runs before
+  /// the memo check and is never skipped. Same visibility story as `pending`.
+  pub(in crate::stages) processed_symbol_masks: FxHashMap<SymbolRef, SymbolProcessMask>,
 }
 
 impl<'a> IncludeContext<'a> {
@@ -149,6 +202,7 @@ impl<'a> IncludeContext<'a> {
       body_demand_keys,
       body_demand_swept: FxHashSet::default(),
       pending: Vec::new(),
+      processed_symbol_masks: FxHashMap::default(),
     }
   }
 }
@@ -656,13 +710,25 @@ fn handle_include_symbol(
     return;
   }
 
-  drain_body_demand_stmts(ctx, canonical_ref);
-
-  // Also include the symbol that points to the canonical ref.
+  // Alias-keyed work: the referencing symbol itself becomes used, and (under
+  // `propertyWriteSideEffects: false`) its property-write statements come along. Keyed by
+  // `symbol_ref`, not the canonical, so it runs for every distinct alias.
   ctx.used_symbol_refs.insert(symbol_ref);
   if ctx.modules[symbol_ref.owner].is_external() {
     ctx.used_external_symbols.insert(symbol_ref);
   }
+  include_property_write_referencing_stmts(ctx, symbol_ref);
+
+  // Everything below is the canonical-level tail: deterministic in (canonical ref, mask) and
+  // monotone, so a covered repeat adds nothing (see [`SymbolProcessMask`]).
+  let mask = SymbolProcessMask::from(include_reason);
+  let seen = ctx.processed_symbol_masks.entry(canonical_ref).or_insert(SymbolProcessMask::empty());
+  if seen.contains(mask) {
+    return;
+  }
+  seen.insert(mask);
+
+  drain_body_demand_stmts(ctx, canonical_ref);
 
   // CJS bailout checks are handled by `include_symbol_and_check_cjs_bailout`
   // at most call sites. This keeps `include_symbol` focused on inclusion only.
@@ -684,8 +750,6 @@ fn handle_include_symbol(
       ctx.pending.push(WorkItem::Module(module.idx));
     }
   }
-
-  include_property_write_referencing_stmts(ctx, symbol_ref);
 }
 
 /// Mirror of the finalizer's constant inlining: a constant value is always inlined at its
@@ -776,10 +840,15 @@ fn note_namespace_inclusion_reason(
   let is_module_namespace =
     ctx.modules[canonical_ref.owner].namespace_object_ref() == Some(canonical_ref);
   if is_module_namespace {
+    // Independent `if`s, not `else if`: each recorded reason must depend on exactly one
+    // include-reason bit for the [`SymbolProcessMask`] memo's skip rule to hold. (The engine
+    // never combines Normal/EntryExport with ReExportDynamicExports in one work item today,
+    // so both shapes behave identically.)
     if include_reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::Unknown);
-    } else if include_reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
+    }
+    if include_reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::ReExportDynamicExports);
     }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -38,7 +38,7 @@ pub type ModuleInclusionVec = IndexBitSet<ModuleIdx>;
 pub type ModuleNamespaceReasonVec = IndexVec<ModuleIdx, ModuleNamespaceIncludedReason>;
 
 bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct SymbolIncludeReason: u8 {
         const Normal = 1;
         const EntryExport = 1 << 1;
@@ -57,52 +57,6 @@ bitflags::bitflags! {
         /// https://github.com/rolldown/rolldown/blob/d6d65f9080e427cd9feef56eb7a110fbcf6c1414/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs#L422
         const SimulatedFacadeChunk = 1 << 4;
     }
-}
-
-bitflags::bitflags! {
-  /// Memo key for the canonical-level tail of [`handle_include_symbol`], normalized from
-  /// [`SymbolIncludeReason`] so that every reason-dependent effect of the tail fires iff a
-  /// single mask bit is *present*:
-  /// - `Normal` and `EntryExport` behave identically in the tail, so both fold into
-  ///   [`Self::Structural`].
-  /// - Effects triggered by the *absence* of a reason bit become synthetic presence bits:
-  ///   [`note_json_self_reference`] fires when `JsonDefaultExportSelfReference` is absent, and
-  ///   the owner-module push fires (for namespace symbols) when `SimulatedFacadeChunk` is
-  ///   absent. The presence of those two reason bits triggers nothing, so it is dropped.
-  ///
-  /// This gives the skip rule its correctness argument: `seen` is a union of masks over
-  /// processed calls, each bit in it implies the corresponding effect already ran in whichever
-  /// call contributed it, so `seen ⊇ mask` means every effect of the incoming call has
-  /// happened and the (monotone) tail can be skipped.
-  #[derive(Debug, Clone, Copy)]
-  pub(in crate::stages) struct SymbolProcessMask: u8 {
-    /// `Normal` or `EntryExport` — the tail treats them identically.
-    const Structural = 1;
-    const ReExportDynamicExports = 1 << 1;
-    /// Synthetic: the reason lacked `JsonDefaultExportSelfReference`.
-    const NonJsonSelfReference = 1 << 2;
-    /// Synthetic: the reason lacked `SimulatedFacadeChunk`.
-    const NonSimulatedFacadeChunk = 1 << 3;
-  }
-}
-
-impl From<SymbolIncludeReason> for SymbolProcessMask {
-  fn from(reason: SymbolIncludeReason) -> Self {
-    let mut mask = Self::empty();
-    if reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
-      mask |= Self::Structural;
-    }
-    if reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
-      mask |= Self::ReExportDynamicExports;
-    }
-    if !reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference) {
-      mask |= Self::NonJsonSelfReference;
-    }
-    if !reason.contains(SymbolIncludeReason::SimulatedFacadeChunk) {
-      mask |= Self::NonSimulatedFacadeChunk;
-    }
-    mask
-  }
 }
 
 #[expect(clippy::struct_excessive_bools)] // Cached option flags; raw booleans read clearest.
@@ -155,17 +109,15 @@ pub struct IncludeContext<'a> {
   /// Work queue of the inclusion engine (see [`drain_work_items`]). Edge producers push typed
   /// work items here instead of recursing; the public `include_*` entry points drain it to
   /// empty before returning. Invariant (debug-asserted at every public entry point): empty
-  /// whenever control is outside the engine. Visible outside this module only because
-  /// `chunk_optimizer` constructs `IncludeContext` with a struct literal; nothing outside this
-  /// module should touch it.
-  pub(in crate::stages) pending: Vec<WorkItem>,
-  /// Memo of [`handle_include_symbol`]'s canonical-level tail: canonical ref -> union of
-  /// [`SymbolProcessMask`]s already processed. The tail is deterministic in (canonical ref,
-  /// mask) and performs only monotone inserts/enqueues, so a repeat whose mask is covered by
-  /// `seen` is skipped — turning O(symbol references) full handlings into O(unique canonicals).
-  /// Alias-keyed work (marking `symbol_ref` itself used, property-write retention) runs before
-  /// the memo check and is never skipped. Same visibility story as `pending`.
-  pub(in crate::stages) processed_symbol_masks: FxHashMap<SymbolRef, SymbolProcessMask>,
+  /// whenever control is outside the engine.
+  pending: Vec<WorkItem>,
+  /// Exact-repeat memo for [`handle_include_symbol`]'s canonical-level tail: the tail is a
+  /// deterministic, monotone (insert/enqueue-only) function of `(canonical ref, include
+  /// reason)`, so a repeated pair adds nothing and is skipped — turning O(symbol references)
+  /// tail runs into O(unique (canonical, reason) pairs), in practice ~one per canonical.
+  /// Alias-keyed work (marking `symbol_ref` itself used, property-write retention) runs
+  /// before the memo check and is never skipped.
+  processed_symbol_reasons: FxHashSet<(SymbolRef, SymbolIncludeReason)>,
 }
 
 impl<'a> IncludeContext<'a> {
@@ -216,28 +168,38 @@ impl<'a> IncludeContext<'a> {
       body_demand_keys,
       body_demand_swept: FxHashSet::default(),
       pending: Vec::new(),
-      processed_symbol_masks: FxHashMap::default(),
+      processed_symbol_reasons: FxHashSet::default(),
     }
   }
 }
 
 /// A unit of inclusion work. Edge producers push these instead of recursing, which keeps the
 /// engine iterative (no stack-depth limit on deep graphs) and makes the traversal a visible
-/// queue rather than an implicit call stack. Visible outside this module only as the `pending`
-/// field's type; not part of the module's API.
+/// queue rather than an implicit call stack.
 #[derive(Debug, Clone, Copy)]
-pub(in crate::stages) enum WorkItem {
+enum WorkItem {
   /// Structurally include a module: sweep its side-effect statements and evaluate its
   /// side-effectful dependencies.
   Module(ModuleIdx),
   /// A symbol became used: retain its declaration, wrapper, and owner module.
-  /// `check_cjs_bailout` is set at sites where the symbol may stand for a full CJS namespace
-  /// used opaquely (see [`check_cjs_bailout`]); producers that know the access is partial (a
-  /// resolved member expression on a CJS namespace) or internal (wrapper refs, CJS-interop
-  /// named exports, runtime symbols) clear it to keep CJS tree-shaking working.
+  /// See [`push_symbol`] for the `check_cjs_bailout` flag.
   Symbol { symbol_ref: SymbolRef, reason: SymbolIncludeReason, check_cjs_bailout: bool },
   /// Include one statement and follow everything it references.
   Statement(ModuleIdx, StmtInfoIdx),
+}
+
+/// Enqueue a symbol work item. `check_cjs_bailout` is set at sites where the symbol may stand
+/// for a full CJS namespace used opaquely (see [`check_cjs_bailout`]); producers that know the
+/// access is partial (a resolved member expression on a CJS namespace) or internal (wrapper
+/// refs, CJS-interop named exports, runtime symbols) pass `false` to keep CJS tree-shaking
+/// working.
+fn push_symbol(
+  ctx: &mut IncludeContext,
+  symbol_ref: SymbolRef,
+  reason: SymbolIncludeReason,
+  check_cjs_bailout: bool,
+) {
+  ctx.pending.push(WorkItem::Symbol { symbol_ref, reason, check_cjs_bailout });
 }
 
 /// Drain the work queue to empty. LIFO order mirrors the depth-first shape of the recursion this
@@ -268,11 +230,7 @@ pub(super) fn include_symbol_and_check_cjs_bailout(
   include_reason: SymbolIncludeReason,
 ) {
   debug_assert!(ctx.pending.is_empty(), "engine queue must be empty between public entry points");
-  ctx.pending.push(WorkItem::Symbol {
-    symbol_ref,
-    reason: include_reason,
-    check_cjs_bailout: true,
-  });
+  push_symbol(ctx, symbol_ref, include_reason, true);
   drain_work_items(ctx);
   debug_assert!(ctx.pending.is_empty(), "public entry points must drain the queue to empty");
 }
@@ -609,20 +567,12 @@ fn handle_include_module(ctx: &mut IncludeContext, module_idx: ModuleIdx) {
   if module.meta.has_eval() && matches!(module.module_type, ModuleType::Js | ModuleType::Jsx) {
     // `eval` can observe any module-level binding, so every import must survive.
     module.named_imports.keys().for_each(|symbol| {
-      ctx.pending.push(WorkItem::Symbol {
-        symbol_ref: *symbol,
-        reason: SymbolIncludeReason::Normal,
-        check_cjs_bailout: true,
-      });
+      push_symbol(ctx, *symbol, SymbolIncludeReason::Normal, true);
     });
   }
 
   ctx.metas[module.idx].included_commonjs_export_symbol.iter().for_each(|symbol_ref| {
-    ctx.pending.push(WorkItem::Symbol {
-      symbol_ref: *symbol_ref,
-      reason: SymbolIncludeReason::Normal,
-      check_cjs_bailout: true,
-    });
+    push_symbol(ctx, *symbol_ref, SymbolIncludeReason::Normal, true);
   });
 
   // With enabling HMR, rolldown will register included esm module's namespace object to the runtime.
@@ -720,11 +670,7 @@ pub fn include_symbol(
   include_reason: SymbolIncludeReason,
 ) {
   debug_assert!(ctx.pending.is_empty(), "engine queue must be empty between public entry points");
-  ctx.pending.push(WorkItem::Symbol {
-    symbol_ref,
-    reason: include_reason,
-    check_cjs_bailout: false,
-  });
+  push_symbol(ctx, symbol_ref, include_reason, false);
   drain_work_items(ctx);
   debug_assert!(ctx.pending.is_empty(), "public entry points must drain the queue to empty");
 }
@@ -737,9 +683,8 @@ fn handle_include_symbol(
 ) {
   let mut canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
 
-  // Before the constant bypass and the memo gate: the check ran unconditionally at push time
-  // when it lived there, and it is the one effect (writing into the per-fixpoint-iteration
-  // bailout set) the memo must not skip.
+  // Must run before the constant bypass and the memo gate: it writes into the
+  // per-fixpoint-iteration bailout set, the one effect the memo must never skip.
   if should_check_cjs_bailout {
     check_cjs_bailout(ctx, canonical_ref);
   }
@@ -757,28 +702,25 @@ fn handle_include_symbol(
   }
   include_property_write_referencing_stmts(ctx, symbol_ref);
 
-  // Everything below is the canonical-level tail: deterministic in (canonical ref, mask) and
-  // monotone, so a covered repeat adds nothing (see [`SymbolProcessMask`]).
-  let mask = SymbolProcessMask::from(include_reason);
-  let seen = ctx.processed_symbol_masks.entry(canonical_ref).or_insert(SymbolProcessMask::empty());
-  if seen.contains(mask) {
+  // Everything below is the canonical-level tail: a deterministic, monotone function of
+  // (canonical ref, include reason), so an exact repeat adds nothing and is skipped (see
+  // `processed_symbol_reasons`).
+  if !ctx.processed_symbol_reasons.insert((canonical_ref, include_reason)) {
     return;
   }
-  seen.insert(mask);
 
   drain_body_demand_stmts(ctx, canonical_ref);
-
-  // CJS bailout checks are handled by `include_symbol_and_check_cjs_bailout`
-  // at most call sites. This keeps `include_symbol` focused on inclusion only.
 
   follow_cjs_namespace_alias(ctx, &mut canonical_ref);
 
   let is_simulated_facade_chunk =
     note_namespace_inclusion_reason(ctx, canonical_ref, include_reason);
 
-  ctx.used_symbol_refs.insert(canonical_ref);
-  if ctx.modules[canonical_ref.owner].is_external() {
-    ctx.used_external_symbols.insert(canonical_ref);
+  if canonical_ref != symbol_ref {
+    ctx.used_symbol_refs.insert(canonical_ref);
+    if ctx.modules[canonical_ref.owner].is_external() {
+      ctx.used_external_symbols.insert(canonical_ref);
+    }
   }
   if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
     demand_esm_init_wrapper(ctx, canonical_ref);
@@ -847,7 +789,7 @@ fn follow_cjs_namespace_alias(ctx: &mut IncludeContext, canonical_ref: &mut Symb
       ctx.metas[canonical_ref.owner].import_record_ns_to_cjs_module.get(canonical_ref)
     {
       // Include specific named export from CJS module.
-      // Default import bailout is handled by check_cjs_bailout at call sites.
+      // Default import bailout is handled via the work item's `check_cjs_bailout` flag.
       // ```js
       // import {a} from './cjs.js'
       // console.log(a)
@@ -859,11 +801,7 @@ fn follow_cjs_namespace_alias(ctx: &mut IncludeContext, canonical_ref: &mut Symb
           return;
         };
         if namespace_alias.property_name.as_str() != "default" {
-          ctx.pending.push(WorkItem::Symbol {
-            symbol_ref: export_symbol.symbol_ref,
-            reason: SymbolIncludeReason::Normal,
-            check_cjs_bailout: false,
-          });
+          push_symbol(ctx, export_symbol.symbol_ref, SymbolIncludeReason::Normal, false);
         }
       });
     }
@@ -882,15 +820,10 @@ fn note_namespace_inclusion_reason(
   let is_module_namespace =
     ctx.modules[canonical_ref.owner].namespace_object_ref() == Some(canonical_ref);
   if is_module_namespace {
-    // Independent `if`s, not `else if`: each recorded reason must depend on exactly one
-    // include-reason bit for the [`SymbolProcessMask`] memo's skip rule to hold. (The engine
-    // never combines Normal/EntryExport with ReExportDynamicExports in one work item today,
-    // so both shapes behave identically.)
     if include_reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::Unknown);
-    }
-    if include_reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
+    } else if include_reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::ReExportDynamicExports);
     }
@@ -911,11 +844,7 @@ fn demand_esm_init_wrapper(ctx: &mut IncludeContext, canonical_ref: SymbolRef) {
       .filter(|wrapper_ref| *wrapper_ref != canonical_ref)
   };
   if let Some(wrapper_ref) = wrapper_ref {
-    ctx.pending.push(WorkItem::Symbol {
-      symbol_ref: wrapper_ref,
-      reason: SymbolIncludeReason::Normal,
-      check_cjs_bailout: false,
-    });
+    push_symbol(ctx, wrapper_ref, SymbolIncludeReason::Normal, false);
   }
 }
 
@@ -949,7 +878,11 @@ fn include_property_write_referencing_stmts(ctx: &mut IncludeContext, symbol_ref
       .unwrap_or(&[]);
     if ctx.modules[symbol_ref.owner].as_normal().is_some() {
       for stmt_info_id in stmt_ids.iter().copied() {
-        ctx.pending.push(WorkItem::Statement(symbol_ref.owner, stmt_info_id));
+        // Pure work-skip for repeat references; the authoritative dedup is still `set_bit`
+        // inside the statement handler.
+        if !ctx.is_included_vec[symbol_ref.owner].has_bit(stmt_info_id) {
+          ctx.pending.push(WorkItem::Statement(symbol_ref.owner, stmt_info_id));
+        }
       }
     }
   }
@@ -1012,11 +945,12 @@ fn handle_include_statement(
         // (e.g., `ns.x`), we skip the bailout check — we know the access is partial
         // and CJS tree-shaking can work. Otherwise, the full namespace may be used
         // opaquely, so we check for bailout.
-        ctx.pending.push(WorkItem::Symbol {
-          symbol_ref: resolved_ref,
-          reason: include_kind,
-          check_cjs_bailout: member_expr_resolution.target_commonjs_exported_symbol.is_none(),
-        });
+        push_symbol(
+          ctx,
+          resolved_ref,
+          include_kind,
+          member_expr_resolution.target_commonjs_exported_symbol.is_none(),
+        );
       } else {
         // If it points to nothing, the expression will be rewritten as `void 0` and there's nothing we need to include
       }
@@ -1037,11 +971,7 @@ fn handle_include_statement(
         .for_each(|sym_ref| {
           enqueue_declaring_statements(ctx, sym_ref);
         });
-      ctx.pending.push(WorkItem::Symbol {
-        symbol_ref: *original_ref,
-        reason: include_kind,
-        check_cjs_bailout: true,
-      });
+      push_symbol(ctx, *original_ref, include_kind, true);
     }
   });
 }


### PR DESCRIPTION
> [!WARNING]
> **DO NOT REVIEW — experiment only.** This PR exists to run CI/CodSpeed against the branch (the benchmark workflows skip drafts). Not seeking review or merge in its current form; it will be closed or re-submitted properly afterwards.

## Summary

- Memoize the canonical-level tail of symbol inclusion in the tree-shaking engine. `Module`/`Statement` work items already dedup via the inclusion bitsets, but `Symbol` items re-ran the full handler once per symbol *reference*. An exact-repeat memo on `(canonical ref, include reason)` cuts tail executions from 42,222 to 8,332 (= the unique-canonical count) and `Module` work items by 74% on three.js ×10.
- Also: run the CJS bailout check inside the symbol handler on the already-resolved canonical (removes a second union-find chain walk per reference), rescan only pending dynamic entries in the inclusion fixpoint, and hoist loop-invariant option flags out of hot closures.
- Verified byte-identical output vs `main` (JS + sourcemap hashes on three.js ×10) and zero snapshot changes across the Rust suite. The tree-shaking pass itself measures ~12% faster locally; end-to-end build time is expected **neutral** on the CodSpeed fixtures (this pass is ~1% of a real build) — confirming that expectation is part of the experiment.