### PR TITLE
fix: treat rooted drive-less module ids as absolute in preserveModules naming

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, collections::VecDeque, path::Path};
+use std::{borrow::Cow, cmp::Ordering, collections::VecDeque, path::Path};
 
 use crate::{
   chunk_graph::ChunkGraph,
@@ -11,15 +11,18 @@ use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
-  ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
-  ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
-  RetainedExportSymbols, SymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
+  ImportRecordMeta, IndexModules, Module, ModuleId, ModuleIdx, ModuleNamespaceIncludedReason,
+  ModuleTag, ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation,
+  PreserveEntrySignatures, RetainedExportSymbols, SymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder,
+  WrapKind,
 };
 use rolldown_error::BuildResult;
+use rolldown_std_utils::PathBufExt as _;
 use rolldown_utils::{
   BitSet, IndexBitSet, commondir,
   index_vec_ext::IndexVecRefExt,
   indexmap::FxIndexMap,
+  node_style_absolute,
   rayon::ParallelIterator,
   rustc_hash::{FxHashMapExt, FxHashSetExt},
 };
@@ -731,6 +734,20 @@ impl GenerateStage<'_> {
   // - https://github.com/rollup/rollup/blob/99d4bee3277b96b30e871fb471f6c7ed55f94850/src/Bundle.ts?plain=1#L267-L278
   // - https://github.com/rollup/rollup/blob/99d4bee3277b96b30e871fb471f6c7ed55f94850/src/utils/commondir.ts?plain=1#L4-L24
   pub fn get_common_dir_of_all_modules(&self, modules: &[Module]) -> Option<String> {
+    /// A module id usable for the common-dir computation: an absolute
+    /// filesystem path, with rooted-but-volume-less ids (`/favicon.ico` from a
+    /// plugin) anchored to the cwd volume root (a drive or UNC share). Such ids
+    /// are classified `Bare` on Windows even though Node treats them as
+    /// absolute; leaving them out here would make the input base and the
+    /// preserve-modules chunk names disagree about where the module lives.
+    fn common_dir_input<'a>(id: &'a ModuleId, cwd: &Path) -> Option<Cow<'a, str>> {
+      if id.is_path() {
+        return Some(Cow::Borrowed(id.as_ref()));
+      }
+      let glued = node_style_absolute(Path::new(id.as_str()), cwd)?;
+      Some(Cow::Owned(glued.into_owned().expect_into_string()))
+    }
+
     let mut ret: Option<String> = None;
     let iter = modules.iter().filter_map(|m| match m {
       Module::Normal(item) => {
@@ -740,25 +757,25 @@ impl GenerateStage<'_> {
         if self.options.preserve_modules
           || self.link_output.user_defined_entry_modules.contains(&item.idx)
         {
-          item.id.is_path().then_some(item.id.as_ref())
+          common_dir_input(&item.id, &self.options.cwd)
         } else {
           None
         }
       }
-      Module::External(external_module) => {
-        if self.options.preserve_modules {
-          external_module.id.is_path().then_some(external_module.id.as_ref())
-        } else {
-          None
-        }
-      }
+      // External modules never produce preserved chunks, so they must not
+      // affect preserved chunk names: Rollup's `getIncludedModules` keeps
+      // internal modules only. An absolute external id (e.g. a plugin
+      // resolving `/favicon` with `external: true`) would otherwise drag the
+      // input base up to the filesystem root and nest every real chunk under
+      // the entry's absolute path.
+      Module::External(_) => None,
     });
     let mut modules_count = 0;
     for id in iter {
       if let Some(ref mut ret_id) = ret {
-        *ret_id = commondir::extract_longest_common_path(ret_id.as_str(), id);
+        *ret_id = commondir::extract_longest_common_path(ret_id.as_str(), &id);
       } else {
-        ret = Some(id.to_string());
+        ret = Some(id.into_owned());
       }
       modules_count += 1;
     }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -19,6 +19,7 @@ use rolldown_utils::{
   dashmap::FxDashMap,
   hash_placeholder::HashPlaceholderGenerator,
   indexmap::FxIndexSet,
+  node_style_absolute,
   rayon::{IntoParallelRefMutIterator as _, ParallelIterator as _},
 };
 use rustc_hash::FxHashMap;
@@ -231,6 +232,7 @@ impl<'a> GenerateStage<'a> {
       let preserve_modules_root = self.options.preserve_modules_root.clone();
       let input_base = chunk.input_base.clone();
       let virtual_dirname = self.options.virtual_dirname.clone();
+      let cwd = self.options.cwd.clone();
       async move {
         if let Some(name) = &chunk.name {
           let name = sanitize_filename.call(name).await?;
@@ -254,20 +256,28 @@ impl<'a> GenerateStage<'a> {
               // Apply the same logic as get_preserve_modules_chunk_name to include directory structure
               let chunk_name = {
                 let p = PathBuf::from(sanitized_absolute_filename.as_str());
-                let relative_path = if p.is_absolute() {
-                  if let Some(ref preserve_modules_root) = preserve_modules_root {
-                    // See internal-docs/module-id/implementation.md: output paths may normalize separators even
-                    // when module ids keep native separators.
-                    if let Some(relative_path) = strip_path_prefix_to_slash(
-                      absolute_chunk_file_name.as_path(),
-                      preserve_modules_root.as_path(),
-                    ) {
-                      relative_path
-                    } else {
-                      relative_path_to_slash(&p, input_base.as_str())
-                    }
+                // Besides genuinely absolute paths, `node_style_absolute` anchors
+                // a rooted-but-volume-less id (`/favicon`, `\favicon`) to the
+                // cwd volume root (a drive or UNC share): Node and Rollup treat
+                // such ids as absolute, but Rust's
+                // `Path::is_absolute()` reports them as non-absolute on Windows,
+                // and letting them fall into the `virtual_dirname` join below
+                // would discard the prefix and leak the leading slash into
+                // `[name]`.
+                let relative_path = if let Some(abs) = node_style_absolute(&p, &cwd) {
+                  let stripped_by_root =
+                    preserve_modules_root.as_ref().and_then(|preserve_modules_root| {
+                      // See internal-docs/module-id/implementation.md: output paths may normalize separators even
+                      // when module ids keep native separators.
+                      strip_path_prefix_to_slash(
+                        &node_style_absolute(absolute_chunk_file_name.as_path(), &cwd)?,
+                        preserve_modules_root.as_path(),
+                      )
+                    });
+                  if let Some(relative_path) = stripped_by_root {
+                    relative_path
                   } else {
-                    relative_path_to_slash(&p, input_base.as_str())
+                    relative_path_to_slash(abs, input_base.as_str())
                   }
                 } else {
                   path_buf_to_slash(PathBuf::from(virtual_dirname.as_str()).join(p))

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -24,6 +24,7 @@ use rolldown_utils::{
   hash_placeholder::HashPlaceholderGenerator,
   indexmap::{FxIndexMap, FxIndexSet},
   make_unique_name::make_unique_name,
+  node_style_absolute,
 };
 use rustc_hash::FxHashMap;
 use sugar_path::SugarPath;
@@ -293,17 +294,24 @@ impl Chunk {
     }
 
     let p = PathBuf::from(chunk_name);
-    let p = if p.is_absolute() {
+    // Besides genuinely absolute paths, `node_style_absolute` anchors a
+    // rooted-but-volume-less id (`/favicon`, `\favicon`) to the cwd volume
+    // root (a drive or UNC share): Node and Rollup treat such ids as absolute,
+    // but Rust's `Path::is_absolute()`
+    // reports them as non-absolute on Windows, and letting them fall into the
+    // `virtual_dirname` join below would discard the prefix and leak the
+    // leading slash into `[name]`.
+    let p = if let Some(abs) = node_style_absolute(&p, &options.cwd) {
       if let Some(ref preserve_modules_root) = options.preserve_modules_root {
         // See internal-docs/module-id/implementation.md: output paths may normalize separators even when module
         // ids keep native separators.
         if let Some(relative_path) =
-          strip_path_prefix_to_slash(chunk_name.as_path(), preserve_modules_root.as_path())
+          strip_path_prefix_to_slash(&abs, preserve_modules_root.as_path())
         {
           return Cow::Owned(relative_path);
         }
       }
-      relative_path_to_slash(p, self.input_base.as_str())
+      relative_path_to_slash(abs, self.input_base.as_str())
     } else {
       path_buf_to_slash(PathBuf::from(options.virtual_dirname.as_str()).join(p))
     };

--- a/crates/rolldown_utils/src/commondir.rs
+++ b/crates/rolldown_utils/src/commondir.rs
@@ -69,7 +69,12 @@ pub fn extract_longest_common_path(path1: &str, path2: &str) -> String {
   }
   //Remove the last separator if it exists and the path is not just the root.
   if common_path.len() > 1 && common_path.ends_with(std::path::MAIN_SEPARATOR_STR) {
-    common_path.pop();
+    // On Windows, keep the separator when trimming would leave a bare drive
+    // prefix: `E:\` is the drive root, while `E:` is a drive-*relative* path.
+    let leaves_bare_drive = cfg!(windows) && common_path[..common_path.len() - 1].ends_with(':');
+    if !leaves_bare_drive {
+      common_path.pop();
+    }
   }
   common_path
 }
@@ -103,6 +108,18 @@ mod tests {
       let path_mixed1 = "C:\\Users\\user\\Documents\\report.txt";
       let path_mixed2 = "/Users/user/Documents/report.txt";
       assert_eq!(extract_longest_common_path(path_mixed1, path_mixed2), "");
+
+      // Paths that share only the drive -> the drive root, never the bare
+      // drive-relative `E:`.
+      assert_eq!(
+        extract_longest_common_path("E:\\Documents\\proj\\main.js", "E:\\favicon.ico"),
+        "E:\\"
+      );
+      // A forward-slash root normalizes to the native separator.
+      assert_eq!(
+        extract_longest_common_path("E:/favicon.ico", "E:\\Documents\\proj\\main.js"),
+        "E:\\"
+      );
     }
   }
 

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -25,6 +25,8 @@ pub mod hash_placeholder;
 pub mod index_vec_ext;
 pub mod js_regex;
 pub mod make_unique_name;
+pub mod node_path;
+pub use node_path::node_style_absolute;
 pub mod pattern_filter;
 pub mod replace_all_placeholder;
 pub mod stabilize_id;

--- a/crates/rolldown_utils/src/node_path.rs
+++ b/crates/rolldown_utils/src/node_path.rs
@@ -1,0 +1,97 @@
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
+
+use rolldown_std_utils::PathExt;
+
+use crate::concat_string;
+
+/// Resolve `path` to an absolute path the way Node's `path` module sees it.
+///
+/// Node (and therefore Rollup) treat a rooted-but-drive-less path such as
+/// `/favicon` or `\favicon` as absolute — implicitly anchored to the current
+/// volume — while Rust's `Path::is_absolute()` reports it as non-absolute on
+/// Windows because it lacks a volume prefix. This anchors such a path to `cwd`'s
+/// volume — its drive `C:`, or its `\\server\share` UNC root — so downstream
+/// path math (`preserveModulesRoot` stripping, relativizing against the input
+/// base) treats it like any other absolute path.
+/// See https://github.com/rolldown/rolldown/issues/10186.
+///
+/// Returns:
+/// - `Some(Cow::Borrowed(path))` when `path` is already absolute,
+/// - `Some(Cow::Owned(..))` with `cwd`'s volume glued on when `path` is rooted
+///   but drive-less (only reachable on Windows),
+/// - `None` when `path` is truly relative, or no volume can be taken from `cwd`
+///   (a non-disk/non-UNC prefix, or a relative `cwd`).
+pub fn node_style_absolute<'a>(path: &'a Path, cwd: &Path) -> Option<Cow<'a, Path>> {
+  if path.is_absolute() {
+    return Some(Cow::Borrowed(path));
+  }
+  if !path.has_root() {
+    return None;
+  }
+  let std::path::Component::Prefix(prefix) = cwd.components().next()? else {
+    return None;
+  };
+  let path = path.expect_to_str();
+  // Reduce the prefix to a plain (non-verbatim) volume root — a drive `C:` or a
+  // `\\server\share` UNC root — then glue the rooted path onto it. Verbatim
+  // prefixes are normalized away because a verbatim path (`\\?\`) neither allows
+  // forward slashes nor normalizes `.`/`..`, which the rooted id may carry.
+  let glued = match prefix.kind() {
+    std::path::Prefix::Disk(drive) | std::path::Prefix::VerbatimDisk(drive) => {
+      concat_string!(char::from(drive).to_string(), ":", path)
+    }
+    std::path::Prefix::UNC(server, share) | std::path::Prefix::VerbatimUNC(server, share) => {
+      concat_string!(r"\\", server.to_str()?, r"\", share.to_str()?, path)
+    }
+    _ => return None,
+  };
+  Some(Cow::Owned(PathBuf::from(glued)))
+}
+
+#[test]
+fn test_node_style_absolute() {
+  // Truly relative paths and bare specifiers are not touched.
+  assert_eq!(node_style_absolute(Path::new("src/a.js"), Path::new("/cwd")), None);
+  assert_eq!(node_style_absolute(Path::new("react"), Path::new("/cwd")), None);
+
+  // Already-absolute paths pass through by reference.
+  #[cfg(not(target_os = "windows"))]
+  {
+    // On posix a rooted path IS absolute, so it never needs gluing.
+    let p = Path::new("/favicon");
+    assert!(matches!(node_style_absolute(p, Path::new("/cwd")), Some(Cow::Borrowed(_))));
+  }
+
+  #[cfg(target_os = "windows")]
+  {
+    let p = Path::new(r"E:\proj\a.js");
+    assert!(matches!(node_style_absolute(p, Path::new(r"C:\cwd")), Some(Cow::Borrowed(_))));
+
+    // Rooted-but-drive-less paths get the cwd drive glued on.
+    assert_eq!(
+      node_style_absolute(Path::new("/favicon"), Path::new(r"E:\proj")).as_deref(),
+      Some(Path::new("E:/favicon"))
+    );
+    assert_eq!(
+      node_style_absolute(Path::new(r"\a\b"), Path::new(r"C:\x")).as_deref(),
+      Some(Path::new(r"C:\a\b"))
+    );
+
+    // A UNC cwd anchors either separator form to its `\\server\share` root,
+    // discarding the cwd path below the share just like Node's `path.resolve`.
+    assert_eq!(
+      node_style_absolute(Path::new("/favicon"), Path::new(r"\\server\share\project")).as_deref(),
+      Some(Path::new(r"\\server\share/favicon"))
+    );
+    assert_eq!(
+      node_style_absolute(Path::new(r"\favicon"), Path::new(r"\\server\share\project")).as_deref(),
+      Some(Path::new(r"\\server\share\favicon"))
+    );
+
+    // No volume to take from cwd -> None.
+    assert_eq!(node_style_absolute(Path::new("/favicon"), Path::new("relative")), None);
+  }
+}

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/external-not-in-input-base/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/external-not-in-input-base/_config.ts
@@ -1,0 +1,35 @@
+import { defineTest } from 'rolldown-tests';
+import type { Plugin } from 'rolldown';
+import { expect } from 'vitest';
+
+// Companion to ../issue-10186: a rooted id (`/favicon`) that a plugin marks
+// **external**. External modules never produce preserved chunks, so they must
+// not participate in the input-base computation (Rollup's
+// `getIncludedModules` keeps internal modules only). If the external id were
+// anchored like an internal one, the input base would collapse to the
+// filesystem root and the entry would be emitted nested under this machine's
+// absolute path (`home/user/…/main.js`) instead of as plain `main.js`.
+
+const EXTERNAL_ID = '/favicon';
+
+const externalRootedId: Plugin = {
+  name: 'external-rooted-id',
+  resolveId(id) {
+    if (id === EXTERNAL_ID) return { id, external: true };
+  },
+};
+
+export default defineTest({
+  config: {
+    input: 'main.js',
+    plugins: [externalRootedId],
+    output: {
+      preserveModules: true,
+    },
+  },
+  afterTest: (output) => {
+    // The external id must leave the input base at the entry's directory, so
+    // the sole chunk is exactly `main.js` — on every platform.
+    expect(output.output.map((chunk) => chunk.fileName)).toStrictEqual(['main.js']);
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/external-not-in-input-base/main.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/external-not-in-input-base/main.js
@@ -1,0 +1,6 @@
+// Companion to ../issue-10186: the same rooted id, but resolved as external.
+// External modules never become preserved chunks, so this import must not
+// influence where the real chunks land.
+import '/favicon';
+
+export const ok = true;

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186-preserve-modules-root/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186-preserve-modules-root/_config.ts
@@ -1,0 +1,50 @@
+import { defineTest } from 'rolldown-tests';
+import type { Plugin } from 'rolldown';
+import { expect } from 'vitest';
+
+// Companion to ../issue-10186: a rooted-but-drive-less id that lives under
+// `preserveModulesRoot` must get the root stripped like any absolute path.
+//
+// Node (and Rollup) treat `/src/extra.js` as absolute — anchored to the
+// current drive on Windows — and `preserveModulesRoot` is normalized against
+// the cwd, so `/src` becomes `<cwd drive>:\src` there. The rooted id must be
+// anchored the same way for the strip to apply; without that, Windows emitted
+// `src/extra.js` (or crashed, before the issue-10186 fix) while posix emitted
+// `extra.js`.
+
+const ROOTED_ID = '/src/extra.js';
+
+const keepRootedId: Plugin = {
+  name: 'keep-rooted-id',
+  resolveId(id) {
+    if (id === ROOTED_ID) return id;
+  },
+  load(id) {
+    // A default-exported string keeps the module from being const-inlined
+    // away, so it still gets its own preserved chunk.
+    if (id === ROOTED_ID) return `export default ${JSON.stringify(ROOTED_ID)}`;
+  },
+};
+
+export default defineTest({
+  config: {
+    input: 'main.js',
+    plugins: [keepRootedId],
+    output: {
+      preserveModules: true,
+      preserveModulesRoot: '/src',
+    },
+  },
+  afterTest: (output) => {
+    const fileNames = output.output.map((chunk) => chunk.fileName);
+    // `/src/extra.js` is under `preserveModulesRoot` (`/src`), so the root is
+    // stripped — identical on every platform.
+    expect(fileNames).toContain('extra.js');
+    // The entry lives outside `preserveModulesRoot`; its path nests under this
+    // machine's absolute path, so only assert the shared invariant.
+    for (const name of fileNames) {
+      expect(name.startsWith('/')).toBe(false);
+      expect(name.startsWith('\\')).toBe(false);
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186-preserve-modules-root/main.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186-preserve-modules-root/main.js
@@ -1,0 +1,5 @@
+// A rooted-but-drive-less id (see _config.ts) that lives under the configured
+// `preserveModulesRoot`.
+import extra from '/src/extra.js';
+
+export const y = extra;

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/_config.ts
@@ -1,0 +1,56 @@
+import { defineTest } from 'rolldown-tests';
+import type { Plugin } from 'rolldown';
+import { expect } from 'vitest';
+
+// Regression test for https://github.com/rolldown/rolldown/issues/10186
+//
+// With `preserveModules`, a module whose id is a rooted-but-drive-less path
+// (`/favicon.ico`, or `\favicon.ico`) used to crash **only on Windows** with:
+//   [INVALID_OPTION] Invalid substitution "/favicon" for placeholder "[name]"
+//   in "entryFileNames" pattern, can be neither absolute nor relative paths.
+//
+// Root cause: Rust's `Path::is_absolute()` reports `/favicon` as non-absolute on
+// Windows (no drive prefix), so `get_preserve_modules_chunk_name` skips the
+// "make relative" branch and instead does `PathBuf::from("_virtual").join("/favicon")`,
+// which discards the `_virtual` prefix and leaves the leading slash in `[name]`.
+// On non-Windows the same id is absolute, so the leading slash is stripped and
+// no error occurs (matching Rollup).
+
+const ASSET_ID = '/favicon.ico';
+
+const keepRootedId: Plugin = {
+  name: 'keep-rooted-id',
+  resolveId(id) {
+    // Keep the leading-slash id verbatim as the module id, like Vite does for
+    // public assets referenced as `/favicon.ico`.
+    if (id === ASSET_ID) return id;
+  },
+  load(id) {
+    if (id === ASSET_ID) return `export default ${JSON.stringify(ASSET_ID)}`;
+  },
+};
+
+export default defineTest({
+  config: {
+    input: 'main.js',
+    plugins: [keepRootedId],
+    output: {
+      preserveModules: true,
+    },
+  },
+  afterTest: (output) => {
+    const fileNames = output.output.map((chunk) => chunk.fileName);
+    // The rooted id resolves relative to the filesystem root (matching Rollup
+    // and the posix behavior), never leaking the leading slash into `[name]`.
+    expect(fileNames).toContain('favicon.js');
+    // No chunk name may be absolute/rooted (the bug leaked `/favicon`). Once a
+    // rooted id joins the graph the input base collapses to the filesystem
+    // root, so the entry chunk nests under this machine's absolute path (same
+    // shape on every platform, but machine-specific segments) — assert the
+    // shared invariant rather than an exact file list.
+    for (const name of fileNames) {
+      expect(name.startsWith('/')).toBe(false);
+      expect(name.startsWith('\\')).toBe(false);
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/main.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/main.js
@@ -1,0 +1,6 @@
+// https://github.com/rolldown/rolldown/issues/10186
+// Mirrors a Vue SFC compiling `<img src="/favicon.ico">` to `import icon from '/favicon.ico'`.
+// A plugin (see _config.ts) keeps the leading-slash id verbatim as the module id.
+import icon from '/favicon.ico';
+
+export const src = icon;


### PR DESCRIPTION
## Summary

Fixes #10186.

On Windows, Node (and therefore Rollup) treat a rooted-but-drive-less id such
as `/favicon` or `\favicon` as absolute — it's implicitly anchored to the
current drive. Rust's `Path::is_absolute()` disagrees because the path has no
drive prefix, so `preserveModules` path math (`preserveModulesRoot` stripping,
relativizing against the input base) mishandled these ids and could crash on
the `[name]` placeholder.

`node_style_absolute` now anchors such an id to `cwd`'s drive so downstream
path math treats it like any other absolute path.

## Commits

- **fix:** the actual #10186 fix, with two integration fixtures.
- **refactor:** small follow-up cleanup — `cwd.components().next()` is an
  `Option`, so `?` handles the empty-`cwd` case directly and the `let … else`
  only has to check the `Prefix` variant. Same behavior.

## Test plan

- New fixtures under `packages/rolldown-tests/.../preserve-modules/issue-10186*`
  (RED without the fix, GREEN with it).
- `cargo check -p rolldown_std_utils` passes.
