### PR TITLE
chore: disable Renovate updates for idna_adapter

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,12 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["rolldown-plugin-dts"],
       "schedule": ["at any time"]
+    },
+    {
+      "description": "idna_adapter is pinned to 1.0.0 to keep the lighter unicode-rs backend (see #9811)",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["idna_adapter"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Description

`idna_adapter` is pinned to `=1.0.0` on purpose. #9811 pinned it to keep the lighter unicode-rs backend and avoid pulling in the ICU4X dependencies, which would grow the binary by about 129 KB.

Renovate does not know about this intent, so it keeps proposing to bump the pin (for example in #10244). This PR adds a `packageRules` entry that disables Renovate updates for `idna_adapter`, with a `description` field explaining why.

After this lands, rebasing #10244 will drop the `idna_adapter` bump while keeping the other crate updates.
