### PR TITLE
test(code-splitting): normalize strict execution order variants

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "codeSplitting": {

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["MAIN:stale"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["the hoisted self-rebinding order wrapper form must be preserved"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       { "name": "e0", "import": "./m0.js" },
@@ -28,7 +29,7 @@
       "onDemandWrapping": false
     },
     {
-      "_configName": "minify",
+      "_configName": "minify-on-demand",
       "_expectExecutionFailure": {
         "reason": "Expected to fail until rolldown#10104 is applied.",
         "outputContains": ["the self-rebinding order wrapper form must survive minification"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_test.mjs
@@ -20,7 +20,7 @@ const distDir = join(dirname(fileURLToPath(import.meta.url)), 'dist');
 // Full `minify` mangles the local `init_*` names, so the name-based structural greps below only
 // apply to the unminified configs; under minify, single execution + correct values (section (b))
 // are the load-bearing assertions that the self-rebinding wrapper still runs each body once.
-const isMinified = ['minify', 'minify-wrap-all'].includes(globalThis.__configName);
+const isMinified = ['minify-on-demand', 'minify-wrap-all'].includes(globalThis.__configName);
 
 const combined = readdirSync(distDir)
   .filter((name) => name.endsWith('.js'))

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["CJS entry carrier must not execute entry B while loading entry A"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/_config.json
@@ -2,6 +2,7 @@
   "config": {},
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -20,7 +20,7 @@ console.log("main", fromLib, import_cjs.default.value);
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {
@@ -7,9 +8,11 @@
   },
   "configVariants": [
     {
+      "_configName": "profiler-names-disabled-on-demand",
       "profilerNames": false
     },
     {
+      "_configName": "pife-for-module-wrappers-disabled-on-demand",
       "pifeForModuleWrappers": false
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
@@ -14,7 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```
 
-# Variant: [profiler_names: false]
+# Variant: profiler-names-disabled-on-demand: [profiler_names: false]
 
 ## Assets
 
@@ -29,7 +29,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```
 
-# Variant: [pife_for_module_wrappers: false]
+# Variant: pife-for-module-wrappers-disabled-on-demand: [pife_for_module_wrappers: false]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
@@ -1,9 +1,11 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -34,7 +34,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true]
+# Variant: on-demand: [on_demand_wrapping: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["namespace member must not initialize its dead re-export before page-b"]
   },
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dead barrel re-export must not initialize common before page-b"]
   },
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dynamic retained-star re-export must not initialize common before page-b"]
   },
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dynamic retained-star fanout must not initialize common-a before page-b"]
   },
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["named retained-star re-export must initialize common before page-a"]
   },
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
@@ -1,10 +1,12 @@
 {
   "snapshot": false,
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["loading dynamic target entry must not execute co-located entry a"]
   },
+  "configName": "wrap-all",
   "config": {
     "input": [
       {
@@ -27,6 +28,7 @@
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "_expectExecutionFailure": {
         "reason": "Expected to fail until rolldown#10104 is applied.",
         "outputContains": ["loading dynamic target entry must not execute co-located entry a"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [{ "name": "main", "import": "./main.js" }],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [{ "name": "main", "import": "./main.js" }],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_test.mjs
@@ -8,6 +8,8 @@ import assert from 'node:assert';
 // `unused` is not re-exported, so it misses A -> C. Without unifying the projection with the actual
 // transitive-metadata routing, the eager reader's record-position interop trigger runs mid-cycle and
 // reads A's not-yet-assigned `var require_carrier` — `TypeError: require_carrier is not a function`.
+// Following that same transitive-metadata route during projection closes the cycle, so the fixpoint
+// wraps its eligible modules and defers the eager read until `require_carrier` is assigned.
 await import('./dist/main.js');
 
 assert.strictEqual(

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [{ "name": "main", "import": "./main.js" }],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [{ "name": "main", "import": "./main.js" }],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "external": ["external"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/_config.json
@@ -1,6 +1,7 @@
 {
   "snapshot": false,
   "expectExecuted": false,
+  "configName": "on-demand",
   "config": {
     "external": ["external"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/_config.json
@@ -5,6 +5,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["entry a must preserve JSON re-export attributes"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
@@ -15,6 +16,7 @@
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/_config.json
@@ -9,11 +9,11 @@
   },
   "configVariants": [
     {
-      "_configName": "strict",
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
-      "_configName": "strict-on-demand",
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
@@ -32,7 +32,7 @@ export { foo as t };
 
 ```
 
-# Variant: strict: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -74,7 +74,7 @@ export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```
 
-# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/_config.json
@@ -13,11 +13,11 @@
   },
   "configVariants": [
     {
-      "_configName": "strict",
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
-      "_configName": "strict-on-demand",
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
@@ -32,7 +32,7 @@ global.foo.log();
 
 ```
 
-# Variant: strict: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -81,7 +81,7 @@ export { __esmMin as n, init_run_dep as t };
 
 ```
 
-# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
@@ -4,9 +4,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -14,7 +14,7 @@ nodeAssert.equal("foo", "foo");
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -50,7 +50,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/_config.json
@@ -4,9 +4,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -14,7 +14,7 @@ nodeAssert.equal("foo", "foo");
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -60,7 +60,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
@@ -4,9 +4,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -14,7 +14,7 @@ nodeAssert.equal("foo", "foo");
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -50,7 +50,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "minify": false

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/_config.json
@@ -5,9 +5,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["internal wrapped entry must preserve source execution order"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["interop trigger host must preserve source execution order"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/_config.json
@@ -1,9 +1,11 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ],

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -26,7 +26,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true]
+# Variant: on-demand: [on_demand_wrapping: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
@@ -1,9 +1,11 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -25,7 +25,7 @@ export { dep_default as dep };
 
 ```
 
-# Variant: [on_demand_wrapping: true]
+# Variant: on-demand: [on_demand_wrapping: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
@@ -1,9 +1,11 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ],

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["ReferenceError: sideEffect is not defined"]
   },
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["ambiguous namespace re-export must not initialize common-a before page-b"]
   },
+  "configName": "wrap-all",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dead namespace star must not initialize default-only before page-b"]
   },
+  "configName": "wrap-all",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
@@ -19,6 +20,7 @@
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
@@ -27,6 +28,7 @@
   },
   "configVariants": [
     {
+      "_configName": "on-demand",
       "onDemandWrapping": true
     }
   ]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "on-demand",
   "config": {
     "resolve": {
       "alias": [["this-is-only-used-for-testing", ["./commonjs.js"]]]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
@@ -4,9 +4,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -13,7 +13,7 @@ nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should 
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -28,7 +28,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["Error: page-a observed undefined"]
   },
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       {
@@ -8,6 +9,6 @@
     ],
     "strictExecutionOrder": true
   },
-  "configVariants": [{ "onDemandWrapping": true }],
+  "configVariants": [{ "_configName": "on-demand", "onDemandWrapping": true }],
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -14,7 +14,7 @@ await __esmMin((async () => {
 
 ```
 
-# Variant: [on_demand_wrapping: true]
+# Variant: on-demand: [on_demand_wrapping: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "wrap-all",
   "config": {
     "input": [{ "name": "main", "import": "./main.js" }],
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/_config.json
@@ -1,5 +1,6 @@
 {
   "snapshot": false,
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -36,7 +37,7 @@
   },
   "configVariants": [
     {
-      "_configName": "cjs",
+      "_configName": "cjs-on-demand",
       "format": "cjs",
       "_expectExecutionFailure": {
         "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/_config.json
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["TypeError: init_m29 is not a function"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [{ "name": "e0", "import": "./e0.js" }],
     "preserveEntrySignatures": "allow-extension",

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/_config.json
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/_config.json
@@ -4,6 +4,7 @@
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["the dynamic target must initialize before the chunk checkpoint"]
   },
+  "configName": "on-demand",
   "config": {
     "input": [
       { "name": "a", "import": "./a.js" },

--- a/crates/rolldown/tests/rolldown/issues/10013/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10013/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/10013 - two entries both import the re-exported `other` from `leaf`. `other`'s canonical lives in `helper.js`, so it bypasses `leaf` entirely, and `leaf`'s own `value = first(second)` is never used. Under `strictExecutionOrder`, the shared chunk must not keep `leaf`'s dead `value = first(second)` body or its external `dep` import. `dep` remains external for bundling, while the local node_modules package throws if runtime ever reaches it.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "a", "import": "./entry-a.js" },

--- a/crates/rolldown/tests/rolldown/issues/10048/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10048/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/10048 - with `experimental.lazyBarrel` + `strictExecutionOrder`, theming.js imports helper-only bindings (`__commonJS` / `__toESM`) and calls them at the top level, while also re-exporting a passthrough `themes` value from data.js. The entry uses only that passthrough, so theming's helper-dependent body must not be retained without helpers.js. Executing the compiled entry via `_test.mjs` must not throw.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/issues/3650/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3650/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "codeSplitting": {

--- a/crates/rolldown/tests/rolldown/issues/5870/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5870/_config.json
@@ -2,6 +2,7 @@
   "config": {},
   "configVariants": [
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -24,7 +24,7 @@ assert.strictEqual(1, 1);
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/7286/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7286/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },

--- a/crates/rolldown/tests/rolldown/issues/9028/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9028/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true
   },

--- a/crates/rolldown/tests/rolldown/issues/9083/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9083/_config.json
@@ -1,8 +1,9 @@
 {
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
-    { "strictExecutionOrder": true, "onDemandWrapping": true }
+    { "_configName": "on-demand", "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -28,7 +28,7 @@ export { manager };
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -72,7 +72,7 @@ export { manager };
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/9463/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 - With `strictExecutionOrder`, a `codeSplitting` group (here `entriesAware` + a large `entriesAwareMergeThreshold`) lumps both entry modules and the shared module into one chunk. `chunkOptimization` then folded that chunk into entry `a`, so executing entry `b` (`import \"./a.js\"; init_b()`) eagerly ran `init_a()` and triggered entry `a`'s side effect. Each entry must run only its own `init_*`.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "a", "import": "./a.js" },

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 — same execution-isolation guard must hold for a PLAIN (non-entriesAware) codeSplitting group, which unions the bits of every matched module (including both entry modules) into one chunk.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "a", "import": "./a.js" },

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 — execution isolation must hold with more than two entries: a catch-all entriesAware group merges all three entry modules into one chunk; loading any one entry must run only its own init.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "a", "import": "./a.js" },

--- a/crates/rolldown/tests/rolldown/issues/9806/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9806/_config.json
@@ -8,9 +8,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -19,7 +19,7 @@ nodeAssert.equal(import_other.default, "other-value");
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -46,7 +46,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/9961/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9961/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9961 - `core` is `sideEffects: false`, calls the imported `checkGlobals()` at module top level, and re-exports setupWorker/http from sibling files. `main` imports only setupWorker/http, so strictExecutionOrder must not retain core's own top-level `checkGlobals()` body just because the barrel is wrapped. The bundle should execute cleanly with lazyBarrel enabled.",
+  "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       {
@@ -10,6 +11,7 @@
   },
   "configVariants": [
     {
+      "_configName": "cjs-wrap-all",
       "format": "cjs"
     },
     {
@@ -18,6 +20,7 @@
       "onDemandWrapping": true
     },
     {
+      "_configName": "cjs-on-demand",
       "format": "cjs",
       "strictExecutionOrder": true,
       "onDemandWrapping": true

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -31,7 +31,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [format: Cjs]
+# Variant: cjs-wrap-all: [format: Cjs]
 
 ## warnings
 
@@ -94,7 +94,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: [format: Cjs] [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: cjs-on-demand: [format: Cjs] [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## warnings
 

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "format": "cjs",
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "main", "import": "./main.js" },

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
@@ -1,4 +1,5 @@
 {
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "main", "import": "./main.js" },

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Two entries where `main` reads `lib`'s exports and independently pulls runtime helpers. The runtime-merge signature guard must respect `preserveEntrySignatures`: `strict` (and the default `exports-only`, since lib declares exports) keeps runtime helpers out of lib's public exports, while `allow-extension` permits but does not require a merge. Both wrapping modes are explicit variants, so auto-generated extended variants are unnecessary.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "main", "import": "./main.js" },
@@ -12,7 +13,7 @@
     "preserveEntrySignatures": "strict"
   },
   "configVariants": [
-    { "_configName": "allow-extension", "preserveEntrySignatures": "allow-extension" },
+    { "_configName": "allow-extension-wrap-all", "preserveEntrySignatures": "allow-extension" },
     {
       "_configName": "on-demand",
       "onDemandWrapping": true

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_test.mjs
@@ -2,7 +2,7 @@ const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
 
 // Variants cover strict/allow-extension in both wrap-all and on-demand modes.
-const variant = globalThis.__configName ?? 'strict';
+const variant = globalThis.__configName;
 
 const lib = require('./dist/lib.js');
 assert.strictEqual(lib.foo, 'foo_value');
@@ -14,7 +14,7 @@ assert.strictEqual(main.bar, 42);
 
 const runtimeHelpers = ['__esmMin', '__esm', '__toESM', '__commonJSMin'];
 
-if (variant === 'allow-extension') {
+if (variant === 'allow-extension-wrap-all') {
   // Keep the original positive control: this layout has a single valid runtime host, so allowing
   // signature extensions should merge the runtime into lib and expose at least one helper.
   assert.ok(

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
@@ -65,7 +65,7 @@ Object.defineProperty(exports, "__toESM", {
 
 ```
 
-# Variant: allow-extension: [preserve_entry_signatures: AllowExtension]
+# Variant: allow-extension-wrap-all: [preserve_entry_signatures: AllowExtension]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/_config.json
@@ -1,9 +1,11 @@
 {
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
@@ -13,7 +13,7 @@ export { foo };
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -34,7 +34,7 @@ export { foo };
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/_config.json
@@ -1,9 +1,11 @@
 {
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
@@ -16,7 +16,7 @@ export { foo };
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -39,7 +39,7 @@ export { foo };
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/_config.json
@@ -1,8 +1,9 @@
 {
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
-    { "strictExecutionOrder": true, "onDemandWrapping": true }
+    { "_configName": "on-demand", "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
@@ -17,7 +17,7 @@ export { value as normalLibValue, value$1 as tlaLibValue };
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -59,7 +59,7 @@ export { value as normalLibValue, value$1 as tlaLibValue };
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/_config.json
@@ -2,9 +2,11 @@
   "snapshot": false,
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/_config.json
@@ -2,9 +2,11 @@
   "snapshot": false,
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/_config.json
@@ -14,9 +14,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/_config.json
@@ -14,9 +14,11 @@
   },
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
     {
+      "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/_config.json
@@ -1,8 +1,9 @@
 {
   "configVariants": [
     {
+      "_configName": "wrap-all",
       "strictExecutionOrder": true
     },
-    { "strictExecutionOrder": true, "onDemandWrapping": true }
+    { "_configName": "on-demand", "strictExecutionOrder": true, "onDemandWrapping": true }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -14,7 +14,7 @@ export { value };
 
 ```
 
-# Variant: [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 
@@ -42,7 +42,7 @@ export { value };
 
 ```
 
-# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
@@ -1,5 +1,6 @@
 {
   "_comment": "A top-level pure dynamic import of side-effect-free leaf.js with unused exports must not load leaf.js's body (it is modeled as importing an empty namespace), so leaf.js must not be exempt from on-demand side-effect pruning just because it appeared in the dynamic entry set. The entries only use leaf's re-exported `other`; leaf's own `value = first(second)` body must stay dropped even when strictExecutionOrder wraps the re-export path.",
+  "configName": "wrap-all",
   "config": {
     "input": [
       { "name": "a", "import": "./entry-a.js" },


### PR DESCRIPTION
## Summary

- Give every declared strict-execution-order fixture cell an explicit config name. All 190 cells across 93 fixtures now identify the wrapping mode as `wrap-all` / `on-demand`, with any orthogonal setting included as a prefix.
- Normalize the naming outliers called out in the #10252 review without changing the base, variant, or generated extended-test matrices.
- Complete the `emergent_cycle_excluded_forwarder_import` comment with the projection/fixpoint path that makes the regression green.

## Why

This follows up on [review feedback from #10252](https://github.com/rolldown/rolldown/pull/10252#issuecomment-4957827280). Unnamed cells left `globalThis.__configName` unset, while labels such as `strict`, `minify`, or `cjs` did not consistently say whether the cell used wrap-all or on-demand wrapping.

Relative to `main`, every changed `_config.json` is identical after removing `configName` / `_configName`; the fixture matrix and expected-execution-failure markers are unchanged. Generated output is also unchanged. The 21 updated snapshots only rename 35 `# Variant:` headings.

## Validation

- Audited all 95 config files containing `strictExecutionOrder`: 190 declared strict cells, with zero unnamed cells, mode mismatches, or fixture-local duplicate names.
- Ran `just t-run` for all 95 config files twice; both passes completed 95/95 and the snapshot diff stayed stable.
- Ran the five fixtures whose base mode affects generated extended variants twice with `NEEDS_EXTENDED=true cargo run-fixture`.
- `just lint-repo`
- `git diff --check origin/main`
