### PR TITLE
fix(watch): drop tsconfig-merged transform options on each rebuild

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_getter.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_getter.rs
@@ -15,6 +15,12 @@ impl Bundler {
     self.bundle_factory.resolver.clear_cache();
   }
 
+  /// Clear the transform options merged from tsconfig files so the next
+  /// build picks up tsconfig edits.
+  pub fn clear_transform_tsconfig_cache(&self) {
+    self.bundle_factory.options.transform_options.clear_transform_tsconfig_cache();
+  }
+
   pub fn watch_files(&self) -> &Arc<FxDashSet<ArcStr>> {
     static EMPTY_SET: LazyLock<Arc<FxDashSet<ArcStr>>> =
       LazyLock::new(|| Arc::new(FxDashSet::default()));

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -44,6 +44,12 @@ impl RawTransformOptions {
     Self { base_options: Arc::new(base_options), cache: FxDashMap::default(), resolver }
   }
 
+  /// Drop the merged transform options so the next build re-merges them.
+  /// The tsconfig contents live in the cache shared with the main resolver.
+  pub fn clear_cache(&self) {
+    self.cache.clear();
+  }
+
   pub fn get_or_create_for_tsconfig(
     &self,
     tsconfig: Option<&oxc_resolver::TsConfig>,
@@ -138,6 +144,13 @@ impl TransformOptions {
         };
         raw.get_or_create_for_tsconfig(tsconfig.as_deref(), warnings)
       }
+    }
+  }
+
+  /// See [RawTransformOptions::clear_cache].
+  pub fn clear_transform_tsconfig_cache(&self) {
+    if let TransformOptionsInner::Raw(raw) = &self.inner {
+      raw.clear_cache();
     }
   }
 }

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -93,9 +93,11 @@ impl WatchTask {
         last_bundle_handle.plugin_driver().clear();
       }
 
-      // Always clear resolver cache before each rebuild in watch mode to avoid
-      // stale resolution results from modified package.json/tsconfig/export maps.
+      // Always clear the resolver and tsconfig caches before each rebuild in
+      // watch mode to avoid stale resolution and transform results from
+      // modified package.json/tsconfig/export maps.
       bundler.clear_resolver_cache();
+      bundler.clear_transform_tsconfig_cache();
 
       // Use with_cached_bundle_experimental to register FS watches between scan and write phases.
       // This ensures changes made during render hooks (e.g. renderStart modifying a file)


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

Part of #9598 (rebuild when tsconfig changes), on top of #10205.

`RawTransformOptions` memoizes the transform options merged from each tsconfig for the lifetime of the bundler. The watch task already clears the resolver cache before every rebuild, so edited tsconfig files are re-read from disk, but the memoized merge results were never dropped, so a rebuild kept transforming with the old tsconfig values. Concretely: edit `useDefineForClassFields` in tsconfig.json, touch a source file to trigger a rebuild, and the output still uses the old semantics.

The fix adds `clear_cache` on `RawTransformOptions` and wires it through `Bundler::clear_transform_tsconfig_cache`, which the watch task now calls next to the existing `clear_resolver_cache`. Thanks to #10205 the tsconfig contents themselves live in the cache shared with the main resolver, so this only needs to drop the memoized merge results, not a second resolver cache.

Note that tsconfig files are not registered as watch files yet, so editing a tsconfig alone still does not trigger a rebuild. That part comes in a follow-up PR. This PR makes sure that once a rebuild is triggered, it picks up the edits.