### PR TITLE
refactor: readability follow-ups to the ReplaceWith migration

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -151,42 +151,41 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           self.dependencies.insert(importee_idx);
           let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
           self.exports.extend(decl.specifiers.iter().map(|specifier| {
-                        self.ast_factory.make_lazy_export_property(
-                          &specifier.exported.name(),
-                          match &specifier.local {
-                            ast::ModuleExportName::IdentifierName(ident) => {
-                              Expression::StaticMemberExpression(
-                                ast::StaticMemberExpression::boxed(
-                                  SPAN,
-                                  self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
-                                  ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_factory),
-                                  false,
-                                  &self.ast_factory,
-                                ),
-                              )
-                            }
-                            ast::ModuleExportName::StringLiteral(str) => {
-                              Expression::ComputedMemberExpression(
-                                ast::ComputedMemberExpression::boxed(
-                                  SPAN,
-                                  self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
-                                  ast::Expression::new_string_literal(
-                                    SPAN, str.value.as_str(), None, &self.ast_factory
-                                  ),
-                                  false,
-                                  &self.ast_factory,
-                                ),
-                              )
-                            }
-                            ast::ModuleExportName::IdentifierReference(_) => {
-                              unreachable!(
-                                "ModuleExportName IdentifierReference is invalid in ExportNamedDeclaration with source"
-                              )
-                            }
-                          },
-                          matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_))
-                        )
-                      }));
+            self.ast_factory.make_lazy_export_property(
+              &specifier.exported.name(),
+              match &specifier.local {
+                ast::ModuleExportName::IdentifierName(ident) => {
+                  Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+                    SPAN,
+                    self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
+                    ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_factory),
+                    false,
+                    &self.ast_factory,
+                  ))
+                }
+                ast::ModuleExportName::StringLiteral(str) => {
+                  Expression::ComputedMemberExpression(ast::ComputedMemberExpression::boxed(
+                    SPAN,
+                    self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
+                    ast::Expression::new_string_literal(
+                      SPAN,
+                      str.value.as_str(),
+                      None,
+                      &self.ast_factory,
+                    ),
+                    false,
+                    &self.ast_factory,
+                  ))
+                }
+                ast::ModuleExportName::IdentifierReference(_) => {
+                  unreachable!(
+                    "ModuleExportName IdentifierReference is invalid in ExportNamedDeclaration with source"
+                  )
+                }
+              },
+              matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)),
+            )
+          }));
           if let Some(stmt) = self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
           {
             program_body.push(stmt);
@@ -307,8 +306,10 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           program_body.push(stmt);
         }
       }
-      // Typescript module declarations should be pre-processed by rolldown. If they aren't,
-      // it means there's an error. Instead of panicking, we'll just keep the original code.
+      // Every other statement is kept as-is. That's ordinary statements, which need no
+      // rewriting, and also the TypeScript module declarations (`export =`, `export as
+      // namespace`), which rolldown should have pre-processed away already - if one reaches
+      // here something went wrong upstream, and keeping it beats panicking.
       node => {
         program_body.push(node);
       }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1867,11 +1867,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
             return;
           }
-        } else if matches!(top_stmt, ast::Statement::ExportDefaultDeclaration(_)) {
+        } else if let ast::Statement::ExportDefaultDeclaration(default_decl) = top_stmt {
           use ast::ExportDefaultDeclarationKind;
-          let ast::Statement::ExportDefaultDeclaration(default_decl) = top_stmt else {
-            unreachable!()
-          };
           let default_decl_span = default_decl.span;
           match default_decl.unbox().declaration {
             // Special case: when exporting an identifier that's already the default export symbol
@@ -2013,8 +2010,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               decl.kind = VariableDeclarationKind::Var;
             }
           }
-          if matches!(top_stmt, Statement::ClassDeclaration(_)) {
-            let Statement::ClassDeclaration(class_decl) = top_stmt else { unreachable!() };
+          if let Statement::ClassDeclaration(class_decl) = top_stmt {
             top_stmt = match self.get_transformed_class_decl(class_decl) {
               Ok(decl) => Statement::from(decl),
               Err(class_decl) => Statement::ClassDeclaration(class_decl),
@@ -2624,7 +2620,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     };
     let first_decl = var_decl.declarations.first_mut()?;
-    let init = first_decl.init.as_mut()?;
+    // Bail out early if there's no initializer; both arms below rely on it being `Some`.
+    first_decl.init.as_ref()?;
     // For synthesis json module, only last symbol of var stmt is `None`, since it is a generated
     // manually.
     let id = first_decl.id.get_binding_identifier()?.symbol_id.get();
@@ -2638,8 +2635,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .as_ref()?
           .contains(&symbol_ref)
         {
-          let init_expr = first_decl.init.take().expect("init is checked to be `Some` above");
-          json_module_inlined_prop.insert(id, init_expr);
+          json_module_inlined_prop.insert(id, first_decl.init.take()?);
           *it = ast::Statement::new_empty_statement(SPAN, &self.ast_factory);
         }
       }
@@ -2650,7 +2646,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // export default { foo, bar };
         // ```
         //
-        let Expression::ObjectExpression(obj_expr) = init else {
+        let Some(Expression::ObjectExpression(obj_expr)) = first_decl.init.as_mut() else {
           return None;
         };
 

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -156,14 +156,10 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     let mut index_map = FxIndexMap::default();
     let ast_factory = AstFactory::new(fields.allocator);
     let program = fields.program;
-    let Some(stmts) = program.body.first_mut() else { unreachable!() };
-    let expr = match stmts {
-      ast::Statement::ExpressionStatement(stmt) => &mut stmt.expression,
-      _ => {
-        unreachable!()
-      }
+    let Some(ast::Statement::ExpressionStatement(stmt)) = program.body.first() else {
+      unreachable!()
     };
-    if !matches!(expr.without_parentheses(), Expression::ObjectExpression(_)) {
+    if !matches!(stmt.expression.without_parentheses(), Expression::ObjectExpression(_)) {
       return false;
     }
     // Take the single-statement body by value; this leaves `program.body` empty.


### PR DESCRIPTION
## What

Readability follow-ups to #10285, which migrated the `take_in`-then-write-back patterns to `ReplaceWith`. No behavior change — this only touches how the code reads.

## How

- **`matches!(…)` + `let … else { unreachable!() }` → `if let`** (module finalizer, ×2: the `export default` arm and the `top_level_var` class rewrite).

  Inside a `replace_with` closure that double-destructure is unavoidable — the closure is handed the whole node, so it has to re-narrow, and that's the shape oxc's own docs use. But `top_stmt` is a plain owned local. `if let` moves the binding out only when the pattern matches, and every arm there already reassigns `top_stmt` or returns, so the second discriminant test and its `unreachable!()` were pure ceremony. Two of them go away.

- **Say what the HMR catch-all arm actually does.** #10285 flattened the inner `match module_decl` into the outer `match node`, which merged two arms: one catching only `TSExportAssignment`/`TSNamespaceExportDeclaration` (carrying the TypeScript comment), and an uncommented `_` catching everything else. Only the TypeScript comment survived the merge, so the arm now reads as though it is about TypeScript when in practice nearly everything reaching it is an ordinary statement.

- **Re-indent the `exports.extend` closure in the HMR finalizer.** rustfmt bails out on this expression, so its body had been stranded ~11 columns right of its header since before #10285, and the flattening widened that to ~15. `cargo fmt --check` passes either way, so CI never flagged it. At the shallower nesting the block now fits `max_width`, so rustfmt formats it again instead of giving up — it should stop drifting.

- **`first_mut()` → `first()`** in `json_object_expr_to_esm`, now that the binding is only read; the two-step destructure folds into one `let … else`.

- **Drop `.expect("init is checked to be `Some` above")`** in `try_inline_json_module_prop`. It re-checked at runtime an invariant established a few lines above, and only existed to dodge a `&mut` that the `Some` arm no longer needs. Each arm now reads `first_decl.init` directly.

## Tests

No new tests. Nothing here changes behavior, so there is no test that would fail before and pass after.

What needs checking is that the output is unchanged, and the snapshot suite is the check for that — but it auto-accepts (as `just test-update` puts it: "Rust tests will update snapshots automatically"), so a green run proves nothing by itself. The real check is what the working tree looks like afterwards:

- `cargo test -p rolldown` → 1869 passed, and **zero `.snap` files modified**.
- `cargo clippy -p rolldown --all-targets -- --deny warnings` and `cargo fmt --all --check` both clean.
