### PR TITLE
perf(sourcemap): owned merge in SourceJoiner::join (4005->5 allocs/chunk)

### DIFF
--- a/crates/bench/benches/bench.rs
+++ b/crates/bench/benches/bench.rs
@@ -4,7 +4,7 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 use std::fmt::Write as _;
 
 use bench::{BenchMode, DeriveOptions, bench_preset, rome_ts_preset, run_bench_group};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use oxc::{
   allocator::Allocator,
   codegen::{Codegen, CodegenOptions, CodegenReturn},
@@ -149,23 +149,27 @@ const BIG_CHUNK: u32 = 2000;
 fn sourcemap_benches(c: &mut Criterion) {
   let mut group = c.benchmark_group("sourcemap");
 
-  // `SourceJoiner::join` rebuilds the `ConcatSourceMapBuilder` and output on
-  // every call, so each joiner is built once here and every iteration measures
-  // a full chunk assembly + sourcemap merge.
+  // `join` takes `&mut self`, so it's rebuilt per iteration in the (excluded) setup; `iter_batched_ref` drops the joiner outside the measured window, so each iteration times just the chunk assembly + sourcemap merge, not the ~2000-source teardown.
 
   // With sourcemaps: a large (shit-mountain-scale) chunk of mapped modules +
   // banner/footer — drives `ConcatSourceMapBuilder` (token buffer + dedup + line offsets).
-  let app_chunk = build_chunk_joiner(BIG_CHUNK);
   group.bench_function("join_with_sourcemap", |b| {
-    b.iter(|| black_box(app_chunk.join()));
+    b.iter_batched_ref(
+      || build_chunk_joiner(BIG_CHUNK),
+      |chunk| black_box(chunk.join()),
+      BatchSize::SmallInput,
+    );
   });
 
   // Without sourcemaps: the same module bodies as plain sources — the
   // `enable_sourcemap == false` fast path that skips the builder entirely (the
   // most common production build, `output.sourcemap` unset).
-  let plain_chunk = build_plain_joiner(BIG_CHUNK);
   group.bench_function("join_no_sourcemap", |b| {
-    b.iter(|| black_box(plain_chunk.join()));
+    b.iter_batched_ref(
+      || build_plain_joiner(BIG_CHUNK),
+      |chunk| black_box(chunk.join()),
+      BatchSize::SmallInput,
+    );
   });
 
   // `collapse_sourcemaps` — the module-transform (`render_chunks.rs`) and

--- a/crates/rolldown_sourcemap/benches/join.rs
+++ b/crates/rolldown_sourcemap/benches/join.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use rolldown_sourcemap::SourceJoiner;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -6,14 +6,21 @@ fn criterion_benchmark(c: &mut Criterion) {
   // A module that is 1kb in size
   let a_norma_module = " ".repeat(1024);
 
+  // `join` takes `&mut self` (it moves each source's map out), so build a fresh
+  // joiner per iteration; `iter_batched_ref` also drops it outside the measured
+  // region, so the timing is the merge alone — not the per-iteration teardown.
   group.bench_function("join", move |b| {
-    let mut joiner = SourceJoiner::default();
-    for _ in 0..10_000 {
-      joiner.append_source(a_norma_module.clone());
-    }
-    b.iter(move || {
-      black_box(joiner.join());
-    });
+    b.iter_batched_ref(
+      || {
+        let mut joiner = SourceJoiner::default();
+        for _ in 0..10_000 {
+          joiner.append_source(a_norma_module.clone());
+        }
+        joiner
+      },
+      |joiner| black_box(joiner.join()),
+      BatchSize::SmallInput,
+    );
   });
 }
 

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -4,6 +4,13 @@ use crate::SourceMap;
 
 pub trait Source {
   fn sourcemap(&self) -> Option<&SourceMap>;
+  /// Move this source's sourcemap out when it is exclusively owned.
+  ///
+  /// Borrowed sources keep the default `None`; `SourceJoiner` then falls back
+  /// to `sourcemap` and copies only those borrowed entries into its owned result.
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    None
+  }
   fn content(&self) -> &str;
   fn lines_count(&self) -> u32 {
     lines_count(self.content())
@@ -33,13 +40,13 @@ impl Source for String {
 #[derive(Debug)]
 pub struct SourceMapSource {
   content: String,
-  sourcemap: SourceMap,
+  sourcemap: Option<SourceMap>,
   pre_computed_lines_count: Option<u32>,
 }
 
 impl SourceMapSource {
   pub fn new(content: String, sourcemap: SourceMap) -> Self {
-    Self { content, sourcemap, pre_computed_lines_count: None }
+    Self { content, sourcemap: Some(sourcemap), pre_computed_lines_count: None }
   }
 
   #[must_use]
@@ -53,7 +60,7 @@ impl SourceMapSource {
 
 impl Source for SourceMapSource {
   fn sourcemap(&self) -> Option<&SourceMap> {
-    Some(&self.sourcemap)
+    self.sourcemap.as_ref()
   }
 
   fn content(&self) -> &str {
@@ -62,6 +69,10 @@ impl Source for SourceMapSource {
 
   fn lines_count(&self) -> u32 {
     self.pre_computed_lines_count.unwrap_or_else(|| lines_count(&self.content))
+  }
+
+  fn take_sourcemap(&mut self) -> Option<SourceMap> {
+    self.sourcemap.take()
   }
 }
 

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -36,49 +36,58 @@ impl<'source> SourceJoiner<'source> {
     self.prepend_source.push(Box::new(source));
   }
 
-  pub fn join(&self) -> (String, Option<SourceMap>) {
+  pub fn join(&mut self) -> (String, Option<SourceMap>) {
     let sources_len = self.prepend_source.len() + self.inner.len();
-    let sources_iter = self.prepend_source.iter().chain(self.inner.iter()).enumerate();
 
-    let size_hint_of_ret_source =
-      sources_iter.clone().map(|(_idx, source)| source.content().len()).sum::<usize>()
-        + sources_len;
+    let size_hint_of_ret_source = self
+      .prepend_source
+      .iter()
+      .chain(self.inner.iter())
+      .map(|source| source.content().len())
+      .sum::<usize>()
+      + sources_len;
     let mut ret_source = String::with_capacity(size_hint_of_ret_source);
 
-    // Fast path: when no source carries a sourcemap, `join` is a plain
-    // concatenation with `\n` separators. `line_offset` and the per-source
-    // `lines_count()` newline scan exist only to feed the sourcemap builder,
-    // so skip them entirely here. Splitting the loop (rather than branching
-    // inside it) also keeps the sourcemap loop below free of per-iteration
-    // builder checks.
-    if !self.enable_sourcemap {
-      for (index, source) in sources_iter {
+    let mut sourcemap_builder = self.enable_sourcemap.then(|| {
+      ConcatSourceMapBuilder::with_capacity(
+        self.names_len,
+        self.sources_len,
+        self.tokens_len,
+        self.token_chunks_len,
+      )
+    });
+    if let Some(sourcemap_builder) = &mut sourcemap_builder {
+      let mut line_offset = 0;
+      // Move exclusively owned maps into the builder. A caller may still pass
+      // a shared source by reference; keep borrowing that map so its mappings
+      // are preserved, then copy only its borrowed strings when detaching.
+      for (index, source) in self.prepend_source.iter_mut().chain(self.inner.iter_mut()).enumerate()
+      {
+        ret_source.push_str(source.content());
+        if let Some(map) = source.take_sourcemap() {
+          sourcemap_builder.add_sourcemap_owned(map, line_offset);
+        } else if let Some(map) = source.sourcemap() {
+          sourcemap_builder.add_sourcemap(map, line_offset);
+        }
+        // The line count only advances the offset for a *following* source, so
+        // scan it inside this branch — never for the final source, which can be
+        // a whole chunk appended without a pre-computed count.
+        if index < sources_len - 1 {
+          ret_source.push('\n');
+          line_offset += source.lines_count() + 1; // +1 for the newline
+        }
+      }
+    } else {
+      // Without a sourcemap there is no line offset to maintain. Avoid scanning
+      // every source for newlines on this common path.
+      for (index, source) in self.prepend_source.iter().chain(self.inner.iter()).enumerate() {
         ret_source.push_str(source.content());
         if index < sources_len - 1 {
           ret_source.push('\n');
         }
       }
-      return (ret_source, None);
     }
-
-    let mut line_offset = 0;
-    let mut sourcemap_builder = ConcatSourceMapBuilder::with_capacity(
-      self.names_len,
-      self.sources_len,
-      self.tokens_len,
-      self.token_chunks_len,
-    );
-    for (index, source) in sources_iter {
-      source.sourcemap().inspect(|map| {
-        sourcemap_builder.add_sourcemap(map, line_offset);
-      });
-      ret_source.push_str(source.content());
-      if index < sources_len - 1 {
-        ret_source.push('\n');
-        line_offset += source.lines_count() + 1; // +1 for the newline
-      }
-    }
-    (ret_source, Some(sourcemap_builder.into_sourcemap().into_owned()))
+    (ret_source, sourcemap_builder.map(|builder| builder.into_owned_sourcemap().into_inner()))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {
@@ -143,4 +152,46 @@ console.log(foo);
 (0:30) ");\n" --> (4:15) ");\n"
 "#
   );
+}
+
+#[test]
+fn test_concat_mixed_owned_and_borrowed_sourcemaps() {
+  use std::borrow::Cow;
+
+  use crate::{Source, SourceJoiner, SourceMap, SourceMapSource};
+  use oxc_sourcemap::Token;
+
+  fn map(filename: &str, source_content: &str) -> SourceMap {
+    SourceMap::new(
+      None,
+      vec![],
+      None,
+      vec![Cow::Owned(filename.to_string())],
+      vec![Some(Cow::Owned(source_content.to_string()))],
+      vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+      None,
+    )
+  }
+
+  // Callers may still pass a shared source that cannot yield ownership of its map.
+  let borrowed_source: Box<dyn Source + Send + Sync> = Box::new(SourceMapSource::new(
+    "borrowed();".to_string(),
+    map("borrowed.js", "borrowed source"),
+  ));
+
+  let mut joiner = SourceJoiner::default();
+  joiner.append_source(&borrowed_source);
+  joiner
+    .append_source(SourceMapSource::new("owned();".to_string(), map("owned.js", "owned source")));
+
+  let (content, map) = joiner.join();
+  let map = map.expect("both input sourcemaps should be preserved");
+
+  assert_eq!(content, "borrowed();\nowned();");
+  assert_eq!(map.get_sources().collect::<Vec<_>>(), ["borrowed.js", "owned.js"]);
+  assert_eq!(map.get_source_content(0), Some("borrowed source"));
+  assert_eq!(map.get_source_content(1), Some("owned source"));
+  assert_eq!(map.get_token(0).and_then(|token| token.get_source_id()), Some(0));
+  assert_eq!(map.get_token(1).map(|token| token.get_dst_line()), Some(1));
+  assert_eq!(map.get_token(1).and_then(|token| token.get_source_id()), Some(1));
 }

--- a/tasks/track_memory_allocations/allocs.snap
+++ b/tasks/track_memory_allocations/allocs.snap
@@ -1,5 +1,5 @@
 Scenario                         |     Allocs |   Reallocs
 ----------------------------------------------------------
-sourcemap/join_with_sourcemap    |       4005 |          0
+sourcemap/join_with_sourcemap    |          5 |          0
 sourcemap/join_no_sourcemap      |          1 |          0
 sourcemap/collapse_codegen_chain |          8 |         15

--- a/tasks/track_memory_allocations/src/main.rs
+++ b/tasks/track_memory_allocations/src/main.rs
@@ -180,12 +180,12 @@ fn collect_rows() -> Vec<Row> {
 
   // `SourceJoiner::join` WITH sourcemaps — per-chunk assembly + merge (the
   // `ConcatSourceMapBuilder` path).
-  let app_chunk = build_chunk_joiner(BIG_CHUNK);
+  let mut app_chunk = build_chunk_joiner(BIG_CHUNK);
   measure(&mut rows, "sourcemap/join_with_sourcemap", || app_chunk.join());
 
   // `join` WITHOUT sourcemaps — the `enable_sourcemap == false` fast path that
   // skips the builder (the most common production build, `output.sourcemap` unset).
-  let plain_chunk = build_plain_joiner(BIG_CHUNK);
+  let mut plain_chunk = build_plain_joiner(BIG_CHUNK);
   measure(&mut rows, "sourcemap/join_no_sourcemap", || plain_chunk.join());
 
   // `collapse_sourcemaps`: real oxc chain, fine-grained, 3 links over a big


### PR DESCRIPTION
`SourceJoiner::join` borrowed every input map's strings into a `ConcatSourceMapBuilder`, then called `into_owned` on the merged result to detach it — deep-copying every name/source/sourcesContent string of every module, one heap allocation each, on the per-chunk codegen path.

This moves each source's owned `SourceMap` into the builder via `ConcatSourceMapBuilder::add_sourcemap_owned`; the merged map is already `'static`, so the trailing `into_owned` is gone. Sources that can only lend a borrowed map (e.g. one shared through an `Arc`) fall back to `add_sourcemap` + copy-on-detach, so output is unchanged.

Measured via `tasks/track_memory_allocations` (2000-module chunk):

```
sourcemap/join_with_sourcemap    4005 -> 5 allocs
```

A second commit refines the join: it takes `&mut self` — the merge only needs `iter_mut()` + `take_sourcemap()`, so it never needed to consume `self` — and the benches move to `iter_batched_ref` so the micro-bench stops timing the per-iteration joiner teardown (that teardown, not the concat, was the spurious `join_no_sourcemap` CodSpeed delta). It also skips the newline scan of the *final* joined source, whose line count only advances the offset for a following source.

This is the focused, measured core extracted from #9881 (original work by @hyf0). It touches only `rolldown_sourcemap` plus the benches/allocation snapshot; the `ecma_generator`/format pipeline is left untouched, so real-build sourcemap output is identical to `main`. Wiring the chunk renderer to hand `join` its owned per-module maps — instead of the `Arc`-shared borrow it copies today — is a follow-up.
