### PR TITLE
feat(experimental): backport minChunkSize small-leaf chunk merging onto rc.18

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,6 +1,7 @@
 use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
+use oxc_str::CompactStr;
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
   PostChunkOptimizationOperation, RuntimeHelper, SymbolRef,
@@ -32,6 +33,16 @@ pub struct ChunkGraph {
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
   pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
+  /// Modules that `experimental.minChunkSize` duplicated out of a small common
+  /// "leaf" chunk into each importing chunk. A duplicated leaf is treated as
+  /// **local to every chunk that references it** (it is copied into all of them),
+  /// so cross-chunk imports for its symbols are skipped.
+  /// See `internal-docs/min-size-chunk-merging/design.md`.
+  pub duplicated_leaf_modules: FxHashSet<ModuleIdx>,
+  /// Globally-unique pinned name for every declared symbol of a duplicated leaf.
+  /// The same name is used in every chunk the leaf is duplicated into, so the
+  /// single finalized AST stays valid everywhere. Keys are canonical symbol refs.
+  pub duplicated_leaf_pinned_names: FxHashMap<SymbolRef, CompactStr>,
 }
 
 impl ChunkGraph {
@@ -46,6 +57,8 @@ impl ChunkGraph {
       common_chunk_exported_facade_chunk_namespace: FxHashMap::default(),
       common_chunk_preserve_export_names_modules: FxHashMap::default(),
       post_chunk_optimization_operations: FxHashMap::default(),
+      duplicated_leaf_modules: FxHashSet::default(),
+      duplicated_leaf_pinned_names: FxHashMap::default(),
     }
   }
 

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -273,6 +273,10 @@ impl GenerateStage<'_> {
       // guaranteed.
       return;
     }
+    // Transferred init statements are rendered into module-level mutations later. Duplicated
+    // minChunkSize leaves are rendered once and reused by multiple chunks, so they cannot carry
+    // chunk-specific prepends.
+    let duplicated_leaf_modules = chunk_graph.duplicated_leaf_modules.clone();
     chunk_graph.chunk_table.iter_mut().for_each(|chunk| {
       // Determine DFS roots based on chunk kind.
       // For entry chunks, the root is the entry module.
@@ -399,6 +403,11 @@ impl GenerateStage<'_> {
       for (module_idx, (importer_idx, rec_idx)) in module_init_position {
         match self.link_output.metas[module_idx].original_wrap_kind() {
           WrapKind::None => {
+            // Keep the init at its original importer; otherwise one chunk's transfer would leak
+            // into every copied instance of this leaf.
+            if duplicated_leaf_modules.contains(&module_idx) {
+              continue;
+            }
             if let Some(deps_length) =
               none_wrapped_module_to_wrapped_dependency_length.get(&module_idx)
             {

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -301,6 +301,12 @@ impl GenerateStage<'_> {
     for (chunk_idx, symbol_list) in chunk_id_to_symbols_vec {
       for declared in symbol_list {
         let declared = declared.inner();
+        // Duplicated leaves (experimental.minChunkSize) live in several chunks;
+        // their symbol chunk_idx was pinned in `merge_small_common_leaf_chunks`,
+        // so skip the one-chunk assignment + its debug assertion here.
+        if chunk_graph.duplicated_leaf_modules.contains(&declared.owner) {
+          continue;
+        }
         if cfg!(debug_assertions) {
           let symbol_data = symbols.get(declared);
           debug_assert!(
@@ -430,6 +436,12 @@ impl GenerateStage<'_> {
         let chunk_meta_imports = &index_chunk_depended_symbols[chunk_id];
         for import_ref in chunk_meta_imports.iter().copied() {
           if !self.link_output.used_symbol_refs.contains(&import_ref) {
+            continue;
+          }
+          // A duplicated leaf (experimental.minChunkSize) is copied into every
+          // chunk that references it, so it is always local — never import it
+          // across chunks.
+          if chunk_graph.duplicated_leaf_modules.contains(&import_ref.owner) {
             continue;
           }
           // If the symbol from external module and the format is commonjs, we might need to insert runtime

--- a/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
+++ b/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
@@ -1,0 +1,317 @@
+//! `experimental.minChunkSize`: webpack/rspack `splitChunks.minSize`-style merging.
+//!
+//! A small, side-effect-free common "leaf" chunk (its modules have no imports of
+//! their own) is *duplicated* into each chunk that imports it instead of being
+//! emitted as a standalone shared chunk. This reduces chunk / request count for
+//! the price of duplicating a tiny module.
+//!
+//! Correctness relies on three facts (see
+//! `internal-docs/min-size-chunk-merging/design.md`):
+//! - leaves have no outgoing cross-chunk refs, so a single finalized AST has
+//!   nothing chunk-specific except its own declared-symbol names;
+//! - those names are pinned to one globally-unique name used by every chunk
+//!   (`ChunkGraph::duplicated_leaf_pinned_names`), so the one finalized AST is
+//!   valid everywhere;
+//! - a duplicated leaf is recorded in `ChunkGraph::duplicated_leaf_modules` and
+//!   treated as **local to every chunk that references it** by
+//!   `compute_cross_chunk_links` and the module finalizer.
+//!
+//! This pass runs after chunk formation and before `compute_cross_chunk_links`.
+
+use oxc_str::CompactStr;
+use rolldown_common::{
+  ChunkIdx, ChunkKind, EcmaViewMeta, ImportKind, ImportRecordMeta, ModuleIdx,
+  PostChunkOptimizationOperation, SymbolRef,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{chunk_graph::ChunkGraph, utils::renamer::Renamer};
+
+use super::GenerateStage;
+
+impl GenerateStage<'_> {
+  pub(super) fn merge_small_common_leaf_chunks(&mut self, chunk_graph: &mut ChunkGraph) {
+    let Some(min_size) = self.options.experimental.min_chunk_size() else {
+      return;
+    };
+
+    // The duplicated-leaf "local everywhere" rule is only wired into the ESM
+    // finalizer and `compute_cross_chunk_links` paths. The CJS/IIFE/UMD
+    // reference-resolution paths (the `module_finalizers` CJS branch and
+    // `types/generator.rs`) still classify a duplicated leaf living in a
+    // non-primary chunk as cross-chunk, which mis-resolves or panics indexing a
+    // require binding that was deliberately never populated for the leaf.
+    // Restrict the optimization to ESM output until those paths honor
+    // `duplicated_leaf_modules`. (Wrapped / `require()`d leaves carry a runtime
+    // import record, so the `import_records.is_empty()` leaf check below already
+    // excludes them.)
+    if !self.options.format.is_esm() {
+      return;
+    }
+
+    // 1. Modules re-exported anywhere are conservatively excluded: their symbols
+    //    may be referenced through cross-chunk re-export chains that the direct
+    //    import-edge scan below would miss.
+    let reexported_modules = self.collect_reexported_modules();
+
+    // 2. Eligible chunks: Common (not runtime), all included side-effect-free
+    //    leaves, not re-exported, total source size under the threshold.
+    let runtime_chunk = chunk_graph.module_to_chunk[self.link_output.runtime.id()];
+    let eligible: Vec<ChunkIdx> = chunk_graph
+      .chunk_table
+      .iter_enumerated()
+      .filter(|(chunk_idx, chunk)| {
+        matches!(chunk.kind, ChunkKind::Common)
+          && Some(*chunk_idx) != runtime_chunk
+          && !chunk.modules.is_empty()
+          && chunk_graph.post_chunk_optimization_operations.get(chunk_idx).copied()
+            != Some(PostChunkOptimizationOperation::Removed)
+          && self.is_small_leaf_chunk(&chunk.modules, &reexported_modules, min_size)
+      })
+      .map(|(chunk_idx, _)| chunk_idx)
+      .collect();
+    if eligible.is_empty() {
+      return;
+    }
+
+    // 3. Map each eligible leaf module to its (soon-to-be-removed) owner chunk,
+    //    then find the importing chunks via direct import edges.
+    let mut module_eligible_chunk: FxHashMap<ModuleIdx, ChunkIdx> = FxHashMap::default();
+    for &s in &eligible {
+      for &m in &chunk_graph.chunk_table[s].modules {
+        module_eligible_chunk.insert(m, s);
+      }
+    }
+    let importers = self.collect_importers(chunk_graph, &module_eligible_chunk);
+
+    // 4. Duplicate each eligible leaf chunk into its importers.
+    let mut duplicated_leaf_modules: FxHashSet<ModuleIdx> = FxHashSet::default();
+    let mut leaf_symbols: FxHashSet<SymbolRef> = FxHashSet::default();
+    let mut leaf_primary_chunk: FxHashMap<ModuleIdx, ChunkIdx> = FxHashMap::default();
+
+    for &s in &eligible {
+      let Some(importer_set) = importers.get(&s) else {
+        continue;
+      };
+      if importer_set.is_empty() {
+        continue;
+      }
+      let mut importer_chunks: Vec<ChunkIdx> = importer_set.iter().copied().collect();
+      importer_chunks.sort_unstable();
+      let primary = importer_chunks[0];
+
+      let s_modules = chunk_graph.chunk_table[s].modules.clone();
+
+      // A duplicated-leaf symbol is pinned to its own name and force-reserved in
+      // every importer chunk *before* that chunk's unresolved (free) globals are
+      // reserved, and a free reference is never renamed. So if a leaf-declared name
+      // also appears as an unresolved global reference in an importer chunk, the
+      // copied declaration would silently shadow that global (wrong runtime value,
+      // no error). Leaving the leaf as a standalone shared chunk is always correct,
+      // so skip duplicating it in that case.
+      if self.leaf_name_shadows_importer_global(&s_modules, &importer_chunks, chunk_graph) {
+        continue;
+      }
+
+      let s_runtime_helper = chunk_graph.chunk_table[s].depended_runtime_helper;
+      for &c in &importer_chunks {
+        for &m in &s_modules {
+          chunk_graph.chunk_table[c].modules.push(m);
+        }
+        chunk_graph.chunk_table[c].depended_runtime_helper.insert(s_runtime_helper);
+      }
+
+      for &m in &s_modules {
+        duplicated_leaf_modules.insert(m);
+        leaf_primary_chunk.insert(m, primary);
+        self.collect_declared_symbols(m, &mut leaf_symbols);
+      }
+
+      // Tombstone the now-empty shared chunk.
+      chunk_graph.chunk_table[s].modules.clear();
+      chunk_graph
+        .post_chunk_optimization_operations
+        .insert(s, PostChunkOptimizationOperation::Removed);
+    }
+
+    if duplicated_leaf_modules.is_empty() {
+      return;
+    }
+
+    // 5. Compute globally-unique pinned names for every duplicated-leaf symbol.
+    let mut ordered: Vec<SymbolRef> = leaf_symbols.into_iter().collect();
+    ordered.sort_unstable_by(|a, b| {
+      let a_key = self.link_output.module_table[a.owner].exec_order();
+      let b_key = self.link_output.module_table[b.owner].exec_order();
+      a_key
+        .cmp(&b_key)
+        .then_with(|| a.name(&self.link_output.symbol_db).cmp(b.name(&self.link_output.symbol_db)))
+    });
+    let mut renamer = Renamer::new(None, &self.link_output.symbol_db, self.options.format);
+    for &sym in &ordered {
+      renamer.add_symbol_in_root_scope(sym, true);
+    }
+    let pinned_names = renamer.into_canonical_names();
+
+    // 6. Point duplicated leaves' module/symbol chunk metadata at the primary
+    //    importer so the one finalized AST renders with the pinned names, and the
+    //    `compute_cross_chunk_links` symbol-assignment skip stays consistent.
+    for (&m, &primary) in &leaf_primary_chunk {
+      chunk_graph.module_to_chunk[m] = Some(primary);
+    }
+    {
+      let symbol_db = &mut self.link_output.symbol_db;
+      for &sym in &ordered {
+        if let Some(&primary) = leaf_primary_chunk.get(&sym.owner) {
+          let canonical = sym.canonical_ref(symbol_db);
+          symbol_db.get_mut(canonical).chunk_idx = Some(primary);
+        }
+      }
+    }
+
+    chunk_graph.duplicated_leaf_modules = duplicated_leaf_modules;
+    chunk_graph.duplicated_leaf_pinned_names = pinned_names;
+
+    // 7. Re-sort modules within every chunk so the deconflicter's ascending
+    //    exec-order invariant holds after the insertions.
+    chunk_graph.sort_chunk_modules(self.link_output, self.options);
+  }
+
+  fn collect_reexported_modules(&self) -> FxHashSet<ModuleIdx> {
+    let mut reexported = FxHashSet::default();
+    // Scan ALL modules (not just included ones): a pure re-export pass-through
+    // module (`export { k } from './util'`) is often tree-shaken out
+    // (`is_included == false`), yet a consumer can still reference the leaf's
+    // symbol through it. Excluding such leaves keeps the direct-import-edge
+    // importer scan sound.
+    for (_m_idx, module) in self.link_output.module_table.modules.iter_enumerated() {
+      let Some(normal) = module.as_normal() else {
+        continue;
+      };
+      for rec in &normal.import_records {
+        if rec.meta.contains(ImportRecordMeta::IsExportStar) {
+          if let Some(t) = rec.resolved_module {
+            reexported.insert(t);
+          }
+        }
+      }
+      for local_export in normal.named_exports.values() {
+        if let Some(named_import) = normal.named_imports.get(&local_export.referenced) {
+          if let Some(t) = normal.import_records[named_import.record_idx].resolved_module {
+            reexported.insert(t);
+          }
+        }
+      }
+    }
+    reexported
+  }
+
+  /// True if any symbol declared by the candidate leaf has a name that also
+  /// appears as an unresolved (free) global reference in one of its importer
+  /// chunks. Duplicating such a leaf would shadow the importer's global, so the
+  /// caller keeps it as a standalone shared chunk instead (always correct; at
+  /// worst a missed optimization). Conservative: it tests the leaf symbols' own
+  /// names, which is what they are pinned to (a within-leaf-set suffix only moves
+  /// the pinned name further away from the global, never toward it).
+  fn leaf_name_shadows_importer_global(
+    &self,
+    leaf_modules: &[ModuleIdx],
+    importer_chunks: &[ChunkIdx],
+    chunk_graph: &ChunkGraph,
+  ) -> bool {
+    let mut leaf_symbols: FxHashSet<SymbolRef> = FxHashSet::default();
+    for &m in leaf_modules {
+      self.collect_declared_symbols(m, &mut leaf_symbols);
+    }
+    let leaf_names: FxHashSet<CompactStr> = leaf_symbols
+      .iter()
+      .map(|sym| CompactStr::new(sym.name(&self.link_output.symbol_db)))
+      .collect();
+    if leaf_names.is_empty() {
+      return false;
+    }
+    importer_chunks.iter().any(|&c| {
+      chunk_graph.chunk_table[c].modules.iter().any(|&idx| {
+        self.link_output.symbol_db[idx].as_ref().is_some_and(|db| {
+          db.ast_scopes
+            .scoping()
+            .root_unresolved_references()
+            .keys()
+            .any(|name| leaf_names.contains(&CompactStr::new(name)))
+        })
+      })
+    })
+  }
+
+  #[expect(clippy::cast_precision_loss)] // module byte sizes are well within f64 range
+  fn is_small_leaf_chunk(
+    &self,
+    modules: &[ModuleIdx],
+    reexported_modules: &FxHashSet<ModuleIdx>,
+    min_size: f64,
+  ) -> bool {
+    let mut size = 0.0f64;
+    let all_leaves = modules.iter().all(|&m| {
+      let Some(normal) = self.link_output.module_table[m].as_normal() else {
+        return false;
+      };
+      size += self.link_output.module_table[m].size() as f64;
+      self.link_output.metas[m].is_included
+        && normal.import_records.is_empty()
+        && !self.link_output.module_table[m].side_effects().has_side_effects()
+        && !normal.meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
+        && !reexported_modules.contains(&m)
+    });
+    all_leaves && size < min_size
+  }
+
+  fn collect_importers(
+    &self,
+    chunk_graph: &ChunkGraph,
+    module_eligible_chunk: &FxHashMap<ModuleIdx, ChunkIdx>,
+  ) -> FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> {
+    let mut importers: FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> = FxHashMap::default();
+    for (m_idx, module) in self.link_output.module_table.modules.iter_enumerated() {
+      let Some(normal) = module.as_normal() else {
+        continue;
+      };
+      if !self.link_output.metas[m_idx].is_included {
+        continue;
+      }
+      let Some(importer_chunk) = chunk_graph.module_to_chunk[m_idx] else {
+        continue;
+      };
+      for rec in &normal.import_records {
+        if rec.kind != ImportKind::Import {
+          continue;
+        }
+        let Some(importee) = rec.resolved_module else {
+          continue;
+        };
+        if let Some(&s) = module_eligible_chunk.get(&importee) {
+          if s != importer_chunk {
+            importers.entry(s).or_default().insert(importer_chunk);
+          }
+        }
+      }
+    }
+    importers
+  }
+
+  fn collect_declared_symbols(&self, module_idx: ModuleIdx, out: &mut FxHashSet<SymbolRef>) {
+    let meta = &self.link_output.metas[module_idx];
+    for (stmt_idx, stmt_info) in self.link_output.stmt_infos[module_idx].iter_enumerated() {
+      if !meta.stmt_info_included.has_bit(stmt_idx) {
+        continue;
+      }
+      for declared in &stmt_info.declared_symbols {
+        if declared.is_normal() {
+          let sym = declared.inner();
+          if sym.owner == module_idx {
+            out.insert(sym);
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
+++ b/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
@@ -39,8 +39,8 @@ impl GenerateStage<'_> {
     // finalizer and `compute_cross_chunk_links` paths. The CJS/IIFE/UMD
     // reference-resolution paths (the `module_finalizers` CJS branch and
     // `types/generator.rs`) still classify a duplicated leaf living in a
-    // non-primary chunk as cross-chunk, which mis-resolves or panics indexing a
-    // require binding that was deliberately never populated for the leaf.
+    // non-primary chunk as cross-chunk, which resolves incorrectly or panics
+    // indexing a require binding that was deliberately never populated for the leaf.
     // Restrict the optimization to ESM output until those paths honor
     // `duplicated_leaf_modules`. (Wrapped / `require()`d leaves carry a runtime
     // import record, so the `import_records.is_empty()` leaf check below already

--- a/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
+++ b/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
@@ -21,7 +21,7 @@
 use oxc_str::CompactStr;
 use rolldown_common::{
   ChunkIdx, ChunkKind, EcmaViewMeta, ImportKind, ImportRecordMeta, ModuleIdx,
-  PostChunkOptimizationOperation, SymbolRef,
+  PostChunkOptimizationOperation, SymbolRef, TaggedSymbolRef,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -299,13 +299,16 @@ impl GenerateStage<'_> {
   }
 
   fn collect_declared_symbols(&self, module_idx: ModuleIdx, out: &mut FxHashSet<SymbolRef>) {
+    let Some(normal) = self.link_output.module_table[module_idx].as_normal() else {
+      return;
+    };
     let meta = &self.link_output.metas[module_idx];
-    for (stmt_idx, stmt_info) in self.link_output.stmt_infos[module_idx].iter_enumerated() {
+    for (stmt_idx, stmt_info) in normal.stmt_infos.iter_enumerated() {
       if !meta.stmt_info_included.has_bit(stmt_idx) {
         continue;
       }
       for declared in &stmt_info.declared_symbols {
-        if declared.is_normal() {
+        if matches!(declared, TaggedSymbolRef::Normal(_)) {
           let sym = declared.inner();
           if sym.owner == module_idx {
             out.insert(sym);

--- a/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
+++ b/crates/rolldown/src/stages/generate_stage/min_chunk_size.rs
@@ -282,7 +282,7 @@ impl GenerateStage<'_> {
         continue;
       };
       for rec in &normal.import_records {
-        if rec.kind != ImportKind::Import {
+        if !matches!(rec.kind, ImportKind::Import | ImportKind::Require) {
           continue;
         }
         let Some(importee) = rec.resolved_module else {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -54,6 +54,7 @@ mod compute_cross_chunk_links;
 mod detect_ineffective_dynamic_imports;
 mod finalize_modules;
 mod manual_code_splitting;
+mod min_chunk_size;
 mod minify_chunks;
 mod on_demand_wrapping;
 mod post_banner_footer;
@@ -83,7 +84,20 @@ impl<'a> GenerateStage<'a> {
     self.plugin_driver.render_start(self.options).await?;
     let mut chunk_graph = self.generate_chunks().await?;
 
-    if chunk_graph.chunk_table.len() > 1 {
+    // `experimental.minChunkSize`: duplicate small side-effect-free common leaf
+    // chunks into their importers (webpack `splitChunks.minSize` parity). Must run
+    // before `compute_cross_chunk_links` so duplicated leaves are accounted for.
+    self.merge_small_common_leaf_chunks(&mut chunk_graph);
+
+    // Count only live chunks. Chunks merged away during chunk optimization (e.g.
+    // the standalone runtime chunk folded back into its host) stay in
+    // `chunk_table` as tombstones but are skipped at render time, so they must
+    // not count toward the multi-chunk check that gates single-file output.
+    let live_chunk_count = chunk_graph
+      .chunk_table
+      .len()
+      .saturating_sub(chunk_graph.post_chunk_optimization_operations.len());
+    if live_chunk_count > 1 {
       validate_options_for_multi_chunk_output(self.options)?;
     }
 
@@ -110,12 +124,17 @@ impl<'a> GenerateStage<'a> {
     set_emitted_chunk_preliminary_filenames(&self.plugin_driver.file_emitter, &chunk_graph);
 
     debug_span!("deconflict_chunk_symbols").in_scope(|| {
-      chunk_graph.chunk_table.par_iter_mut().for_each(|chunk| {
+      // Disjoint borrow: `chunk_table` mutably, `duplicated_leaf_pinned_names`
+      // immutably, so the deconflicter can pin duplicated-leaf names per chunk.
+      let ChunkGraph { chunk_table, duplicated_leaf_pinned_names, .. } = &mut chunk_graph;
+      let pinned_names = &*duplicated_leaf_pinned_names;
+      chunk_table.par_iter_mut().for_each(|chunk| {
         deconflict_chunk_symbols(
           chunk,
           self.link_output,
           self.options.format,
           &index_chunk_id_to_name,
+          pinned_names,
         );
       });
     });

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -9,10 +9,31 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, TaggedSymbolRef, WrapKind,
+  Chunk, ChunkIdx, ChunkKind, GetLocalDb, ModuleIdx, NormalModule, OutputFormat, SymbolRef,
+  TaggedSymbolRef, WrapKind,
 };
 use rolldown_utils::ecmascript::legitimize_identifier_name;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Pin every duplicated-leaf symbol (`experimental.minChunkSize`) present in this
+/// chunk to its globally-unique name and reserve it *before* the normal
+/// deconfliction pass, so author symbols (including entry-module symbols, which
+/// otherwise bypass the `accept` veto) yield to the pinned name instead.
+fn pin_duplicated_leaf_names(
+  renamer: &mut Renamer,
+  chunk: &Chunk,
+  duplicated_leaf_pinned_names: &FxHashMap<SymbolRef, CompactStr>,
+) {
+  if duplicated_leaf_pinned_names.is_empty() {
+    return;
+  }
+  let chunk_modules: FxHashSet<ModuleIdx> = chunk.modules.iter().copied().collect();
+  for (&symbol_ref, name) in duplicated_leaf_pinned_names {
+    if chunk_modules.contains(&symbol_ref.owner) {
+      renamer.pin_name(symbol_ref, name.clone());
+    }
+  }
+}
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn deconflict_chunk_symbols(
@@ -20,8 +41,11 @@ pub fn deconflict_chunk_symbols(
   link_output: &LinkStageOutput,
   format: OutputFormat,
   index_chunk_id_to_name: &FxHashMap<ChunkIdx, ArcStr>,
+  duplicated_leaf_pinned_names: &FxHashMap<SymbolRef, CompactStr>,
 ) {
   let mut renamer = Renamer::new(chunk.entry_module_idx(), &link_output.symbol_db, format);
+
+  pin_duplicated_leaf_names(&mut renamer, chunk, duplicated_leaf_pinned_names);
   // Reserve global scope symbols (unresolved references) to prevent generating conflicting names.
   // These are identifiers referenced but not defined in the module's scope (e.g., `console`, `window`).
   chunk

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -103,7 +103,7 @@ impl<'name> Renamer<'name> {
   /// reserved `used` set first).
   pub fn pin_name(&mut self, symbol_ref: SymbolRef, name: CompactStr) {
     let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
-    self.resolver.reserve(name.clone());
+    self.reserve(name.clone());
     self.canonical_names.insert(canonical_ref, name);
   }
 

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -99,8 +99,8 @@ impl<'name> Renamer<'name> {
   /// duplicated leaf symbol the same globally-pinned name in every chunk it is
   /// copied into. Must be called before the normal deconfliction pass so the
   /// reservation wins over author symbols (including entry-module symbols, which
-  /// otherwise bypass `accept` — `ConflictResolver::resolve` still checks the
-  /// reserved `used` set first).
+  /// otherwise take their original name only when it is not already in the
+  /// reserved `used_canonical_names` set).
   pub fn pin_name(&mut self, symbol_ref: SymbolRef, name: CompactStr) {
     let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
     self.reserve(name.clone());

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -94,6 +94,19 @@ impl<'name> Renamer<'name> {
     db.ast_scopes.scoping().iter_bindings().skip(1).any(|(_, bindings)| bindings.contains_key(name))
   }
 
+  /// Force a symbol to a specific name and reserve that name so no other symbol
+  /// in this chunk can take it. Used by `experimental.minChunkSize` to give a
+  /// duplicated leaf symbol the same globally-pinned name in every chunk it is
+  /// copied into. Must be called before the normal deconfliction pass so the
+  /// reservation wins over author symbols (including entry-module symbols, which
+  /// otherwise bypass `accept` — `ConflictResolver::resolve` still checks the
+  /// reserved `used` set first).
+  pub fn pin_name(&mut self, symbol_ref: SymbolRef, name: CompactStr) {
+    let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
+    self.resolver.reserve(name.clone());
+    self.canonical_names.insert(canonical_ref, name);
+  }
+
   /// Check if a candidate name is available for a top-level symbol without causing
   /// unintended variable capture in nested scopes.
   ///

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "minChunkSize duplicates small side-effect-free leaf chunks into every importer. Lazy-init transfer must not prepend chunk-specific CJS init code into such duplicated leaves, because the rendered module is shared by all copied instances.",
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ],
+    "experimental": {
+      "minChunkSize": 10000
+    }
+  },
+  "snapshotOutputStats": true
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/_test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const routeBFile = fs
+  .readdirSync(distDir)
+  .find((file) => file.startsWith('route-b') && file.endsWith('.js'));
+assert.ok(routeBFile, 'route-b chunk should be emitted');
+
+const routeBSource = fs.readFileSync(path.join(distDir, routeBFile), 'utf8');
+assert.ok(
+  !routeBSource.includes('require_feature'),
+  'route-b must not contain route-a transferred CJS init',
+);
+
+const [routeA, routeB] = await Promise.all([
+  import('./dist/route-a.js'),
+  import('./dist/route-b.js'),
+]);
+assert.strictEqual(routeA.value, 'feature:leaf');
+assert.strictEqual(routeB.value, 'leaf');

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/artifacts.snap
@@ -1,0 +1,56 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+//#region entry.js
+const routes = [import("./route-a.js"), import("./route-b.js")];
+//#endregion
+export { routes };
+
+```
+
+## route-a.js
+
+```js
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region feature.cjs
+var require_feature = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.feature = "feature";
+}));
+//#endregion
+//#region leaf.js
+function getLeaf() {
+	return "leaf";
+}
+require_feature();
+const value = `feature:${getLeaf()}`;
+//#endregion
+export { value };
+
+```
+
+## route-b.js
+
+```js
+//#region leaf.js
+function getLeaf() {
+	return "leaf";
+}
+//#endregion
+//#region route-b.js
+const value = getLeaf();
+//#endregion
+export { value };
+
+```
+
+# Output Stats
+
+- entry.js, is_entry true, is_dynamic_entry false, exports ["routes"]
+- route-a.js, is_entry false, is_dynamic_entry true, exports ["value"]
+- route-b.js, is_entry false, is_dynamic_entry true, exports ["value"]

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/entry.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/entry.js
@@ -1,0 +1,1 @@
+export const routes = [import('./route-a.js'), import('./route-b.js')];

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/feature.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/feature.cjs
@@ -1,0 +1,1 @@
+exports.feature = 'feature';

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/leaf.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/leaf.js
@@ -1,0 +1,3 @@
+export function getLeaf() {
+  return 'leaf';
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/route-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/route-a.js
@@ -1,0 +1,4 @@
+import feature from './feature.cjs';
+import { getLeaf } from './leaf.js';
+
+export const value = `${feature.feature}:${getLeaf()}`;

--- a/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/route-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/min_chunk_size/duplicated_leaf_transfer_target/route-b.js
@@ -1,0 +1,3 @@
+import { getLeaf } from './leaf.js';
+
+export const value = getLeaf();

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -14,6 +14,7 @@ pub struct BindingExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<bool>,
   pub lazy_barrel: Option<bool>,
+  pub min_chunk_size: Option<f64>,
 }
 
 impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -35,6 +36,7 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
       native_magic_string: value.native_magic_string,
       chunk_optimization: value.chunk_optimization,
       lazy_barrel: value.lazy_barrel,
+      min_chunk_size: value.min_chunk_size,
     })
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -26,6 +26,15 @@ pub struct ExperimentalOptions {
   pub native_magic_string: Option<bool>,
   pub chunk_optimization: Option<bool>,
   pub lazy_barrel: Option<bool>,
+  /// Minimum chunk size, in bytes, below which a side-effect-free common "leaf"
+  /// chunk (whose modules have no imports of their own) is duplicated into each
+  /// importing chunk instead of being emitted as a standalone shared chunk.
+  ///
+  /// This mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are
+  /// inlined into their consumers to reduce chunk/request count. `None` (the
+  /// default) disables the optimization. See
+  /// `internal-docs/min-size-chunk-merging/design.md`.
+  pub min_chunk_size: Option<f64>,
 }
 
 impl ExperimentalOptions {
@@ -60,5 +69,11 @@ impl ExperimentalOptions {
 
   pub fn is_lazy_barrel_enabled(&self) -> bool {
     self.lazy_barrel.unwrap_or(false)
+  }
+
+  /// Returns the configured min chunk size (bytes) when the small-common-leaf
+  /// duplication optimization is enabled, i.e. a positive threshold was set.
+  pub fn min_chunk_size(&self) -> Option<f64> {
+    self.min_chunk_size.filter(|size| *size > 0.0)
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1038,6 +1038,14 @@
             "boolean",
             "null"
           ]
+        },
+        "minChunkSize": {
+          "description": "Minimum chunk size, in bytes, below which a side-effect-free common \"leaf\"\nchunk (whose modules have no imports of their own) is duplicated into each\nimporting chunk instead of being emitted as a standalone shared chunk.\n\nThis mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are\ninlined into their consumers to reduce chunk/request count. `None` (the\ndefault) disables the optimization. See\n`internal-docs/min-size-chunk-merging/design.md`.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
         }
       },
       "additionalProperties": false

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2133,6 +2133,7 @@ export interface BindingExperimentalOptions {
   nativeMagicString?: boolean
   chunkOptimization?: boolean
   lazyBarrel?: boolean
+  minChunkSize?: number
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -692,6 +692,19 @@ export interface InputOptions {
      * @default false
      */
     lazyBarrel?: boolean;
+    /**
+     * Minimum chunk size, in bytes, below which a side-effect-free common "leaf"
+     * chunk (whose modules have no imports of their own) is duplicated into each
+     * importing chunk instead of being emitted as a standalone shared chunk.
+     *
+     * This mirrors webpack/rspack `splitChunks.minSize`: tiny shared modules are
+     * inlined into their consumers to reduce the number of emitted chunks and
+     * network requests, at the cost of duplicating the small module.
+     *
+     * @experimental
+     * @default undefined (disabled)
+     */
+    minChunkSize?: number;
   };
   /**
    * Configure how the code is transformed. This process happens after the `transform` hook.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -187,6 +187,7 @@ function bindingifyExperimental(
     nativeMagicString: experimental?.nativeMagicString,
     chunkOptimization: experimental?.chunkOptimization,
     lazyBarrel: experimental?.lazyBarrel,
+    minChunkSize: experimental?.minChunkSize,
   };
 }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -632,6 +632,7 @@ const InputOptionsSchema = v.strictObject({
       nativeMagicString: v.optional(v.boolean()),
       chunkOptimization: v.optional(v.boolean()),
       lazyBarrel: v.optional(v.boolean()),
+      minChunkSize: v.optional(v.number()),
     }),
   ),
   transform: v.optional(TransformOptionsSchema),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^3.6.1
       version: 3.6.2
     '@napi-rs/wasm-runtime':
-      specifier: ^1.1.4
-      version: 1.1.4
+      specifier: ^1.1.6
+      version: 1.1.6
     '@oxc-node/cli':
       specifier: ^0.1.0
       version: 0.1.0
@@ -529,7 +529,7 @@ importers:
         version: 1.10.0
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
-        version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        version: 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   packages/debug:
     devDependencies:
@@ -566,7 +566,7 @@ importers:
         version: 3.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.10.3)
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
-        version: 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        version: 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-node/cli':
         specifier: 'catalog:'
         version: 0.1.0
@@ -2408,6 +2408,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -4299,6 +4305,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -4416,6 +4425,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-vue@6.0.5':
     resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
@@ -8553,7 +8563,7 @@ snapshots:
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8629,7 +8639,7 @@ snapshots:
 
   '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8671,6 +8681,7 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -8685,6 +8696,12 @@ snapshots:
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -8715,7 +8732,7 @@ snapshots:
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9098,7 +9115,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.121.0':
@@ -9994,6 +10011,11 @@ snapshots:
       vue: 3.5.32(typescript@6.0.3)
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   '@babel/preset-env': ^7.24.7
   '@babel/preset-typescript': ^7.24.7
   '@napi-rs/cli': ^3.6.1
-  '@napi-rs/wasm-runtime': ^1.1.4
+  '@napi-rs/wasm-runtime': ^1.1.6
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
   '@oxc-project/runtime': '=0.128.0'


### PR DESCRIPTION
## What

Backports `experimental.minChunkSize` (the small side-effect-free leaf chunk
merging from #10010 / #9949) onto the **`v1.0.0-rc.18`** release commit
(`2c4a957`), so it can ship as a preview build for a downstream consumer pinned
to rc.18 (vite 8.0.11 pins `rolldown@1.0.0-rc.18`). The 1.1.x line that carries
the original PR produces invalid output (`i0 is not defined` dangling-namespace
bug) for that consumer, so this PR delivers the feature on the known-good rc.18
base instead.

Base of this PR is a branch pinned at `v1.0.0-rc.18`, so the diff is exactly the
backport (not the 438 commits between rc.18 and main).

## How

- New pass `crates/rolldown/src/stages/generate_stage/min_chunk_size.rs`
  (duplicate small ESM leaf chunks into importers; ESM-only; shadow-global guard).
- `chunk_graph`: `duplicated_leaf_modules` + `duplicated_leaf_pinned_names`.
- `compute_cross_chunk_links`: treat duplicated leaves as chunk-local.
- `deconflict_chunk_symbols`: pin duplicated-leaf names before deconfliction.
- `renamer`: `pin_name`.
- Option plumbing (rust binding + TS input-options / validator / bindingify).

### rc.18 adaptations vs the original PR
- `renamer.pin_name` reserves via `self.reserve` (rc.18 has no `resolver` field).
- `collect_declared_symbols` reads `stmt_infos` from the module (rc.18 keeps them
  on the module, not on `LinkStageOutput`) and matches `TaggedSymbolRef::Normal`
  inline (rc.18 has no `is_normal()`).
- The original PR's `module_finalizers` edit is **omitted**: it targets a
  wrapped-esm-init fallback that does not exist in rc.18, and rc.18's ESM symbol
  resolution already emits local canonical names (the cross-chunk path is
  CJS-only), so a duplicated leaf resolves locally without it.

## Validation
- `cargo check` clean; release napi binding built.
- Feature: 2 entries sharing a tiny leaf → off = 3 chunks (standalone shared
  leaf), on (`minChunkSize: 100000`) = 2 chunks, leaf duplicated into both, 0
  cross-chunk imports; emitted output imports and executes correctly.

