### PR TITLE
fix: incorrect `EMPTY_IMPORT_META` warning for `import.meta.ROLLUP_FILE_URL_*` for CJS output

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -285,8 +285,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         .as_member_expression_kind()
         .map(|member_expr| {
           let static_name = member_expr.static_property_name().unwrap_or(ast::Str::from(""));
-          let is_special_property =
-            static_name == "url" || static_name == "dirname" || static_name == "filename";
+          // `import.meta.ROLLUP_FILE_URL_*` is rewritten to `new URL(..., import.meta.url).href`,
+          // so it degrades exactly like `import.meta.url` does.
+          let is_special_property = static_name == "url"
+            || static_name == "dirname"
+            || static_name == "filename"
+            || static_name.as_str().starts_with("ROLLUP_FILE_URL_");
           let format = &self.immutable_ctx.options.format;
           !is_special_property || matches!(format, OutputFormat::Iife | OutputFormat::Umd)
         })

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-non-esm-format/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-non-esm-format/_config.ts
@@ -1,0 +1,60 @@
+import { stripVTControlCharacters } from 'node:util';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const logs: { code?: string; message: string }[] = [];
+
+export default defineTest({
+  config: {
+    output: [
+      { format: 'esm', entryFileNames: 'main.mjs' },
+      { format: 'cjs', entryFileNames: 'main.cjs' },
+      { format: 'iife', entryFileNames: 'main.iife.js', name: 'iifeName' },
+      { format: 'umd', entryFileNames: 'main.umd.js', name: 'umdName' },
+    ],
+    onLog(_level, log) {
+      logs.push(log);
+    },
+    plugins: [
+      {
+        name: 'emit-asset',
+        resolveId(source) {
+          if (source === 'virtual:asset') {
+            return '\0virtual:asset';
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:asset') {
+            const referenceId = this.emitFile({
+              type: 'asset',
+              name: 'asset.txt',
+              source: 'hello',
+            });
+            return `export default import.meta.ROLLUP_FILE_URL_${referenceId};`;
+          }
+        },
+      },
+    ],
+  },
+  afterTest: (outputs) => {
+    const [esm, cjs, iife, umd] = outputs.map((output) => output.output[0].code);
+
+    expect(esm).toContain('import.meta.url');
+    // For `cjs` on the `node` platform, the generated `import.meta.url` is polyfilled too.
+    expect(cjs).toContain('pathToFileURL');
+    expect(cjs).not.toContain('import.meta');
+    // `iife` and `umd` have no way to polyfill `import.meta.url`, so it becomes `{}.url`.
+    expect(iife).toContain('{}.url');
+    expect(umd).toContain('{}.url');
+
+    // Only the formats whose output actually ends up with an empty `import.meta` are warned about.
+    const emptyImportMetaLogs = logs.filter((log) => log.code === 'EMPTY_IMPORT_META');
+    expect(emptyImportMetaLogs).toHaveLength(2);
+    expect(stripVTControlCharacters(emptyImportMetaLogs[0].message)).toContain(
+      '`import.meta` may not be a valid syntax with the `iife` output format.',
+    );
+    expect(stripVTControlCharacters(emptyImportMetaLogs[1].message)).toContain(
+      '`import.meta` may not be a valid syntax with the `umd` output format.',
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-non-esm-format/main.js
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-non-esm-format/main.js
@@ -1,0 +1,3 @@
+import assetUrl from 'virtual:asset';
+
+export default assetUrl;


### PR DESCRIPTION
Avoid `EMPTY_IMPORT_META` warning which was output for `output.format: 'cjs'` even though the `import.meta.url` is replaced.