### PR TITLE
fix: skip init-call transfer for circular wrapper deps

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -429,14 +429,12 @@ impl GenerateStage<'_> {
                 // later in the output — calling it eagerly here would run before
                 // that later wrapper is assigned (circular imports: a↔b).
                 let target_exec_order = chunk_module_to_exec_order[&module_idx];
-                let has_later_wrapped_dep = self.link_output.metas[midx]
-                  .dependencies
-                  .iter()
-                  .any(|dep_idx| {
+                let has_later_wrapped_dep =
+                  self.link_output.metas[midx].dependencies.iter().any(|dep_idx| {
                     matches!(self.link_output.metas[*dep_idx].wrap_kind(), WrapKind::Esm)
-                      && chunk_module_to_exec_order.get(dep_idx).is_some_and(
-                        |&dep_order| dep_order > target_exec_order,
-                      )
+                      && chunk_module_to_exec_order
+                        .get(dep_idx)
+                        .is_some_and(|&dep_order| dep_order > target_exec_order)
                   });
                 if has_later_wrapped_dep {
                   continue;

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -419,10 +419,26 @@ impl GenerateStage<'_> {
             {
               let transfer_item = pending_transfer
                 .extract_if(0.., |(midx, _, _)| wrapped_modules[0..*deps_length].contains(midx));
-              for (_midx, iidx, ridx) in transfer_item {
+              for (midx, iidx, ridx) in transfer_item {
                 // Should always avoid transfer any initialization from a low execution order module to a high execution order module.
                 if chunk_module_to_exec_order[&iidx] <= chunk_module_to_exec_order[&module_idx] {
                   // If the module is the same, we can skip the transfer.
+                  continue;
+                }
+                // Skip if the wrapper depends on another wrapped module defined
+                // later in the output — calling it eagerly here would run before
+                // that later wrapper is assigned (circular imports: a↔b).
+                let target_exec_order = chunk_module_to_exec_order[&module_idx];
+                let has_later_wrapped_dep = self.link_output.metas[midx]
+                  .dependencies
+                  .iter()
+                  .any(|dep_idx| {
+                    matches!(self.link_output.metas[*dep_idx].wrap_kind(), WrapKind::Esm)
+                      && chunk_module_to_exec_order.get(dep_idx).is_some_and(
+                        |&dep_order| dep_order > target_exec_order,
+                      )
+                  });
+                if has_later_wrapped_dep {
                   continue;
                 }
                 insert_map.entry(module_idx).or_default().push((iidx, ridx));

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { result } from './dist/main.js';
+
+assert.strictEqual(result, 'a');

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/a.js
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/a.js
@@ -1,0 +1,6 @@
+import { getB } from './b.js';
+import { leaf } from './leaf.js';
+
+export function getA() {
+  return getB && leaf ? 'a' : 'unreachable';
+}

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region b.js
+function getB() {
+	return getA ? "b" : "unreachable";
+}
+var init_b = __esmMin((() => {
+	init_a();
+}));
+//#endregion
+//#region leaf.js
+function leaf() {
+	return "leaf";
+}
+function getA() {
+	return getB && leaf ? "a" : "unreachable";
+}
+var init_a = __esmMin((() => {
+	init_b();
+}));
+//#endregion
+//#region main.js
+init_a();
+init_a();
+const result = getA();
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/b.js
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/b.js
@@ -1,0 +1,5 @@
+import { getA } from './a.js';
+
+export function getB() {
+  return getA ? 'b' : 'unreachable';
+}

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/leaf.js
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/leaf.js
@@ -1,0 +1,3 @@
+export function leaf() {
+  return 'leaf';
+}

--- a/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/main.js
+++ b/crates/rolldown/tests/rolldown/topics/esm_circular_init_order/main.js
@@ -1,0 +1,4 @@
+import { getA } from './a.js';
+require('./a.js');
+
+export const result = getA();


### PR DESCRIPTION
When a wrapped ESM module imports another wrapped module that appears later in the output (circular imports), the init-call transfer logic in `ensure_lazy_module_initialization_order` can move an `init_*()` call to an earlier unwrapped module's top-level position. The call then runs before the later wrapper's `var init_* = __esmMin(...)` is assigned, causing `TypeError: init_* is not a function`.

This was reported in #10265 with `onDemandWrapping`, but the underlying issue can trigger whenever unwrapped modules coexist with circular wrapped dependencies.

Fixes #10265