### PR TITLE
refactor(rolldown): unify link/generate diagnostics into a Diagnostics accumulator

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
+++ b/crates/rolldown/src/stages/generate_stage/detect_ineffective_dynamic_imports.rs
@@ -30,7 +30,7 @@ impl GenerateStage<'_> {
         });
 
         if has_ineffective {
-          self.link_output.warnings.push(
+          self.link_output.diagnostics.push(
             BuildDiagnostic::ineffective_dynamic_import(
               module.id.to_string(),
               module.ecma_view.importers.iter().map(ToString::to_string).collect(),

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -177,7 +177,7 @@ impl<'a> GenerateStage<'a> {
     let mut warnings = vec![];
     self.compute_chunk_output_exports(&mut chunk_graph, &mut warnings, &used_symbol_refs)?;
     if !warnings.is_empty() {
-      self.link_output.warnings.extend(warnings);
+      self.link_output.diagnostics.extend(warnings);
     }
 
     let index_chunk_id_to_name =

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -9,7 +9,7 @@ use rolldown_common::{
   SymbolRef, UsedSymbolRefs,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
-use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult};
+use rolldown_error::{BatchedBuildDiagnostic, BuildResult, Diagnostics};
 use rolldown_utils::{
   indexmap::{FxIndexMap, FxIndexSet},
   rayon::{IntoParallelRefIterator, ParallelIterator},
@@ -45,19 +45,22 @@ impl GenerateStage<'_> {
     ast_table: IndexEcmaAst,
     used_symbol_refs: &UsedSymbolRefs,
   ) -> BuildResult<BundleOutput> {
-    let mut errors = std::mem::take(&mut self.link_output.errors);
-    let mut warnings = std::mem::take(&mut self.link_output.warnings);
+    // Move the mixed-severity accumulator out of `link_output` so it can be
+    // passed by `&mut` to `instantiate_chunks` (which borrows `&self`, and so
+    // cannot also borrow `self.link_output.diagnostics`). The split into
+    // warnings vs. errors is deferred to the end of the function, where their
+    // fates finally diverge (errors -> `Err`, warnings -> `BundleOutput`).
+    let mut diagnostics = std::mem::take(&mut self.link_output.diagnostics);
     // `ast_table` is threaded by value into `create_chunk_to_codegen_ret_map`
     // (the last reader), where it is dropped at scope exit by the compiler —
     // releasing the per-module bumpalo arenas before `minify_chunks` and
     // `finalize_assets` allocate.
-    let (mut instantiated_chunks, index_chunk_to_instances) = self
-      .instantiate_chunks(chunk_graph, ast_table, &mut errors, &mut warnings, used_symbol_refs)
-      .await?;
+    let (mut instantiated_chunks, index_chunk_to_instances) =
+      self.instantiate_chunks(chunk_graph, ast_table, &mut diagnostics, used_symbol_refs).await?;
 
     self.trace_action_package_graph_ready(chunk_graph, &instantiated_chunks);
 
-    warnings
+    diagnostics
       .extend(render_chunks(self.plugin_driver, &mut instantiated_chunks, self.options).await?);
 
     augment_chunk_hash(self.plugin_driver, &mut instantiated_chunks).await?;
@@ -134,10 +137,10 @@ impl GenerateStage<'_> {
       a_type.cmp(&b_type)
     });
 
-    if !errors.is_empty() {
-      return Err(errors.into());
-    }
-
+    // Now that all diagnostics are collected, drain by severity: any error
+    // aborts the build, otherwise the warnings ride out on the `BundleOutput`.
+    // `into_result` fast-paths the common no-error case, skipping the partition.
+    let warnings = diagnostics.into_result()?;
     Ok(BundleOutput { assets: output, warnings })
   }
 
@@ -146,8 +149,7 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &ChunkGraph,
     ast_table: IndexEcmaAst,
-    errors: &mut Vec<BuildDiagnostic>,
-    warnings: &mut Vec<BuildDiagnostic>,
+    diagnostics: &mut Diagnostics,
     used_symbol_refs: &UsedSymbolRefs,
   ) -> BuildResult<(IndexInstantiatedChunks, IndexChunkToInstances)> {
     let mut index_chunk_to_instances: IndexChunkToInstances =
@@ -212,9 +214,9 @@ impl GenerateStage<'_> {
           let ins_chunk_idx = index_instantiated_chunks.push(ins_chunk);
           index_chunk_to_instances[base_chunk_idx].insert(ins_chunk_idx);
         });
-        warnings.extend(generate_output.warnings);
+        diagnostics.extend(generate_output.warnings);
       }
-      Err(e) => errors.extend(e.into_vec()),
+      Err(e) => diagnostics.extend(e.into_vec()),
     });
 
     index_chunk_to_instances.iter_mut().for_each(|instances| {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -11,7 +11,7 @@ use rolldown_common::{
   OutputFormat, ResolvedExport, Specifier, StmtInfos, SymbolOrMemberExprRef, SymbolRef,
   SymbolRefDb, SymbolRefFlags,
 };
-use rolldown_error::{AmbiguousExternalNamespaceModule, BuildDiagnostic};
+use rolldown_error::{AmbiguousExternalNamespaceModule, BuildDiagnostic, Diagnostics};
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
@@ -160,8 +160,7 @@ impl LinkStage<'_> {
       metas: &mut self.metas,
       symbol_db: &mut self.symbols,
       options: self.options,
-      errors: Vec::default(),
-      warnings: Vec::default(),
+      diagnostics: Diagnostics::new(),
       external_import_binding_merger: FxHashMap::default(),
       side_effects_modules: &side_effects_modules,
       normal_symbol_exports_chain_map: &mut normal_symbol_exports_chain_map,
@@ -171,8 +170,7 @@ impl LinkStage<'_> {
       binding_ctx.match_imports_with_exports(module.idx());
     });
 
-    self.errors.extend(binding_ctx.errors);
-    self.warnings.extend(binding_ctx.warnings);
+    self.diagnostics.extend(binding_ctx.diagnostics);
 
     self.external_import_namespace_merger = binding_ctx.external_import_namespace_merger;
 
@@ -712,7 +710,7 @@ impl LinkStage<'_> {
       .collect::<Vec<_>>();
 
     debug_assert_eq!(self.metas.len(), resolved_meta_data.len());
-    self.warnings.extend(warnings);
+    self.diagnostics.extend(warnings);
     // Remove CJS exported symbols that are written to by importers from the constant map
     // to prevent incorrect inlining of mutated values.
     // First, collect statically-known written symbols gathered during resolution above.
@@ -847,8 +845,7 @@ struct BindImportsAndExportsContext<'a> {
   pub metas: &'a mut LinkingMetadataVec,
   pub symbol_db: &'a mut SymbolRefDb,
   pub options: &'a SharedOptions,
-  pub errors: Vec<BuildDiagnostic>,
-  pub warnings: Vec<BuildDiagnostic>,
+  pub diagnostics: Diagnostics,
   pub external_import_binding_merger:
     FxHashMap<ModuleIdx, FxHashMap<CompactStr, IndexSet<SymbolRef>>>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
@@ -950,7 +947,7 @@ impl BindImportsAndExportsContext<'_> {
             None
           }));
 
-          self.errors.push(BuildDiagnostic::ambiguous_external_namespace(
+          self.diagnostics.push(BuildDiagnostic::ambiguous_external_namespace(
             named_import.imported.to_string(),
             importee,
             AmbiguousExternalNamespaceModule {
@@ -1012,7 +1009,7 @@ impl BindImportsAndExportsContext<'_> {
             named_import.span_imported,
             is_ts_like_importing_ts_like.then(|| format!("If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import {{ type Foo }} from '{}'`).", rec.module_request))
           );
-          self.errors.push(diagnostic);
+          self.diagnostics.push(diagnostic);
         }
       }
     }
@@ -1109,7 +1106,9 @@ impl BindImportsAndExportsContext<'_> {
           let importer_module = &index_modules[tracker.importer];
           let importer_id = importer_module.id().to_string();
           let imported_specifier = tracker.imported.to_string();
-          self.errors.push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
+          self
+            .diagnostics
+            .push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
           return MatchImportKind::Cycle;
         }
       }

--- a/crates/rolldown/src/stages/link_stage/compute_tla.rs
+++ b/crates/rolldown/src/stages/link_stage/compute_tla.rs
@@ -168,7 +168,7 @@ impl LinkStage<'_> {
         );
         let tla_keyword_span = tla_keyword_span.unwrap_or(Span::empty(0));
 
-        self.errors.push(BuildDiagnostic::require_tla(RequireTla {
+        self.diagnostics.push(BuildDiagnostic::require_tla(RequireTla {
           importer_stable_id: module.stable_id.as_arc_str().clone(),
           importer_source: module.source.clone(),
           require_span,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -10,7 +10,7 @@ use rolldown_common::{
   SymbolRef, SymbolRefDb, UsedExternalSymbols, UsedSymbolRefsBuilder,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::Diagnostics;
 #[cfg(target_family = "wasm")]
 use rolldown_utils::rayon::IteratorExt as _;
 use rolldown_utils::{
@@ -64,8 +64,7 @@ pub struct LinkStageOutput {
   /// Per-module statement-info table; see `LinkStage.stmt_infos`.
   pub stmt_infos: IndexStmtInfos,
   pub runtime: RuntimeModuleBrief,
-  pub warnings: Vec<BuildDiagnostic>,
-  pub errors: Vec<BuildDiagnostic>,
+  pub diagnostics: Diagnostics,
   pub used_external_symbols: UsedExternalSymbols,
   /// See [`RetainedExportSymbols`]; empty until the generate stage projects it.
   pub retained_export_symbols: RetainedExportSymbols,
@@ -103,8 +102,7 @@ pub struct LinkStage<'a> {
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
-  pub warnings: Vec<BuildDiagnostic>,
-  pub errors: Vec<BuildDiagnostic>,
+  pub diagnostics: Diagnostics,
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
   pub used_symbol_refs: UsedSymbolRefsBuilder,
@@ -206,8 +204,7 @@ impl<'a> LinkStage<'a> {
       },
       symbols: scan_stage_output.symbol_ref_db,
       runtime: scan_stage_output.runtime,
-      warnings: scan_stage_output.warnings,
-      errors: vec![],
+      diagnostics: scan_stage_output.warnings.into(),
       ast_table: scan_stage_output.index_ecma_ast,
       dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
       options,
@@ -254,8 +251,7 @@ impl<'a> LinkStage<'a> {
         symbol_db: self.symbols,
         stmt_infos: self.stmt_infos,
         runtime: self.runtime,
-        warnings: self.warnings,
-        errors: self.errors,
+        diagnostics: self.diagnostics,
         used_external_symbols: self.used_external_symbols,
         retained_export_symbols: RetainedExportSymbols::default(),
         dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,

--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -117,7 +117,7 @@ impl LinkStage<'_> {
           .iter()
           .filter_map(|id| self.module_table[*id].as_normal().map(|module| module.id.to_string()))
           .collect::<Vec<_>>();
-        self.warnings.push(BuildDiagnostic::circular_dependency(paths).with_severity_warning());
+        self.diagnostics.push(BuildDiagnostic::circular_dependency(paths).with_severity_warning());
       }
     }
 

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -214,6 +214,92 @@ impl DerefMut for BatchedBuildDiagnostic {
   }
 }
 
+/// A mixed-severity diagnostic accumulator.
+///
+/// Unlike [`BatchedBuildDiagnostic`] — which is error-only and lives in the
+/// `Result` `Err` channel — `Diagnostics` holds warnings, infos, and errors
+/// together. Severity is read from each element via [`BuildDiagnostic::severity`],
+/// so callers no longer need to thread a separate `errors` and `warnings` `Vec`
+/// side by side.
+///
+/// At a drain checkpoint, [`Diagnostics::partition`] (or [`Diagnostics::into_result`])
+/// splits the error-severity subset back out to feed the `Result` channel.
+#[derive(Debug, Default)]
+pub struct Diagnostics {
+  diagnostics: Vec<BuildDiagnostic>,
+  /// Cached: `true` once any error-severity diagnostic has been stored. Kept in
+  /// sync by every mutator, so [`Diagnostics::has_errors`] is O(1) and
+  /// [`Diagnostics::into_result`] can skip the partition scan on the common
+  /// (no-error) path. A diagnostic's severity is frozen once stored — it is set
+  /// only by the consuming `with_severity*` builders before `push`, and this
+  /// type hands out no `&mut` to its elements — so the flag never goes stale.
+  has_error: bool,
+}
+
+impl Diagnostics {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn push(&mut self, diagnostic: BuildDiagnostic) {
+    self.has_error |= diagnostic.severity() == Severity::Error;
+    self.diagnostics.push(diagnostic);
+  }
+
+  pub fn extend(&mut self, diagnostics: impl IntoIterator<Item = BuildDiagnostic>) {
+    // Route through `push` so `has_error` stays in sync for each element.
+    for diagnostic in diagnostics {
+      self.push(diagnostic);
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.diagnostics.is_empty()
+  }
+
+  pub fn has_errors(&self) -> bool {
+    self.has_error
+  }
+
+  /// Splits into `(warnings + infos, errors)`, preserving the relative order
+  /// within each group. Because error- and warning-severity diagnostics were
+  /// never interleaved into a single ordered stream before this type existed,
+  /// merging then re-splitting yields the same two `Vec`s callers used to hold.
+  pub fn partition(self) -> (Vec<BuildDiagnostic>, Vec<BuildDiagnostic>) {
+    self.diagnostics.into_iter().partition(|d| d.severity() != Severity::Error)
+  }
+
+  /// Drain checkpoint: returns `Err(errors)` if any error-severity diagnostic is
+  /// present, otherwise `Ok(warnings + infos)`. Mirrors the existing
+  /// `if !errors.is_empty() { return Err(errors.into()) }` guard.
+  ///
+  /// When no error was ever stored, returns every diagnostic as-is without
+  /// partitioning — the cached `has_error` flag makes this the common fast path.
+  pub fn into_result(self) -> crate::BuildResult<Vec<BuildDiagnostic>> {
+    if !self.has_error {
+      return Ok(self.diagnostics);
+    }
+    let (warnings, errors) = self.partition();
+    if errors.is_empty() { Ok(warnings) } else { Err(errors.into()) }
+  }
+}
+
+impl From<Vec<BuildDiagnostic>> for Diagnostics {
+  fn from(diagnostics: Vec<BuildDiagnostic>) -> Self {
+    let has_error = diagnostics.iter().any(|d| d.severity() == Severity::Error);
+    Self { diagnostics, has_error }
+  }
+}
+
+impl IntoIterator for Diagnostics {
+  type Item = BuildDiagnostic;
+  type IntoIter = std::vec::IntoIter<BuildDiagnostic>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.diagnostics.into_iter()
+  }
+}
+
 /// Consolidates diagnostics by merging those that can be grouped together.
 ///
 /// Currently consolidates:

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::{
   build_diagnostic::events::require_tla::{ImportChainNote, RequireTla},
   build_diagnostic::events::resolve_error::DiagnosableResolveError,
   build_diagnostic::events::unloadable_dependency::UnloadableDependencyContext,
-  build_diagnostic::{BatchedBuildDiagnostic, BuildDiagnostic, Severity},
+  build_diagnostic::{BatchedBuildDiagnostic, BuildDiagnostic, Diagnostics, Severity},
   generated::event_kind_switcher::EventKindSwitcher,
   types::diagnostic_options::DiagnosticOptions,
   types::event_kind::EventKind,


### PR DESCRIPTION
### Description

Collapse the paired `errors: Vec<BuildDiagnostic>` / `warnings: Vec<BuildDiagnostic>` fields threaded through the link and generate stages into a single mixed-severity `Diagnostics` accumulator, keyed on each diagnostic's own `Severity`.

- Add `Diagnostics` to `rolldown_error`: `push`/`extend`/`has_errors`/`is_empty`/`partition`/`into_result`, plus `From<Vec<_>>` and `IntoIterator`. A cached `has_error` flag is set at store time (severity is frozen once stored), making `has_errors` O(1) and letting `into_result` fast-path the common no-error case without partitioning.
- Migrate `LinkStage`/`LinkStageOutput` and `BindImportsAndExportsContext` (whose `warnings` field was dead) to the single field; drain once at the end of `render_chunk_to_assets` via `into_result`, where errors become `Err` and warnings go to the output.

The `Result<T, BatchedBuildDiagnostic>` fatal channel is untouched.

### Behavior

Behavior-preserving: partition-by-severity matches the old route-by-vec (the error side is already `debug_assert`-guaranteed all-Error), verified by ~950 fixtures with zero snapshot drift. No new tests are included since this is a pure refactor covered by the existing snapshot suite.