### PR TITLE
feat(dev): per-client ship map for HMR patch sizing

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -3,13 +3,17 @@ use super::Bundler;
 #[cfg(feature = "experimental")]
 use crate::hmr::hmr_stage::{HmrStage, HmrStageInput};
 #[cfg(feature = "experimental")]
+use arcstr::ArcStr;
+#[cfg(feature = "experimental")]
 use rolldown_common::WatcherChangeKind;
 #[cfg(feature = "experimental")]
-use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput};
+use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrStampTable};
 #[cfg(feature = "experimental")]
 use rolldown_error::BuildResult;
 #[cfg(feature = "experimental")]
 use rolldown_utils::indexmap::FxIndexMap;
+#[cfg(feature = "experimental")]
+use rustc_hash::FxHashMap;
 #[cfg(feature = "experimental")]
 use std::sync::{Arc, atomic::AtomicU32};
 
@@ -20,6 +24,7 @@ impl Bundler {
     &mut self,
     changed_file_paths: &FxIndexMap<String, WatcherChangeKind>,
     clients: &[ClientHmrInput<'_>],
+    stamp_table: &mut HmrStampTable,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     // HMR partial scans use the shared rayon pool without passing through
@@ -39,10 +44,11 @@ impl Bundler {
       cache: &mut self.cache,
       next_hmr_patch_id,
     });
-    hmr_stage.compute_hmr_update_for_file_changes(changed_file_paths, clients).await
+    hmr_stage.compute_hmr_update_for_file_changes(changed_file_paths, clients, stamp_table).await
   }
 
-  /// Compile a lazy entry module and return the compiled chunk.
+  /// Compile a lazy entry module and return compiled code plus the pending-payload
+  /// entry the delivery-time ship-map write consumes.
   ///
   /// This is called when a dynamically imported module is first requested at runtime.
   /// The module was previously stubbed with a proxy, and now we need to compile the
@@ -51,6 +57,8 @@ impl Bundler {
     &mut self,
     module_id: String,
     client_id: &str,
+    shipped: &FxHashMap<ArcStr, u32>,
+    stamp_table: &HmrStampTable,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<HmrLazyChunkOutput> {
     // HMR partial scans use the shared rayon pool without passing through
@@ -68,6 +76,6 @@ impl Bundler {
       cache: &mut self.cache,
       next_hmr_patch_id,
     });
-    hmr_stage.compile_lazy_entry(&module_id, client_id).await
+    hmr_stage.compile_lazy_entry(&module_id, client_id, shipped, stamp_table).await
   }
 }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -9,8 +9,8 @@ use std::{
 use arcstr::ArcStr;
 use oxc_traverse::traverse_mut;
 use rolldown_common::{
-  ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrPatch, HmrUpdate, ImportKind, Module,
-  ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
+  ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrPatch, HmrStampTable, HmrUpdate,
+  ImportKind, Module, ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
 use rolldown_ecmascript_utils::AstFactory;
@@ -80,6 +80,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     &mut self,
     changed_file_paths: &FxIndexMap<String, WatcherChangeKind>,
     clients: &[ClientHmrInput<'_>],
+    stamp_table: &mut HmrStampTable,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     tracing::trace!(
       "[HmrStage] starts computing HMR updates\n - changed_file_paths: {:#?}\n - clients: {:#?}",
@@ -198,11 +199,20 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       new_added_modules
     };
 
-    // 2. Collect the factories to ship. The client's walk may remove modules from its cache and re-run
+    // 2. Stamp the rebuild: `latest[m] = rebuild_seq` for every changed or newly added
+    // module — the versioned ship map's staleness source.
+    let rebuild_seq = stamp_table.begin_rebuild();
+    for module_idx in changed_modules.iter().chain(new_added_modules.iter()) {
+      if let Module::Normal(module) = &self.module_table().modules[*module_idx] {
+        stamp_table.stamp(module.stable_id.as_arc_str(), rebuild_seq);
+      }
+    }
+
+    // 3. Collect the factories to ship. The client's walk may remove modules from its cache and re-run
     // anything up the changed ids' importer chains, and a re-run without a resident
     // factory forces a reload — so the server must ship a SUPERSET of any client's
     // possible update set, over-approximated on static truth (it never sees runtime
-    // acceptance).
+    // acceptance). The ship map below subtracts what each tab already holds.
     let changed_ids = changed_modules
       .iter()
       .filter_map(|module_idx| {
@@ -226,19 +236,50 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         affected.extend(new_added_modules.iter().copied());
         affected.retain(|idx| self.module_table().modules[*idx].is_normal());
 
-        // 3. Every client receives the full affected set. The per-client ship map
-        // (`shipped[C]`) that narrows this to what each tab lacks lands in a
-        // follow-up; until then the patch depends on no per-client input, so render
-        // it once and fan the same payload out (`seq` is stamped per client after
-        // compute).
-        if !clients.is_empty() {
-          let update = self.render_hmr_patch(affected, changed_ids).await?;
-          for client in clients {
-            client_updates.push(ClientHmrUpdate {
-              client_id: client.client_id.to_string(),
-              update: update.clone(),
-            });
+        // Client-invariant per-module data, resolved once instead of per client:
+        // `(idx, stable id, latest stamp)` for every affected module.
+        let affected_with_stamps = affected
+          .iter()
+          .map(|module_idx| {
+            let stable_id = self.module_table().modules[*module_idx].stable_id().as_str();
+            (*module_idx, stable_id, stamp_table.render_time_stamp(stable_id))
+          })
+          .collect::<Vec<_>>();
+
+        // 4. Per client: `need[C] = (affected ∖ shipped[C]) ∪ stale sweep`. The sweep
+        // covers everything the client holds, not just `affected` — a parked factory can
+        // go stale behind a skipped patch in either graph direction. It iterates the
+        // stamp table (modules ever changed this session) rather than `shipped[C]`
+        // (modules ever delivered): only stamped modules can be stale, and `latest`
+        // stays far smaller than a tab's full delivery record.
+        for client in clients {
+          let mut carried = FxIndexSet::default();
+          for (module_idx, stable_id, latest_stamp) in &affected_with_stamps {
+            match client.shipped.get(*stable_id) {
+              None => {
+                carried.insert(*module_idx);
+              }
+              Some(stamp) => {
+                if *latest_stamp > *stamp {
+                  carried.insert(*module_idx);
+                }
+              }
+            }
           }
+          for (stable_id, latest_stamp) in stamp_table.iter_latest() {
+            if client.shipped.get(stable_id.as_str()).is_some_and(|stamp| latest_stamp > *stamp) {
+              if let Some(module_idx) =
+                self.cache.module_idx_by_stable_id.get(stable_id.as_str()).copied()
+              {
+                if self.module_table().modules[module_idx].is_normal() {
+                  carried.insert(module_idx);
+                }
+              }
+            }
+          }
+
+          let update = self.render_hmr_patch(carried, changed_ids.clone(), stamp_table).await?;
+          client_updates.push(ClientHmrUpdate { client_id: client.client_id.to_string(), update });
         }
       }
     }
@@ -280,15 +321,18 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     UpdateSupersetOutcome::Superset(affected)
   }
 
-  /// Compile a lazy entry module and return the compiled chunk.
+  /// Compile a lazy entry module and return compiled code plus the pending-payload
+  /// entry (`carried`) the delivery-time ship-map write consumes.
   ///
-  /// The chunk carries every reachable sync dependency's factory — never filtered by
-  /// execution state. The per-client ship map that narrows this to what each
-  /// tab lacks lands in a follow-up; re-shipped factories are idempotent.
+  /// Factory selection filters the reachable set by the ship-map comparison — absent from
+  /// `shipped[C]` or stale stamp — never by execution state. The ship map itself is
+  /// written only when the serving middleware observes the response complete.
   pub async fn compile_lazy_entry(
     &mut self,
     module_id: &str,
     _client_id: &str,
+    shipped: &FxHashMap<ArcStr, u32>,
+    stamp_table: &HmrStampTable,
   ) -> BuildResult<HmrLazyChunkOutput> {
     tracing::debug!(
       target: "hmr",
@@ -359,10 +403,17 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     let options = Arc::clone(&self.options);
     self.cache.update_defer_sync_data(&options).await?;
 
-    // Collect all reachable sync dependencies. Overlapping lazy compiles re-ship
-    // shared factories — duplicate idempotent bytes, never a missing factory.
+    // Collect all sync dependencies, stopping at modules whose current copy this client
+    // already holds per the ship map. Overlapping concurrent lazy compiles both see an
+    // unmarked ship map and re-ship shared factories — duplicate idempotent bytes, never
+    // a missing factory.
     let mut modules_to_be_updated = FxIndexSet::default();
-    self.collect_sync_dependencies_for_client(entry_module_idx, &mut modules_to_be_updated);
+    self.collect_sync_dependencies_for_client(
+      entry_module_idx,
+      &mut modules_to_be_updated,
+      shipped,
+      stamp_table,
+    );
 
     // Remove external modules - no way to "compile" them
     modules_to_be_updated.retain(|idx| self.module_table().modules[*idx].is_normal());
@@ -506,13 +557,22 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       .await?;
     }
 
-    Ok(HmrLazyChunkOutput { code, filename })
+    let carried = modules_to_be_updated
+      .iter()
+      .map(|module_idx| {
+        let stable_id = self.module_table().modules[*module_idx].stable_id();
+        (stable_id.as_arc_str().clone(), stamp_table.render_time_stamp(stable_id.as_str()))
+      })
+      .collect();
+
+    Ok(HmrLazyChunkOutput { code, filename, carried })
   }
 
   async fn render_hmr_patch(
     &self,
     mut carried_modules: FxIndexSet<ModuleIdx>,
     changed_ids: Vec<String>,
+    stamp_table: &HmrStampTable,
   ) -> BuildResult<HmrUpdate> {
     // Note: the carried set might include external modules. There's no way to "update" them, so we need to remove them.
     carried_modules.retain(|idx| self.module_table().modules[*idx].is_normal());
@@ -651,6 +711,14 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       None
     };
 
+    let carried = carried_modules
+      .iter()
+      .map(|module_idx| {
+        let stable_id = self.module_table().modules[*module_idx].stable_id();
+        (stable_id.as_arc_str().clone(), stamp_table.render_time_stamp(stable_id.as_str()))
+      })
+      .collect();
+
     Ok(HmrUpdate::Patch(HmrPatch {
       code,
       filename,
@@ -660,6 +728,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       // The envelope seq is a delivery-layer concern; the dev engine stamps it onto the
       // patches it actually sends (see `bundling_task`), so this is only a placeholder.
       seq: 0,
+      carried,
     }))
   }
 
@@ -781,6 +850,8 @@ impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {
     &self,
     proxy_entry_idx: ModuleIdx,
     result: &mut FxIndexSet<ModuleIdx>,
+    shipped: &FxHashMap<ArcStr, u32>,
+    stamp_table: &HmrStampTable,
   ) {
     let modules = &self.module_table().modules;
     let mut stack = vec![proxy_entry_idx];
@@ -802,6 +873,19 @@ impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {
           || (module_idx == proxy_entry_idx && rec.kind == ImportKind::DynamicImport);
 
         if should_follow && let Some(dep_idx) = rec.resolved_module {
+          // A module with N importers hits this edge check N times; the cheap
+          // visited test spares the ship-map string hashing for all but the first.
+          if result.contains(&dep_idx) {
+            continue;
+          }
+          if let Module::Normal(normal_dep) = &modules[dep_idx] {
+            // Skip deps whose current copy this client already holds per the ship map.
+            let stable_id = normal_dep.stable_id.as_str();
+            if shipped.get(stable_id).is_some_and(|stamp| !stamp_table.is_stale(stable_id, *stamp))
+            {
+              continue;
+            }
+          }
           stack.push(dep_idx);
         }
       }

--- a/crates/rolldown_common/src/hmr/client_hmr_input.rs
+++ b/crates/rolldown_common/src/hmr/client_hmr_input.rs
@@ -1,7 +1,13 @@
-/// Per-client input for an HMR push. The server never sees execution state; every
-/// client currently receives the full affected factory set, and the per-client
-/// ship map (`shipped[C]`) that narrows it lands in a follow-up.
+use arcstr::ArcStr;
+use rustc_hash::FxHashMap;
+
+/// Per-client input for selecting the factories an HMR push ships. The server never
+/// sees execution state — the selection reads only `shipped[C]`, the record of the
+/// server's own deliveries (module stable id → rebuild stamp of the copy this client
+/// holds).
 #[derive(Debug)]
 pub struct ClientHmrInput<'a> {
   pub client_id: &'a str,
+  /// The ship map `shipped[C]`: module stable id → rebuild stamp.
+  pub shipped: &'a FxHashMap<ArcStr, u32>,
 }

--- a/crates/rolldown_common/src/hmr/hmr_patch.rs
+++ b/crates/rolldown_common/src/hmr/hmr_patch.rs
@@ -1,3 +1,5 @@
+use arcstr::ArcStr;
+
 #[derive(Debug, Clone)]
 pub struct HmrPatch {
   pub code: String,
@@ -9,4 +11,8 @@ pub struct HmrPatch {
   pub changed_ids: Vec<String>,
   /// Per-client envelope sequence number.
   pub seq: u32,
+  /// `(stable id, render-time stamp)` for every module this patch carries — the
+  /// pending-payload entry that the delivery-time ship-map write consumes when the
+  /// serving middleware observes the response complete.
+  pub carried: Vec<(ArcStr, u32)>,
 }

--- a/crates/rolldown_common/src/hmr/hmr_stamp_table.rs
+++ b/crates/rolldown_common/src/hmr/hmr_stamp_table.rs
@@ -1,0 +1,46 @@
+use arcstr::ArcStr;
+use rustc_hash::FxHashMap;
+
+/// Dev-engine-wide rebuild-stamp table backing the versioned shipped map: the server numbers
+/// every rebuild and blind-stamps `latest[m] = rebuild_seq` for each changed module, so
+/// `latest[m] > shipped[C][m]` reads exactly "this client's copy of `m` is stale".
+///
+/// A module that never changed since dev-server start has no entry; its stamp is 0
+/// everywhere, which compares as never-stale until its first change.
+///
+/// Keys are `ArcStr` (the backing store of `StableModuleId`), so stamping and copying
+/// entries into ship maps and pending payloads bumps a refcount instead of copying the
+/// id string.
+#[derive(Debug, Default)]
+pub struct HmrStampTable {
+  rebuild_seq: u32,
+  /// module stable id → the rebuild that last changed it
+  latest: FxHashMap<ArcStr, u32>,
+}
+
+impl HmrStampTable {
+  /// Advances the rebuild counter and returns the new rebuild's stamp.
+  pub fn begin_rebuild(&mut self) -> u32 {
+    self.rebuild_seq += 1;
+    self.rebuild_seq
+  }
+
+  pub fn stamp(&mut self, module_stable_id: &ArcStr, rebuild_seq: u32) {
+    self.latest.insert(module_stable_id.clone(), rebuild_seq);
+  }
+
+  /// The stamp a delivery of `module_stable_id` records right now.
+  pub fn render_time_stamp(&self, module_stable_id: &str) -> u32 {
+    self.latest.get(module_stable_id).copied().unwrap_or(0)
+  }
+
+  pub fn is_stale(&self, module_stable_id: &str, shipped_stamp: u32) -> bool {
+    self.render_time_stamp(module_stable_id) > shipped_stamp
+  }
+
+  /// Every module ever stamped this session with its latest stamp. This is the sweep
+  /// domain for staleness: a module without an entry has stamp 0 and can never be stale.
+  pub fn iter_latest(&self) -> impl Iterator<Item = (&ArcStr, u32)> {
+    self.latest.iter().map(|(id, stamp)| (id, *stamp))
+  }
+}

--- a/crates/rolldown_common/src/hmr/lazy_chunk_output.rs
+++ b/crates/rolldown_common/src/hmr/lazy_chunk_output.rs
@@ -1,5 +1,11 @@
+use arcstr::ArcStr;
+
 #[derive(Debug)]
 pub struct HmrLazyChunkOutput {
   pub code: String,
   pub filename: String,
+  /// `(stable id, render-time stamp)` for every module this chunk carries — the
+  /// pending-payload entry that the delivery-time ship-map write consumes when the
+  /// serving middleware observes the response complete.
+  pub carried: Vec<(ArcStr, u32)>,
 }

--- a/crates/rolldown_common/src/hmr/mod.rs
+++ b/crates/rolldown_common/src/hmr/mod.rs
@@ -2,5 +2,6 @@ pub mod client_hmr_input;
 pub mod client_hmr_update;
 pub mod hmr_boundary;
 pub mod hmr_patch;
+pub mod hmr_stamp_table;
 pub mod hmr_update;
 pub mod lazy_chunk_output;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -130,8 +130,8 @@ pub use crate::{
   },
   hmr::{
     client_hmr_input::ClientHmrInput, client_hmr_update::ClientHmrUpdate,
-    hmr_boundary::HmrBoundary, hmr_patch::HmrPatch, hmr_update::HmrUpdate,
-    lazy_chunk_output::HmrLazyChunkOutput,
+    hmr_boundary::HmrBoundary, hmr_patch::HmrPatch, hmr_stamp_table::HmrStampTable,
+    hmr_update::HmrUpdate, lazy_chunk_output::HmrLazyChunkOutput,
   },
   module::{
     Module,

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -3,8 +3,10 @@ use std::{
   sync::{Arc, atomic::AtomicU32},
 };
 
+use arcstr::ArcStr;
 use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrUpdate, ScanMode};
 use rolldown_utils::indexmap::FxIndexMap;
+use rustc_hash::FxHashMap;
 use tokio::sync::Mutex;
 
 use rolldown::Bundler;
@@ -12,7 +14,10 @@ use rolldown::Bundler;
 use crate::{
   BundleOutput,
   dev_context::SharedDevContext,
-  types::{coordinator_msg::CoordinatorMsg, error_stage::ErrorStage, task_input::TaskInput},
+  types::{
+    coordinator_msg::CoordinatorMsg, error_stage::ErrorStage, pending_payload::PendingPayload,
+    task_input::TaskInput,
+  },
 };
 
 pub struct BundlingTask {
@@ -203,24 +208,34 @@ impl BundlingTask {
       .collect::<FxIndexMap<_, _>>();
 
     // Read-only per-client inputs for this push. No seq here: it is assigned after compute,
-    // only to the patches we actually deliver (see below). Snapshot the ids and release the
-    // clients lock before the compute await — nothing per-client is read during compute, and
-    // holding it would block connect/disconnect for the whole rebuild.
-    let client_ids: Vec<String> = {
+    // only to the patches we actually deliver (see below). Snapshot the ids and ship maps
+    // and release the clients lock before the compute await — the compute only reads the
+    // snapshot, and a delivery notification landing mid-compute is folded into the next
+    // push either way; holding the lock would block connect/disconnect and delivery
+    // notifications for the whole rebuild.
+    let client_snapshots: Vec<(String, FxHashMap<ArcStr, u32>)> = {
       let client_sessions = self.dev_context.clients.lock().await;
-      client_sessions.keys().cloned().collect()
+      client_sessions
+        .iter()
+        .map(|(client_key, client)| (client_key.clone(), client.shipped.clone()))
+        .collect()
     };
-    let client_inputs: Vec<ClientHmrInput> =
-      client_ids.iter().map(|client_id| ClientHmrInput { client_id: client_id.as_str() }).collect();
+    let client_inputs: Vec<ClientHmrInput> = client_snapshots
+      .iter()
+      .map(|(client_id, shipped)| ClientHmrInput { client_id: client_id.as_str(), shipped })
+      .collect();
 
     // Compute HMR updates for all clients in one call
+    let mut stamp_table = self.dev_context.stamp_table.lock().await;
     let mut hmr_result = bundler
       .compute_hmr_update_for_file_changes(
         &changed_files,
         &client_inputs,
+        &mut stamp_table,
         Arc::clone(&self.next_hmr_patch_id),
       )
       .await;
+    drop(stamp_table);
     drop(client_inputs);
 
     // `seq` is incremented only when the client actually receives an update — i.e. an
@@ -241,11 +256,29 @@ impl BundlingTask {
       }
     }
 
-    // Check if any update is a full reload (only if successful)
-    if let Ok(client_updates) = &hmr_result {
-      for update in client_updates {
-        if update.update.is_full_reload() {
-          *has_full_reload_update = true;
+    // Check if any update is a full reload (only if successful), and record each
+    // rendered patch as pending: the delivery notification max-merges its stamps
+    // into `shipped[C]` when the serving middleware sees the response for
+    // `patch.filename` complete. `carried` is handed over instead of cloned — the
+    // binding layer drops it (it stays server-side), so the pending entry is its
+    // only consumer from here on.
+    if let Ok(client_updates) = &mut hmr_result {
+      for update in client_updates.iter_mut() {
+        match &mut update.update {
+          HmrUpdate::FullReload { .. } => *has_full_reload_update = true,
+          HmrUpdate::Patch(patch) => {
+            self
+              .dev_context
+              .insert_pending_payload(
+                patch.filename.clone(),
+                PendingPayload {
+                  client_id: update.client_id.clone(),
+                  modules: std::mem::take(&mut patch.carried),
+                },
+              )
+              .await;
+          }
+          HmrUpdate::Noop => {}
         }
       }
     }

--- a/crates/rolldown_dev/src/dev_context.rs
+++ b/crates/rolldown_dev/src/dev_context.rs
@@ -1,8 +1,14 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use futures::future::Shared;
+use rolldown_common::HmrStampTable;
+use rustc_hash::FxHashMap;
+use tokio::sync::Mutex;
 
-use crate::{NormalizedDevOptions, SharedClients, type_aliases::CoordinatorSender};
+use crate::{
+  NormalizedDevOptions, SharedClients, type_aliases::CoordinatorSender,
+  types::pending_payload::PendingPayload,
+};
 
 pub type SharedDevContext = Arc<DevContext>;
 
@@ -11,8 +17,62 @@ pub type PinBoxSendStaticFuture<T = ()> = Pin<Box<dyn Future<Output = T> + Send 
 // The future represents an ongoing `BundlingTask`
 pub type BundlingFuture = Shared<PinBoxSendStaticFuture<()>>;
 
+/// Keep at most this many rendered-but-undelivered payloads per client. A dropped
+/// entry just degrades to the existing delivery-failure reload path: its modules
+/// stay stale in the ship map, so a later push re-ships or full-reloads them.
+const MAX_PENDING_PAYLOADS_PER_CLIENT: usize = 8;
+
 pub struct DevContext {
   pub options: NormalizedDevOptions,
   pub coordinator_tx: CoordinatorSender,
   pub clients: SharedClients,
+  /// Dev-engine-wide rebuild-stamp ship map of the versioned delivery protocol.
+  pub stamp_table: Arc<Mutex<HmrStampTable>>,
+  /// Rendered-but-not-yet-delivered payloads, keyed by output filename. The
+  /// delivery notification consumes an entry when the serving middleware sees
+  /// the response for that filename complete.
+  pub pending_payloads: Arc<Mutex<FxHashMap<String, PendingPayload>>>,
+}
+
+impl DevContext {
+  /// Record a rendered payload as pending so the delivery notification can
+  /// max-merge its stamps into that client's `shipped[C]` once the serving
+  /// middleware observes the response complete.
+  ///
+  /// Bounds per-client growth: past `MAX_PENDING_PAYLOADS_PER_CLIENT` entries
+  /// the oldest ones are dropped — see the constant's doc for why that is safe.
+  pub async fn insert_pending_payload(&self, filename: String, payload: PendingPayload) {
+    let client_id = payload.client_id.clone();
+    let mut pending_payloads = self.pending_payloads.lock().await;
+    pending_payloads.insert(filename, payload);
+
+    // Count first: the common case is far below the bound, so don't build the
+    // eviction list (filename clones + id parses) until it is actually needed.
+    let client_count =
+      pending_payloads.values().filter(|payload| payload.client_id == client_id).count();
+    if client_count > MAX_PENDING_PAYLOADS_PER_CLIENT {
+      let mut client_entries = pending_payloads
+        .iter()
+        .filter(|(_, payload)| payload.client_id == client_id)
+        .map(|(filename, _)| (patch_id_of(filename), filename.clone()))
+        .collect::<Vec<_>>();
+      client_entries.sort_unstable();
+      for (_, filename) in &client_entries[..client_entries.len() - MAX_PENDING_PAYLOADS_PER_CLIENT]
+      {
+        pending_payloads.remove(filename);
+      }
+    }
+  }
+}
+
+/// The numeric id embedded in a payload filename (`hmr_patch_{id}.js` /
+/// `lazy_compile_{id}.js`). Both formats draw from the engine's single patch-id
+/// counter, so the id orders pending entries by age across the two kinds.
+fn patch_id_of(filename: &str) -> u32 {
+  filename
+    .rsplit('_')
+    .next()
+    .and_then(|rest| rest.strip_suffix(".js"))
+    .and_then(|id| id.parse().ok())
+    .unwrap_or(0)
 }

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -5,11 +5,12 @@ use std::sync::{
 
 use anyhow::Context;
 use futures::{FutureExt, future::Shared};
-use rolldown_common::HmrLazyChunkOutput;
 #[cfg(feature = "testing")]
 use rolldown_common::WatcherChangeKind;
+use rolldown_common::{HmrLazyChunkOutput, HmrStampTable};
 use rolldown_error::{BuildResult, ResultExt};
 use rolldown_fs_watcher::{FsWatcher, FsWatcherConfig, FsWatcherExt, NoopFsWatcher};
+use rustc_hash::FxHashMap;
 #[cfg(feature = "testing")]
 use rustc_hash::FxHashSet;
 use tokio::sync::{Mutex, mpsc::unbounded_channel};
@@ -24,7 +25,7 @@ use crate::{
   type_aliases::CoordinatorSender,
   types::{
     coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot,
-    error_stage::ErrorStage,
+    error_stage::ErrorStage, pending_payload::PendingPayload,
   },
 };
 
@@ -50,8 +51,10 @@ pub struct DevEngine {
   pub clients: SharedClients,
   is_closed: AtomicBool,
   /// The engine's single patch-id counter, shared with the coordinator's bundling
-  /// tasks. Both consumers embed the id in served filenames, so two independent
-  /// counters would let a lazy chunk and a patch collide on one name.
+  /// tasks. Both counters' consumers format filenames as `hmr_patch_{id}.js` /
+  /// `lazy_compile_{id}.js`, and pending-payload entries are keyed by those
+  /// filenames — so two independent counters would let two different payloads
+  /// collide on one key.
   next_hmr_patch_id: Arc<AtomicU32>,
 }
 
@@ -79,6 +82,8 @@ impl DevEngine {
       options: normalized_options,
       coordinator_tx: coordinator_tx.clone(),
       clients: Arc::clone(&clients),
+      stamp_table: Arc::new(Mutex::new(HmrStampTable::default())),
+      pending_payloads: Arc::new(Mutex::new(FxHashMap::default())),
     });
 
     let watcher_config = FsWatcherConfig {
@@ -266,22 +271,34 @@ impl DevEngine {
     Ok(())
   }
 
-  /// Client-connect signal (the clientId hello): creates the per-client session.
-  /// Reconnects arrive as fresh clientIds.
+  /// Client-connect signal (the clientId hello): creates the per-client session with an
+  /// empty ship map. Reconnects arrive as fresh clientIds, which is the ship-map reset.
   pub async fn register_client(&self, client_id: String) {
     self.clients.lock().await.entry(client_id).or_default();
   }
 
-  /// Client-disconnect signal: drops the session.
+  /// Client-disconnect signal: drops the session together with any
+  /// rendered-but-undelivered payloads addressed to it.
   pub async fn remove_client(&self, client_id: &str) {
     self.clients.lock().await.remove(client_id);
+    self.dev_context.pending_payloads.lock().await.retain(|_, p| p.client_id != client_id);
   }
 
   /// Delivery notification from the serving middleware: the response for `filename`
-  /// completed. Currently a no-op — every push ships the full affected factory set.
-  /// The per-client ship map that consumes this signal lands in a follow-up.
-  #[expect(clippy::unused_async, reason = "the ship-map follow-up awaits its state locks here")]
-  pub async fn notify_payload_delivered(&self, _filename: &str) {}
+  /// completed. Max-merges the pending entry's stamps into that client's shipped[C] —
+  /// idempotent, and a late or repeated delivery can never move the record backwards.
+  pub async fn notify_payload_delivered(&self, filename: &str) {
+    let Some(pending) = self.dev_context.pending_payloads.lock().await.remove(filename) else {
+      return;
+    };
+    let mut clients = self.clients.lock().await;
+    let Some(session) = clients.get_mut(&pending.client_id) else {
+      return;
+    };
+    for (id, stamp) in pending.modules {
+      session.shipped.entry(id).and_modify(|e| *e = (*e).max(stamp)).or_insert(stamp);
+    }
+  }
 
   /// Compile a lazy entry module and return compiled code.
   ///
@@ -294,7 +311,7 @@ impl DevEngine {
   /// * `client_id` - The client ID requesting this compilation
   ///
   /// # Returns
-  /// The compiled chunk: its code plus the filename it is served under
+  /// The compiled chunk plus the modules and render-time stamps it carries
   ///
   /// # Panics
   /// - If lazy compilation is not enabled
@@ -308,6 +325,11 @@ impl DevEngine {
     self.create_error_if_closed()?;
     let mut bundler = self.bundler.lock().await;
 
+    // Snapshot the ship map `shipped[C]` for this client so the compile runs without
+    // the clients lock. `ArcStr` keys make the copy refcount bumps, not string copies.
+    let shipped =
+      self.clients.lock().await.get(&client_id).map(|c| c.shipped.clone()).unwrap_or_default();
+
     // Mark the proxy module as fetched BEFORE compilation.
     // This changes the content returned by the lazy compilation plugin's load hook
     // from a stub (fetches via /lazy endpoint) to actual code that imports the real module.
@@ -318,11 +340,34 @@ impl DevEngine {
     // Compile starting from the proxy module.
     // The plugin will return new content (fetched template) that imports the real module,
     // which triggers compilation of the actual module and its dependencies.
-    let result = bundler
-      .compile_lazy_entry(proxy_module_id.clone(), &client_id, Arc::clone(&self.next_hmr_patch_id))
+    let stamp_table = self.dev_context.stamp_table.lock().await;
+    let mut result = bundler
+      .compile_lazy_entry(
+        proxy_module_id.clone(),
+        &client_id,
+        &shipped,
+        &stamp_table,
+        Arc::clone(&self.next_hmr_patch_id),
+      )
       .await;
+    drop(stamp_table);
 
-    if result.is_ok() {
+    if let Ok(output) = &mut result {
+      // Record the rendered chunk as pending: the delivery notification
+      // max-merges its stamps into `shipped[C]` when the serving middleware
+      // sees the response for `output.filename` complete. The binding layer
+      // drops `carried`, so hand it to the pending entry instead of cloning.
+      self
+        .dev_context
+        .insert_pending_payload(
+          output.filename.clone(),
+          PendingPayload {
+            client_id: client_id.clone(),
+            modules: std::mem::take(&mut output.carried),
+          },
+        )
+        .await;
+
       // Deliver assets emitted while compiling the lazy entry (e.g. an image
       // imported by the lazy module) before returning the code, so the consumer
       // can register/serve them before the client requests them.
@@ -457,6 +502,8 @@ impl DevEngine {
   pub async fn create_client_for_testing(&self) {
     let client_session = ClientSession::default();
     // A fixed client ID so HMR steps in tests have a session to compute updates for.
+    // Its ship map starts empty and no delivery is ever marked, so every step ships
+    // the full affected factory set.
     self.clients.lock().await.insert("rolldown-tests".to_string(), client_session);
   }
 

--- a/crates/rolldown_dev/src/types/client_session.rs
+++ b/crates/rolldown_dev/src/types/client_session.rs
@@ -1,5 +1,13 @@
+use arcstr::ArcStr;
+use rustc_hash::FxHashMap;
+
 #[derive(Default)]
 pub struct ClientSession {
+  /// `shipped[C]`: module stable id → rebuild stamp of the copy this client holds.
+  /// Written ONLY when the serving middleware observes a payload response complete
+  /// (the delivery notification), never at render or push. `ArcStr` keys share the
+  /// id strings with the stamp table and every other client's ship map.
+  pub shipped: FxHashMap<ArcStr, u32>,
   /// Per-client envelope sequence counter.
   pub next_seq: u32,
 }

--- a/crates/rolldown_dev/src/types/mod.rs
+++ b/crates/rolldown_dev/src/types/mod.rs
@@ -4,5 +4,6 @@ pub mod coordinator_state;
 pub mod coordinator_state_snapshot;
 pub mod ensure_latest_bundle_output_return;
 pub mod error_stage;
+pub mod pending_payload;
 pub mod schedule_build_return;
 pub mod task_input;

--- a/crates/rolldown_dev/src/types/pending_payload.rs
+++ b/crates/rolldown_dev/src/types/pending_payload.rs
@@ -1,0 +1,9 @@
+use arcstr::ArcStr;
+
+/// A rendered-but-not-yet-delivered payload: filename → the modules and render-time
+/// stamps it carries. Consumed by the delivery notification when the middleware sees
+/// the response for `filename` complete.
+pub struct PendingPayload {
+  pub client_id: String,
+  pub modules: Vec<(ArcStr, u32)>,
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -100,6 +100,9 @@
     "packages/test-dev-server/tests/playground/*": {
       "entry": ["dev.config.mjs", "*.js", "__tests__/*.spec.ts"],
     },
+    "packages/test-dev-server/tests/playground/lazy-overlap-dedup": {
+      "entry": ["dev.config.mjs", "*.js", "__tests__/*.spec.ts", "__tests__/serve.ts"],
+    },
     "packages/test-dev-server/tests/playground/hmr-full-bundle-mode": {
       "entry": [
         "dev.config.mjs",

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/__tests__/hmr-patch-dedup.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/__tests__/hmr-patch-dedup.spec.ts
@@ -1,0 +1,65 @@
+import type { Response } from 'playwright';
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+// The ship-map factory selection: a patch carries only the factories this
+// client lacks or holds stale. The first edit of a chain ships the whole
+// re-execution chain (up to the accepting boundary); a repeat edit of the same
+// file ships only that file's factory — the parked copies of the rest are
+// still current per the server's shipped[C] ship map.
+
+const countFactories = (body: string) => body.match(/registerFactory\(/g)?.length ?? 0;
+
+// Stable ids are cwd-relative paths (e.g. `playground-temp/hmr-patch-dedup/baz.js`),
+// so match a factory registration by the id's file-name suffix.
+const factoryFor = (file: string) => new RegExp(`registerFactory\\("[^"]*/${file}"`);
+
+describe('hmr-patch-dedup', () => {
+  test('first edit ships the whole chain; a repeat edit ships only the changed file', async () => {
+    // Collect every HMR patch the page imports (the client fetches the patch
+    // at the envelope's `url`, e.g. `/hmr_patch_0.js`).
+    const patchBodies: Promise<string>[] = [];
+    const onResponse = (res: Response) => {
+      if (/\/hmr_patch_\d+\.js(?:\?|$)/.test(res.url())) {
+        patchBodies.push(res.text());
+      }
+    };
+    page.on('response', onResponse);
+
+    try {
+      await waitForBuildStable();
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v1)');
+
+      // First edit of baz: the client holds no factories yet (the initial
+      // bundle is scope-hoisted), so the patch must carry the full re-run
+      // chain baz -> bar -> foo (foo is the self-accepting boundary).
+      editFile('baz.js', (code) => code.replace("'baz-v1'", "'baz-v2'"));
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v2)');
+
+      expect(patchBodies.length).toBe(1);
+      const firstPatch = await patchBodies[0];
+      expect(firstPatch).toMatch(factoryFor('baz.js'));
+      expect(firstPatch).toMatch(factoryFor('bar.js'));
+      expect(firstPatch).toMatch(factoryFor('foo.js'));
+      expect(countFactories(firstPatch)).toBe(3);
+
+      await waitForBuildStable();
+
+      // Repeat edit of the same file: bar and foo were already delivered and
+      // are not stale, so the second patch carries baz's factory alone.
+      editFile('baz.js', (code) => code.replace("'baz-v2'", "'baz-v3'"));
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v3)');
+
+      expect(patchBodies.length).toBe(2);
+      const secondPatch = await patchBodies[1];
+      expect(secondPatch).toMatch(factoryFor('baz.js'));
+      expect(secondPatch).not.toMatch(factoryFor('bar.js'));
+      expect(secondPatch).not.toMatch(factoryFor('foo.js'));
+      expect(countFactories(secondPatch)).toBe(1);
+
+      await waitForBuildStable();
+    } finally {
+      page.off('response', onResponse);
+    }
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/bar.js
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/bar.js
@@ -1,0 +1,3 @@
+import { baz } from './baz.js';
+
+export const bar = `bar(${baz})`;

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/baz.js
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/baz.js
@@ -1,0 +1,1 @@
+export const baz = 'baz-v1';

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/foo.js
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/foo.js
@@ -1,0 +1,5 @@
+import { bar } from './bar.js';
+
+document.querySelector('.chain').textContent = bar;
+
+import.meta.hot?.accept();

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/index.html
@@ -1,0 +1,5 @@
+<h1>HMR Patch Dedup</h1>
+
+<div class="chain"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/main.js
@@ -1,0 +1,1 @@
+import './foo.js';

--- a/packages/test-dev-server/tests/playground/hmr-patch-dedup/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-patch-dedup/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-patch-dedup",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/__tests__/hmr-reconnect-ship-map.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/__tests__/hmr-reconnect-ship-map.spec.ts
@@ -1,0 +1,66 @@
+import { setTimeout } from 'node:timers/promises';
+import type { Response } from 'playwright';
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+// A page reload mints a fresh clientId, so the server's per-client delivery
+// ship map resets: the next edit ships the FULL chain of factories again (the
+// new session holds none), and still applies as a hot update.
+
+const countFactories = (body: string) => body.match(/registerFactory\(/g)?.length ?? 0;
+const factoryFor = (file: string) => new RegExp(`registerFactory\\("[^"]*/${file}"`);
+
+const plantMarker = () => page.evaluate(() => ((window as unknown as { __marker?: string }).__marker = 'alive'));
+const readMarker = () =>
+  page.evaluate(() => (window as unknown as { __marker?: string }).__marker ?? null);
+
+describe('hmr-reconnect-ship-map', () => {
+  test('a reload resets the ship map: the next edit re-ships the whole chain and still hot-updates', async () => {
+    const patchBodies: Promise<string>[] = [];
+    const onResponse = (res: Response) => {
+      if (/\/hmr_patch_\d+\.js(?:\?|$)/.test(res.url())) {
+        patchBodies.push(res.text());
+      }
+    };
+    page.on('response', onResponse);
+
+    try {
+      await waitForBuildStable();
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v1)');
+
+      // First edit: hot update; the fresh session receives the whole chain.
+      editFile('baz.js', (code) => code.replace("'baz-v1'", "'baz-v2'"));
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v2)');
+      expect(patchBodies.length).toBe(1);
+      expect(countFactories(await patchBodies[0])).toBe(3);
+      await waitForBuildStable();
+
+      // Reload: fresh clientId -> the server-side ship map for this tab resets.
+      await page.reload();
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v2)');
+      await waitForBuildStable();
+      // Let the debounced post-regeneration reload (if any) land before we
+      // start measuring hot-vs-reload with the marker.
+      await setTimeout(600);
+      await plantMarker();
+
+      // Second edit, post-reload: still a HOT update (marker survives), and
+      // the patch carries the full chain again — bar's and foo's factories
+      // are re-shipped because this session never received them.
+      editFile('baz.js', (code) => code.replace("'baz-v2'", "'baz-v3'"));
+      await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v3)');
+      expect(await readMarker()).toBe('alive');
+
+      expect(patchBodies.length).toBe(2);
+      const postReloadPatch = await patchBodies[1];
+      expect(postReloadPatch).toMatch(factoryFor('baz.js'));
+      expect(postReloadPatch).toMatch(factoryFor('bar.js'));
+      expect(postReloadPatch).toMatch(factoryFor('foo.js'));
+      expect(countFactories(postReloadPatch)).toBe(3);
+
+      await waitForBuildStable();
+    } finally {
+      page.off('response', onResponse);
+    }
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/bar.js
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/bar.js
@@ -1,0 +1,3 @@
+import { baz } from './baz.js';
+
+export const bar = `bar(${baz})`;

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/baz.js
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/baz.js
@@ -1,0 +1,1 @@
+export const baz = 'baz-v1';

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/foo.js
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/foo.js
@@ -1,0 +1,5 @@
+import { bar } from './bar.js';
+
+document.querySelector('.chain').textContent = bar;
+
+import.meta.hot?.accept();

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/index.html
@@ -1,0 +1,5 @@
+<h1>HMR Reconnect Ship Map</h1>
+
+<div class="chain"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/main.js
@@ -1,0 +1,1 @@
+import './foo.js';

--- a/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-reconnect-ship-map/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-reconnect-ship-map",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/__tests__/lazy-overlap-dedup.spec.ts
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/__tests__/lazy-overlap-dedup.spec.ts
@@ -1,0 +1,57 @@
+import { setTimeout } from 'node:timers/promises';
+import type { Response } from 'playwright';
+import { describe, expect, test } from 'vitest';
+import { page, serverUrl, waitForBuildStable } from '~utils';
+
+// Lazy chunks are sized by the same per-client ship map as HMR
+// patches: a lazy response omits every factory this client already received.
+// Route A and route B both statically import shared.js — loaded sequentially,
+// A's chunk carries shared.js's factory, B's does NOT, and B still renders
+// shared values through the registry.
+
+const factoryFor = (file: string) => new RegExp(`registerFactory\\("[^"]*/${file}"`);
+
+describe('lazy-overlap-dedup', () => {
+  test('the second lazy route omits the already-delivered shared factory', { retry: 0 }, async () => {
+    // Keyed by the lazy request's `id` param (the proxy module id).
+    const lazyBodies: { id: string; body: Promise<string> }[] = [];
+    const onResponse = (res: Response) => {
+      const url = res.url();
+      if (url.includes('/@vite/lazy?')) {
+        const id = new URL(url).searchParams.get('id') ?? '';
+        lazyBodies.push({ id, body: res.text() });
+      }
+    };
+    page.on('response', onResponse);
+
+    try {
+      await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
+      await waitForBuildStable();
+
+      // Route A first: its chunk delivers page-a AND the shared module.
+      await page.click('#route-a-btn');
+      await expect.poll(() => page.textContent('#route-a-content')).toBe('A:shared-value');
+
+      // The ship map records a delivery when the response completes; give the
+      // (async, in-process) ship-map write a beat before the next compile reads it.
+      await setTimeout(300);
+
+      // Route B second: shared.js was already delivered to this client, so
+      // B's chunk must NOT re-ship it — and B still works via the registry.
+      await page.click('#route-b-btn');
+      await expect.poll(() => page.textContent('#route-b-content')).toBe('B:shared-value');
+
+      expect(lazyBodies.length).toBe(2);
+      const bodyA = await lazyBodies.find((e) => e.id.includes('page-a'))!.body;
+      const bodyB = await lazyBodies.find((e) => e.id.includes('page-b'))!.body;
+
+      expect(bodyA).toMatch(factoryFor('page-a.js'));
+      expect(bodyA).toMatch(factoryFor('shared.js'));
+
+      expect(bodyB).toMatch(factoryFor('page-b.js'));
+      expect(bodyB).not.toMatch(factoryFor('shared.js'));
+    } finally {
+      page.off('response', onResponse);
+    }
+  });
+});

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/__tests__/serve.ts
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/__tests__/serve.ts
@@ -1,0 +1,8 @@
+import type { DevServerHandle, ServeContext } from '~utils';
+
+// Create the server but do NOT navigate: the ship-map-driven dedup is about the
+// very first deliveries to a fresh client, so the spec does its own
+// `page.goto` and controls the click order.
+export async function serve(ctx: ServeContext): Promise<DevServerHandle> {
+  return ctx.createServer();
+}

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: { lazy: true },
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>lazy-overlap-dedup</title>
+  </head>
+  <body>
+    <h1>lazy-overlap-dedup</h1>
+
+    <section id="route-a">
+      <button id="route-a-btn">load A</button>
+      <div id="route-a-content">pending</div>
+    </section>
+
+    <section id="route-b">
+      <button id="route-b-btn">load B</button>
+      <div id="route-b-content">pending</div>
+    </section>
+
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/main.js
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/main.js
@@ -1,0 +1,11 @@
+// Two lazy "routes" that both statically import shared.js. Loaded via
+// buttons so the spec controls the (sequential) navigation order.
+document.getElementById('route-a-btn').addEventListener('click', async () => {
+  const mod = await import('./page-a.js');
+  document.getElementById('route-a-content').textContent = mod.a;
+});
+
+document.getElementById('route-b-btn').addEventListener('click', async () => {
+  const mod = await import('./page-b.js');
+  document.getElementById('route-b-content').textContent = mod.b;
+});

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/package.json
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-lazy-overlap-dedup",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/page-a.js
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/page-a.js
@@ -1,0 +1,3 @@
+import { shared } from './shared.js';
+
+export const a = `A:${shared}`;

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/page-b.js
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/page-b.js
@@ -1,0 +1,3 @@
+import { shared } from './shared.js';
+
+export const b = `B:${shared}`;

--- a/packages/test-dev-server/tests/playground/lazy-overlap-dedup/shared.js
+++ b/packages/test-dev-server/tests/playground/lazy-overlap-dedup/shared.js
@@ -1,0 +1,1 @@
+export const shared = 'shared-value';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,7 +388,7 @@ importers:
         version: link:../../packages/rolldown
       unplugin-isolated-decl:
         specifier: ^0.8.1
-        version: 0.8.3(oxc-transform@0.140.0)(rollup@4.62.2)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 0.8.3(oxc-transform@0.140.0)(rollup@4.62.2)(typescript@6.0.3)
 
   examples/lazy-compilation:
     devDependencies:
@@ -412,13 +412,13 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
-        version: 7.29.7(supports-color@8.1.1)
+        version: 7.29.7
       '@babel/preset-env':
         specifier: 'catalog:'
-        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript':
         specifier: 'catalog:'
-        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+        version: 7.29.7(@babel/core@7.29.7)
       rolldown:
         specifier: workspace:*
         version: link:../../packages/rolldown
@@ -427,7 +427,7 @@ importers:
     dependencies:
       rollup-plugin-esbuild:
         specifier: ^6.1.1
-        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
+        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)
     devDependencies:
       rolldown:
         specifier: workspace:*
@@ -542,7 +542,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.7.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.10.3)(supports-color@8.1.1)
+        version: 3.7.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.10.3)
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
         version: 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
@@ -715,7 +715,7 @@ importers:
         version: link:../rolldown
       serve-static:
         specifier: 'catalog:'
-        version: 2.2.1(supports-color@8.1.1)
+        version: 2.2.1
       ws:
         specifier: 'catalog:'
         version: 8.21.0
@@ -800,6 +800,18 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-patch-dedup:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/hmr-reconnect-ship-map:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-runtime-acceptance:
     devDependencies:
       '@rolldown/test-dev-server':
@@ -831,6 +843,12 @@ importers:
         version: link:../../..
 
   packages/test-dev-server/tests/playground/lazy-compilation:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
+  packages/test-dev-server/tests/playground/lazy-overlap-dedup:
     devDependencies:
       '@rolldown/test-dev-server':
         specifier: workspace:*
@@ -8514,27 +8532,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.29.7(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -8574,19 +8572,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -8595,17 +8580,10 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      regexpu-core: 6.4.0
-      semver: 6.3.1
 
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -8613,17 +8591,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
-
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
@@ -8640,24 +8607,15 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8666,7 +8624,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8676,30 +8634,12 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-wrap-function': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-wrap-function': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8708,13 +8648,13 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -8732,7 +8672,7 @@ snapshots:
   '@babel/helper-wrap-function@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -8750,35 +8690,17 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)':
@@ -8786,28 +8708,11 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8820,43 +8725,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
@@ -8864,30 +8747,14 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
@@ -8896,40 +8763,17 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8942,19 +8786,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
@@ -8962,26 +8796,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -8994,18 +8812,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -9014,15 +8820,9 @@ snapshots:
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/template': 7.29.7
 
   '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9030,27 +8830,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9058,20 +8844,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
@@ -9080,23 +8855,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9106,33 +8868,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9142,37 +8886,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
@@ -9180,19 +8905,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)':
@@ -9200,26 +8915,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9232,31 +8931,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9268,21 +8949,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)':
@@ -9290,36 +8960,15 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9328,15 +8977,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9348,23 +8989,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9374,37 +9002,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9418,30 +9024,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)':
@@ -9450,33 +9040,15 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9486,19 +9058,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
@@ -9506,26 +9068,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9538,20 +9084,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)':
@@ -9560,22 +9095,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)':
@@ -9583,83 +9106,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7(supports-color@8.1.1))
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))
-      core-js-compat: 3.49.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9738,30 +9184,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.29.7
-      esutils: 2.0.3
-
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
-
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9782,7 +9210,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -10611,10 +10039,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/cli@3.7.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.10.3)(supports-color@8.1.1)':
+  '@napi-rs/cli@3.7.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.10.3)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.10.3)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(supports-color@8.1.1)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -10643,7 +10071,7 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(supports-color@8.1.1)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@napi-rs/lzma': 1.4.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@napi-rs/tar': 1.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
@@ -12816,15 +12244,6 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -12834,26 +12253,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7(supports-color@8.1.1)):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      core-js-compat: 3.49.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7(supports-color@8.1.1)):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15007,7 +14411,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -15088,7 +14492,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@8.1.1):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -15108,12 +14512,12 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@2.2.1(supports-color@8.1.1):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -15514,7 +14918,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-isolated-decl@0.8.3(oxc-transform@0.140.0)(rollup@4.62.2)(supports-color@8.1.1)(typescript@6.0.3):
+  unplugin-isolated-decl@0.8.3(oxc-transform@0.140.0)(rollup@4.62.2)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

## Summary

For full design and principles, please refer to https://github.com/rolldown/rolldown/pull/10164#issue-4824909361.

This PR adds the server-side **ship map**: a per-client record of which factory versions each browser tab already has, so patches and lazy chunks carry only changed, not-yet-shipped factories.

## Example

The stateful server's ship map would incrementally ship factories that are only outdated or never shipped.

### The module graph

```mermaid
flowchart LR
    app["app.js"] --> foo["foo.js<br/>(import.meta.hot.accept — boundary)"]
    foo --> bar["bar.js"]
    bar --> baz["baz.js<br/>(edited twice)"]
```

### Server & client interaction

```mermaid
sequenceDiagram
    participant S as Server (keeps shipped[C])
    participant C as Browser tab C

    Note over C: initial bundle is scope-hoisted — no factories registered on the client yet
    Note over S: shipped[C] = { }

    Note over S,C: ① first edit of baz.js
    S->>C: patch 1 — factories foo@v0 + bar@v0 + baz@v1 (whole re-run chain, nothing shipped yet)
    C->>C: re-run baz → bar → foo, foo accepts
    Note over S: shipped[C] = { foo@v0, bar@v0, baz@v1 }

    Note over S,C: ② second edit of baz.js
    S->>C: patch 2 — factory baz@v2 only (foo@v0 and bar@v0 are still current in shipped[C])
    C->>C: re-run baz → bar → foo, foo accepts
    Note over S: shipped[C] = { foo@v0, bar@v0, baz@v2 }
```

The first edit ships the whole re-run chain because the initial bundle is scope-hoisted, so the client holds no factories yet. The second edit ships only `baz` — the ship map says `foo` and `bar` were already delivered and are not stale.

Rendered, the flow reads:

app.js ──> foo.js ──> bar.js ──> baz.js
           (accept)              (edited)

edit ①  patch = [foo@v0, bar@v0, baz@v1]   shipped[C]: {} -> {foo@v0, bar@v0, baz@v1}
edit ②  patch = [baz@v2]                   shipped[C]: baz v1 -> v2, rest untouched