### PR TITLE
perf(ast_scanner): stop order-sensitivity checks once a module is flagged

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -92,8 +92,9 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       // Tree-shaking side effects / global reads / pure annotations come from the analyzer.
       // Top-level reads of imported bindings are detected by a separate uniform walk so the
       // signal is complete by construction (no per-expression-form gaps).
-      if stmt_eval_facts.is_order_sensitive()
-        || TopLevelImportReadDetector::detect(&self.result.symbol_ref_db.ast_scopes, stmt)
+      if !self.result.ecma_view_meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
+        && (stmt_eval_facts.is_order_sensitive()
+          || TopLevelImportReadDetector::detect(&self.result.symbol_ref_db.ast_scopes, stmt))
       {
         self.result.ecma_view_meta.insert(EcmaViewMeta::ExecutionOrderSensitive);
       }


### PR DESCRIPTION
Follow-up to #10180.

`ExecutionOrderSensitive` is a module-level flag, so a single positive is enough. This guards the per-statement check in the scanner loop with `!contains(ExecutionOrderSensitive)`, so once a module has been flagged the remaining statements skip both the analyzer's order-sensitive check and the `TopLevelImportReadDetector` walk.

Pure perf — no behavior change (the flag's final value is identical).
