### PR TITLE
fix(watch): rebuild when tsconfig files change

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -267,6 +267,16 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       // - Only add watch files for files read from disk.
       // - Add watch files as early as possible for we might be able to recover from build errors.
       self.ctx.plugin_driver.watch_files.insert(self.resolved_id.id.as_arc_str().clone());
+      // The tsconfig governing this module affects its transform and
+      // resolution results, so watch it as well (#9598).
+      if let Some(tsconfig_path) = self
+        .ctx
+        .options
+        .transform_options
+        .discover_tsconfig_file(std::path::Path::new(self.resolved_id.id.as_str()))
+      {
+        self.ctx.plugin_driver.watch_files.insert(tsconfig_path.to_string_lossy().as_ref().into());
+      }
     }
     let (source, mut module_type) = result.map_err(|err| {
       downcast_napi_error_diagnostics(err).unwrap_or_else(|e| {

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -147,6 +147,17 @@ impl TransformOptions {
     }
   }
 
+  /// Find the tsconfig governing `file_path` so callers can watch it.
+  /// Discovery errors are ignored because they surface later in
+  /// `options_for_file`.
+  pub fn discover_tsconfig_file(&self, file_path: &Path) -> Option<PathBuf> {
+    let TransformOptionsInner::Raw(raw) = &self.inner else {
+      return None;
+    };
+    let tsconfig = raw.resolver.find_tsconfig(file_path).ok().flatten()?;
+    Some(tsconfig.path.clone())
+  }
+
   /// See [RawTransformOptions::clear_cache].
   pub fn clear_transform_tsconfig_cache(&self) {
     if let TransformOptionsInner::Raw(raw) = &self.inner {

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1426,6 +1426,97 @@ async function waitBuildFinished(watcher: RolldownWatcher, updateFn?: () => void
   });
 }
 
+// https://github.com/rolldown/rolldown/issues/9598
+test.concurrent(
+  'rebuild when tsconfig changes (auto-discovery)',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-tsconfig-auto', retryCount, {
+      'main.ts': 'export class Foo { bar = 1 }',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ESNext', useDefineForClassFields: false },
+      }),
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    const output = path.join(dir, 'dist', 'main.js');
+
+    const watcher = watch({
+      input: path.join(dir, 'main.ts'),
+      cwd: dir,
+      tsconfig: true,
+      output: { file: output },
+    });
+
+    try {
+      await waitBuildFinished(watcher);
+      // useDefineForClassFields: false compiles the field to a constructor assignment
+      expect(fs.readFileSync(output, 'utf-8')).toContain('this.bar = 1');
+
+      // Changing only the tsconfig must trigger a rebuild that uses the new options
+      await editFile(
+        path.join(dir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ESNext', useDefineForClassFields: true },
+        }),
+      );
+      // useDefineForClassFields: true keeps the field declaration in the class body
+      await expect.poll(() => fs.readFileSync(output, 'utf-8')).not.toContain('this.bar = 1');
+      expect(fs.readFileSync(output, 'utf-8')).toContain('bar = 1');
+    } finally {
+      await watcher.close();
+    }
+  },
+);
+
+// https://github.com/rolldown/rolldown/issues/9598
+test.concurrent(
+  'rebuild when tsconfig changes (manual path)',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-tsconfig-manual', retryCount, {
+      'main.ts': 'export class Foo { bar = 1 }',
+      'tsconfig.build.json': JSON.stringify({
+        compilerOptions: { target: 'ESNext', useDefineForClassFields: false },
+      }),
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    const output = path.join(dir, 'dist', 'main.js');
+
+    const watcher = watch({
+      input: path.join(dir, 'main.ts'),
+      cwd: dir,
+      tsconfig: './tsconfig.build.json',
+      output: { file: output },
+    });
+
+    try {
+      await waitBuildFinished(watcher);
+      expect(fs.readFileSync(output, 'utf-8')).toContain('this.bar = 1');
+
+      await editFile(
+        path.join(dir, 'tsconfig.build.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ESNext', useDefineForClassFields: true },
+        }),
+      );
+      await expect.poll(() => fs.readFileSync(output, 'utf-8')).not.toContain('this.bar = 1');
+      expect(fs.readFileSync(output, 'utf-8')).toContain('bar = 1');
+    } finally {
+      await watcher.close();
+    }
+  },
+);
+
 // https://github.com/rolldown/rolldown/issues/8937
 test.concurrent(
   'watcher.close() should cancel an in-progress build',


### PR DESCRIPTION
Fixes the watch-mode part of #9598, on top of the cache clearing PR.

tsconfig files were never registered as watch files, so editing one did not trigger a rebuild. Every module read from disk now registers its governing tsconfig as a watch file, using the same mechanism as module files, so both the classic watcher and the dev engine pick it up. Plain JS modules register too because `compilerOptions.paths` also affects how their imports resolve. The extra `find_tsconfig` call is answered from the resolver cache after the first module in a directory.

Two watch tests cover auto-discovery and a manual tsconfig path. Each flips `useDefineForClassFields` as the only change and asserts the rebuilt output switches semantics, which exercises this PR together with the cache clearing from the previous one.

Known limits, left as follow-ups: files pulled in via `extends` are not watched until oxc-resolver reports them, creating a brand-new tsconfig.json is not detected because the per-file watcher cannot watch missing paths, and a solution-style root tsconfig that only routes to references is not watched since `find_tsconfig` returns the matched reference without reporting the root.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

