### PR TITLE
docs: show plugin kinds in JSDoc and each hook's description

### DIFF
--- a/docs/.vitepress/scripts/custom-theme-plugin.ts
+++ b/docs/.vitepress/scripts/custom-theme-plugin.ts
@@ -2,7 +2,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { Converter, ReflectionKind, type Application, type Reflection } from 'typedoc';
+import {
+  Converter,
+  ReflectionKind,
+  type Application,
+  type Comment,
+  type Reflection,
+} from 'typedoc';
 import {
   type MarkdownPageEvent,
   MarkdownTheme,
@@ -64,7 +70,8 @@ class CustomThemeContext extends MarkdownThemeContext {
         return `<DefinedIn :sources="${escapeAttr(JSON.stringify(sources))}" />`;
       },
       comment: (model, options) => {
-        const result = superPartials.comment.call(this, model, options);
+        // `@kind` is rendered by `signatureTitle` / `declarationTitle` instead
+        const result = superPartials.comment.call(this, withoutKindTag(model), options);
         // Remove the `**`Experimental`**` text that comes from `@experimental` tag
         return result.replace(/\*\*`Experimental`\*\*/g, '');
       },
@@ -90,6 +97,12 @@ class CustomThemeContext extends MarkdownThemeContext {
         const returnType = model.type ? this.partials.someType(model.type) : '`void`';
 
         md.push(`- **Type**: (${params}) => ${returnType}`);
+
+        // The comment of a hook may live on the signature or on its parent declaration.
+        const kind = formatKindTag(model.comment) ?? formatKindTag(model.parent?.comment);
+        if (kind) {
+          md.push(`- **Kind**: ${kind}`);
+        }
 
         if (model.comment?.modifierTags?.has('@experimental')) {
           md.push('- **Experimental**');
@@ -134,6 +147,11 @@ class CustomThemeContext extends MarkdownThemeContext {
           md.push(`- **Type**: ${typeStr}`);
         }
 
+        const kind = formatKindTag(model.comment);
+        if (kind) {
+          md.push(`- **Kind**: ${kind}`);
+        }
+
         if (model.flags?.isOptional) {
           md.push('- **Optional**');
         }
@@ -158,4 +176,34 @@ class CustomThemeContext extends MarkdownThemeContext {
 
 function escapeAttr(str: string) {
   return str.replace(/"/g, '&quot;');
+}
+
+const KIND_TAG = '@kind';
+
+/**
+ * Formats a `@kind async parallel` tag as `` `async`, `parallel` ``.
+ */
+function formatKindTag(comment: Comment | undefined): string | undefined {
+  const tag = comment?.getTag(KIND_TAG);
+  if (!tag) return undefined;
+
+  const kinds = tag.content
+    .map((part) => part.text)
+    .join('')
+    .split(/[\s,]+/)
+    .filter(Boolean);
+  if (kinds.length === 0) return undefined;
+
+  return kinds.map((kind) => `\`${kind}\``).join(', ');
+}
+
+/**
+ * Returns a copy of `comment` without the `@kind` tag, so that the default comment
+ * partial does not render it a second time below the title.
+ */
+function withoutKindTag(comment: Comment): Comment {
+  if (!comment.getTag(KIND_TAG)) return comment;
+  const cloned = comment.clone();
+  cloned.removeTags(KIND_TAG);
+  return cloned;
 }

--- a/docs/.vitepress/scripts/generate-reference.ts
+++ b/docs/.vitepress/scripts/generate-reference.ts
@@ -1,6 +1,6 @@
 import { copyFile, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Application, type TypeDocOptions } from 'typedoc';
+import { Application, OptionDefaults, type TypeDocOptions } from 'typedoc';
 import type { PluginOptions } from 'typedoc-plugin-markdown';
 
 const root = path.resolve(import.meta.dirname, '../../..');
@@ -72,6 +72,9 @@ async function runTypedoc(entryPoints: string[]): Promise<void> {
     out: './reference',
     entryPoints,
     readme: 'none',
+    // `@kind` documents a plugin hook's kind, e.g. `@kind async parallel`.
+    // It is rendered by `custom-theme-plugin.ts`, not by the default comment partial.
+    blockTags: [...OptionDefaults.blockTags, '@kind'],
     excludeInternal: true,
     excludeExternals: true,
     externalPattern: ['**/packages/pluginutils/**', '**/node_modules/**/@oxc-project/types/**'],

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -248,6 +248,7 @@ export interface FunctionPluginHooks {
    *
    * {@include ./docs/plugin-hooks-onlog.md}
    *
+   * @kind sync sequential
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.onLog]: (
@@ -265,6 +266,7 @@ export interface FunctionPluginHooks {
    * the {@linkcode buildStart} hook as that hook has access to the options
    * after the transformations from all `options` hooks have been taken into account.
    *
+   * @kind async sequential
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.options]: (
@@ -284,6 +286,7 @@ export interface FunctionPluginHooks {
    * the {@linkcode renderStart} hook as this hook has access to the output options
    * after the transformations from all `outputOptions` hooks have been taken into account.
    *
+   * @kind sync sequential
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.outputOptions]: (
@@ -296,6 +299,7 @@ export interface FunctionPluginHooks {
    *
    * This is the recommended hook to use when you need access to the options passed to {@linkcode rolldown | rolldown()} as it takes the transformations by all options hooks into account and also contains the right default values for unset options.
    *
+   * @kind async parallel
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.buildStart]: (this: PluginContext, options: NormalizedInputOptions) => void;
@@ -315,6 +319,7 @@ export interface FunctionPluginHooks {
    * Rolldown will continue with the {@linkcode load} and {@linkcode transform} hooks for that
    * module that may override these values and should take precedence if they do so.
    *
+   * @kind async first
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.resolveId]: (
@@ -347,6 +352,7 @@ export interface FunctionPluginHooks {
    * @deprecated
    * This hook exists only for Rollup compatibility. Please use {@linkcode resolveId} instead.
    *
+   * @kind async first
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.resolveDynamicImport]: (
@@ -374,6 +380,7 @@ export interface FunctionPluginHooks {
    *
    * You can use {@linkcode PluginContext.getModuleInfo | this.getModuleInfo()} to find out the previous values of `meta`, `moduleSideEffects` inside this hook.
    *
+   * @kind async first
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.load]: (this: PluginContext, id: string) => MaybePromise<LoadResult>;
@@ -387,6 +394,7 @@ export interface FunctionPluginHooks {
    *
    * {@include ./docs/plugin-hooks-transform.md}
    *
+   * @kind async sequential
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.transform]: (
@@ -410,6 +418,7 @@ export interface FunctionPluginHooks {
    * may be incomplete as additional importers could be discovered later.
    * If you need this information, use the {@linkcode buildEnd} hook.
    *
+   * @kind async parallel
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.moduleParsed]: (this: PluginContext, moduleInfo: ModuleInfo) => void;
@@ -418,6 +427,7 @@ export interface FunctionPluginHooks {
    * Called when Rolldown has finished bundling, but before Output Generation Hooks.
    * If an error occurred during the build, it is passed on to this hook.
    *
+   * @kind async parallel
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.buildEnd]: (
@@ -441,6 +451,7 @@ export interface FunctionPluginHooks {
    * plugins that can be used as output plugins, i.e. plugins that only use generate phase hooks,
    * can get access to them.
    *
+   * @kind async parallel
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.renderStart]: (
@@ -459,6 +470,7 @@ export interface FunctionPluginHooks {
    * That means if you add or remove imports or exports in this hook, you should update
    * {@linkcode RenderedChunk.imports | imports}, {@linkcode RenderedChunk.importedBindings | importedBindings} and/or {@linkcode RenderedChunk.exports | exports} accordingly.
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.renderChunk]: (
@@ -484,6 +496,7 @@ export interface FunctionPluginHooks {
    *
    * {@include ./docs/plugin-hooks-augmentchunkhash.md}
    *
+   * @kind sync sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.augmentChunkHash]: (
@@ -499,6 +512,7 @@ export interface FunctionPluginHooks {
    * To get notified when generation completes successfully, use the
    * {@linkcode generateBundle} hook.
    *
+   * @kind async parallel
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.renderError]: (
@@ -516,6 +530,7 @@ export interface FunctionPluginHooks {
    *
    * {@include ./docs/plugin-hooks-generatebundle.md}
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.generateBundle]: (
@@ -530,6 +545,7 @@ export interface FunctionPluginHooks {
    * Called only at the end of {@linkcode RolldownBuild.write | bundle.write()} once
    * all files have been written.
    *
+   * @kind async parallel
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.writeBundle]: (
@@ -552,6 +568,7 @@ export interface FunctionPluginHooks {
    * {@linkcode PluginContextMeta.watchMode | this.meta.watchMode} in this hook and perform
    * the necessary cleanup for watch mode in closeWatcher.
    *
+   * @kind async parallel
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.closeBundle]: (
@@ -570,6 +587,7 @@ export interface FunctionPluginHooks {
    *
    * If you need to be notified immediately when a file changed, you can use the {@linkcode WatcherOptions.onInvalidate | watch.onInvalidate} option.
    *
+   * @kind async parallel
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.watchChange]: (
@@ -583,6 +601,7 @@ export interface FunctionPluginHooks {
    *
    * This hook cannot be used by output plugins.
    *
+   * @kind async parallel
    * @group Build Hooks
    */
   [DEFINED_HOOK_NAMES.closeWatcher]: (this: PluginContext) => void;
@@ -638,24 +657,28 @@ interface AddonHooks {
   /**
    * A hook equivalent to {@linkcode OutputOptions.banner | output.banner} option.
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.banner]: AddonHook;
   /**
    * A hook equivalent to {@linkcode OutputOptions.footer | output.footer} option.
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.footer]: AddonHook;
   /**
    * A hook equivalent to {@linkcode OutputOptions.intro | output.intro} option.
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.intro]: AddonHook;
   /**
    * A hook equivalent to {@linkcode OutputOptions.outro | output.outro} option.
    *
+   * @kind async sequential
    * @group Output Generation Hooks
    */
   [DEFINED_HOOK_NAMES.outro]: AddonHook;


### PR DESCRIPTION
JSDoc:

<img width="622" height="162" alt="image" src="https://github.com/user-attachments/assets/c07eb353-01d1-4717-9b74-2b5365b89d58" />

Description in docs:

<img width="900" height="426" alt="image" src="https://github.com/user-attachments/assets/83456aa0-1b77-4dc3-855d-9a405dd5e8da" />


