### PR TITLE
test(code-splitting): harden strict execution order coverage

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
@@ -9,5 +9,12 @@
         }
       ]
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -42,3 +42,43 @@ var init_foo = __esmMin((() => {
 export { init_foo as n, foo as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_foo, t as foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### vendor.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region foo.js
+var foo;
+var init_foo = __esmMin((() => {
+	foo = "foo bar";
+}));
+//#endregion
+export { init_foo as n, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
@@ -1,5 +1,12 @@
 {
   "config": {
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -35,3 +35,36 @@ __esmMin((() => {
 export { all };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+const stages = {
+	a: "1",
+	b: "2",
+	c: "3"
+};
+//#endregion
+//#region main.js
+var first, rest, all;
+//#endregion
+__esmMin((() => {
+	[first, ...rest] = Object.values(stages);
+	if (!first) throw new Error("empty");
+	all = [first, ...rest];
+	assert.deepStrictEqual(all, [
+		"1",
+		"2",
+		"3"
+	]);
+}))();
+export { all };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
@@ -1,0 +1,49 @@
+{
+  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "Expected to fail until rolldown#10104 is applied.",
+    "outputContains": ["the hoisted self-rebinding order wrapper form must be preserved"]
+  },
+  "config": {
+    "input": [
+      { "name": "e0", "import": "./m0.js" },
+      { "name": "e1", "import": "./m1.js" }
+    ],
+    "format": "cjs",
+    "preserveEntrySignatures": "allow-extension",
+    "strictExecutionOrder": true,
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [{ "name": "g", "test": "[\\\\/]m[12]\\.js$" }]
+    },
+    "experimental": { "onDemandWrapping": true }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["the hoisted self-rebinding order wrapper form must be preserved"]
+      },
+      "onDemandWrapping": false
+    },
+    {
+      "_configName": "minify",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["the self-rebinding order wrapper form must survive minification"]
+      },
+      "minify": true
+    },
+    {
+      "_configName": "minify-wrap-all",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["the self-rebinding order wrapper form must survive minification"]
+      },
+      "minify": true,
+      "onDemandWrapping": false
+    }
+  ],
+  "hiddenRuntimeModule": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Strict-execution-order + `format: cjs` with code splitting: `g.js` (m1, m2) and `m3.js` form a
+// cross-chunk cycle, so `g.js` exports its `init_m2` wrapper to `m3.js` and vice versa. The order
+// wrappers self-rebind on first call, so their cross-chunk exports MUST be live getters. A future
+// degradation to a value snapshot (`exports.init_m2 = init_m2`) would freeze the pre-rebind
+// function and re-run a module body on every later call — that would surface here as a duplicate
+// entry in `__log` (or as unbounded recursion through the cycle). Today these exports render
+// through the common-chunk arm of `render_chunk_exports` (entry chunks holding wrapped modules
+// are split into facades, so `e0.js`/`e1.js` export no wrappers themselves); this fixture pins
+// the emitted shape wherever it renders. It is also the first executed strict+cjs coverage (the
+// invariants harness forces ESM), so it pins that strict+cjs runs at all.
+
+const require = createRequire(import.meta.url);
+const distDir = join(dirname(fileURLToPath(import.meta.url)), 'dist');
+// Full `minify` mangles the local `init_*` names, so the name-based structural greps below only
+// apply to the unminified configs; under minify, single execution + correct values (section (b))
+// are the load-bearing assertions that the self-rebinding wrapper still runs each body once.
+const isMinified = ['minify', 'minify-wrap-all'].includes(globalThis.__configName);
+
+const combined = readdirSync(distDir)
+  .filter((name) => name.endsWith('.js'))
+  .map((name) => readFileSync(join(distDir, name), 'utf8'))
+  .join('\n');
+
+if (isMinified) {
+  // (a-min) Loose, name-agnostic pin that the hoisted self-rebinding form survived compression: a
+  // function that reassigns its own binding and immediately calls it
+  // (`function X(){return(X=...)()}`).
+  assert.match(
+    combined,
+    /function (\w+)\(\)\{return\(?\1=/,
+    'the self-rebinding order wrapper form must survive minification',
+  );
+} else {
+  // (a) Structural pin: every cross-chunk `init_*` export must be a live getter, never a value
+  // snapshot. Read the emitted chunks directly so the guard fails loudly even if someone
+  // regenerates the artifacts snapshot. Written to survive `minifyInternalExports` (which shortens
+  // the export KEY, e.g. `init_m2` -> `i`, but keeps the local `init_m2` name), so it matches on
+  // the local wrapper name rather than the export key.
+  //
+  // The order wrapper is returned from a getter body (`get: function() { return init_m2; }`).
+  assert.match(
+    combined,
+    /return init_m\d+;/,
+    'expected at least one order wrapper to be exported as a live getter',
+  );
+  // The degradation this guards against: a value snapshot of the wrapper (`exports.<key> =
+  // init_m2`), which would freeze the pre-rebind function regardless of how the export key is named.
+  assert.doesNotMatch(
+    combined,
+    /\bexports\.\w+\s*=\s*init_\w+/,
+    'an order wrapper must never be exported as a value snapshot (`exports.x = init_x`)',
+  );
+  // The self-rebinding wrapper form must survive so first-call rebinding caches the module body.
+  assert.match(
+    combined,
+    /function init_m2\(\)\s*\{\s*return \(init_m2 =/,
+    'the hoisted self-rebinding order wrapper form must be preserved',
+  );
+}
+
+// (b) Behavioural pin: loading both entries must run every module body EXACTLY once and produce
+// the correct values.
+globalThis.__log = [];
+const e0 = require('./dist/e0.js');
+const e1 = require('./dist/e1.js');
+
+for (const name of ['m0', 'm1', 'm2', 'm3']) {
+  const count = globalThis.__log.filter((entry) => entry === name).length;
+  assert.strictEqual(count, 1, `module ${name} body must execute exactly once, ran ${count} times`);
+}
+
+assert.strictEqual(e0.v0, 10, 'e0 should re-export m0.v0');
+assert.strictEqual(e1.v1, 1, 'e1 should re-export m1.v1');
+// v2 = v0 + 2 proves m2 observed m0's initialized export under strict order.
+assert.strictEqual(e1.v2, 12, 'e1.v2 must equal m0.v0 + 2, proving in-order initialization');
+
+delete globalThis.__log;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m0.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m0.js
@@ -1,0 +1,2 @@
+globalThis.__log.push('m0');
+export const v0 = 10;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m1.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m1.js
@@ -1,0 +1,5 @@
+import './m3.js';
+import { v2 } from './m2.js';
+globalThis.__log.push('m1');
+export const v1 = 1;
+export { v2 };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m2.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m2.js
@@ -1,0 +1,4 @@
+import { v0 } from './m0.js';
+import './m3.js';
+globalThis.__log.push('m2');
+export const v2 = v0 + 2;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m3.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/m3.js
@@ -1,0 +1,3 @@
+import './m2.js';
+globalThis.__log.push('m3');
+export const v3 = 3;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
@@ -3,6 +3,11 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -51,3 +51,31 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	console.log("cjs");
+	module.exports = { value: 1 };
+}));
+//#endregion
+var import_cjs$1, fromLib, import_cjs;
+__esmMin((() => {
+	//#region lib.js
+	import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
+	fromLib = import_cjs$1.default.value;
+	//#endregion
+	//#region main.js
+	import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+	console.log("main", fromLib, import_cjs.default.value);
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_config.json
@@ -1,0 +1,29 @@
+{
+  "snapshot": false,
+  "config": {
+    "external": ["node:assert"]
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": [
+          "inlined namespace member must not initialize its dead re-export before page-b"
+        ]
+      },
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": [
+          "inlined namespace member must not initialize its dead re-export before page-b"
+        ]
+      },
+      "strictExecutionOrder": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/bridge.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/bridge.js
@@ -1,0 +1,1 @@
+export * from './constants.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/constants.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/constants.js
@@ -1,0 +1,7 @@
+export const x = 1;
+
+function mark() {
+  globalThis.inlineNamespaceValue = 0;
+}
+
+export const y = /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/main.js
@@ -1,0 +1,2 @@
+await import('./page-b.js').then(console.log);
+await import('./page-a.js').then(console.log);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/page-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/page-a.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { x, y } from './constants.js';
+
+assert.strictEqual(globalThis.inlineNamespaceValue, 0);
+
+export function render() {
+  console.log(x, y);
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/page-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/page-b.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+import * as bridge from './bridge.js';
+
+assert.strictEqual(bridge.x, 1);
+assert.strictEqual(
+  globalThis.inlineNamespaceValue,
+  undefined,
+  'inlined namespace member must not initialize its dead re-export before page-b',
+);
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
@@ -1,0 +1,24 @@
+{
+  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "Expected to fail until rolldown#10104 is applied.",
+    "outputContains": ["namespace member must not initialize its dead re-export before page-b"]
+  },
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["namespace member must not initialize its dead re-export before page-b"]
+      },
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/bridge.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/bridge.js
@@ -1,0 +1,5 @@
+export function x() {
+  return 1;
+}
+
+export * from './common.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/common.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/common.js
@@ -1,0 +1,8 @@
+export const common = 'common';
+
+function mark() {
+  globalThis.namespaceValue =
+    typeof globalThis.namespaceValue === 'number' ? globalThis.namespaceValue + 1 : 0;
+}
+
+export const _ = /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/main.js
@@ -1,0 +1,2 @@
+await import('./page-b.js').then(console.log);
+await import('./page-a.js').then(console.log);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/page-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/page-a.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { common, _ } from './common.js';
+
+assert.strictEqual(globalThis.namespaceValue, 0);
+
+export function render() {
+  console.log(common, _);
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/page-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/page-b.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+import * as bridge from './bridge.js';
+
+bridge.x();
+assert.strictEqual(
+  globalThis.namespaceValue,
+  undefined,
+  'namespace member must not initialize its dead re-export before page-b',
+);
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
@@ -1,0 +1,11 @@
+{
+  "snapshot": false,
+  "config": {
+    "strictExecutionOrder": true
+  },
+  "configVariants": [
+    {
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const { loadPage } = await import('./dist/main.js');
+await loadPage();
+
+// The definer is reachable only through barrel-outer -> barrel-inner -> definer, and the reader
+// that consumes it lives inside the dynamically imported chunk. The wrap-all cell exercises init
+// forwarding through both barrel wrappers; on-demand may keep this particular graph eager. In both
+// modes the definer must run before the reader reads `value`. A regression in wrapper forwarding
+// left the inner barrel's `init_*` empty, so `value` read `undefined` (issue family #8777 / #8989).
+assert.ok(globalThis.__events.includes('definer'), 'definer module must have been initialized');
+assert.ok(
+  globalThis.__events.includes('reader:5'),
+  `reader must read the initialized definer value; got ${JSON.stringify(globalThis.__events)}`,
+);
+assert.ok(
+  globalThis.__events.indexOf('definer') < globalThis.__events.indexOf('reader:5'),
+  'definer must initialize before the reader reads it',
+);
+assert.deepStrictEqual(globalThis.__events, [
+  'main',
+  'leaf',
+  'definer',
+  'reader:5',
+  'reader-host:105',
+  'dynamic-page',
+]);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/barrel-inner.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/barrel-inner.js
@@ -1,0 +1,1 @@
+export { value } from './definer.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/barrel-outer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/barrel-outer.js
@@ -1,0 +1,1 @@
+export { value } from './barrel-inner.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/definer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/definer.js
@@ -1,0 +1,9 @@
+(globalThis.__events ??= []).push('definer');
+
+// A runtime-computed value (not a bare literal) so it cannot be constant-inlined away: the reader
+// must actually read it through the barrel chain, which is what forces the barrel wrappers to
+// initialize this definer.
+function makeValue() {
+  return 5;
+}
+export const value = makeValue();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/dynamic-page.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/dynamic-page.js
@@ -1,0 +1,3 @@
+import './reader-host.js';
+
+(globalThis.__events ??= []).push('dynamic-page');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/leaf.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/leaf.js
@@ -1,0 +1,3 @@
+(globalThis.__events ??= []).push('leaf');
+
+export const leafMarker = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/main.js
@@ -1,0 +1,7 @@
+(globalThis.__events ??= []).push('main');
+
+// The page (and everything it reaches) lives behind a dynamic import, so the reader that consumes
+// the definer ends up inside an order-wrapped dynamic chunk.
+export function loadPage() {
+  return import('./dynamic-page.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/reader-host.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/reader-host.js
@@ -1,0 +1,9 @@
+import { readerValue } from './reader.js';
+
+(globalThis.__events ??= []).push('reader-host:' + readerValue);
+
+// A second dynamic import of `leaf`, which `reader` also statically namespace-imports. This mirrors
+// the shape the fuzzer minimized to and keeps `leaf` in the dynamic chunk next to the reader.
+export function loadLeaf() {
+  return import('./leaf.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/reader.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/reader.js
@@ -1,0 +1,11 @@
+import * as leaf from './leaf.js';
+import { value } from './barrel-outer.js';
+
+// `value` is defined in `definer.js`, reachable only through the two-level re-export barrel chain
+// barrel-outer -> barrel-inner -> definer. Under strict execution order the barrel wrappers must
+// initialize the definer before this read; the regression left the inner barrel's wrapper empty,
+// so `value` read `undefined`.
+(globalThis.__events ??= []).push('reader:' + value);
+
+export const readerValue = value + 100;
+export const leafSeen = typeof leaf;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
@@ -1,0 +1,37 @@
+{
+  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "Expected to fail until rolldown#10104 is applied.",
+    "outputContains": ["loading dynamic target entry must not execute co-located entry a"]
+  },
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "c",
+        "import": "./c.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "group",
+          "test": "[\\\\/](?:a|b)\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["loading dynamic target entry must not execute co-located entry a"]
+      },
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+// A manual group places entry `a` next to `b`, and `c` dynamically imports `b`. Loading that
+// shared chunk must not run entry `a`'s program.
+const c = await import('./dist/c.js');
+await c.default.load();
+assert.deepStrictEqual(
+  globalThis.__events,
+  ['b'],
+  'loading dynamic target entry must not execute co-located entry a',
+);
+
+await import('./dist/a.js');
+assert.deepStrictEqual(globalThis.__events, ['b', 'a']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/a.js
@@ -1,0 +1,2 @@
+globalThis.__events?.push('a');
+module.exports = { a: true };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/b.js
@@ -1,0 +1,2 @@
+globalThis.__events?.push('b');
+module.exports = { b: true };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/c.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/c.js
@@ -1,0 +1,1 @@
+module.exports.load = () => import('./b.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": { "onDemandWrapping": true },
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "a",
+          "test": "[\\\\/]emergent_cycle_eager_reexport_overlay[\\\\/]a[\\\\/]"
+        },
+        {
+          "name": "b",
+          "test": "[\\\\/]emergent_cycle_eager_reexport_overlay[\\\\/]b[\\\\/]"
+        }
+      ]
+    }
+  },
+  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+
+// The pre-lowering chunk graph is acyclic; applying the wrap plan adds the eager forwarder's
+// cross-chunk `init_definer` overlay import (A -> B), which closes a chunk cycle with the baseline
+// B -> A edge from the eager reader's CJS carrier. Chunk B's body then evaluates before chunk A's.
+// The forwarder carries no `init_forwarder` of its own, so the fixpoint projector — which only
+// walks importers that own an ESM `init_*` — skips it and misses the A -> B overlay edge. Without
+// projecting overlay edges the eager reader's record-position interop trigger runs mid-cycle and
+// reads A's not-yet-assigned `var require_carrier` — `TypeError: require_carrier is not a function`
+// (vue-vben-admin's `qe is not a function`). Projecting the overlay edge wraps chunk B's eligible
+// modules, deferring the read until after both chunk bodies.
+await import('./dist/main.js');
+
+assert.strictEqual(
+  globalThis.__carried,
+  'CARRIED',
+  `the eager interop read must observe the assigned CJS wrapper; got ${JSON.stringify(globalThis.__carried)}`,
+);
+assert.deepStrictEqual(
+  globalThis.__result,
+  { pv: 'PV', marker: 'F', carried: 'CARRIED' },
+  `strict order must deliver initialized values; got ${JSON.stringify(globalThis.__result)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/a-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/a-first.js
@@ -1,0 +1,5 @@
+// Earliest-discovered side-effectful member of chunk A: makes the entry import chunk A before
+// chunk B, so at runtime A starts evaluating first and the lowering-added A -> B overlay import
+// (the forwarder's `init_definer`) is what first reaches B.
+(globalThis.__events ??= []).push('a-first');
+export const aFirst = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/carrier.cjs.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/carrier.cjs.js
@@ -1,0 +1,7 @@
+// CJS interop carrier hosted in chunk A. Its `var require_carrier = __commonJSMin(...)`
+// declaration is assigned in A's chunk *body* — during the emergent cycle's evaluation, chunk B's
+// body runs before A's, so an eager read of this wrapper from B observes the unassigned var
+// (vue-vben-admin's `qe is not a function` shape).
+module.exports = function carrier() {
+  return 'CARRIED';
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/forwarder.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/a/forwarder.js
@@ -1,0 +1,18 @@
+// Eager pure re-export barrel in chunk A. It has no side effect and no order-sensitive
+// initializer of its own, so on-demand wrapping never plans it — yet its retained
+// `export { pv } from '../b/definer.js'` re-export of the order-wrapped `definer` makes the
+// lowering give it an `OrderImportOverlay` that references `init_definer` and emit that
+// `init_definer()` call in chunk A's body. That is a *new* cross-chunk import A -> B carried by
+// the overlay, not by any `init_forwarder` the fixpoint projector inspects (it skips every
+// importer without its own ESM `init_*`). Together with the baseline B -> A edge this closes the
+// emergent chunk cycle the one-shot analysis never saw.
+//
+// The exported function declaration is hoisted and contributes nothing to an `__esm` closure, so
+// it keeps the barrel a real, retained module in chunk A (its named re-export is not inlined away)
+// without making it order-sensitive — the barrel stays eager. Consuming `marker` in the entry is
+// what pins the barrel; the retained `export { pv } from` beside it is what creates the overlay.
+export function marker() {
+  return 'F';
+}
+
+export { pv } from '../b/definer.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/b/definer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/b/definer.js
@@ -1,0 +1,10 @@
+// Side-effect-free definer in chunk B, order-wrapped through the premature deviation. It is the
+// target of the forwarder's re-export hop, so its `init_definer` is what the lowering imports
+// across the chunk boundary via the eager forwarder's overlay, creating the emergent A -> B edge.
+function makePv() {
+  return 'PV';
+}
+
+// A pure call initializer: order-sensitive (so the deviation can flag this module) yet
+// side-effect-free and not const-inlinable (so the binding stays materialized).
+export const pv = /* @__PURE__ */ makePv();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/b/eagerhaz.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/b/eagerhaz.js
@@ -1,0 +1,9 @@
+// The eager hazard in chunk B: earlier than every planned module in the root's expected order, so
+// on-demand wrapping legitimately leaves it eager — its record-position interop trigger runs in
+// chunk B's *body*. Once the lowering closes the A <-> B cycle through the forwarder's overlay,
+// B's body evaluates before A's, and this eager `require_carrier()` call reads the not-yet-assigned
+// CJS wrapper var from chunk A: `TypeError: require_carrier is not a function`. The emergent-cycle
+// fixpoint must project the overlay edge and wrap it.
+import carrier from '../a/carrier.cjs.js';
+globalThis.__carried = carrier();
+export const ready = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/e-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/e-first.js
@@ -1,0 +1,5 @@
+// Side-effectful module hosted in the entry chunk: the predicted order runs it after the grouped
+// chunks, the source order runs it before the definer subtree — the deviation that seeds the wrap
+// plan with `definer` (imported after it through the forwarder) without touching `eagerhaz`.
+(globalThis.__events ??= []).push('e-first');
+export const first = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/main.js
@@ -1,0 +1,24 @@
+// Hole 1 — an *eager* re-export barrel closes an emergent chunk cycle through its import overlay.
+//
+// The forwarder in chunk A stays eager (a pure `export { x } from` with no order-sensitivity of
+// its own), so on-demand wrapping never plans it. But its retained re-export of the order-wrapped
+// `definer` still makes the lowering emit `init_definer()` in A's body and register A's dependency
+// on `init_definer` — a cross-chunk A -> B edge carried by an `OrderImportOverlay`, not by an
+// `init_A` the projector can see. Together with the baseline B -> A edge (chunk B's `eagerhaz`
+// eagerly requires chunk A's CJS carrier) that closes a real A <-> B cycle. Chunk B's body then
+// runs before chunk A assigns its `var require_carrier`, so `eagerhaz`'s record-position
+// `require_carrier()` reads the unassigned var — the C-class `require_* is not a function` startup
+// crash, recurring because the projector skips every importer without its own ESM `init_*`.
+//
+// Source order pins the expected evaluation: a-first (A), the eager carrier reader (B), e-first
+// (entry chunk), then the definer subtree (B). The entry-chunk-hosted e-first runs after the
+// grouped chunks in the predicted order but before the definer subtree in source order, so
+// `definer` deviates (premature) and joins the wrap plan — while `eagerhaz`, earlier than every
+// planned module in this root's expected order, legitimately stays eager, and the pure forwarder
+// is never order-sensitive so it stays eager too.
+import './a/a-first.js';
+import './b/eagerhaz.js';
+import './e-first.js';
+import { marker, pv } from './a/forwarder.js';
+
+globalThis.__result = { pv, marker: marker(), carried: globalThis.__carried };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": { "onDemandWrapping": true },
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "a",
+          "test": "[\\\\/]emergent_cycle_excluded_forwarder_import[\\\\/]a[\\\\/]"
+        },
+        {
+          "name": "c",
+          "test": "[\\\\/]emergent_cycle_excluded_forwarder_import[\\\\/]c[\\\\/]"
+        }
+      ]
+    }
+  },
+  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+
+// The pre-lowering chunk graph is acyclic; applying the wrap plan adds chunk A's `init_t` import
+// (A -> C) through the wrapped barrel's excluded `export * from f` hop — the excluded-statement
+// metadata walks every static import of the non-included `f` and finds `import { unused } from
+// '../c/t.js'`. That closes a chunk cycle with the baseline C -> A edge from the eager reader's CJS
+// carrier. The fixpoint projector resolves that hop through `f`'s resolved exports instead, and
+// `unused` is not re-exported, so it misses A -> C. Without unifying the projection with the actual
+// transitive-metadata routing, the eager reader's record-position interop trigger runs mid-cycle and
+// reads A's not-yet-assigned `var require_carrier` — `TypeError: require_carrier is not a function`.
+await import('./dist/main.js');
+
+assert.strictEqual(
+  globalThis.__carried,
+  'CARRIED',
+  `the eager interop read must observe the assigned CJS wrapper; got ${JSON.stringify(globalThis.__carried)}`,
+);
+assert.deepStrictEqual(
+  globalThis.__result,
+  { wv: 'WV', tv: 'TV', carried: 'CARRIED' },
+  `strict order must deliver initialized values; got ${JSON.stringify(globalThis.__result)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/a-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/a-first.js
@@ -1,0 +1,5 @@
+// Earliest-discovered side-effectful member of chunk A: makes the first root import chunk A before
+// chunk C, so at runtime A starts evaluating first and the lowering-added A -> C hop import is what
+// first reaches C.
+(globalThis.__events ??= []).push('a-first');
+export const aFirst = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/carrier.cjs.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/carrier.cjs.js
@@ -1,0 +1,7 @@
+// CJS interop carrier hosted in chunk A. Its `var require_carrier = __commonJSMin(...)` declaration
+// is assigned in A's chunk *body* — during the emergent cycle's evaluation, chunk C's body runs
+// before A's, so an eager read of this wrapper from C observes the unassigned var (vue-vben-admin's
+// `qe is not a function` shape).
+module.exports = function carrier() {
+  return 'CARRIED';
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/wrapper.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/a/wrapper.js
@@ -1,0 +1,15 @@
+// Order-wrapped barrel in chunk A. Its own pure-call export `wv` makes it order-sensitive so the
+// first root's deviation wraps it. Beside `wv` it carries a tree-shaken `export * from '../f.js'`:
+// nothing consumes `f`'s exports, so the statement is excluded — but because this barrel is
+// order-wrapped, the excluded-statement metadata still forwards through the hop, walking the
+// non-included `f`'s static imports and forwarding `init_wrapper` to the `init_t` it finds there.
+// That is the cross-chunk A -> C edge the projector's resolved-exports walk cannot see.
+export * from '../f.js';
+
+function mkWv() {
+  return 'WV';
+}
+
+// Pure call initializer: order-sensitive (so the deviation can flag this module) yet side-effect
+// free and not const-inlinable (so the binding stays materialized).
+export const wv = /* @__PURE__ */ mkWv();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/c/eagerhaz.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/c/eagerhaz.js
@@ -1,0 +1,8 @@
+// The eager hazard in chunk C: earlier than every planned module in the first root's expected
+// order, so on-demand wrapping legitimately leaves it eager — its record-position interop trigger
+// runs in chunk C's *body*. Once the lowering closes the A <-> C cycle through the wrapped barrel's
+// excluded hop, C's body evaluates before A's, and this eager `require_carrier()` call reads the
+// not-yet-assigned CJS wrapper var from chunk A: `TypeError: require_carrier is not a function`.
+import carrier from '../a/carrier.cjs.js';
+globalThis.__carried = carrier();
+export const ready = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/c/t.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/c/t.js
@@ -1,0 +1,10 @@
+// Definer in chunk C, order-wrapped through the second root's premature deviation. `tv` is consumed
+// by the second root (keeps `t` order-sensitive and included); `unused` is imported by the
+// non-included forwarder `f` but never re-exported, so only the excluded-statement metadata's
+// walk-every-static-import routing reaches it — the divergence the projector misses.
+function mkTv() {
+  return 'TV';
+}
+
+export const tv = /* @__PURE__ */ mkTv();
+export const unused = 'UNUSED';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/e-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/e-first.js
@@ -1,0 +1,5 @@
+// Side-effectful module hosted in the first root's entry chunk: the predicted order runs it after
+// the grouped chunks, the source order runs it before the wrapper subtree — the deviation that
+// wraps the `wrapper` barrel without touching `eagerhaz`.
+(globalThis.__events ??= []).push('e-first');
+export const first = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/f.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/f.js
@@ -1,0 +1,9 @@
+// Non-included forwarder. Nothing consumes its exports (the barrel's `export * from` hop is
+// tree-shaken), so `f` itself is dropped from the output — but its `import { unused } from` record
+// still resolves to the order-wrapped `t`. The excluded-statement metadata walks every static
+// import of a non-included forwarder, so it registers `init_t` for the barrel that re-exports `f`;
+// the projector, which only follows `f`'s resolved *exports*, never reaches `t` because `unused` is
+// not re-exported.
+import { unused } from './c/t.js';
+
+export const forwarded = unused;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/main.js
@@ -1,0 +1,26 @@
+// Hole 2 — a wrapped barrel's *excluded* `export * from` hop routes init through a non-included
+// forwarder's plain static import, an edge the projector never resolves.
+//
+// The wrapped barrel `wrapper` (chunk A) carries a tree-shaken `export * from '../f.js'`. The real
+// excluded-statement metadata walks EVERY static import of the non-included `f` — including its
+// `import { unused } from '../c/t.js'` — and registers `init_t`, so the lowering makes chunk A
+// import `init_t` from chunk C (A -> C). The fixpoint projector instead resolves that same hop with
+// `collect_wrapped_esm_init_targets_for_import_record`, which follows `f`'s resolved *exports*;
+// `unused` is imported by `f` but never re-exported, so it is not among them and the projector
+// misses A -> C. Together with the baseline C -> A edge (chunk C's `eagerhaz` eagerly requires chunk
+// A's CJS carrier) that is an undetected emergent A <-> C cycle: chunk C's body runs before chunk A
+// assigns its `var require_carrier`, so `eagerhaz`'s record-position `require_carrier()` reads the
+// unassigned var — the C-class `require_* is not a function` startup crash.
+//
+// `t` is imported directly (last) only so it is a live, order-wrapped module: its own source
+// position, reached first through the `wrapper` subtree after the entry-chunk `e-first`, makes it
+// deviate (premature) and join the wrap plan. That direct import adds an entry-chunk -> C edge but
+// never reveals the A -> C hop, so the A <-> C cycle stays invisible to the projector, while
+// `eagerhaz` — earlier than every planned module in the expected order — legitimately stays eager.
+import './a/a-first.js';
+import './c/eagerhaz.js';
+import './e-first.js';
+import { wv } from './a/wrapper.js';
+import { tv } from './c/t.js';
+
+globalThis.__result = { wv, tv, carried: globalThis.__carried };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": { "onDemandWrapping": true },
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "a",
+          "test": "[\\\\/]emergent_cycle_partial_forwarder[\\\\/]a[\\\\/]"
+        },
+        {
+          "name": "b",
+          "test": "[\\\\/]emergent_cycle_partial_forwarder[\\\\/]b[\\\\/]"
+        }
+      ]
+    }
+  },
+  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+// Regression pin for the B (partial forwarder discharge) x C (emergent cycle) composition: the
+// forwarder discharges its live `pv` hop (closing the emergent A <-> B cycle the fixpoint wraps),
+// its dead `unused` hop triggers nothing, and the eager interop reader is deferred past both chunk
+// bodies. Must deliver initialized values in both strict modes with no startup crash.
+await import('./dist/main.js');
+
+assert.strictEqual(
+  globalThis.__carried,
+  'CARRIED',
+  `the eager interop read must observe the assigned CJS wrapper; got ${JSON.stringify(globalThis.__carried)}`,
+);
+assert.deepStrictEqual(
+  globalThis.__result,
+  { pv: 'PV', bv: 'BV', marker: 'F', carried: 'CARRIED' },
+  `strict order must deliver initialized values; got ${JSON.stringify(globalThis.__result)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/a-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/a-first.js
@@ -1,0 +1,3 @@
+// Earliest side-effectful member of chunk A: makes the entry import chunk A before chunk B.
+(globalThis.__events ??= []).push('a-first');
+export const aFirst = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/carrier.cjs.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/carrier.cjs.js
@@ -1,0 +1,5 @@
+// CJS interop carrier in chunk A, body-assigned so an eager mid-cycle read from chunk B observes
+// the not-yet-assigned wrapper var without the fixpoint.
+module.exports = function carrier() {
+  return 'CARRIED';
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/forwarder.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/a/forwarder.js
@@ -1,0 +1,14 @@
+// Eager partial forwarder in chunk A. The exported function keeps it retained without making it
+// order-sensitive (it stays eager). It has two re-export hops:
+//   - `export { pv } from '../b/definer.js'` — pv is consumed through this forwarder, so the hop is
+//     included and the forwarder discharges it: this is the included hop that closes the emergent
+//     A <-> B cycle (its `init_definer` overlay makes chunk A import chunk B).
+//   - `export { unused } from '../b/definer_b.js'` — nothing consumes this binding, so the hop is
+//     tree-shaken (excluded). A legally dead pure hop must trigger nothing; the projection must not
+//     route it, or it would over-init definer_b for pages consuming none of its bindings.
+export function marker() {
+  return 'F';
+}
+
+export { pv } from '../b/definer.js';
+export { unused } from '../b/definer_b.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/definer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/definer.js
@@ -1,0 +1,5 @@
+// Order-wrapped definer in chunk B, target of the forwarder's *included* hop.
+function makePv() {
+  return 'PV';
+}
+export const pv = /* @__PURE__ */ makePv();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/definer_b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/definer_b.js
@@ -1,0 +1,8 @@
+// Second order-wrapped definer in chunk B. `bv` is consumed directly by the entry (so definer_b is
+// included and order-wrapped), while `unused` is only re-exported by the forwarder and consumed by
+// nobody — the forwarder's excluded hop targets it.
+function makeBv() {
+  return 'BV';
+}
+export const bv = /* @__PURE__ */ makeBv();
+export const unused = 'UNUSED';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/eagerhaz.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/b/eagerhaz.js
@@ -1,0 +1,6 @@
+// Eager interop reader in chunk B: its record-position require runs in chunk B's body. Once the
+// forwarder's included hop closes the A <-> B cycle, the fixpoint must wrap this so the read waits
+// for chunk A's carrier assignment.
+import carrier from '../a/carrier.cjs.js';
+globalThis.__carried = carrier();
+export const ready = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/e-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/e-first.js
@@ -1,0 +1,4 @@
+// Entry-chunk side effect: the predicted order runs it after the grouped chunks, the source order
+// before the forwarder subtree — the deviation that seeds the wrap plan.
+(globalThis.__events ??= []).push('e-first');
+export const first = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/main.js
@@ -1,0 +1,16 @@
+// Composition regression pin — a *partial* eager forwarder (one included hop to a wrapped definer,
+// one tree-shaken excluded hop to another wrapped definer) sitting inside the emergent chunk cycle.
+//
+// This guards the B/C interaction: the forwarder owns the init of the binding it actually
+// discharges (`pv`, an included hop → the B per-obligation rule), the excluded `export { unused }`
+// hop stays silent (tree-shaking equivalence), and at the same time the forwarder's included hop
+// closes the emergent A <-> B cycle that the fixpoint must wrap (the C rule). The two rules compose:
+// the projection routes only the live included hop, the fixpoint converges, and the eager interop
+// reader is deferred so nothing crashes. Expected green in both strict modes.
+import './a/a-first.js';
+import './b/eagerhaz.js';
+import './e-first.js';
+import { pv, marker } from './a/forwarder.js';
+import { bv } from './b/definer_b.js';
+
+globalThis.__result = { pv, bv, marker: marker(), carried: globalThis.__carried };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": false,
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": { "onDemandWrapping": true },
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "s",
+          "test": "[\\\\/]emergent_init_cycle_eager_interop[\\\\/]s[\\\\/]"
+        },
+        {
+          "name": "h",
+          "test": "[\\\\/]emergent_init_cycle_eager_interop[\\\\/]h[\\\\/]"
+        }
+      ]
+    }
+  },
+  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+
+// The pre-lowering chunk graph is acyclic; applying the wrap plan adds the barrel's cross-chunk
+// `init_pure` import (S -> H), which closes a chunk cycle with the baseline H -> S edge from the
+// eager module's CJS carrier. Chunk H's body then evaluates before chunk S's. Without the
+// emergent-cycle fixpoint the eager module's record-position interop trigger runs mid-cycle and
+// reads S's not-yet-assigned `var require_carrier_cjs` — `TypeError: require_carrier_cjs is not a
+// function` (vue-vben-admin's `qe is not a function`). The fixpoint wraps chunk H's eligible
+// modules, deferring the read until after both chunk bodies.
+await import('./dist/main.js');
+
+assert.strictEqual(
+  globalThis.__carried,
+  'CARRIED',
+  `the eager interop read must observe the assigned CJS wrapper; got ${JSON.stringify(globalThis.__carried)}`,
+);
+assert.deepStrictEqual(
+  globalThis.__result,
+  { pv: 'PV', bmark: 'B', carried: 'CARRIED' },
+  `strict order must deliver initialized values; got ${JSON.stringify(globalThis.__result)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/e-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/e-first.js
@@ -1,0 +1,5 @@
+// Side-effectful module hosted in the entry chunk: the predicted order runs it after the grouped
+// chunks, the source order runs it before the barrel subtree — the deviation that seeds the wrap
+// plan with the two modules imported after it (pure, barrel) without touching eagerhaz.
+(globalThis.__events ??= []).push('e-first');
+export const first = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/h/eagerhaz.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/h/eagerhaz.js
@@ -1,0 +1,8 @@
+// The eager hazard: earlier than every planned module in the root's expected order, so on-demand
+// wrapping legitimately leaves it eager — its record-position interop trigger runs in chunk H's
+// *body*. Once the lowering closes the S <-> H cycle, H's body evaluates before S's, and this
+// eager `require_carrier_cjs()` call reads the not-yet-assigned CJS wrapper var from chunk S:
+// `TypeError: require_carrier_cjs is not a function`. The emergent-cycle fixpoint must wrap it.
+import carrier from '../s/carrier.cjs.js';
+globalThis.__carried = carrier();
+export const ready = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/h/pure.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/h/pure.js
@@ -1,0 +1,8 @@
+// Side-effect-free definer in chunk H, order-wrapped through the premature deviation. It is the
+// target of the barrel's re-export hop, so its `init_pure` is what the lowering imports across
+// the chunk boundary, creating the emergent S -> H edge.
+function makePv() {
+  return 'PV';
+}
+
+export const pv = /* @__PURE__ */ makePv();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/main.js
@@ -1,0 +1,11 @@
+// Entry for the emergent-chunk-cycle shape. Source order pins the expected evaluation:
+// s-first (chunk S), the eager interop reader (chunk H), e-first (entry chunk), then the barrel
+// (chunk S). The entry-chunk-hosted e-first runs *after* the grouped chunks in the predicted
+// order but *before* the barrel subtree in source order, so `pure` and `barrel` deviate
+// (premature) and join the wrap plan — while `eagerhaz`, earlier than every planned module in
+// this root's expected order, legitimately stays eager.
+import './s/s-first.js';
+import './h/eagerhaz.js';
+import './e-first.js';
+import { pv, bmark } from './s/barrel.js';
+globalThis.__result = { pv, bmark, carried: globalThis.__carried };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/barrel.js
@@ -1,0 +1,13 @@
+// Order-wrapped barrel in chunk S. Its re-export hop targets the wrapped `pure` in chunk H, so
+// the lowering forwards `init_barrel` to `init_pure` — a *new* cross-chunk import S -> H that no
+// pre-lowering analysis edge predicted. Together with the baseline H -> S edge (eagerhaz's CJS
+// carrier) this closes the emergent chunk cycle.
+export { pv } from '../h/pure.js';
+
+function makeBmark() {
+  return 'B';
+}
+
+// A pure call initializer: order-sensitive (so the deviation can flag this module) yet
+// side-effect-free and not const-inlinable (so the binding stays materialized).
+export const bmark = /* @__PURE__ */ makeBmark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/carrier.cjs.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/carrier.cjs.js
@@ -1,0 +1,7 @@
+// CJS interop carrier hosted in chunk S. Its `var require_carrier_cjs = __commonJSMin(...)`
+// declaration is assigned in S's chunk *body* — during the emergent cycle's evaluation, chunk H's
+// body runs before S's, so an eager read of this wrapper from H observes the unassigned var
+// (vue-vben-admin's `qe is not a function` shape).
+module.exports = function carrier() {
+  return 'CARRIED';
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/s-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/s/s-first.js
@@ -1,0 +1,5 @@
+// Earliest-discovered side-effectful member of chunk S: makes the entry import chunk S before
+// chunk H, so at runtime S starts evaluating first and the lowering-added S -> H wrapper import
+// (not the entry) is what first reaches H.
+(globalThis.__events ??= []).push('s-first');
+export const sFirst = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
@@ -1,0 +1,21 @@
+{
+  "snapshot": false,
+  "config": {
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "pref",
+          "test": "[\\\\/]node_modules[\\\\/]pref-pkg[\\\\/](?:facade|manager)\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+
+await import('./dist/main.js');
+
+assert.strictEqual(
+  globalThis.__result,
+  'tag:PREF_OK',
+  'sync capture must observe the initialized wrapped facade',
+);
+assert.strictEqual(
+  await globalThis.__ready,
+  'tag:PREF_OK',
+  'async capture must observe the initialized wrapped facade',
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/first.js
@@ -1,0 +1,7 @@
+// Side-effectful module hosted in the entry chunk. Source order runs it before the manager, but
+// the manager sits in a grouped chunk the entry chunk imports, so the predicted evaluation order
+// runs the manager's chunk first — a real order deviation that puts the manager (and, through the
+// plan closure, the facade and the entry) into the on-demand wrap plan without a chunk cycle.
+(globalThis.__events ??= []).push('first');
+
+export const ready = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/main.js
@@ -1,0 +1,16 @@
+import './first.js';
+import { getPref, tag } from 'pref-pkg';
+
+(globalThis.__events ??= []).push('main');
+
+function boot() {
+  return tag(getPref());
+}
+
+async function initApplication() {
+  const pref = await getPref();
+  return tag(pref);
+}
+
+globalThis.__result = boot();
+globalThis.__ready = initApplication();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/facade.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/facade.js
@@ -1,0 +1,7 @@
+// The order-wrapped facade (`@vben-core/preferences` shape): declared side-effect free by the
+// package, but its exported value is assigned at init time from the wrapped side-effectful manager
+// — so `getPref` is `undefined` until `init_facade()` runs. It joins the wrap plan through the
+// closure rules: it statically imports the planned manager and reads its export at top level.
+import { makePref } from './manager.js';
+
+export const getPref = makePref();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/index.js
@@ -1,0 +1,14 @@
+// Pure package barrel (`@vben/preferences` shape): one own helper the entry uses — which keeps the
+// barrel included — plus a star re-export of the wrapped facade. The package declares only
+// `./manager.js` as side-effectful, so this barrel is side-effect free: on-demand wrapping leaves
+// it eager in the entry chunk, and the star statement is excluded because `getPref` resolves
+// through it to the facade's own declaration. Because the barrel is eager and that hop is
+// tree-shaken, the barrel itself forwards nothing (its excluded statement emits no `init_facade()`)
+// — so the consuming entry owns the trigger and emits `init_facade()` at its own import position,
+// as the caller-side golden shows. Delegation would only apply to a forwarder that actually
+// discharges its hops.
+export function tag(value) {
+  return `tag:${value}`;
+}
+
+export * from './facade.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/manager.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/manager.js
@@ -1,0 +1,8 @@
+// The package's one side-effectful module, grouped into its own chunk with the facade. The entry
+// chunk imports this chunk (the entry consumes `getPref`), so the predicted order runs this module
+// before `first.js` while source order runs it after — the deviation that seeds the wrap plan.
+(globalThis.__events ??= []).push('manager');
+
+export function makePref() {
+  return () => 'PREF_OK';
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/node_modules/pref-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pref-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": ["./manager.js"],
+  "main": "index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/_config.json
@@ -11,6 +11,11 @@
     {
       "_configName": "strict",
       "strictExecutionOrder": true
+    },
+    {
+      "_configName": "strict-on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ],
   "expectExecuted": false

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
@@ -73,3 +73,43 @@ __esmMin((() => {
 export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```
+
+# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### lazy-chunk.js
+
+```js
+import { n as init_user_lib, r as __esmMin, t as foo } from "./main.js";
+//#endregion
+__esmMin((() => {
+	init_user_lib();
+	foo();
+}))();
+
+```
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region user-lib.js
+async function foo() {
+	return import("./lazy-chunk.js");
+}
+var init_user_lib = __esmMin((() => {
+	Object.somePolyfilledFunction();
+}));
+__esmMin((() => {
+	//#region polyfill.js
+	Object.somePolyfilledFunction = () => {};
+	//#endregion
+	//#region main.js
+	init_user_lib();
+	foo();
+	//#endregion
+}))();
+export { init_user_lib as n, __esmMin as r, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/_config.json
@@ -15,6 +15,11 @@
     {
       "_configName": "strict",
       "strictExecutionOrder": true
+    },
+    {
+      "_configName": "strict-on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ],
   "expectExecuted": false

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
@@ -80,3 +80,50 @@ var init_run_dep = __esmMin((() => {
 export { __esmMin as n, init_run_dep as t };
 
 ```
+
+# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### entry1.js
+
+```js
+import { n as __esmMin, t as init_run_dep } from "./run-dep.js";
+__esmMin((() => {
+	//#region init-dep-1.js
+	global.foo = { log: () => console.log("foo.log() (from entry 1) called") };
+	//#endregion
+	//#region entry1.js
+	init_run_dep();
+	//#endregion
+}))();
+
+```
+
+### entry2.js
+
+```js
+import { n as __esmMin, t as init_run_dep } from "./run-dep.js";
+__esmMin((() => {
+	//#region init-dep-2.js
+	global.foo = { log: () => console.log("foo.log() (from entry 2) called") };
+	//#endregion
+	//#region entry2.js
+	init_run_dep();
+	//#endregion
+}))();
+
+```
+
+### run-dep.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region run-dep.js
+var init_run_dep = __esmMin((() => {
+	global.foo.log();
+}));
+//#endregion
+export { __esmMin as n, init_run_dep as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
@@ -5,6 +5,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -49,3 +49,24 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+var value;
+__esmMin((() => {
+	//#region lib-foo.js
+	value = "foo";
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(value, "foo");
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
@@ -5,6 +5,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -49,3 +49,24 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+var value;
+__esmMin((() => {
+	//#region lib-foo.js
+	value = "foo";
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(value, "foo");
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
@@ -2,5 +2,12 @@
   "config": {
     "strictExecutionOrder": true,
     "minify": false
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -42,3 +42,34 @@ var init_main = __esmMin((() => {
 init_main();
 export { inner_exports as star };
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+var inner_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+
+var foo;
+var init_inner = __esmMin((() => {
+//#region leaf.js
+	;
+	foo = 1;
+
+//#endregion
+}));
+
+
+var init_main = __esmMin((() => {
+//#region outer.js
+	init_inner();
+
+//#endregion
+}));
+
+init_main();
+export { inner_exports as star };
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
@@ -5,5 +5,12 @@
     "experimental": {
       "devMode": {}
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -26,3 +26,31 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.cjs
+var require_foo = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	__rolldown_runtime__.createModuleHotContext("foo.cjs");
+	__rolldown_runtime__.registerModule("foo.cjs", module);
+	module.exports.value = "foo";
+}));
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({}), import_foo;
+//#endregion
+__esmMin((() => {
+	import_foo = require_foo();
+	__rolldown_runtime__.createModuleHotContext("main.js");
+	__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+	nodeAssert.strictEqual(import_foo.value, "foo");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
@@ -1,5 +1,12 @@
 {
   "config": {
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -40,3 +40,34 @@ __esmMin((() => {
 export { Foo, fooClasses, getFooUtilityClass };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region components/Foo/fooClasses.js
+function getFooUtilityClass(slot) {
+	return "MuiFoo-" + slot;
+}
+const fooClasses = { root: "MuiFoo-root" };
+//#endregion
+//#region components/Foo/Foo.js
+var Foo;
+var init_Foo$1 = __esmMin((() => {
+	Foo = {
+		name: "Foo",
+		root: fooClasses.root
+	};
+}));
+__esmMin((() => {
+	//#region components/Foo/index.js
+	init_Foo$1();
+	//#endregion
+}))();
+export { Foo, fooClasses, getFooUtilityClass };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
@@ -9,5 +9,12 @@
     "external": ["node:assert"],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "false"
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -52,3 +52,57 @@ export { node2_exports as n, init_node2 as t };
 export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### node0.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node0.js
+var node_0;
+//#endregion
+__esmMin((() => {
+	globalThis.__acyclic_output_fuzz_0 = 0;
+	import("./node1.js").then((n) => (n.t(), n.n));
+	node_0 = {};
+	node_0.value = 0;
+}))();
+
+```
+
+### node1.js
+
+```js
+import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node2.js
+var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
+var node_2;
+var init_node2 = __esmMin((() => {
+	globalThis.__acyclic_output_fuzz_2 = 2;
+	import("./node0.js");
+	node_2 = {};
+	node_2.value = 2;
+}));
+//#endregion
+//#region node1.cjs
+var require_node1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__acyclic_output_fuzz_1 = 1;
+	init_node2();
+	exports.node_1 = 1;
+}));
+//#endregion
+export default require_node1();
+export { node2_exports as n, init_node2 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "Expected to fail until rolldown#10104 is applied.",
+    "outputContains": ["ambiguous namespace re-export must not initialize common-a before page-b"]
+  },
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": [
+          "ambiguous namespace re-export must not initialize common-a before page-b"
+        ]
+      },
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/bridge.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/bridge.js
@@ -1,0 +1,7 @@
+export function ok() {
+  return 1;
+}
+
+// `collision` is ambiguous and therefore absent from this module's namespace.
+export * from './common-a.js';
+export * from './common-b.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/common-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/common-a.js
@@ -1,0 +1,6 @@
+function mark() {
+  globalThis.valueA = typeof globalThis.valueA === 'number' ? globalThis.valueA + 1 : 0;
+  return 'a';
+}
+
+export const collision = /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/common-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/common-b.js
@@ -1,0 +1,6 @@
+function mark() {
+  globalThis.valueB = typeof globalThis.valueB === 'number' ? globalThis.valueB + 1 : 0;
+  return 'b';
+}
+
+export const collision = /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/main.js
@@ -1,0 +1,2 @@
+await import('./page-b.js');
+await import('./page-a.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/page-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/page-a.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import { collision as a } from './common-a.js';
+import { collision as b } from './common-b.js';
+
+assert.strictEqual(globalThis.valueA, 0);
+assert.strictEqual(globalThis.valueB, 0);
+assert.strictEqual(a, 'a');
+assert.strictEqual(b, 'b');
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/page-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/page-b.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import * as bridge from './bridge.js';
+
+assert.strictEqual(bridge[globalThis.__bridgeKey || 'ok'](), 1);
+assert.strictEqual(
+  globalThis.valueA,
+  undefined,
+  'ambiguous namespace re-export must not initialize common-a before page-b',
+);
+assert.strictEqual(globalThis.valueB, undefined);
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
@@ -1,0 +1,21 @@
+{
+  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "Expected to fail until rolldown#10104 is applied.",
+    "outputContains": ["dead namespace star must not initialize default-only before page-b"]
+  },
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "_expectExecutionFailure": {
+        "reason": "Expected to fail until rolldown#10104 is applied.",
+        "outputContains": ["dead namespace star must not initialize default-only before page-b"]
+      },
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/bridge.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/bridge.js
@@ -1,0 +1,8 @@
+export function x() {
+  return 1;
+}
+
+// Neither star contributes to this module's namespace: the first `x` is shadowed by the local
+// declaration above, while `export *` never forwards the second module's default export.
+export * from './shadowed.js';
+export * from './default-only.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/default-only.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/default-only.js
@@ -1,0 +1,7 @@
+function mark() {
+  globalThis.defaultValue =
+    typeof globalThis.defaultValue === 'number' ? globalThis.defaultValue + 1 : 0;
+  return 42;
+}
+
+export default /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/main.js
@@ -1,0 +1,2 @@
+await import('./page-b.js');
+await import('./page-a.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/page-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/page-a.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import defaultValue from './default-only.js';
+import { x } from './shadowed.js';
+
+assert.strictEqual(globalThis.defaultValue, 0);
+assert.strictEqual(globalThis.shadowedValue, 0);
+assert.strictEqual(defaultValue, 42);
+assert.strictEqual(x, 2);
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/page-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/page-b.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import * as bridge from './bridge.js';
+
+assert.strictEqual(bridge[globalThis.__bridgeKey || 'x'](), 1);
+assert.strictEqual(
+  globalThis.defaultValue,
+  undefined,
+  'dead namespace star must not initialize default-only before page-b',
+);
+assert.strictEqual(globalThis.shadowedValue, undefined);
+
+export function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/shadowed.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/shadowed.js
@@ -1,0 +1,7 @@
+function mark() {
+  globalThis.shadowedValue =
+    typeof globalThis.shadowedValue === 'number' ? globalThis.shadowedValue + 1 : 0;
+  return 2;
+}
+
+export const x = /* @__PURE__ */ mark();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
@@ -1,0 +1,25 @@
+{
+  "snapshot": false,
+  "config": {
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "ca",
+          "test": "[\\\\/]cyc-a\\.js$"
+        },
+        {
+          "name": "cb",
+          "test": "[\\\\/]cyc-b\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const page = await import('./dist/main.js');
+const loaded = await page.loadPage();
+
+// The reader captured the barrel namespace at init but reads a member only now, through this
+// deferred call (like recharts' render-time `scales[realScaleType]()`). The factory reads the
+// definer's module-level `unit`, which is only assigned when the definer's `init_*()` runs. Under
+// strict execution order the barrel's own `init_*` must forward to the side-effect-free definer's
+// `init_*` at init time. The regression left the barrel init empty, so `unit` stayed `undefined`
+// and the scale reads back `NO_UNIT`.
+const result = loaded.getScale('scaleLinear');
+assert.strictEqual(
+  result,
+  7,
+  `barrel must forward init to the pure definer so the scale reads its unit; got ${JSON.stringify(result)} events=${JSON.stringify(globalThis.__events)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/cyc-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/cyc-a.js
@@ -1,0 +1,10 @@
+// Half of a two-chunk static import cycle (paired with cyc-b.js). Manual chunk groups place cyc-a
+// and cyc-b in separate chunks that import each other, so the predicted chunk-import graph has a
+// cycle reachable from this subtree. Under on-demand wrapping that cycle forces every wrap-eligible
+// module in the subtree — including the otherwise-eager pure definers — into the wrap plan, so the
+// barrel-forward bug reproduces in on-demand mode as well.
+import './cyc-b.js';
+
+(globalThis.__events ??= []).push('cyc-a');
+
+export const a = 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/cyc-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/cyc-b.js
@@ -1,0 +1,6 @@
+// Other half of the two-chunk static import cycle (paired with cyc-a.js).
+import './cyc-a.js';
+
+(globalThis.__events ??= []).push('cyc-b');
+
+export const b = 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/dynamic-page.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/dynamic-page.js
@@ -1,0 +1,3 @@
+export { getScale } from './reader.js';
+
+(globalThis.__events ??= []).push('dynamic-page');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/linear.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/linear.js
@@ -1,0 +1,13 @@
+// Side-effect-free definer: a hoisted factory function plus a module-level `unit` assigned from a
+// pure call at init time (mirrors d3-scale's `var unit` / `class InternMap`). Tree-shaking judges
+// this module side-effect-free, so it is not an execution dependency of the barrel that re-exports
+// it. The `unit` binding is only assigned when `init_linear()` runs.
+function makeUnit() {
+  return { value: 7 };
+}
+
+var unit = /* @__PURE__ */ makeUnit();
+
+export function scaleLinear() {
+  return unit;
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/main.js
@@ -1,0 +1,7 @@
+(globalThis.__events ??= []).push('main');
+
+// The page (and the reader that consumes the pure re-export barrel) lives behind a dynamic import,
+// so the barrel and its side-effect-free definers end up inside an order-wrapped dynamic chunk.
+export function loadPage() {
+  return import('./dynamic-page.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/outer-barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/outer-barrel.js
@@ -1,0 +1,6 @@
+// Outer star-re-export barrel (like victory-vendor's `export * from "d3-scale"`). It re-exports the
+// inner barrel. Its own namespace getters resolve (canonically) to the *leaf* definer bindings, so
+// the leaf definers are its execution dependencies but the intermediate inner barrel is NOT — which
+// is exactly why the barrel-forward decision judges the re-export record dead and emits an empty
+// `init_*`.
+export * from './scale-barrel.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/pow.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/pow.js
@@ -1,0 +1,10 @@
+// Second side-effect-free definer sibling re-exported by the same barrel.
+function makePow() {
+  return { value: 3 };
+}
+
+var unit = /* @__PURE__ */ makePow();
+
+export function scalePow() {
+  return unit;
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/reader.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/reader.js
@@ -1,0 +1,19 @@
+import * as scales from './outer-barrel.js';
+import './cyc-a.js';
+
+(globalThis.__events ??= []).push('reader');
+
+// The barrel namespace is referenced ONLY inside this deferred function, through a computed member
+// key — exactly like recharts' `getD3ScaleFromType`: `var scales = d3Scales; scales[realScaleType]()`.
+// There is no top-level read of the namespace or of any individual member, so no individual
+// `scaleLinear` facade is ever a named import: the whole namespace object is what's retained. Under
+// strict execution order, importing the barrel namespace forwards this module's `init_*` to the
+// outer barrel's `init_*`, and the outer barrel's `init_*` must in turn forward through the inner
+// barrel to the side-effect-free definer's `init_*`. The regression drops that hop, so the
+// definer's `unit` is never assigned.
+export function getScale(name) {
+  const scaleNs = scales;
+  const factory = scaleNs[name];
+  const built = factory();
+  return built ? built.value : 'NO_UNIT';
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/scale-barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/scale-barrel.js
@@ -1,0 +1,5 @@
+// A pure star-re-export barrel (like victory-vendor's `export * from "d3-scale"`): no top-level
+// side effects, only `export *` clauses. Its wrapper `init_*` is emitted as an empty
+// `__esmMin(() => {})` unless the order machinery forwards it to the definers it re-exports.
+export * from './linear.js';
+export * from './pow.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
@@ -1,0 +1,33 @@
+{
+  "snapshot": false,
+  "config": {
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "carbon",
+          "test": "[\\\\/]barrel\\.js$"
+        },
+        {
+          "name": "comp",
+          "test": "[\\\\/](?:checkbox|radio)\\.js$"
+        },
+        {
+          "name": "ca",
+          "test": "[\\\\/]cyc-a\\.js$"
+        },
+        {
+          "name": "cb",
+          "test": "[\\\\/]cyc-b\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const page = await import('./dist/main.js');
+const loaded = await page.loadPage();
+
+// The reader imported two side-effect-free components through a package barrel that plain-imports
+// and re-exports them, and reads them only now in a deferred "render". Under strict execution order
+// the barrel's `init_*` must forward to each component's `init_*` at init time. The regression left
+// the components' `init_*` with zero call sites, so they were still `undefined` at render and
+// `render()` came back `NO_CHECKBOX|NO_RADIO`.
+const result = loaded.render();
+assert.strictEqual(
+  result,
+  'Checkbox|Radio',
+  `barrel must forward init to the plain-imported, re-exported components before the deferred render reads them; got ${JSON.stringify(result)} events=${JSON.stringify(globalThis.__events)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/barrel.js
@@ -1,0 +1,15 @@
+// A package barrel in the `@carbon/react` shape: it does NOT use `export { X } from './x'`
+// (a re-export record). Instead it *plain-imports* each component and re-exports the local binding
+// through a source-less `export { ... }` clause. The plain-import records are not marked
+// `IsReExportOnly`, and the side-effect-free components are not top-level execution dependencies, so
+// under strict order the barrel's `init_*` dropped its forward to each component's `init_*` — the
+// component's `init_*` ended up with zero call sites and its `forwardRef`/definition stayed
+// `undefined` until a render read it. The barrel carries a top-level side effect (like the package's
+// `feature-flags` import) so it stays a real wrapped module in its own chunk rather than being
+// inlined, which is what makes the barrel's own cross-chunk `init_*` forward the load-bearing path.
+import Checkbox from './checkbox.js';
+import Radio from './radio.js';
+
+(globalThis.__events ??= []).push('barrel');
+
+export { Checkbox, Radio };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/checkbox.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/checkbox.js
@@ -1,0 +1,10 @@
+// Side-effect-free component definer (mirrors a `@carbon/react` `forwardRef` component): a pure call
+// builds the component, assigned to a module-level binding at init time. Only assigned when
+// `init_checkbox()` runs.
+function buildComponent() {
+  return { name: 'Checkbox' };
+}
+
+const Checkbox = /* @__PURE__ */ buildComponent();
+
+export default Checkbox;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/cyc-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/cyc-a.js
@@ -1,0 +1,10 @@
+// Half of a two-chunk static import cycle (paired with cyc-b.js). Manual chunk groups place cyc-a
+// and cyc-b in separate chunks that import each other, so the predicted chunk-import graph has a
+// cycle reachable from this subtree. Under on-demand wrapping that cycle forces every wrap-eligible
+// module in the subtree — including the otherwise-eager pure definers — into the wrap plan, so the
+// barrel-forward bug reproduces in on-demand mode as well.
+import './cyc-b.js';
+
+(globalThis.__events ??= []).push('cyc-a');
+
+export const a = 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/cyc-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/cyc-b.js
@@ -1,0 +1,6 @@
+// Other half of the two-chunk static import cycle (paired with cyc-a.js).
+import './cyc-a.js';
+
+(globalThis.__events ??= []).push('cyc-b');
+
+export const b = 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/dynamic-page.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/dynamic-page.js
@@ -1,0 +1,3 @@
+export { render } from './reader.js';
+
+(globalThis.__events ??= []).push('dynamic-page');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/main.js
@@ -1,0 +1,7 @@
+(globalThis.__events ??= []).push('main');
+
+// The page (and the reader that consumes the pure re-export barrel) lives behind a dynamic import,
+// so the barrel and its side-effect-free definers end up inside an order-wrapped dynamic chunk.
+export function loadPage() {
+  return import('./dynamic-page.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/radio.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/radio.js
@@ -1,0 +1,8 @@
+// Second side-effect-free component definer plain-imported and re-exported by the same barrel.
+function buildComponent() {
+  return { name: 'Radio' };
+}
+
+const Radio = /* @__PURE__ */ buildComponent();
+
+export default Radio;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/reader.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/reader.js
@@ -1,0 +1,14 @@
+import { Checkbox, Radio } from './barrel.js';
+import './cyc-a.js';
+
+(globalThis.__events ??= []).push('reader');
+
+// The imported components are read only later, from this deferred "render" function (like a React
+// component body referencing a `@carbon/react` component). By then the barrel's `init_*` must have
+// forwarded to each component's `init_*`; the regression dropped that forward, so the components
+// were still `undefined` at render time.
+export function render() {
+  const c = Checkbox ? Checkbox.name : 'NO_CHECKBOX';
+  const r = Radio ? Radio.name : 'NO_RADIO';
+  return `${c}|${r}`;
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
@@ -5,6 +5,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -27,3 +27,18 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+__esmMin((() => {
+	nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should be removed");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
@@ -2,5 +2,12 @@
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -65,3 +65,67 @@ export { render };
 export { __esmMin as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-a.js").then(console.log);
+	await import("./page-b.js").then(console.log);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import nodeAssert from "node:assert";
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+function render() {
+	console.log(common, _);
+}
+var common, _;
+__esmMin((() => {
+	//#region common.js
+	common = "common";
+	_ = /*#__PURE__*/ foo();
+	//#endregion
+	//#region page-a.js
+	nodeAssert.strictEqual(globalThis.value, 0);
+	//#endregion
+}))();
+export { render };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import nodeAssert from "node:assert";
+//#region page-b.js
+function render() {}
+//#endregion
+__esmMin((() => {
+	nodeAssert.strictEqual(globalThis.value, 0);
+}))();
+export { render };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
@@ -9,5 +9,12 @@
     "strictExecutionOrder": true,
     "minify": true
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -8,3 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}var n=e((()=>{}));await e((async()=>{n(),await t()}))();
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}await e((async()=>{await t()}))();
+```

--- a/crates/rolldown/tests/rolldown/issues/10013/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10013/_config.json
@@ -13,5 +13,12 @@
     "treeshake": {
       "moduleSideEffects": false
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
@@ -45,3 +45,45 @@ var init_leaf = __esmMin((() => {
 export { __esmMin as i, init_helper as n, other as r, init_leaf as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### b.js
+
+```js
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### leaf.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region helper.js
+const other = "other";
+//#endregion
+//#region leaf.js
+var init_leaf = __esmMin((() => {}));
+//#endregion
+export { other as n, __esmMin as r, init_leaf as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10048/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10048/_config.json
@@ -12,5 +12,12 @@
     "experimental": {
       "lazyBarrel": true
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
@@ -39,3 +39,35 @@ __esmMin((() => {
 export { getProjectAnnotations };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region data.js
+const themes = {
+	light: {
+		base: "light",
+		appBg: "#ffffff"
+	},
+	dark: {
+		base: "dark",
+		appBg: "#000000"
+	}
+};
+//#endregion
+function getProjectAnnotations() {
+	return [globalThis.__themes];
+}
+__esmMin((() => {
+	//#region entry.js
+	globalThis.__themes = themes;
+	//#endregion
+}))();
+export { getProjectAnnotations };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/3650/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3650/_config.json
@@ -6,13 +6,20 @@
       "groups": [
         {
           "name": "first",
-          "test": "first"
+          "test": "[\\\\/]first\\.js$"
         },
         {
           "name": "second",
-          "test": "second|\\0rolldown/runtime\\.js"
+          "test": "[\\\\/]second\\.js$|^\\0rolldown/runtime\\.js$"
         }
       ]
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -74,3 +74,79 @@ var init_second = __esmMin((() => {
 export { second_exports as n, value as r, init_second as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## warnings
+
+### INVALID_OPTION
+
+```text
+[INVALID_OPTION] `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
+
+- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+
+To fix:
+
+- Set `preserveEntrySignatures` either to `false` or 'allow-extension' in your config
+
+```
+
+## Assets
+
+### first.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { r as value$1, t as init_second } from "./second.js";
+//#region first.js
+var first_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+var init_first = __esmMin((() => {
+	init_second();
+	value = "first" + value$1;
+}));
+//#endregion
+export { init_first as n, value as r, first_exports as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as second_exports, t as init_second } from "./second.js";
+import { n as init_first, t as first_exports } from "./first.js";
+//#endregion
+__esmMin((() => {
+	init_first();
+	init_second();
+	console.log(first_exports, second_exports);
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+### second.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_first, r as value$1 } from "./first.js";
+//#region second.js
+var second_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+var init_second = __esmMin((() => {
+	init_first();
+	value = "second" + value$1;
+}));
+//#endregion
+export { second_exports as n, value as r, init_second as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/7286/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7286/_config.json
@@ -1,5 +1,12 @@
 {
   "config": {
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
@@ -18,3 +18,23 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+var A, foo;
+//#endregion
+__esmMin((() => {
+	A = { A: "A" };
+	({[A.A]: foo} = { A: "foo" });
+	assert.strictEqual(foo, "foo");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9028/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9028/_config.json
@@ -1,5 +1,12 @@
 {
   "config": {
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
@@ -21,3 +21,15 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463/_config.json
@@ -18,5 +18,12 @@
         }
       ]
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -57,3 +57,60 @@ var init_b = __esmMin((() => {
 export { init_a as n, init_b as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] shared.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a } from "./common~a~b~shared.js";
+init_a();
+
+```
+
+### b.js
+
+```js
+import { t as init_b } from "./common~a~b~shared.js";
+init_b();
+
+```
+
+### common~a~b~shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("b");
+	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
+		foo();
+	});
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
@@ -8,5 +8,12 @@
     "strictExecutionOrder": true,
     "experimental": { "chunkOptimization": true },
     "codeSplitting": { "groups": [{ "name": "common", "entriesAwareMergeThreshold": 10000 }] }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -57,3 +57,60 @@ var init_b = __esmMin((() => {
 export { init_a as n, init_b as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] shared.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a } from "./common.js";
+init_a();
+
+```
+
+### b.js
+
+```js
+import { t as init_b } from "./common.js";
+init_b();
+
+```
+
+### common.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("b");
+	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
+		foo();
+	});
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
@@ -11,5 +11,12 @@
     "codeSplitting": {
       "groups": [{ "name": "common", "entriesAware": true, "entriesAwareMergeThreshold": 10000 }]
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
@@ -61,3 +61,62 @@ var init_c = __esmMin((() => {
 export { init_b as n, init_a as r, init_c as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { r as init_a } from "./common~a~b~c.js";
+init_a();
+
+```
+
+### b.js
+
+```js
+import { n as init_b } from "./common~a~b~c.js";
+init_b();
+
+```
+
+### c.js
+
+```js
+import { t as init_c } from "./common~a~b~c.js";
+init_c();
+
+```
+
+### common~a~b~c.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("a");
+	foo();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("b");
+	foo();
+}));
+//#endregion
+//#region c.js
+var init_c = __esmMin((() => {
+	(globalThis.sideEffectLog ??= []).push("c");
+	foo();
+}));
+//#endregion
+export { init_b as n, init_a as r, init_c as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9806/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9806/_config.json
@@ -9,6 +9,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -45,3 +45,29 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region pkg-barrel/other.cjs
+var require_other = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "other-value";
+}));
+//#endregion
+var import_other;
+__esmMin((() => {
+	//#region pkg-barrel/index.mjs
+	import_other = /* @__PURE__ */ __toESM(require_other(), 1);
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(import_other.default, "other-value");
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9961/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9961/_config.json
@@ -6,5 +6,11 @@
       "lazyBarrel": true
     }
   },
-  "configVariants": []
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
@@ -35,3 +35,31 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region core/setupWorker.js
+function setupWorker(handler) {
+	return { handler };
+}
+//#endregion
+//#region core/http.js
+function http() {
+	return "http";
+}
+//#endregion
+var worker;
+__esmMin((() => {
+	//#region main.js
+	worker = setupWorker(http());
+	console.log(worker);
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
@@ -11,6 +11,16 @@
   "configVariants": [
     {
       "format": "cjs"
+    },
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    },
+    {
+      "format": "cjs",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -63,3 +63,64 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] lib.js is dynamically imported by entry.js but also statically imported by entry.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### entry.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
+//#endregion
+__esmMin((() => {
+	Promise.resolve().then(() => lib_exports).then((mod) => {
+		assert.strictEqual(mod.a, 123);
+		assert.strictEqual(123, 123);
+	});
+}))();
+
+```
+
+# Variant: [format: Cjs] [on_demand_wrapping: true] [strict_execution_order: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] lib.js is dynamically imported by entry.js but also statically imported by entry.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
+//#endregion
+__esmMin((() => {
+	Promise.resolve().then(() => lib_exports).then((mod) => {
+		node_assert.default.strictEqual(mod.a, 123);
+		node_assert.default.strictEqual(123, 123);
+	});
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
@@ -7,5 +7,12 @@
       }
     ],
     "strictExecutionOrder": true
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
@@ -38,3 +38,32 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+	//#region foo.js
+	{
+		const foo = "foo" + globalThis.foo;
+		setTimeout(() => {
+			globalThis.array.push(foo);
+		}, 100);
+	}
+	//#endregion
+	//#region bar.js
+	{
+		const foo = "bar" + globalThis.bar;
+		globalThis.array.push(foo);
+	}
+	//#endregion
+	//#region main.js
+	console.log(globalThis.array);
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
@@ -11,5 +11,12 @@
       ]
     }
   },
-  "_comment": "Tests Common chunk + Esm WrapKind + Named OutputExports + named export access"
+  "_comment": "Tests Common chunk + Esm WrapKind + Named OutputExports + named export access",
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
@@ -51,3 +51,20 @@ Object.defineProperty(exports, "init_shared", {
 });
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(42, 42);
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
@@ -8,5 +8,12 @@
     "exports": "named",
     "strictExecutionOrder": true
   },
-  "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + default export access"
+  "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + default export access",
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
@@ -65,3 +65,39 @@ Object.defineProperty(exports, "__toESM", {
 });
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperties(exports, {
+	__esModule: { value: true },
+	[Symbol.toStringTag]: { value: "Module" }
+});
+//#region lib.js
+var lib_default = { value: 42 };
+const named = "named_value";
+//#endregion
+exports.default = lib_default;
+exports.named = named;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.default.value, 42);
+}))();
+exports.lib = require_lib.default;
+
+```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
@@ -8,5 +8,12 @@
     "exports": "named",
     "strictExecutionOrder": true
   },
-  "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + named export access"
+  "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + named export access",
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
@@ -64,3 +64,38 @@ Object.defineProperty(exports, "__toESM", {
 });
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region lib.js
+const foo = "foo_value";
+const bar = 42;
+//#endregion
+exports.bar = bar;
+exports.foo = foo;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.foo, "foo_value");
+	node_assert.default.strictEqual(42, 42);
+}))();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
+
+```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Two entries where `main` reads `lib`'s exports and independently pulls runtime helpers, so the runtime is a candidate to fold into the `lib` entry chunk. The runtime-merge signature guard must respect `preserveEntrySignatures`: for `strict` (and the default `exports-only`, since lib declares exports) it must keep the runtime — and thus its helpers — out of lib's public exports; for `allow-extension` the merge is allowed and helpers become extension exports on lib. The `strict`/`allow-extension` cases are covered explicitly via `configVariants`, so the auto-generated `extendedTests` variants for them are disabled to avoid redundant runs.",
+  "_comment": "Two entries where `main` reads `lib`'s exports and independently pulls runtime helpers. The runtime-merge signature guard must respect `preserveEntrySignatures`: `strict` (and the default `exports-only`, since lib declares exports) keeps runtime helpers out of lib's public exports, while `allow-extension` permits but does not require a merge. Both wrapping modes are explicit variants, so auto-generated extended variants are unnecessary.",
   "config": {
     "input": [
       { "name": "main", "import": "./main.js" },
@@ -12,6 +12,15 @@
     "preserveEntrySignatures": "strict"
   },
   "configVariants": [
-    { "_configName": "allow-extension", "preserveEntrySignatures": "allow-extension" }
+    { "_configName": "allow-extension", "preserveEntrySignatures": "allow-extension" },
+    {
+      "_configName": "on-demand",
+      "onDemandWrapping": true
+    },
+    {
+      "_configName": "allow-extension-on-demand",
+      "preserveEntrySignatures": "allow-extension",
+      "onDemandWrapping": true
+    }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_test.mjs
@@ -1,7 +1,7 @@
 const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
 
-// Variants: undefined (the base config, `strict`) and 'allow-extension'.
+// Variants cover strict/allow-extension in both wrap-all and on-demand modes.
 const variant = globalThis.__configName ?? 'strict';
 
 const lib = require('./dist/lib.js');
@@ -14,23 +14,17 @@ assert.strictEqual(main.bar, 42);
 
 const runtimeHelpers = ['__esmMin', '__esm', '__toESM', '__commonJSMin'];
 
-if (variant.includes('allow-extension')) {
-  // Extension is permitted, so the runtime is allowed to merge into the `lib`
-  // entry chunk; its helpers then appear as extension exports on lib.
+if (variant === 'allow-extension') {
+  // Keep the original positive control: this layout has a single valid runtime host, so allowing
+  // signature extensions should merge the runtime into lib and expose at least one helper.
   assert.ok(
     runtimeHelpers.some((helper) => helper in lib),
     `${variant}: expected the runtime to merge into the lib entry chunk; exports were ${JSON.stringify(Object.keys(lib))}`,
   );
-} else {
-  // `strict` (the base config) fixes lib's signature, so the guard keeps the
-  // runtime — and its helpers — out of lib. (The default `exports-only` behaves
-  // the same for an entry that declares exports; that path is exercised by the
-  // broader entry-exports snapshots.)
-  //
-  // NOTE: `init_lib` (lib's own ESM wrapper, present because `strictExecutionOrder`
-  // wraps the module) is still re-exported because `main` triggers lib's init
-  // cross-chunk. That is a separate facade/chunking concern, tracked apart from the
-  // runtime-merge guard, so it is intentionally not asserted here.
+} else if (!variant.includes('allow-extension')) {
+  // `strict` fixes lib's signature, so neither wrapping mode may leak runtime helpers. The default
+  // `exports-only` behaves the same for an entry that declares exports. Other allow-extension
+  // variants permit either runtime topology, so they only assert the declared exports above.
   for (const leaked of runtimeHelpers) {
     assert.ok(
       !(leaked in lib),

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
@@ -112,3 +112,73 @@ exports.bar = require_lib.bar;
 exports.foo = require_lib.foo;
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region lib.js
+const foo = "foo_value";
+const bar = 42;
+//#endregion
+exports.bar = bar;
+exports.foo = foo;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.foo, "foo_value");
+	node_assert.default.strictEqual(42, 42);
+}))();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
+
+```
+
+# Variant: allow-extension-on-demand: [on_demand_wrapping: true] [preserve_entry_signatures: AllowExtension]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region lib.js
+const foo = "foo_value";
+const bar = 42;
+//#endregion
+exports.bar = bar;
+exports.foo = foo;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.foo, "foo_value");
+	node_assert.default.strictEqual(42, 42);
+}))();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/_config.json
@@ -2,6 +2,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
@@ -33,3 +33,24 @@ await __esmMin((async () => {
 export { foo };
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var foo;
+var init_lib = __esmMin((async () => {
+	foo = await Promise.resolve("foo");
+}));
+//#endregion
+await __esmMin((async () => {
+	await init_lib();
+}))();
+export { foo };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/_config.json
@@ -2,6 +2,10 @@
   "configVariants": [
     {
       "strictExecutionOrder": true
+    },
+    {
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
@@ -38,3 +38,26 @@ await __esmMin((async () => {
 export { foo };
 
 ```
+
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var foo;
+var init_lib = __esmMin((async () => {
+	try {
+		foo = await Promise.resolve("foo");
+	} catch (_e) {}
+}));
+//#endregion
+await __esmMin((async () => {
+	await init_lib();
+}))();
+export { foo };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
@@ -13,5 +13,12 @@
     "treeshake": {
       "moduleSideEffects": false
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
@@ -46,3 +46,46 @@ var init_leaf = __esmMin((() => {
 export { __esmMin as i, init_helper as n, other as r, init_leaf as t };
 
 ```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+	console.log(other);
+}))();
+
+```
+
+### b.js
+
+```js
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### leaf.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region helper.js
+const other = "other";
+//#endregion
+//#region leaf.js
+var init_leaf = __esmMin((() => {}));
+//#endregion
+export { other as n, __esmMin as r, init_leaf as t };
+
+```


### PR DESCRIPTION
## Summary

This is the second test-only PR in the #10104 stack. It extends the core layer from #10253 with the later real-app and fuzzer-derived regressions, and it runs existing strict fixtures in both wrap-all and on-demand wherever the baseline can be established before the implementation lands.

It contains no production code, test-harness code, or documentation changes. All 185 changed files are under Rolldown fixture directories.

## What is covered

- Adds 14 executed integration fixtures for re-export and barrel init forwarding, dead and ambiguous namespace paths, post-lowering emergent chunk cycles, cross-chunk CJS init exports, entry isolation, dynamic targets hosted in entry chunks, and wrapped-value capture through package barrels.
- Adds or strengthens runtime assertions so failures are checked by observable execution, not snapshots alone.
- Adds paired wrap-all/on-demand configurations to existing strict fixtures while preserving the same non-mode options in each pair.
- Preserves structural snapshots for output-sensitive cases and updates the `runtime_merge_respects_preserve_entry_signatures` oracle so both legal `allow-extension` layouts are accepted while `strict` still requires helper isolation.

Wrap-all and on-demand must preserve the same observable behavior and link-stage tree-shaking result. Their emitted files are not expected to be byte-identical: wrap-all intentionally wraps more modules and may choose additional facades or a separate runtime chunk.

This layer still runs against pre-implementation behavior, so known runtime failures remain guarded by the fail-closed markers introduced in #10253. The final #10104 baseline commit removes every marker, adds the remaining legacy output counterparts whose snapshots depend on the implementation, and establishes the repository-wide 100-pair matrix.

## Review guide

1. Review the 14 new fixture directories and their `_test.mjs` runtime assertions first.
2. Treat most remaining `_config.json` and `artifacts.snap` changes as the mechanical paired-mode sweep; compare the non-mode options within each pair.
3. Review `runtime_merge_respects_preserve_entry_signatures` separately: both entries intentionally demand runtime helpers, `allow-extension` permits either valid layout, and `strict` requires entry isolation.
4. Review the manual-group regular expressions in the affected fixtures for separator-neutral matching; the same cells were also exercised from a deliberately deep checkout path.

## Stack

Merge and review in this order:

1. #10253: fail-closed runtime-failure harness and core integration regressions.
2. #10252 (this PR): additional hardening fixtures and paired-mode coverage.
3. #10104: on-demand implementation, removal of all temporary failure markers, and final output baselines.

## Validation

Validated at `bb18ff9270554026993d06d437764346aa2ba93f`:

- Strict execution-order fixture tests: 77/77 passed on this layer.
- The PR contains 185 changed files: 118 new files and 67 modified files, all under Rolldown fixture directories.
- 14 new fixture directories, 15 changed runtime test scripts, and 33 changed artifact snapshots were checked.
- GitHub's Rolldown, Rust, Node, repository, WASI, and Ubuntu matrix checks pass.
- `Vite Test Ubuntu` retains the known `scan jsx-runtime` / `ERR_OUTDATED_OPTIMIZED_DEP` and tsconfig error-overlay expectation failures; both signatures reproduce on current `main` and are unrelated to these fixture-only changes.
