### PR TITLE
fix(sourcemap_filenames): use public option name in pattern errors

### DIFF
--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -258,7 +258,7 @@ impl Chunk {
     };
     let sourcemap_filename = sourcemap_filename.call(rollup_pre_rendered_chunk).await?;
 
-    let filename_template = FilenameTemplate::new(sourcemap_filename, "sourcemap_filename");
+    let filename_template = FilenameTemplate::new(sourcemap_filename, "sourcemapFileNames");
     let has_hash_pattern = filename_template.has_hash_pattern();
 
     let mut hash_placeholder = has_hash_pattern.then_some(vec![]);

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/_config.ts
@@ -1,0 +1,21 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// An absolute `sourcemapFileNames` pattern is invalid and must be rejected. The diagnostic
+// has to name the public camelCase option (`sourcemapFileNames`); before the fix it leaked the
+// internal snake_case identifier `sourcemap_filename`, which is not a real option name.
+export default defineTest({
+  config: {
+    output: {
+      sourcemap: true,
+      sourcemapFileNames: '/absolute.map',
+    },
+  },
+  afterTest: () => {
+    expect.unreachable('an absolute sourcemapFileNames pattern should fail validation');
+  },
+  catchError: (error: unknown) => {
+    expect(String(error)).toContain('for "sourcemapFileNames"');
+    expect(String(error)).not.toContain('sourcemap_filename');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/main.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/main.js
@@ -1,0 +1,1 @@
+export const value = 42;


### PR DESCRIPTION
## Summary

An invalid `output.sourcemapFileNames` pattern reported its diagnostic against the internal `sourcemap_filename` identifier, which is not a real option name:

```
[INVALID_OPTION] Invalid pattern "/absolute.map" for "sourcemap_filename", patterns can be neither absolute nor relative paths.
```

`generate_preliminary_sourcemap_filename` now passes the public camelCase `sourcemapFileNames` to `FilenameTemplate`, matching every other filename-template site (`entryFileNames`, `chunkFileNames`), so the error reads `for "sourcemapFileNames"`.

## Test Plan

- New fixture `output/sourcemap-filenames/invalid-pattern-diagnostic` asserts the diagnostic names `sourcemapFileNames` (and not the snake_case leak). Verified **RED** on `main`, **GREEN** on this branch.

Follow-up to #9271 / #10178.
