### PR TITLE
fix(rolldown): drop the unused runtime module after entry-level external flattening

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -165,6 +165,15 @@ impl GenerateStage<'_> {
 
     chunk_graph.sort_chunk_modules(self.link_output, self.options);
 
+    self.find_entry_level_external_module(&mut chunk_graph);
+
+    self.finalized_module_namespace_ref_usage();
+
+    // Runs after the two passes above invalidated the link-time reasons for including the
+    // runtime module, and before chunk exec-order assignment so a dropped runtime chunk is
+    // tombstoned like any other removed chunk.
+    self.sweep_unused_runtime_module(&mut chunk_graph, used_symbol_refs);
+
     chunk_graph
       .chunk_table
       .iter_mut_enumerated()
@@ -227,8 +236,6 @@ impl GenerateStage<'_> {
     // [order by chunk index]               [order by exec order]
 
     chunk_graph.rebuild_sorted_chunk_idx_vec();
-
-    self.find_entry_level_external_module(&mut chunk_graph);
 
     Ok(chunk_graph)
   }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -111,6 +111,7 @@ mod minify_chunks;
 mod on_demand_wrapping;
 mod post_banner_footer;
 mod render_chunk_to_assets;
+mod runtime_module_sweep;
 
 pub struct GenerateStage<'a> {
   link_output: &'a mut LinkStageOutput,
@@ -144,8 +145,9 @@ impl<'a> GenerateStage<'a> {
     self.plugin_driver.render_start(self.options).await?;
     let mut chunk_graph = self.generate_chunks(&mut used_symbol_refs).await?;
 
-    // The chunk optimizer's re-run of the inclusion pass (inside `generate_chunks`) was the
-    // last writer; sealing consumes the builder, so nothing downstream can mutate the set.
+    // The unused-runtime-module sweep (inside `generate_chunks`, after the chunk optimizer's
+    // re-run of the inclusion pass) was the last writer; sealing consumes the builder, so
+    // nothing downstream can mutate the set.
     let used_symbol_refs = used_symbol_refs.seal();
 
     // Count only live chunks. Chunks merged away during chunk optimization (e.g.
@@ -159,8 +161,6 @@ impl<'a> GenerateStage<'a> {
     if live_chunk_count > 1 {
       validate_options_for_multi_chunk_output(self.options)?;
     }
-
-    self.finalized_module_namespace_ref_usage();
 
     self.compute_retained_export_symbols(&used_symbol_refs);
 

--- a/crates/rolldown/src/stages/generate_stage/runtime_module_sweep.rs
+++ b/crates/rolldown/src/stages/generate_stage/runtime_module_sweep.rs
@@ -1,0 +1,205 @@
+use rolldown_common::{
+  ImportRecordMeta, Module, ModuleIdx, NormalModule, PostChunkOptimizationOperation, RuntimeHelper,
+  StmtInfos, SymbolOrMemberExprRef, UsedSymbolRefsBuilder,
+};
+use rolldown_utils::IndexBitSet;
+
+use crate::{chunk_graph::ChunkGraph, types::linking_metadata::LinkingMetadata};
+
+use super::GenerateStage;
+
+impl GenerateStage<'_> {
+  /// Drop the runtime module when nothing in the final output will reference it.
+  ///
+  /// Tree-shaking includes runtime helpers while linking, before chunks exist. Some of the
+  /// link-time reasons are later invalidated by `find_entry_level_external_module`: a star
+  /// re-export chain that ends at an external module is flattened to a chunk-level
+  /// `export * from '<external>'` (or the CJS equivalent), `has_dynamic_exports` is
+  /// re-propagated to `false`, and `finalized_module_namespace_ref_usage` drops the namespace
+  /// objects that only existed to serve that chain. The module finalizer then emits no
+  /// `__reExport`/`__exportAll` call — but the runtime module is already included and already
+  /// assigned to a chunk, so it used to ship as a dead chunk plus bare imports of it (#9374).
+  ///
+  /// This sweep re-derives the runtime demand from the same post-walk-back facts the finalizer
+  /// reads. It is all-or-nothing: if any included statement still demands any helper, everything
+  /// stays exactly as tree-shaking decided; only a runtime module with zero remaining demand is
+  /// un-included and stripped from its chunk.
+  ///
+  /// Must run after `find_entry_level_external_module` and
+  /// `finalized_module_namespace_ref_usage` (the facts it reads), and before the chunk
+  /// exec-order assignment and `compute_cross_chunk_links` (the consumers of what it mutates).
+  ///
+  /// See internal-docs/code-splitting/implementation.md ("Unused-Runtime Sweep") for the
+  /// pipeline position and the liveness invariants this pass relies on.
+  pub fn sweep_unused_runtime_module(
+    &mut self,
+    chunk_graph: &mut ChunkGraph,
+    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+  ) {
+    // Without tree-shaking, inclusion is not demand-based; leave everything in place.
+    if self.options.treeshake.is_none() {
+      return;
+    }
+    let runtime_idx = self.link_output.runtime.id();
+    if !self.link_output.metas[runtime_idx].is_included {
+      return;
+    }
+    let Some(runtime_module) = self.link_output.module_table[runtime_idx].as_normal() else {
+      return;
+    };
+    // A side-effectful runtime (dev/HMR mode, or a plugin transformed it) must load no matter
+    // whether its helpers are referenced; see `has_side_effectful_runtime_dep`.
+    if runtime_module.side_effects.has_side_effects() {
+      return;
+    }
+    if self.runtime_helpers_still_demanded(runtime_idx) {
+      return;
+    }
+
+    let runtime_stmt_count = self.link_output.stmt_infos[runtime_idx].len();
+    let runtime_meta = &mut self.link_output.metas[runtime_idx];
+    runtime_meta.is_included = false;
+    runtime_meta.stmt_info_included = IndexBitSet::new(runtime_stmt_count);
+    runtime_meta.depended_runtime_helper = RuntimeHelper::default();
+    // Stale references to runtime symbols may survive on included statements (e.g. a namespace
+    // statement that `finalized_module_namespace_ref_usage` decided not to render keeps its
+    // `__exportAll` reference, and chunk-level `depended_runtime_helper` flags keep their bits).
+    // Downstream passes filter those against `used_symbol_refs`, so purging the runtime's
+    // symbols here is what actually severs every cross-chunk edge to it.
+    used_symbol_refs.remove_owned_by(runtime_idx);
+
+    if let Some(chunk_idx) = chunk_graph.module_to_chunk[runtime_idx] {
+      chunk_graph.module_to_chunk[runtime_idx] = None;
+      let chunk = &mut chunk_graph.chunk_table[chunk_idx];
+      chunk.modules.retain(|module_idx| *module_idx != runtime_idx);
+      if chunk.modules.is_empty()
+        && !chunk_graph.post_chunk_optimization_operations.contains_key(&chunk_idx)
+      {
+        chunk_graph
+          .post_chunk_optimization_operations
+          .insert(chunk_idx, PostChunkOptimizationOperation::Removed);
+      }
+    }
+  }
+
+  /// Re-derive whether any included module still needs a runtime helper, using the
+  /// post-walk-back facts the module finalizer will render from. Conservative by design:
+  /// any uncertain case answers `true` (keep the runtime), which is at worst today's
+  /// behavior.
+  fn runtime_helpers_still_demanded(&self, runtime_idx: ModuleIdx) -> bool {
+    let link = &self.link_output;
+    let symbol_db = &link.symbol_db;
+    for (module_idx, module) in link.module_table.modules.iter_enumerated() {
+      if module_idx == runtime_idx {
+        continue;
+      }
+      let Some(module) = module.as_normal() else {
+        continue;
+      };
+      let meta = &link.metas[module_idx];
+      if !meta.is_included {
+        continue;
+      }
+
+      // Helper-flag channel (`reference_needed_symbols` registrations folded by tree-shaking).
+      // `ReExport` is the one flag whose link-time justification the walk-back can invalidate:
+      // it was registered for `export * from './normal'` statements because the importee had
+      // dynamic exports at link time. The finalizer emits the `__reExport` call only when the
+      // importee still has them (see `remove_unused_top_level_stmt`), so mirror that here.
+      // Every other flag's condition (wrap kinds, formats, interop) is stable after linking.
+      let mut helpers = meta.depended_runtime_helper;
+      if helpers.contains(RuntimeHelper::ReExport)
+        && !Self::star_re_export_still_demanded(link, module, meta)
+      {
+        helpers.remove(RuntimeHelper::ReExport);
+      }
+      if !helpers.is_empty() {
+        return true;
+      }
+
+      // Namespace-object channel: `create_exports_for_ecma_modules` put `__exportAll` (and
+      // `__reExport` for star re-exports of externals) on the namespace statement. The
+      // statement renders only when `finalized_module_namespace_ref_usage` retained the
+      // namespace; mirror `generate_declaration_of_module_namespace_object`.
+      if meta.namespace_included {
+        if !meta.is_canonical_exports_empty() || self.options.generated_code.symbols {
+          // `__exportAll` (over-approximate: the finalizer may still render `var ns = {}` if
+          // every export got trimmed from the object literal, but keeping the runtime for
+          // that corner is the safe direction).
+          return true;
+        }
+        if meta.star_exports_from_external_modules.iter().any(|rec_idx| {
+          meta.ns_star_external_re_export_emitted(
+            module.import_records[*rec_idx].meta,
+            self.options.format,
+          )
+        }) {
+          // `__reExport(ns, <external>)`
+          return true;
+        }
+      }
+
+      // Direct-reference channel: statements whose `referenced_symbols` point into the runtime
+      // module (wrapper statements referencing `__esm`/`__commonJS`, `__require` rewrites, …).
+      // The namespace statement is skipped — it is exactly the statement whose rendering the
+      // generate stage re-decides, and it is handled above.
+      for (stmt_idx, stmt_info) in link.stmt_infos[module_idx].iter_enumerated() {
+        if stmt_idx == StmtInfos::NAMESPACE_STMT_IDX || !meta.stmt_info_included.has_bit(stmt_idx) {
+          continue;
+        }
+        for reference in &stmt_info.referenced_symbols {
+          let symbol_ref = match reference {
+            SymbolOrMemberExprRef::Symbol(symbol_ref) => Some(*symbol_ref),
+            SymbolOrMemberExprRef::MemberExpr(member_expr) => {
+              member_expr.represent_symbol_ref(&meta.resolved_member_expr_refs)
+            }
+          };
+          if let Some(symbol_ref) = symbol_ref
+            && symbol_db.canonical_ref_for(symbol_ref).owner == runtime_idx
+          {
+            return true;
+          }
+        }
+      }
+
+      // Entry-chunk channel: symbols referenced by generated entry-chunk code without a
+      // carrying statement.
+      if meta
+        .referenced_symbols_by_entry_point_chunk
+        .iter()
+        .any(|(symbol_ref, _)| symbol_db.canonical_ref_for(*symbol_ref).owner == runtime_idx)
+      {
+        return true;
+      }
+    }
+    false
+  }
+
+  /// Whether the finalizer will still emit a `__reExport` call for one of `module`'s included
+  /// `export * from './normal'` statements: true iff some star importee still has dynamic
+  /// exports after `find_entry_level_external_module` re-propagated the flag. A CommonJS
+  /// importee always keeps `has_dynamic_exports`, so this also covers the wrapped-CJS star
+  /// re-export registration.
+  fn star_re_export_still_demanded(
+    link: &crate::stages::link_stage::LinkStageOutput,
+    module: &NormalModule,
+    meta: &LinkingMetadata,
+  ) -> bool {
+    link.stmt_infos[module.idx].iter_enumerated().any(|(stmt_idx, stmt_info)| {
+      if !meta.stmt_info_included.has_bit(stmt_idx) {
+        return false;
+      }
+      stmt_info.import_records.iter().any(|rec_idx| {
+        let rec = &module.import_records[*rec_idx];
+        if !rec.meta.contains(ImportRecordMeta::IsExportStar) {
+          return false;
+        }
+        let Some(importee_idx) = rec.resolved_module else {
+          return false;
+        };
+        matches!(link.module_table[importee_idx], Module::Normal(_))
+          && link.metas[importee_idx].has_dynamic_exports
+      })
+    })
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/4472/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4472/artifacts.snap
@@ -9,7 +9,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 export * from "ext-index";
 export * from "ext-file";
 export * from "ext-folder";
-//#endregion
 //#region file.js
 const file = {};
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
@@ -7,7 +7,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 export * from "external";
-//#endregion
 //#region main.js
 let foo;
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -3,18 +3,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## _virtual/_rolldown/runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll, __reExport };
-
-```
-
 ## main.js
 
 ```js
-import "./_virtual/_rolldown/runtime.js";
 import "./server/index.js";
 export * from "@sentry/node";
 
@@ -23,7 +14,6 @@ export * from "@sentry/node";
 ## server/index.js
 
 ```js
-import "../_virtual/_rolldown/runtime.js";
 export * from "@sentry/node";
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
@@ -3,19 +3,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## _virtual/_rolldown/runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
-
-```
-
 ## main.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 var external_lib = require("external-lib");
 Object.keys(external_lib).forEach(function(k) {
@@ -32,7 +22,6 @@ Object.keys(external_lib).forEach(function(k) {
 ## server.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 var external_lib = require("external-lib");
 Object.keys(external_lib).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -3,20 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## _virtual/_rolldown/runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
-
-```
-
 ## index.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {
@@ -45,7 +35,6 @@ Object.keys(zod).forEach(function(k) {
 ## server.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {
 	enumerable: true,

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -3,20 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## _virtual/_rolldown/runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-exports.__exportAll = __exportAll;
-exports.__reExport = __reExport;
-
-```
-
 ## index.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-require("./_virtual/_rolldown/runtime.js");
 require("./middle.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {
@@ -45,7 +35,6 @@ Object.keys(zod).forEach(function(k) {
 ## middle.js
 
 ```js
-require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
 Object.defineProperty(exports, "object", {

--- a/crates/rolldown/tests/rolldown/issues/9374/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9374/_config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/9374 - a star re-export chain that ends at an external module (`entry_a` -> `entry_b` -> `external`) is representable as chunk-level `export * from 'external'` statements, so no runtime helper is needed. The runtime module used to be included anyway (tree-shaking ran before the entry-level-external walk-back), shipping a dead rolldown-runtime chunk imported by both entries. The output must contain no runtime chunk and no runtime imports.",
+  "config": {
+    "input": [
+      {
+        "name": "entry_a",
+        "import": "./entry_a.js"
+      },
+      {
+        "name": "entry_b",
+        "import": "./entry_b.js"
+      }
+    ],
+    "external": ["external"],
+    "minify": false
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_a.js
+
+```js
+import { b } from "./entry_b.js";
+
+export * from "external"
+
+//#region entry_a.js
+const a = "a";
+
+//#endregion
+export { a, b };
+```
+
+## entry_b.js
+
+```js
+export * from "external"
+
+//#region entry_b.js
+const b = "b";
+
+//#endregion
+export { b };
+```

--- a/crates/rolldown/tests/rolldown/issues/9374/entry_a.js
+++ b/crates/rolldown/tests/rolldown/issues/9374/entry_a.js
@@ -1,0 +1,3 @@
+export * from './entry_b.js';
+
+export const a = 'a';

--- a/crates/rolldown/tests/rolldown/issues/9374/entry_b.js
+++ b/crates/rolldown/tests/rolldown/issues/9374/entry_b.js
@@ -1,0 +1,3 @@
+export * from 'external';
+
+export const b = 'b';

--- a/crates/rolldown_common/src/types/used_symbol_refs.rs
+++ b/crates/rolldown_common/src/types/used_symbol_refs.rs
@@ -1,5 +1,7 @@
 use rustc_hash::FxHashSet;
 
+use crate::ModuleIdx;
+
 use super::symbol_ref::SymbolRef;
 
 /// The sealed record of inclusion-fixpoint liveness: symbols the inclusion machinery
@@ -12,8 +14,9 @@ use super::symbol_ref::SymbolRef;
 /// separately, on `LinkingMetadata::namespace_included`.
 ///
 /// Read-only by construction: produced by [`UsedSymbolRefsBuilder::seal`] once the last
-/// writer (the chunk optimizer's facade-elimination re-run of the inclusion pass) has
-/// finished. There is no way to mutate it afterwards.
+/// writer (the generate stage's unused-runtime-module sweep, after the chunk optimizer's
+/// facade-elimination re-run of the inclusion pass) has finished. There is no way to
+/// mutate it afterwards.
 ///
 /// Purpose-specific views exist for common questions — prefer them:
 /// `LinkingMetadata::namespace_included` for namespace retention,
@@ -32,7 +35,8 @@ impl UsedSymbolRefs {
 }
 
 /// The mutable phase of [`UsedSymbolRefs`], held only by the inclusion machinery
-/// (the link-stage fixpoint and the chunk optimizer's re-run of it).
+/// (the link-stage fixpoint, the chunk optimizer's re-run of it, and the generate
+/// stage's unused-runtime-module sweep).
 #[derive(Debug, Default)]
 pub struct UsedSymbolRefsBuilder {
   inner: FxHashSet<SymbolRef>,
@@ -47,6 +51,14 @@ impl UsedSymbolRefsBuilder {
   #[inline]
   pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
     self.inner.contains(symbol_ref)
+  }
+
+  /// Drop every symbol owned by `owner`. Used by the generate stage's runtime
+  /// module sweep when the runtime module turns out to be unused after the
+  /// entry-level-external walk-back invalidated the link-time reasons for
+  /// including it.
+  pub fn remove_owned_by(&mut self, owner: ModuleIdx) {
+    self.inner.retain(|symbol_ref| symbol_ref.owner != owner);
   }
 
   pub fn seal(self) -> UsedSymbolRefs {

--- a/internal-docs/code-splitting/implementation.md
+++ b/internal-docs/code-splitting/implementation.md
@@ -43,22 +43,33 @@ generate_chunks()
     │
     ├─ init_entry_point()             Assign bit positions, create entry chunks
     │
-    └─ split_chunks()
-         │
-         ├─ determine_reachable_modules_for_entry()   BFS per entry, set bits on reachable modules
-         │
-         ├─ apply_manual_code_splitting()             User-defined chunk groups (manualChunks)
-         │
-         ├─ Module assignment         Group modules by identical BitSet → chunks
-         │
-         └─ ChunkOptimizer           Merge common chunks into entry chunks, remove empty facades
-              │
-              ▼
-         ChunkGraph                   Final module-to-chunk assignment
+    ├─ split_chunks()
+    │    │
+    │    ├─ determine_reachable_modules_for_entry()   BFS per entry, set bits on reachable modules
+    │    │
+    │    ├─ apply_manual_code_splitting()             User-defined chunk groups (manualChunks)
+    │    │
+    │    ├─ Module assignment         Group modules by identical BitSet → chunks
+    │    │
+    │    ├─ ChunkOptimizer           Merge common chunks into entry chunks, remove empty facades
+    │    └─ try_merge_runtime_chunk() Optionally merge the standalone runtime into a safe host
+    │
+    ├─ find_entry_level_external_module()             Flatten star-to-external chains to chunk-level
+    │                                                 re-exports; re-propagate has_dynamic_exports
+    │
+    ├─ finalized_module_namespace_ref_usage()         Final namespace-object retention decision
+    │
+    ├─ sweep_unused_runtime_module()                  Drop the runtime module when the walk-back
+    │                                                 left zero helper demand (see Runtime Module
+    │                                                 Placement below)
+    │
+    └─ Chunk exec-order assignment    → ChunkGraph    Final module-to-chunk assignment
 
 Post-ChunkGraph processing (in generate()):
 
 ChunkGraph
+    │
+    ├─ used_symbol_refs.seal()                        Freeze liveness; the sweep is the last writer
     │
     ├─ compute_cross_chunk_links()                    Determine cross-chunk imports/exports
     │
@@ -74,6 +85,7 @@ ChunkGraph
 - `crates/rolldown/src/stages/generate_stage/code_splitting.rs` — pipeline orchestration, `generate_chunks()`, `ensure_lazy_module_initialization_order()`
 - `crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs` — Rollup-style dynamic import already-loaded atom reduction
 - `crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs` — merge/optimization
+- `crates/rolldown/src/stages/generate_stage/runtime_module_sweep.rs` — post-optimization runtime-demand sweep
 - `crates/rolldown/src/chunk_graph.rs` — output data structure
 - `crates/rolldown_utils/src/bitset.rs` — compact reachability representation
 - `crates/rolldown/src/types/linking_metadata.rs` — `original_wrap_kind()` used for init order analysis
@@ -198,9 +210,21 @@ The merge target must not create a static cycle or force unrelated entry chunks 
 - **Safe target found** → runtime moves into that chunk, and the empty standalone runtime chunk is marked removed.
 - **No safe target** → keep the standalone runtime chunk. Runtime imports that resolve only to externals are ignored for chunk-cycle checks; live internal runtime imports keep the runtime standalone instead.
 
+### Unused-Runtime Sweep (`sweep_unused_runtime_module`)
+
+Tree-shaking includes runtime helpers at link time, before chunks exist, and some of its reasons are pessimistic: a star re-export chain ending at an external module registers `__reExport`/`__exportAll` demand that only chunking can invalidate. `find_entry_level_external_module` performs that walk-back (flattening the chain to chunk-level `export * from '<external>'` statements and re-propagating `has_dynamic_exports` to `false` through transitive star importers), and `finalized_module_namespace_ref_usage` then drops the namespace objects that only served the chain. The finalizer consequently emits no helper call — but the runtime module was already included and placed, so it used to ship as a dead chunk plus bare imports (#9374, #7233).
+
+`sweep_unused_runtime_module` (in `runtime_module_sweep.rs`) closes that gap. It runs at the tail of `generate_chunks()`, strictly after `try_merge_runtime_chunk` and the two walk-back passes above, and before chunk exec-order assignment. It re-derives runtime demand from the same post-walk-back facts the module finalizer renders from, through four channels: per-module `depended_runtime_helper` flags (with `ReExport` discounted unless some included `export * from './normal'` importee still has `has_dynamic_exports` — the exact condition the finalizer checks; CommonJS importees always keep it), the namespace-object channel gated on `namespace_included` (sharing `LinkingMetadata::ns_star_external_re_export_emitted` with the finalizer so the prediction cannot diverge from the emission), runtime-owned symbols referenced by included statements, and `referenced_symbols_by_entry_point_chunk`.
+
+The sweep is **all-or-nothing and conservative**: any remaining demand — or any bail-out condition (tree-shaking disabled, runtime not included, runtime has side effects as in dev/HMR mode) — leaves everything exactly as tree-shaking decided. Only a runtime with zero demand is un-included: its statement/module inclusion is cleared, its symbols are purged from `used_symbol_refs` via `remove_owned_by`, it is removed from its chunk, and a now-empty chunk is tombstoned with `PostChunkOptimizationOperation::Removed`.
+
+**Liveness invariants the sweep relies on.** Stale references to runtime symbols survive the sweep by design — namespace statements that will not render keep their `__exportAll` reference, chunk-level `depended_runtime_helper` bits keep their flags, and `compute_cross_chunk_links` speculatively inserts `__toCommonJS` for CJS-format ESM entries. All of these are filtered against `used_symbol_refs` before becoming imports or exports, so purging the runtime's symbols is what actually severs every cross-chunk edge. Every bare-import emitter tolerates `module_to_chunk == None`, and naming/rendering already skip tombstoned chunks (the same lifecycle the chunk optimizer's removals use). This is why the sweep must be the **last writer** of `used_symbol_refs` — `generate()` seals the builder immediately after `generate_chunks()` returns.
+
+**Regression coverage:** `crates/rolldown/tests/rolldown/issues/9374/` (snapshot-asserted: no runtime chunk for a multi-entry star-to-external chain, `minify: false` so vestigial namespace declarations would also surface); issues `6992`, `7115`, `7233`, `7233_chain` cover the same class under `preserveModules` for both ESM and CJS output.
+
 **Why this shape**
 
-Runtime used to be placed by normal bitset grouping and later peeled out when a cycle was detected. That made every optimizer responsible for understanding runtime-host edge cases. Standalone-first flips the default: the initial layout is always cycle-safe, and the only runtime-specific optimization is a final, optional merge into a proven dominator.
+Runtime used to be placed by normal bitset grouping and later peeled out when a cycle was detected. That made every optimizer responsible for understanding runtime-host edge cases. Standalone-first flips the default: the initial layout is always cycle-safe, and runtime-specific processing is confined to two final passes — the optional merge into a proven dominator above, then the unused-runtime sweep once the entry-level-external walk-back has settled what the finalizer will actually emit.
 
 **Regression coverage**
 


### PR DESCRIPTION
### What is this PR solving?

Top of the #9374 stack (#10238 ← #10239 ← this).

For a star re-export chain that ends at an external module:

```js
// entry_a.js
export * from './entry_b.js';
export const a = 'a';

// entry_b.js
export * from 'external';
export const b = 'b';
```

both entry chunks emit a literal `export * from "external"` and never call a runtime helper — yet the build still ships a dead `rolldown-runtime-*.js` chunk that exports `__reExport`/`__exportAll` to nobody, with a bare import of it in every entry.

Root cause: tree-shaking includes the runtime helpers at link time, when `entry_b` still counts as having dynamic exports. The generate stage later proves the whole chain can be represented statically (`find_entry_level_external_module` marks the records `EntryLevelExternal` and re-propagates `has_dynamic_exports = false` — including to transitive star importers since #10239; `finalized_module_namespace_ref_usage` drops the namespace objects that only served the chain), so the module finalizer emits no helper call — but by then the runtime module is already included and already placed in a chunk, and nothing un-includes it.

### The fix

Add `sweep_unused_runtime_module` (new pass at the tail of `generate_chunks()`, after the walk-back passes and before chunk exec-order assignment). It re-derives runtime helper demand from the same post-walk-back facts the finalizer renders from, through four channels: per-module `depended_runtime_helper` flags (with `ReExport` discounted unless some included star importee still has `has_dynamic_exports` — CommonJS importees always do, so wrapped-CJS star re-exports are unaffected), the namespace-object channel gated on `namespace_included` (calling the `LinkingMetadata::ns_star_external_re_export_emitted` rule extracted in #10238, so the prediction cannot drift from the emission), runtime-owned symbols referenced by included statements, and entry-chunk synthesized references.

If zero demand remains, the runtime module is un-included, its symbols are purged from `used_symbol_refs` (which severs every cross-chunk edge — all downstream consumers are liveness-filtered), and its now-empty chunk is tombstoned via the same `PostChunkOptimizationOperation::Removed` lifecycle the chunk optimizer uses. Any surviving demand, or any bail-out (tree-shaking disabled, side-effectful dev/HMR runtime), leaves everything exactly as tree-shaking decided.

### What other alternatives have you explored?

Teaching the link stage to skip the eager helper inclusion for the statically decidable cases was rejected: the flattening decision depends on chunk shapes (dynamic entries, `SimulateFacadeChunk`), so a link-time copy of the predicate would have to stay in sync with the generate stage forever, and drift in the optimistic direction produces broken output (a rendered helper that was never included) rather than dead bytes. Recomputing demand after the walk-back, where all facts are final, fails conservative instead.

### Effects on existing tests

Six snapshots change, all in the fixed direction: `6992`, `7115`, `7233`, `7233_chain` lose their dead runtime files and the bare imports/requires of them (the same bug shape under `preserveModules`, in both ESM and CJS output); `4472`/`5923` lose the last phantom `//#region` markers (the bulk of the marker cleanup happened in #10239).

### Tests

New fixture `crates/rolldown/tests/rolldown/issues/9374/` — fails on this PR's base (#10239's head still ships the runtime chunk; verified) and passes here. It uses `minify: false` so vestigial namespace declarations would also surface in the snapshot. Verified the legitimate cases still keep the runtime: `import * as ns` observation over the same chain (helpers are genuinely used to merge the external's exports into the namespace), and star re-exports of CJS modules (`__commonJSMin` wrapper kept).

`internal-docs/code-splitting/implementation.md` is updated with the new pipeline ordering and the sweep's liveness invariants.

fixes #9374
