### PR TITLE
fix: keep deduplicated asset filenames stable once they can be observed

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -92,6 +92,19 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     &mut self,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<NormalizedScanStageOutput> {
+    // The whole scan (buildStart through buildEnd) is the build phase. Resetting on every exit
+    // means a failed scan cannot leave the emitter stuck in the build phase, where a later emit
+    // (e.g. an HMR patch after a failed rebuild) could still change an already-emitted filename.
+    self.plugin_driver.file_emitter.enter_build_phase();
+    let result = self.scan_modules_impl(scan_mode).await;
+    self.plugin_driver.file_emitter.enter_output_phase();
+    result
+  }
+
+  async fn scan_modules_impl(
+    &mut self,
+    scan_mode: ScanMode<ArcStr>,
+  ) -> BuildResult<NormalizedScanStageOutput> {
     trace_action!(action::BuildStart { action: "BuildStart" });
     let is_full_scan_mode = scan_mode.is_full();
 

--- a/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/asset_dedup_filename/mod.rs
@@ -3,7 +3,10 @@ use std::{borrow::Cow, sync::Arc};
 use arcstr::ArcStr;
 use rolldown::{AssetFilenamesOutputOption, Bundler, BundlerOptions, InputItem};
 use rolldown_common::{EmittedAsset, Output, OutputAsset};
-use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+use rolldown_plugin::{
+  __inner::SharedPluginable, HookRenderChunkArgs, HookRenderChunkReturn, HookUsage, Plugin,
+  PluginContext,
+};
 
 /// Identical content shared by every deduplicated asset; only the name varies.
 const SHARED_SOURCE: &str = "shared";
@@ -82,8 +85,104 @@ impl Plugin for EmitPlugin {
   }
 }
 
+/// Emits the configured assets from `render_chunk`, i.e. during the output phase,
+/// exercising the first-emitted-wins path that keeps `get_file_name` stable for Vite.
+#[derive(Debug)]
+struct RenderChunkEmitPlugin {
+  emits: Vec<Emit>,
+}
+
+impl Plugin for RenderChunkEmitPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "render-chunk-emit".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::RenderChunk
+  }
+
+  async fn render_chunk(
+    &self,
+    ctx: &PluginContext,
+    _args: &HookRenderChunkArgs<'_>,
+  ) -> HookRenderChunkReturn {
+    for emit in &self.emits {
+      ctx.emit_file(emit.to_emitted(), None, None)?;
+    }
+    Ok(None)
+  }
+}
+
+/// Emits the configured assets from `build_end`, the last build-phase hook. It runs after the
+/// module loader is torn down but is still the build phase, so dedup keeps shortest-name-wins.
+#[derive(Debug)]
+struct BuildEndEmitPlugin {
+  emits: Vec<Emit>,
+}
+
+impl Plugin for BuildEndEmitPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "build-end-emit".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildEnd
+  }
+
+  async fn build_end(
+    &self,
+    ctx: &PluginContext,
+    _args: Option<&rolldown_plugin::HookBuildEndArgs<'_>>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    for emit in &self.emits {
+      ctx.emit_file(emit.to_emitted(), None, None)?;
+    }
+    Ok(())
+  }
+}
+
+/// Emits `build_emits` from `build_start` (build phase) and `render_emits` from `render_chunk`
+/// (output phase), to exercise cross-phase deduplication of same-source assets.
+#[derive(Debug)]
+struct CrossPhaseEmitPlugin {
+  build_emits: Vec<Emit>,
+  render_emits: Vec<Emit>,
+}
+
+impl Plugin for CrossPhaseEmitPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "cross-phase-emit".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildStart | HookUsage::RenderChunk
+  }
+
+  async fn build_start(
+    &self,
+    ctx: &PluginContext,
+    _args: &rolldown_plugin::HookBuildStartArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    for emit in &self.build_emits {
+      ctx.emit_file(emit.to_emitted(), None, None)?;
+    }
+    Ok(())
+  }
+
+  async fn render_chunk(
+    &self,
+    ctx: &PluginContext,
+    _args: &HookRenderChunkArgs<'_>,
+  ) -> HookRenderChunkReturn {
+    for emit in &self.render_emits {
+      ctx.emit_file(emit.to_emitted(), None, None)?;
+    }
+    Ok(None)
+  }
+}
+
 /// Bundles a dummy entry with `plugin` and returns the emitted output assets.
-async fn bundle(plugin: EmitPlugin) -> Vec<Arc<OutputAsset>> {
+async fn bundle(plugin: SharedPluginable) -> Vec<Arc<OutputAsset>> {
   let mut bundler = Bundler::with_plugins(
     BundlerOptions {
       input: Some(vec![InputItem {
@@ -98,7 +197,7 @@ async fn bundle(plugin: EmitPlugin) -> Vec<Arc<OutputAsset>> {
       )),
       ..Default::default()
     },
-    vec![Arc::new(plugin)],
+    vec![plugin],
   )
   .expect("failed to create bundler");
 
@@ -116,11 +215,19 @@ async fn bundle(plugin: EmitPlugin) -> Vec<Arc<OutputAsset>> {
 }
 
 async fn emit_assets(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
-  bundle(EmitPlugin { emits, concurrent: false }).await
+  bundle(Arc::new(EmitPlugin { emits, concurrent: false })).await
 }
 
 async fn emit_assets_concurrently(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
-  bundle(EmitPlugin { emits, concurrent: true }).await
+  bundle(Arc::new(EmitPlugin { emits, concurrent: true })).await
+}
+
+async fn emit_assets_in_render_chunk(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
+  bundle(Arc::new(RenderChunkEmitPlugin { emits })).await
+}
+
+async fn emit_assets_in_build_end(emits: Vec<Emit>) -> Vec<Arc<OutputAsset>> {
+  bundle(Arc::new(BuildEndEmitPlugin { emits })).await
 }
 
 /// The surviving file name must be deterministic across emission orders and is
@@ -201,4 +308,63 @@ async fn concurrent_dedup_keeps_every_name() {
 
   assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
   assert_eq!(assets[0].names.len(), COUNT, "no concurrently-emitted name may be lost");
+}
+
+/// In the output phase a duplicate must not change the survivor filename, even a shorter one,
+/// so a name already read via `get_file_name` and cached by a consumer (Vite) stays valid.
+/// This is the vitejs/vite#22856 fix. Contrast with the build-phase shortest-wins tests above.
+#[tokio::test(flavor = "multi_thread")]
+async fn output_phase_keeps_first_emitted_name_not_shortest() {
+  // Emit the longer name first, then a strictly shorter one, during renderChunk.
+  let assets =
+    emit_assets_in_render_chunk(vec![Emit::dedup("aaaa.txt"), Emit::dedup("z.txt")]).await;
+
+  assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
+  assert!(
+    assets[0].filename.starts_with("assets/aaaa-"),
+    "first emitted name must win in the output phase and never be mutated to the shorter one, got: {}",
+    assets[0].filename
+  );
+  // Every duplicate's name is still collected on the survivor.
+  let names: Vec<&str> = assets[0].names.iter().map(String::as_str).collect();
+  assert_eq!(
+    names,
+    ["z.txt", "aaaa.txt"],
+    "all names collected, sorted shortest-then-lexicographic"
+  );
+}
+
+/// `buildEnd` is the last build-phase hook, so its emissions still get shortest-name dedup.
+/// Emitting the shorter name second must still win, unlike the output-phase test above.
+#[tokio::test(flavor = "multi_thread")]
+async fn build_end_emissions_still_use_shortest_name() {
+  let assets = emit_assets_in_build_end(vec![Emit::dedup("aaaa.txt"), Emit::dedup("z.txt")]).await;
+
+  assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
+  assert!(
+    assets[0].filename.starts_with("assets/z-"),
+    "buildEnd is still the build phase, so the shortest name must win, got: {}",
+    assets[0].filename
+  );
+}
+
+/// The real vitejs/vite#22856 shape: an asset emitted in the build phase, then a shorter
+/// same-source duplicate in renderChunk. The build-phase name may already be cached by a
+/// consumer, so the shorter output-phase name must not win or mutate the survivor.
+#[tokio::test(flavor = "multi_thread")]
+async fn build_then_output_phase_duplicate_keeps_build_name() {
+  let assets = bundle(Arc::new(CrossPhaseEmitPlugin {
+    build_emits: vec![Emit::dedup("aaaa.txt")],
+    render_emits: vec![Emit::dedup("z.txt")],
+  }))
+  .await;
+
+  assert_eq!(assets.len(), 1, "identical content deduplicates into one asset");
+  assert!(
+    assets[0].filename.starts_with("assets/aaaa-"),
+    "the build-phase name must survive; a shorter output-phase duplicate must not mutate it, got: {}",
+    assets[0].filename
+  );
+  let names: Vec<&str> = assets[0].names.iter().map(String::as_str).collect();
+  assert_eq!(names, ["z.txt", "aaaa.txt"], "both names collected on the survivor");
 }

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -14,7 +14,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use sugar_path::SugarPath;
 
 #[derive(Debug, Default)]
@@ -80,6 +80,10 @@ pub struct FileEmitter {
   chunks: FxDashMap<ArcStr, Arc<EmittedChunk>>,
   prebuilt_chunks: FxDashMap<ArcStr, Arc<EmittedPrebuiltChunk>>,
   base_reference_id: AtomicUsize,
+  /// True during the build phase (buildStart through buildEnd), false during the output
+  /// phase. Dedup only re-picks the shortest same-source name while this is true; see the
+  /// guard in `emit_file`.
+  is_build_phase: AtomicBool,
   options: Arc<NormalizedBundlerOptions>,
   /// Mark the files that have been emitted to bundle.
   emitted_files: FxDashSet<ArcStr>,
@@ -102,6 +106,7 @@ impl FileEmitter {
       prebuilt_chunks: DashMap::default(),
       emitted_chunks: DashMap::default(),
       base_reference_id: AtomicUsize::new(0),
+      is_build_phase: AtomicBool::new(false),
       options,
       emitted_files: DashSet::default(),
       emitted_filenames: FxDashSet::default(),
@@ -177,13 +182,18 @@ impl FileEmitter {
         Entry::Occupied(entry) => {
           let reference_id = entry.get().clone();
           if let Some(mut output) = self.files.get_mut(&reference_id) {
-            // Keep the shortest name (ties broken lexicographically), so the
-            // surviving file name is deterministic regardless of emission order
-            // and matches Rollup. Uses the same ordering as `names` below.
-            if file
-              .name
-              .as_deref()
-              .is_some_and(|n| output.names.iter().all(|e| (n.len(), n) < (e.len(), e.as_str())))
+            // Re-pick the shortest name (ties broken lexicographically) only while building and
+            // before the asset is flushed to a bundle. Afterwards its name may already have been
+            // read via `get_file_name` and cached by a consumer (Vite does this in renderChunk),
+            // so changing it would leave a stale filename (vitejs/vite#22856). `emitted_files`
+            // covers assets kept from an earlier incremental rebuild, since the emitter is reused.
+            // This matches Rollup: shortest-wins while building, first-wins once output started.
+            if self.is_build_phase.load(Ordering::Relaxed)
+              && !self.emitted_files.contains(&reference_id)
+              && file
+                .name
+                .as_deref()
+                .is_some_and(|n| output.names.iter().all(|e| (n.len(), n) < (e.len(), e.as_str())))
             {
               self.generate_file_name(
                 &mut file,
@@ -411,6 +421,16 @@ impl FileEmitter {
     Ok(())
   }
 
+  /// Enter the build phase, where dedup re-picks the shortest same-source name (see `emit_file`).
+  pub fn enter_build_phase(&self) {
+    self.is_build_phase.store(true, Ordering::Relaxed);
+  }
+
+  /// Enter the output phase, where dedup stops changing already-observed filenames (see `emit_file`).
+  pub fn enter_output_phase(&self) {
+    self.is_build_phase.store(false, Ordering::Relaxed);
+  }
+
   /// Associate a module ID with an emitted file reference ID.
   /// This allows the `new URL()` finalizer to look up asset filenames by module ID.
   pub fn associate_module_with_file_ref(&self, module_id: &str, reference_id: &str) {
@@ -429,6 +449,7 @@ impl FileEmitter {
     self.names.clear();
     self.source_hash_to_reference_id.clear();
     self.base_reference_id.store(0, Ordering::Relaxed);
+    self.is_build_phase.store(false, Ordering::Relaxed);
     self.emitted_files.clear();
     self.emitted_chunks.clear();
     self.emitted_filenames.clear();


### PR DESCRIPTION
### Problem

When two emitted assets have identical content but different names, rolldown deduplicates them into a single file. How that file's name gets chosen caused two bugs:

- **vitejs/vite#22856**: rolldown could rename the surviving asset to a shorter name *after* Vite had already read and cached the old name via `getFileName`. Vite's `manifest.json` (and ssr-manifest, preloads, injected `<link>`) then pointed at a CSS file that was never written.
- **rolldown#9940**: when the survivor name depended on which duplicate emitted first, the output was non-deterministic (assets emit concurrently), so identical input produced different filenames between builds.

### Fix

Choose the survivor name based on the phase, matching Rollup:

- **Build phase** (emitted while loading modules, e.g. `import x from './a.png'`): keep the shortest name. This is order-independent, so builds stay deterministic (#9940).
- **Output phase** (emitted from `renderChunk` or `generateBundle`, e.g. Vite's CSS): keep the first emitted name and never rename it, so a name already returned by `getFileName` cannot go stale (#22856).

An asset already written to an earlier incremental build is also never renamed.

### Related

- Fixes vitejs/vite#22856
- Keeps rolldown#9940 fixed