### PR TITLE
fix(plugin): avoid load deadlock during entry resolution

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -155,6 +155,11 @@ pub struct ModuleLoaderOutput {
   pub tla_keyword_span_map: FxHashMap<ModuleIdx, Span>,
 }
 
+struct ResolvedUserDefinedEntries {
+  entries: Vec<(Option<ArcStr>, ResolvedId)>,
+  pending_messages: VecDeque<ModuleLoaderMsg>,
+}
+
 impl<Fs: FileSystem + Clone> Drop for ModuleLoader<'_, Fs> {
   fn drop(&mut self) {
     self.cache.importers = std::mem::take(&mut self.intermediate_normal_modules.importers);
@@ -319,6 +324,9 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
   ) -> ModuleIdx {
     let idx = match self.cache.module_id_to_idx.get(&resolved_id.id).copied() {
       Some(VisitState::Seen(idx)) => {
+        if is_user_defined_entry {
+          self.shared_context.plugin_driver.mark_module_info_as_entry(&resolved_id.id);
+        }
         if self.flat_options.is_lazy_barrel_enabled() && owner.is_none() {
           self.request_all_exports_for_entry(idx, user_defined_entries);
         }
@@ -390,6 +398,15 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     let barrel_state_backup = (!self.is_full_scan && self.flat_options.is_lazy_barrel_enabled())
       .then(|| self.cache.barrel_state.clone());
 
+    let ResolvedUserDefinedEntries { entries: resolved_user_defined_entries, mut pending_messages } =
+      match fetch_mode {
+        ScanMode::Full => self.resolve_user_defined_entries().await?,
+        ScanMode::Partial(_) => {
+          ResolvedUserDefinedEntries { entries: vec![], pending_messages: VecDeque::new() }
+        }
+      };
+    let user_defined_entries = Arc::new(resolved_user_defined_entries);
+
     // Initialize runtime module task if not yet started
     if let Entry::Vacant(e) = self.cache.module_id_to_idx.entry(RUNTIME_MODULE_ID) {
       let idx = self.intermediate_normal_modules.alloc_ecma_module_idx();
@@ -398,11 +415,6 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       e.insert(VisitState::Seen(idx));
       self.remaining += 1;
     }
-
-    let user_defined_entries = Arc::new(match fetch_mode {
-      ScanMode::Full => self.resolve_user_defined_entries().await?,
-      ScanMode::Partial(_) => vec![],
-    });
 
     let entries_count = user_defined_entries.len() + /* runtime */ 1;
     self.intermediate_normal_modules.modules.reserve(entries_count);
@@ -479,8 +491,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     let mut overrode_preserve_entry_signature_map = FxHashMap::default();
 
     while self.remaining > 0 {
-      let Some(msg) = self.rx.recv().await else {
-        break;
+      let msg = if let Some(msg) = pending_messages.pop_front() {
+        msg
+      } else {
+        let Some(msg) = self.rx.recv().await else {
+          break;
+        };
+        msg
       };
       match msg {
         ModuleLoaderMsg::NormalModuleDone(task_result) => {
@@ -925,22 +942,39 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
   }
 
   #[tracing::instrument(target = "devtool", level = "debug", skip_all)]
-  pub async fn resolve_user_defined_entries(
-    &self,
-  ) -> BuildResult<Vec<(Option<ArcStr>, ResolvedId)>> {
-    let resolved_ids =
-      join_all(self.shared_context.options.input.iter().map(|input_item| async move {
-        let resolved = load_entry_module(
-          &self.shared_context.resolver,
-          &self.shared_context.plugin_driver,
-          &input_item.import,
-          None,
-        )
-        .await;
+  async fn resolve_user_defined_entries(&mut self) -> BuildResult<ResolvedUserDefinedEntries> {
+    let inputs = self.shared_context.options.input.clone();
+    let resolver = Arc::clone(&self.shared_context.resolver);
+    let plugin_driver = Arc::clone(&self.shared_context.plugin_driver);
+    let resolve_entries = async move {
+      join_all(inputs.iter().map(|input_item| async {
+        let resolved = load_entry_module(&resolver, &plugin_driver, &input_item.import, None).await;
 
         resolved.map(|info| (input_item.name.as_ref().map(Into::into), info))
       }))
-      .await;
+      .await
+    };
+    tokio::pin!(resolve_entries);
+
+    let no_user_defined_entries = Arc::new(vec![]);
+    let mut pending_messages = VecDeque::new();
+    let resolved_ids = loop {
+      tokio::select! {
+        resolved_ids = &mut resolve_entries => break resolved_ids,
+        Some(msg) = self.rx.recv() => match msg {
+          ModuleLoaderMsg::FetchModule(resolved_id) => {
+            self.try_spawn_new_task(
+              *resolved_id,
+              None,
+              false,
+              None,
+              &no_user_defined_entries,
+            );
+          }
+          msg => pending_messages.push_back(msg),
+        }
+      }
+    };
 
     let mut ret = Vec::with_capacity(self.shared_context.options.input.len());
 
@@ -959,7 +993,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       Err(errors)?;
     }
 
-    Ok(ret)
+    Ok(ResolvedUserDefinedEntries { entries: ret, pending_messages })
   }
 
   /// Traces the import chain from a module back to an entry point.

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -64,6 +64,28 @@ impl PluginDriver {
     self.module_infos.insert(module_id.as_arc_str().into(), module_info);
   }
 
+  pub fn mark_module_info_as_entry(&self, module_id: &ModuleId) {
+    let Some(module_info) = self.module_infos.get(module_id.as_str()) else {
+      return;
+    };
+    if module_info.is_entry {
+      return;
+    }
+    let updated_module_info = ModuleInfo {
+      code: module_info.code.clone(),
+      id: module_info.id.clone(),
+      is_entry: true,
+      importers: module_info.importers.clone(),
+      dynamic_importers: module_info.dynamic_importers.clone(),
+      imported_ids: module_info.imported_ids.clone(),
+      dynamically_imported_ids: module_info.dynamically_imported_ids.clone(),
+      exports: module_info.exports.clone(),
+      input_format: module_info.input_format,
+    };
+    drop(module_info);
+    self.set_module_info(module_id, Arc::new(updated_module_info));
+  }
+
   pub fn set_context_load_modules_tx(
     &self,
     tx: Option<tokio::sync::mpsc::UnboundedSender<ModuleLoaderMsg>>,

--- a/internal-docs/plugin-context-load/implementation.md
+++ b/internal-docs/plugin-context-load/implementation.md
@@ -1,0 +1,7 @@
+# Plugin context module loading
+
+`this.load()` sends a `ModuleLoaderMsg::FetchModule` request to the module loader and waits on the plugin driver's `ContextLoadCompletionManager`. A module task marks that ID complete after parsing and `moduleParsed`, before its result is consumed by the module loader.
+
+Entry `resolveId` hooks run before normal module-loader message processing begins. While entry resolution is pending, `ModuleLoader::resolve_user_defined_entries` therefore pumps `FetchModule` messages and starts their module tasks. Other task results are buffered and consumed by the regular message loop once entry resolution finishes. This keeps `this.load()` safe inside an entry's `resolveId` hook without creating a second message consumer.
+
+A module loaded through `this.load()` can later become an entry. When the resolved entry is registered, `try_spawn_new_task` reuses the existing module and promotes its `ModuleInfo.is_entry` flag. Transform and `moduleParsed` hooks may already have run before that promotion, matching the public API warning that entry status can change after parsing.

--- a/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/_config.ts
@@ -1,0 +1,31 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+let entryId: string | undefined;
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'load-in-resolve',
+        async resolveId(source, importer, options) {
+          const resolved = await this.resolve(source, importer, {
+            ...options,
+            skipSelf: true,
+          });
+          if (resolved && !resolved.external) {
+            if (options.isEntry) {
+              entryId = resolved.id;
+            }
+            const moduleInfo = await this.load(resolved);
+            expect(moduleInfo.code).not.toBeNull();
+          }
+          return resolved;
+        },
+        buildEnd() {
+          expect(this.getModuleInfo(entryId!)?.isEntry).toBe(true);
+        },
+      },
+    ],
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/dep.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/dep.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-in-resolve-entry/main.js
@@ -1,0 +1,3 @@
+import { value } from './dep.js';
+
+console.log(value);


### PR DESCRIPTION
Fixes #10195.

`this.load()` sends a `FetchModule` message and waits for the module task to finish. Entry `resolveId` hooks run before the module loader's normal receive loop starts, so awaiting `this.load()` from that hook left the request queued forever.

This change lets entry resolution pump only `FetchModule` requests while it is pending. Completed task messages are buffered and handed to the existing module-loader loop afterward, so there is still a single consumer for module results. If a module loaded this way is subsequently registered as an entry, its `ModuleInfo.isEntry` flag is promoted at that point.

I considered rejecting or short-circuiting a self-load from `resolveId`, but Rollup supports this pattern and plugins use it to inspect transformed module contents before returning a resolution.

The new fixture covers an entry and its dependency being loaded from `resolveId`, and checks that the entry is promoted after parsing. I also added an internal implementation note for the message and completion flow.

Checks:

- `cargo clippy --workspace --all-targets -- --deny warnings`
- `cargo test -p rolldown_plugin`
- plugin-context `load` fixtures, including concurrent loads and error propagation
- cycle-loading warning fixture
- `vp check`
- `just lint-repo`

AI assistance disclosure: OpenAI Codex was used to investigate and implement this change. The contribution is submitted under the human contributor's responsibility.
