### PR TITLE
refactor(rolldown): extract the ns star-external __reExport emission rule into LinkingMetadata

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -16,9 +16,9 @@ use oxc::{
 };
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConcatenateWrappedModuleKind, ExportsKind, ImportRecordIdx,
-  ImportRecordMeta, InlineConstMode, MemberExprRefResolution, Module, ModuleIdx,
-  ModuleNamespaceIncludedReason, ModuleType, NamespaceAlias, NormalModule, OutputExports,
-  OutputFormat, Platform, RenderedConcatenatedModuleParts, Specifier, SymbolRef, WrapKind,
+  ImportRecordMeta, InlineConstMode, MemberExprRefResolution, Module, ModuleIdx, ModuleType,
+  NamespaceAlias, NormalModule, OutputExports, OutputFormat, Platform,
+  RenderedConcatenatedModuleParts, Specifier, SymbolRef, WrapKind,
 };
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{
@@ -893,12 +893,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let re_export_name = self.canonical_name_for_runtime("__reExport");
           let stmts = export_all_externals_rec_ids.iter().copied().flat_map(|idx| {
             let rec = &self.ctx.module.import_records[idx];
-            if rec.meta.contains(ImportRecordMeta::EntryLevelExternal)
-              && !self
-                .ctx
-                .linking_info
-                .module_namespace_included_reason
-                .contains(ModuleNamespaceIncludedReason::Unknown)
+            if !self
+              .ctx
+              .linking_info
+              .ns_star_external_re_export_emitted(rec.meta, self.ctx.options.format)
             {
               return vec![];
             }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -2,9 +2,10 @@ use crate::stages::link_stage::{ModuleInclusionVec, ModuleNamespaceReasonVec, St
 use oxc_index::IndexVec;
 use oxc_str::CompactStr;
 use rolldown_common::{
-  ConcatenateWrappedModuleKind, EntryPointKind, ImportRecordIdx, MemberExprRefResolutionMap,
-  ModuleIdx, ModuleNamespaceIncludedReason, ResolvedExport, RuntimeHelper, StmtInfoIdx, SymbolRef,
-  WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
+  ConcatenateWrappedModuleKind, EntryPointKind, ImportRecordIdx, ImportRecordMeta,
+  MemberExprRefResolutionMap, ModuleIdx, ModuleNamespaceIncludedReason, OutputFormat,
+  ResolvedExport, RuntimeHelper, StmtInfoIdx, SymbolRef, WrapKind,
+  dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_utils::IndexBitSet;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -168,6 +169,30 @@ impl LinkingMetadata {
     self
       .wrapper_ref
       .map(|wrapper_ref| EsmInitTarget { wrapper_ref, init_is_noop: self.init_is_noop })
+  }
+
+  /// Whether the namespace-object declaration will emit a `__reExport(ns, <external>)` call for
+  /// this `export * from <external>` record when the namespace is rendered.
+  ///
+  /// This is the single source of truth for the emission decision: the module finalizer emits
+  /// the call through it, and any pass that needs to predict the emission must call it instead
+  /// of re-deriving the condition. In ESM output an entry-level external star
+  /// re-export is flattened to a chunk-level `export * from '<external>'` statement instead, so
+  /// no runtime call is needed — unless the namespace object is genuinely observed
+  /// ([`ModuleNamespaceIncludedReason::Unknown`]), in which case the namespace must still merge
+  /// the external's exports at runtime.
+  pub fn ns_star_external_re_export_emitted(
+    &self,
+    rec_meta: ImportRecordMeta,
+    format: OutputFormat,
+  ) -> bool {
+    match format {
+      OutputFormat::Esm => {
+        !rec_meta.contains(ImportRecordMeta::EntryLevelExternal)
+          || self.module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown)
+      }
+      OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => true,
+    }
   }
 
   pub fn referenced_canonical_exports_symbols<'b, 'a: 'b>(


### PR DESCRIPTION
### What is this PR solving?

Refactor only, no behavior change. Groundwork for the #9374 stack (#10239, #10237).

The module finalizer decided inline whether an `export * from '<external>'` record emits a `__reExport(ns, <external>)` call when the namespace object renders: in ESM output the call is skipped for `EntryLevelExternal` records (the re-export is representable as a chunk-level `export * from` statement) unless the namespace object is genuinely observed (`ModuleNamespaceIncludedReason::Unknown`); in CJS-family formats it is always emitted.

This PR extracts that condition into `LinkingMetadata::ns_star_external_re_export_emitted` so that any pass needing to *predict* the emission (the unused-runtime sweep added upstack in #10237) calls the same rule as the emitter instead of re-deriving it — the two cannot drift apart.

Verified pure: the full integration suite passes with zero snapshot drift on this commit.
