### PR TITLE
refactor(rolldown): collapse vestigial wrap-kind state and share chunk sort helper

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -2,7 +2,7 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
+  Chunk, ChunkIdx, ChunkKind, ChunkMeta, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
   PostChunkOptimizationOperation, RuntimeHelper, SymbolRef,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -58,6 +58,22 @@ impl ChunkGraph {
     let idx = self.chunk_table.push(chunk);
     self.finalized_cjs_ns_map_idx_vec.push(FxHashMap::default());
     idx
+  }
+
+  /// Render order: user-defined entry chunks first (stable by index), everything else by
+  /// execution order.
+  pub fn rebuild_sorted_chunk_idx_vec(&mut self) {
+    self.sorted_chunk_idx_vec = self
+      .chunk_table
+      .iter_enumerated()
+      .sorted_unstable_by_key(|(index, chunk)| match &chunk.kind {
+        ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry) => {
+          (0, index.raw())
+        }
+        _ => (1, chunk.exec_order),
+      })
+      .map(|(idx, _)| idx)
+      .collect();
   }
 
   pub fn add_module_to_chunk(

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -39,7 +39,6 @@ pub type IndexSplittingInfo = IndexVec<ModuleIdx, SplittingInfo>;
 
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
-  #[expect(clippy::too_many_lines)]
   pub async fn generate_chunks(
     &mut self,
     used_symbol_refs: &mut UsedSymbolRefsBuilder,
@@ -253,19 +252,7 @@ impl GenerateStage<'_> {
     // EntryPoint (is_user_defined: true) < EntryPoint (is_user_defined: false) or Common
     // [order by chunk index]               [order by exec order]
 
-    let sorted_chunk_idx_vec = chunk_graph
-      .chunk_table
-      .iter_enumerated()
-      .sorted_unstable_by_key(|(index, chunk)| match &chunk.kind {
-        ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry) => {
-          (0, index.raw())
-        }
-        _ => (1, chunk.exec_order),
-      })
-      .map(|(idx, _)| idx)
-      .collect::<Vec<_>>();
-
-    chunk_graph.sorted_chunk_idx_vec = sorted_chunk_idx_vec;
+    chunk_graph.rebuild_sorted_chunk_idx_vec();
 
     self.find_entry_level_external_module(&mut chunk_graph);
 
@@ -329,7 +316,7 @@ impl GenerateStage<'_> {
         })
         .filter_map(|idx| {
           let module = self.link_output.module_table[idx].as_normal()?;
-          (!self.link_output.metas[module.idx].original_wrap_kind().is_none()).then_some(idx)
+          (!self.link_output.metas[module.idx].wrap_kind().is_none()).then_some(idx)
         })
         .collect::<FxHashSet<_>>();
       let chunk_module_to_exec_order = chunk
@@ -345,7 +332,7 @@ impl GenerateStage<'_> {
       let mut none_wrapped_module_to_wrapped_dependency_length = FxHashMap::default();
       let js_import_order = self.js_import_order(&roots, &chunk_module_to_exec_order);
       for idx in js_import_order {
-        match self.link_output.metas[idx].original_wrap_kind() {
+        match self.link_output.metas[idx].wrap_kind() {
           WrapKind::None => {
             if !wrapped_modules.is_empty() {
               none_wrapped_module_to_wrapped_dependency_length.insert(idx, wrapped_modules.len());
@@ -402,7 +389,7 @@ impl GenerateStage<'_> {
         FxHashMap::default();
       let mut remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>> = FxHashMap::default();
       for (module_idx, (importer_idx, rec_idx)) in module_init_position {
-        match self.link_output.metas[module_idx].original_wrap_kind() {
+        match self.link_output.metas[module_idx].wrap_kind() {
           WrapKind::None => {
             if let Some(deps_length) =
               none_wrapped_module_to_wrapped_dependency_length.get(&module_idx)

--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -49,13 +49,13 @@ impl LinkStage<'_> {
           }
           ImportKind::Require => match importee_kind {
             ExportsKind::Esm => {
-              self.metas[importee_idx].sync_wrap_kind(WrapKind::Esm);
+              self.metas[importee_idx].set_wrap_kind(WrapKind::Esm);
             }
             ExportsKind::CommonJs => {
-              self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+              self.metas[importee_idx].set_wrap_kind(WrapKind::Cjs);
             }
             ExportsKind::None => {
-              self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+              self.metas[importee_idx].set_wrap_kind(WrapKind::Cjs);
               // A `require`'d module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`.
               if let Some(m) = self.module_table[importee_idx].as_normal_mut() {
                 m.exports_kind = ExportsKind::CommonJs;
@@ -68,13 +68,13 @@ impl LinkStage<'_> {
               // like a `require()` that returns a promise, so the imported module must be wrapped.
               match importee_kind {
                 ExportsKind::Esm => {
-                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Esm);
+                  self.metas[importee_idx].set_wrap_kind(WrapKind::Esm);
                 }
                 ExportsKind::CommonJs => {
-                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+                  self.metas[importee_idx].set_wrap_kind(WrapKind::Cjs);
                 }
                 ExportsKind::None => {
-                  self.metas[importee_idx].sync_wrap_kind(WrapKind::Cjs);
+                  self.metas[importee_idx].set_wrap_kind(WrapKind::Cjs);
                   // A dynamically-imported module with `ExportsKind::None` is promoted to `ExportsKind::CommonJs`
                   // since we wrap it as CJS.
                   if let Some(m) = self.module_table[importee_idx].as_normal_mut() {
@@ -102,7 +102,7 @@ impl LinkStage<'_> {
           || (matches!(self.options.format, OutputFormat::Iife | OutputFormat::Umd)
             && importer.ast_usage.intersects(EcmaModuleAstUsage::ModuleOrExports)))
       {
-        self.metas[importer.idx].sync_wrap_kind(WrapKind::Cjs);
+        self.metas[importer.idx].set_wrap_kind(WrapKind::Cjs);
       }
     }
   }

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -316,7 +316,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   // for a es json module it did not needs to be wrapped anyway.
   link_staged.metas[module_idx].wrapper_stmt_info = None;
   link_staged.metas[module_idx].wrapper_ref = None;
-  link_staged.metas[module_idx].sync_wrap_kind(WrapKind::None);
+  link_staged.metas[module_idx].set_wrap_kind(WrapKind::None);
 
   link_staged.symbols.store_local_db(module_idx, symbol_ref_db);
   true

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -48,7 +48,7 @@ fn wrap_module_recursively(ctx: &mut Context, target: ModuleIdx) {
       ExportsKind::Esm | ExportsKind::None => WrapKind::Esm,
       ExportsKind::CommonJs => WrapKind::Cjs,
     };
-    ctx.linking_infos[target].sync_wrap_kind(new_wrap_kind);
+    ctx.linking_infos[target].set_wrap_kind(new_wrap_kind);
   }
 
   module.import_records.iter().for_each(|rec| {
@@ -171,7 +171,7 @@ impl LinkStage<'_> {
         };
         if cjs_exports_kind_modules.contains(&idx) {
           // If the module is CommonJs, we need to wrap it.
-          linking_info.update_wrap_kind(WrapKind::Cjs);
+          linking_info.set_wrap_kind(WrapKind::Cjs);
         } else {
           // If the module is a pure esm, only exports function or expression without side
           // effects and is not execution order sensitive , we don't need to wrap it.
@@ -179,11 +179,7 @@ impl LinkStage<'_> {
             && !module.meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
             && module.import_records.is_empty()
             && !linking_info.required_by_other_module;
-          linking_info.update_wrap_kind(if avoid_wrapping {
-            WrapKind::None
-          } else {
-            WrapKind::Esm
-          });
+          linking_info.set_wrap_kind(if avoid_wrapping { WrapKind::None } else { WrapKind::Esm });
         }
       }
     }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -39,13 +39,7 @@ pub struct LinkingMetadata {
   /// `wrapper_ref` is the `require_cjs` identifier in above example.
   pub wrapper_ref: Option<SymbolRef>,
   pub wrapper_stmt_info: Option<StmtInfoIdx>,
-  /// Because when `strictExecutionOrder` is enabled, all modules will be wrapped
-  /// we need to store the original wrap kind that used for
-  /// [rolldown::stages::generate_stage::code_splitting::GenerateStage::ensure_lazy_module_initialization_order] analysis
-  original_wrap_kind: WrapKind,
-  /// The `wrap_kind` used for linking and code generation.
-  /// Intent to make those two fields private, so that we could ensure they are mutated in a more
-  /// safe way.
+  /// The module representation decided during linking.
   wrap_kind: WrapKind,
   // Store the export info for each module, including export named declaration and export star declaration.
   pub resolved_exports: FxHashMap<CompactStr, ResolvedExport>,
@@ -148,21 +142,7 @@ impl LinkingMetadata {
   }
 
   #[inline]
-  pub fn original_wrap_kind(&self) -> WrapKind {
-    self.original_wrap_kind
-  }
-
-  /// Synchronize the `wrap_kind` with the original wrap kind.
-  #[inline]
-  pub fn sync_wrap_kind(&mut self, wrap_kind: WrapKind) {
-    self.original_wrap_kind = wrap_kind;
-    self.wrap_kind = wrap_kind;
-  }
-
-  /// Use this api with caution, ideally it should be only used for https://github.com/rolldown/rolldown/blob/76350f2b77364dbba29ba93562589a6eba6211dd/crates/rolldown/src/stages/link_stage/wrapping.rs?plain=1#L165-L185
-  /// override the wrapping kind when `strictExecutionOrder` is enabled.
-  #[inline]
-  pub fn update_wrap_kind(&mut self, wrap_kind: WrapKind) {
+  pub fn set_wrap_kind(&mut self, wrap_kind: WrapKind) {
     self.wrap_kind = wrap_kind;
   }
 

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -34,17 +34,23 @@ pub struct NormalModule {
 }
 
 impl NormalModule {
-  pub fn star_export_module_ids(&self) -> impl Iterator<Item = ModuleIdx> + '_ {
+  pub fn star_export_records(&self) -> impl Iterator<Item = (ImportRecordIdx, ModuleIdx)> + '_ {
     if self.has_star_export() {
-      itertools::Either::Left(self.ecma_view.import_records.iter().filter_map(|rec| {
-        if !rec.meta.contains(ImportRecordMeta::IsExportStar) {
-          return None;
-        }
-        rec.resolved_module
-      }))
+      itertools::Either::Left(self.ecma_view.import_records.iter_enumerated().filter_map(
+        |(rec_idx, rec)| {
+          if !rec.meta.contains(ImportRecordMeta::IsExportStar) {
+            return None;
+          }
+          rec.resolved_module.map(|module_idx| (rec_idx, module_idx))
+        },
+      ))
     } else {
       itertools::Either::Right(std::iter::empty())
     }
+  }
+
+  pub fn star_export_module_ids(&self) -> impl Iterator<Item = ModuleIdx> + '_ {
+    self.star_export_records().map(|(_, module_idx)| module_idx)
   }
 
   pub fn has_star_export(&self) -> bool {


### PR DESCRIPTION
**What this does (and doesn't).** Byte-neutral cleanup of wrap-kind bookkeeping plus one shared chunk-graph helper. It (a) removes the `LinkingMetadata::original_wrap_kind` field, collapsing it into `wrap_kind` and merging `sync_wrap_kind`/`update_wrap_kind` into a single `set_wrap_kind`; (b) adds `NormalModule::star_export_records` and reroutes `star_export_module_ids` through it; (c) extracts the chunk render-order sort out of `generate_chunks` into `ChunkGraph::rebuild_sorted_chunk_idx_vec`. It does NOT change any generated output, add any feature, or introduce the liveness helpers (`chunk_is_live` / `module_is_in_live_chunk`) — those have no caller in this PR and are left for the later feature layer.

**Why.** `original_wrap_kind` existed only to remember a module's pre-strict wrap kind for the code-splitting lazy-init analysis. But that analysis (`ensure_lazy_module_initialization_order`) early-returns whenever strict execution order is enabled, which is the only situation where `wrap_kind` and `original_wrap_kind` ever diverge — so the second copy is never actually read, and dropping it changes nothing. The `star_export_records` and `rebuild_sorted_chunk_idx_vec` extractions turn two inline blobs into named, reusable helpers with identical behavior, so the later strict-execution-order layers can build on them without a churny diff.

**Validation.** `cargo test -p rolldown --test integration`: 1801 fixtures pass; the 5 failures are pre-existing and environment-only (missing `cjs-module-lexer` / `util-deprecate` npm packages and an unpopulated `test262` submodule), unrelated to this change. `cargo clippy -p rolldown --all-targets -- -D warnings` is clean and `cargo fmt --all` produces no diff. Zero snapshot changes across the ~1800 fixtures — byte-identical output.

**Stack.** Part of a stack slicing the `output.strictExecutionOrder` work into reviewable layers. Next: (2) route interop ESM init emission through a shared init-target view; (3) skip CJS namespace merging under strict execution order.
