### PR TITLE
refactor(sourcemap_filenames): drop dead sourcemap-filename plumbing

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -301,7 +301,7 @@ impl Generator for EcmaGenerator {
           .preliminary_filename
           .clone()
           .expect("should have preliminary filename"),
-        preliminary_sourcemap_filename: ctx.chunk.preliminary_sourcemap_filename.clone().into(),
+        preliminary_sourcemap_filename: ctx.chunk.preliminary_sourcemap_filename.clone(),
         augment_chunk_hash: None,
         post_banner,
         post_footer,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -6,7 +6,7 @@ use oxc_index::IndexVec;
 use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames;
 use rolldown_common::{
   ChunkIdx, ChunkKind, InstantiationKind, OutputExports, PackageJson, PathsOutputOption,
-  PreliminarySourcemapFilename, UsedSymbolRefs, UsedSymbolRefsBuilder,
+  UsedSymbolRefs, UsedSymbolRefsBuilder,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -354,10 +354,9 @@ impl<'a> GenerateStage<'a> {
 
     for chunk_id in &chunk_graph.sorted_chunk_idx_vec {
       let chunk = &mut chunk_graph.chunk_table[*chunk_id];
-      if chunk.preliminary_filename.is_some()
-        && chunk.preliminary_sourcemap_filename != PreliminarySourcemapFilename::Uninstantiated
-      {
-        // Already generated
+      // `preliminary_filename` is the single source of truth for "already generated": it is
+      // written only here, together with `preliminary_sourcemap_filename`.
+      if chunk.preliminary_filename.is_some() {
         continue;
       }
 
@@ -367,40 +366,38 @@ impl<'a> GenerateStage<'a> {
         .insert(*chunk_id, pre_generated_chunk_name.representative_chunk_name.clone());
       let pre_rendered_chunk =
         generate_pre_rendered_chunk(chunk, &pre_generated_chunk_name.chunk_name, self.link_output);
-      if chunk.preliminary_filename.is_none() {
-        let preliminary_filename = chunk
-          .generate_preliminary_filename(
-            self.options,
-            &pre_rendered_chunk,
-            &pre_generated_chunk_name.chunk_filename,
-            &mut hash_placeholder_generator,
-            &used_name_counts,
-          )
-          .await?;
-        // Defer chunk name assignment to make sure at this point only entry chunk have a name
-        // if user provided one.
-        chunk.name = Some(pre_generated_chunk_name.chunk_name.clone());
+      let preliminary_filename = chunk
+        .generate_preliminary_filename(
+          self.options,
+          &pre_rendered_chunk,
+          &pre_generated_chunk_name.chunk_filename,
+          &mut hash_placeholder_generator,
+          &used_name_counts,
+        )
+        .await?;
+      // Defer chunk name assignment to make sure at this point only entry chunk have a name
+      // if user provided one.
+      chunk.name = Some(pre_generated_chunk_name.chunk_name.clone());
 
-        chunk.absolute_preliminary_filename = Some(
-          preliminary_filename
-            .absolutize_with(self.options.cwd.join(&self.options.out_dir))
-            .into_owned()
-            .expect_into_string(),
-        );
-        chunk.preliminary_filename = Some(preliminary_filename);
-      }
-      if chunk.preliminary_sourcemap_filename == PreliminarySourcemapFilename::Uninstantiated {
-        let preliminary_sourcemap_filename = chunk
-          .generate_preliminary_sourcemap_filename(
-            self.options,
-            &pre_rendered_chunk,
-            &pre_generated_chunk_name.chunk_filename,
-            &mut hash_placeholder_generator,
-            &used_name_counts,
-          )
-          .await?;
-        chunk.preliminary_sourcemap_filename = preliminary_sourcemap_filename;
-      }
+      chunk.absolute_preliminary_filename = Some(
+        preliminary_filename
+          .absolutize_with(self.options.cwd.join(&self.options.out_dir))
+          .into_owned()
+          .expect_into_string(),
+      );
+      chunk.preliminary_filename = Some(preliminary_filename);
+      // Derives its `[chunkhash]` from the just-assigned `preliminary_filename`, so it must run
+      // after it.
+      let preliminary_sourcemap_filename = chunk
+        .generate_preliminary_sourcemap_filename(
+          self.options,
+          &pre_rendered_chunk,
+          &pre_generated_chunk_name.chunk_filename,
+          &mut hash_placeholder_generator,
+          &used_name_counts,
+        )
+        .await?;
+      chunk.preliminary_sourcemap_filename = preliminary_sourcemap_filename;
       chunk.pre_rendered_chunk = Some(pre_rendered_chunk);
     }
     Ok(index_chunk_id_to_representative_name)

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -149,7 +149,6 @@ pub struct JsOutputChunk {
   pub map: Option<BindingSourcemap>,
   pub sourcemap_filename: Option<String>,
   pub preliminary_filename: String,
-  pub preliminary_sourcemap_filename: Option<String>,
 }
 
 pub fn update_output_chunk(

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -58,23 +58,6 @@ pub enum PostChunkOptimizationOperation {
   RemovedWithPreservedExports,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub enum PreliminarySourcemapFilename {
-  #[default]
-  Uninstantiated,
-  Empty,
-  Template(PreliminaryFilename),
-}
-
-impl From<PreliminarySourcemapFilename> for Option<PreliminaryFilename> {
-  fn from(value: PreliminarySourcemapFilename) -> Self {
-    match value {
-      PreliminarySourcemapFilename::Uninstantiated | PreliminarySourcemapFilename::Empty => None,
-      PreliminarySourcemapFilename::Template(preliminary_filename) => Some(preliminary_filename),
-    }
-  }
-}
-
 impl ChunkMeta {
   #[inline]
   pub fn is_pure_user_defined_entry(&self) -> bool {
@@ -93,7 +76,7 @@ pub struct Chunk {
   // emitted chunk corresponding reference_id, used to `PluginContext#getFileName` to search the emitted chunk name
   pub pre_rendered_chunk: Option<RollupPreRenderedChunk>,
   pub preliminary_filename: Option<PreliminaryFilename>,
-  pub preliminary_sourcemap_filename: PreliminarySourcemapFilename,
+  pub preliminary_sourcemap_filename: Option<PreliminaryFilename>,
   pub absolute_preliminary_filename: Option<String>,
   pub canonical_names: FxHashMap<SymbolRef, CompactStr>,
   /// For mixed-mode externals: maps external `namespace_ref` to the node-mode binding name.
@@ -252,9 +235,9 @@ impl Chunk {
     chunk_name: &ArcStr,
     hash_placeholder_generator: &mut HashPlaceholderGenerator,
     used_name_counts: &FxDashMap<ArcStr, u32>,
-  ) -> anyhow::Result<PreliminarySourcemapFilename> {
+  ) -> anyhow::Result<Option<PreliminaryFilename>> {
     let Some(sourcemap_filename) = &options.sourcemap_filenames else {
-      return Ok(PreliminarySourcemapFilename::Empty);
+      return Ok(None);
     };
     let sourcemap_filename = sourcemap_filename.call(rollup_pre_rendered_chunk).await?;
 
@@ -286,12 +269,12 @@ impl Chunk {
       .into();
 
     if options.sourcemap.is_none() {
-      return Ok(PreliminarySourcemapFilename::Empty);
+      return Ok(None);
     }
 
     let name = make_unique_name(&filename, used_name_counts);
 
-    Ok(PreliminarySourcemapFilename::Template(PreliminaryFilename::new(name, hash_placeholder)))
+    Ok(Some(PreliminaryFilename::new(name, hash_placeholder)))
   }
 
   fn get_preserve_modules_chunk_name<'a, 'b: 'a>(

--- a/crates/rolldown_common/src/chunk/types/preliminary_filename.rs
+++ b/crates/rolldown_common/src/chunk/types/preliminary_filename.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use arcstr::ArcStr;
 
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone)]
 /// Represents a filename that might contains hash placeholder.
 pub struct PreliminaryFilename {
   /// Might contains preliminary hash
@@ -26,10 +26,5 @@ impl Deref for PreliminaryFilename {
 
   fn deref(&self) -> &Self::Target {
     &self.filename
-  }
-}
-impl PartialEq for PreliminaryFilename {
-  fn eq(&self, other: &Self) -> bool {
-    self.filename == other.filename
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -102,7 +102,7 @@ pub mod bundler_options {
 // We don't want internal position adjustment of files affect users, so all items are exported in the root.
 pub use crate::{
   chunk::{
-    Chunk, ChunkMeta, PostChunkOptimizationOperation, PreliminarySourcemapFilename,
+    Chunk, ChunkMeta, PostChunkOptimizationOperation,
     chunk_table::ChunkTable,
     types::{
       AddonRenderContext,

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2991,7 +2991,6 @@ export interface JsOutputChunk {
   map?: BindingSourcemap
   sourcemapFilename?: string
   preliminaryFilename: string
-  preliminarySourcemapFilename?: string
 }
 
 /** Error emitted from native side, it only contains kind and message, no stack trace. */


### PR DESCRIPTION
## Summary

Dead-code cleanup around sourcemap filename generation. **No behavior change** — all `output/sourcemap-filenames/*` fixtures pass unchanged.

- Remove `JsOutputChunk.preliminary_sourcemap_filename`: it is written from the JS side but never read back, and leaked a phantom `preliminarySourcemapFilename?: string` into the published binding typings (`binding.d.cts`).
- Replace the three-state `PreliminarySourcemapFilename` enum with plain `Option<PreliminaryFilename>`. The `Uninstantiated` state was unreachable after generation, so the sourcemap filename is now generated in lockstep with `preliminary_filename` inside the single `is_none()` block, and the skip guard collapses to `preliminary_filename.is_some()`.
- Drop the now-dead filename-only `PartialEq`/`Eq` on `PreliminaryFilename` (nothing compares them once the enum's derive is gone).

## Test Plan

- `cargo clippy -p rolldown -p rolldown_common --lib --features experimental -- --deny warnings`
- `just build-rolldown` + all `output/sourcemap-filenames/*` fixtures pass (8/8).

Stacked on #10188.
