### PR TITLE
feat(dev): skip shipping factories for newly imported top-level modules

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -7,7 +7,9 @@ use arcstr::ArcStr;
 #[cfg(feature = "experimental")]
 use rolldown_common::WatcherChangeKind;
 #[cfg(feature = "experimental")]
-use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrStampTable};
+use rolldown_common::{
+  ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrStampTable, ImportKind, Module,
+};
 #[cfg(feature = "experimental")]
 use rolldown_error::BuildResult;
 #[cfg(feature = "experimental")]
@@ -47,6 +49,56 @@ impl Bundler {
     hmr_stage.compute_hmr_update_for_file_changes(changed_file_paths, clients, stamp_table).await
   }
 
+  /// Compute the top-level-evaluated set of the current snapshot: the modules whose
+  /// evaluation is unconditionally triggered by entry-chunk top-level execution.
+  /// These are the modules reachable from the user-defined entry through
+  /// `ImportKind::Import` edges only — static `import` / `export … from` statements,
+  /// whose init calls the renderer hoists unconditionally into the importer.
+  /// `Require` and dynamic edges are excluded: a `require()` site may be
+  /// conditional, so counting it could mark a module "evaluated" that never ran —
+  /// the one unsafe direction. Missing a module here only costs re-shipped bytes.
+  ///
+  /// Values are the modules' render-time stamps at computation, so consumers
+  /// compare currency with `HmrStampTable::is_stale` exactly like the ship map.
+  ///
+  /// Returns an empty (inert) map when there is no snapshot or when the build has
+  /// several user-defined entries: the server cannot yet tell which entry a given
+  /// client loaded, and a union would mark modules evaluated for clients that
+  /// never loaded them.
+  pub fn compute_top_level_evaluated_modules(
+    &self,
+    stamp_table: &HmrStampTable,
+  ) -> FxHashMap<ArcStr, u32> {
+    let Some(snapshot) = self.cache.snapshot() else {
+      return FxHashMap::default();
+    };
+    if snapshot.user_defined_entry_modules.len() != 1 {
+      return FxHashMap::default();
+    }
+
+    let modules = &snapshot.module_table.modules;
+    let mut evaluated = FxHashMap::default();
+    let mut stack: Vec<_> = snapshot.user_defined_entry_modules.iter().copied().collect();
+    while let Some(module_idx) = stack.pop() {
+      let Module::Normal(module) = &modules[module_idx] else {
+        continue;
+      };
+      let stable_id = module.stable_id.as_arc_str();
+      if evaluated.contains_key(stable_id) {
+        continue;
+      }
+      evaluated.insert(stable_id.clone(), stamp_table.render_time_stamp(stable_id.as_str()));
+      for rec in &module.import_records {
+        if rec.kind == ImportKind::Import
+          && let Some(dep_idx) = rec.resolved_module
+        {
+          stack.push(dep_idx);
+        }
+      }
+    }
+    evaluated
+  }
+
   /// Compile a lazy entry module and return compiled code plus the pending-payload
   /// entry the delivery-time ship-map write consumes.
   ///
@@ -58,6 +110,7 @@ impl Bundler {
     module_id: String,
     client_id: &str,
     shipped: &FxHashMap<ArcStr, u32>,
+    evaluated: &FxHashMap<ArcStr, u32>,
     stamp_table: &HmrStampTable,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<HmrLazyChunkOutput> {
@@ -76,6 +129,6 @@ impl Bundler {
       cache: &mut self.cache,
       next_hmr_patch_id,
     });
-    hmr_stage.compile_lazy_entry(&module_id, client_id, shipped, stamp_table).await
+    hmr_stage.compile_lazy_entry(&module_id, client_id, shipped, evaluated, stamp_table).await
   }
 }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -332,14 +332,20 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
   /// Compile a lazy entry module and return compiled code plus the pending-payload
   /// entry (`carried`) the delivery-time ship-map write consumes.
   ///
-  /// Factory selection filters the reachable set by the ship-map comparison — absent from
-  /// `shipped[C]` or stale stamp — never by execution state. The ship map itself is
-  /// written only when the serving middleware observes the response complete.
+  /// A lazy chunk is pure first-evaluation demand: nothing already evaluated ever
+  /// re-runs, so factory selection subtracts BOTH per-client records — the ship map
+  /// (`shipped[C]`, factory resident) and the top-level-evaluated map (exports live from
+  /// entry-chunk execution; `initModule` returns them without a factory). Both are
+  /// server-derived; selection never reads client-reported runtime state. Contrast
+  /// with HMR patches, whose affected set must re-run and therefore subtracts the
+  /// ship map only. The ship map itself is written only when the serving middleware
+  /// observes the response complete.
   pub async fn compile_lazy_entry(
     &mut self,
     module_id: &str,
     _client_id: &str,
     shipped: &FxHashMap<ArcStr, u32>,
+    evaluated: &FxHashMap<ArcStr, u32>,
     stamp_table: &HmrStampTable,
   ) -> BuildResult<HmrLazyChunkOutput> {
     tracing::debug!(
@@ -412,7 +418,8 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     self.cache.update_defer_sync_data(&options).await?;
 
     // Collect all sync dependencies, stopping at modules whose current copy this client
-    // already holds per the ship map. Overlapping concurrent lazy compiles both see an
+    // already holds — factory resident per the ship map, or exports live per the
+    // top-level-evaluated map. Overlapping concurrent lazy compiles both see an
     // unmarked ship map and re-ship shared factories — duplicate idempotent bytes, never
     // a missing factory.
     let mut modules_to_be_updated = FxIndexSet::default();
@@ -420,6 +427,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       entry_module_idx,
       &mut modules_to_be_updated,
       shipped,
+      evaluated,
       stamp_table,
     );
 
@@ -752,6 +760,7 @@ impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {
     proxy_entry_idx: ModuleIdx,
     result: &mut FxIndexSet<ModuleIdx>,
     shipped: &FxHashMap<ArcStr, u32>,
+    evaluated: &FxHashMap<ArcStr, u32>,
     stamp_table: &HmrStampTable,
   ) {
     let modules = &self.module_table().modules;
@@ -780,10 +789,15 @@ impl<Fs: FileSystem + Clone + 'static> HmrStage<'_, Fs> {
             continue;
           }
           if let Module::Normal(normal_dep) = &modules[dep_idx] {
-            // Skip deps whose current copy this client already holds per the ship map.
+            // Skip deps whose current copy this client already holds: factory
+            // resident per the ship map, or exports live per the top-level-evaluated
+            // map (a lazy import never re-runs an evaluated module, so
+            // `initModule` serves it without a factory).
             let stable_id = normal_dep.stable_id.as_str();
-            if shipped.get(stable_id).is_some_and(|stamp| !stamp_table.is_stale(stable_id, *stamp))
-            {
+            let holds_current = |map: &FxHashMap<ArcStr, u32>| {
+              map.get(stable_id).is_some_and(|stamp| !stamp_table.is_stale(stable_id, *stamp))
+            };
+            if holds_current(shipped) || holds_current(evaluated) {
               continue;
             }
           }

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -328,6 +328,14 @@ impl BundlingTask {
     if let Err(err) = &build_result {
       tracing::error!("[BundlingTask] rebuild failed: {:?}", err);
       self.rebuild_errored = true;
+    } else {
+      // The output just written is what any newly loading client evaluates; refresh
+      // the top-level-evaluated snapshot new sessions freeze in at hello (`register_client`).
+      let top_level_evaluated = {
+        let stamp_table = self.dev_context.stamp_table.lock().await;
+        bundler.compute_top_level_evaluated_modules(&stamp_table)
+      };
+      *self.dev_context.top_level_evaluated.lock().await = Arc::new(top_level_evaluated);
     }
 
     // Call on_output callback if provided

--- a/crates/rolldown_dev/src/dev_context.rs
+++ b/crates/rolldown_dev/src/dev_context.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
+use arcstr::ArcStr;
 use futures::future::Shared;
 use rolldown_common::HmrStampTable;
 use rustc_hash::FxHashMap;
@@ -32,6 +33,13 @@ pub struct DevContext {
   /// delivery notification consumes an entry when the serving middleware sees
   /// the response for that filename complete.
   pub pending_payloads: Arc<Mutex<FxHashMap<String, PendingPayload>>>,
+  /// Boot-evaluated map of the latest written bundle output: module stable id →
+  /// render stamp of the copy the entry chunk evaluates at top level (computed
+  /// statically — see `Bundler::compute_top_level_evaluated_modules`). Swapped whole
+  /// after every successful rebuild; `register_client` freezes the then-current
+  /// `Arc` into the new session, since a hello can only come from the runtime
+  /// inside a served entry chunk.
+  pub top_level_evaluated: Mutex<Arc<FxHashMap<ArcStr, u32>>>,
 }
 
 impl DevContext {

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -29,7 +29,6 @@ use crate::{
   },
 };
 
-#[cfg(feature = "testing")]
 use crate::ClientSession;
 #[cfg(feature = "testing")]
 use rolldown_utils::indexmap::FxIndexMap;
@@ -84,6 +83,7 @@ impl DevEngine {
       clients: Arc::clone(&clients),
       stamp_table: Arc::new(Mutex::new(HmrStampTable::default())),
       pending_payloads: Arc::new(Mutex::new(FxHashMap::default())),
+      top_level_evaluated: Mutex::new(Arc::new(FxHashMap::default())),
     });
 
     let watcher_config = FsWatcherConfig {
@@ -272,9 +272,20 @@ impl DevEngine {
   }
 
   /// Client-connect signal (the clientId hello): creates the per-client session with an
-  /// empty ship map. Reconnects arrive as fresh clientIds, which is the ship-map reset.
+  /// empty ship map and the current top-level-evaluated map frozen in. The hello comes from
+  /// the runtime inside the entry chunk, so it doubles as the entry delivery
+  /// notification. (A client that loaded an output older than the latest rebuild
+  /// gets the newer map; the mismatched entries then read as current copies the client
+  /// does not hold — the reload fallback covers that window until the hello carries a
+  /// build id.) Reconnects arrive as fresh clientIds, which is the per-client reset.
   pub async fn register_client(&self, client_id: String) {
-    self.clients.lock().await.entry(client_id).or_default();
+    let top_level_evaluated = Arc::clone(&*self.dev_context.top_level_evaluated.lock().await);
+    self
+      .clients
+      .lock()
+      .await
+      .entry(client_id)
+      .or_insert_with(|| ClientSession { top_level_evaluated, ..ClientSession::default() });
   }
 
   /// Client-disconnect signal: drops the session together with any
@@ -325,10 +336,16 @@ impl DevEngine {
     self.create_error_if_closed()?;
     let mut bundler = self.bundler.lock().await;
 
-    // Snapshot the ship map `shipped[C]` for this client so the compile runs without
-    // the clients lock. `ArcStr` keys make the copy refcount bumps, not string copies.
-    let shipped =
-      self.clients.lock().await.get(&client_id).map(|c| c.shipped.clone()).unwrap_or_default();
+    // Snapshot the ship map `shipped[C]` and the top-level-evaluated map for this client so
+    // the compile runs without the clients lock. `ArcStr` keys make the ship-map copy
+    // refcount bumps, not string copies; the top-level-evaluated map is shared by `Arc`.
+    let (shipped, top_level_evaluated) = self
+      .clients
+      .lock()
+      .await
+      .get(&client_id)
+      .map(|c| (c.shipped.clone(), Arc::clone(&c.top_level_evaluated)))
+      .unwrap_or_default();
 
     // Mark the proxy module as fetched BEFORE compilation.
     // This changes the content returned by the lazy compilation plugin's load hook
@@ -346,6 +363,7 @@ impl DevEngine {
         proxy_module_id.clone(),
         &client_id,
         &shipped,
+        &top_level_evaluated,
         &stamp_table,
         Arc::clone(&self.next_hmr_patch_id),
       )

--- a/crates/rolldown_dev/src/types/client_session.rs
+++ b/crates/rolldown_dev/src/types/client_session.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arcstr::ArcStr;
 use rustc_hash::FxHashMap;
 
@@ -8,6 +10,13 @@ pub struct ClientSession {
   /// (the delivery notification), never at render or push. `ArcStr` keys share the
   /// id strings with the stamp table and every other client's ship map.
   pub shipped: FxHashMap<ArcStr, u32>,
+  /// Boot-evaluated map: module stable id → rebuild stamp of the copy the entry
+  /// chunk evaluated at top level. Frozen at hello from the engine-wide snapshot
+  /// (`DevContext::top_level_evaluated`) and never written again — a module that
+  /// evaluates later got its factory through a payload, so `shipped` covers it
+  /// with a fresher stamp. Shared, not owned: every client of one build points
+  /// at the same map.
+  pub top_level_evaluated: Arc<FxHashMap<ArcStr, u32>>,
   /// Per-client envelope sequence counter.
   pub next_seq: u32,
 }

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -67,3 +67,61 @@ test(
     ).rejects.toThrow('Lazy entry module not found in cache');
   },
 );
+
+// A lazy chunk is pure first-evaluation demand: a module the entry chunk already
+// evaluated at top level serves lazy imports from its live exports, so its factory must
+// not be re-shipped to a registered client (whose session froze the top-level-evaluated
+// map at hello). An unregistered client has no session and must still receive the
+// full closure.
+test(
+  'lazy chunk omits factories for modules the entry chunk evaluated at top level',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-evaluated-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'main.js'),
+      `import { shared } from './shared.js';\nconsole.log(shared);\nimport('./lazy.js');\n`,
+    );
+    fs.writeFileSync(path.join(dir, 'shared.js'), `export const shared = 'shared';\n`);
+    fs.writeFileSync(
+      path.join(dir, 'lazy.js'),
+      `import { shared } from './shared.js';\nexport const lazy = shared + '-lazy';\n`,
+    );
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+
+    const lazyProxyId = `${path.join(dir, 'lazy.js')}?rolldown-lazy=1`;
+    const sharedFactory = /registerFactory\("[^"]*shared\.js"/;
+    const lazyFactory = /registerFactory\("[^"]*lazy\.js\b[^"]*"/;
+
+    // The hello freezes the top-level-evaluated map into the session: `shared.js` is
+    // statically imported by the entry, so its exports are already live.
+    await engine.registerClient('registered-client');
+    const chunk = await engine.compileEntry(lazyProxyId, 'registered-client');
+    expect(chunk.code).toMatch(lazyFactory);
+    expect(chunk.code).not.toMatch(sharedFactory);
+
+    // No session → both per-client maps empty → the full closure ships.
+    const coldChunk = await engine.compileEntry(lazyProxyId, 'client-without-session');
+    expect(coldChunk.code).toMatch(lazyFactory);
+    expect(coldChunk.code).toMatch(sharedFactory);
+  },
+);

--- a/packages/rolldown/tests/dev/dev-watch.test.ts
+++ b/packages/rolldown/tests/dev/dev-watch.test.ts
@@ -211,6 +211,66 @@ test.concurrent(
   },
 );
 
+// An HMR patch's factories are re-evaluation demand: only modules the client may
+// re-run belong in it. When an edit makes a hot module import a module the entry
+// chunk already evaluated at top level, the patch must carry the edited module's
+// factory only — the new import is served by the live exports already registered
+// on the client (`initModule` is registry-gated), never by re-shipping a factory.
+test.concurrent(
+  'HMR patch does not ship factories for a newly imported top-level-evaluated module',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir: cwd } = createTestWithMultiFiles('dev-patch-top-level-evaluated', retryCount, {
+      'main.js': `import './lib.js';\nimport './hot.js';\n`,
+      'lib.js': `export const value = 'lib';\n`,
+      'hot.js': `export const tag = 'hot';\nimport.meta.hot.accept();\n`,
+    });
+
+    const onHmrUpdates = vi.fn();
+    const engine = await dev(
+      {
+        cwd,
+        input: './main.js',
+        experimental: { devMode: true },
+      },
+      { dir: path.join(cwd, 'dist') },
+      { onHmrUpdates },
+    );
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    // The hello: updates are computed per registered client.
+    await engine.registerClient('registered-client');
+
+    // The edit adds an import of `lib.js`, which the entry chunk already
+    // evaluated at top level (`main.js` imports it statically).
+    await editFile(
+      path.join(cwd, 'hot.js'),
+      `import { value } from './lib.js';\nexport const tag = 'hot-' + value;\nimport.meta.hot.accept();\n`,
+    );
+
+    const findPatch = () =>
+      onHmrUpdates.mock.calls
+        .flatMap(([result]) => (result instanceof Error ? [] : result.updates))
+        .find((u) => u.clientId === 'registered-client' && u.update.type === 'Patch');
+    await expect.poll(findPatch, { timeout: 20_000 }).toBeTruthy();
+
+    const patch = findPatch()!.update as { type: 'Patch'; code: string };
+    // The edited module re-runs, so its factory ships.
+    expect(patch.code).toMatch(/registerFactory\("[^"]*hot\.js"/);
+    // The newly imported module stays live on the client; no factory for it.
+    expect(patch.code).not.toMatch(/registerFactory\("[^"]*lib\.js"/);
+    // The re-run resolves the new import through the registry instead.
+    expect(patch.code).toMatch(/initModule\("[^"]*lib\.js"\)/);
+  },
+);
+
 function createTestInputAndOutput(testLabel: string, retryCount: number) {
   const uniqueId = crypto.randomUUID().slice(0, 8);
   const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

## Summary

For full design and principles, please refer to https://github.com/rolldown/rolldown/pull/10164#issue-4824909361.

The dev server tracks which module factories it has shipped per client in https://github.com/rolldown/rolldown/pull/10208. But modules that the entry chunk evaluated at top level never in the ship map. A lazy compile that subtracts only the ship man therefor re-ships factories the client already holds, which causes a size bloat in lazy-compilation chunks.

This PR introduces a second per-client record - the `top_level_evaluated` map. This map contains the statically evaluated modules so that these modules are not shipped as factories in lazy compilation chunks again when the factories are not changed and only their exports are needed.