### PR TITLE
fix(dev): force a full rebuild when a tsconfig changes

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -9,7 +9,7 @@ use oxc::transformer::{ESFeature, EngineTargets, TransformOptions as OxcTransfor
 use oxc_resolver::ResolverGeneric;
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_fs::OsFileSystem;
-use rolldown_utils::dashmap::FxDashMap;
+use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 
 use super::tsconfig_merge::merge_transform_options_with_tsconfig as merge_tsconfig;
 use crate::BundlerTransformOptions;
@@ -34,6 +34,9 @@ pub struct RawTransformOptions {
   /// Derived from the main resolver and shares its cache, so tsconfig
   /// lookups here and in module resolution stay consistent.
   resolver: Arc<ResolverGeneric<OsFileSystem>>,
+  /// Every tsconfig file discovered so far. Survives `clear_cache` so
+  /// watchers can still recognize tsconfig files when routing file changes.
+  known_tsconfig_paths: FxDashSet<PathBuf>,
 }
 
 impl RawTransformOptions {
@@ -41,7 +44,12 @@ impl RawTransformOptions {
     base_options: BundlerTransformOptions,
     resolver: Arc<ResolverGeneric<OsFileSystem>>,
   ) -> Self {
-    Self { base_options: Arc::new(base_options), cache: FxDashMap::default(), resolver }
+    Self {
+      base_options: Arc::new(base_options),
+      cache: FxDashMap::default(),
+      resolver,
+      known_tsconfig_paths: FxDashSet::default(),
+    }
   }
 
   /// Drop the merged transform options so the next build re-merges them.
@@ -155,7 +163,16 @@ impl TransformOptions {
       return None;
     };
     let tsconfig = raw.resolver.find_tsconfig(file_path).ok().flatten()?;
+    raw.known_tsconfig_paths.insert(tsconfig.path.clone());
     Some(tsconfig.path.clone())
+  }
+
+  /// Whether `path` was discovered as a tsconfig file by an earlier build.
+  pub fn is_known_tsconfig(&self, path: &Path) -> bool {
+    match &self.inner {
+      TransformOptionsInner::Normal(_) => false,
+      TransformOptionsInner::Raw(raw) => raw.known_tsconfig_paths.contains(path),
+    }
   }
 
   /// See [RawTransformOptions::clear_cache].

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -114,6 +114,24 @@ impl BundlingTask {
       }
     }
 
+    // A tsconfig edit affects every module the tsconfig governs, which HMR
+    // patches and partial scans cannot represent. Clear the caches and fall
+    // back to a full rebuild.
+    {
+      let bundler = self.bundler.lock().await;
+      let changed_tsconfig = self
+        .input
+        .changed_files()
+        .keys()
+        .any(|path| bundler.options().transform_options.is_known_tsconfig(path));
+      if changed_tsconfig {
+        tracing::trace!("[BundlingTask] detects a tsconfig change, upgrading to a full rebuild");
+        bundler.clear_resolver_cache();
+        bundler.clear_transform_tsconfig_cache();
+        self.input = TaskInput::FullBuild;
+      }
+    }
+
     let mut has_full_reload_update = false;
     if self.input.require_generate_hmr_update() {
       tracing::trace!("[BundlingTask] starts to generate HMR updates");


### PR DESCRIPTION
Part of #9598, on top of #10258. Addresses the review comment there about the dev API.

After #10258 the dev engine watches tsconfig files, but being watched is not enough: a tsconfig is neither a module nor a transform dependency, so the HMR mapper observes the change and maps it to `Noop`, and dev output keeps the old transform and resolution results. A tsconfig edit affects every module the tsconfig governs, which neither an HMR patch nor a partial scan can represent, so the only correct reaction is a full rebuild with fresh caches.

Discovered tsconfig paths are remembered in a set on `RawTransformOptions` that `discover_tsconfig_file` fills during watch registration. The set deliberately survives `clear_cache`, so the bundling task can still classify a changed path after the caches were dropped. When a changed file hits the set, the bundling task clears the resolver and tsconfig caches and upgrades itself to `TaskInput::FullBuild`.

Registering the tsconfig as a transform dependency was considered and rejected: the HMR mapper would patch every module the tsconfig governs instead of doing one clean rebuild, and a pure `Hmr` task never clears the caches, so those patches would still use the stale options.

Review notes: detection lives in `BundlingTask`, not the coordinator, because the coordinator must not lock the bundler while a running build holds the lock. The upgrade happens after the `watchChange` hooks so they still see the changed files. The coordinator reads `requires_full_rebuild()` only at scheduling time, so a task that upgrades itself mid-run completes through the normal `InProgress` path.

Client notification (a `FullReload` update so browsers refresh automatically) and the dev fixtures come in a follow-up.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

