### PR TITLE
refactor(rolldown): skip CJS namespace merging under strict execution order

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -113,6 +113,14 @@ impl LinkStage<'_> {
   /// a single namespace binding, reducing code size.
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_safely_merge_cjs_ns(&mut self) {
+    // Merging moves the surviving `require` call to whichever importer statement stays included,
+    // which can shift a CommonJS module's evaluation past later statements. Under strict execution
+    // order that reordering is an observable correctness break that wrapping cannot repair, so we
+    // keep every importer's own call site instead (the CJS wrapper memoizes, so the only cost is a
+    // few extra bytes).
+    if self.options.is_strict_execution_order_enabled() {
+      return;
+    }
     for importer in self.module_table.modules.iter().filter_map(Module::as_normal) {
       for (rec_idx, rec) in importer.import_records.iter_enumerated() {
         if !matches!(rec.kind, ImportKind::Import)

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {},
+  "configVariants": [
+    {
+      "strictExecutionOrder": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	console.log("cjs");
+	module.exports = { value: 1 };
+})))());
+const fromLib = import_cjs.default.value;
+//#endregion
+//#region main.js
+console.log("main", fromLib, import_cjs.default.value);
+//#endregion
+
+```
+
+# Variant: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	console.log("cjs");
+	module.exports = { value: 1 };
+}));
+//#endregion
+//#region lib.js
+var import_cjs$1, fromLib;
+var init_lib = __esmMin((() => {
+	import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
+	fromLib = import_cjs$1.default.value;
+}));
+//#endregion
+//#region main.js
+var import_cjs;
+//#endregion
+__esmMin((() => {
+	init_lib();
+	import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+	console.log("main", fromLib, import_cjs.default.value);
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/cjs.cjs
@@ -1,0 +1,2 @@
+console.log('cjs');
+module.exports = { value: 1 };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/lib.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/lib.js
@@ -1,0 +1,3 @@
+import cjs from './cjs.cjs';
+
+export const fromLib = cjs.value;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/main.js
@@ -1,0 +1,4 @@
+import { fromLib } from './lib.js';
+import cjs from './cjs.cjs';
+
+console.log('main', fromLib, cjs.value);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
@@ -27,9 +27,10 @@ function test() {
 var import_commonjs;
 __esmMin((() => {
 	//#region lib.js
-	import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
+	require_commonjs();
 	//#endregion
 	//#region main.js
+	import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 	assert.equal(import_commonjs.createReactElement(), "div");
 	assert.equal(1 .toString(), "1");
 	assert.equal(test().toString(), "1");


### PR DESCRIPTION
**What this does (and doesn't).** Under `output.strictExecutionOrder`, skip the "safely merge CJS namespace" optimization: `determine_safely_merge_cjs_ns` now early-returns when strict execution order is enabled. This is the one piece of strict-gated link-stage groundwork that stands on its own. It does NOT change flag-off behavior, and it deliberately excludes the feature's other strict bookkeeping (`star_export_record_by_name`, `execution_dependencies`, star-reexport path recording) because none of it has a reader in this PR — that lands with the analysis that consumes it.

**Why.** The optimization lets several ESM importers of the same CommonJS module share one namespace binding, which relocates the surviving `require()` to whichever importer statement stays included. That reordering can move a CommonJS module's evaluation past statements that should run after it — an execution-order break that no amount of wrapping can repair. Under strict execution order, correctness must win over the small byte saving, so we keep each importer's own call site (the CJS wrapper memoizes, so the module still evaluates exactly once). The added `cjs_ns_merge_skipped` fixture shows the contrast directly: the default variant shares one `import_cjs`, while the strict variant gives `lib.js` and `main.js` their own bindings materialized at their own use sites.

**Validation.** `cargo test -p rolldown --test integration`: passing (same 5 pre-existing environment-only failures as the rest of the stack). `cargo clippy -p rolldown --all-targets -- -D warnings` is clean and `cargo fmt --all` produces no diff. Flag-off output is byte-identical — no non-strict snapshot changed. Exactly one existing strict-only snapshot changed, `react-like`: the shared `import_commonjs = __toESM(require_commonjs())` is now split so `lib.js` does a bare `require_commonjs()` and `main.js` materializes the namespace at its own use site. That is the intended strict-only correctness improvement.

**Stack.** Top of a three-layer stack slicing the `output.strictExecutionOrder` work; builds on (1) wrap-kind / chunk-graph cleanup and (2) the interop init-target view. The strict analysis and code generation that consume the deferred bookkeeping come in later layers.
