### PR TITLE
fix(rolldown): re-propagate has_dynamic_exports to transitive star importers

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -687,16 +687,21 @@ impl GenerateStage<'_> {
       vec.sort_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order());
       chunk_graph.chunk_table[chunk_idx].entry_level_external_module_idx = vec;
     }
-    // re propagate `meta.has_dynamic_exports` for affect modules
+    // Re-propagate `meta.has_dynamic_exports` for affected modules: the seeds (modules whose
+    // external star re-exports were just flattened) plus every transitive importer, since any
+    // module whose own star chain passes through a seed derived its flag from the seed's
+    // pre-flattening value. Enqueue importers on first discovery — the seeds themselves are
+    // already members, so testing membership on pop would skip them and never traverse.
     let mut q = invalidated_modules.iter().copied().collect::<VecDeque<_>>();
     while let Some(idx) = q.pop_front() {
-      if !invalidated_modules.insert(idx) {
-        continue;
-      }
       let Module::Normal(module) = &self.link_output.module_table[idx] else {
         continue;
       };
-      q.extend(module.importers_idx.iter());
+      for importer_idx in module.importers_idx.iter().copied() {
+        if invalidated_modules.insert(importer_idx) {
+          q.push_back(importer_idx);
+        }
+      }
     }
 
     if invalidated_modules.is_empty() {

--- a/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 export * from "external";
+//#endregion
+//#region main.js
 let foo;
 //#endregion
 export { foo };

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -17,7 +17,6 @@ export { __exportAll, __reExport };
 import "./_virtual/_rolldown/runtime.js";
 import "./server/index.js";
 export * from "@sentry/node";
-//#endregion
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
@@ -17,7 +17,6 @@ exports.__reExport = __reExport;
 ```js
 require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
-//#endregion
 var external_lib = require("external-lib");
 Object.keys(external_lib).forEach(function(k) {
 	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -19,7 +19,6 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 require("./_virtual/_rolldown/runtime.js");
 require("./server.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -19,7 +19,6 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 require("./_virtual/_rolldown/runtime.js");
 require("./middle.js");
 let zod = require("zod");
-//#endregion
 Object.defineProperty(exports, "object", {
 	enumerable: true,
 	get: function() {


### PR DESCRIPTION
### What is this PR solving?

Part of the #9374 stack (#10238 ← this ← #10237).

`find_entry_level_external_module` flattens star re-export chains that end at an external module into chunk-level re-exports, marks the records `EntryLevelExternal`, and re-propagates `has_dynamic_exports = false` for the affected modules. A BFS is supposed to extend that invalidation to every *transitive* star importer — a module whose own star chain passes through a seed derived its flag from the seed's pre-flattening value.

That BFS was dead on arrival: it tested set membership on pop —

```rust
while let Some(idx) = q.pop_front() {
  if !invalidated_modules.insert(idx) { continue; }
  ...
  q.extend(module.importers_idx.iter());
}
```

— but the seeds are pre-inserted into `invalidated_modules`, so every seed skipped itself and no importer was ever enqueued. Only the modules with a *direct* external star re-export were ever walked back.

Consequences for a chain like `entry_a → export * → entry_b → export * → 'external'`:

- `entry_a` kept a stale `has_dynamic_exports = true`, so `finalized_module_namespace_ref_usage` retained its namespace object. The finalizer rendered `var entry_a_exports = /* @__PURE__ */ __exportAll({...})` for nothing; the default dce-only minifier usually deleted it again, but the unbalanced `//#region` markers it left behind are visible in several existing snapshots.
- In chains of **three or more** modules, the middle module's stale flag made the finalizer emit a genuinely dead `__reExport(a_exports, b_exports)` call — a call expression, so not pure-droppable — which shipped to users.

The fix enqueues importers on first discovery instead of testing membership on pop.

### Effects on existing tests

Five snapshots change, all region-marker corrections from the namespace declarations that no longer render-then-vanish (`5923`, `6992`, `7115`, `7233`, `7233_chain`). The dead `rolldown-runtime` files still visible in those snapshots are removed by #10237 upstack — inclusion is already frozen when this pass runs, so fixing the flag alone cannot un-include the runtime module.
