### PR TITLE
refactor: resolve the manual tsconfig per file instead of once at startup

### DIFF
--- a/crates/rolldown/src/utils/load_entry_module.rs
+++ b/crates/rolldown/src/utils/load_entry_module.rs
@@ -44,6 +44,14 @@ pub async fn load_entry_module<Fs: FileSystem>(
         package_json_path: _,
         conditions: _,
       } => Err(BuildDiagnostic::unresolved_entry(id, Some(e))),
+      ResolveError::TsconfigNotFound(ref path) | ResolveError::TsconfigSelfReference(ref path) => {
+        let file_path = path.display().to_string();
+        Err(BuildDiagnostic::tsconfig_error(file_path, e))
+      }
+      ResolveError::TsconfigCircularExtend(ref paths) => {
+        let file_path = paths.paths().first().map(|p| p.display().to_string()).unwrap_or_default();
+        Err(BuildDiagnostic::tsconfig_error(file_path, e))
+      }
       _ => Err(e).map_err_to_unhandleable()?,
     },
   }

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -358,38 +358,21 @@ pub fn prepare_build_context(
     }
 
     // Create TransformOptions based on tsconfig mode:
-    // - Auto: Create Raw mode (will resolve tsconfig per file)
-    // - None/Manual: Create Normal mode (resolve tsconfig once now)
+    // - Auto(true)/Manual: Raw mode, resolves tsconfig per file so rebuilds
+    //   can re-read edited tsconfig files
+    // - Auto(false): Normal mode without tsconfig
     match tsconfig {
-      ref v @ TsConfig::Manual(ref path) => {
-        // Manual mode: Resolve tsconfig now and create Normal mode
-        let resolved_tsconfig = resolver
-          .resolve_tsconfig(&path)
-          .map_err(|err| BuildDiagnostic::tsconfig_error(path.display().to_string(), err))?;
-        Box::new(if resolved_tsconfig.references_resolved.is_empty() {
-          TransformOptions::new(
-            merge_transform_options_with_tsconfig(
-              raw_transform_options,
-              Some(&resolved_tsconfig),
-              &mut warnings,
-            )?,
-            target,
-            jsx_preset,
-          )
-        } else {
-          TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v.clone(), yarn_pnp),
-            target,
-            jsx_preset,
-          )
-        })
-      }
-      v @ TsConfig::Auto(is_auto) => {
+      TsConfig::Manual(path) => Box::new(TransformOptions::new_raw(
+        RawTransformOptions::new(raw_transform_options, TsConfig::Manual(path), yarn_pnp),
+        target,
+        jsx_preset,
+      )),
+      TsConfig::Auto(is_auto) => {
         Box::new(if is_auto {
           // Auto mode: Create Raw mode TransformOptions
           // Each file will find its nearest tsconfig during compilation
           TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v, yarn_pnp),
+            RawTransformOptions::new(raw_transform_options, TsConfig::Auto(true), yarn_pnp),
             target,
             jsx_preset,
           )


### PR DESCRIPTION
Groundwork for #9598 (rebuild when tsconfig changes).

A manual tsconfig without references was resolved and merged into the transform options once when the bundler is created (Normal mode). That merged result lives as long as the bundler, so a watch rebuild can never pick up tsconfig edits. This PR makes manual mode always go through Raw mode, the same per-file resolution path that auto-discovery and manual-with-references already use. Together with a follow-up that clears the tsconfig caches on watch rebuilds, tsconfig edits become re-readable for every mode.

Since the eager `resolve_tsconfig` call is gone, a broken manual tsconfig now fails on the first resolution instead of at startup: every resolve consults the tsconfig for `paths`/`baseUrl`/`rootDirs` before doing normal path resolution, which lazily loads the tsconfig file. For the entry this used to end up as `UNHANDLEABLE_ERROR`, because `load_entry_module` only mapped `NotFound` and `PackagePathNotExported` and sent everything else to the unhandleable fallback. `TsconfigNotFound`, `TsconfigSelfReference` and `TsconfigCircularExtend` are now mapped to a proper `TSCONFIG_ERROR`. The rendered message is identical to the old startup-time one, so existing snapshots stay unchanged. The import side (`resolve_utils`) already prints readable messages for these variants and needs no change.

Two behavior differences worth knowing while reviewing: files that per-file discovery skips (inside node_modules, virtual modules, plain JS) now get the base transform options instead of the merged manual tsconfig, which matches what auto-discovery and manual-with-references already do. And tsconfig merge-conflict warnings show up when the first file using that tsconfig is compiled, not at startup.

Part of #9598.
