### PR TITLE
fix: add EMPTY_IMPORT_META warning for non-node CJS output

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -20,7 +20,7 @@ use rolldown_common::{
 #[cfg(debug_assertions)]
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{ExpressionExt, is_top_level};
-use rolldown_error::{BuildDiagnostic, EmptyImportMetaKind};
+use rolldown_error::BuildDiagnostic;
 use rolldown_std_utils::OptionExt;
 
 use crate::{ast_scanner::cjs_export_analyzer::CommonJsAstType, utils};
@@ -301,55 +301,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     {
       self.result.rolldown_file_url_references.push(RolldownFileUrlReference {
         node_id: it.node_id(),
-        span: it.span(),
         stmt_info_idx: self.current_stmt_idx,
         reference_id: CompactStr::from(reference_id),
       });
     }
     walk::walk_member_expression(self, it);
   }
-
-  fn visit_meta_property(&mut self, it: &ast::MetaProperty<'ast>) {
-    if self.immutable_ctx.flat_options.keep_esm_import_export_syntax() {
-      walk::walk_meta_property(self, it);
-      return;
-    }
-    if let Some(parent) = self.visit_path.last() {
-      let should_warn = parent
-        .as_member_expression_kind()
-        .map(|member_expr| {
-          let static_name = member_expr.static_property_name().unwrap_or(ast::Str::from(""));
-          // `import.meta.ROLLDOWN_FILE_URL_*` is deferred to the `resolveFileUrl` hook as it can configure the output
-          if utils::file_url::starts_with_file_url_prefix(static_name.as_str()) {
-            return false;
-          }
-
-          let is_special_property =
-            static_name == "url" || static_name == "dirname" || static_name == "filename";
-          let format = &self.immutable_ctx.options.format;
-          !is_special_property || matches!(format, OutputFormat::Iife | OutputFormat::Umd)
-        })
-        // Here we need to set it to `true` to emit warnings when leaving `import.meta` alone along with the logic head of this.
-        .unwrap_or(true);
-
-      if should_warn && it.meta.name == "import" && it.property.name == "meta" {
-        let is_import_meta_url = parent.as_member_expression_kind().is_some_and(|member_expr| {
-          member_expr.static_property_name().is_some_and(|static_name| static_name == "url")
-        });
-        self.result.warnings.push(
-          BuildDiagnostic::empty_import_meta(
-            self.immutable_ctx.id.to_string(),
-            self.immutable_ctx.source.clone(),
-            it.span(),
-            self.immutable_ctx.options.format.as_str().into(),
-            if is_import_meta_url { EmptyImportMetaKind::Url } else { EmptyImportMetaKind::Plain },
-          )
-          .with_severity_warning(),
-        );
-      }
-    }
-  }
-
   fn visit_this_expression(&mut self, it: &ast::ThisExpression) {
     if !self.is_this_nested() {
       self.top_level_this_expr_set.insert(it.node_id());

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -8,7 +8,7 @@ use rolldown_common::{
 pub type FinalizerMutableFields = (
   FxIndexMap<ImportRecordIdx, String>, // transferred_import_record
   RenderedConcatenatedModuleParts,     // rendered_concatenated_wrapped_module_parts
-  Vec<BuildDiagnostic>,                // errors
+  Vec<BuildDiagnostic>,                // diagnostics
 );
 
 use oxc::ast_visit::VisitMut as _;
@@ -147,26 +147,40 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         json_module_inlined_prop: need_inline_json_prop.then(|| Box::new(FxHashMap::default())),
         missing_file_reference_ids: FxIndexMap::default(),
         resolve_file_url_errors: Vec::new(),
+        surviving_import_meta_spans: FxIndexMap::default(),
       };
       finalizer.visit_program(oxc_program);
 
-      let missing_file_reference_ids = finalizer.missing_file_reference_ids;
-      let mut errors: Vec<BuildDiagnostic> = if missing_file_reference_ids.is_empty() {
-        vec![]
-      } else {
+      let mut diagnostics = {
         let module = finalizer.ctx.module;
-        missing_file_reference_ids
-          .into_iter()
-          .map(|(reference_id, span)| {
-            BuildDiagnostic::file_not_found(
-              reference_id.as_str(),
+        finalizer
+          .surviving_import_meta_spans
+          .iter()
+          .map(|(span, kind)| {
+            BuildDiagnostic::empty_import_meta(
               module.id.to_string(),
               module.ecma_view.source.clone(),
-              span,
+              *span,
+              finalizer.ctx.options.format.as_str().into(),
+              *kind,
             )
+            .with_severity_warning()
           })
-          .collect()
+          .collect::<Vec<_>>()
       };
+
+      let missing_file_reference_ids = finalizer.missing_file_reference_ids;
+      if !missing_file_reference_ids.is_empty() {
+        let module = finalizer.ctx.module;
+        diagnostics.extend(missing_file_reference_ids.into_iter().map(|(reference_id, span)| {
+          BuildDiagnostic::file_not_found(
+            reference_id.as_str(),
+            module.id.to_string(),
+            module.ecma_view.source.clone(),
+            span,
+          )
+        }));
+      }
 
       let mut resolve_file_url_errors = finalizer.resolve_file_url_errors;
       if !resolve_file_url_errors.is_empty() {
@@ -175,7 +189,7 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         resolve_file_url_errors.sort_unstable();
         resolve_file_url_errors.dedup();
         // Attribute each failure to its plugin, so the user sees `[plugin foo] ...`
-        errors.extend(resolve_file_url_errors.into_iter().map(|(plugin_name, message)| {
+        diagnostics.extend(resolve_file_url_errors.into_iter().map(|(plugin_name, message)| {
           BuildDiagnostic::plugin_error(CausedPlugin::new(plugin_name), anyhow::anyhow!(message))
         }));
       }
@@ -183,7 +197,7 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
       (
         finalizer.transferred_import_record,
         finalizer.rendered_concatenated_wrapped_module_parts,
-        errors,
+        diagnostics,
       )
     })
   }

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -18,6 +18,7 @@ use rolldown_ecmascript_utils::{
   EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperDeclKind, EsmWrapperStmtOptions, ExpressionExt,
   JsxExt, JsxMemberExpressionObjectExt,
 };
+use rolldown_error::EmptyImportMetaKind;
 
 use crate::module_finalizers::{KeepNameId, ModuleWrapperMode, TraverseState};
 
@@ -495,6 +496,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           && meta.meta.name == "import"
           && meta.property.name == "meta"
         {
+          self.record_surviving_import_meta(meta.span, EmptyImportMetaKind::Plain);
           *expr = ast::Expression::new_object_expression(
             SPAN,
             oxc::allocator::Vec::new_in(&self.ast_factory),

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -22,6 +22,7 @@ use rolldown_ecmascript_utils::{
   AstFactory, BindingPatternExt, CallExpressionExt, ExpressionExt, StatementExt,
   parse_injected_expression,
 };
+use rolldown_error::EmptyImportMetaKind;
 use std::borrow::Cow;
 
 mod finalizer_context;
@@ -117,6 +118,13 @@ pub struct ScopeHoistingFinalizer<'me, 'ast: 'me> {
   /// Collected here because the finalizer is sync and rayon-parallel; `finalize_modules`
   /// turns these into plugin-attributed build errors once the parallel pass is done.
   pub resolve_file_url_errors: Vec<(Cow<'static, str>, String)>,
+  /// Spans of the `import.meta` accesses this finalizer could not rewrite away, and so replaced
+  /// with an empty object.
+  ///
+  /// Keyed by span, because an `import.meta.<prop>` that fails to rewrite is reached twice: once
+  /// as the member expression (which knows the property) and once as the bare `import.meta`
+  /// object it walks into. The first insert wins, so the property-aware one is kept.
+  pub surviving_import_meta_spans: FxIndexMap<Span, EmptyImportMetaKind>,
 }
 
 impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
@@ -938,16 +946,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   ) -> Option<Expression<'ast>> {
     if member_expr.object().is_import_meta() {
       let original_expr_span = member_expr.span();
-      let is_node_cjs = matches!(
-        (self.ctx.options.platform, &self.ctx.options.format),
-        (Platform::Node, OutputFormat::Cjs)
-      );
+      let can_polyfill_import_meta_url = self.can_polyfill_import_meta_url();
 
       let property_name = member_expr.static_property_name()?;
       match property_name {
         // Try to polyfill `import.meta.url`
         "url" => {
-          let new_expr = if is_node_cjs {
+          let new_expr = if can_polyfill_import_meta_url {
             // Replace it with `require('url').pathToFileURL(__filename).href`
 
             // require('url')
@@ -1006,6 +1011,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           } else {
             // If we don't support polyfill `import.meta.url` in this platform and format, we just keep it as it is
             // so users may handle it in their own way.
+            if !self.ctx.options.format.keep_esm_import_export_syntax() {
+              // Claim the span before walking reaches the bare `import.meta`, so the warning knows
+              // this is an `import.meta.url`
+              self.record_surviving_import_meta(
+                member_expr.object().span(),
+                EmptyImportMetaKind::Url,
+              );
+            }
             None
           };
           return new_expr;
@@ -1013,7 +1026,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         "dirname" | "filename" => {
           let name =
             oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), &self.ast_factory);
-          return is_node_cjs.then_some(ast::Expression::Identifier(
+          return can_polyfill_import_meta_url.then_some(ast::Expression::Identifier(
             ast::IdentifierReference::boxed(SPAN, name, &self.ast_factory),
           ));
         }
@@ -1026,6 +1039,20 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       );
     }
     None
+  }
+
+  fn can_polyfill_import_meta_url(&self) -> bool {
+    matches!(
+      (self.ctx.options.platform, &self.ctx.options.format),
+      (Platform::Node, OutputFormat::Cjs)
+    )
+  }
+
+  /// Remember an `import.meta` that no rewrite could get rid of, so it is left to be replaced with
+  /// an empty object. Callers are responsible for only reaching this on a non-esm output, which
+  /// keeps `import.meta` as-is rather than replacing it.
+  pub fn record_surviving_import_meta(&mut self, span: Span, kind: EmptyImportMetaKind) {
+    self.surviving_import_meta_spans.entry(span).or_insert(kind);
   }
 
   fn rewrite_rolldown_file_url(
@@ -1044,7 +1071,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // The only place this code is parsed. The driver deliberately hands it over
         // unparsed, along with the plugin that produced it.
         match parse_injected_expression(self.alloc, &resolved.code) {
-          Ok(expr) => return Some(expr),
+          Ok(mut expr) => {
+            let mut rewriter = ResolveFileUrlHookResultSpanRewriter(original_expr_span);
+            oxc::ast_visit::VisitMut::visit_expression(&mut rewriter, &mut expr);
+            return Some(expr);
+          }
           Err(diagnostics) => {
             self.resolve_file_url_errors.push((
               resolved.plugin_name.clone(),
@@ -1073,6 +1104,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       let absolute_asset_file_name = asset_file_name.absolutize_with(output_dir);
       let relative_asset_path = &self.ctx.chunk.relative_path_for(&absolute_asset_file_name);
 
+      if !self.ctx.options.format.keep_esm_import_export_syntax()
+        && !self.can_polyfill_import_meta_url()
+      {
+        // Record the origin before walking the generated `import.meta.url`. The generic URL
+        // handler reaches the same span later, and first-insert-wins preserves this richer kind.
+        self.record_surviving_import_meta(original_expr_span, EmptyImportMetaKind::RolldownFileUrl);
+      }
+
       // new URL({relative_asset_path}, import.meta.url).href
       // TODO: needs import.meta.url polyfill for non esm
       let new_expr = ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
@@ -1092,7 +1131,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               ast::Argument::StaticMemberExpression(ast::StaticMemberExpression::boxed(
                 SPAN,
                 ast::Expression::new_meta_property(
-                  SPAN,
+                  // Carry the source span, so that if this generated `import.meta.url` cannot be
+                  // polyfilled either, the diagnostic points at the `import.meta.ROLLDOWN_FILE_URL_*`
+                  // the user actually wrote.
+                  original_expr_span,
                   ast::IdentifierName::new(SPAN, "import", &self.ast_factory),
                   ast::IdentifierName::new(SPAN, "meta", &self.ast_factory),
                   &self.ast_factory,
@@ -2731,5 +2773,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
 
     Some(())
+  }
+}
+
+struct ResolveFileUrlHookResultSpanRewriter(Span);
+
+impl oxc::ast_visit::VisitMut<'_> for ResolveFileUrlHookResultSpanRewriter {
+  fn visit_span(&mut self, span: &mut Span) {
+    *span = self.0;
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rolldown_common::{ConcatenateWrappedModuleKind, PrependRenderedImport, UsedSymbolRefs};
-use rolldown_error::BuildResult;
+use rolldown_error::{BuildResult, Severity};
 use rolldown_utils::{index_vec_ext::IndexVecExt as _, rayon::ParallelIterator as _};
 use rustc_hash::FxHashMap;
 use tracing::debug_span;
@@ -75,21 +75,21 @@ impl GenerateStage<'_> {
           let (
             transferred_import_record,
             rendered_concatenated_wrapped_module_parts,
-            module_errors,
+            module_diagnostics,
           ) = ctx.finalize_normal_module(ast, ast_scope);
 
           let payload = (!transferred_import_record.is_empty()
             || !matches!(concatenated_wrapped_module_kind, ConcatenateWrappedModuleKind::None))
           .then_some((idx, transferred_import_record, rendered_concatenated_wrapped_module_parts));
-          Some((payload, module_errors))
+          Some((payload, module_diagnostics))
         })
         .collect::<Vec<_>>()
     });
 
     let mut normalized_transfer_parts_rendered_maps = FxHashMap::default();
-    let mut errors = vec![];
-    for (payload, module_errors) in finalized {
-      errors.extend(module_errors);
+    let mut diagnostics = vec![];
+    for (payload, module_diagnostics) in finalized {
+      diagnostics.extend(module_diagnostics);
       let Some((idx, transferred_import_record, rendered_concatenated_module_parts)) = payload
       else {
         continue;
@@ -104,7 +104,10 @@ impl GenerateStage<'_> {
         .insert(idx, rendered_concatenated_module_parts);
     }
 
-    if !errors.is_empty() {
+    let has_error = diagnostics.iter().any(|diagnostic| diagnostic.severity() == Severity::Error);
+    self.link_output.diagnostics.extend(diagnostics);
+    if has_error {
+      let errors = self.link_output.diagnostics.extract_errors();
       Err(errors)?;
     }
 

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -220,11 +220,7 @@ impl<'a> GenerateStage<'a> {
       self.resolved_paths = Some(paths.resolve_all(ids).await);
     }
 
-    let (resolved_file_urls, empty_import_meta_warnings) =
-      self.resolve_file_urls(&chunk_graph).await?;
-    if !empty_import_meta_warnings.is_empty() {
-      self.link_output.diagnostics.extend(empty_import_meta_warnings);
-    }
+    let resolved_file_urls = self.resolve_file_urls(&chunk_graph).await?;
     self.finalize_modules(
       &mut chunk_graph,
       &mut ast_table,

--- a/crates/rolldown/src/stages/generate_stage/resolve_file_urls.rs
+++ b/crates/rolldown/src/stages/generate_stage/resolve_file_urls.rs
@@ -1,6 +1,5 @@
 use oxc::semantic::NodeId;
-use rolldown_common::{ModuleIdx, OutputFormat, RolldownFileUrlReference};
-use rolldown_error::{BuildDiagnostic, EmptyImportMetaKind};
+use rolldown_common::{ModuleIdx, RolldownFileUrlReference};
 use rolldown_plugin::{HookResolveFileUrlArgs, HookResolveFileUrlOutput};
 use rustc_hash::FxHashMap;
 use sugar_path::SugarPath;
@@ -27,18 +26,12 @@ impl GenerateStage<'_> {
   pub(super) async fn resolve_file_urls(
     &self,
     chunk_graph: &ChunkGraph,
-  ) -> anyhow::Result<(ResolvedFileUrls, Vec<BuildDiagnostic>)> {
+  ) -> anyhow::Result<ResolvedFileUrls> {
     let mut resolved = FxHashMap::default();
-    let mut warnings = Vec::new();
 
     let has_hook = !self.plugin_driver.order_by_resolve_file_url_meta.is_empty();
-    // Only `iife`/`umd` leave `import.meta.url` unpolyfilled, so only they can end up with
-    // an empty `import.meta` from the default rewrite.
-    let format_needs_warning =
-      matches!(self.options.format, OutputFormat::Iife | OutputFormat::Umd);
-
-    if !has_hook && !format_needs_warning {
-      return Ok((resolved, warnings));
+    if !has_hook {
+      return Ok(resolved);
     }
 
     let out_dir = self.options.cwd.as_path().join(&self.options.out_dir);
@@ -66,7 +59,7 @@ impl GenerateStage<'_> {
           continue;
         }
 
-        for RolldownFileUrlReference { node_id, span, stmt_info_idx, reference_id } in
+        for RolldownFileUrlReference { node_id, stmt_info_idx, reference_id } in
           &module.ecma_view.rolldown_file_url_references
         {
           if !self.link_output.metas[module.idx].stmt_info_included.has_bit(*stmt_info_idx) {
@@ -94,30 +87,13 @@ impl GenerateStage<'_> {
             None
           };
 
-          match output {
-            Some(output) => {
-              resolved.insert((module.idx, *node_id), output);
-            }
-            // No hook replacement: the default `new URL(..., import.meta.url).href` rewrite is
-            // used, whose `import.meta.url` becomes `{}.url` in `iife`/`umd`.
-            None if format_needs_warning => {
-              warnings.push(
-                BuildDiagnostic::empty_import_meta(
-                  module.id.to_string(),
-                  module.ecma_view.source.clone(),
-                  *span,
-                  self.options.format.as_str().into(),
-                  EmptyImportMetaKind::RolldownFileUrl,
-                )
-                .with_severity_warning(),
-              );
-            }
-            None => {}
+          if let Some(output) = output {
+            resolved.insert((module.idx, *node_id), output);
           }
         }
       }
     }
 
-    Ok((resolved, warnings))
+    Ok(resolved)
   }
 }

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/_config.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "An `esm` output keeps `import.meta` as-is, so nothing is replaced and nothing is warned about.",
+  "config": {
+    "format": "esm"
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+console.log(import.meta.hello);
+console.log(import.meta.dirname);
+console.log(import.meta.filename);
+console.log(import.meta.url);
+console.log(import.meta.url);
+console.log(import.meta["url"]);
+console.log(import.meta);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_esm/main.js
@@ -1,0 +1,7 @@
+console.log(import.meta.hello);
+console.log(import.meta.dirname);
+console.log(import.meta.filename);
+console.log(import.meta.url);
+console.log(import.meta?.url);
+console.log(import.meta['url']);
+console.log(import.meta);

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/_config.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "`import.meta.url` and friends are only polyfilled for `cjs` on the `node` platform, so every `import.meta` access has to be warned about here.",
+  "config": {
+    "format": "cjs",
+    "platform": "neutral"
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/artifacts.snap
@@ -1,0 +1,118 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:1:13 ]
+   │
+ 1 │ console.log(import.meta.hello);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:2:13 ]
+   │
+ 2 │ console.log(import.meta.dirname);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:3:13 ]
+   │
+ 3 │ console.log(import.meta.filename);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:4:13 ]
+   │
+ 4 │ console.log(import.meta.url);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+   │ 
+   │ Help: If you want to polyfill `import.meta.url` like Rollup does, check out the Document: https://rolldown.rs/in-depth/non-esm-output-formats#well-known-import-meta-properties
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:5:13 ]
+   │
+ 5 │ console.log(import.meta?.url);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+   │ 
+   │ Help: If you want to polyfill `import.meta.url` like Rollup does, check out the Document: https://rolldown.rs/in-depth/non-esm-output-formats#well-known-import-meta-properties
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:6:13 ]
+   │
+ 6 │ console.log(import.meta['url']);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+   │ 
+   │ Help: If you want to polyfill `import.meta.url` like Rollup does, check out the Document: https://rolldown.rs/in-depth/non-esm-output-formats#well-known-import-meta-properties
+───╯
+
+```
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] `import.meta` may not be a valid syntax with the `cjs` output format.
+   ╭─[ main.js:7:13 ]
+   │
+ 7 │ console.log(import.meta);
+   │             ─────┬─────  
+   │                  ╰─────── This `import.meta` will be replaced with an empty object (`{}`) automatically. If this is desired, you can suppress this warning by adding `transform.define: { 'import.meta': {} }`. If `import.meta` needs to be kept as-is, you need to set the output format to `esm`.
+───╯
+
+```
+
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+console.log({}.hello);
+console.log({}.dirname);
+console.log({}.filename);
+console.log({}.url);
+console.log({}.url);
+console.log({}["url"]);
+console.log({});
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta_non_node_platform/main.js
@@ -1,0 +1,7 @@
+console.log(import.meta.hello);
+console.log(import.meta.dirname);
+console.log(import.meta.filename);
+console.log(import.meta.url);
+console.log(import.meta?.url);
+console.log(import.meta['url']);
+console.log(import.meta);

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -39,9 +39,6 @@ pub struct RolldownFileUrlReference {
   /// Cross-pass identity of the member expression; the key the module finalizer
   /// looks the replacement up by (see internal-docs/ast-mutation/implementation.md).
   pub node_id: NodeId,
-  /// Span of the whole member expression, as a source location for the iife/umd
-  /// empty-`import.meta` warning.
-  pub span: Span,
   /// The enclosing top-level statement, so occurrences whose statement is
   /// tree-shaken away can be skipped when invoking the `resolveFileUrl` hook.
   pub stmt_info_idx: StmtInfoIdx,

--- a/crates/rolldown_error/src/build_diagnostic/events/empty_import_meta.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/empty_import_meta.rs
@@ -5,7 +5,7 @@ use arcstr::ArcStr;
 use oxc::span::Span;
 
 /// What produced the empty `import.meta` a warning is being raised about.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum EmptyImportMetaKind {
   /// A bare `import.meta` (or a member access other than `url`) the user wrote.
   Plain,

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -269,6 +269,12 @@ impl Diagnostics {
     self.diagnostics.into_iter().partition(|d| d.severity() != Severity::Error)
   }
 
+  /// Extracts all error-severity diagnostics, leaving the rest in `self`.
+  pub fn extract_errors(&mut self) -> Vec<BuildDiagnostic> {
+    self.has_error = false;
+    self.diagnostics.extract_if(0.., |d| d.severity() == Severity::Error).collect()
+  }
+
   /// Drain checkpoint: returns `Err(errors)` if any error-severity diagnostic is
   /// present, otherwise `Ok(warnings + infos)`. Mirrors the existing
   /// `if !errors.is_empty() { return Err(errors.into()) }` guard.

--- a/internal-docs/ast-mutation/implementation.md
+++ b/internal-docs/ast-mutation/implementation.md
@@ -44,7 +44,7 @@ The main cross-pass side tables keyed by `NodeId` are:
 - `EcmaView::imports` - import declarations, export-from declarations, dynamic `import()` expressions, and recognized `require()` call expressions.
 - `EcmaView::dummy_record_set` - `require` identifier references that need the runtime helper rewrite.
 - `EcmaView::new_url_references` - `new URL('...', import.meta.url)` nodes mapped to asset import records.
-- `EcmaView::rolldown_file_url_references` and the generate stage's `ResolvedFileUrls` - `import.meta.ROLLDOWN_FILE_URL_<referenceId>` member expressions recorded at scan; `resolveFileUrl` hook results are keyed by `(ModuleIdx, NodeId)` for the finalizer's rewrite (the record keeps a `Span` purely as the warning location).
+- `EcmaView::rolldown_file_url_references` and the generate stage's `ResolvedFileUrls` - `import.meta.ROLLDOWN_FILE_URL_<referenceId>` member expressions recorded at scan; `resolveFileUrl` hook results are keyed by `(ModuleIdx, NodeId)` for the finalizer's rewrite.
 - `EcmaView::this_expr_replace_map` - top-level `this` expressions that should become `exports` or `undefined`.
 - `MemberExprRef::node_id` and `LinkingMetadata::resolved_member_expr_refs` - namespace/member-expression resolution from scan through link to finalization.
 - `DynamicImportExprInfo::node_id` records the dynamic `import()` node within its own module; `EntryPoint::related_stmt_infos` then carries `(ModuleIdx, …, NodeId, …)` tuples so a dynamic-import entry can be traced back across the module graph.

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/_config.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { stripVTControlCharacters } from 'node:util';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const seen: Record<string, string>[] = [];
+const logs: { code?: string; message: string }[] = [];
+
+// Without a `resolveFileUrl` replacement, the default `new URL(..., import.meta.url).href`
+// rewrite stands. Unlike `cjs` on the `node` platform, `cjs` on the `neutral` platform
+// cannot polyfill `import.meta.url`, so it becomes `{}.url` and emits one warning.
+export default defineTest({
+  config: {
+    platform: 'neutral',
+    output: { format: 'cjs' },
+    onLog(_level, log) {
+      logs.push(log);
+    },
+    plugins: [
+      {
+        name: 'emit-asset',
+        load(id) {
+          if (!id.endsWith('main.js')) return;
+          const referenceId = this.emitFile({
+            type: 'asset',
+            name: 'asset.txt',
+            source: fs.readFileSync(path.join(import.meta.dirname, 'asset.txt')),
+          });
+          return `export const url = import.meta.ROLLUP_FILE_URL_${referenceId};`;
+        },
+      },
+      {
+        name: 'declines',
+        resolveFileUrl(args) {
+          seen.push({ ...args });
+          return null;
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const chunk = output.output.find((item) => item.type === 'chunk')!;
+    expect(chunk.code).toContain('new URL(');
+    expect(chunk.code).toContain('{}.url');
+    expect(chunk.code).not.toContain('import.meta');
+
+    expect(seen).toHaveLength(1);
+    const args = seen[0];
+    expect(args.format).toBe('cjs');
+    expect(args.chunkId).toBe('main.js');
+    expect(args.moduleId.replace(/\\/g, '/')).toContain(
+      'resolve-file-url/cjs-neutral-fallback-warns/main.js',
+    );
+    expect(args.referenceId).toMatch(/^[$_a-zA-Z][$\w]*$/);
+    expect(args.fileName).toMatch(/^assets\/asset-\w+\.txt$/);
+    expect(args.relativePath).toBe(args.fileName);
+
+    const emptyImportMetaLogs = logs.filter((log) => log.code === 'EMPTY_IMPORT_META');
+    expect(emptyImportMetaLogs).toHaveLength(1);
+    const message = stripVTControlCharacters(emptyImportMetaLogs[0].message);
+    expect(message).toContain('`cjs` output format');
+    expect(message).toContain('ROLLUP_FILE_URL_');
+    expect(message).toContain('import.meta.url');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/asset.txt
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/asset.txt
@@ -1,0 +1,1 @@
+asset contents

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/cjs-neutral-fallback-warns/main.js
@@ -1,0 +1,2 @@
+// The `load` hook replaces this module's source.
+export const url = 'placeholder';

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/iife-hook-import-meta-url-warns/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/iife-hook-import-meta-url-warns/_config.ts
@@ -1,0 +1,49 @@
+import { stripVTControlCharacters } from 'node:util';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const logs: { code?: string; message: string }[] = [];
+
+// A plugin-provided replacement is finalized like user code. If it introduces
+// `import.meta.url` in a non-ESM format where it cannot be polyfilled, it must
+// trigger the same warning as a direct `import.meta.url` access.
+export default defineTest({
+  config: {
+    output: { format: 'iife', name: 'iifeName' },
+    onLog(_level, log) {
+      logs.push(log);
+    },
+    plugins: [
+      {
+        name: 'emit-asset',
+        load(id) {
+          if (!id.endsWith('main.js')) return;
+          const referenceId = this.emitFile({
+            type: 'asset',
+            name: 'asset.txt',
+            source: 'asset',
+          });
+          return `export const url = import.meta.ROLLUP_FILE_URL_${referenceId};`;
+        },
+      },
+      {
+        name: 'resolve-to-import-meta-url',
+        resolveFileUrl() {
+          return 'import.meta.url';
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const chunk = output.output.find((item) => item.type === 'chunk')!;
+    expect(chunk.code).toContain('{}.url');
+    expect(chunk.code).not.toContain('import.meta');
+
+    const emptyImportMetaLogs = logs.filter((log) => log.code === 'EMPTY_IMPORT_META');
+    expect(emptyImportMetaLogs).toHaveLength(1);
+    const message = stripVTControlCharacters(emptyImportMetaLogs[0].message);
+    expect(message).toContain('`iife` output format');
+    expect(message).toContain('import.meta.url');
+    expect(message).toContain('import.meta.ROLLUP_FILE_URL_');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/iife-hook-import-meta-url-warns/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/iife-hook-import-meta-url-warns/main.js
@@ -1,0 +1,2 @@
+// The `load` hook replaces this module's source.
+export const url = 'placeholder';


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

The `EMPTY_IMPORT_META` warning was no emitted for non-node CJS output. This PR fixes that.