### PR TITLE
refactor: replace take_in-then-write-back with ReplaceWith and by-value moves

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -1,7 +1,7 @@
 use oxc::allocator::GetAllocator;
 use oxc::ast::ast::Str;
 use oxc::{
-  allocator::{Box as ArenaBox, IntoIn, TakeIn},
+  allocator::IntoIn,
   ast::{
     NONE,
     ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind, Statement},
@@ -80,83 +80,77 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
   pub fn handle_top_level_stmt(
     &mut self,
     program_body: &mut oxc::allocator::Vec<'ast, ast::Statement<'ast>>,
-    mut node: ast::Statement<'ast>,
+    node: ast::Statement<'ast>,
     scoping: &Scoping,
   ) {
     match node {
-      ref mut module_decl @ ast::match_module_declaration!(Statement) => {
-        let module_decl = module_decl.to_module_declaration_mut();
-
-        match module_decl {
-          ast::ModuleDeclaration::ImportDeclaration(import_decl) => {
-            // Transform
-            // ```js
-            // import foo, { bar } from './foo.js';
-            // console.log(foo, bar);
-            // ```
-            // to
-            // ```js
-            // const import_foo = __rolldown_runtime__.loadExports('./foo.js');
-            // console.log(import_foo.default, import_foo.bar);
-            // ```
-            let rec_id = self.module.imports[&import_decl.node_id()];
-            let rec = &self.module.import_records[rec_id];
-            let Some(importee_idx) = rec.resolved_module else { return };
-            let importee = &self.modules[importee_idx];
-            self.dependencies.insert(importee_idx);
-            let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
-            import_decl.specifiers.as_ref().inspect(|specifiers| {
-              specifiers.iter().for_each(|spec| match spec {
-                ast::ImportDeclarationSpecifier::ImportSpecifier(import_specifier) => {
-                  self.import_bindings.insert(
-                    import_specifier.local.symbol_id(),
-                    format!("{binding_name}.{}", import_specifier.imported.name()),
-                  );
-                }
-                ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(
-                  import_default_specifier,
-                ) => {
-                  self.import_bindings.insert(
-                    import_default_specifier.local.symbol_id(),
-                    format!("{binding_name}.default"),
-                  );
-                }
-                ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-                  import_namespace_specifier,
-                ) => {
-                  self
-                    .import_bindings
-                    .insert(import_namespace_specifier.local.symbol_id(), binding_name.clone());
-                }
-              });
-            });
-            match importee {
-              Module::Normal(_) => {
-                if let Some(stmt) =
-                  self.create_load_exports_call_stmt(importee, &binding_name, import_decl.span)
-                {
-                  program_body.push(stmt);
-                }
-              }
-              Module::External(importee_ext) => {
-                self.create_static_import_stmt_from_external_module(
-                  importee_ext,
-                  &binding_name,
-                  import_decl.span,
-                );
-              }
+      ast::Statement::ImportDeclaration(import_decl) => {
+        // Transform
+        // ```js
+        // import foo, { bar } from './foo.js';
+        // console.log(foo, bar);
+        // ```
+        // to
+        // ```js
+        // const import_foo = __rolldown_runtime__.loadExports('./foo.js');
+        // console.log(import_foo.default, import_foo.bar);
+        // ```
+        let rec_id = self.module.imports[&import_decl.node_id()];
+        let rec = &self.module.import_records[rec_id];
+        let Some(importee_idx) = rec.resolved_module else { return };
+        let importee = &self.modules[importee_idx];
+        self.dependencies.insert(importee_idx);
+        let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
+        import_decl.specifiers.as_ref().inspect(|specifiers| {
+          specifiers.iter().for_each(|spec| match spec {
+            ast::ImportDeclarationSpecifier::ImportSpecifier(import_specifier) => {
+              self.import_bindings.insert(
+                import_specifier.local.symbol_id(),
+                format!("{binding_name}.{}", import_specifier.imported.name()),
+              );
+            }
+            ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(import_default_specifier) => {
+              self.import_bindings.insert(
+                import_default_specifier.local.symbol_id(),
+                format!("{binding_name}.default"),
+              );
+            }
+            ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+              import_namespace_specifier,
+            ) => {
+              self
+                .import_bindings
+                .insert(import_namespace_specifier.local.symbol_id(), binding_name.clone());
+            }
+          });
+        });
+        match importee {
+          Module::Normal(_) => {
+            if let Some(stmt) =
+              self.create_load_exports_call_stmt(importee, &binding_name, import_decl.span)
+            {
+              program_body.push(stmt);
             }
           }
-          ast::ModuleDeclaration::ExportNamedDeclaration(decl) => {
-            if let Some(_source) = &decl.source {
-              // export {} from '...'
-              let rec_id = self.module.imports[&decl.node_id()];
-              let rec = &self.module.import_records[rec_id];
-              let Some(importee_idx) = rec.resolved_module else { return };
-              let importee = &self.modules[importee_idx];
-              self.dependencies.insert(importee_idx);
-              let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
-              self.exports.extend(decl.specifiers.iter().map(|specifier| {
+          Module::External(importee_ext) => {
+            self.create_static_import_stmt_from_external_module(
+              importee_ext,
+              &binding_name,
+              import_decl.span,
+            );
+          }
+        }
+      }
+      ast::Statement::ExportNamedDeclaration(mut decl) => {
+        if decl.source.is_some() {
+          // export {} from '...'
+          let rec_id = self.module.imports[&decl.node_id()];
+          let rec = &self.module.import_records[rec_id];
+          let Some(importee_idx) = rec.resolved_module else { return };
+          let importee = &self.modules[importee_idx];
+          self.dependencies.insert(importee_idx);
+          let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
+          self.exports.extend(decl.specifiers.iter().map(|specifier| {
                         self.ast_factory.make_lazy_export_property(
                           &specifier.exported.name(),
                           match &specifier.local {
@@ -193,145 +187,129 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                           matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_))
                         )
                       }));
-              if let Some(stmt) =
-                self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
-              {
-                program_body.push(stmt);
-              }
-            } else if let Some(decl) = &mut decl.declaration {
-              match decl {
-                ast::Declaration::VariableDeclaration(var_decl) => {
-                  // export var foo = 1
-                  // export var { foo, bar } = { foo: 1, bar: 2 }
-                  self.exports.extend(var_decl.declarations.iter().flat_map(|decl| {
-                    decl.id.get_binding_identifiers().into_iter().map(|ident| {
-                      self.ast_factory.make_lazy_export_property(
-                        ident.name.as_str(),
-                        self.ast_factory.make_id_ref_expr(SPAN, ident.name.as_str()),
-                        false,
-                      )
-                    })
-                  }));
-                }
-                ast::Declaration::FunctionDeclaration(fn_decl) => {
-                  // export function foo() {}
-                  let id = fn_decl.id.as_ref().unwrap().name.as_str();
-                  self.exports.push(self.ast_factory.make_lazy_export_property(
-                    id,
-                    self.ast_factory.make_id_ref_expr(SPAN, id),
-                    false,
-                  ));
-                }
-                ast::Declaration::ClassDeclaration(cls_decl) => {
-                  // export class Foo {}
-                  let id = cls_decl.id.as_ref().unwrap().name.as_str();
-                  self.exports.push(self.ast_factory.make_lazy_export_property(
-                    id,
-                    self.ast_factory.make_id_ref_expr(SPAN, id),
-                    false,
-                  ));
-                }
-                _ => unreachable!("doesn't support ts now"),
-              }
-              program_body.push(ast::Statement::from(decl.take_in(&self.ast_factory.allocator())));
-            } else {
-              // export { foo, bar as bar2 }
-              decl.specifiers.iter().for_each(|specifier| {
-                if let Some(symbol_id) = scoping.get_root_binding(specifier.local.name().into()) {
-                  self
-                    .named_exports
-                    .insert(specifier.exported.name(), NamedExport { local_binding: symbol_id });
-                } else {
-                  // TODO: export undefined variable
-                }
-              });
-            }
+          if let Some(stmt) = self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
+          {
+            program_body.push(stmt);
           }
-          ast::ModuleDeclaration::ExportDefaultDeclaration(decl) => match &mut decl.declaration {
-            ast::ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
-              if let Some(id) = &function.id {
-                self.exports.push(self.ast_factory.make_lazy_export_property(
-                  "default",
-                  self.ast_factory.make_id_ref_expr(SPAN, &id.name),
-                  false,
-                ));
-              } else {
-                function.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
-                self.exports.push(self.ast_factory.make_lazy_export_property(
-                  "default",
-                  self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
-                  false,
-                ));
-              }
-              program_body.push(ast::Statement::FunctionDeclaration(ArenaBox::new_in(
-                function.as_mut().take_in(&self.ast_factory.allocator()),
-                &self.ast_factory.allocator(),
-              )));
+        } else if let Some(declaration) = decl.declaration.take() {
+          match &declaration {
+            ast::Declaration::VariableDeclaration(var_decl) => {
+              // export var foo = 1
+              // export var { foo, bar } = { foo: 1, bar: 2 }
+              self.exports.extend(var_decl.declarations.iter().flat_map(|decl| {
+                decl.id.get_binding_identifiers().into_iter().map(|ident| {
+                  self.ast_factory.make_lazy_export_property(
+                    ident.name.as_str(),
+                    self.ast_factory.make_id_ref_expr(SPAN, ident.name.as_str()),
+                    false,
+                  )
+                })
+              }));
             }
-            ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
-              if let Some(id) = &class.id {
-                self.exports.push(self.ast_factory.make_lazy_export_property(
-                  "default",
-                  self.ast_factory.make_id_ref_expr(SPAN, &id.name),
-                  false,
-                ));
-              } else {
-                class.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
-                self.exports.push(self.ast_factory.make_lazy_export_property(
-                  "default",
-                  self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
-                  false,
-                ));
-              }
-              program_body.push(ast::Statement::ClassDeclaration(ArenaBox::new_in(
-                class.as_mut().take_in(&self.ast_factory.allocator()),
-                &self.ast_factory.allocator(),
-              )));
-            }
-            expr @ ast::match_expression!(ExportDefaultDeclarationKind) => {
-              let expr = expr.to_expression_mut();
-              // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
-              program_body.push(self.ast_factory.make_var_decl(
-                "__rolldown_default__",
-                expr.take_in(&self.ast_factory.allocator()),
-              ));
+            ast::Declaration::FunctionDeclaration(fn_decl) => {
+              // export function foo() {}
+              let id = fn_decl.id.as_ref().unwrap().name.as_str();
               self.exports.push(self.ast_factory.make_lazy_export_property(
-                "default",
-                self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+                id,
+                self.ast_factory.make_id_ref_expr(SPAN, id),
                 false,
               ));
             }
-            unhandled_kind => {
-              unreachable!("Unexpected export default declaration kind: {unhandled_kind:#?}");
+            ast::Declaration::ClassDeclaration(cls_decl) => {
+              // export class Foo {}
+              let id = cls_decl.id.as_ref().unwrap().name.as_str();
+              self.exports.push(self.ast_factory.make_lazy_export_property(
+                id,
+                self.ast_factory.make_id_ref_expr(SPAN, id),
+                false,
+              ));
             }
-          },
-          ast::ModuleDeclaration::ExportAllDeclaration(export_all_decl) => {
-            let rec_id = self.module.imports[&export_all_decl.node_id()];
-            let rec = &self.module.import_records[rec_id];
-            let Some(importee_idx) = rec.resolved_module else { return };
-            let importee = &self.modules[importee_idx];
-            self.dependencies.insert(importee_idx);
-            let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
-            if let Some(stmt) =
-              self.create_load_exports_call_stmt(importee, &binding_name, export_all_decl.span)
-            {
-              program_body.push(stmt);
-            }
-            if let Some(stmt) =
-              self.create_re_export_call_stmt(importee, &binding_name, export_all_decl.span)
-            {
-              program_body.push(stmt);
-            }
+            _ => unreachable!("doesn't support ts now"),
           }
-          ast::ModuleDeclaration::TSExportAssignment(_)
-          | ast::ModuleDeclaration::TSNamespaceExportDeclaration(_) => {
-            // Typescript code should be pre-processed by rolldown. If it doesn't, it means there's error. Instead of panic, we'll just keep
-            // the original code.
-            program_body.push(node);
-          }
+          program_body.push(ast::Statement::from(declaration));
+        } else {
+          // export { foo, bar as bar2 }
+          decl.specifiers.iter().for_each(|specifier| {
+            if let Some(symbol_id) = scoping.get_root_binding(specifier.local.name().into()) {
+              self
+                .named_exports
+                .insert(specifier.exported.name(), NamedExport { local_binding: symbol_id });
+            } else {
+              // TODO: export undefined variable
+            }
+          });
         }
       }
-      _ => {
+      ast::Statement::ExportDefaultDeclaration(decl) => match decl.unbox().declaration {
+        ast::ExportDefaultDeclarationKind::FunctionDeclaration(mut function) => {
+          if let Some(id) = &function.id {
+            self.exports.push(self.ast_factory.make_lazy_export_property(
+              "default",
+              self.ast_factory.make_id_ref_expr(SPAN, &id.name),
+              false,
+            ));
+          } else {
+            function.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
+            self.exports.push(self.ast_factory.make_lazy_export_property(
+              "default",
+              self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+              false,
+            ));
+          }
+          program_body.push(ast::Statement::FunctionDeclaration(function));
+        }
+        ast::ExportDefaultDeclarationKind::ClassDeclaration(mut class) => {
+          if let Some(id) = &class.id {
+            self.exports.push(self.ast_factory.make_lazy_export_property(
+              "default",
+              self.ast_factory.make_id_ref_expr(SPAN, &id.name),
+              false,
+            ));
+          } else {
+            class.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
+            self.exports.push(self.ast_factory.make_lazy_export_property(
+              "default",
+              self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+              false,
+            ));
+          }
+          program_body.push(ast::Statement::ClassDeclaration(class));
+        }
+        expr @ ast::match_expression!(ExportDefaultDeclarationKind) => {
+          let expr = expr.into_expression();
+          // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
+          program_body.push(self.ast_factory.make_var_decl("__rolldown_default__", expr));
+          self.exports.push(self.ast_factory.make_lazy_export_property(
+            "default",
+            self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+            false,
+          ));
+        }
+        unhandled_kind => {
+          unreachable!("Unexpected export default declaration kind: {unhandled_kind:#?}");
+        }
+      },
+      ast::Statement::ExportAllDeclaration(export_all_decl) => {
+        let rec_id = self.module.imports[&export_all_decl.node_id()];
+        let rec = &self.module.import_records[rec_id];
+        let Some(importee_idx) = rec.resolved_module else { return };
+        let importee = &self.modules[importee_idx];
+        self.dependencies.insert(importee_idx);
+        let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
+        if let Some(stmt) =
+          self.create_load_exports_call_stmt(importee, &binding_name, export_all_decl.span)
+        {
+          program_body.push(stmt);
+        }
+        if let Some(stmt) =
+          self.create_re_export_call_stmt(importee, &binding_name, export_all_decl.span)
+        {
+          program_body.push(stmt);
+        }
+      }
+      // Typescript module declarations should be pre-processed by rolldown. If they aren't,
+      // it means there's an error. Instead of panicking, we'll just keep the original code.
+      node => {
         program_body.push(node);
       }
     }

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use oxc::ast::AstType;
 use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::{
-  allocator::{self, IntoIn, TakeIn},
+  allocator::{self, IntoIn, ReplaceWith, TakeIn},
   ast::{
     NONE,
     ast::{self, BindingPattern, Expression, SimpleAssignmentTarget, Statement},
@@ -404,16 +404,17 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 // - visit_binding_identifier won't re-rename
                 id.symbol_id.get_mut().take();
 
-                let fn_expr = expr.take_in(&self.alloc);
                 let name_ref = self.canonical_ref_for_runtime("__name");
                 let (finalized_callee, _) =
                   self.finalized_expr_for_symbol_ref(name_ref, false, false);
-                *expr = self.ast_factory.make_keep_name_call(
-                  &original_name,
-                  fn_expr,
-                  finalized_callee,
-                  true,
-                );
+                expr.replace_with(|fn_expr| {
+                  self.ast_factory.make_keep_name_call(
+                    &original_name,
+                    fn_expr,
+                    finalized_callee,
+                    true,
+                  )
+                });
               }
             }
           }
@@ -784,16 +785,21 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         ) {
           decl.body.body.insert(0, element);
         }
-        if let Some(new_decl) = self.get_transformed_class_decl(decl) {
-          *it = new_decl;
-          // Clear symbol_id on class expression's id to prevent visit_expression
-          // from inserting a duplicate __name static block during walk
-          if let ast::Declaration::VariableDeclaration(var_decl) = it {
-            if let Some(declarator) = var_decl.declarations.first_mut() {
-              if let Some(ast::Expression::ClassExpression(class_expr)) = &mut declarator.init {
-                if let Some(id) = &mut class_expr.id {
-                  id.symbol_id.get_mut().take();
-                }
+        it.replace_with(|old| {
+          let ast::Declaration::ClassDeclaration(class_box) = old else { unreachable!() };
+          match self.get_transformed_class_decl(class_box) {
+            Ok(new_decl) => new_decl,
+            Err(class_box) => ast::Declaration::ClassDeclaration(class_box),
+          }
+        });
+        // Clear symbol_id on class expression's id to prevent visit_expression
+        // from inserting a duplicate __name static block during walk
+        // (`it` is only a `VariableDeclaration` when the class was transformed above).
+        if let ast::Declaration::VariableDeclaration(var_decl) = it {
+          if let Some(declarator) = var_decl.declarations.first_mut() {
+            if let Some(ast::Expression::ClassExpression(class_expr)) = &mut declarator.init {
+              if let Some(id) = &mut class_expr.id {
+                id.symbol_id.get_mut().take();
               }
             }
           }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -4,7 +4,7 @@ use oxc::ast::ast::ObjectPropertyKind;
 use oxc::ast::builder::GetAstBuilder;
 use oxc::semantic::{ReferenceId, ScopeFlags, SymbolId};
 use oxc::{
-  allocator::{self, Allocator, Box as ArenaBox, CloneIn, Dummy, IntoIn, TakeIn},
+  allocator::{self, Allocator, CloneIn, Dummy, IntoIn, ReplaceWith, TakeIn},
   ast::{
     NONE,
     ast::{
@@ -772,21 +772,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
     let mut ret = vec![];
-    let exprs = decl.declarations.iter_mut().filter_map(|var_decl| {
+    let exprs = decl.declarations.take_in(&self.alloc).into_iter().filter_map(|var_decl| {
       ret.extend(var_decl.id.get_binding_identifiers().iter().map(|item| item.name));
       // Turn `var ... = ...` to `... = ...`
-      if let Some(ref mut init_expr) = var_decl.init {
-        let left = var_decl.id.take_in(&self.alloc).into_assignment_target(&self.ast_factory);
-        Some(ast::Expression::AssignmentExpression(ast::AssignmentExpression::boxed(
-          SPAN,
-          ast::AssignmentOperator::Assign,
-          left,
-          init_expr.take_in(&self.alloc),
-          &self.ast_factory,
-        )))
-      } else {
-        None
-      }
+      let init_expr = var_decl.init?;
+      let left = var_decl.id.into_assignment_target(&self.ast_factory);
+      Some(ast::Expression::AssignmentExpression(ast::AssignmentExpression::boxed(
+        SPAN,
+        ast::AssignmentOperator::Assign,
+        left,
+        init_expr,
+        &self.ast_factory,
+      )))
     });
     Some((
       ast::Expression::new_sequence_expression(
@@ -1333,18 +1330,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   }
 
   /// rewrite toplevel `class ClassName {}` to `var ClassName = class {}`
+  ///
+  /// Takes the class by value so its box can be reused as the class expression;
+  /// gives it back unchanged when no transformation applies.
   fn get_transformed_class_decl(
     &self,
-    class: &mut allocator::Box<'ast, ast::Class<'ast>>,
-  ) -> Option<ast::Declaration<'ast>> {
-    let scope_id = class.scope_id.get()?;
+    mut class: allocator::Box<'ast, ast::Class<'ast>>,
+  ) -> Result<ast::Declaration<'ast>, allocator::Box<'ast, ast::Class<'ast>>> {
+    let Some(scope_id) = class.scope_id.get() else { return Err(class) };
 
     if self.scope.scoping().scope_parent_id(scope_id) != Some(self.scope.scoping().root_scope_id())
     {
-      return None;
+      return Err(class);
     }
 
-    let id = class.id.take()?;
+    let Some(id) = class.id.take() else { return Err(class) };
 
     if let Some(symbol_id) = id.symbol_id.get() {
       if self.ctx.module.self_referenced_class_decl_symbol_ids.contains(&symbol_id) {
@@ -1356,7 +1356,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         class.id = Some(id);
       }
     }
-    Some(ast::Declaration::new_variable_declaration(
+    Ok(ast::Declaration::new_variable_declaration(
       class.span,
       VariableDeclarationKind::Var,
       oxc::allocator::Vec::from_value_in(
@@ -1368,10 +1368,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             &self.ast_factory,
           )),
           NONE,
-          Some(Expression::ClassExpression(ArenaBox::new_in(
-            class.as_mut().take_in(&self.alloc),
-            &self.alloc,
-          ))),
+          Some(Expression::ClassExpression(class)),
           false,
           &self.ast_factory,
         ),
@@ -1870,10 +1867,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
             return;
           }
-        } else if let Some(default_decl) = top_stmt.as_export_default_declaration_mut() {
+        } else if matches!(top_stmt, ast::Statement::ExportDefaultDeclaration(_)) {
           use ast::ExportDefaultDeclarationKind;
+          let ast::Statement::ExportDefaultDeclaration(default_decl) = top_stmt else {
+            unreachable!()
+          };
           let default_decl_span = default_decl.span;
-          match &mut default_decl.declaration {
+          match default_decl.unbox().declaration {
             // Special case: when exporting an identifier that's already the default export symbol
             ast::ExportDefaultDeclarationKind::Identifier(id)
               if self.scope.scoping().get_reference(id.reference_id()).symbol_id().is_some_and(
@@ -1884,12 +1884,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               return;
             }
             decl @ ast::match_expression!(ExportDefaultDeclarationKind) => {
-              let expr = decl.to_expression_mut();
+              let mut init_expr = decl.into_expression();
               let canonical_name_for_default_export_ref =
                 self.canonical_name_for(self.ctx.module.default_export_ref);
 
               // Check if we need to add __name() helper for anonymous function/class expressions or arrow functions
-              let mut init_expr = expr.take_in(&self.alloc);
               if self.ctx.options.keep_names {
                 let inner_expr = init_expr.without_parentheses_mut();
                 let needs_inline_name = match inner_expr {
@@ -1927,7 +1926,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               top_stmt =
                 self.ast_factory.make_var_decl(canonical_name_for_default_export_ref, init_expr);
             }
-            ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
+            ast::ExportDefaultDeclarationKind::FunctionDeclaration(mut func) => {
               // "export default function() {}" => "function default() {}"
               // "export default function foo() {}" => "function foo() {}"
               if func.id.is_none() {
@@ -1947,10 +1946,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   ));
                 }
               }
-              let func = func.as_mut().take_in(&self.alloc);
-              top_stmt = ast::Statement::FunctionDeclaration(ArenaBox::new_in(func, &self.alloc));
+              top_stmt = ast::Statement::FunctionDeclaration(func);
             }
-            ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+            ast::ExportDefaultDeclarationKind::ClassDeclaration(mut class) => {
               // "export default class {}" => "class default {}"
               // "export default class Foo {}" => "class Foo {}"
               if class.id.is_none() {
@@ -1973,37 +1971,38 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               }
 
               // Class should be handled specially, because the `ClassDecl` will be transformed again.
-              let mut class = class.as_mut().take_in(&self.alloc);
               class.span = default_decl_span;
-              top_stmt = ast::Statement::ClassDeclaration(ArenaBox::new_in(class, &self.alloc));
+              top_stmt = ast::Statement::ClassDeclaration(class);
             }
-            _ => {}
+            ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
+              unreachable!("TypeScript declarations are stripped before the finalizer runs")
+            }
           }
 
           // Transfer span of ExportDefaultDeclaration to FunctionDeclaration to preserve the
           // comments
           *top_stmt.span_mut() = default_decl_span;
-        } else if let Some(named_decl) = top_stmt.as_export_named_declaration_mut() {
-          if named_decl.source.is_none() {
-            let named_decl_span = named_decl.span;
-            if let Some(decl) = &mut named_decl.declaration {
-              // `export var foo = 1` => `var foo = 1`
-              // `export function foo() {}` => `function foo() {}`
-              // `export class Foo {}` => `class Foo {}`
+        } else if matches!(&top_stmt, ast::Statement::ExportNamedDeclaration(named_decl) if named_decl.source.is_none())
+        {
+          let ast::Statement::ExportNamedDeclaration(named_decl) = top_stmt else { unreachable!() };
+          let named_decl_span = named_decl.span;
+          if let Some(mut decl) = named_decl.unbox().declaration {
+            // `export var foo = 1` => `var foo = 1`
+            // `export function foo() {}` => `function foo() {}`
+            // `export class Foo {}` => `class Foo {}`
 
-              *decl.span_mut() = named_decl_span;
-              top_stmt = ast::Statement::from(decl.take_in(&self.alloc));
-            } else {
-              // `export { foo }`
-              // Remove this statement by ignoring it
-              return;
-            }
+            *decl.span_mut() = named_decl_span;
+            top_stmt = ast::Statement::from(decl);
           } else {
-            // `export { foo } from 'path'`
-            let rec_idx = self.ctx.module.imports[&named_decl.node_id()];
-            if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
-              return;
-            }
+            // `export { foo }`
+            // Remove this statement by ignoring it
+            return;
+          }
+        } else if let Some(named_decl) = top_stmt.as_export_named_declaration_mut() {
+          // `export { foo } from 'path'`
+          let rec_idx = self.ctx.module.imports[&named_decl.node_id()];
+          if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
+            return;
           }
         }
 
@@ -2014,10 +2013,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               decl.kind = VariableDeclarationKind::Var;
             }
           }
-          if let Statement::ClassDeclaration(class_decl) = &mut top_stmt {
-            if let Some(mut decl) = self.get_transformed_class_decl(class_decl) {
-              top_stmt = Statement::from(decl.take_in(&self.alloc));
-            }
+          if matches!(top_stmt, Statement::ClassDeclaration(_)) {
+            let Statement::ClassDeclaration(class_decl) = top_stmt else { unreachable!() };
+            top_stmt = match self.get_transformed_class_decl(class_decl) {
+              Ok(decl) => Statement::from(decl),
+              Err(class_decl) => Statement::ClassDeclaration(class_decl),
+            };
           }
         }
         program.body.push(top_stmt);
@@ -2074,22 +2075,22 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if let Some((_insert_position, original_name, _)) =
           self.process_fn(keep_name_id, keep_name_id)
         {
-          let fn_expr = expr.take_in(&self.alloc);
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-          *expr =
-            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true);
+          expr.replace_with(|fn_expr| {
+            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true)
+          });
         }
       }
       ast::Expression::ArrowFunctionExpression(_fn_expr) => {
         if let Some((_insert_position, original_name, _)) =
           self.process_fn(keep_name_id, keep_name_id)
         {
-          let fn_expr = expr.take_in(&self.alloc);
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-          *expr =
-            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true);
+          expr.replace_with(|fn_expr| {
+            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true)
+          });
         }
       }
       _ => {}
@@ -2374,19 +2375,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         && !self.ctx.options.dynamic_import_in_cjs
       {
         // Transform `import(expr)` to `Promise.resolve().then(() => __toESM(require(expr)))`
-        let source = expr.source.take_in(&self.alloc);
-        let require_call = self.ast_factory.make_call_with_arg(
-          ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
-          source,
-          false,
-        );
         let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
-        let wrapped = self.ast_factory.make_to_esm_wrapper(
-          to_esm_fn_name,
-          require_call,
-          self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-        );
-        *node = self.ast_factory.make_promise_resolve_then(wrapped);
+        node.replace_with(|old| {
+          let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
+          let require_call = self.ast_factory.make_call_with_arg(
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            import_expr.unbox().source,
+            false,
+          );
+          let wrapped = self.ast_factory.make_to_esm_wrapper(
+            to_esm_fn_name,
+            require_call,
+            self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+          );
+          self.ast_factory.make_promise_resolve_then(wrapped)
+        });
         return true;
       }
       return false;
@@ -2492,19 +2495,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if matches!(self.ctx.options.format, OutputFormat::Cjs)
           && !self.ctx.options.dynamic_import_in_cjs
         {
-          let source = expr.source.take_in(&self.alloc);
-          let require_call = self.ast_factory.make_call_with_arg(
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
-            source,
-            false,
-          );
           let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
-          let wrapped = self.ast_factory.make_to_esm_wrapper(
-            to_esm_fn_name,
-            require_call,
-            self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-          );
-          *node = self.ast_factory.make_promise_resolve_then(wrapped);
+          node.replace_with(|old| {
+            let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
+            let require_call = self.ast_factory.make_call_with_arg(
+              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+              import_expr.unbox().source,
+              false,
+            );
+            let wrapped = self.ast_factory.make_to_esm_wrapper(
+              to_esm_fn_name,
+              require_call,
+              self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+            );
+            self.ast_factory.make_promise_resolve_then(wrapped)
+          });
           return true;
         }
       }
@@ -2514,97 +2519,97 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // Turn `import('./some-cjs-module.js')` into `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
       // Inline __toDynamicImportESM
 
-      // `import('./some-cjs-module.js')`
-      let original_import_expr = node.take_in(&self.alloc);
-
       // __toESM
       let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
 
-      // Build arrow function: (m) => __toESM(m.default, isNodeMode)
-      // m.default
-      let m_default_expr =
-        ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
-          SPAN,
-          ast::Expression::new_identifier(SPAN, "m", &self.ast_factory),
-          ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
-          false,
-          &self.ast_factory,
-        ));
+      // `import('./some-cjs-module.js')`
+      node.replace_with(|original_import_expr| {
+        // Build arrow function: (m) => __toESM(m.default, isNodeMode)
+        // m.default
+        let m_default_expr =
+          ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+            SPAN,
+            ast::Expression::new_identifier(SPAN, "m", &self.ast_factory),
+            ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+            false,
+            &self.ast_factory,
+          ));
 
-      // __toESM(m.default, isNodeMode)
-      let to_esm_call = self.ast_factory.make_to_esm_wrapper(
-        to_esm_fn_name,
-        m_default_expr,
-        self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-      );
+        // __toESM(m.default, isNodeMode)
+        let to_esm_call = self.ast_factory.make_to_esm_wrapper(
+          to_esm_fn_name,
+          m_default_expr,
+          self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+        );
 
-      // (m) => __toESM(m.default, isNodeMode)
-      let arrow_fn = ast::ArrowFunctionExpression::boxed(
-        SPAN,
-        true,  // expression
-        false, // async
-        NONE,
-        ast::FormalParameters::new(
+        // (m) => __toESM(m.default, isNodeMode)
+        let arrow_fn = ast::ArrowFunctionExpression::boxed(
           SPAN,
-          ast::FormalParameterKind::ArrowFormalParameters,
-          oxc::allocator::Vec::from_value_in(
-            ast::FormalParameter::new(
-              SPAN,
-              oxc::allocator::Vec::new_in(&self.ast_factory),
-              ast::BindingPattern::new_binding_identifier(
+          true,  // expression
+          false, // async
+          NONE,
+          ast::FormalParameters::new(
+            SPAN,
+            ast::FormalParameterKind::ArrowFormalParameters,
+            oxc::allocator::Vec::from_value_in(
+              ast::FormalParameter::new(
                 SPAN,
-                oxc::ast::ast::Str::from_str_in("m", &self.ast_factory),
+                oxc::allocator::Vec::new_in(&self.ast_factory),
+                ast::BindingPattern::new_binding_identifier(
+                  SPAN,
+                  oxc::ast::ast::Str::from_str_in("m", &self.ast_factory),
+                  &self.ast_factory,
+                ),
+                NONE,
+                NONE,
+                false,
+                None,
+                false,
+                false,
                 &self.ast_factory,
               ),
-              NONE,
-              NONE,
-              false,
-              None,
-              false,
-              false,
+              &self.ast_factory,
+            ),
+            NONE,
+            &self.ast_factory,
+          ),
+          NONE,
+          ast::FunctionBody::new(
+            SPAN,
+            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::from_value_in(
+              ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_factory),
               &self.ast_factory,
             ),
             &self.ast_factory,
           ),
-          NONE,
           &self.ast_factory,
-        ),
-        NONE,
-        ast::FunctionBody::new(
+        );
+
+        // `import('./some-cjs-module.js').then
+        let callee = ast::StaticMemberExpression::boxed(
           SPAN,
-          oxc::allocator::Vec::new_in(&self.ast_factory),
+          original_import_expr,
+          ast::IdentifierName::new(SPAN, "then", &self.ast_factory),
+          false,
+          &self.ast_factory,
+        );
+
+        // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
+        let call_expr = ast::CallExpression::boxed(
+          SPAN,
+          ast::Expression::StaticMemberExpression(callee),
+          NONE,
           oxc::allocator::Vec::from_value_in(
-            ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_factory),
+            ast::Argument::ArrowFunctionExpression(arrow_fn),
             &self.ast_factory,
           ),
+          false,
           &self.ast_factory,
-        ),
-        &self.ast_factory,
-      );
+        );
 
-      // `import('./some-cjs-module.js').then
-      let callee = ast::StaticMemberExpression::boxed(
-        SPAN,
-        original_import_expr,
-        ast::IdentifierName::new(SPAN, "then", &self.ast_factory),
-        false,
-        &self.ast_factory,
-      );
-
-      // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
-      let call_expr = ast::CallExpression::boxed(
-        SPAN,
-        ast::Expression::StaticMemberExpression(callee),
-        NONE,
-        oxc::allocator::Vec::from_value_in(
-          ast::Argument::ArrowFunctionExpression(arrow_fn),
-          &self.ast_factory,
-        ),
-        false,
-        &self.ast_factory,
-      );
-
-      *node = ast::Expression::CallExpression(call_expr);
+        ast::Expression::CallExpression(call_expr)
+      });
     }
 
     true
@@ -2633,7 +2638,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .as_ref()?
           .contains(&symbol_ref)
         {
-          json_module_inlined_prop.insert(id, init.take_in(&self.alloc));
+          let init_expr = first_decl.init.take().expect("init is checked to be `Some` above");
+          json_module_inlined_prop.insert(id, init_expr);
           *it = ast::Statement::new_empty_statement(SPAN, &self.ast_factory);
         }
       }

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -1,7 +1,7 @@
 use indexmap::map::Entry;
 use oxc::allocator::GetAllocator;
 use oxc::{
-  allocator::{Allocator, TakeIn},
+  allocator::{ReplaceWith, TakeIn},
   ast::ast::{self, Expression},
   semantic::{SemanticBuilder, Stats},
   span::SPAN,
@@ -109,30 +109,23 @@ fn replace_first_expr_stmt(ecma_ast: &mut EcmaAst, kind: LazyExportWrap) {
   ecma_ast.program.with_mut(|fields| {
     let ast_factory = AstFactory::new(fields.allocator);
     let Some(stmt) = fields.program.body.first_mut() else { unreachable!() };
-    let expr = match stmt {
-      ast::Statement::ExpressionStatement(stmt) => {
-        stmt.expression.take_in(&ast_factory.allocator())
+    stmt.replace_with(|old| {
+      let ast::Statement::ExpressionStatement(expr_stmt) = old else { unreachable!() };
+      let expr = expr_stmt.unbox().expression;
+      match kind {
+        LazyExportWrap::CjsExport => ast_factory.make_module_exports_stmt(expr),
+        LazyExportWrap::EsmDefault => ast_factory.make_export_default_stmt(expr),
       }
-      _ => unreachable!(),
-    };
-    *stmt = match kind {
-      LazyExportWrap::CjsExport => ast_factory.make_module_exports_stmt(expr),
-      LazyExportWrap::EsmDefault => ast_factory.make_export_default_stmt(expr),
-    };
+    });
   });
 }
 
-/// Takes `expr` (leaving a dummy in its place) and returns the owned inner
-/// expression with any wrapping `(...)` parentheses removed.
-fn take_without_parentheses<'ast>(
-  expr: &mut Expression<'ast>,
-  allocator: &'ast Allocator,
-) -> Expression<'ast> {
-  let mut inner_expr = expr.take_in(&allocator);
-  while let Expression::ParenthesizedExpression(mut paren_expr) = inner_expr {
-    inner_expr = paren_expr.expression.take_in(&allocator);
+/// Returns the owned expression with any wrapping `(...)` parentheses removed.
+fn into_without_parentheses(mut expr: Expression<'_>) -> Expression<'_> {
+  while let Expression::ParenthesizedExpression(paren_expr) = expr {
+    expr = paren_expr.unbox().expression;
   }
-  inner_expr
+  expr
 }
 
 fn update_module_default_export_info(
@@ -173,13 +166,17 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     if !matches!(expr.without_parentheses(), Expression::ObjectExpression(_)) {
       return false;
     }
-    let Expression::ObjectExpression(mut obj_expr) =
-      take_without_parentheses(expr, ast_factory.allocator())
+    // Take the single-statement body by value; this leaves `program.body` empty.
+    let Some(ast::Statement::ExpressionStatement(stmt)) =
+      program.body.take_in(&ast_factory.allocator()).into_iter().next()
     else {
       unreachable!();
     };
-    // clean program body, since we already take it and left a dummy expr
-    program.body.clear();
+    let Expression::ObjectExpression(mut obj_expr) =
+      into_without_parentheses(stmt.unbox().expression)
+    else {
+      unreachable!();
+    };
 
     // convert {"a": "b", "c": "d"} to
     // {"a": b, "c": d}

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use oxc::allocator::GetAllocator;
-use oxc::allocator::{Allocator, TakeIn};
+use oxc::allocator::{Allocator, ReplaceWith, TakeIn};
 use oxc::ast::NONE;
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
 use oxc::ast_visit::{VisitMut, walk_mut};
@@ -236,90 +236,83 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_expression(&mut self, it: &mut ast::Expression<'ast>) {
-    let to_replaced = match it {
-      // transpose `require(test ? 'a' : 'b')` into `test ? require('a') : require('b')`
-      ast::Expression::CallExpression(expr)
-        if expr.callee.is_specific_id("require") && expr.arguments.len() == 1 =>
-      {
-        let arg = expr.arguments.get_mut(0).unwrap();
-        if let Some(cond_expr) = arg.as_expression_mut().and_then(|item| match item {
-          ast::Expression::ConditionalExpression(cond) => Some(cond),
-          _ => None,
-        }) {
-          let test = cond_expr.test.take_in(&self.ast_factory.allocator());
-          let consequent = cond_expr.consequent.take_in(&self.ast_factory.allocator());
-          let alternative = cond_expr.alternate.take_in(&self.ast_factory.allocator());
-          let new_cond_expr = ast::ConditionalExpression::boxed(
+    // transpose `require(test ? 'a' : 'b')` into `test ? require('a') : require('b')`
+    if matches!(it, ast::Expression::CallExpression(expr)
+    if expr.callee.is_specific_id("require")
+      && expr.arguments.len() == 1
+      && matches!(
+        expr.arguments[0].as_expression(),
+        Some(ast::Expression::ConditionalExpression(_))
+      ))
+    {
+      it.replace_with(|old| {
+        let ast::Expression::CallExpression(call_expr) = old else { unreachable!() };
+        let Some(ast::Argument::ConditionalExpression(cond_expr)) =
+          call_expr.unbox().arguments.into_iter().next()
+        else {
+          unreachable!()
+        };
+        let cond_expr = cond_expr.unbox();
+        ast::Expression::ConditionalExpression(ast::ConditionalExpression::boxed(
+          SPAN,
+          cond_expr.test,
+          ast::Expression::new_call_expression(
             SPAN,
-            test,
-            ast::Expression::new_call_expression(
-              SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
-              NONE,
-              oxc::allocator::Vec::from_value_in(
-                ast::Argument::from(consequent),
-                &self.ast_factory,
-              ),
-              false,
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            NONE,
+            oxc::allocator::Vec::from_value_in(
+              ast::Argument::from(cond_expr.consequent),
               &self.ast_factory,
             ),
-            ast::Expression::new_call_expression(
-              SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
-              NONE,
-              oxc::allocator::Vec::from_value_in(
-                ast::Argument::from(alternative),
-                &self.ast_factory,
-              ),
-              false,
-              &self.ast_factory,
-            ),
+            false,
             &self.ast_factory,
-          );
-
-          Some(ast::Expression::ConditionalExpression(new_cond_expr))
-        } else {
-          None
-        }
-      }
-      // transpose `import(test ? 'a' : 'b')` into `test ? import('a') : import('b')`
-      ast::Expression::ImportExpression(expr) if expr.options.is_none() => {
-        let source = &mut expr.source;
-        match source {
-          ast::Expression::ConditionalExpression(cond_expr) => {
-            let test = cond_expr.test.take_in(&self.ast_factory.allocator());
-            let consequent = cond_expr.consequent.take_in(&self.ast_factory.allocator());
-            let alternative = cond_expr.alternate.take_in(&self.ast_factory.allocator());
-
-            let new_cond_expr = ast::Expression::new_conditional_expression(
-              SPAN,
-              test,
-              ast::Expression::new_import_expression(
-                SPAN,
-                consequent,
-                None,
-                None,
-                &self.ast_factory,
-              ),
-              ast::Expression::new_import_expression(
-                SPAN,
-                alternative,
-                None,
-                None,
-                &self.ast_factory,
-              ),
+          ),
+          ast::Expression::new_call_expression(
+            SPAN,
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            NONE,
+            oxc::allocator::Vec::from_value_in(
+              ast::Argument::from(cond_expr.alternate),
               &self.ast_factory,
-            );
-
-            Some(new_cond_expr)
-          }
-          _ => None,
-        }
-      }
-      _ => None,
-    };
-    if let Some(replaced) = to_replaced {
-      *it = replaced;
+            ),
+            false,
+            &self.ast_factory,
+          ),
+          &self.ast_factory,
+        ))
+      });
+    }
+    // transpose `import(test ? 'a' : 'b')` into `test ? import('a') : import('b')`
+    else if matches!(it, ast::Expression::ImportExpression(expr)
+      if expr.options.is_none()
+        && matches!(expr.source, ast::Expression::ConditionalExpression(_)))
+    {
+      it.replace_with(|old| {
+        let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
+        let ast::Expression::ConditionalExpression(cond_expr) = import_expr.unbox().source else {
+          unreachable!()
+        };
+        let cond_expr = cond_expr.unbox();
+        ast::Expression::new_conditional_expression(
+          SPAN,
+          cond_expr.test,
+          ast::Expression::new_import_expression(
+            SPAN,
+            cond_expr.consequent,
+            None,
+            None,
+            &self.ast_factory,
+          ),
+          ast::Expression::new_import_expression(
+            SPAN,
+            cond_expr.alternate,
+            None,
+            None,
+            &self.ast_factory,
+          ),
+          &self.ast_factory,
+        )
+      });
     }
     walk_mut::walk_expression(self, it);
   }


### PR DESCRIPTION
## What

Converts the `take_in` → build → write-back patterns in the module finalizer, scan pre-processor, HMR finalizer, and lazy-export generation to `oxc_allocator::ReplaceWith` (available since oxc 0.139) or plain by-value moves.

## Why

Each `take_in` writes a `Dummy` node into the vacated slot; for AST enums that dummy is a real arena allocation (16 bytes boxed) that is overwritten an instant later but stays in the pooled module arena until the generate stage ends. It advances the bump pointer (raising the pool's retained high-water mark) and lowers live-node density for every later walk over the same arena — scanner, DCE, finalizer, codegen. oxc's own parser (oxc-project/oxc#24018) and minifier (oxc-project/oxc#24017) made the same move in 0.140.0.

## How

- **Slot-level `replace_with`**: keep-name wraps (finalizer ×3), both dynamic-`import()`-in-CJS rewrites, the `.then((m) => __toESM(...))` interop wrapper, `replace_first_expr_stmt`, and the PreProcessor's `require(a?b:c)` / `import(a?b:c)` transposes (those destructure the conditional by value — 3 dummies each, now 0).
- **By-value with box reuse**: the finalizer's export-default block and the HMR finalizer's `handle_top_level_stmt` now match the owned statement directly, so `export default function/class` reuses the existing `Box<Function>`/`Box<Class>` instead of take-dummy-rebox (also saves the ~200-byte struct copy). `get_transformed_class_decl` takes the class box by value and returns `Result<Declaration, Box<Class>>`, giving the box back when no transform applies.
- **Plain moves where no trait is needed**: var-hoisting drains `declarations` by value (`Vec`'s dummy is an empty vec — no allocation), JSON prop inlining uses `Option::take`, and paren unwrapping in lazy export works by value.

Left as-is: the `Vec` drain-and-rebuild `take_in`s (free dummy, structurally required) and the `take_in_box` in the dynamic-import-to-other-chunk path, whose `Option`-returning protocol tolerates a partially consumed node on the warn paths.

One behavior note: the finalizer's export-default fallback arm is now `unreachable!()` for `TSInterfaceDeclaration` (TS is stripped before finalization), matching the convention already used by `visit_declaration` and the HMR finalizer for TS variants.

Output is byte-identical: the snapshot suite passes with zero snapshot updates.