### PR TITLE
fix: `[format]` in `*FileNames` option for ESM format should be `es` instead of `esm`

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/6437/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/6437/_test.mjs
@@ -3,14 +3,14 @@ import nodeFs from 'node:fs';
 import nodeAssert from 'node:assert';
 
 const distDir = nodePath.join(import.meta.dirname, 'dist');
-const entryFile = nodePath.join(distDir, 'entries', 'main-esm.js');
+const entryFile = nodePath.join(distDir, 'entries', 'main-es.js');
 nodeAssert(nodeFs.existsSync(entryFile), `expected entry chunk ${entryFile} to exist`);
 
 const chunkDir = nodePath.join(distDir, 'chunks');
 const chunkFiles = nodeFs.readdirSync(chunkDir);
 nodeAssert(
-  chunkFiles.some((file) => file.endsWith('-esm.js')),
-  'expected a chunk filename with "-esm.js"',
+  chunkFiles.some((file) => file.endsWith('-es.js')),
+  'expected a chunk filename with "-es.js"',
 );
 
 nodeAssert(

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -118,12 +118,7 @@ impl BindingNormalizedOptions {
 
   #[napi(getter, ts_return_type = "'es' | 'cjs' | 'iife' | 'umd'")]
   pub fn format(&self) -> &'static str {
-    match self.inner.format {
-      rolldown::OutputFormat::Esm => "es",
-      rolldown::OutputFormat::Cjs => "cjs",
-      rolldown::OutputFormat::Iife => "iife",
-      rolldown::OutputFormat::Umd => "umd",
-    }
+    self.inner.format.as_str()
   }
 
   #[napi(getter, ts_return_type = "'default' | 'named' | 'none' | 'auto'")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -21,8 +21,9 @@ pub enum OutputFormat {
 impl OutputFormat {
   #[inline]
   pub const fn as_str(&self) -> &'static str {
+    // Aligned with InternalModuleFormat type on JS side
     match self {
-      Self::Esm => "esm",
+      Self::Esm => "es",
       Self::Cjs => "cjs",
       Self::Iife => "iife",
       Self::Umd => "umd",


### PR DESCRIPTION
Rollup uses `es` instead of `esm` ([REPL](https://rollupjs.org/repl/?version=4.62.2&shareable=eyJleGFtcGxlIjpudWxsLCJtb2R1bGVzIjpbeyJjb2RlIjoiY29uc29sZS5sb2coXCJtYWluXCIpXG5pbXBvcnQoJy4vcXV4LmpzJykiLCJpc0VudHJ5Ijp0cnVlLCJuYW1lIjoibWFpbi5qcyJ9LHsiY29kZSI6ImNvbnNvbGUubG9nKFwicXV4XCIpIiwiaXNFbnRyeSI6ZmFsc2UsIm5hbWUiOiJxdXguanMifV0sIm9wdGlvbnMiOnsib3V0cHV0Ijp7ImVudHJ5RmlsZU5hbWVzIjoiW25hbWVdLVtmb3JtYXRdLmpzIiwiZm9ybWF0IjoiZXMifX19)).

Given that this change may have a larger impact than other bug fixes, **this should land on minor versions.**
