### PR TITLE
fix: deduplicate re-exported external named imports within chunks

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -248,6 +248,13 @@ impl GenerateStage<'_> {
   /// stays inside the chunk that declares its members, so every chunk keeps rendering its own
   /// `import ... from 'ext'` statement and cross-chunk references keep flowing through the
   /// regular cross-chunk import/export machinery (the constraint behind #3405).
+  ///
+  /// Two kinds of groups are handled:
+  /// - namespace imports (`import * as ns from 'ext'`), collected in
+  ///   `external_import_namespace_merger`;
+  /// - named imports whose local binding is re-exported (`export { a } from 'ext'`), collected in
+  ///   `deferred_external_binding_merges` because `bind_imports_and_exports` cannot merge them
+  ///   eagerly like plain named imports (#3427).
   fn merge_external_import_symbols(
     &mut self,
     chunk_graph: &ChunkGraph,
@@ -277,6 +284,68 @@ impl GenerateStage<'_> {
         // https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=38bb53e79b4f7aaa73ef9d6b4cfb3cc2
         for symbol in &group[idx + 1..] {
           self.link_output.symbol_db.link(**symbol, *group[idx]);
+        }
+      }
+    }
+
+    // Merge re-exported named imports of the same external binding at chunk level.
+    for ((_, imported_name), merge) in &self.link_output.deferred_external_binding_merges {
+      // The eager facade's references all come from the modules holding the plain imports that
+      // were merged into it, so it may be folded into at most one chunk's canonical: the single
+      // chunk containing every included one of those modules. `None` when they span chunks (the
+      // facade must stay a root so each chunk renders its own import of it) or when none is
+      // included (dead facade — nothing worth folding).
+      let facade_fold_chunk = merge.eager_facade.and_then(|_| {
+        merge
+          .eager_import_owners
+          .iter()
+          .filter(|owner| self.link_output.metas[**owner].is_included)
+          .map(|owner| chunk_graph.module_to_chunk[*owner].expect("should have chunk idx"))
+          .all_equal_value()
+          .ok()
+      });
+
+      for (chunk_idx, mut group) in merge
+        .symbols
+        .iter()
+        .filter_map(|item| {
+          let module = self.link_output.module_table[item.owner].as_normal()?;
+          self.link_output.metas[module.idx].is_included.then_some(item)
+        })
+        .into_group_map_by(|item| {
+          chunk_graph.module_to_chunk[item.owner].expect("should have chunk idx")
+        })
+      {
+        if group.len() <= 1 && facade_fold_chunk != Some(chunk_idx) {
+          continue;
+        }
+        // Deterministic canonical pick: `exec_order` is unique per module, and the symbol index
+        // breaks ties between two re-exports of the same binding living in one module.
+        group.sort_unstable_by_key(|item| {
+          (self.link_output.module_table[item.owner].exec_order(), item.symbol)
+        });
+        let Some(first_used) = group.iter().position(|item| used_symbol_refs.contains(item))
+        else {
+          // No member is a used symbol; an unused canonical would render nothing (mirrors the
+          // namespace merger above).
+          continue;
+        };
+        // Prefer a used member whose name matches the imported name, so the merged group renders
+        // as `import { a }` / `export { a }` instead of the aliased `import { a as a$1 }`.
+        let canonical = *group
+          .iter()
+          .copied()
+          .filter(|item| used_symbol_refs.contains(item))
+          .find(|item| item.name(&self.link_output.symbol_db) == imported_name.as_str())
+          .unwrap_or(group[first_used]);
+        for symbol in &group {
+          if **symbol != canonical {
+            self.link_output.symbol_db.link(**symbol, canonical);
+          }
+        }
+        if facade_fold_chunk == Some(chunk_idx) {
+          let facade = merge.eager_facade.expect("fold chunk implies a facade");
+          self.link_output.symbol_db.link(facade, canonical);
         }
       }
     }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -324,8 +324,7 @@ impl GenerateStage<'_> {
         group.sort_unstable_by_key(|item| {
           (self.link_output.module_table[item.owner].exec_order(), item.symbol)
         });
-        let Some(first_used) = group.iter().position(|item| used_symbol_refs.contains(item))
-        else {
+        let Some(first_used) = group.iter().position(|item| used_symbol_refs.contains(item)) else {
           // No member is a used symbol; an unused canonical would render nothing (mirrors the
           // namespace merger above).
           continue;

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -25,7 +25,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{SharedOptions, types::linking_metadata::LinkingMetadataVec};
 
-use super::LinkStage;
+use super::{DeferredExternalBindingMerge, LinkStage};
 
 #[derive(Clone, Debug)]
 struct ImportTracker {
@@ -165,16 +165,27 @@ impl LinkStage<'_> {
       side_effects_modules: &side_effects_modules,
       normal_symbol_exports_chain_map: &mut normal_symbol_exports_chain_map,
       external_import_namespace_merger: FxHashMap::default(),
+      deferred_external_binding_merges: FxHashMap::default(),
     };
     self.module_table.modules.iter().for_each(|module| {
       binding_ctx.match_imports_with_exports(module.idx());
     });
 
-    self.diagnostics.extend(binding_ctx.diagnostics);
+    // Destructure so the loop below can take `&mut self.symbols` again: keeping `binding_ctx`
+    // alive would keep the `&mut` borrows stored in it (`symbol_db`, `metas`) alive too.
+    let BindImportsAndExportsContext {
+      diagnostics,
+      external_import_binding_merger,
+      external_import_namespace_merger,
+      mut deferred_external_binding_merges,
+      ..
+    } = binding_ctx;
 
-    self.external_import_namespace_merger = binding_ctx.external_import_namespace_merger;
+    self.diagnostics.extend(diagnostics);
 
-    for (module_idx, map) in &binding_ctx.external_import_binding_merger {
+    self.external_import_namespace_merger = external_import_namespace_merger;
+
+    for (module_idx, map) in &external_import_binding_merger {
       // `map` is a `FxHashMap` with randomized iteration order. Facade symbols must be created
       // deterministically, but only an external imported under more than one name has anything to
       // order — so sort by name only in that (rare) case and skip the work otherwise.
@@ -213,8 +224,19 @@ impl LinkStage<'_> {
         for symbol_ref in symbol_set {
           self.symbols.link(*symbol_ref, target_symbol);
         }
+        // If the same binding is also re-exported somewhere, hand the facade to the deferred
+        // chunk-level merge: when all the plain imports merged here land in one chunk, the
+        // facade can be folded into that chunk's canonical re-export symbol too.
+        if let Some(deferred) =
+          deferred_external_binding_merges.get_mut(&(*module_idx, key.clone()))
+        {
+          deferred.eager_facade = Some(target_symbol);
+          deferred.eager_import_owners.extend(symbol_set.iter().map(|symbol_ref| symbol_ref.owner));
+        }
       }
     }
+
+    self.deferred_external_binding_merges = deferred_external_binding_merges;
 
     self.metas.par_iter_mut().for_each(|meta| {
       let mut sorted_and_non_ambiguous_resolved_exports = vec![];
@@ -849,6 +871,9 @@ struct BindImportsAndExportsContext<'a> {
   pub external_import_binding_merger:
     FxHashMap<ModuleIdx, FxHashMap<CompactStr, IndexSet<SymbolRef>>>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
+  /// See [`DeferredExternalBindingMerge`]. Keyed by `(external module, imported name)`.
+  pub deferred_external_binding_merges:
+    FxHashMap<(ModuleIdx, CompactStr), DeferredExternalBindingMerge>,
   pub side_effects_modules: &'a FxHashSet<ModuleIdx>,
   pub normal_symbol_exports_chain_map: &'a mut FxHashMap<SymbolRef, Vec<SymbolRef>>,
 }
@@ -899,7 +924,19 @@ impl BindImportsAndExportsContext<'_> {
               .or_default()
               .insert(*imported_as_ref);
           }
-          Specifier::Literal(_) => {}
+          // The local binding of this import backs an entry in `resolved_exports`
+          // (e.g. `export { a } from 'ext'`), so other chunks can reach it through internal
+          // import chains and chunk exports. Merging it eagerly would move references across
+          // chunks that have no import statement rendering the merged symbol (#3405), so the
+          // merge is deferred until chunk assignment is known and done per chunk (#3427).
+          Specifier::Literal(ref name) => {
+            self
+              .deferred_external_binding_merges
+              .entry((resolved_module_idx, name.clone()))
+              .or_default()
+              .symbols
+              .insert(*imported_as_ref);
+          }
         }
       }
       matching_ctx.tracker_stack.clear();

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -2,6 +2,7 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc::span::Span;
 use oxc_index::IndexVec;
+use oxc_str::CompactStr;
 #[cfg(debug_assertions)]
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
@@ -45,6 +46,26 @@ pub use tree_shaking::{
 };
 mod wrapping;
 
+/// Merge state for named imports of one `(external module, imported name)` binding whose local
+/// binding is re-exported (e.g. `export { a } from 'ext'`). Unlike plain imports, these symbols
+/// can be reached from other chunks (through internal import chains and chunk exports), so
+/// `bind_imports_and_exports` must not merge them eagerly across modules (#3405). They are
+/// collected here instead and merged chunk-by-chunk in
+/// `GenerateStage::merge_external_import_symbols`, once chunk assignment is known (#3427).
+#[derive(Debug, Default)]
+pub struct DeferredExternalBindingMerge {
+  /// The re-exported named-import symbols importing this binding. Each is a union-find root:
+  /// links made during import matching always point from the importer side into these symbols.
+  pub symbols: FxIndexSet<SymbolRef>,
+  /// Facade symbol the eager merger created for the plain (non-re-exported) imports of the same
+  /// binding, if any. A plain import is only referenced from its own module, so when every
+  /// module in `eager_import_owners` lands in one chunk, the facade's references all live in
+  /// that chunk and it can be folded into that chunk's canonical symbol as well.
+  pub eager_facade: Option<SymbolRef>,
+  /// Owner modules of the plain imports merged into `eager_facade`.
+  pub eager_import_owners: Vec<ModuleIdx>,
+}
+
 /// Information about safely merged CJS namespaces for a module
 #[derive(Debug, Default, Clone)]
 pub struct SafelyMergeCjsNsInfo {
@@ -71,6 +92,9 @@ pub struct LinkStageOutput {
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
+  /// See [`DeferredExternalBindingMerge`].
+  pub deferred_external_binding_merges:
+    FxHashMap<(ModuleIdx, CompactStr), DeferredExternalBindingMerge>,
   /// https://rollupjs.org/plugin-development/#this-emitfile
   /// Used to store `preserveSignature` specified with `this.emitFile` in plugins.
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
@@ -111,6 +135,9 @@ pub struct LinkStage<'a> {
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
+  /// See [`DeferredExternalBindingMerge`].
+  pub deferred_external_binding_merges:
+    FxHashMap<(ModuleIdx, CompactStr), DeferredExternalBindingMerge>,
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
@@ -213,6 +240,7 @@ impl<'a> LinkStage<'a> {
       safely_merge_cjs_ns_map: FxHashMap::default(),
       normal_symbol_exports_chain_map: FxHashMap::default(),
       external_import_namespace_merger: FxHashMap::default(),
+      deferred_external_binding_merges: FxHashMap::default(),
       overrode_preserve_entry_signature_map: scan_stage_output
         .overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids: scan_stage_output.entry_point_to_reference_ids,
@@ -257,6 +285,7 @@ impl<'a> LinkStage<'a> {
         dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
         safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
         external_import_namespace_merger: self.external_import_namespace_merger,
+        deferred_external_binding_merges: self.deferred_external_binding_merges,
         overrode_preserve_entry_signature_map: self.overrode_preserve_entry_signature_map,
         entry_point_to_reference_ids: self.entry_point_to_reference_ids,
         global_constant_symbol_map: self.global_constant_symbol_map,

--- a/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
@@ -7,11 +7,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import * as ext1 from "external";
-import { a, a as a$1, a as a1, b, b as b$1, b as b1 } from "external";
+import { a, b } from "external";
 console.log(1);
 //#endregion
 //#region main.js
-console.log(ext1, a1, b1, ext1, a$1, b$1);
+console.log(ext1, a, b, ext1, a, b);
 //#endregion
 export { a, b };
 

--- a/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/_config.json
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/_config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Within one chunk, plain imports, re-exports and pass-through re-exports of the same external binding collapse into a single import specifier (#3427), including the default import.",
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "external": ["node:fs", "node:assert"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+import fsDefault, { readFileSync } from "node:fs";
+//#region main.js
+assert.strictEqual(readFileSync, readFileSync);
+assert.strictEqual(fsDefault, fsDefault);
+//#endregion
+export { readFileSync };
+
+```

--- a/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/lib.js
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/lib.js
@@ -1,0 +1,2 @@
+export { readFileSync as rfs } from 'node:fs';
+export { default as fsDefault } from 'node:fs';

--- a/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/reexport_external_binding_dedup/main.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import fsDef from 'node:fs';
+import { readFileSync } from 'node:fs';
+import { rfs, fsDefault } from './lib.js';
+
+assert.strictEqual(rfs, readFileSync);
+assert.strictEqual(fsDefault, fsDef);
+
+export { readFileSync } from 'node:fs';

--- a/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/_config.json
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/_config.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Re-exported external bindings are merged per chunk (#3427) without reintroducing the cross-chunk crash of #3405: the shared chunk collapses its duplicate re-exports of `readFileSync` into one import, while the eager facade for the entries' plain imports stays split because its importers live in different chunks.",
+  "config": {
+    "input": [
+      {
+        "name": "entry_a",
+        "import": "entry_a.js"
+      },
+      {
+        "name": "entry_b",
+        "import": "entry_b.js"
+      }
+    ],
+    "external": ["node:fs", "node:assert"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_a.js
+
+```js
+import { t as x } from "./shared.js";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+//#region entry_a.js
+assert.strictEqual(typeof x, "function");
+assert.strictEqual(x, readFileSync);
+//#endregion
+
+```
+
+## entry_b.js
+
+```js
+import { t as x } from "./shared.js";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+//#region entry_b.js
+assert.strictEqual(typeof x, "function");
+assert.strictEqual(x, readFileSync);
+//#endregion
+
+```
+
+## shared.js
+
+```js
+import { readFileSync as x } from "node:fs";
+export { x as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/entry_a.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/entry_a.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { x } from './shared.js';
+
+assert.strictEqual(typeof x, 'function');
+assert.strictEqual(x, readFileSync);

--- a/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/entry_b.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/entry_b.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { y } from './shared.js';
+
+assert.strictEqual(typeof y, 'function');
+assert.strictEqual(y, readFileSync);

--- a/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/shared.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_reexport_external_dedup/shared.js
@@ -1,0 +1,3 @@
+export { readFileSync as x } from 'node:fs';
+export { readFileSync as y } from 'node:fs';
+export { writeFileSync as dead } from 'node:fs';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close #3427

Supersedes #8218.

#### Root cause

#3405 stopped merging external named imports whose local binding is re-exported (`export { a } from 'ext'`), because eager merging happens before chunks exist and can move a symbol's canonical ref where a chunk can't render it: in ESM output a chunk renders external imports only from its own modules' `named_imports` (`direct_imports_from_external_modules`), and `compute_chunk_imports` intentionally skips external-owned symbols. That fixed the Nuxt crash, but it left every re-export of the same `(external module, name)` pair as its own symbol:

```js
// tests/rolldown/function/external/export_external, before
import { a, a as a$1, a as a1, b, b as b$1, b as b1 } from "external";
```

#### Fix

Defer the merge until chunk assignment is known, then merge strictly per chunk (next to the existing namespace merger in `merge_external_import_symbols`):

- `bind_imports_and_exports` now collects re-exported external named imports into `deferred_external_binding_merges`, keyed by `(external module, imported name)`, instead of skipping them.
- At chunk level, each group merges within its chunk. The canonical is the first used symbol by `(exec_order, symbol index)`, preferring a member whose name equals the imported name so the output reads `import { a }` rather than `import { a as a$1 }`.
- The facade created by the eager merger (for plain, non-re-exported imports) is folded into that canonical only when every module owning those plain imports lives in the same chunk. A plain import is only referenced from its own module, so in that case all of the facade's references stay inside the chunk; otherwise the facade stays a root and each chunk keeps rendering its own import.

The per-chunk restriction preserves #3405's constraint by construction: a merged group's canonical always stays a symbol declared inside that chunk, so cross-chunk references keep flowing through the regular cross-chunk import/export machinery. (This is also where #8218 went wrong: it linked re-export symbols from every chunk into the external-owned facade, which reintroduces the #3405 scenario for indirect importers.)

```js
// tests/rolldown/function/external/export_external, after
import { a, b } from "external";
```

#### Tests

Two node-executed fixtures assert runtime identity of the merged bindings:

- `external/reexport_external_binding_dedup`: single chunk; plain import + re-export + pass-through re-export (named and default) collapse to one specifier each.
- `external/splitting_reexport_external_dedup`: the #3405 splitting shape; the shared chunk collapses its duplicate re-exports into one import/one cross-chunk export, while the entry chunks' facade correctly does *not* fold across chunks.

Rollup compat suite: 1214 passed / 0 failed.
