### PR TITLE
chore(docs): migrate Netlify redirects to Void config

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -3,4 +3,8 @@
 /llms-full.txt /llms-full.txt 200!
 /llms-full.md /llms-full.txt 200!
 /llms.md /llms.txt 301
-/:document.txt /:document.md 301
+/acknowledgements.txt /acknowledgements.md 301
+/builtin-plugins.txt /builtin-plugins.md 301
+/contribution-guide.txt /contribution-guide.md 301
+/glossary.txt /glossary.md 301
+/reference.txt /reference.md 301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,6 @@
+# Keep the exact LLM routes ahead of the root-level .txt redirect.
+/llms.txt /llms.txt 200!
+/llms-full.txt /llms-full.txt 200!
+/llms-full.md /llms-full.txt 200!
+/llms.md /llms.txt 301
+/:document.txt /:document.md 301

--- a/docs/void.json
+++ b/docs/void.json
@@ -4,11 +4,10 @@
   },
   "routing": {
     "redirects": {
-      "/about/": { "to": "/guide/", "status": 301 },
-      "/plugins/hook-filters": { "to": "/apis/plugin-hook-filters", "status": 301 },
-      "/guide/plugin-development": { "to": "/plugins/", "status": 301 },
-      "/reference/": { "to": "/apis/", "status": 301 },
-      "/guide/in-depth/": { "to": "/in-depth/", "status": 301 },
+      "/about/": { "to": "/guide/introduction", "status": 301 },
+      "/plugins/hook-filters": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
+      "/guide/plugin-development": { "to": "/apis/plugin-api", "status": 301 },
+      "/guide/in-depth/": { "to": "/in-depth/why-bundlers", "status": 301 },
       "/apis/config-options/": { "to": "/reference/", "status": 301 },
       "/options/": { "to": "/reference", "status": 301 },
       "/apis/plugin-hook-filters": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
@@ -48,13 +47,13 @@
       "/in-depth/advanced-chunks": { "to": "/in-depth/manual-code-splitting", "status": 301 },
       "/in-depth/code-splitting": { "to": "/in-depth/automatic-code-splitting", "status": 301 },
       "/options/output-clean-dir": { "to": "/reference/OutputOptions.cleanDir", "status": 301 },
-      "/*.txt": { "to": "/:splat.md", "status": 301 },
       "/llms.md": { "to": "/llms.txt", "status": 301 }
     },
     "rewrites": {
-      "/llms.txt": "/llms.txt",
-      "/llms-full.md": "/llms-full.txt",
-      "/llms-full.txt": "/llms-full.txt"
+      "/llms-full.md": "/llms-full.txt"
+    },
+    "fallbacks": {
+      "/*.txt": "/:splat.md"
     }
   },
   "inference": {

--- a/docs/void.json
+++ b/docs/void.json
@@ -4,39 +4,75 @@
   },
   "routing": {
     "redirects": {
+      "/about": { "to": "/guide/introduction", "status": 301 },
       "/about/": { "to": "/guide/introduction", "status": 301 },
       "/plugins/hook-filters": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
+      "/plugins/hook-filters/": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
       "/guide/plugin-development": { "to": "/apis/plugin-api", "status": 301 },
+      "/guide/plugin-development/": { "to": "/apis/plugin-api", "status": 301 },
+      "/guide/in-depth": { "to": "/in-depth/why-bundlers", "status": 301 },
       "/guide/in-depth/": { "to": "/in-depth/why-bundlers", "status": 301 },
+      "/apis/config-options": { "to": "/reference/", "status": 301 },
       "/apis/config-options/": { "to": "/reference/", "status": 301 },
+      "/options": { "to": "/reference", "status": 301 },
       "/options/": { "to": "/reference", "status": 301 },
       "/apis/plugin-hook-filters": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
+      "/apis/plugin-hook-filters/": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
       "/options/input": { "to": "/reference/InputOptions.input", "status": 301 },
+      "/options/input/": { "to": "/reference/InputOptions.input", "status": 301 },
       "/options/external": { "to": "/reference/InputOptions.external", "status": 301 },
+      "/options/external/": { "to": "/reference/InputOptions.external", "status": 301 },
       "/options/resolve": { "to": "/reference/InputOptions.resolve", "status": 301 },
+      "/options/resolve/": { "to": "/reference/InputOptions.resolve", "status": 301 },
       "/options/cwd": { "to": "/reference/InputOptions.cwd", "status": 301 },
+      "/options/cwd/": { "to": "/reference/InputOptions.cwd", "status": 301 },
       "/options/platform": { "to": "/reference/InputOptions.platform", "status": 301 },
+      "/options/platform/": { "to": "/reference/InputOptions.platform", "status": 301 },
       "/options/shim-missing-exports": {
         "to": "/reference/InputOptions.shimMissingExports",
         "status": 301
       },
+      "/options/shim-missing-exports/": {
+        "to": "/reference/InputOptions.shimMissingExports",
+        "status": 301
+      },
       "/options/treeshake": { "to": "/reference/InputOptions.treeshake", "status": 301 },
+      "/options/treeshake/": { "to": "/reference/InputOptions.treeshake", "status": 301 },
       "/options/log-level": { "to": "/reference/InputOptions.logLevel", "status": 301 },
+      "/options/log-level/": { "to": "/reference/InputOptions.logLevel", "status": 301 },
       "/options/on-log": { "to": "/reference/InputOptions.onLog", "status": 301 },
+      "/options/on-log/": { "to": "/reference/InputOptions.onLog", "status": 301 },
       "/options/onwarn": { "to": "/reference/InputOptions.onwarn", "status": 301 },
+      "/options/onwarn/": { "to": "/reference/InputOptions.onwarn", "status": 301 },
       "/options/module-types": { "to": "/reference/InputOptions.moduleTypes", "status": 301 },
+      "/options/module-types/": { "to": "/reference/InputOptions.moduleTypes", "status": 301 },
       "/options/preserve-entry-signatures": {
         "to": "/reference/InputOptions.preserveEntrySignatures",
         "status": 301
       },
+      "/options/preserve-entry-signatures/": {
+        "to": "/reference/InputOptions.preserveEntrySignatures",
+        "status": 301
+      },
       "/options/optimization": { "to": "/reference/InputOptions.optimization", "status": 301 },
+      "/options/optimization/": { "to": "/reference/InputOptions.optimization", "status": 301 },
       "/options/context": { "to": "/reference/InputOptions.context", "status": 301 },
+      "/options/context/": { "to": "/reference/InputOptions.context", "status": 301 },
       "/options/tsconfig": { "to": "/reference/InputOptions.tsconfig", "status": 301 },
+      "/options/tsconfig/": { "to": "/reference/InputOptions.tsconfig", "status": 301 },
       "/options/checks": { "to": "/reference/InputOptions.checks", "status": 301 },
+      "/options/checks/": { "to": "/reference/InputOptions.checks", "status": 301 },
       "/options/experimental": { "to": "/reference/InputOptions.experimental", "status": 301 },
+      "/options/experimental/": { "to": "/reference/InputOptions.experimental", "status": 301 },
       "/options/output": { "to": "/reference/Interface.OutputOptions", "status": 301 },
+      "/options/output/": { "to": "/reference/Interface.OutputOptions", "status": 301 },
       "/options/output-sourcemap": { "to": "/reference/OutputOptions.sourcemap", "status": 301 },
+      "/options/output-sourcemap/": { "to": "/reference/OutputOptions.sourcemap", "status": 301 },
       "/options/output-generated-code": {
+        "to": "/reference/OutputOptions.generatedCode",
+        "status": 301
+      },
+      "/options/output-generated-code/": {
         "to": "/reference/OutputOptions.generatedCode",
         "status": 301
       },
@@ -44,16 +80,16 @@
         "to": "/reference/OutputOptions.codeSplitting",
         "status": 301
       },
+      "/options/output-advanced-chunks/": {
+        "to": "/reference/OutputOptions.codeSplitting",
+        "status": 301
+      },
       "/in-depth/advanced-chunks": { "to": "/in-depth/manual-code-splitting", "status": 301 },
+      "/in-depth/advanced-chunks/": { "to": "/in-depth/manual-code-splitting", "status": 301 },
       "/in-depth/code-splitting": { "to": "/in-depth/automatic-code-splitting", "status": 301 },
+      "/in-depth/code-splitting/": { "to": "/in-depth/automatic-code-splitting", "status": 301 },
       "/options/output-clean-dir": { "to": "/reference/OutputOptions.cleanDir", "status": 301 },
-      "/llms.md": { "to": "/llms.txt", "status": 301 }
-    },
-    "rewrites": {
-      "/llms-full.md": "/llms-full.txt"
-    },
-    "fallbacks": {
-      "/*.txt": "/:splat.md"
+      "/options/output-clean-dir/": { "to": "/reference/OutputOptions.cleanDir", "status": 301 }
     }
   },
   "inference": {

--- a/docs/void.json
+++ b/docs/void.json
@@ -2,6 +2,61 @@
   "worker": {
     "compatibility_date": "2026-02-24"
   },
+  "routing": {
+    "redirects": {
+      "/about/": { "to": "/guide/", "status": 301 },
+      "/plugins/hook-filters": { "to": "/apis/plugin-hook-filters", "status": 301 },
+      "/guide/plugin-development": { "to": "/plugins/", "status": 301 },
+      "/reference/": { "to": "/apis/", "status": 301 },
+      "/guide/in-depth/": { "to": "/in-depth/", "status": 301 },
+      "/apis/config-options/": { "to": "/reference/", "status": 301 },
+      "/options/": { "to": "/reference", "status": 301 },
+      "/apis/plugin-hook-filters": { "to": "/apis/plugin-api/hook-filters", "status": 301 },
+      "/options/input": { "to": "/reference/InputOptions.input", "status": 301 },
+      "/options/external": { "to": "/reference/InputOptions.external", "status": 301 },
+      "/options/resolve": { "to": "/reference/InputOptions.resolve", "status": 301 },
+      "/options/cwd": { "to": "/reference/InputOptions.cwd", "status": 301 },
+      "/options/platform": { "to": "/reference/InputOptions.platform", "status": 301 },
+      "/options/shim-missing-exports": {
+        "to": "/reference/InputOptions.shimMissingExports",
+        "status": 301
+      },
+      "/options/treeshake": { "to": "/reference/InputOptions.treeshake", "status": 301 },
+      "/options/log-level": { "to": "/reference/InputOptions.logLevel", "status": 301 },
+      "/options/on-log": { "to": "/reference/InputOptions.onLog", "status": 301 },
+      "/options/onwarn": { "to": "/reference/InputOptions.onwarn", "status": 301 },
+      "/options/module-types": { "to": "/reference/InputOptions.moduleTypes", "status": 301 },
+      "/options/preserve-entry-signatures": {
+        "to": "/reference/InputOptions.preserveEntrySignatures",
+        "status": 301
+      },
+      "/options/optimization": { "to": "/reference/InputOptions.optimization", "status": 301 },
+      "/options/context": { "to": "/reference/InputOptions.context", "status": 301 },
+      "/options/tsconfig": { "to": "/reference/InputOptions.tsconfig", "status": 301 },
+      "/options/checks": { "to": "/reference/InputOptions.checks", "status": 301 },
+      "/options/experimental": { "to": "/reference/InputOptions.experimental", "status": 301 },
+      "/options/output": { "to": "/reference/Interface.OutputOptions", "status": 301 },
+      "/options/output-sourcemap": { "to": "/reference/OutputOptions.sourcemap", "status": 301 },
+      "/options/output-generated-code": {
+        "to": "/reference/OutputOptions.generatedCode",
+        "status": 301
+      },
+      "/options/output-advanced-chunks": {
+        "to": "/reference/OutputOptions.codeSplitting",
+        "status": 301
+      },
+      "/in-depth/advanced-chunks": { "to": "/in-depth/manual-code-splitting", "status": 301 },
+      "/in-depth/code-splitting": { "to": "/in-depth/automatic-code-splitting", "status": 301 },
+      "/options/output-clean-dir": { "to": "/reference/OutputOptions.cleanDir", "status": 301 },
+      "/*.txt": { "to": "/:splat.md", "status": 301 },
+      "/llms.md": { "to": "/llms.txt", "status": 301 }
+    },
+    "rewrites": {
+      "/llms.txt": "/llms.txt",
+      "/llms-full.md": "/llms-full.txt",
+      "/llms-full.txt": "/llms-full.txt"
+    }
+  },
   "inference": {
     "appType": "static",
     "outputDir": ".vitepress/dist"


### PR DESCRIPTION
The migration to Void in #9509 omitted the redirects added in #7834, leaving old documentation links broken. For example, these URLs currently return 404 instead of redirecting to the correct page:

   - [`https://rolldown.rs/about/`](https://rolldown.rs/about/) -> `/guide/`
   - [`https://rolldown.rs/options/input`](https://rolldown.rs/options/input) -> `/reference/InputOptions.input`
   - [`https://rolldown.rs/in-depth/code-splitting`](https://rolldown.rs/in-depth/code-splitting) -> `/in-depth/automatic-code-splitting`

This ports the existing rules from `docs/netlify.toml` to `docs/void.json`. The changes follow Void's [redirect](https://void.cloud/guide/edge/redirects) and [rewrite](https://void.cloud/guide/edge/rewrites) documentation.

The configuration has not been tested on Void Cloud since it's currently in private beta. The JSON syntax was validated locally, and all Netlify rules were verified against the resulting Void redirects and rewrites.

**Disclosure:** AI assistance was used to verify the redirect-matching configuration.