### PR TITLE
fix(dev): clear tsconfig caches for bare full builds

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.ts"
+      }
+    ],
+    "tsconfig": true,
+    "experimental": {
+      "devMode": {}
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Could not resolve './missing' in main.ts
+   ╭─[ main.ts:1:8 ]
+   │
+ 1 │ import './missing';
+   │        ─────┬─────  
+   │             ╰─────── Module not found.
+───╯
+
+```
+
+# HMR Step 0
+
+## Build Output
+
+### Assets
+
+#### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.ts
+var main_exports = /* @__PURE__ */ __exportAll({ Foo: () => Foo });
+__rolldown_runtime__.createModuleHotContext("main.ts");
+__rolldown_runtime__.registerModule("main.ts", { exports: main_exports });
+var Foo = class {
+	bar = 1;
+};
+//#endregion
+export { Foo };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/main.hmr-0.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/main.hmr-0.ts
@@ -1,0 +1,3 @@
+export class Foo {
+  bar = 1;
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/main.ts
@@ -1,0 +1,5 @@
+import './missing';
+
+export class Foo {
+  bar = 1;
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/tsconfig.hmr-0.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/tsconfig.hmr-0.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/fix_broken_file_and_tsconfig/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": false
+  }
+}

--- a/crates/rolldown_dev/src/bundling_task.rs
+++ b/crates/rolldown_dev/src/bundling_task.rs
@@ -126,6 +126,12 @@ impl BundlingTask {
         .any(|path| bundler.options().transform_options.is_known_tsconfig(path));
       if changed_tsconfig {
         tracing::trace!("[BundlingTask] detects a tsconfig change, upgrading to a full rebuild");
+      }
+      // A bare full build carries no changed-file list (startup, restart,
+      // failure recovery), so whether a tsconfig changed cannot be answered
+      // there. Clear defensively; full builds are rare and the clears are
+      // cheap.
+      if changed_tsconfig || self.input.requires_full_rebuild() {
         bundler.clear_resolver_cache();
         bundler.clear_transform_tsconfig_cache();
       }


### PR DESCRIPTION
Closes #10269.

The tsconfig detection in `BundlingTask` checks `changed_files()` against the known tsconfig paths, but a bare `TaskInput::FullBuild` carries no changed-file list by construction. Three coordinator paths produce such inputs and erase the file names on the way: `handle_file_changes` in the `FullBuildFailed` state, `trigger_full_build` (which also clears queued tasks), and `merge_with` where `FullBuild` absorbs other inputs. On those paths "did a tsconfig change" cannot be answered, so the caches were never cleared and the full scan reused the stale tsconfig. In the failure-recovery case this locks the dev server up for good: every edit in `FullBuildFailed` becomes a bare `FullBuild`, each one rebuilds with the cached tsconfig, fails again, and returns to `FullBuildFailed`, even though the file on disk has long been fixed.

The fix clears the resolver and tsconfig caches for every input with `requires_full_rebuild()`, alongside the existing detection for inputs that still carry their file list. Full builds only happen at startup, on restart, and in failure recovery, so the extra clears are cheap. The `FullReload` client notification still fires only when a tsconfig change is positively detected. Keeping the changed-file information alive through the three coordinator paths would be the precise alternative, but that is a much larger change to the state machine for no practical gain.

The regression fixture reproduces the erasure path: the initial build fails on an unresolved import, and the recovery step fixes the import and edits the tsconfig in the same batch, which the `FullBuildFailed` state folds into a bare `FullBuild`. With the fix the recovered output uses the new tsconfig (`useDefineForClassFields` flips the emitted class field), and without it the output keeps the stale semantics, which was verified by temporarily reverting the fix.
