### PR TITLE
feat(dev): send a full-reload update to clients when a tsconfig changes

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.ts"
+      }
+    ],
+    "tsconfig": true,
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/artifacts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ Foo: () => Foo });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+var Foo = class {
+	constructor() {
+		this.bar = 1;
+	}
+};
+//#endregion
+export { Foo };
+
+```
+
+# HMR Step 0
+
+## Meta
+
+- update type: full-reload
+- reason: tsconfig change
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ Foo: () => Foo });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+var Foo = class {
+	bar = 1;
+};
+//#endregion
+export { Foo };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/main.ts
@@ -1,0 +1,3 @@
+export class Foo {
+  bar = 1;
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.hmr-0.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.hmr-0.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_change/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.ts"
+      }
+    ],
+    "tsconfig": true,
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/a.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/a.ts
@@ -1,0 +1,1 @@
+export const value = 'from-a';

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/artifacts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.ts
+var a_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("a.ts");
+__rolldown_runtime__.registerModule("a.ts", { exports: a_exports });
+const value = "from-a";
+//#endregion
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ result: () => result });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+const result = value;
+//#endregion
+export { result };
+
+```
+
+# HMR Step 0
+
+## Meta
+
+- update type: full-reload
+- reason: tsconfig change
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region b.ts
+var b_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("b.ts");
+__rolldown_runtime__.registerModule("b.ts", { exports: b_exports });
+const value = "from-b";
+//#endregion
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ result: () => result });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+const result = value;
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/b.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/b.ts
@@ -1,0 +1,1 @@
+export const value = 'from-b';

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/main.ts
@@ -1,0 +1,3 @@
+import { value } from '@dep';
+
+export const result = value;

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.hmr-0.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.hmr-0.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dep": ["./b.ts"]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/tsconfig_paths_change/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dep": ["./a.ts"]
+    }
+  }
+}

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -3,7 +3,7 @@ use std::{
   sync::{Arc, atomic::AtomicU32},
 };
 
-use rolldown_common::{ClientHmrInput, ScanMode};
+use rolldown_common::{ClientHmrInput, ClientHmrUpdate, HmrUpdate, ScanMode};
 use rolldown_utils::indexmap::FxIndexMap;
 use tokio::sync::Mutex;
 
@@ -115,9 +115,9 @@ impl BundlingTask {
     }
 
     // A tsconfig edit affects every module the tsconfig governs, which HMR
-    // patches and partial scans cannot represent. Clear the caches and fall
-    // back to a full rebuild.
-    {
+    // patches and partial scans cannot represent. Clear the caches, tell
+    // clients to fully reload, and fall back to a full rebuild.
+    let changed_tsconfig = {
       let bundler = self.bundler.lock().await;
       let changed_tsconfig = self
         .input
@@ -128,8 +128,27 @@ impl BundlingTask {
         tracing::trace!("[BundlingTask] detects a tsconfig change, upgrading to a full rebuild");
         bundler.clear_resolver_cache();
         bundler.clear_transform_tsconfig_cache();
-        self.input = TaskInput::FullBuild;
       }
+      changed_tsconfig
+    };
+    if changed_tsconfig {
+      if let Some(on_hmr_updates) = self.dev_context.options.on_hmr_updates.as_ref() {
+        let changed_files = self
+          .input
+          .changed_files()
+          .keys()
+          .map(|path| path.to_string_lossy().to_string())
+          .collect::<Vec<_>>();
+        let updates = (self.dev_context.clients.lock().await)
+          .keys()
+          .map(|client_id| ClientHmrUpdate {
+            client_id: client_id.clone(),
+            update: HmrUpdate::FullReload { reason: "tsconfig change".to_owned() },
+          })
+          .collect();
+        on_hmr_updates(Ok((updates, changed_files)));
+      }
+      self.input = TaskInput::FullBuild;
     }
 
     let mut has_full_reload_update = false;


### PR DESCRIPTION
Part of #9598, on top of the full-rebuild PR. This is the last piece of the tsconfig watching work on the rolldown side.

The previous PR makes the dev engine rebuild fully with fresh caches when a known tsconfig changes, but connected clients were not told anything, so the browser kept running the old bundle until a manual refresh. The bundling task now sends a `FullReload` update (reason: "tsconfig change") to every client before the rebuild, matching the ordering of the existing full-reload flow where updates are emitted first and the dev server's build-stable machinery gates the follow-up fetch.

Two HMR fixtures cover both sides that a tsconfig governs. `tsconfig_change` flips `useDefineForClassFields` and the rebuilt output switches from a constructor assignment to a class field declaration. `tsconfig_paths_change` remaps `compilerOptions.paths` so the same import resolves to a different file, which proves the shared resolver cache is really cleared, since a stale cache would keep resolving the old target. Both snapshots record the full-reload update with its reason and the rebuilt output. The test harness additionally asserts that the changed tsconfig is present in the watched files and that the incremental scan state matches a fresh full build after each step.

Remaining known limits of the tsconfig watching work, tracked on #9598: `extends` chains wait on oxc-resolver reporting the loaded files, creating a brand-new tsconfig.json cannot be watched by the per-file watcher, and a solution-style root tsconfig that only routes to references is not reported by `find_tsconfig`.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

