### PR TITLE
refactor(rolldown): route interop ESM init emission through a shared init-target view

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -2,6 +2,7 @@ use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
   ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts,
   RetainedExportSymbols, RuntimeModuleBrief, SharedFileEmitter, StmtInfos, SymbolRef, SymbolRefDb,
+  WrapKind,
 };
 
 pub type FinalizerMutableFields = (
@@ -20,7 +21,7 @@ use crate::{
   chunk_graph::ChunkGraph,
   module_finalizers::{ScopeHoistingFinalizer, TraverseState},
   stages::link_stage::SafelyMergeCjsNsInfo,
-  types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
+  types::linking_metadata::{EsmInitTarget, LinkingMetadata, LinkingMetadataVec},
 };
 
 pub struct ScopeHoistingFinalizerContext<'me> {
@@ -49,7 +50,39 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub has_enum_inlining: bool,
 }
 
+/// How the finalizer must wrap the current module, resolved once from its linking metadata.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ModuleWrapperMode {
+  /// No wrapper declaration is emitted for this module.
+  None,
+  /// CJS interop wrapper (`__commonJS`); carries the wrapper symbol.
+  InteropCjs(SymbolRef),
+  /// ESM interop wrapper (`__esm`); carries the init target the call sites reference.
+  InteropEsm(EsmInitTarget),
+}
+
 impl<'me> ScopeHoistingFinalizerContext<'me> {
+  /// Classify how this module's wrapper is emitted. Replaces the finalizer's inline
+  /// `wrap_kind() + wrapper-statement-included` checks with a single view so all wrapper and
+  /// `init_*()` decisions read the same source of truth.
+  pub(super) fn wrapper_mode(&self) -> ModuleWrapperMode {
+    let legacy_wrapper_is_included = self
+      .linking_info
+      .wrapper_stmt_info
+      .is_some_and(|stmt_idx| self.linking_info.stmt_info_included.has_bit(stmt_idx));
+
+    if matches!(self.linking_info.wrap_kind(), WrapKind::Cjs) && legacy_wrapper_is_included {
+      return ModuleWrapperMode::InteropCjs(
+        self.linking_info.wrapper_ref.expect("included CJS wrapper should have a symbol"),
+      );
+    }
+
+    match self.linking_info.esm_init_target() {
+      Some(target) if legacy_wrapper_is_included => ModuleWrapperMode::InteropEsm(target),
+      _ => ModuleWrapperMode::None,
+    }
+  }
+
   #[tracing::instrument(level = "trace", skip_all)]
   pub fn finalize_normal_module(
     self,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -12,11 +12,14 @@ use oxc::{
   span::{SPAN, Span},
 };
 use oxc_str::CompactStr;
-use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKind, WrapKind};
+use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKind};
 use rolldown_ecmascript::ToSourceString;
-use rolldown_ecmascript_utils::{ExpressionExt, JsxExt, JsxMemberExpressionObjectExt};
+use rolldown_ecmascript_utils::{
+  EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperStmtOptions, ExpressionExt, JsxExt,
+  JsxMemberExpressionObjectExt,
+};
 
-use crate::module_finalizers::{KeepNameId, TraverseState};
+use crate::module_finalizers::{KeepNameId, ModuleWrapperMode, TraverseState};
 
 use super::ScopeHoistingFinalizer;
 
@@ -104,14 +107,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     }
 
     // check if we need to add wrapper
-    let included_wrap_kind = self
-      .ctx
-      .linking_info
-      .wrapper_stmt_info
-      .is_some_and(|idx| self.ctx.linking_info.stmt_info_included.has_bit(idx))
-      .then_some(self.ctx.linking_info.wrap_kind());
-
-    self.needs_hosted_top_level_binding = matches!(included_wrap_kind, Some(WrapKind::Esm));
+    let wrapper_mode = self.ctx.wrapper_mode();
+    self.needs_hosted_top_level_binding = matches!(wrapper_mode, ModuleWrapperMode::InteropEsm(_));
 
     // the order should be
     // 1. module namespace object declaration
@@ -148,9 +145,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     self.insert_keep_name_statements(&mut program.body);
     self.keep_name_statement_to_insert.clear();
 
-    match included_wrap_kind {
-      Some(WrapKind::Cjs) => {
-        let wrap_ref_name = self.canonical_name_for(self.ctx.linking_info.wrapper_ref.unwrap());
+    match wrapper_mode {
+      ModuleWrapperMode::InteropCjs(wrapper_ref) => {
+        let wrap_ref_name = self.canonical_name_for(wrapper_ref);
         let commonjs_ref = if self.ctx.options.profiler_names {
           self.canonical_ref_for_runtime("__commonJS")
         } else {
@@ -172,7 +169,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.ctx.linking_info.is_tla_or_contains_tla_dependency,
         ));
       }
-      Some(WrapKind::Esm) => {
+      ModuleWrapperMode::InteropEsm(target) => {
         let is_concatenated_wrapped_module = !matches!(
           self.ctx.linking_info.concatenated_wrapped_module_kind,
           ConcatenateWrappedModuleKind::None
@@ -207,7 +204,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         // Otherwise we'd have marked a side-effecting `init_*()` as `@__PURE__` and DCE could
         // wrongly drop it. Turns any misclassification into a loud failure across the fixtures.
         debug_assert!(
-          !self.ctx.linking_info.init_is_noop || stmts_inside_closure.is_empty(),
+          !target.init_is_noop || stmts_inside_closure.is_empty(),
           "init_is_noop set but the __esm closure is non-empty for {}",
           self.ctx.module.stable_id
         );
@@ -266,7 +263,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.canonical_ref_for_runtime("__esmMin")
         };
         let (esm_ref_expr, _) = self.finalized_expr_for_symbol_ref(esm_ref, false, false);
-        let wrap_ref_name = self.canonical_name_for(self.ctx.linking_info.wrapper_ref.unwrap());
+        let wrap_ref_name = self.canonical_name_for(target.wrapper_ref);
 
         if matches!(
           self.ctx.linking_info.concatenated_wrapped_module_kind,
@@ -281,18 +278,25 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           return;
         }
 
-        program.body.push(self.ast_factory.make_esm_wrapper_stmt(
-          wrap_ref_name,
-          esm_ref_expr,
-          stmts_inside_closure,
-          self.ctx.options.profiler_names,
-          self.ctx.options.optimization.is_pife_for_module_wrappers_enabled(),
-          &self.ctx.module.stable_id,
-          self.ctx.linking_info.is_tla_or_contains_tla_dependency,
-        ));
+        program.body.push(self.ast_factory.make_esm_wrapper_stmt(EsmWrapperStmtOptions {
+          binding_name: wrap_ref_name,
+          esm_fn_expr: esm_ref_expr,
+          statements: stmts_inside_closure,
+          profiler_name:
+            self.ctx.options.profiler_names.then_some(self.ctx.module.stable_id.as_str()),
+          call_kind: if self.ctx.options.optimization.is_pife_for_module_wrappers_enabled() {
+            EsmWrapperCallKind::Pife
+          } else {
+            EsmWrapperCallKind::Plain
+          },
+          body_kind: if self.ctx.linking_info.is_tla_or_contains_tla_dependency {
+            EsmWrapperBodyKind::Async
+          } else {
+            EsmWrapperBodyKind::Sync
+          },
+        }));
       }
-      Some(WrapKind::None) => {}
-      None => {
+      ModuleWrapperMode::None => {
         program.body.splice(0..0, declaration_of_module_namespace_object);
       }
     }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -27,6 +27,7 @@ use rolldown_ecmascript_utils::{
 
 mod finalizer_context;
 mod impl_visit_mut;
+use finalizer_context::ModuleWrapperMode;
 pub use finalizer_context::ScopeHoistingFinalizerContext;
 use oxc_str::{CompactStr, Ident};
 use rolldown_utils::ecmascript::is_validate_identifier_name;

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -10,6 +10,18 @@ use rolldown_utils::IndexBitSet;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// The interop ESM wrapper a wrapped (`WrapKind::Esm`) module exposes: the `init_*()` binding the
+/// finalizer emits its call sites against, plus whether calling it is a no-op.
+///
+/// Extracted so wrapper declaration emission and `init_*()` call sites read the same view of
+/// [`LinkingMetadata`] instead of reaching into the raw fields independently. This keeps a single
+/// place for later strict-execution-order wrapper paths to extend.
+#[derive(Clone, Copy, Debug)]
+pub struct EsmInitTarget {
+  pub(crate) wrapper_ref: SymbolRef,
+  pub(crate) init_is_noop: bool,
+}
+
 /// Module metadata about linking
 #[derive(Debug, Default)]
 #[expect(clippy::struct_excessive_bools)]
@@ -144,6 +156,18 @@ impl LinkingMetadata {
   #[inline]
   pub fn set_wrap_kind(&mut self, wrap_kind: WrapKind) {
     self.wrap_kind = wrap_kind;
+  }
+
+  /// The wrapped-ESM init target of a module, derived from its linking metadata alone: a
+  /// `WrapKind::Esm` module with an allocated wrapper symbol exposes an `init_*()` the finalizer
+  /// emits; anything else has none.
+  pub fn esm_init_target(&self) -> Option<EsmInitTarget> {
+    if !matches!(self.wrap_kind(), WrapKind::Esm) {
+      return None;
+    }
+    self
+      .wrapper_ref
+      .map(|wrapper_ref| EsmInitTarget { wrapper_ref, init_is_noop: self.init_is_noop })
   }
 
   pub fn referenced_canonical_exports_symbols<'b, 'a: 'b>(

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -33,6 +33,30 @@ use rolldown_utils::ecmascript::is_validate_identifier_name;
 #[derive(Clone, Copy)]
 pub struct AstFactory<'ast>(AstBuilder<'ast>);
 
+/// Options for [`AstFactory::make_esm_wrapper_stmt`], grouping the wrapper's binding, body and
+/// call shape so new emission modes can be added without growing the argument list.
+pub struct EsmWrapperStmtOptions<'ast, 'data> {
+  pub binding_name: &'data str,
+  pub esm_fn_expr: Expression<'ast>,
+  pub statements: allocator::Vec<'ast, Statement<'ast>>,
+  /// `Some(stable_id)` wraps the closure in a profiler-named object argument.
+  pub profiler_name: Option<&'data str>,
+  pub call_kind: EsmWrapperCallKind,
+  pub body_kind: EsmWrapperBodyKind,
+}
+
+#[derive(Clone, Copy)]
+pub enum EsmWrapperCallKind {
+  Plain,
+  Pife,
+}
+
+#[derive(Clone, Copy)]
+pub enum EsmWrapperBodyKind {
+  Sync,
+  Async,
+}
+
 impl<'ast> AstFactory<'ast> {
   pub fn new(allocator: &'ast Allocator) -> Self {
     Self(AstBuilder::new(allocator))
@@ -608,17 +632,15 @@ impl<'ast> AstFactory<'ast> {
   }
 
   /// `var <binding_name> = __esm(... () => { <statements> } ...)`
-  #[expect(clippy::too_many_arguments)]
-  pub fn make_esm_wrapper_stmt(
-    &self,
-    binding_name: &str,
-    esm_fn_expr: Expression<'ast>,
-    statements: allocator::Vec<'ast, Statement<'ast>>,
-    profiler_names: bool,
-    use_pife: bool,
-    stable_id: &str,
-    is_async: bool,
-  ) -> Statement<'ast> {
+  pub fn make_esm_wrapper_stmt(&self, options: EsmWrapperStmtOptions<'ast, '_>) -> Statement<'ast> {
+    let EsmWrapperStmtOptions {
+      binding_name,
+      esm_fn_expr,
+      statements,
+      profiler_name,
+      call_kind,
+      body_kind,
+    } = options;
     let params = FormalParameters::new(
       SPAN,
       FormalParameterKind::Signature,
@@ -629,10 +651,18 @@ impl<'ast> AstFactory<'ast> {
     let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(self), statements, self);
     let mut esm_call_expr =
       CallExpression::new(SPAN, esm_fn_expr, NONE, oxc::allocator::Vec::new_in(self), false, self);
-    let mut arrow_expr =
-      ArrowFunctionExpression::boxed(SPAN, false, is_async, NONE, params, NONE, body, self);
-    arrow_expr.pife = use_pife;
-    if profiler_names {
+    let mut arrow_expr = ArrowFunctionExpression::boxed(
+      SPAN,
+      false,
+      matches!(body_kind, EsmWrapperBodyKind::Async),
+      NONE,
+      params,
+      NONE,
+      body,
+      self,
+    );
+    arrow_expr.pife = matches!(call_kind, EsmWrapperCallKind::Pife);
+    if let Some(stable_id) = profiler_name {
       let obj_expr = ObjectExpression::boxed(
         SPAN,
         oxc::allocator::Vec::from_value_in(

--- a/crates/rolldown_ecmascript_utils/src/lib.rs
+++ b/crates/rolldown_ecmascript_utils/src/lib.rs
@@ -4,7 +4,7 @@ mod scope;
 mod source_utils;
 
 pub use crate::{
-  ast_factory::AstFactory,
+  ast_factory::{AstFactory, EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperStmtOptions},
   extensions::ast_ext::{
     binding_pattern_ext::BindingPatternExt,
     call_expression_ext::CallExpressionExt,


### PR DESCRIPTION
**What this does (and doesn't).** A byte-neutral decoupling refactor of how the module finalizer emits interop module wrappers. It introduces a small `EsmInitTarget` view (a wrapped-ESM module's `init_*()` wrapper symbol plus whether calling it is a no-op) with a free-standing accessor over `LinkingMetadata`, and a finalizer `ModuleWrapperMode` enum (`None` / `InteropCjs` / `InteropEsm`) that classifies a module's wrapper once. The finalizer's inline `wrap_kind()`-plus-"wrapper statement included" checks now route through these seams, and `AstFactory::make_esm_wrapper_stmt` takes an `EsmWrapperStmtOptions` struct (call/body kind) instead of a 7-argument positional list. It does NOT change output, and it deliberately omits the execution-order wrapper mode and the `HoistedFunction` declaration kind (no caller here yet) — those land with the feature.

**Why.** Today the finalizer decides how to wrap a module by reading several `LinkingMetadata` fields inline at each emission site (`wrap_kind()`, `wrapper_stmt_info`, `wrapper_ref`, `init_is_noop`). The strict-execution-order work needs a second way to construct these wrappers (order wrappers) without duplicating that scattered logic. This PR pulls the "what init does this module's wrapper expose?" question behind one accessor and the "how do I wrap it?" decision behind one enum, so the later feature adds a construction path instead of editing every emission site. Grouping `make_esm_wrapper_stmt`'s arguments into a struct is the same move at the AST layer.

**Validation.** `cargo test -p rolldown --test integration`: 1801 fixtures pass (same 5 pre-existing environment-only failures as the rest of the stack). `cargo clippy -p rolldown --all-targets -- -D warnings` is clean and `cargo fmt --all` produces no diff. Zero snapshot changes across ~1800 fixtures — byte-identical output. Equivalence was checked by case analysis: for every (`wrap_kind`, wrapper-included) combination, `wrapper_mode()` selects the same arm the old inline match did, and `InteropEsm`/`InteropCjs` carry exactly the `wrapper_ref` the old code unwrapped.

**Stack.** Builds on layer (1) of the `strictExecutionOrder` slicing stack. Next: (3) skip CJS namespace merging under strict execution order. Later layers move/extend `EsmInitTarget` and add the execution-order wrapper mode.
