### PR TITLE
fix: improve invalid annotation warnings

### DIFF
--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -4,14 +4,15 @@ use json_escape_simd::escape;
 use oxc::{semantic::Scoping, span::SourceType as OxcSourceType};
 use oxc_str::CompactStr;
 use rolldown_common::{
-  ConstExportMeta, ModuleDefFormat, ModuleType, NormalizedBundlerOptions, RUNTIME_MODULE_KEY,
-  StrOrBytes, json_value_to_ecma_ast,
+  ConstExportMeta, ModuleDefFormat, ModuleId, ModuleType, NormalizedBundlerOptions,
+  RUNTIME_MODULE_KEY, StrOrBytes, json_value_to_ecma_ast,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
-use rolldown_error::{BuildDiagnostic, BuildResult};
+use rolldown_error::{BuildDiagnostic, BuildResult, EventKindSwitcher};
 use rolldown_plugin::HookTransformAstArgs;
 use rolldown_utils::mime::guess_mime;
 use rustc_hash::FxHashMap;
+use sugar_path::SugarPath as _;
 
 use super::pre_process_ecma_ast::PreProcessEcmaAst;
 
@@ -113,15 +114,28 @@ pub async fn parse_to_ecma_ast(
     })
     .await?;
 
+  let is_local_project_file = is_local_project_file(&resolved_id.id, &options.normalized_cwd);
+  let should_warn_on_invalid_annotation =
+    options.checks.contains(EventKindSwitcher::InvalidAnnotation) && is_local_project_file;
+
   PreProcessEcmaAst::default().build(
     ecma_ast,
     stable_id,
     resolved_id.id.as_str(),
+    should_warn_on_invalid_annotation,
     &parsed_type,
     replace_global_define_config.as_ref(),
     options,
     has_lazy_export,
   )
+}
+
+fn is_local_project_file(id: &ModuleId, normalized_cwd: &Path) -> bool {
+  if id.is_in_node_modules() {
+    return false;
+  }
+
+  id.as_path().is_some_and(|path| path.normalize().starts_with(normalized_cwd))
 }
 
 fn pre_process_source(
@@ -199,4 +213,30 @@ fn pre_process_source(
   };
 
   Ok((has_lazy_export, source, module_type.into()))
+}
+
+#[cfg(test)]
+mod tests {
+  use rolldown_common::ModuleId;
+  use sugar_path::SugarPath as _;
+
+  use super::is_local_project_file;
+
+  #[test]
+  fn parent_dir_cannot_escape_cwd() {
+    let cwd = std::env::current_dir().unwrap().join("project");
+    let normalized_cwd = cwd.normalize();
+    let id = ModuleId::new(cwd.join("src/../../dependency.js").to_string_lossy().into_owned());
+
+    assert!(!is_local_project_file(&id, normalized_cwd.as_ref()));
+  }
+
+  #[test]
+  fn node_modules_component_is_excluded() {
+    let cwd = std::env::current_dir().unwrap().join("project");
+    let normalized_cwd = cwd.normalize();
+    let id = ModuleId::new(cwd.join("node_modules/pkg/index.js").to_string_lossy().into_owned());
+
+    assert!(!is_local_project_file(&id, normalized_cwd.as_ref()));
+  }
 }

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -39,6 +39,7 @@ impl PreProcessEcmaAst {
     mut ast: EcmaAst,
     stable_id: &str,
     resolved_id: &str,
+    should_warn_on_invalid_annotation: bool,
     parsed_type: &OxcParseType,
     replace_global_define_config: Option<&ReplaceGlobalDefinesConfig>,
     bundle_options: &NormalizedBundlerOptions,
@@ -94,9 +95,11 @@ impl PreProcessEcmaAst {
     // `CommentContent::PureNotApplied` when their position prevents the parser
     // from applying them (expression-level, statement-level, or variable declarator).
     // Aligns with Rollup's `INVALID_ANNOTATION` log code.
-    warnings.extend(ast.program.with_dependent(|_owner, dep| {
-      invalid_pure_annotation_warnings(&dep.program, &source, resolved_id)
-    }));
+    if should_warn_on_invalid_annotation {
+      warnings.extend(ast.program.with_dependent(|_owner, dep| {
+        invalid_pure_annotation_warnings(&dep.program, &source, resolved_id)
+      }));
+    }
 
     self.stats = semantic_ret.semantic.stats();
     let mut scoping = Some(semantic_ret.semantic.into_scoping());
@@ -376,6 +379,30 @@ fn invalid_pure_annotation_warnings(
         span,
         is_before_function_declaration,
       )
+      .with_severity_warning()
     })
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use oxc::span::SourceType;
+  use rolldown_ecmascript::EcmaCompiler;
+  use rolldown_error::Severity;
+
+  use super::invalid_pure_annotation_warnings;
+
+  #[test]
+  fn invalid_pure_annotations_are_warning_severity() {
+    let ast =
+      EcmaCompiler::parse("main.js", "/* #__PURE__ */ globalThis.foo;", SourceType::default())
+        .unwrap();
+    let source = ast.source().clone();
+    let warnings = ast.program.with_dependent(|_owner, dep| {
+      invalid_pure_annotation_warnings(&dep.program, &source, "main.js")
+    });
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].severity(), Severity::Warning);
+  }
 }

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -304,6 +304,7 @@ pub fn prepare_build_context(
   );
   let cwd =
     raw_options.cwd.unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
+  let normalized_cwd = cwd.normalize().into_owned();
 
   let tsconfig = raw_options.tsconfig.map(|tsconfig| tsconfig.with_base(&cwd)).unwrap_or_default();
   let yarn_pnp = raw_resolve.yarn_pnp.unwrap_or(false);
@@ -488,6 +489,7 @@ pub fn prepare_build_context(
       cwd.join(p).normalize().to_string_lossy().to_string()
     }),
     cwd,
+    normalized_cwd,
     preserve_entry_signatures,
     devtools: raw_options.devtools.is_some(),
     optimization: normalize_optimization_option(raw_options.optimization, platform),

--- a/crates/rolldown/tests/esbuild/dce/remove_unused_pure_comment_calls/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/remove_unused_pure_comment_calls/artifacts.snap
@@ -13,7 +13,9 @@ source: crates/rolldown_testing/src/integration_test.rs
     │                  ───────┬───────  
     │                         ╰───────── comment ignored due to position
     │ 
-    │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+    │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+    │ 
+    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ────╯
 
 ```
@@ -28,7 +30,9 @@ source: crates/rolldown_testing/src/integration_test.rs
     │                          ───────┬───────  
     │                                 ╰───────── comment ignored due to position
     │ 
-    │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+    │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+    │ 
+    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ────╯
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10183/dependency.js
+++ b/crates/rolldown/tests/rolldown/issues/10183/dependency.js
@@ -1,0 +1,1 @@
+/* #__PURE__ */ globalThis.dependency;

--- a/crates/rolldown/tests/rolldown/issues/10183/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/10183/mod.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use rolldown::{Bundler, BundlerOptions, ChecksOptions, InputItem};
+
+async fn invalid_annotation_warning_count(checks: Option<ChecksOptions>) -> usize {
+  let project_dir =
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/rolldown/issues/10183/project"));
+
+  let mut bundler = Bundler::new(BundlerOptions {
+    cwd: Some(project_dir),
+    input: Some(vec![InputItem {
+      name: Some("main".to_string()),
+      import: "./main.js".to_string(),
+    }]),
+    checks,
+    ..Default::default()
+  })
+  .expect("failed to create bundler");
+
+  let output = bundler.generate().await.expect("build should succeed");
+  output
+    .warnings
+    .iter()
+    .filter(|warning| warning.kind().to_string() == "INVALID_ANNOTATION")
+    .count()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn suppresses_invalid_annotation_warning_outside_cwd() {
+  assert_eq!(invalid_annotation_warning_count(None).await, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_true_keeps_local_project_scope() {
+  assert_eq!(
+    invalid_annotation_warning_count(Some(ChecksOptions {
+      invalid_annotation: Some(true),
+      ..Default::default()
+    }))
+    .await,
+    0
+  );
+}

--- a/crates/rolldown/tests/rolldown/issues/10183/project/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10183/project/main.js
@@ -1,0 +1,1 @@
+import '../dependency.js';

--- a/crates/rolldown/tests/rolldown/issues/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/mod.rs
@@ -1,3 +1,5 @@
+#[path = "./10183/mod.rs"]
+mod _10183;
 #[path = "./1733/mod.rs"]
 mod _1733;
 #[path = "./4895/mod.rs"]

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_alongside_valid/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_alongside_valid/artifacts.snap
@@ -13,7 +13,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ───────┬───────  
    │        ╰───────── comment ignored due to position
    │ 
-   │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_at_variant/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_at_variant/artifacts.snap
@@ -13,7 +13,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ───────┬───────  
    │        ╰───────── comment ignored due to position
    │ 
-   │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_disabled/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_disabled/_config.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Explicitly disabling invalidAnnotation suppresses warnings from project source.",
+  "config": {
+    "checks": {
+      "invalidAnnotation": false
+    }
+  },
+  "expectExecuted": false,
+  "expectWarning": false,
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_disabled/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_disabled/main.js
@@ -1,0 +1,1 @@
+/* #__PURE__ */ globalThis.foo;

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_expression/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_expression/artifacts.snap
@@ -13,7 +13,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ───────┬───────  
    │        ╰───────── comment ignored due to position
    │ 
-   │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_nested_function_declaration/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_nested_function_declaration/artifacts.snap
@@ -15,7 +15,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ 
    │ Help 1: If you intended to mark all calls of this function as side-effect-free, use `/* @__NO_SIDE_EFFECTS__ */` before the function declaration.
    │ 
-   │ Help 2: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 2: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 3: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/_config.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Invalid pure annotations in dependencies are not actionable for the app author, so they are suppressed by default.",
+  "expectExecuted": false,
+  "expectWarning": false,
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/main.js
@@ -1,0 +1,1 @@
+import 'dep';

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/node_modules/dep/index.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_node_modules_no_warning/node_modules/dep/index.js
@@ -1,0 +1,1 @@
+/* #__PURE__ */ globalThis.dep;

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_statement/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_statement/artifacts.snap
@@ -15,7 +15,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ 
    │ Help 1: If you intended to mark all calls of this function as side-effect-free, use `/* @__NO_SIDE_EFFECTS__ */` before the function declaration.
    │ 
-   │ Help 2: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 2: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 3: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_var_declarator/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_pure_annotation_var_declarator/artifacts.snap
@@ -13,7 +13,9 @@ source: crates/rolldown_testing/src/integration_test.rs
    │           ───────┬───────  
    │                  ╰───────── comment ignored due to position
    │ 
-   │ Help: For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
 
 ```

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -43,6 +43,7 @@ pub struct NormalizedBundlerOptions {
   // --- Input
   pub input: Vec<InputItem>,
   pub cwd: PathBuf,
+  pub normalized_cwd: PathBuf,
   pub external: IsExternal,
   /// corresponding to `false | NormalizedTreeshakeOption`
   pub treeshake: NormalizedTreeshakeOptions,
@@ -126,6 +127,7 @@ impl Default for NormalizedBundlerOptions {
     Self {
       input: Default::default(),
       cwd: Default::default(),
+      normalized_cwd: Default::default(),
       external: Default::default(),
       treeshake: Default::default(),
       platform: Platform::Neutral,

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_annotation.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_annotation.rs
@@ -53,6 +53,37 @@ impl BuildEvent for InvalidAnnotation {
       ));
     }
 
-    diagnostic.add_help(String::from("For more information on how to use pure annotations correctly, check the documentation: https://rolldown.rs/in-depth/dead-code-elimination#pure"));
+    diagnostic.add_help(String::from(
+      "Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure",
+    ));
+    diagnostic.add_help(String::from("Disable with `checks.invalidAnnotation: false`."));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use arcstr::ArcStr;
+  use oxc::span::Span;
+
+  use crate::BuildDiagnostic;
+
+  #[test]
+  fn renders_concise_guide_and_disable_help() {
+    let rendered = BuildDiagnostic::invalid_annotation(
+      "main.js".to_string(),
+      "/* #__PURE__ */".to_string(),
+      ArcStr::from("/* #__PURE__ */ foo;"),
+      Span::new(0, 15),
+      false,
+    )
+    .with_severity_warning()
+    .to_diagnostic()
+    .convert_to_string(false);
+
+    assert!(rendered.contains(
+      "Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure"
+    ));
+    assert!(rendered.contains("Help 2: Disable with `checks.invalidAnnotation: false`."));
+    assert_eq!(rendered.matches("Help ").count(), 2);
   }
 }

--- a/crates/rolldown_error/src/types/event_kind.rs
+++ b/crates/rolldown_error/src/types/event_kind.rs
@@ -34,6 +34,9 @@ pub enum EventKind {
   /// Annotations placed where they cannot annotate a call expression (e.g. before a non-call expression,
   /// before a statement declaration, or between an identifier and `=` in a variable declarator) are
   /// ignored by the parser. Matches Rollup's `INVALID_ANNOTATION` log code.
+  ///
+  /// By default, warnings are emitted only for local project files inside `cwd` and outside
+  /// `node_modules`. Set this option to `false` to disable the warning entirely.
   InvalidAnnotation = 10,
   /// Whether to emit warnings when the way to export values is ambiguous.
   ///

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -42,6 +42,9 @@ export interface ChecksOptions {
    * Annotations placed where they cannot annotate a call expression (e.g. before a non-call expression,
    * before a statement declaration, or between an identifier and `=` in a variable declarator) are
    * ignored by the parser. Matches Rollup's `INVALID_ANNOTATION` log code.
+   *
+   * By default, warnings are emitted only for local project files inside `cwd` and outside
+   * `node_modules`. Set this option to `false` to disable the warning entirely.
    * @default true
    * */
   invalidAnnotation?: boolean;


### PR DESCRIPTION
## Summary

- render `INVALID_ANNOTATION` diagnostics with warning severity so they use warning colors
- warn by default only for real local project files inside `cwd` and outside `node_modules`
- keep dependencies, outside-`cwd` files, and virtual IDs quiet by default so builds do not report warnings users cannot act on
- keep `checks.invalidAnnotation` as a normal boolean: omitted/`true` use the local project scope, while `false` disables the check
- normalize parent-directory components and match `node_modules` case-insensitively to avoid false-positive local classification
- show concise help for correct annotation placement and disabling the check
- document the conservative default and add regression coverage

## Test plan

- `cargo test -p rolldown --lib`
- `cargo test -p rolldown_error`
- `NEEDS_EXTENDED=false cargo test -p rolldown --test integration invalid_pure_annotation -- --ignored --nocapture`
- `cargo test -p rolldown --test integration 10183 -- --nocapture`
- `just t-run crates/rolldown/tests/esbuild/dce/remove_unused_pure_comment_calls/_config.json`
- `cargo clippy -p rolldown -p rolldown_error -p generator --all-targets -- --deny warnings`
- `just build-rolldown`
- `just lint-node`
- `just lint-repo`
- end-to-end Node API check for the conservative default, boolean enable/disable behavior, yellow output, and concise help

Fixes #10183