### PR TITLE
chore(deps): upgrade sugar_path to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,10 +2813,10 @@ dependencies = [
  "memchr",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "rolldown_utils",
  "rustc-hash",
  "string_wizard",
- "sugar_path",
  "tokio",
 ]
 
@@ -2827,11 +2827,11 @@ dependencies = [
  "arcstr",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "rolldown_utils",
  "rustc-hash",
  "serde",
  "serde_json",
- "sugar_path",
 ]
 
 [[package]]
@@ -2856,10 +2856,10 @@ dependencies = [
  "memchr",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "rolldown_utils",
  "rustc-hash",
  "string_wizard",
- "sugar_path",
  "tokio",
 ]
 
@@ -2992,6 +2992,7 @@ dependencies = [
  "oxc",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "rolldown_utils",
  "string_wizard",
  "sugar_path",
@@ -3010,6 +3011,7 @@ dependencies = [
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",
+ "rolldown_std_utils",
  "rolldown_utils",
  "string_wizard",
  "sugar_path",
@@ -3088,6 +3090,7 @@ dependencies = [
  "rayon",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "sugar_path",
  "supports-color",
  "terminal_size",
@@ -3177,6 +3180,7 @@ name = "rolldown_std_utils"
 version = "1.1.5"
 dependencies = [
  "regex",
+ "sugar_path",
 ]
 
 [[package]]
@@ -3583,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "sugar_path"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fe837e881ad5c3b60fadeb8e9b0bc5c907c4b7d84b4415a7f0bbc3f9073631"
+checksum = "b75b52e25042df94d848c33b7048a6726e728fa649c561c7510784ed11c1ffd2"
 dependencies = [
  "memchr",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ serde_json = "1.0.150"
 serde_yaml = "0.9.34"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.2", features = ["union"] }
-sugar_path = { version = "2.0.1", features = ["cached_current_dir"] }
+sugar_path = { version = "3", features = ["cached_current_dir"] }
 supports-color = "3"
 terminal_size = "0.4.4"
 testing_macros = "1.0.1"

--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -428,18 +428,86 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
 
 /// Check if a filename would escape the output directory.
 ///
-/// Rejects absolute paths and paths that normalize to a location outside the
-/// output directory (e.g. via `..` traversal).
+/// Rejects paths rooted in POSIX or Windows syntax and relative paths that
+/// normalize outside the output directory or to the directory itself.
 fn is_filename_outside_output_dir(filename: &str) -> bool {
-  if Path::new(filename).is_absolute() {
+  let bytes = filename.as_bytes();
+  let starts_with_path_root = bytes.first().is_some_and(|byte| matches!(*byte, b'/' | b'\\'));
+  let has_windows_drive_prefix =
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+  // Drive-relative paths can escape only on Windows; absolute drive paths are
+  // rejected on every host for cross-platform consistency.
+  let has_disallowed_windows_drive_prefix = has_windows_drive_prefix
+    && (cfg!(windows) || bytes.get(2).is_some_and(|byte| matches!(*byte, b'/' | b'\\')));
+  if starts_with_path_root || has_disallowed_windows_drive_prefix {
     return true;
   }
 
   let normalized = filename.normalize();
-  let normalized = normalized.to_string_lossy();
 
-  normalized == "."
-    || normalized == ".."
-    || normalized.starts_with("../")
-    || normalized.starts_with("..\\")
+  normalized == Path::new(".")
+    || normalized.starts_with(Path::new(".."))
+    // Preserve the existing cross-platform guard for a leading Windows parent.
+    || normalized.to_string_lossy().starts_with("..\\")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::is_filename_outside_output_dir;
+
+  #[test]
+  fn output_filename_cannot_resolve_to_or_escape_output_directory() {
+    for filename in [
+      "",
+      ".",
+      "./",
+      "foo/..",
+      "foo/../",
+      "foo/bar/../..",
+      "..",
+      "../file",
+      "..\\file",
+      "a/../../file",
+      "/file",
+      "\\file",
+      "C:/file",
+      "C:\\file",
+      "c:\\file",
+      "\\\\server\\share\\file",
+      "\\\\?\\C:\\file",
+    ] {
+      assert!(is_filename_outside_output_dir(filename), "expected {filename:?} to be rejected");
+    }
+
+    for filename in [
+      "file.js",
+      "dir/file.js",
+      "dir\\file.js",
+      "./asset.txt",
+      ".\\asset.txt",
+      "foo/",
+      "foo\\",
+      "..file.js",
+      ".hidden",
+      "foo/bar/../baz.js",
+    ] {
+      assert!(!is_filename_outside_output_dir(filename), "expected {filename:?} to be accepted");
+    }
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn windows_output_filename_cannot_use_drive_relative_or_backslash_traversal() {
+    for filename in [".\\", "C:", "C:file", "c:file", "foo\\..", "a\\..\\..\\file"] {
+      assert!(is_filename_outside_output_dir(filename), "expected {filename:?} to be rejected");
+    }
+  }
+
+  #[cfg(not(windows))]
+  #[test]
+  fn unix_output_filename_keeps_host_native_backslash_and_colon_semantics() {
+    for filename in [".\\", "C:", "C:file", "c:file", "foo\\..", "a\\..\\..\\file"] {
+      assert!(!is_filename_outside_output_dir(filename), "expected {filename:?} to be accepted");
+    }
+  }
 }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -165,7 +165,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     // 1. Identify changed modules
     let mut changed_modules = FxIndexSet::default();
     for (changed_file_path, event) in changed_file_paths {
-      let changed_file_path = ArcStr::from(changed_file_path.to_slash().unwrap());
+      let changed_file_path = ArcStr::from(changed_file_path.to_slash());
       // Check if the file itself is a module
       if let Some(module_idx) = self.cache.module_idx_by_abs_path.get(&changed_file_path) {
         if *event == WatcherChangeKind::Delete {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -30,6 +30,7 @@ mod impl_visit_mut;
 use finalizer_context::ModuleWrapperMode;
 pub use finalizer_context::ScopeHoistingFinalizerContext;
 use oxc_str::{CompactStr, Ident};
+use rolldown_std_utils::absolutize_path_buf;
 use rolldown_utils::ecmascript::is_validate_identifier_name;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1072,8 +1073,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       let Ok(asset_file_name) = self.ctx.file_emitter.get_file_name(reference_id) else {
         return None;
       };
-      let absolute_asset_file_name = asset_file_name
-        .absolutize_with(self.ctx.options.cwd.as_path().join(&self.ctx.options.out_dir));
+      let output_dir =
+        absolutize_path_buf(self.ctx.options.cwd.as_path().join(&self.ctx.options.out_dir));
+      let absolute_asset_file_name = asset_file_name.absolutize_with(output_dir);
       let relative_asset_path = &self.ctx.chunk.relative_path_for(&absolute_asset_file_name);
 
       // new URL({relative_asset_path}, import.meta.url).href

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -76,17 +76,14 @@ impl<Fs: FileSystem> ExternalModuleTask<Fs> {
       )
       .expect("should have common dir for entries");
       let relative_path = Path::new(resolved_id.id.as_str()).relative(&entries_common_dir);
-      relative_path.to_slash_lossy().into()
+      ArcStr::from(relative_path.to_slash())
     } else {
       resolved_id.id.as_arc_str().clone()
     };
 
     let identifier_name: ArcStr = if need_renormalize_render_path {
-      Path::new(resolved_id.id.as_str())
-        .relative(&self.ctx.options.cwd)
-        .normalize()
-        .to_slash_lossy()
-        .into()
+      let relative_path = Path::new(resolved_id.id.as_str()).relative(&self.ctx.options.cwd);
+      ArcStr::from(relative_path.to_slash())
     } else {
       resolved_id.id.as_arc_str().clone()
     };

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -12,7 +12,8 @@ use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_std_utils::{
-  PathBufExt as _, representative_file_name_for_preserve_modules, strip_path_prefix_to_slash,
+  PathBufExt as _, absolutize_path_buf, path_buf_to_slash, relative_path_to_slash,
+  representative_file_name_for_preserve_modules, strip_path_prefix_to_slash,
 };
 use rolldown_utils::{
   dashmap::FxDashMap,
@@ -263,13 +264,13 @@ impl<'a> GenerateStage<'a> {
                     ) {
                       relative_path
                     } else {
-                      p.relative(input_base.as_str()).to_slash_lossy().into_owned()
+                      relative_path_to_slash(&p, input_base.as_str())
                     }
                   } else {
-                    p.relative(input_base.as_str()).to_slash_lossy().into_owned()
+                    relative_path_to_slash(&p, input_base.as_str())
                   }
                 } else {
-                  PathBuf::from(virtual_dirname.as_str()).join(p).to_slash_lossy().into_owned()
+                  path_buf_to_slash(PathBuf::from(virtual_dirname.as_str()).join(p))
                 };
                 // `p` may be an absolute or relative path without extension, depending on the module path.
                 // Now we need to add the extension back when generating the relative chunk name.
@@ -351,6 +352,7 @@ impl<'a> GenerateStage<'a> {
     let mut hash_placeholder_generator = HashPlaceholderGenerator::default();
 
     let used_name_counts = FxDashMap::default();
+    let output_dir = absolutize_path_buf(self.options.cwd.join(&self.options.out_dir));
 
     for chunk_id in &chunk_graph.sorted_chunk_idx_vec {
       let chunk = &mut chunk_graph.chunk_table[*chunk_id];
@@ -379,12 +381,8 @@ impl<'a> GenerateStage<'a> {
       // if user provided one.
       chunk.name = Some(pre_generated_chunk_name.chunk_name.clone());
 
-      chunk.absolute_preliminary_filename = Some(
-        preliminary_filename
-          .absolutize_with(self.options.cwd.join(&self.options.out_dir))
-          .into_owned()
-          .expect_into_string(),
-      );
+      chunk.absolute_preliminary_filename =
+        Some(preliminary_filename.absolutize_with(&output_dir).into_owned().expect_into_string());
       chunk.preliminary_filename = Some(preliminary_filename);
       // Derives its `[chunkhash]` from the just-assigned `preliminary_filename`, so it must run
       // after it.

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -155,7 +155,7 @@ impl ScanStageCache {
       if let rolldown_common::Module::Normal(normal_module) = &new_module {
         self
           .module_idx_by_abs_path
-          .insert(normal_module.id.as_arc_str().to_slash().unwrap().into(), normal_module.idx);
+          .insert(ArcStr::from(normal_module.id.as_arc_str().to_slash()), normal_module.idx);
       }
       // Update `module_idx_by_stable_id`
       self.module_idx_by_stable_id.insert(new_module.stable_id().clone(), new_module.idx());
@@ -306,7 +306,7 @@ impl ScanStageCache {
 
     for module in &build_snapshot.module_table.modules {
       if let rolldown_common::Module::Normal(normal_module) = module {
-        let filename = normal_module.id.as_arc_str().to_slash().unwrap().into();
+        let filename = ArcStr::from(normal_module.id.as_arc_str().to_slash());
         let module_idx = normal_module.idx;
         self.module_idx_by_abs_path.insert(filename, module_idx);
       }

--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -5,6 +5,7 @@ use oxc::ast::CommentKind;
 use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
 use rolldown_error::{BuildResult, ResultExt};
 use rolldown_sourcemap::SourceMap;
+use rolldown_std_utils::relative_path_to_slash;
 use sugar_path::SugarPath;
 use url::Url;
 
@@ -92,10 +93,8 @@ pub async fn prepare_sourcemap(
     map.set_sources(sources);
   } else if cfg!(windows) {
     // Normalize the windows path at final.
-    let sources = map
-      .get_sources()
-      .map(|x| x.as_path().relative(file_dir).to_slash_lossy().to_string())
-      .collect::<Vec<_>>();
+    let sources =
+      map.get_sources().map(|x| relative_path_to_slash(x.as_path(), file_dir)).collect::<Vec<_>>();
     map.set_sources(sources);
   } else {
     map.set_sources(

--- a/crates/rolldown/tests/integration/test262.rs
+++ b/crates/rolldown/tests/integration/test262.rs
@@ -134,7 +134,7 @@ impl TestResult {
     actual: TestOutcome,
     cwd: &Path,
   ) -> Self {
-    let relative_path = path.relative(cwd);
+    let relative_path = path.relative(cwd).into_owned();
     let display_path = relative_path.to_slash_lossy();
     let clean_path = Self::clean_path(&display_path);
 

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -17,7 +17,7 @@ pub mod types;
 
 use arcstr::ArcStr;
 use oxc_str::CompactStr;
-use rolldown_std_utils::{PathExt, strip_path_prefix_to_slash};
+use rolldown_std_utils::{path_buf_to_slash, relative_path_to_slash, strip_path_prefix_to_slash};
 use rolldown_utils::{
   BitSet,
   dashmap::FxDashMap,
@@ -160,7 +160,7 @@ impl Chunk {
       .as_path()
       .parent()
       .expect("absolute_preliminary_filename should have a parent directory");
-    target.relative(source_dir).as_path().expect_to_slash()
+    relative_path_to_slash(target, source_dir)
   }
 
   pub async fn filename_template(
@@ -303,11 +303,11 @@ impl Chunk {
           return Cow::Owned(relative_path);
         }
       }
-      p.relative(self.input_base.as_str())
+      relative_path_to_slash(p, self.input_base.as_str())
     } else {
-      PathBuf::from(options.virtual_dirname.as_str()).join(p)
+      path_buf_to_slash(PathBuf::from(options.virtual_dirname.as_str()).join(p))
     };
-    Cow::Owned(p.to_slash_lossy().into_owned())
+    Cow::Owned(p)
   }
 
   pub fn user_defined_entry_module_idx(&self) -> Option<ModuleIdx> {

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use dashmap::{DashMap, DashSet, Entry};
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
+use rolldown_std_utils::path_buf_to_slash;
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 use rolldown_utils::make_unique_name::make_unique_name;
 use rolldown_utils::xxhash::{xxhash_base64_url, xxhash_with_base};
@@ -15,7 +16,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use sugar_path::SugarPath;
+use sugar_path::SugarPathBuf;
 
 #[derive(Debug, Default)]
 pub struct EmittedAsset {
@@ -293,7 +294,7 @@ impl FileEmitter {
       let name = path.file_stem().and_then(OsStr::to_str).map(|stem| {
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
           // Normalize to resolve ".." and "." where possible, then convert to forward slashes
-          parent.join(stem).normalize().to_slash_lossy().into_owned()
+          path_buf_to_slash(parent.join(stem).into_normalized())
         } else {
           stem.to_string()
         }

--- a/crates/rolldown_common/src/module/external_module.rs
+++ b/crates/rolldown_common/src/module/external_module.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use arcstr::ArcStr;
 use oxc_index::IndexVec;
+use rolldown_std_utils::relative_path_as_js_specifier;
 use rolldown_utils::concat_string;
-use sugar_path::SugarPath;
 
 #[derive(Debug, Clone)]
 pub struct ExternalModule {
@@ -80,18 +80,12 @@ impl ExternalModule {
       target = &target[3..];
       importer = concat_string!("_/", importer);
     }
-    let relative_path = Path::new(target).relative(
-      importer
-        .as_path()
+    relative_path_as_js_specifier(
+      target,
+      Path::new(&importer)
         .parent()
         .expect("the importer chunk preliminary filename should have a parent directory"),
-    );
-    if relative_path.starts_with("..") {
-      relative_path.to_slash_lossy().into()
-    } else if relative_path.as_os_str().is_empty() {
-      ".".into()
-    } else {
-      concat_string!("./", relative_path.to_slash_lossy()).into()
-    }
+    )
+    .into()
   }
 }

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -141,7 +141,7 @@ impl ModuleId {
   }
 
   pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
-    Path::new(self.as_str()).relative(root)
+    Path::new(self.as_str()).relative(root).into_owned()
   }
 
   pub fn stabilize(&self, cwd: &Path) -> StableModuleId {

--- a/crates/rolldown_common/src/types/stable_module_id.rs
+++ b/crates/rolldown_common/src/types/stable_module_id.rs
@@ -1,8 +1,10 @@
 use std::{borrow::Borrow, path::Path};
 
 use arcstr::ArcStr;
+use rolldown_std_utils::relative_path_to_slash;
+
+#[cfg(test)]
 use rolldown_std_utils::PathExt as _;
-use sugar_path::SugarPath as _;
 
 use crate::{ModuleId, ModuleIdKind};
 
@@ -28,7 +30,7 @@ impl StableModuleId {
     // instead of re-detecting absolute/virtual here.
     let inner: ArcStr = match id.kind() {
       // Absolute path → relative to cwd, slashed (stable across machines/OSes).
-      ModuleIdKind::Path => id.as_str().relative(cwd).as_path().expect_to_slash().into(),
+      ModuleIdKind::Path => relative_path_to_slash(id.as_str(), cwd).into(),
       // Virtual module → escape the `\0` prefix.
       ModuleIdKind::Virtual => id.as_str().replace('\0', "\\0").into(),
       // Bare specifier / URL / … → as-is (cheap `Arc` clone).

--- a/crates/rolldown_error/src/types/diagnostic_options.rs
+++ b/crates/rolldown_error/src/types/diagnostic_options.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use sugar_path::SugarPath;
+use sugar_path::{SugarPath, SugarPathBuf};
 
 pub struct DiagnosticOptions {
   pub cwd: PathBuf,
@@ -19,11 +19,26 @@ impl DiagnosticOptions {
   pub fn stabilize_path(&self, path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
     let result = if path.is_absolute() {
-      path.relative(&self.cwd).to_slash_lossy().into_owned()
+      path.relative(&self.cwd).into_owned().into_slash_lossy()
     } else {
       path.to_string_lossy().to_string()
     };
     // Escape virtual module prefix (\0 → \\0) so null bytes don't appear in diagnostics
     if result.contains('\0') { result.replace('\0', "\\0") } else { result }
+  }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+  use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+  use super::*;
+
+  #[test]
+  fn stabilize_path_replaces_invalid_utf8() {
+    let options = DiagnosticOptions { cwd: PathBuf::from("/workspace") };
+    let path = PathBuf::from(OsString::from_vec(b"/workspace/invalid-\xff.js".to_vec()));
+
+    assert_eq!(options.stabilize_path(path), "invalid-\u{fffd}.js");
   }
 }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -101,7 +101,7 @@ impl PluginDriver {
   }
 
   pub fn add_transform_dependency(&self, module_idx: ModuleIdx, dependency: &str) {
-    let dependency = ArcStr::from(dependency.to_slash().unwrap());
+    let dependency = ArcStr::from(dependency.to_slash());
 
     self
       .transform_dependencies

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -11,7 +11,10 @@ use rolldown_common::{
 use rolldown_fs::FileSystem;
 use rolldown_resolver::{ResolveError, Resolver};
 use rolldown_utils::dataurl::is_data_url;
-use std::{path::Path, sync::Arc};
+use std::{
+  path::{Path, PathBuf},
+  sync::Arc,
+};
 use sugar_path::SugarPath;
 
 use crate::__inner::resolve_id_with_plugins;
@@ -150,7 +153,7 @@ fn normalize_relative_external_id(cwd: &Path, specifier: &str, importer: Option<
   } else {
     cwd.join(specifier)
   };
-  path.normalize().to_string_lossy().into()
+  path.normalize().components().collect::<PathBuf>().to_string_lossy().into()
 }
 
 #[inline]
@@ -177,5 +180,14 @@ mod tests {
   #[test]
   fn test_is_absolute() {
     assert!(is_absolute("/a.js")); // make sure it is true at windows
+  }
+
+  #[test]
+  fn normalized_external_id_drops_trailing_separator() {
+    let cwd = std::env::current_dir().unwrap();
+    assert_eq!(
+      normalize_relative_external_id(&cwd, "./external", None),
+      normalize_relative_external_id(&cwd, "./external/", None)
+    );
   }
 }

--- a/crates/rolldown_plugin_asset_module/Cargo.toml
+++ b/crates/rolldown_plugin_asset_module/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = { workspace = true }
 memchr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 string_wizard = { workspace = true }
-sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/rolldown_plugin_asset_module/src/lib.rs
+++ b/crates/rolldown_plugin_asset_module/src/lib.rs
@@ -7,10 +7,10 @@ use rolldown_plugin::{
   HookRenderChunkReturn, HookTransformOutputMap, HookUsage, Plugin, PluginHookMeta, PluginOrder,
   SharedLoadPluginContext,
 };
+use rolldown_std_utils::relative_path_as_js_specifier;
 use rolldown_utils::url::clean_url;
 use rustc_hash::FxHashSet;
 use string_wizard::{MagicString, SourceMapOptions};
-use sugar_path::SugarPath;
 
 const PREFIX: &str = "__ROLLDOWN_ASSET__#";
 
@@ -204,14 +204,5 @@ impl AssetModulePlugin {
 fn compute_relative_path(chunk_filename: &str, asset_filename: &str) -> String {
   let chunk_dir = Path::new(chunk_filename).parent().unwrap_or(Path::new(""));
 
-  let relative = Path::new(asset_filename).relative(chunk_dir);
-  let relative_str = relative.to_slash_lossy();
-
-  if relative_str.starts_with("..") {
-    relative_str.into_owned()
-  } else if relative_str.is_empty() {
-    ".".to_string()
-  } else {
-    format!("./{relative_str}")
-  }
+  relative_path_as_js_specifier(asset_filename, chunk_dir)
 }

--- a/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
+++ b/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
@@ -15,8 +15,8 @@ test = false
 arcstr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_bundle_analyzer/src/lib.rs
+++ b/crates/rolldown_plugin_bundle_analyzer/src/lib.rs
@@ -3,10 +3,10 @@ use std::{borrow::Cow, path::Path, sync::Arc};
 use arcstr::ArcStr;
 use rolldown_common::{EmittedAsset, Output, OutputChunk};
 use rolldown_plugin::{HookNoopReturn, HookUsage, Plugin, PluginContext};
+use rolldown_std_utils::relative_path_to_slash;
 use rolldown_utils::rustc_hash::FxHashMapExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
-use sugar_path::SugarPath;
 
 mod render_markdown;
 use render_markdown::render_markdown;
@@ -357,7 +357,7 @@ fn stabilize_module_id(id: &str, cwd: &Path) -> String {
   let path = Path::new(id);
   if path.is_absolute() {
     // Convert absolute path to relative path from cwd using forward slashes
-    path.relative(cwd).to_slash().map_or_else(|| id.to_string(), |s| s.to_string())
+    relative_path_to_slash(path, cwd)
   } else if id.starts_with('\0') {
     // Escape virtual module prefix
     id.replace('\0', "\\0")

--- a/crates/rolldown_plugin_copy_module/Cargo.toml
+++ b/crates/rolldown_plugin_copy_module/Cargo.toml
@@ -17,8 +17,8 @@ arcstr = { workspace = true }
 memchr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 string_wizard = { workspace = true }
-sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -8,10 +8,10 @@ use rolldown_plugin::{
   HookResolveIdOutput, HookResolveIdReturn, HookTransformOutputMap, HookUsage, Plugin,
   PluginContext, PluginHookMeta, PluginOrder,
 };
+use rolldown_std_utils::relative_path_as_js_specifier;
 use rolldown_utils::url::clean_url;
 use rustc_hash::FxHashSet;
 use string_wizard::{MagicString, SourceMapOptions};
-use sugar_path::SugarPath;
 
 const PREFIX: &str = "__ROLLDOWN_COPY_MODULE__#";
 
@@ -204,14 +204,5 @@ impl Plugin for CopyModulePlugin {
 fn compute_relative_path(chunk_filename: &str, asset_filename: &str) -> String {
   let chunk_dir = Path::new(chunk_filename).parent().unwrap_or(Path::new(""));
 
-  let relative = Path::new(asset_filename).relative(chunk_dir);
-  let relative_str = relative.to_slash_lossy();
-
-  if relative_str.starts_with("..") {
-    relative_str.into_owned()
-  } else if relative_str.is_empty() {
-    ".".to_string()
-  } else {
-    format!("./{relative_str}")
-  }
+  relative_path_as_js_specifier(asset_filename, chunk_dir)
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -25,6 +25,7 @@ memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
@@ -6,8 +6,8 @@ use oxc::{
   ast_visit::{Visit, walk},
 };
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
+use rolldown_std_utils::relative_path_to_slash;
 use string_wizard::MagicString;
-use sugar_path::SugarPath as _;
 
 use super::dynamic_import_to_glob::{
   has_special_query_param, should_ignore, template_literal_to_glob, to_valid_glob,
@@ -106,14 +106,12 @@ impl<'ast> DynamicImportVarsVisit<'ast, '_> {
 
       let base = self.importer.parent().unwrap_or(self.root);
       let normalized = if raw_pattern.as_bytes()[0] == b'/' {
-        self.root.join(&raw_pattern[1..]).relative(base)
+        relative_path_to_slash(self.root.join(&raw_pattern[1..]), base)
       } else {
-        base.join(raw_pattern.as_ref()).relative(base)
+        relative_path_to_slash(base.join(raw_pattern.as_ref()), base)
       };
-
-      let normalized = normalized.to_slash_lossy();
       let new_raw_pattern = if normalized.starts_with("./") || normalized.starts_with("../") {
-        normalized.into_owned()
+        normalized
       } else {
         rolldown_utils::concat_string!("./", normalized)
       };

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -11,6 +11,7 @@ use rolldown_plugin::{
   HookResolveIdReturn, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
   PluginContext, SharedLoadPluginContext,
 };
+use rolldown_std_utils::relative_path_as_js_specifier;
 use rolldown_utils::{
   futures::{block_on, block_on_spawn_all},
   pattern_filter::StringOrRegex,
@@ -122,15 +123,10 @@ impl Plugin for ViteDynamicImportVarsPlugin {
         let result = block_on(block_on_spawn_all(task));
         for (i, item) in result.into_iter().enumerate() {
           if let Some(id) = item {
-            let id = id.relative(importer);
-            let id = id.to_slash_lossy();
-            let id = if id.is_empty() {
+            let id = relative_path_as_js_specifier(id, importer);
+            if id == "." {
               continue;
-            } else if id.as_bytes()[0] == b'.' {
-              id.into_owned()
-            } else {
-              rolldown_utils::concat_string!("./", id)
-            };
+            }
 
             let addr = visitor.async_imports_addrs[i];
             visitor.rewrite_variable_dynamic_import(unsafe { &*addr }, Some(&id));

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -27,6 +27,7 @@ rolldown_common = { workspace = true }
 rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_utils = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -10,6 +10,7 @@ use oxc::ast_visit::{Visit, walk};
 use rolldown_ecmascript_utils::ExpressionExt;
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
 use rolldown_plugin_utils::constants::{ViteImportGlob, ViteImportGlobValue};
+use rolldown_std_utils::relative_path_to_slash;
 use string_wizard::MagicString;
 use sugar_path::SugarPath;
 
@@ -335,10 +336,9 @@ impl GlobImportVisit<'_> {
   }
 
   fn relative_path(&self, path: &Path, to: Option<&Path>) -> String {
-    let path = path.relative(to.unwrap_or(self.root));
-    let path = path.to_slash_lossy();
+    let path = relative_path_to_slash(path, to.unwrap_or(self.root));
     if path.starts_with("./") || path.starts_with("../") {
-      path.to_string()
+      path
     } else {
       let prefix = if to.is_none() { "/" } else { "./" };
       format!("{prefix}{path}")

--- a/crates/rolldown_plugin_vite_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_vite_reporter/Cargo.toml
@@ -26,6 +26,7 @@ owo-colors = { workspace = true }
 rayon = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 sugar_path = { workspace = true }
 supports-color = { workspace = true }
 terminal_size = { workspace = true }

--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -16,6 +16,7 @@ use cow_utils::CowUtils;
 use owo_colors::Style;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+use rolldown_std_utils::relative_path_to_slash;
 use sugar_path::SugarPath as _;
 
 pub type LogInfoFn =
@@ -214,9 +215,10 @@ impl Plugin for ViteReporterPlugin {
       let map_pad = utils::display_size(biggest_map_size).len();
       let compress_pad = utils::display_size(biggest_compress_size).len();
 
-      let out_dir =
-        args.options.cwd.join(&args.options.out_dir).normalize().relative(&args.options.cwd);
-      let out_dir = out_dir.to_slash_lossy();
+      let out_dir = relative_path_to_slash(
+        args.options.cwd.join(&args.options.out_dir).normalize(),
+        &args.options.cwd,
+      );
       let out_dir_prefix = format!("{out_dir}/");
 
       let mut info = String::new();

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -283,7 +283,7 @@ impl Plugin for ViteResolvePlugin {
           })
           .flatten();
         return Ok(Some(HookResolveIdOutput {
-          id: path.to_slash_lossy().into(),
+          id: ArcStr::from(path.to_slash()),
           package_json_path,
           ..Default::default()
         }));

--- a/crates/rolldown_std_utils/Cargo.toml
+++ b/crates/rolldown_std_utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 regex = { workspace = true }
+sugar_path = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/rolldown_std_utils/src/lib.rs
+++ b/crates/rolldown_std_utils/src/lib.rs
@@ -8,6 +8,10 @@ mod pretty_type_name;
 pub use crate::{
   option_ext::OptionExt,
   path_buf_ext::PathBufExt,
-  path_ext::{PathExt, representative_file_name_for_preserve_modules, strip_path_prefix_to_slash},
+  path_ext::{
+    PathExt, absolute_path_to_relative_slash, absolutize_path_buf, path_buf_to_slash,
+    relative_path_as_js_specifier, relative_path_to_slash,
+    representative_file_name_for_preserve_modules, strip_path_prefix_to_slash,
+  },
   pretty_type_name::pretty_type_name,
 };

--- a/crates/rolldown_std_utils/src/path_ext.rs
+++ b/crates/rolldown_std_utils/src/path_ext.rs
@@ -1,4 +1,18 @@
-use std::{borrow::Cow, ffi::OsStr, path::Path};
+//! Path helpers for Rolldown's known-UTF-8 module / filesystem path domain.
+//!
+//! Prefer these over open-coding `sugar_path` compositions. sugar_path 3 returns
+//! `Cow<Path>` from `relative` and makes slash conversion explicit; the patterns
+//! below are the ones we want in call sites so later code does not reintroduce
+//! lossy or double-allocating chains like
+//! `relative(...).to_slash_lossy().into_owned()`.
+
+use std::{
+  borrow::Cow,
+  ffi::OsStr,
+  path::{Path, PathBuf},
+};
+
+use sugar_path::{SugarPath as _, SugarPathBuf as _};
 
 pub trait PathExt {
   fn expect_to_str(&self) -> &str;
@@ -18,15 +32,8 @@ impl PathExt for Path {
   }
 
   fn expect_to_slash(&self) -> String {
-    let path = if std::path::MAIN_SEPARATOR == '/' {
-      self.to_str().map(Cow::Borrowed)
-    } else {
-      self.to_str().map(|s| Cow::Owned(s.replace(std::path::MAIN_SEPARATOR, "/")))
-    };
-
-    path
-      .unwrap_or_else(|| panic!("Failed to convert {:?} to slash str", self.display()))
-      .into_owned()
+    // Strict slash conversion: panics on invalid UTF-8, matching the prior contract.
+    self.to_slash().into_owned()
   }
 
   fn is_in_node_modules(&self) -> bool {
@@ -67,6 +74,78 @@ pub fn representative_file_name_for_preserve_modules(
 
 pub fn strip_path_prefix_to_slash(path: &Path, prefix: &Path) -> Option<String> {
   path.strip_prefix(prefix).ok().map(PathExt::expect_to_slash)
+}
+
+/// Lexical path from `base` to `target` as a `/`-separated UTF-8 string.
+///
+/// Uses sugar_path 3's intended composition for known-UTF-8 Rolldown paths:
+/// `relative` may borrow a clean descendant, then one owned buffer becomes the
+/// final slash `String` via [`SugarPathBuf::into_slash`].
+///
+/// Prefer this over `relative(...).to_slash_lossy().into_owned()` or
+/// `relative(...).as_path().expect_to_slash()`.
+#[inline]
+pub fn relative_path_to_slash(target: impl AsRef<Path>, base: impl AsRef<Path>) -> String {
+  target.as_ref().relative(base).into_owned().into_slash()
+}
+
+/// Like [`relative_path_to_slash`], but formats a JS-style relative specifier:
+/// - equal paths → `"."`
+/// - paths that leave the base (`..`…) → the slash relative as-is
+/// - otherwise → `"./…"`
+///
+/// sugar_path 3 returns an empty path for equal inputs; this helper keeps the
+/// historical Rolldown/Rollup `./` spelling at call sites that emit import
+/// specifiers or chunk-relative asset URLs.
+#[inline]
+pub fn relative_path_as_js_specifier(target: impl AsRef<Path>, base: impl AsRef<Path>) -> String {
+  let relative = target.as_ref().relative(base);
+  if relative.as_os_str().is_empty() {
+    return ".".to_string();
+  }
+  let slash = relative.into_owned().into_slash();
+  // Only true parent segments (`..` / `../…`), not filenames like `..foo`.
+  if slash == ".." || slash.starts_with("../") { slash } else { format!("./{slash}") }
+}
+
+/// Absolute `path` → slash-separated path relative to `cwd` (stable ids / diagnostics).
+///
+/// Non-absolute inputs are returned as `path` with native separators converted via
+/// strict slash conversion when they are valid UTF-8 paths; virtual ids should be
+/// handled by the caller before calling this.
+#[inline]
+pub fn absolute_path_to_relative_slash(path: impl AsRef<Path>, cwd: impl AsRef<Path>) -> String {
+  let path = path.as_ref();
+  if path.is_absolute() { relative_path_to_slash(path, cwd) } else { path.expect_to_slash() }
+}
+
+/// Ensure an owned path is absolute before using it as sugar_path 3's explicit cwd.
+#[inline]
+pub fn absolutize_path_buf(path: PathBuf) -> PathBuf {
+  if path.is_absolute() { path } else { path.absolutize().into_owned() }
+}
+
+/// Consume a `PathBuf` into a `/`-separated UTF-8 string (known-UTF-8 invariant).
+#[inline]
+pub fn path_buf_to_slash(path: PathBuf) -> String {
+  path.into_slash()
+}
+
+#[test]
+fn test_relative_path_helpers() {
+  let workspace = std::env::current_dir().unwrap().join("path-helper-tests");
+  let base = workspace.join("src");
+  let nested = base.join("lib").join("mod.js");
+  assert_eq!(relative_path_to_slash(&nested, &base), "lib/mod.js");
+  assert_eq!(relative_path_as_js_specifier(&nested, &base), "./lib/mod.js");
+  assert_eq!(relative_path_as_js_specifier(&base, &base), ".");
+  assert_eq!(relative_path_as_js_specifier(workspace.join("other"), &base), "../other");
+  // Filename `..foo` is not a parent segment — still needs the `./` prefix.
+  assert_eq!(relative_path_as_js_specifier(base.join("..foo.js"), &base), "./..foo.js");
+  assert_eq!(relative_path_as_js_specifier(base.join(".hidden.js"), &base), "./.hidden.js");
+  assert_eq!(absolute_path_to_relative_slash(&nested, &workspace), "src/lib/mod.js");
+  assert!(absolutize_path_buf(PathBuf::from("path-helper-tests")).is_absolute());
+  assert_eq!(path_buf_to_slash(PathBuf::from("src").join("lib.js")), "src/lib.js");
 }
 
 #[test]

--- a/crates/rolldown_utils/src/stabilize_id.rs
+++ b/crates/rolldown_utils/src/stabilize_id.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-use rolldown_std_utils::PathExt as _;
-use sugar_path::SugarPath as _;
+use rolldown_std_utils::absolute_path_to_relative_slash;
 
 pub fn stabilize_id(module_id: &str, cwd: &Path) -> String {
-  if module_id.as_path().is_absolute() {
-    module_id.relative(cwd).as_path().expect_to_slash()
+  let path = Path::new(module_id);
+  if path.is_absolute() {
+    absolute_path_to_relative_slash(path, cwd)
   } else if module_id.starts_with('\0') {
     // handle virtual modules
     module_id.replace('\0', "\\0")
@@ -16,6 +16,8 @@ pub fn stabilize_id(module_id: &str, cwd: &Path) -> String {
 
 #[test]
 fn test_stabilize_id() {
+  use rolldown_std_utils::PathExt as _;
+
   let cwd = std::env::current_dir().unwrap();
   // absolute path
   assert_eq!(stabilize_id(cwd.join("src").join("main.js").expect_to_str(), &cwd), "src/main.js");

--- a/internal-docs/module-id/implementation.md
+++ b/internal-docs/module-id/implementation.md
@@ -88,9 +88,7 @@ Note: some plugins may internally assume `/` separators when doing string matchi
 
 ### Existing Normalization Utilities
 
-- `PathExt::expect_to_slash()` — Converts `\` to `/` (only on non-Unix platforms). Used in `StableModuleId`, HMR, source maps.
-- `SugarPath::relative()` — Produces relative paths. Used in `StableModuleId`.
-- `stabilize_id()` — Absolute → cwd-relative with forward slashes. Legacy utility, functionality now in `StableModuleId`.
+After sugar_path 3, use `rolldown_std_utils` helpers (`relative_path_to_slash`, `relative_path_as_js_specifier`, …). Style guide: [path-manipulation/style-guide.md](../path-manipulation/style-guide.md).
 
 ## The Core Problem
 

--- a/internal-docs/path-manipulation/style-guide.md
+++ b/internal-docs/path-manipulation/style-guide.md
@@ -1,0 +1,32 @@
+# Path manipulation
+
+Rolldown module / resolver paths are **known UTF-8**. Prefer `rolldown_std_utils` over open-coding sugar_path chains.
+
+Implementation: `crates/rolldown_std_utils/src/path_ext.rs`. Module-id identity: [module-id/implementation.md](../module-id/implementation.md).
+
+## Use these
+
+| Helper                                        | For                                     |
+| --------------------------------------------- | --------------------------------------- |
+| `absolutize_path_buf(path)`                   | Ensure an owned path is absolute        |
+| `relative_path_to_slash(target, base)`        | Relative path as `/`-separated `String` |
+| `relative_path_as_js_specifier(target, base)` | Same, JS form: `.` / `./…` / `../…`     |
+| `absolute_path_to_relative_slash(path, cwd)`  | Absolute → cwd-relative slash string    |
+| `path_buf_to_slash(path)`                     | Owned `PathBuf` → slash `String`        |
+| `PathExt::expect_to_slash`                    | Borrowed path → slash `String`          |
+
+sugar_path 3: `relative` returns `Cow<Path>` (empty when equal); `normalize` preserves a trailing separator; slash conversion is strict by default. Explicit cwd arguments must be absolute. Keep workspace feature `cached_current_dir`.
+
+When the destination is `ArcStr`, pass `to_slash()` directly instead of calling `into_owned()` first; `ArcStr` copies strings into its own allocation.
+
+## Don't
+
+```rust
+target.relative(base).to_slash_lossy().into_owned()  // lossy on known UTF-8
+path.to_slash().unwrap()                             // 2.x API
+target.relative(base).as_path().expect_to_slash()    // skip into_slash reuse
+let p: PathBuf = target.relative(base);              // not PathBuf anymore
+path.to_string_lossy().replace('\\', "/")            // hand-rolled policy
+```
+
+Module **ids** stay native separators; slash form is for output / stable strings only.


### PR DESCRIPTION
## Summary

Upgrade workspace `sugar_path` from **2.0.1 → 3.0.0**, migrate every call site that broke, and centralize Rolldown's known-UTF-8 path compositions so the “right” usage is hard to miss.

### Why sugar_path 3 helps Rolldown

sugar_path 3 is the breaking redesign aimed at Rolldown-shaped work:

- **`relative` → `Cow<Path>`**: clean descendant paths can return a borrowed suffix with **zero result allocation** (the package-sideEffects-style shape was about **19–21% faster** in same-machine microbenches vs the old owned-`PathBuf` API; not a whole-build claim).
- **Strict / consuming slash conversion**: `into_slash` can reuse an owned `PathBuf` buffer for the final UTF-8 `String` (one allocation for the final container).
- **Owned cwd reuse**: `absolutize_with(cwd.join(out_dir))` can grow the joined buffer instead of cloning after normalize (already how Rolldown calls it).
- **Windows**: relative calculation no longer allocates slash-normalized copies just to compare clean native paths.

Rolldown already enables `cached_current_dir`; that stays.

Those wins only show up if call sites use the intended composition. Open-coding `relative(...).to_slash_lossy().into_owned()` or `relative(...).as_path().expect_to_slash()` leaves performance on the table and fights the 3.0 API.

### API migration (compile / contract)

- `relative` returns `Cow<Path>` → `.into_owned()` where a `PathBuf` is required
- `to_slash()` is strict (no `Option`) → drop `.unwrap()` / `.map_or_else`
- Equal paths → empty relative path; call sites that need `.` / `./` keep that policy via helpers
- `absolutize_with(cwd.join(out_dir))` already passes owned cwd (no change needed)

### Prevent wrong usage next time

1. **Helpers** in `rolldown_std_utils` (`relative_path_to_slash`, `relative_path_as_js_specifier`, `path_buf_to_slash`, …) with unit tests — hot call sites use these.
2. **Style guide**: [`internal-docs/path-manipulation/style-guide.md`](https://github.com/rolldown/rolldown/blob/chore/upgrade-sugar-path-3/internal-docs/path-manipulation/style-guide.md) — domain assumptions, preferred helpers, anti-patterns, PR checklist. Linked from `internal-docs/module-id/implementation.md`.

**Guidance for future code:** if you need “path relative to X as a `/` string for a module id / import / diagnostic”, use `rolldown_std_utils` first. Do not reintroduce `to_slash_lossy` on known-UTF-8 module paths.

### Intentionally left as direct sugar_path / lossy

Simple display conversions that are not a relative→String composition (import-glob bases, package.json realpath, some cwd display). Those are not the measured hot composition.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p rolldown_std_utils`
- [x] `cargo test -p rolldown_utils stabilize_id`
- [x] `cargo test -p rolldown_common stabilize`
- [x] `cargo clippy` on touched crates with `-D warnings`
- [ ] CI full matrix

## Related

- sugar_path 3.0.0: https://crates.io/crates/sugar_path/3.0.0
- sugar_path redesign: https://github.com/hyf0/sugar_path/pull/40