### PR TITLE
refactor: share the main resolver's cache with the transformer's tsconfig lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "oxc_str",
  "rolldown_ecmascript",
  "rolldown_error",
+ "rolldown_fs",
  "rolldown_sourcemap",
  "rolldown_std_utils",
  "rolldown_utils",

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -358,32 +358,22 @@ pub fn prepare_build_context(
     }
 
     // Create TransformOptions based on tsconfig mode:
-    // - Auto(true)/Manual: Raw mode, resolves tsconfig per file so rebuilds
-    //   can re-read edited tsconfig files
+    // - Manual/Auto(true): Raw mode, resolves the tsconfig per file
     // - Auto(false): Normal mode without tsconfig
     match tsconfig {
-      TsConfig::Manual(path) => Box::new(TransformOptions::new_raw(
-        RawTransformOptions::new(raw_transform_options, TsConfig::Manual(path), yarn_pnp),
+      TsConfig::Manual(_) | TsConfig::Auto(true) => Box::new(TransformOptions::new_raw(
+        RawTransformOptions::new(
+          raw_transform_options,
+          Arc::new(resolver.clone_default_resolver()),
+        ),
         target,
         jsx_preset,
       )),
-      TsConfig::Auto(is_auto) => {
-        Box::new(if is_auto {
-          // Auto mode: Create Raw mode TransformOptions
-          // Each file will find its nearest tsconfig during compilation
-          TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, TsConfig::Auto(true), yarn_pnp),
-            target,
-            jsx_preset,
-          )
-        } else {
-          TransformOptions::new(
-            merge_transform_options_with_tsconfig(raw_transform_options, None, &mut warnings)?,
-            target,
-            jsx_preset,
-          )
-        })
-      }
+      TsConfig::Auto(false) => Box::new(TransformOptions::new(
+        merge_transform_options_with_tsconfig(raw_transform_options, None, &mut warnings)?,
+        target,
+        jsx_preset,
+      )),
     }
   };
 

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -29,6 +29,7 @@ oxc_resolver = { workspace = true }
 oxc_sourcemap = { workspace = true }
 rolldown_ecmascript = { workspace = true }
 rolldown_error = { workspace = true }
+rolldown_fs = { workspace = true, features = ["os"] }
 rolldown_sourcemap = { workspace = true }
 rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -6,12 +6,13 @@ use std::{
 
 use dashmap::Entry;
 use oxc::transformer::{ESFeature, EngineTargets, TransformOptions as OxcTransformOptions};
-use oxc_resolver::{ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions};
+use oxc_resolver::ResolverGeneric;
 use rolldown_error::{BuildDiagnostic, BuildResult};
+use rolldown_fs::OsFileSystem;
 use rolldown_utils::dashmap::FxDashMap;
 
 use super::tsconfig_merge::merge_transform_options_with_tsconfig as merge_tsconfig;
-use crate::{BundlerTransformOptions, TsConfig};
+use crate::BundlerTransformOptions;
 
 #[derive(Debug, Default, Clone)]
 pub enum JsxPreset {
@@ -30,26 +31,17 @@ pub struct RawTransformOptions {
   pub base_options: Arc<BundlerTransformOptions>,
   /// Cache key: tsconfig path, or empty PathBuf for files without tsconfig
   pub cache: FxDashMap<PathBuf, Arc<OxcTransformOptions>>,
-  resolver: Arc<Resolver>,
+  /// Derived from the main resolver and shares its cache, so tsconfig
+  /// lookups here and in module resolution stay consistent.
+  resolver: Arc<ResolverGeneric<OsFileSystem>>,
 }
 
 impl RawTransformOptions {
-  pub fn new(base_options: BundlerTransformOptions, tsconfig: TsConfig, yarn_pnp: bool) -> Self {
-    Self {
-      base_options: Arc::new(base_options),
-      cache: FxDashMap::default(),
-      resolver: Arc::new(Resolver::new(ResolveOptions {
-        tsconfig: match tsconfig {
-          TsConfig::Auto(v) => v.then_some(TsconfigDiscovery::Auto),
-          TsConfig::Manual(config_file) => Some(TsconfigDiscovery::Manual(TsconfigOptions {
-            config_file,
-            references: oxc_resolver::TsconfigReferences::Auto,
-          })),
-        },
-        yarn_pnp,
-        ..Default::default()
-      })),
-    }
+  pub fn new(
+    base_options: BundlerTransformOptions,
+    resolver: Arc<ResolverGeneric<OsFileSystem>>,
+  ) -> Self {
+    Self { base_options: Arc::new(base_options), cache: FxDashMap::default(), resolver }
   }
 
   pub fn get_or_create_for_tsconfig(

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -66,6 +66,12 @@ impl<Fs: FileSystem + Clone + 'static> Resolver<Fs> {
       package_json_cache: DashMap::default(),
     }
   }
+
+  /// The clone shares this resolver's cache, so tsconfig lookups and cache
+  /// clearing stay consistent with module resolution.
+  pub fn clone_default_resolver(&self) -> ResolverGeneric<Fs> {
+    self.default_resolver.clone_with_options(self.default_resolver.options().clone())
+  }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Groundwork for #9598 (rebuild when tsconfig changes), on top of #10200.

`RawTransformOptions` used to build its own private oxc `Resolver` just for per-file tsconfig discovery. That means two resolvers with two caches: the same tsconfig file is read and parsed twice, and clearing the main resolver's cache (as the watcher already does before every rebuild) never touches the transformer's copy, so the two sides can end up seeing different tsconfig contents. For #9598 we need one clear to invalidate both.

`RawTransformOptions` now receives an `Arc<ResolverGeneric<OsFileSystem>>` derived from the main resolver via the new `Resolver::derive_cache_sharing_resolver()`. oxc's `clone_with_options` shares the cache `Arc` when the `yarn_pnp` option matches, and since we clone with the resolver's own options it always matches. Both sides now read the same tsconfig/fs/package.json cache, and one `clear_cache` on the main resolver invalidates both. The `TsConfig` and `yarn_pnp` parameters of `RawTransformOptions::new` are gone because the tsconfig discovery config comes with the shared resolver, which was built from the same `TsConfig` value.

Notes for reviewers: `rolldown_common` gains a `rolldown_fs` dependency, which is cycle-free since `rolldown_fs` only depends on `oxc_resolver` and `vfs`. The two Raw-mode arms in `prepare_build_context` became identical after this change and were merged into one. The derived resolver inherits the main resolver's full options instead of oxc defaults, but `find_tsconfig` only depends on the `tsconfig` option, which was already configured identically on both sides, so per-file discovery results are unchanged. The transformer also now reads files through the same `OsFileSystem` instance as module resolution, so the yarn pnp setting is applied consistently.

Part of #9598.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

