### PR TITLE
test(code-splitting): establish strict-order review baselines

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "codeSplitting": {
@@ -9,13 +9,15 @@
           "name": "vendor"
         }
       ]
+    },
+    "experimental": {
+      "onDemandWrapping": true
     }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -29,13 +29,9 @@ export { __esmMin as t };
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
-//#region bar.js
-var init_bar = __esmMin((() => {}));
-//#endregion
 //#region foo.js
 var foo;
 var init_foo = __esmMin((() => {
-	init_bar();
 	foo = "foo bar";
 }));
 //#endregion
@@ -43,7 +39,7 @@ export { init_foo as n, foo as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -73,9 +69,13 @@ export { __esmMin as t };
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
+//#region bar.js
+var init_bar = __esmMin((() => {}));
+//#endregion
 //#region foo.js
 var foo;
 var init_foo = __esmMin((() => {
+	init_bar();
 	foo = "foo bar";
 }));
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/_config.json
@@ -1,13 +1,15 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -9,6 +9,39 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
+const stages = {
+	a: "1",
+	b: "2",
+	c: "3"
+};
+//#endregion
+//#region main.js
+var first, rest, all;
+//#endregion
+__esmMin((() => {
+	[first, ...rest] = Object.values(stages);
+	if (!first) throw new Error("empty");
+	all = [first, ...rest];
+	assert.deepStrictEqual(all, [
+		"1",
+		"2",
+		"3"
+	]);
+}))();
+export { all };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
 var stages;
 var init_lib = __esmMin((() => {
 	stages = {
@@ -23,39 +56,6 @@ var first, rest, all;
 //#endregion
 __esmMin((() => {
 	init_lib();
-	[first, ...rest] = Object.values(stages);
-	if (!first) throw new Error("empty");
-	all = [first, ...rest];
-	assert.deepStrictEqual(all, [
-		"1",
-		"2",
-		"3"
-	]);
-}))();
-export { all };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import assert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-//#region lib.js
-const stages = {
-	a: "1",
-	b: "2",
-	c: "3"
-};
-//#endregion
-//#region main.js
-var first, rest, all;
-//#endregion
-__esmMin((() => {
 	[first, ...rest] = Object.values(stages);
 	if (!first) throw new Error("empty");
 	all = [first, ...rest];

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
@@ -1,0 +1,117 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { n as __esmMin, t as init_p } from "./p.js";
+__esmMin((() => {
+	//#region e.js
+	console.log("E");
+	//#endregion
+	//#region main.js
+	init_p();
+	console.log("MAIN");
+	//#endregion
+}))();
+
+```
+
+## p.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region c.js
+var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	console.log("C");
+	module.exports = {};
+}));
+var init_p = __esmMin((() => {
+	require_c();
+}));
+//#endregion
+export { __esmMin as n, init_p as t };
+
+```
+
+## second.js
+
+```js
+import { n as __esmMin, t as init_p } from "./p.js";
+//#endregion
+__esmMin((() => {
+	init_p();
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import { n as __esmMin, t as init_p } from "./p.js";
+//#region e.js
+var init_e = __esmMin((() => {
+	console.log("E");
+}));
+//#endregion
+__esmMin((() => {
+	init_e();
+	init_p();
+	console.log("MAIN");
+}))();
+
+```
+
+### p.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region c.js
+var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	console.log("C");
+	module.exports = {};
+}));
+var init_p = __esmMin((() => {
+	require_c();
+}));
+//#endregion
+export { __esmMin as n, init_p as t };
+
+```
+
+### second.js
+
+```js
+import { n as __esmMin, t as init_p } from "./p.js";
+//#endregion
+__esmMin((() => {
+	init_p();
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["MAIN:stale"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
@@ -1,0 +1,213 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## carrier.js
+
+```js
+import { n as __esmMin, t as require_pure_cjs } from "./cjs.js";
+//#region node_modules/pure-carrier/index.js
+var import_pure_cjs;
+var init_pure_carrier = __esmMin((() => {
+	import_pure_cjs = require_pure_cjs();
+}));
+//#endregion
+init_pure_carrier();
+var snapshot = import_pure_cjs.snapshot;
+export { init_pure_carrier as n, snapshot, import_pure_cjs as t };
+
+```
+
+## cjs.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region node_modules/pure-cjs/index.cjs
+var require_pure_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { snapshot: globalThis.__strict_order_value ?? "stale" };
+}));
+//#endregion
+export default require_pure_cjs();
+export { __esmMin as n, require_pure_cjs as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { n as read, t as init_reader } from "./reader.js";
+__esmMin((() => {
+	//#region e.js
+	globalThis.__strict_order_value = "ready";
+	console.log("E");
+	//#endregion
+	//#region main.js
+	init_reader();
+	console.log(`MAIN:${read()}`);
+	//#endregion
+}))();
+
+```
+
+## reader.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { t as import_pure_cjs } from "./carrier.js";
+//#region node_modules/pure-forwarder/index.js
+var init_pure_forwarder = __esmMin((() => {}));
+//#endregion
+//#region reader.js
+function read() {
+	return import_pure_cjs.snapshot;
+}
+var init_reader = __esmMin((() => {
+	init_pure_forwarder();
+}));
+//#endregion
+export { read as n, init_reader as t };
+
+```
+
+## second.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { n as read, t as init_reader } from "./reader.js";
+//#endregion
+__esmMin((() => {
+	init_reader();
+	console.log(read());
+}))();
+
+```
+
+## unused.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+//#endregion
+__esmMin((() => {
+	console.log("UNUSED");
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### carrier.js
+
+```js
+import { n as __esmMin, t as require_pure_cjs } from "./cjs.js";
+//#region node_modules/pure-carrier/index.js
+var import_pure_cjs;
+var init_pure_carrier = __esmMin((() => {
+	import_pure_cjs = require_pure_cjs();
+}));
+//#endregion
+init_pure_carrier();
+var snapshot = import_pure_cjs.snapshot;
+export { init_pure_carrier as n, snapshot, import_pure_cjs as t };
+
+```
+
+### cjs.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+//#endregion
+//#region node_modules/pure-cjs/index.cjs
+var require_pure_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { snapshot: globalThis.__strict_order_value ?? "stale" };
+}));
+//#endregion
+export default require_pure_cjs();
+export { __esmMin as n, require_pure_cjs as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { n as read, t as init_reader } from "./reader.js";
+//#region e.js
+var init_e = __esmMin((() => {
+	globalThis.__strict_order_value = "ready";
+	console.log("E");
+}));
+//#endregion
+__esmMin((() => {
+	init_e();
+	init_reader();
+	console.log(`MAIN:${read()}`);
+}))();
+
+```
+
+### reader.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { t as import_pure_cjs } from "./carrier.js";
+//#region node_modules/pure-forwarder/index.js
+var init_pure_forwarder = __esmMin((() => {}));
+//#endregion
+//#region reader.js
+function read() {
+	return import_pure_cjs.snapshot;
+}
+var init_reader = __esmMin((() => {
+	init_pure_forwarder();
+}));
+//#endregion
+export { read as n, init_reader as t };
+
+```
+
+### second.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+import { n as read, t as init_reader } from "./reader.js";
+//#endregion
+__esmMin((() => {
+	init_reader();
+	console.log(read());
+}))();
+
+```
+
+### unused.js
+
+```js
+import { n as __esmMin } from "./cjs.js";
+//#endregion
+__esmMin((() => {
+	console.log("UNUSED");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["the hoisted self-rebinding order wrapper form must be preserved"]
@@ -7,17 +6,30 @@
   "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "e0", "import": "./m0.js" },
-      { "name": "e1", "import": "./m1.js" }
+      {
+        "name": "e0",
+        "import": "./m0.js"
+      },
+      {
+        "name": "e1",
+        "import": "./m1.js"
+      }
     ],
     "format": "cjs",
     "preserveEntrySignatures": "allow-extension",
     "strictExecutionOrder": true,
     "codeSplitting": {
       "includeDependenciesRecursively": false,
-      "groups": [{ "name": "g", "test": "[\\\\/]m[12]\\.js$" }]
+      "groups": [
+        {
+          "name": "g",
+          "test": "[\\\\/]m[12]\\.js$"
+        }
+      ]
     },
-    "experimental": { "onDemandWrapping": true }
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_cross_chunk_init_cycle/artifacts.snap
@@ -1,0 +1,266 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## e0.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region m0.js
+var v0;
+var init_m0 = __esmMin((() => {
+	globalThis.__log.push("m0");
+	v0 = 10;
+}));
+//#endregion
+init_m0();
+exports.__esmMin = __esmMin;
+Object.defineProperty(exports, "init_m0", {
+	enumerable: true,
+	get: function() {
+		return init_m0;
+	}
+});
+exports.v0 = v0;
+
+```
+
+## e1.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_e0 = require("./e0.js");
+const require_g = require("./g.js");
+//#region m3.js
+var init_m3 = require_e0.__esmMin((() => {
+	require_g.init_m2();
+	globalThis.__log.push("m3");
+}));
+//#endregion
+require_g.init_m1();
+Object.defineProperty(exports, "init_m3", {
+	enumerable: true,
+	get: function() {
+		return init_m3;
+	}
+});
+exports.v1 = require_g.v1;
+exports.v2 = require_g.v2;
+
+```
+
+## g.js
+
+```js
+const require_e0 = require("./e0.js");
+const require_e1 = require("./e1.js");
+//#region m2.js
+var v2;
+var init_m2 = require_e0.__esmMin((() => {
+	require_e0.init_m0();
+	require_e1.init_m3();
+	globalThis.__log.push("m2");
+	v2 = 12;
+}));
+//#endregion
+//#region m1.js
+var v1;
+var init_m1 = require_e0.__esmMin((() => {
+	require_e1.init_m3();
+	init_m2();
+	globalThis.__log.push("m1");
+	v1 = 1;
+}));
+//#endregion
+Object.defineProperty(exports, "init_m1", {
+	enumerable: true,
+	get: function() {
+		return init_m1;
+	}
+});
+Object.defineProperty(exports, "init_m2", {
+	enumerable: true,
+	get: function() {
+		return init_m2;
+	}
+});
+Object.defineProperty(exports, "v1", {
+	enumerable: true,
+	get: function() {
+		return v1;
+	}
+});
+Object.defineProperty(exports, "v2", {
+	enumerable: true,
+	get: function() {
+		return v2;
+	}
+});
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### e0.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region m0.js
+var v0;
+var init_m0 = __esmMin((() => {
+	globalThis.__log.push("m0");
+	v0 = 10;
+}));
+//#endregion
+init_m0();
+exports.__esmMin = __esmMin;
+Object.defineProperty(exports, "init_m0", {
+	enumerable: true,
+	get: function() {
+		return init_m0;
+	}
+});
+exports.v0 = v0;
+
+```
+
+### e1.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_e0 = require("./e0.js");
+const require_g = require("./g.js");
+//#region m3.js
+var init_m3 = require_e0.__esmMin((() => {
+	require_g.init_m2();
+	globalThis.__log.push("m3");
+}));
+//#endregion
+require_g.init_m1();
+Object.defineProperty(exports, "init_m3", {
+	enumerable: true,
+	get: function() {
+		return init_m3;
+	}
+});
+exports.v1 = require_g.v1;
+exports.v2 = require_g.v2;
+
+```
+
+### g.js
+
+```js
+const require_e0 = require("./e0.js");
+const require_e1 = require("./e1.js");
+//#region m2.js
+var v2;
+var init_m2 = require_e0.__esmMin((() => {
+	require_e0.init_m0();
+	require_e1.init_m3();
+	globalThis.__log.push("m2");
+	v2 = 12;
+}));
+//#endregion
+//#region m1.js
+var v1;
+var init_m1 = require_e0.__esmMin((() => {
+	require_e1.init_m3();
+	init_m2();
+	globalThis.__log.push("m1");
+	v1 = 1;
+}));
+//#endregion
+Object.defineProperty(exports, "init_m1", {
+	enumerable: true,
+	get: function() {
+		return init_m1;
+	}
+});
+Object.defineProperty(exports, "init_m2", {
+	enumerable: true,
+	get: function() {
+		return init_m2;
+	}
+});
+Object.defineProperty(exports, "v1", {
+	enumerable: true,
+	get: function() {
+		return v1;
+	}
+});
+Object.defineProperty(exports, "v2", {
+	enumerable: true,
+	get: function() {
+		return v2;
+	}
+});
+
+```
+
+# Variant: minify-on-demand: [minify: true]
+
+## Assets
+
+### e0.js
+
+```js
+Object.defineProperty(exports,Symbol.toStringTag,{value:`Module`});var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}},t,n=e((()=>{globalThis.__log.push(`m0`),t=10}));n(),exports.n=e,Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return n}}),exports.v0=t;
+```
+
+### e1.js
+
+```js
+Object.defineProperty(exports,Symbol.toStringTag,{value:`Module`});const e=require("./e0.js"),t=require("./g.js");var n=e.n((()=>{t.r(),globalThis.__log.push(`m3`)}));t.t(),Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return n}}),exports.v1=t.n,exports.v2=t.i;
+```
+
+### g.js
+
+```js
+const e=require("./e0.js"),t=require("./e1.js");var n,r=e.n((()=>{e.t(),t.t(),globalThis.__log.push(`m2`),n=12})),i,a=e.n((()=>{t.t(),r(),globalThis.__log.push(`m1`),i=1}));Object.defineProperty(exports,"i",{enumerable:!0,get:function(){return n}}),Object.defineProperty(exports,"n",{enumerable:!0,get:function(){return i}}),Object.defineProperty(exports,"r",{enumerable:!0,get:function(){return r}}),Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return a}});
+```
+
+# Variant: minify-wrap-all: [minify: true] [on_demand_wrapping: false]
+
+## Assets
+
+### e0.js
+
+```js
+Object.defineProperty(exports,Symbol.toStringTag,{value:`Module`});var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}},t,n=e((()=>{globalThis.__log.push(`m0`),t=10}));n(),exports.n=e,Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return n}}),exports.v0=t;
+```
+
+### e1.js
+
+```js
+Object.defineProperty(exports,Symbol.toStringTag,{value:`Module`});const e=require("./e0.js"),t=require("./g.js");var n=e.n((()=>{t.r(),globalThis.__log.push(`m3`)}));t.t(),Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return n}}),exports.v1=t.n,exports.v2=t.i;
+```
+
+### g.js
+
+```js
+const e=require("./e0.js"),t=require("./e1.js");var n,r=e.n((()=>{e.t(),t.t(),globalThis.__log.push(`m2`),n=12})),i,a=e.n((()=>{t.t(),r(),globalThis.__log.push(`m1`),i=1}));Object.defineProperty(exports,"i",{enumerable:!0,get:function(){return n}}),Object.defineProperty(exports,"n",{enumerable:!0,get:function(){return i}}),Object.defineProperty(exports,"r",{enumerable:!0,get:function(){return r}}),Object.defineProperty(exports,"t",{enumerable:!0,get:function(){return a}});
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["CJS entry carrier must not execute entry B while loading entry A"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/artifacts.snap
@@ -1,0 +1,78 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { r as __commonJSMin, t as init_s1 } from "./b.js";
+//#region a.cjs
+var require_a = /* @__PURE__ */ __commonJSMin((() => {
+	init_s1();
+	console.log("A");
+}));
+//#endregion
+export default require_a();
+
+```
+
+## b.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region s1.mjs
+var s1_exports = /* @__PURE__ */ __exportAll({});
+var init_s1 = __esmMin((() => {
+	console.log("S");
+}));
+//#endregion
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_s1();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+export { s1_exports as n, __commonJSMin as r, init_s1 as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { r as __commonJSMin, t as init_s1 } from "./b.js";
+//#region a.cjs
+var require_a = /* @__PURE__ */ __commonJSMin((() => {
+	init_s1();
+	console.log("A");
+}));
+//#endregion
+export default require_a();
+
+```
+
+### b.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region s1.mjs
+var s1_exports = /* @__PURE__ */ __exportAll({});
+var init_s1 = __esmMin((() => {
+	console.log("S");
+}));
+//#endregion
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_s1();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+export { s1_exports as n, __commonJSMin as r, init_s1 as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/_config.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Covers plain execution-order concatenation of side-effect modules — everything inlines flat, nothing is order-wrapped. It does NOT exercise the concatenated-wrapper (ConcatenateWrappedModuleKind Inner/Root) x order-wrap interaction, which is dormant/unsupported on this branch, so it must not be counted as wrapper coverage.",
   "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
@@ -14,6 +15,20 @@
     {
       "_configName": "pife-for-module-wrappers-disabled-on-demand",
       "pifeForModuleWrappers": false
+    },
+    {
+      "_configName": "profiler-names-wrap-all",
+      "profilerNames": false,
+      "onDemandWrapping": false
+    },
+    {
+      "_configName": "pife-for-module-wrappers-wrap-all",
+      "pifeForModuleWrappers": false,
+      "onDemandWrapping": false
+    },
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
@@ -43,3 +43,63 @@ source: crates/rolldown_testing/src/integration_test.rs
 })();
 
 ```
+
+# Variant: profiler-names-wrap-all: [on_demand_wrapping: false] [profiler_names: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.globalValue = "foo";
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	console.log("main");
+}))();
+
+```
+
+# Variant: pife-for-module-wrappers-wrap-all: [on_demand_wrapping: false] [pife_for_module_wrappers: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin(() => {
+	globalThis.globalValue = "foo";
+});
+//#endregion
+__esmMin(() => {
+	init_setup();
+	console.log("main");
+})();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.globalValue = "foo";
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	console.log("main");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
@@ -1,12 +1,16 @@
 {
-  "configName": "wrap-all",
+  "_comment": "Despite the name, nothing here is order-wrapped or concatenated-wrapped: the modules inline flat with no init_*/__esm and no module group. It does NOT exercise the concatenated-wrapper (ConcatenateWrappedModuleKind Inner/Root) x order-wrap interaction, which is dormant/unsupported on this branch, so it must not be counted as wrapper coverage.",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -8,6 +8,33 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+var foo_inner_default;
+__esmMin((() => {
+	//#region setup.js
+	globalThis.globalValue = "foo";
+	//#endregion
+	//#region foo_inner.js
+	foo_inner_default = { foo: /* #__PURE__ */ (() => globalValue)() };
+	//#endregion
+	//#region foo.js
+	assert.strictEqual(foo_inner_default.foo, "foo");
+	//#endregion
+	//#region main.js
+	assert.equal(foo_inner_default.foo, "foo");
+	//#endregion
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var init_setup = __esmMin((() => {
 	globalThis.globalValue = "foo";
@@ -30,33 +57,6 @@ __esmMin((() => {
 	init_foo();
 	init_foo_inner();
 	assert.equal(foo_inner_default.foo, "foo");
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true]
-
-## Assets
-
-### main.js
-
-```js
-import assert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-var foo_inner_default;
-__esmMin((() => {
-	//#region setup.js
-	globalThis.globalValue = "foo";
-	//#endregion
-	//#region foo_inner.js
-	foo_inner_default = { foo: /* #__PURE__ */ (() => globalValue)() };
-	//#endregion
-	//#region foo.js
-	assert.strictEqual(foo_inner_default.foo, "foo");
-	//#endregion
-	//#region main.js
-	assert.equal(foo_inner_default.foo, "foo");
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "config": {
     "external": ["node:assert"]
   },

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
@@ -1,0 +1,217 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## constants.js
+
+```js
+function mark() {
+	globalThis.inlineNamespaceValue = 0;
+}
+const y = /* @__PURE__ */ mark();
+//#endregion
+export { y as t };
+
+```
+
+## main.js
+
+```js
+//#region main.js
+await import("./page-b.js").then(console.log);
+await import("./page-a.js").then(console.log);
+//#endregion
+
+```
+
+## page-a.js
+
+```js
+import { t as y } from "./constants.js";
+import assert from "node:assert";
+//#region page-a.js
+assert.strictEqual(globalThis.inlineNamespaceValue, 0);
+function render() {
+	console.log(1, y);
+}
+//#endregion
+export { render };
+
+```
+
+## page-b.js
+
+```js
+import assert from "node:assert";
+//#region page-b.js
+assert.strictEqual(1, 1);
+assert.strictEqual(globalThis.inlineNamespaceValue, void 0, "inlined namespace member must not initialize its dead re-export before page-b");
+function render() {}
+//#endregion
+export { render };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### constants.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region constants.js
+function mark() {
+	globalThis.inlineNamespaceValue = 0;
+}
+var y;
+var init_constants = __esmMin((() => {
+	y = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { y as n, init_constants as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as y, t as init_constants } from "./constants.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(1, y);
+}
+//#endregion
+__esmMin((() => {
+	init_constants();
+	assert.strictEqual(globalThis.inlineNamespaceValue, 0);
+}))();
+export { render };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_constants } from "./constants.js";
+import assert from "node:assert";
+function render() {}
+__esmMin((() => {
+	//#region bridge.js
+	init_constants();
+	//#endregion
+	//#region page-b.js
+	assert.strictEqual(1, 1);
+	assert.strictEqual(globalThis.inlineNamespaceValue, void 0, "inlined namespace member must not initialize its dead re-export before page-b");
+	//#endregion
+}))();
+export { render };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### constants.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region constants.js
+function mark() {
+	globalThis.inlineNamespaceValue = 0;
+}
+var y;
+var init_constants = __esmMin((() => {
+	y = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { y as n, init_constants as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as y, t as init_constants } from "./constants.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(1, y);
+}
+//#endregion
+__esmMin((() => {
+	init_constants();
+	assert.strictEqual(globalThis.inlineNamespaceValue, 0);
+}))();
+export { render };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_constants } from "./constants.js";
+import assert from "node:assert";
+//#region bridge.js
+var init_bridge = __esmMin((() => {
+	init_constants();
+}));
+//#endregion
+//#region page-b.js
+function render() {}
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(1, 1);
+	assert.strictEqual(globalThis.inlineNamespaceValue, void 0, "inlined namespace member must not initialize its dead re-export before page-b");
+}))();
+export { render };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["namespace member must not initialize its dead re-export before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
@@ -1,0 +1,160 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function mark() {
+	globalThis.namespaceValue = typeof globalThis.namespaceValue === "number" ? globalThis.namespaceValue + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { common as n, init_common as r, _ as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as common, r as init_common, t as _ } from "./common.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(common, _);
+}
+//#endregion
+__esmMin((() => {
+	init_common();
+	assert.strictEqual(globalThis.namespaceValue, 0);
+}))();
+export { render };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_common } from "./common.js";
+import assert from "node:assert";
+function render() {}
+__esmMin((() => {
+	//#region bridge.js
+	init_common();
+	assert.strictEqual(globalThis.namespaceValue, void 0, "namespace member must not initialize its dead re-export before page-b");
+	//#endregion
+}))();
+export { render };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### common.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function mark() {
+	globalThis.namespaceValue = typeof globalThis.namespaceValue === "number" ? globalThis.namespaceValue + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { common as n, init_common as r, _ as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as common, r as init_common, t as _ } from "./common.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(common, _);
+}
+//#endregion
+__esmMin((() => {
+	init_common();
+	assert.strictEqual(globalThis.namespaceValue, 0);
+}))();
+export { render };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_common } from "./common.js";
+import assert from "node:assert";
+var init_bridge = __esmMin((() => {
+	init_common();
+}));
+//#endregion
+//#region page-b.js
+function render() {}
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.namespaceValue, void 0, "namespace member must not initialize its dead re-export before page-b");
+}))();
+export { render };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dead barrel re-export must not initialize common before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
@@ -1,0 +1,160 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ foo();
+}));
+//#endregion
+export { common as n, init_common as r, _ as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as common, r as init_common, t as _ } from "./common.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(common, _);
+}
+//#endregion
+__esmMin((() => {
+	init_common();
+	assert.strictEqual(globalThis.value, 0);
+}))();
+export { render };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_common } from "./common.js";
+import assert from "node:assert";
+function render() {}
+__esmMin((() => {
+	//#region bridge.js
+	init_common();
+	assert.strictEqual(globalThis.value, void 0, "dead barrel re-export must not initialize common before page-b");
+	//#endregion
+}))();
+export { render };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### common.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ foo();
+}));
+//#endregion
+export { common as n, init_common as r, _ as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js").then(console.log);
+	await import("./page-a.js").then(console.log);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as common, r as init_common, t as _ } from "./common.js";
+import assert from "node:assert";
+//#region page-a.js
+function render() {
+	console.log(common, _);
+}
+//#endregion
+__esmMin((() => {
+	init_common();
+	assert.strictEqual(globalThis.value, 0);
+}))();
+export { render };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_common } from "./common.js";
+import assert from "node:assert";
+var init_bridge = __esmMin((() => {
+	init_common();
+}));
+//#endregion
+//#region page-b.js
+function render() {}
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.value, void 0, "dead barrel re-export must not initialize common before page-b");
+}))();
+export { render };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dynamic retained-star re-export must not initialize common before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/artifacts.snap
@@ -1,0 +1,166 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ foo();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_common();
+}));
+//#endregion
+export { init_common as a, common as i, x as n, _ as r, init_bridge as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as common, r as _, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.value, 0);
+}))();
+export { _, common };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.value, void 0, "dynamic retained-star re-export must not initialize common before page-b");
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ foo();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_common();
+}));
+//#endregion
+export { init_common as a, common as i, x as n, _ as r, init_bridge as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as common, r as _, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.value, 0);
+}))();
+export { _, common };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.value, void 0, "dynamic retained-star re-export must not initialize common before page-b");
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dynamic retained-star fanout must not initialize common-a before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/artifacts.snap
@@ -1,0 +1,188 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common-a.js
+function init$1() {
+	globalThis.valueA = typeof globalThis.valueA === "number" ? globalThis.valueA + 1 : 0;
+}
+var commonA;
+var init_common_a = __esmMin((() => {
+	commonA = /* @__PURE__ */ init$1();
+}));
+//#endregion
+//#region common-b.js
+function init() {
+	globalThis.valueB = typeof globalThis.valueB === "number" ? globalThis.valueB + 1 : 0;
+}
+var commonB;
+var init_common_b = __esmMin((() => {
+	commonB = /* @__PURE__ */ init();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_common_a();
+	init_common_b();
+}));
+//#endregion
+export { commonA as a, init_common_b as i, x as n, init_common_a as o, commonB as r, init_bridge as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.commonA, pageA.commonB);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { a as commonA, r as commonB, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.valueA, 0);
+	assert.strictEqual(globalThis.valueB, 0);
+}))();
+export { commonA, commonB };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.valueA, void 0, "dynamic retained-star fanout must not initialize common-a before page-b");
+	assert.strictEqual(globalThis.valueB, void 0);
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common-a.js
+function init$1() {
+	globalThis.valueA = typeof globalThis.valueA === "number" ? globalThis.valueA + 1 : 0;
+}
+var commonA;
+var init_common_a = __esmMin((() => {
+	commonA = /* @__PURE__ */ init$1();
+}));
+//#endregion
+//#region common-b.js
+function init() {
+	globalThis.valueB = typeof globalThis.valueB === "number" ? globalThis.valueB + 1 : 0;
+}
+var commonB;
+var init_common_b = __esmMin((() => {
+	commonB = /* @__PURE__ */ init();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_common_a();
+	init_common_b();
+}));
+//#endregion
+export { commonA as a, init_common_b as i, x as n, init_common_a as o, commonB as r, init_bridge as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.commonA, pageA.commonB);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { a as commonA, r as commonB, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.valueA, 0);
+	assert.strictEqual(globalThis.valueB, 0);
+}))();
+export { commonA, commonB };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.valueA, void 0, "dynamic retained-star fanout must not initialize common-a before page-b");
+	assert.strictEqual(globalThis.valueB, void 0);
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["named retained-star re-export must initialize common before page-a"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/artifacts.snap
@@ -1,0 +1,170 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region middle.js
+var init_middle = __esmMin((() => {}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_middle();
+}));
+//#endregion
+export { x as n, init_bridge as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#region common.js
+function init() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+__esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ init();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.value, 0, "named retained-star re-export must initialize common before page-a");
+}))();
+export { _, common };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.value, void 0);
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region middle.js
+var init_middle = __esmMin((() => {}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_middle();
+}));
+//#endregion
+export { x as n, init_bridge as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#region common.js
+function init() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+__esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ init();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(globalThis.value, 0, "named retained-star re-export must initialize common before page-a");
+}))();
+export { _, common };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	assert.strictEqual(globalThis.value, void 0);
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/artifacts.snap
@@ -1,0 +1,155 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] leaf.js is dynamically imported by reader-host.js but also statically imported by reader.js, dynamic import will not move module into another chunk.
+
+```
+
+# Assets
+
+## dynamic-page.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region leaf.js
+var init_leaf = __esmMin((() => {
+	(globalThis.__events ??= []).push("leaf");
+}));
+//#endregion
+//#region definer.js
+function makeValue() {
+	return 5;
+}
+var value;
+var init_definer = __esmMin((() => {
+	(globalThis.__events ??= []).push("definer");
+	value = makeValue();
+}));
+//#endregion
+//#region barrel-inner.js
+var init_barrel_inner = __esmMin((() => {
+	init_definer();
+}));
+//#endregion
+//#region barrel-outer.js
+var init_barrel_outer = __esmMin((() => {
+	init_barrel_inner();
+}));
+//#endregion
+//#region reader.js
+var readerValue;
+var init_reader = __esmMin((() => {
+	init_leaf();
+	init_barrel_outer();
+	(globalThis.__events ??= []).push("reader:" + value);
+	readerValue = value + 100;
+}));
+//#endregion
+//#region reader-host.js
+var init_reader_host = __esmMin((() => {
+	init_reader();
+	(globalThis.__events ??= []).push("reader-host:" + readerValue);
+}));
+//#endregion
+__esmMin((() => {
+	init_reader_host();
+	(globalThis.__events ??= []).push("dynamic-page");
+}))();
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] leaf.js is dynamically imported by reader-host.js but also statically imported by reader.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### dynamic-page.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+function makeValue() {
+	return 5;
+}
+var value, readerValue;
+__esmMin((() => {
+	//#region leaf.js
+	(globalThis.__events ??= []).push("leaf");
+	//#endregion
+	//#region definer.js
+	(globalThis.__events ??= []).push("definer");
+	value = makeValue();
+	//#endregion
+	//#region reader.js
+	(globalThis.__events ??= []).push("reader:" + value);
+	readerValue = value + 100;
+	//#endregion
+	//#region reader-host.js
+	(globalThis.__events ??= []).push("reader-host:" + readerValue);
+	//#endregion
+	//#region dynamic-page.js
+	(globalThis.__events ??= []).push("dynamic-page");
+	//#endregion
+}))();
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["loading dynamic target entry must not execute co-located entry a"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/artifacts.snap
@@ -1,0 +1,92 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+//#region a.js
+var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events?.push("a");
+	module.exports = { a: true };
+}));
+//#endregion
+//#region b.js
+var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events?.push("b");
+	module.exports = { b: true };
+}));
+//#endregion
+export default require_a();
+export { require_b as t };
+
+```
+
+## c.js
+
+```js
+import { n as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region c.js
+var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports.load = () => import("./a.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
+}));
+//#endregion
+export default require_c();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### a.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+//#region a.js
+var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events?.push("a");
+	module.exports = { a: true };
+}));
+//#endregion
+//#region b.js
+var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events?.push("b");
+	module.exports = { b: true };
+}));
+//#endregion
+export default require_a();
+export { require_b as t };
+
+```
+
+### c.js
+
+```js
+import { n as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region c.js
+var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports.load = () => import("./a.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
+}));
+//#endregion
+export default require_c();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/_config.json
@@ -1,11 +1,17 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
-    "input": [{ "name": "main", "import": "./main.js" }],
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
-    "experimental": { "onDemandWrapping": true },
+    "experimental": {
+      "onDemandWrapping": true
+    },
     "codeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
@@ -20,5 +26,10 @@
       ]
     }
   },
-  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/artifacts.snap
@@ -1,0 +1,181 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_definer } from "./b.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/forwarder.js
+function marker() {
+	return "F";
+}
+var init_forwarder = __esmMin((() => {
+	init_definer();
+}));
+//#endregion
+export { init_a_first as i, marker as n, require_carrier_cjs as r, init_forwarder as t };
+
+```
+
+## b.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region b/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region b/definer.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_definer = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+export { pv as n, init_eagerhaz as r, init_definer as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as marker, t as init_forwarder } from "./a.js";
+import { n as pv, r as init_eagerhaz } from "./b.js";
+__esmMin((() => {
+	//#region e-first.js
+	(globalThis.__events ??= []).push("e-first");
+	//#endregion
+	//#region main.js
+	init_a_first();
+	init_eagerhaz();
+	init_forwarder();
+	globalThis.__result = {
+		pv,
+		marker: marker(),
+		carried: globalThis.__carried
+	};
+	//#endregion
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_definer } from "./b.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/forwarder.js
+function marker() {
+	return "F";
+}
+var init_forwarder = __esmMin((() => {
+	init_definer();
+}));
+//#endregion
+export { init_a_first as i, marker as n, require_carrier_cjs as r, init_forwarder as t };
+
+```
+
+### b.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region b/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region b/definer.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_definer = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+export { pv as n, init_eagerhaz as r, init_definer as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as marker, t as init_forwarder } from "./a.js";
+import { n as pv, r as init_eagerhaz } from "./b.js";
+//#region e-first.js
+var init_e_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("e-first");
+}));
+//#endregion
+__esmMin((() => {
+	init_a_first();
+	init_eagerhaz();
+	init_e_first();
+	init_forwarder();
+	globalThis.__result = {
+		pv,
+		marker: marker(),
+		carried: globalThis.__carried
+	};
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/_config.json
@@ -1,11 +1,17 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
-    "input": [{ "name": "main", "import": "./main.js" }],
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
-    "experimental": { "onDemandWrapping": true },
+    "experimental": {
+      "onDemandWrapping": true
+    },
     "codeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
@@ -20,5 +26,10 @@
       ]
     }
   },
-  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/artifacts.snap
@@ -1,0 +1,194 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_f } from "./main.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/wrapper.js
+function mkWv() {
+	return "WV";
+}
+var wv;
+var init_wrapper = __esmMin((() => {
+	init_f();
+	wv = /* @__PURE__ */ mkWv();
+}));
+//#endregion
+export { init_a_first as i, wv as n, require_carrier_cjs as r, init_wrapper as t };
+
+```
+
+## c.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region c/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region c/t.js
+function mkTv() {
+	return "TV";
+}
+var tv;
+var init_t = __esmMin((() => {
+	tv = /* @__PURE__ */ mkTv();
+}));
+//#endregion
+export { tv as n, init_eagerhaz as r, init_t as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as wv, t as init_wrapper } from "./a.js";
+import { n as tv, r as init_eagerhaz, t as init_t } from "./c.js";
+//#region f.js
+var init_f = __esmMin((() => {}));
+__esmMin((() => {
+	//#region e-first.js
+	(globalThis.__events ??= []).push("e-first");
+	//#endregion
+	//#region main.js
+	init_a_first();
+	init_eagerhaz();
+	init_wrapper();
+	init_t();
+	globalThis.__result = {
+		wv,
+		tv,
+		carried: globalThis.__carried
+	};
+	//#endregion
+}))();
+export { init_f as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_f } from "./main.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/wrapper.js
+function mkWv() {
+	return "WV";
+}
+var wv;
+var init_wrapper = __esmMin((() => {
+	init_f();
+	wv = /* @__PURE__ */ mkWv();
+}));
+//#endregion
+export { init_a_first as i, wv as n, require_carrier_cjs as r, init_wrapper as t };
+
+```
+
+### c.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region c/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region c/t.js
+function mkTv() {
+	return "TV";
+}
+var tv;
+var init_t = __esmMin((() => {
+	tv = /* @__PURE__ */ mkTv();
+}));
+//#endregion
+export { tv as n, init_eagerhaz as r, init_t as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as wv, t as init_wrapper } from "./a.js";
+import { n as tv, r as init_eagerhaz, t as init_t } from "./c.js";
+//#region e-first.js
+var init_e_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("e-first");
+}));
+//#endregion
+//#region f.js
+var init_f = __esmMin((() => {}));
+//#endregion
+__esmMin((() => {
+	init_a_first();
+	init_eagerhaz();
+	init_e_first();
+	init_wrapper();
+	init_t();
+	globalThis.__result = {
+		wv,
+		tv,
+		carried: globalThis.__carried
+	};
+}))();
+export { init_f as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/_config.json
@@ -1,11 +1,17 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
-    "input": [{ "name": "main", "import": "./main.js" }],
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
-    "experimental": { "onDemandWrapping": true },
+    "experimental": {
+      "onDemandWrapping": true
+    },
     "codeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
@@ -20,5 +26,10 @@
       ]
     }
   },
-  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/artifacts.snap
@@ -1,0 +1,203 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { r as init_definer } from "./b.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/forwarder.js
+function marker() {
+	return "F";
+}
+var init_forwarder = __esmMin((() => {
+	init_definer();
+}));
+//#endregion
+export { init_a_first as i, marker as n, require_carrier_cjs as r, init_forwarder as t };
+
+```
+
+## b.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region b/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region b/definer.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_definer = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+//#region b/definer_b.js
+function makeBv() {
+	return "BV";
+}
+var bv;
+var init_definer_b = __esmMin((() => {
+	bv = /* @__PURE__ */ makeBv();
+}));
+//#endregion
+export { init_eagerhaz as a, pv as i, init_definer_b as n, init_definer as r, bv as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as marker, t as init_forwarder } from "./a.js";
+import { a as init_eagerhaz, i as pv, n as init_definer_b, t as bv } from "./b.js";
+__esmMin((() => {
+	//#region e-first.js
+	(globalThis.__events ??= []).push("e-first");
+	//#endregion
+	//#region main.js
+	init_a_first();
+	init_eagerhaz();
+	init_forwarder();
+	init_definer_b();
+	globalThis.__result = {
+		pv,
+		bv,
+		marker: marker(),
+		carried: globalThis.__carried
+	};
+	//#endregion
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { r as init_definer } from "./b.js";
+//#region a/a-first.js
+var init_a_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("a-first");
+}));
+//#endregion
+//#region a/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region a/forwarder.js
+function marker() {
+	return "F";
+}
+var init_forwarder = __esmMin((() => {
+	init_definer();
+}));
+//#endregion
+export { init_a_first as i, marker as n, require_carrier_cjs as r, init_forwarder as t };
+
+```
+
+### b.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./a.js";
+//#region b/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region b/definer.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_definer = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+//#region b/definer_b.js
+function makeBv() {
+	return "BV";
+}
+var bv;
+var init_definer_b = __esmMin((() => {
+	bv = /* @__PURE__ */ makeBv();
+}));
+//#endregion
+export { init_eagerhaz as a, pv as i, init_definer_b as n, init_definer as r, bv as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_a_first, n as marker, t as init_forwarder } from "./a.js";
+import { a as init_eagerhaz, i as pv, n as init_definer_b, t as bv } from "./b.js";
+//#region e-first.js
+var init_e_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("e-first");
+}));
+//#endregion
+__esmMin((() => {
+	init_a_first();
+	init_eagerhaz();
+	init_e_first();
+	init_forwarder();
+	init_definer_b();
+	globalThis.__result = {
+		pv,
+		bv,
+		marker: marker(),
+		carried: globalThis.__carried
+	};
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/_config.json
@@ -1,11 +1,17 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
-    "input": [{ "name": "main", "import": "./main.js" }],
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension",
-    "experimental": { "onDemandWrapping": true },
+    "experimental": {
+      "onDemandWrapping": true
+    },
     "codeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
@@ -20,5 +26,10 @@
       ]
     }
   },
-  "configVariants": [{ "_configName": "wrap-all", "onDemandWrapping": false }]
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/artifacts.snap
@@ -1,0 +1,185 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## h.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./s.js";
+//#region h/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region h/pure.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_pure = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+export { pv as n, init_eagerhaz as r, init_pure as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_s_first, n as init_barrel, t as bmark } from "./s.js";
+import { n as pv, r as init_eagerhaz } from "./h.js";
+__esmMin((() => {
+	//#region e-first.js
+	(globalThis.__events ??= []).push("e-first");
+	//#endregion
+	//#region main.js
+	init_s_first();
+	init_eagerhaz();
+	init_barrel();
+	globalThis.__result = {
+		pv,
+		bmark,
+		carried: globalThis.__carried
+	};
+	//#endregion
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+## s.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_pure } from "./h.js";
+//#region s/s-first.js
+var init_s_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("s-first");
+}));
+//#endregion
+//#region s/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region s/barrel.js
+function makeBmark() {
+	return "B";
+}
+var bmark;
+var init_barrel = __esmMin((() => {
+	init_pure();
+	bmark = /* @__PURE__ */ makeBmark();
+}));
+//#endregion
+export { init_s_first as i, init_barrel as n, require_carrier_cjs as r, bmark as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### h.js
+
+```js
+import { n as __esmMin, r as __toESM } from "./rolldown-runtime.js";
+import { r as require_carrier_cjs } from "./s.js";
+//#region h/eagerhaz.js
+var import_carrier_cjs;
+var init_eagerhaz = __esmMin((() => {
+	import_carrier_cjs = /* @__PURE__ */ __toESM(require_carrier_cjs());
+	globalThis.__carried = (0, import_carrier_cjs.default)();
+}));
+//#endregion
+//#region h/pure.js
+function makePv() {
+	return "PV";
+}
+var pv;
+var init_pure = __esmMin((() => {
+	pv = /* @__PURE__ */ makePv();
+}));
+//#endregion
+export { pv as n, init_eagerhaz as r, init_pure as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { i as init_s_first, n as init_barrel, t as bmark } from "./s.js";
+import { n as pv, r as init_eagerhaz } from "./h.js";
+//#region e-first.js
+var init_e_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("e-first");
+}));
+//#endregion
+__esmMin((() => {
+	init_s_first();
+	init_eagerhaz();
+	init_e_first();
+	init_barrel();
+	globalThis.__result = {
+		pv,
+		bmark,
+		carried: globalThis.__carried
+	};
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+### s.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_pure } from "./h.js";
+//#region s/s-first.js
+var init_s_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("s-first");
+}));
+//#endregion
+//#region s/carrier.cjs.js
+var require_carrier_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = function carrier() {
+		return "CARRIED";
+	};
+}));
+//#endregion
+//#region s/barrel.js
+function makeBmark() {
+	return "B";
+}
+var bmark;
+var init_barrel = __esmMin((() => {
+	init_pure();
+	bmark = /* @__PURE__ */ makeBmark();
+}));
+//#endregion
+export { init_s_first as i, init_barrel as n, require_carrier_cjs as r, bmark as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "external": ["external"],

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/artifacts.snap
@@ -1,0 +1,85 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_reader } from "./reader.js";
+export * from "external";
+__esmMin((() => {
+	//#region setup.js
+	globalThis.setupValue = "ready";
+	//#endregion
+	//#region main.js
+	init_reader();
+	//#endregion
+}))();
+
+```
+
+## reader.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+export { init_reader as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_reader } from "./reader.js";
+export * from "external";
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.setupValue = "ready";
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_reader();
+}))();
+
+```
+
+### reader.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+export { init_reader as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecuted": false,
   "configName": "on-demand",
   "config": {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/artifacts.snap
@@ -1,0 +1,85 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_reader } from "./reader.js";
+export * from "external" with { type: "json" };
+__esmMin((() => {
+	//#region setup.js
+	globalThis.setupValue = "ready";
+	//#endregion
+	//#region main.js
+	init_reader();
+	//#endregion
+}))();
+
+```
+
+## reader.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+export { init_reader as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_reader } from "./reader.js";
+export * from "external" with { type: "json" };
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.setupValue = "ready";
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_reader();
+}))();
+
+```
+
+### reader.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+export { init_reader as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecuted": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/artifacts.snap
@@ -1,0 +1,104 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as init_a } from "./shared.js";
+export * from "external";
+init_a();
+
+```
+
+## b.js
+
+```js
+import { t as init_b } from "./shared.js";
+export * from "external";
+init_b();
+
+```
+
+## shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.setupValue = "ready";
+}));
+//#endregion
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	init_setup();
+	init_reader();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	init_setup();
+	init_reader();
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a } from "./shared.js";
+export * from "external";
+init_a();
+
+```
+
+### b.js
+
+```js
+import { t as init_b } from "./shared.js";
+export * from "external";
+init_b();
+
+```
+
+### shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.setupValue = "ready";
+}));
+//#endregion
+//#region reader.js
+var init_reader = __esmMin((() => {
+	console.log(globalThis.setupValue);
+}));
+//#endregion
+//#region a.js
+var init_a = __esmMin((() => {
+	init_setup();
+	init_reader();
+}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {
+	init_setup();
+	init_reader();
+}));
+//#endregion
+export { init_a as n, init_b as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/artifacts.snap
@@ -1,0 +1,136 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_facade, t as getPref } from "./pref.js";
+//#region first.js
+var init_first = __esmMin((() => {
+	(globalThis.__events ??= []).push("first");
+}));
+//#endregion
+//#region node_modules/pref-pkg/index.js
+function tag(value) {
+	return `tag:${value}`;
+}
+var init_pref_pkg = __esmMin((() => {
+	init_facade();
+}));
+//#endregion
+//#region main.js
+function boot() {
+	return tag(getPref());
+}
+async function initApplication() {
+	return tag(await getPref());
+}
+//#endregion
+__esmMin((() => {
+	init_first();
+	init_pref_pkg();
+	(globalThis.__events ??= []).push("main");
+	globalThis.__result = boot();
+	globalThis.__ready = initApplication();
+}))();
+
+```
+
+## pref.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pref-pkg/manager.js
+function makePref() {
+	return () => "PREF_OK";
+}
+var init_manager = __esmMin((() => {
+	(globalThis.__events ??= []).push("manager");
+}));
+//#endregion
+//#region node_modules/pref-pkg/facade.js
+var getPref;
+var init_facade = __esmMin((() => {
+	init_manager();
+	getPref = makePref();
+}));
+//#endregion
+export { init_facade as n, getPref as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_facade, t as getPref } from "./pref.js";
+function tag(value) {
+	return `tag:${value}`;
+}
+function boot() {
+	return tag(getPref());
+}
+async function initApplication() {
+	return tag(await getPref());
+}
+__esmMin((() => {
+	//#region first.js
+	(globalThis.__events ??= []).push("first");
+	//#endregion
+	//#region node_modules/pref-pkg/index.js
+	init_facade();
+	//#endregion
+	//#region main.js
+	(globalThis.__events ??= []).push("main");
+	globalThis.__result = boot();
+	globalThis.__ready = initApplication();
+	//#endregion
+}))();
+
+```
+
+### pref.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pref-pkg/manager.js
+function makePref() {
+	return () => "PREF_OK";
+}
+var init_manager = __esmMin((() => {
+	(globalThis.__events ??= []).push("manager");
+}));
+//#endregion
+//#region node_modules/pref-pkg/facade.js
+var getPref;
+var init_facade = __esmMin((() => {
+	init_manager();
+	getPref = makePref();
+}));
+//#endregion
+export { init_facade as n, getPref as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/artifacts.snap
@@ -1,0 +1,114 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { n as init_e } from "./e.js";
+//#endregion
+__esmMin((() => {
+	init_e();
+	console.log("A");
+}))();
+
+```
+
+## b.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_e } from "./e.js";
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_e();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+
+```
+
+## e.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region e.js
+var e_exports = /* @__PURE__ */ __exportAll({ v: () => "v" });
+var v;
+var init_e = __esmMin((() => {
+	v = "v";
+	console.log("E");
+}));
+//#endregion
+init_e();
+export { init_e as n, e_exports as t, v };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { n as init_e } from "./e.js";
+//#endregion
+__esmMin((() => {
+	init_e();
+	console.log("A");
+}))();
+
+```
+
+### b.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_e } from "./e.js";
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_e();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+
+```
+
+### e.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region e.js
+var e_exports = /* @__PURE__ */ __exportAll({ v: () => "v" });
+var v;
+var init_e = __esmMin((() => {
+	v = "v";
+	console.log("E");
+}));
+//#endregion
+init_e();
+export { init_e as n, e_exports as t, v };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
@@ -4,13 +4,13 @@
   },
   "configVariants": [
     {
-      "_configName": "wrap-all",
-      "strictExecutionOrder": true
-    },
-    {
       "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -14,6 +14,27 @@ nodeAssert.equal("foo", "foo");
 
 ```
 
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+var value;
+__esmMin((() => {
+	//#region lib-foo.js
+	value = "foo";
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(value, "foo");
+	//#endregion
+}))();
+
+```
+
 # Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
@@ -46,27 +67,6 @@ var init_proxy = __esmMin((() => {
 __esmMin((() => {
 	init_proxy();
 	nodeAssert.equal(value, "foo");
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-var value;
-__esmMin((() => {
-	//#region lib-foo.js
-	value = "foo";
-	//#endregion
-	//#region main.js
-	nodeAssert.equal(value, "foo");
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/_config.json
@@ -1,16 +1,16 @@
 {
+  "configName": "on-demand",
   "config": {
-    "external": ["node:assert"]
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
       "_configName": "wrap-all",
-      "strictExecutionOrder": true
-    },
-    {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -7,14 +7,20 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import nodeAssert from "node:assert";
-//#endregion
-//#region main.js
-nodeAssert.equal("foo", "foo");
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
+var value;
+__esmMin((() => {
+	//#region lib-foo.js
+	value = "foo";
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(value, "foo");
+	//#endregion
+}))();
 
 ```
 
-# Variant: wrap-all: [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -56,27 +62,6 @@ var init_ns_proxy_2 = __esmMin((() => {
 __esmMin((() => {
 	init_ns_proxy_2();
 	nodeAssert.equal(value, "foo");
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-var value;
-__esmMin((() => {
-	//#region lib-foo.js
-	value = "foo";
-	//#endregion
-	//#region main.js
-	nodeAssert.equal(value, "foo");
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
@@ -4,13 +4,13 @@
   },
   "configVariants": [
     {
-      "_configName": "wrap-all",
-      "strictExecutionOrder": true
-    },
-    {
       "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -14,6 +14,27 @@ nodeAssert.equal("foo", "foo");
 
 ```
 
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+var value;
+__esmMin((() => {
+	//#region lib-foo.js
+	value = "foo";
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(value, "foo");
+	//#endregion
+}))();
+
+```
+
 # Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
@@ -46,27 +67,6 @@ var init_proxy = __esmMin((() => {
 __esmMin((() => {
 	init_proxy();
 	nodeAssert.equal(value, "foo");
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-var value;
-__esmMin((() => {
-	//#region lib-foo.js
-	value = "foo";
-	//#endregion
-	//#region main.js
-	nodeAssert.equal(value, "foo");
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
@@ -1,14 +1,16 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
-    "minify": false
+    "minify": false,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -7,6 +7,37 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+var inner_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+
+var foo;
+var init_inner = __esmMin((() => {
+//#region leaf.js
+	;
+	foo = 1;
+
+//#endregion
+}));
+
+
+var init_main = __esmMin((() => {
+//#region outer.js
+	init_inner();
+
+//#endregion
+}));
+
+init_main();
+export { inner_exports as star };
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
 var init_dep = __esmMin((() => {}));
 
@@ -39,37 +70,6 @@ var init_main = __esmMin((() => {
 }));
 
 //#endregion
-init_main();
-export { inner_exports as star };
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-var inner_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-
-var foo;
-var init_inner = __esmMin((() => {
-//#region leaf.js
-	;
-	foo = 1;
-
-//#endregion
-}));
-
-
-var init_main = __esmMin((() => {
-//#region outer.js
-	init_inner();
-
-//#endregion
-}));
-
 init_main();
 export { inner_exports as star };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "config": {
     "external": ["node:path"]
   },

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
@@ -1,0 +1,68 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { sep } from "node:path";
+//#region dep.js
+globalThis.__depRan = true;
+//#endregion
+//#region main.js
+const out = `dep:${sep.length > 0}`;
+//#endregion
+export { out };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { sep } from "node:path";
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var marker;
+var init_dep = __esmMin((() => {
+	globalThis.__depRan = true;
+	marker = `dep:${sep.length > 0}`;
+}));
+//#endregion
+//#region main.js
+var out;
+//#endregion
+__esmMin((() => {
+	init_dep();
+	out = marker;
+}))();
+export { out };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { sep } from "node:path";
+// HIDDEN [\0rolldown/runtime.js]
+var marker, out;
+__esmMin((() => {
+	//#region dep.js
+	globalThis.__depRan = true;
+	marker = `dep:${sep.length > 0}`;
+	//#endregion
+	//#region main.js
+	out = marker;
+	//#endregion
+}))();
+export { out };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["internal wrapped entry must preserve source execution order"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/artifacts.snap
@@ -1,0 +1,188 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## e1.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_m5 } from "./m5.js";
+import { t as init_m2 } from "./m2.js";
+//#region e1.cjs
+var require_e1 = /* @__PURE__ */ __commonJSMin((() => {
+	require_m5();
+	init_m2();
+	globalThis.__entryInteropOrder.push("e1");
+}));
+//#endregion
+export default require_e1();
+
+```
+
+## e2.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_m5 } from "./m5.js";
+//#region e2.cjs
+var require_e2 = /* @__PURE__ */ __commonJSMin((() => {
+	require_m5();
+	globalThis.__entryInteropOrder.push("e2");
+}));
+//#endregion
+export default require_e2();
+
+```
+
+## m2.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region m2.js
+var m2_exports = /* @__PURE__ */ __exportAll({ value: () => 2 });
+var value;
+var init_m2 = __esmMin((() => {
+	globalThis.__entryInteropOrder.push("m2");
+	value = 2;
+}));
+//#endregion
+init_m2();
+export { m2_exports as n, init_m2 as t, value };
+
+```
+
+## m5.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+//#region m5.cjs
+var require_m5 = /* @__PURE__ */ __commonJSMin((() => {
+	globalThis.__entryInteropOrder.push("m5");
+}));
+//#endregion
+export { require_m5 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### e1.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_m5 } from "./m5.js";
+import { t as init_m2 } from "./m2.js";
+//#region e1.cjs
+var require_e1 = /* @__PURE__ */ __commonJSMin((() => {
+	require_m5();
+	init_m2();
+	globalThis.__entryInteropOrder.push("e1");
+}));
+//#endregion
+export default require_e1();
+
+```
+
+### e2.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_m5 } from "./m5.js";
+//#region e2.cjs
+var require_e2 = /* @__PURE__ */ __commonJSMin((() => {
+	require_m5();
+	globalThis.__entryInteropOrder.push("e2");
+}));
+//#endregion
+export default require_e2();
+
+```
+
+### m2.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region m2.js
+var m2_exports = /* @__PURE__ */ __exportAll({ value: () => 2 });
+var value;
+var init_m2 = __esmMin((() => {
+	globalThis.__entryInteropOrder.push("m2");
+	value = 2;
+}));
+//#endregion
+init_m2();
+export { m2_exports as n, init_m2 as t, value };
+
+```
+
+### m5.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+//#region m5.cjs
+var require_m5 = /* @__PURE__ */ __commonJSMin((() => {
+	globalThis.__entryInteropOrder.push("m5");
+}));
+//#endregion
+export { require_m5 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["interop trigger host must preserve source execution order"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
@@ -1,0 +1,169 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## b.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_s } from "./s.js";
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_s();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+
+```
+
+## m3.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region c2.cjs
+var require_c2 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("C2");
+}));
+//#endregion
+//#region c1.cjs
+var require_c1 = /* @__PURE__ */ __commonJSMin((() => {
+	require_c2();
+	console.log("C1");
+}));
+var init_m3 = __esmMin((() => {
+	require_c1();
+	console.log("M3");
+}));
+//#endregion
+init_m3();
+export { init_m3 as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { t as init_s } from "./s.js";
+import { t as init_m3 } from "./m3.js";
+__esmMin((() => {
+	//#region m1.js
+	init_s();
+	init_m3();
+	console.log("M1");
+	//#endregion
+	//#region main.js
+	console.log("A");
+	//#endregion
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## s.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region s.mjs
+var s_exports = /* @__PURE__ */ __exportAll({});
+var init_s = __esmMin((() => {
+	console.log("S");
+}));
+//#endregion
+export { s_exports as n, init_s as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### b.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_s } from "./s.js";
+//#region b.cjs
+var require_b = /* @__PURE__ */ __commonJSMin((() => {
+	init_s();
+	console.log("B");
+}));
+//#endregion
+export default require_b();
+
+```
+
+### m3.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region c2.cjs
+var require_c2 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("C2");
+}));
+//#endregion
+//#region c1.cjs
+var require_c1 = /* @__PURE__ */ __commonJSMin((() => {
+	require_c2();
+	console.log("C1");
+}));
+var init_m3 = __esmMin((() => {
+	require_c1();
+	console.log("M3");
+}));
+//#endregion
+init_m3();
+export { init_m3 as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { t as init_s } from "./s.js";
+import { t as init_m3 } from "./m3.js";
+//#region m1.js
+var init_m1 = __esmMin((() => {
+	init_s();
+	init_m3();
+	console.log("M1");
+}));
+//#endregion
+__esmMin((() => {
+	init_m1();
+	console.log("A");
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+### s.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+//#region s.mjs
+var s_exports = /* @__PURE__ */ __exportAll({});
+var init_s = __esmMin((() => {
+	console.log("S");
+}));
+//#endregion
+export { s_exports as n, init_s as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/_config.json
@@ -1,17 +1,17 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
     "strictExecutionOrder": true,
     "experimental": {
-      "devMode": {}
+      "devMode": {},
+      "onDemandWrapping": true
     }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -33,7 +33,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/_config.json
@@ -1,14 +1,16 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -20,6 +20,56 @@ __esmMin((() => {
 ```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region read.js
+var foo, read;
+var init_read = __esmMin((() => {
+	foo = globalThis.foo;
+	read = () => {
+		console.log("read", foo);
+	};
+}));
+//#endregion
+var setup;
+__esmMin((() => {
+	//#region setup.js
+	setup = () => {
+		globalThis.foo = "foo";
+	};
+	setup();
+	//#endregion
+	//#region main.js
+	init_read();
+	setup();
+	read();
+	import("./dynamic.js");
+	nodeAssert.strictEqual(globalThis.foo, "foo");
+	//#endregion
+}))();
+export { read as n, __esmMin as r, init_read as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### dynamic.js
+
+```js
+import { n as read, r as __esmMin, t as init_read } from "./main.js";
+//#endregion
+__esmMin((() => {
+	init_read();
+	read();
+}))();
+
+```
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var setup;
 var init_setup = __esmMin((() => {
@@ -45,56 +95,6 @@ __esmMin((() => {
 	read();
 	import("./dynamic.js");
 	nodeAssert.strictEqual(globalThis.foo, "foo");
-}))();
-export { read as n, __esmMin as r, init_read as t };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### dynamic.js
-
-```js
-import { n as read, r as __esmMin, t as init_read } from "./main.js";
-//#endregion
-__esmMin((() => {
-	init_read();
-	read();
-}))();
-
-```
-
-### main.js
-
-```js
-import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-//#region read.js
-var foo, read;
-var init_read = __esmMin((() => {
-	foo = globalThis.foo;
-	read = () => {
-		console.log("read", foo);
-	};
-}));
-//#endregion
-var setup;
-__esmMin((() => {
-	//#region setup.js
-	setup = () => {
-		globalThis.foo = "foo";
-	};
-	setup();
-	//#endregion
-	//#region main.js
-	init_read();
-	setup();
-	read();
-	import("./dynamic.js");
-	nodeAssert.strictEqual(globalThis.foo, "foo");
-	//#endregion
 }))();
 export { read as n, __esmMin as r, init_read as t };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/_config.json
@@ -1,13 +1,16 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
-  },
-  "configVariants": [
-    {
-      "_configName": "on-demand",
+    "strictExecutionOrder": true,
+    "experimental": {
       "onDemandWrapping": true
     }
-  ],
-  "expectExecuted": false
+  },
+  "expectExecuted": false,
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -13,20 +13,18 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.sideEffect = {};
 	module.exports = sideEffect;
 }));
-//#endregion
-//#region dep-b.js
-var init_dep_b = __esmMin((() => {
-	sideEffect.touched = true;
-}));
-//#endregion
 __esmMin((() => {
+	//#region dep-b.js
+	sideEffect.touched = true;
+	//#endregion
+	//#region main.js
 	require_dep_a();
-	init_dep_b();
+	//#endregion
 }))();
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -40,13 +38,15 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.sideEffect = {};
 	module.exports = sideEffect;
 }));
-__esmMin((() => {
-	//#region dep-b.js
+//#endregion
+//#region dep-b.js
+var init_dep_b = __esmMin((() => {
 	sideEffect.touched = true;
-	//#endregion
-	//#region main.js
+}));
+//#endregion
+__esmMin((() => {
 	require_dep_a();
-	//#endregion
+	init_dep_b();
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
@@ -1,12 +1,15 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -25,7 +25,7 @@ export { dep_default as dep };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
@@ -2,9 +2,6 @@
   "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
-    "experimental": {
-      "onDemandWrapping": true
-    },
     "codeSplitting": {
       "groups": [
         {
@@ -12,6 +9,15 @@
           "test": "foo(?:_\\w+)?\\.js"
         }
       ]
+    },
+    "experimental": {
+      "onDemandWrapping": true
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
@@ -47,3 +47,53 @@ var init_foo = __esmMin((() => {
 export { init_foo as t };
 
 ```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_foo } from "./test.js";
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.globalValue = "foo";
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_foo();
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### test.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region foo_inner.js
+var foo_inner_default;
+var init_foo_inner = __esmMin((() => {
+	foo_inner_default = { foo: /* #__PURE__ */ (() => globalValue)() };
+}));
+//#endregion
+//#region foo.js
+var init_foo = __esmMin((() => {
+	init_foo_inner();
+	assert.strictEqual(foo_inner_default.foo, "foo");
+}));
+//#endregion
+export { init_foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
@@ -1,13 +1,16 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
-  },
-  "configVariants": [
-    {
-      "_configName": "on-demand",
+    "strictExecutionOrder": true,
+    "experimental": {
       "onDemandWrapping": true
     }
-  ],
-  "snapshot": false
+  },
+  "snapshot": false,
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
@@ -1,13 +1,15 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -11,6 +11,37 @@ source: crates/rolldown_testing/src/integration_test.rs
 function getFooUtilityClass(slot) {
 	return "MuiFoo-" + slot;
 }
+const fooClasses = { root: "MuiFoo-root" };
+//#endregion
+//#region components/Foo/Foo.js
+var Foo;
+var init_Foo$1 = __esmMin((() => {
+	Foo = {
+		name: "Foo",
+		root: fooClasses.root
+	};
+}));
+__esmMin((() => {
+	//#region components/Foo/index.js
+	init_Foo$1();
+	//#endregion
+}))();
+export { Foo, fooClasses, getFooUtilityClass };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region components/Foo/fooClasses.js
+function getFooUtilityClass(slot) {
+	return "MuiFoo-" + slot;
+}
 var fooClasses;
 var init_fooClasses = __esmMin((() => {
 	fooClasses = { root: "MuiFoo-root" };
@@ -36,37 +67,6 @@ var init_Foo = __esmMin((() => {
 __esmMin((() => {
 	init_Foo();
 	init_Foo();
-}))();
-export { Foo, fooClasses, getFooUtilityClass };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region components/Foo/fooClasses.js
-function getFooUtilityClass(slot) {
-	return "MuiFoo-" + slot;
-}
-const fooClasses = { root: "MuiFoo-root" };
-//#endregion
-//#region components/Foo/Foo.js
-var Foo;
-var init_Foo$1 = __esmMin((() => {
-	Foo = {
-		name: "Foo",
-		root: fooClasses.root
-	};
-}));
-__esmMin((() => {
-	//#region components/Foo/index.js
-	init_Foo$1();
-	//#endregion
 }))();
 export { Foo, fooClasses, getFooUtilityClass };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -9,13 +9,15 @@
     ],
     "external": ["node:assert"],
     "strictExecutionOrder": true,
-    "preserveEntrySignatures": "false"
+    "preserveEntrySignatures": "false",
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -53,7 +53,7 @@ export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_chunk_cycle_order/artifacts.snap
@@ -1,0 +1,130 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## e0.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region m0.js
+var init_m0 = __esmMin((() => {
+	globalThis.logs.push("m0");
+}));
+//#endregion
+init_m0();
+export { __esmMin as n, init_m0 as t };
+
+```
+
+## e1.js
+
+```js
+import { n as __esmMin } from "./e0.js";
+import { n as init_m2, t as init_m1 } from "./g.js";
+//#region m3.js
+var init_m3 = __esmMin((() => {
+	init_m2();
+	globalThis.logs.push("m3");
+}));
+//#endregion
+init_m1();
+export { init_m3 as t };
+
+```
+
+## g.js
+
+```js
+import { n as __esmMin, t as init_m0 } from "./e0.js";
+import { t as init_m3 } from "./e1.js";
+//#region m2.js
+var init_m2 = __esmMin((() => {
+	init_m0();
+	init_m3();
+	globalThis.logs.push("m2");
+}));
+//#endregion
+//#region m1.js
+var init_m1 = __esmMin((() => {
+	init_m3();
+	globalThis.logs.push("m1");
+}));
+//#endregion
+export { init_m2 as n, init_m1 as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### e0.js
+
+```js
+//#region \0rolldown/runtime.js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region m0.js
+var init_m0 = __esmMin((() => {
+	globalThis.logs.push("m0");
+}));
+//#endregion
+init_m0();
+export { __esmMin as n, init_m0 as t };
+
+```
+
+### e1.js
+
+```js
+import { n as __esmMin } from "./e0.js";
+import { n as init_m2, t as init_m1 } from "./g.js";
+//#region m3.js
+var init_m3 = __esmMin((() => {
+	init_m2();
+	globalThis.logs.push("m3");
+}));
+//#endregion
+init_m1();
+export { init_m3 as t };
+
+```
+
+### g.js
+
+```js
+import { n as __esmMin, t as init_m0 } from "./e0.js";
+import { t as init_m3 } from "./e1.js";
+//#region m2.js
+var init_m2 = __esmMin((() => {
+	init_m0();
+	init_m3();
+	globalThis.logs.push("m2");
+}));
+//#endregion
+//#region m1.js
+var init_m1 = __esmMin((() => {
+	init_m3();
+	globalThis.logs.push("m1");
+}));
+//#endregion
+export { init_m2 as n, init_m1 as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_entry_with_leaf/artifacts.snap
@@ -1,0 +1,121 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## group-0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m2, t as init_m1 } from "./main.js";
+//#region m4.js
+var init_m4 = __esmMin((() => {
+	console.log("m4");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}));
+//#endregion
+export { init_m4 as n, init_main as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m4, t as init_main } from "./group-0.js";
+var init_m2 = __esmMin((() => {
+	//#region m3.js
+	init_m4();
+	console.log("m3");
+	//#endregion
+	//#region m2.js
+	console.log("m2");
+	//#endregion
+}));
+//#region m1.js
+var init_m1 = __esmMin((() => {
+	init_m2();
+	init_m4();
+	console.log("m1");
+}));
+//#endregion
+init_main();
+export { init_m2 as n, init_m1 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### group-0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m2, t as init_m1 } from "./main.js";
+//#region m4.js
+var init_m4 = __esmMin((() => {
+	console.log("m4");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}));
+//#endregion
+export { init_m4 as n, init_main as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m4, t as init_main } from "./group-0.js";
+//#region m3.js
+var init_m3 = __esmMin((() => {
+	init_m4();
+	console.log("m3");
+}));
+//#endregion
+//#region m2.js
+var init_m2 = __esmMin((() => {
+	init_m3();
+	console.log("m2");
+}));
+//#endregion
+//#region m1.js
+var init_m1 = __esmMin((() => {
+	init_m2();
+	init_m4();
+	console.log("m1");
+}));
+//#endregion
+init_main();
+export { init_m2 as n, init_m1 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/artifacts.snap
@@ -1,0 +1,106 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## group-0.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_m1 } from "./main.js";
+//#region m3.cjs
+var require_m3 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("m3");
+}));
+//#endregion
+//#region m2.js
+var init_m2 = __esmMin((() => {
+	console.log("m2");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}));
+//#endregion
+export { require_m3 as n, init_main as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { n as require_m3, t as init_main } from "./group-0.js";
+var init_m1 = __esmMin((() => {
+	require_m3();
+	console.log("m1");
+}));
+//#endregion
+init_main();
+export { init_m1 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### group-0.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as init_m1 } from "./main.js";
+//#region m3.cjs
+var require_m3 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("m3");
+}));
+//#endregion
+//#region m2.js
+var init_m2 = __esmMin((() => {
+	console.log("m2");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}));
+//#endregion
+export { require_m3 as n, init_main as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { n as require_m3, t as init_main } from "./group-0.js";
+var init_m1 = __esmMin((() => {
+	require_m3();
+	console.log("m1");
+}));
+//#endregion
+init_main();
+export { init_m1 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
@@ -1,0 +1,140 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## group-0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_leafhost } from "./group-l.js";
+import { t as init_x } from "./main.js";
+//#region y.js
+var init_y = __esmMin((() => {
+	console.log("Y");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_x();
+	init_leafhost();
+	console.log("A");
+}));
+//#endregion
+export { init_y as n, init_main as t };
+
+```
+
+## group-l.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region leafhost.js
+var init_leafhost = __esmMin((() => {
+	globalThis.__loadM6 = () => Promise.resolve().then(() => (init_m6(), m6_exports));
+	console.log("L");
+}));
+//#endregion
+//#region m6.js
+var m6_exports = /* @__PURE__ */ __exportAll({});
+var init_m6 = __esmMin((() => {
+	console.log("M6");
+}));
+//#endregion
+export { init_leafhost as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_y, t as init_main } from "./group-0.js";
+//#region x.js
+var init_x = __esmMin((() => {
+	init_y();
+	console.log("X");
+}));
+//#endregion
+init_main();
+export { init_x as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### group-0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_leafhost } from "./group-l.js";
+import { t as init_x } from "./main.js";
+//#region y.js
+var init_y = __esmMin((() => {
+	console.log("Y");
+}));
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_x();
+	init_leafhost();
+	console.log("A");
+}));
+//#endregion
+export { init_y as n, init_main as t };
+
+```
+
+### group-l.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region leafhost.js
+var init_leafhost = __esmMin((() => {
+	globalThis.__loadM6 = () => Promise.resolve().then(() => (init_m6(), m6_exports));
+	console.log("L");
+}));
+//#endregion
+//#region m6.js
+var m6_exports = /* @__PURE__ */ __exportAll({});
+var init_m6 = __esmMin((() => {
+	console.log("M6");
+}));
+//#endregion
+export { init_leafhost as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_y, t as init_main } from "./group-0.js";
+//#region x.js
+var init_x = __esmMin((() => {
+	init_y();
+	console.log("X");
+}));
+//#endregion
+init_main();
+export { init_x as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["ReferenceError: sideEffect is not defined"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
@@ -1,0 +1,75 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] dep-b.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep-a.js
+var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const sideEffect = {};
+	globalThis.sideEffect = sideEffect;
+	module.exports = sideEffect;
+}));
+//#endregion
+var dep_b_exports = /* @__PURE__ */ __exportAll({});
+__esmMin((() => {
+	//#region dep-b.js
+	sideEffect.touched = true;
+	//#endregion
+	//#region main.js
+	require_dep_a();
+	Promise.resolve().then(() => (init_dep_b(), dep_b_exports));
+	//#endregion
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] dep-b.js is dynamically imported by main.js but also statically imported by main.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep-a.js
+var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const sideEffect = {};
+	globalThis.sideEffect = sideEffect;
+	module.exports = sideEffect;
+}));
+//#endregion
+//#region dep-b.js
+var dep_b_exports = /* @__PURE__ */ __exportAll({});
+var init_dep_b = __esmMin((() => {
+	sideEffect.touched = true;
+}));
+//#endregion
+__esmMin((() => {
+	require_dep_a();
+	init_dep_b();
+	Promise.resolve().then(() => (init_dep_b(), dep_b_exports));
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["ambiguous namespace re-export must not initialize common-a before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/artifacts.snap
@@ -1,0 +1,189 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common-a.js
+function mark$1() {
+	globalThis.valueA = typeof globalThis.valueA === "number" ? globalThis.valueA + 1 : 0;
+	return "a";
+}
+var collision$1;
+var init_common_a = __esmMin((() => {
+	collision$1 = /* @__PURE__ */ mark$1();
+}));
+//#endregion
+//#region common-b.js
+function mark() {
+	globalThis.valueB = typeof globalThis.valueB === "number" ? globalThis.valueB + 1 : 0;
+	return "b";
+}
+var collision;
+var init_common_b = __esmMin((() => {
+	collision = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { init_common_a as i, init_common_b as n, collision$1 as r, collision as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	await import("./page-a.js");
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_common_a, n as init_common_b, r as collision, t as collision$1 } from "./common-b.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_common_a();
+	init_common_b();
+	assert.strictEqual(globalThis.valueA, 0);
+	assert.strictEqual(globalThis.valueB, 0);
+	assert.strictEqual(collision, "a");
+	assert.strictEqual(collision$1, "b");
+}))();
+
+```
+
+## page-b.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_common_a, n as init_common_b } from "./common-b.js";
+import assert from "node:assert";
+//#region bridge.js
+var bridge_exports = /* @__PURE__ */ __exportAll({ ok: () => ok });
+function ok() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_common_a();
+	init_common_b();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(bridge_exports[globalThis.__bridgeKey || "ok"](), 1);
+	assert.strictEqual(globalThis.valueA, void 0, "ambiguous namespace re-export must not initialize common-a before page-b");
+	assert.strictEqual(globalThis.valueB, void 0);
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### common-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region common-a.js
+function mark$1() {
+	globalThis.valueA = typeof globalThis.valueA === "number" ? globalThis.valueA + 1 : 0;
+	return "a";
+}
+var collision$1;
+var init_common_a = __esmMin((() => {
+	collision$1 = /* @__PURE__ */ mark$1();
+}));
+//#endregion
+//#region common-b.js
+function mark() {
+	globalThis.valueB = typeof globalThis.valueB === "number" ? globalThis.valueB + 1 : 0;
+	return "b";
+}
+var collision;
+var init_common_b = __esmMin((() => {
+	collision = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { init_common_a as i, init_common_b as n, collision$1 as r, collision as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	await import("./page-a.js");
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_common_a, n as init_common_b, r as collision, t as collision$1 } from "./common-b.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_common_a();
+	init_common_b();
+	assert.strictEqual(globalThis.valueA, 0);
+	assert.strictEqual(globalThis.valueB, 0);
+	assert.strictEqual(collision, "a");
+	assert.strictEqual(collision$1, "b");
+}))();
+
+```
+
+### page-b.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_common_a, n as init_common_b } from "./common-b.js";
+import assert from "node:assert";
+var bridge_exports = /* @__PURE__ */ __exportAll({ ok: () => ok });
+function ok() {
+	return 1;
+}
+__esmMin((() => {
+	//#region bridge.js
+	init_common_a();
+	init_common_b();
+	//#endregion
+	//#region page-b.js
+	assert.strictEqual(bridge_exports[globalThis.__bridgeKey || "ok"](), 1);
+	assert.strictEqual(globalThis.valueA, void 0, "ambiguous namespace re-export must not initialize common-a before page-b");
+	assert.strictEqual(globalThis.valueB, void 0);
+	//#endregion
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["dead namespace star must not initialize default-only before page-b"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
@@ -1,0 +1,189 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	await import("./page-a.js");
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_default_only, n as x, r as default_only_default, t as init_shadowed } from "./shadowed.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_default_only();
+	init_shadowed();
+	assert.strictEqual(globalThis.defaultValue, 0);
+	assert.strictEqual(globalThis.shadowedValue, 0);
+	assert.strictEqual(default_only_default, 42);
+	assert.strictEqual(x, 2);
+}))();
+
+```
+
+## page-b.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_default_only, t as init_shadowed } from "./shadowed.js";
+import assert from "node:assert";
+//#region bridge.js
+var bridge_exports = /* @__PURE__ */ __exportAll({ x: () => x });
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_shadowed();
+	init_default_only();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	assert.strictEqual(bridge_exports[globalThis.__bridgeKey || "x"](), 1);
+	assert.strictEqual(globalThis.defaultValue, void 0, "dead namespace star must not initialize default-only before page-b");
+	assert.strictEqual(globalThis.shadowedValue, void 0);
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+## shadowed.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region default-only.js
+function mark$1() {
+	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
+	return 42;
+}
+var default_only_default;
+var init_default_only = __esmMin((() => {
+	default_only_default = /* @__PURE__ */ mark$1();
+}));
+//#endregion
+//#region shadowed.js
+function mark() {
+	globalThis.shadowedValue = typeof globalThis.shadowedValue === "number" ? globalThis.shadowedValue + 1 : 0;
+	return 2;
+}
+var x;
+var init_shadowed = __esmMin((() => {
+	x = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { init_default_only as i, x as n, default_only_default as r, init_shadowed as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	await import("./page-a.js");
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_default_only, n as x, r as default_only_default, t as init_shadowed } from "./shadowed.js";
+import assert from "node:assert";
+//#endregion
+__esmMin((() => {
+	init_default_only();
+	init_shadowed();
+	assert.strictEqual(globalThis.defaultValue, 0);
+	assert.strictEqual(globalThis.shadowedValue, 0);
+	assert.strictEqual(default_only_default, 42);
+	assert.strictEqual(x, 2);
+}))();
+
+```
+
+### page-b.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+import { i as init_default_only, t as init_shadowed } from "./shadowed.js";
+import assert from "node:assert";
+var bridge_exports = /* @__PURE__ */ __exportAll({ x: () => x });
+function x() {
+	return 1;
+}
+__esmMin((() => {
+	//#region bridge.js
+	init_shadowed();
+	init_default_only();
+	//#endregion
+	//#region page-b.js
+	assert.strictEqual(bridge_exports[globalThis.__bridgeKey || "x"](), 1);
+	assert.strictEqual(globalThis.defaultValue, void 0, "dead namespace star must not initialize default-only before page-b");
+	assert.strictEqual(globalThis.shadowedValue, void 0);
+	//#endregion
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+### shadowed.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region default-only.js
+function mark$1() {
+	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
+	return 42;
+}
+var default_only_default;
+var init_default_only = __esmMin((() => {
+	default_only_default = /* @__PURE__ */ mark$1();
+}));
+//#endregion
+//#region shadowed.js
+function mark() {
+	globalThis.shadowedValue = typeof globalThis.shadowedValue === "number" ? globalThis.shadowedValue + 1 : 0;
+	return 2;
+}
+var x;
+var init_shadowed = __esmMin((() => {
+	x = /* @__PURE__ */ mark();
+}));
+//#endregion
+export { init_default_only as i, x as n, default_only_default as r, init_shadowed as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/artifacts.snap
@@ -1,0 +1,212 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## ca.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_b } from "./cb.js";
+//#region cyc-a.js
+var init_cyc_a = __esmMin((() => {
+	init_cyc_b();
+	(globalThis.__events ??= []).push("cyc-a");
+}));
+//#endregion
+export { init_cyc_a as t };
+
+```
+
+## cb.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region cyc-b.js
+var init_cyc_b = __esmMin((() => {
+	init_cyc_a();
+	(globalThis.__events ??= []).push("cyc-b");
+}));
+//#endregion
+export { init_cyc_b as t };
+
+```
+
+## dynamic-page.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region linear.js
+function makeUnit() {
+	return { value: 7 };
+}
+function scaleLinear() {
+	return unit$1;
+}
+var unit$1;
+var init_linear = __esmMin((() => {
+	unit$1 = /* @__PURE__ */ makeUnit();
+}));
+//#endregion
+//#region pow.js
+function makePow() {
+	return { value: 3 };
+}
+function scalePow() {
+	return unit;
+}
+var unit;
+var init_pow = __esmMin((() => {
+	unit = /* @__PURE__ */ makePow();
+}));
+//#endregion
+//#region scale-barrel.js
+var init_scale_barrel = __esmMin((() => {
+	init_linear();
+	init_pow();
+}));
+//#endregion
+//#region outer-barrel.js
+var outer_barrel_exports = /* @__PURE__ */ __exportAll({
+	scaleLinear: () => scaleLinear,
+	scalePow: () => scalePow
+});
+var init_outer_barrel = __esmMin((() => {
+	init_scale_barrel();
+}));
+//#endregion
+//#region reader.js
+function getScale(name) {
+	const factory = outer_barrel_exports[name];
+	const built = factory();
+	return built ? built.value : "NO_UNIT";
+}
+var init_reader = __esmMin((() => {
+	init_outer_barrel();
+	init_cyc_a();
+	(globalThis.__events ??= []).push("reader");
+}));
+//#endregion
+__esmMin((() => {
+	init_reader();
+	(globalThis.__events ??= []).push("dynamic-page");
+}))();
+export { getScale };
+
+```
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage, __exportAll as n, __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### ca.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_b } from "./cb.js";
+//#region cyc-a.js
+var init_cyc_a = __esmMin((() => {
+	init_cyc_b();
+	(globalThis.__events ??= []).push("cyc-a");
+}));
+//#endregion
+export { init_cyc_a as t };
+
+```
+
+### cb.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region cyc-b.js
+var init_cyc_b = __esmMin((() => {
+	init_cyc_a();
+	(globalThis.__events ??= []).push("cyc-b");
+}));
+//#endregion
+export { init_cyc_b as t };
+
+```
+
+### dynamic-page.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+function makeUnit() {
+	return { value: 7 };
+}
+function scaleLinear() {
+	return unit$1;
+}
+function makePow() {
+	return { value: 3 };
+}
+function scalePow() {
+	return unit;
+}
+var outer_barrel_exports = /* @__PURE__ */ __exportAll({
+	scaleLinear: () => scaleLinear,
+	scalePow: () => scalePow
+});
+function getScale(name) {
+	const factory = outer_barrel_exports[name];
+	const built = factory();
+	return built ? built.value : "NO_UNIT";
+}
+var unit$1, unit;
+var init_reader = __esmMin((() => {
+	//#region linear.js
+	unit$1 = /* @__PURE__ */ makeUnit();
+	//#endregion
+	//#region pow.js
+	unit = /* @__PURE__ */ makePow();
+	//#endregion
+	//#region reader.js
+	init_cyc_a();
+	(globalThis.__events ??= []).push("reader");
+	//#endregion
+}));
+//#endregion
+__esmMin((() => {
+	init_reader();
+	(globalThis.__events ??= []).push("dynamic-page");
+}))();
+export { getScale };
+
+```
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage, __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
@@ -16,5 +16,11 @@
       "onDemandWrapping": true
     }
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
@@ -42,3 +42,53 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### dynamic.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dynamic.js
+var require_dynamic = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = 1e3;
+	globalThis.a = 1e3;
+}));
+//#endregion
+export default require_dynamic();
+export { __esmMin as n, require_dynamic as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin, t as require_dynamic } from "./dynamic.js";
+import { strictEqual } from "node:assert";
+//#region sideeffects.js
+var init_sideeffects = __esmMin((() => {
+	globalThis.a = 2;
+})), a;
+var init_esm = __esmMin((() => {
+	require_dynamic();
+	init_sideeffects();
+	a = globalThis.a;
+	strictEqual(a, 2);
+}));
+//#endregion
+//#region cjs.js
+function foo() {
+	return 100;
+}
+var init_cjs = __esmMin((() => {
+	init_esm();
+}));
+//#endregion
+__esmMin((() => {
+	init_cjs();
+	console.log(`mod.foo: `, foo);
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "input": [

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/artifacts.snap
@@ -1,0 +1,110 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## group-1.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_c3 } from "./main.js";
+//#region c4.cjs
+var require_c4 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("c4");
+}));
+var init_m2 = __esmMin((() => {
+	require_c4();
+	require_c3();
+	console.log("m2");
+}));
+var init_m1 = __esmMin((() => {
+	require_c3();
+	init_m2();
+	console.log("m1");
+}));
+//#endregion
+export { init_m2 as n, init_m1 as t };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_m2, t as init_m1 } from "./group-1.js";
+//#region c3.cjs
+var require_c3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	console.log("c3");
+}));
+//#endregion
+__esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}))();
+export { require_c3 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __commonJSMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### group-1.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_c3 } from "./main.js";
+//#region c4.cjs
+var require_c4 = /* @__PURE__ */ __commonJSMin((() => {
+	console.log("c4");
+}));
+var init_m2 = __esmMin((() => {
+	require_c4();
+	require_c3();
+	console.log("m2");
+}));
+var init_m1 = __esmMin((() => {
+	require_c3();
+	init_m2();
+	console.log("m1");
+}));
+//#endregion
+export { init_m2 as n, init_m1 as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_m2, t as init_m1 } from "./group-1.js";
+//#region c3.cjs
+var require_c3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	console.log("c3");
+}));
+//#endregion
+__esmMin((() => {
+	init_m1();
+	init_m2();
+	console.log("m0");
+}))();
+export { require_c3 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "wrap-all",
   "config": {
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/artifacts.snap
@@ -1,0 +1,234 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## ca.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_b } from "./cb.js";
+//#region cyc-a.js
+var init_cyc_a = __esmMin((() => {
+	init_cyc_b();
+	(globalThis.__events ??= []).push("cyc-a");
+}));
+//#endregion
+export { init_cyc_a as t };
+
+```
+
+## carbon.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { i as init_checkbox, n as init_radio } from "./comp.js";
+//#region barrel.js
+var init_barrel = __esmMin((() => {
+	init_checkbox();
+	init_radio();
+	(globalThis.__events ??= []).push("barrel");
+}));
+//#endregion
+export { init_barrel as t };
+
+```
+
+## cb.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region cyc-b.js
+var init_cyc_b = __esmMin((() => {
+	init_cyc_a();
+	(globalThis.__events ??= []).push("cyc-b");
+}));
+//#endregion
+export { init_cyc_b as t };
+
+```
+
+## comp.js
+
+```js
+import { t as __esmMin } from "./main.js";
+//#region checkbox.js
+function buildComponent$1() {
+	return { name: "Checkbox" };
+}
+var Checkbox;
+var init_checkbox = __esmMin((() => {
+	Checkbox = /* @__PURE__ */ buildComponent$1();
+}));
+//#endregion
+//#region radio.js
+function buildComponent() {
+	return { name: "Radio" };
+}
+var Radio;
+var init_radio = __esmMin((() => {
+	Radio = /* @__PURE__ */ buildComponent();
+}));
+//#endregion
+export { init_checkbox as i, init_radio as n, Checkbox as r, Radio as t };
+
+```
+
+## dynamic-page.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { r as Checkbox, t as Radio } from "./comp.js";
+import { t as init_barrel } from "./carbon.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region reader.js
+function render() {
+	return `${Checkbox ? Checkbox.name : "NO_CHECKBOX"}|${Radio ? Radio.name : "NO_RADIO"}`;
+}
+var init_reader = __esmMin((() => {
+	init_barrel();
+	init_cyc_a();
+	(globalThis.__events ??= []).push("reader");
+}));
+//#endregion
+__esmMin((() => {
+	init_reader();
+	(globalThis.__events ??= []).push("dynamic-page");
+}))();
+export { render };
+
+```
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage, __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### ca.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_b } from "./cb.js";
+//#region cyc-a.js
+var init_cyc_a = __esmMin((() => {
+	init_cyc_b();
+	(globalThis.__events ??= []).push("cyc-a");
+}));
+//#endregion
+export { init_cyc_a as t };
+
+```
+
+### carbon.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { i as init_checkbox, n as init_radio } from "./comp.js";
+//#region barrel.js
+var init_barrel = __esmMin((() => {
+	init_checkbox();
+	init_radio();
+	(globalThis.__events ??= []).push("barrel");
+}));
+//#endregion
+export { init_barrel as t };
+
+```
+
+### cb.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region cyc-b.js
+var init_cyc_b = __esmMin((() => {
+	init_cyc_a();
+	(globalThis.__events ??= []).push("cyc-b");
+}));
+//#endregion
+export { init_cyc_b as t };
+
+```
+
+### comp.js
+
+```js
+import { t as __esmMin } from "./main.js";
+//#region checkbox.js
+function buildComponent$1() {
+	return { name: "Checkbox" };
+}
+var Checkbox;
+var init_checkbox = __esmMin((() => {
+	Checkbox = /* @__PURE__ */ buildComponent$1();
+}));
+//#endregion
+//#region radio.js
+function buildComponent() {
+	return { name: "Radio" };
+}
+var Radio;
+var init_radio = __esmMin((() => {
+	Radio = /* @__PURE__ */ buildComponent();
+}));
+//#endregion
+export { init_checkbox as i, init_radio as n, Checkbox as r, Radio as t };
+
+```
+
+### dynamic-page.js
+
+```js
+import { t as __esmMin } from "./main.js";
+import { r as Checkbox, t as Radio } from "./comp.js";
+import { t as init_barrel } from "./carbon.js";
+import { t as init_cyc_a } from "./ca.js";
+//#region reader.js
+function render() {
+	return `${Checkbox ? Checkbox.name : "NO_CHECKBOX"}|${Radio ? Radio.name : "NO_RADIO"}`;
+}
+var init_reader = __esmMin((() => {
+	init_barrel();
+	init_cyc_a();
+	(globalThis.__events ??= []).push("reader");
+}));
+//#endregion
+__esmMin((() => {
+	init_reader();
+	(globalThis.__events ??= []).push("dynamic-page");
+}))();
+export { render };
+
+```
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+function loadPage() {
+	return import("./dynamic-page.js");
+}
+//#endregion
+__esmMin((() => {
+	(globalThis.__events ??= []).push("main");
+}))();
+export { loadPage, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
@@ -5,5 +5,11 @@
     "experimental": {
       "onDemandWrapping": true
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
@@ -25,3 +25,34 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var init_setup = __esmMin((() => {
+	globalThis.globalValue = "foo";
+}));
+//#endregion
+//#region dep.js
+function getGlobalValue() {
+	return globalValue;
+}
+var dep_default;
+var init_dep = __esmMin((() => {
+	dep_default = /*#__PURE__*/ getGlobalValue();
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_dep();
+	assert.strictEqual(dep_default, "foo");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/_config.json
@@ -8,5 +8,11 @@
     "experimental": {
       "onDemandWrapping": true
     }
-  }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
@@ -38,3 +38,46 @@ __esmMin((() => {
 }))();
 
 ```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region react.js
+var require_react = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.createReactElement = function() {
+		return "div";
+	};
+	exports.version = 1;
+}));
+//#endregion
+//#region commonjs.js
+var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = require_react();
+}));
+//#endregion
+//#region lib.js
+function test() {
+	return 1;
+}
+var init_lib = __esmMin((() => {
+	require_commonjs();
+}));
+//#endregion
+//#region main.js
+var import_commonjs;
+//#endregion
+__esmMin((() => {
+	import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
+	init_lib();
+	assert.equal(import_commonjs.createReactElement(), "div");
+	assert.equal(1 .toString(), "1");
+	assert.equal(test().toString(), "1");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
@@ -4,13 +4,13 @@
   },
   "configVariants": [
     {
-      "_configName": "wrap-all",
-      "strictExecutionOrder": true
-    },
-    {
       "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -13,7 +13,7 @@ nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should 
 
 ```
 
-# Variant: wrap-all: [strict_execution_order: true]
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
 
 ## Assets
 
@@ -28,7 +28,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["Error: page-a observed undefined"]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/artifacts.snap
@@ -1,0 +1,170 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region middle.js
+var init_middle = __esmMin((() => {
+	init_bridge();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_middle();
+}));
+//#endregion
+export { x as n, init_bridge as t };
+
+```
+
+## main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+## page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bridge } from "./bridge.js";
+//#region common.js
+function init() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+__esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ init();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	if (globalThis.value !== 0) throw new Error(`page-a observed ${globalThis.value}`);
+}))();
+export { _, common };
+
+```
+
+## page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	if (globalThis.value !== void 0) throw new Error(`page-b observed ${globalThis.value}`);
+}))();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### bridge.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region middle.js
+var init_middle = __esmMin((() => {
+	init_bridge();
+}));
+//#endregion
+//#region bridge.js
+function x() {
+	return 1;
+}
+var init_bridge = __esmMin((() => {
+	init_middle();
+}));
+//#endregion
+export { x as n, init_bridge as t };
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var pageA;
+//#endregion
+await __esmMin((async () => {
+	await import("./page-b.js");
+	pageA = await import("./page-a.js");
+	console.log(pageA.common, pageA._);
+}))();
+
+```
+
+### page-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_bridge } from "./bridge.js";
+//#region common.js
+function init() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+__esmMin((() => {
+	common = "common";
+	_ = /* @__PURE__ */ init();
+}));
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	if (globalThis.value !== 0) throw new Error(`page-a observed ${globalThis.value}`);
+}))();
+export { _, common };
+
+```
+
+### page-b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as x, t as init_bridge } from "./bridge.js";
+//#endregion
+__esmMin((() => {
+	init_bridge();
+	x();
+	if (globalThis.value !== void 0) throw new Error(`page-b observed ${globalThis.value}`);
+}))();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
@@ -1,14 +1,16 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "external": ["node:assert"],
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -20,24 +20,21 @@ await __esmMin((async () => {
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
-//#region common.js
 function foo() {
 	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
 }
-var common, _;
-var init_common = __esmMin((() => {
-	common = "common";
-	_ = /*#__PURE__*/ foo();
-}));
-//#endregion
-//#region page-a.js
 function render() {
 	console.log(common, _);
 }
-//#endregion
+var common, _;
 __esmMin((() => {
-	init_common();
+	//#region common.js
+	common = "common";
+	_ = /*#__PURE__*/ foo();
+	//#endregion
+	//#region page-a.js
 	nodeAssert.strictEqual(globalThis.value, 0);
+	//#endregion
 }))();
 export { render };
 
@@ -66,7 +63,7 @@ export { __esmMin as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -87,21 +84,24 @@ await __esmMin((async () => {
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+//#region common.js
 function foo() {
 	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
 }
+var common, _;
+var init_common = __esmMin((() => {
+	common = "common";
+	_ = /*#__PURE__*/ foo();
+}));
+//#endregion
+//#region page-a.js
 function render() {
 	console.log(common, _);
 }
-var common, _;
+//#endregion
 __esmMin((() => {
-	//#region common.js
-	common = "common";
-	_ = /*#__PURE__*/ foo();
-	//#endregion
-	//#region page-a.js
+	init_common();
 	nodeAssert.strictEqual(globalThis.value, 0);
-	//#endregion
 }))();
 export { render };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
@@ -1,0 +1,100 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dyn.js
+
+```js
+import { i as __esmMin, n as init_setup, r as setup, t as init_intermediate } from "./main.js";
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_intermediate();
+	console.log("dyn", typeof setup);
+}))();
+
+```
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var setup;
+var init_setup = __esmMin((() => {
+	setup = () => {
+		globalThis.foo = "foo";
+	};
+	setup();
+}));
+//#endregion
+var captured;
+var init_intermediate = __esmMin((() => {
+	//#region reader.js
+	captured = globalThis.foo;
+	console.log("captured", captured);
+	//#endregion
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_intermediate();
+	setup();
+	import("./dyn.js");
+}))();
+export { __esmMin as i, init_setup as n, setup as r, init_intermediate as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### dyn.js
+
+```js
+import { i as __esmMin, n as init_setup, r as setup, t as init_intermediate } from "./main.js";
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_intermediate();
+	console.log("dyn", typeof setup);
+}))();
+
+```
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region setup.js
+var setup;
+var init_setup = __esmMin((() => {
+	setup = () => {
+		globalThis.foo = "foo";
+	};
+	setup();
+}));
+//#endregion
+//#region reader.js
+var captured;
+var init_reader = __esmMin((() => {
+	captured = globalThis.foo;
+	console.log("captured", captured);
+}));
+//#endregion
+//#region intermediate.js
+var init_intermediate = __esmMin((() => {
+	init_reader();
+}));
+//#endregion
+__esmMin((() => {
+	init_setup();
+	init_intermediate();
+	setup();
+	import("./dyn.js");
+}))();
+export { __esmMin as i, init_setup as n, setup as r, init_intermediate as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -7,8 +7,16 @@
         "import": "./main.js"
       }
     ],
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
-  "configVariants": [{ "_configName": "on-demand", "onDemandWrapping": true }],
-  "expectExecuted": false
+  "expectExecuted": false,
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -7,14 +7,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-await __esmMin((async () => {
-	await init_foo();
+	//#region main.js
 	console.log(123);
+	//#endregion
 }))();
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -22,9 +22,9 @@ await __esmMin((async () => {
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-	//#region main.js
+await __esmMin((async () => {
+	await init_foo();
 	console.log(123);
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -8,14 +8,16 @@
       }
     ],
     "strictExecutionOrder": true,
-    "minify": true
+    "minify": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "expectExecuted": false,
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -6,15 +6,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}var n=e((()=>{}));await e((async()=>{n(),await t()}))();
+var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}await e((async()=>{await t()}))();
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
 ### main.js
 
 ```js
-var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}await e((async()=>{await t()}))();
+var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}var n=e((()=>{}));await e((async()=>{n(),await t()}))();
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/_config.json
@@ -1,18 +1,22 @@
 {
-  "snapshot": false,
   "configName": "wrap-all",
   "config": {
-    "input": [{ "name": "main", "import": "./main.js" }],
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
     "strictExecutionOrder": true
   },
   "configVariants": [
     {
       "_configName": "on-demand",
-      "onDemandWrapping": true,
       "_expectExecutionFailure": {
         "reason": "#10104: on-demand wrapping still changes a hazard-free build on main",
         "outputContains": ["on-demand must not wrap a hazard-free graph"]
-      }
+      },
+      "onDemandWrapping": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var init_dep = __esmMin((() => {
+	console.log("dep");
+}));
+//#endregion
+__esmMin((() => {
+	init_dep();
+	console.log("main", "v");
+}))();
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+	//#region main.js
+	console.log("main", "v");
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/_config.json
@@ -1,5 +1,8 @@
 {
-  "snapshot": false,
+  "expectExecutionFailure": {
+    "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",
+    "outputContains": ["is not a function", "wrapped_entry_chunk_cycle"]
+  },
   "configName": "on-demand",
   "config": {
     "input": [
@@ -31,35 +34,31 @@
       "onDemandWrapping": true
     }
   },
-  "expectExecutionFailure": {
-    "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",
-    "outputContains": ["is not a function", "wrapped_entry_chunk_cycle"]
-  },
   "configVariants": [
     {
       "_configName": "cjs-on-demand",
-      "format": "cjs",
       "_expectExecutionFailure": {
         "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",
         "outputContains": ["is not a function", "wrapped_entry_chunk_cycle"]
-      }
+      },
+      "format": "cjs"
     },
     {
       "_configName": "cjs-wrap-all",
-      "format": "cjs",
-      "onDemandWrapping": false,
       "_expectExecutionFailure": {
         "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",
         "outputContains": ["is not a function", "wrapped_entry_chunk_cycle"]
-      }
+      },
+      "format": "cjs",
+      "onDemandWrapping": false
     },
     {
       "_configName": "wrap-all",
-      "onDemandWrapping": false,
       "_expectExecutionFailure": {
         "reason": "#9887 / #10104: wrapped entry chunk cycle crashes on main",
         "outputContains": ["is not a function", "wrapped_entry_chunk_cycle"]
-      }
+      },
+      "onDemandWrapping": false
     }
   ],
   "hiddenRuntimeModule": false

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
@@ -1,0 +1,466 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## dep.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+import { extend, t as init_hub } from "./hub.js";
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ useDep: () => useDep });
+var useDep;
+var init_dep = __esmMin((() => {
+	init_hub();
+	useDep = () => extend({}, {});
+}));
+//#endregion
+export { init_dep as n, useDep as r, dep_exports as t };
+
+```
+
+## hub.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_dep, r as useDep } from "./dep.js";
+var extend;
+var init_shared = __esmMin((() => {
+	extend = Object.assign;
+}));
+//#endregion
+//#region interop.cjs
+var require_interop = /* @__PURE__ */ __commonJSMin((() => {
+	init_shared();
+	init_dep();
+}));
+var init_hub = __esmMin((() => {
+	require_interop();
+	init_shared();
+	init_dep();
+}));
+//#endregion
+init_hub();
+export { extend, init_shared as n, init_hub as t, useDep };
+
+```
+
+## main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { r as useDep } from "./dep.js";
+import { extend, t as init_hub } from "./hub.js";
+//#region main.js
+var go;
+//#endregion
+__esmMin((() => {
+	init_hub();
+	go = () => [useDep, extend];
+}))();
+export { go };
+
+```
+
+## rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+# Variant: cjs-on-demand: [format: Cjs]
+
+## Assets
+
+### dep.js
+
+```js
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_hub = require("./hub.js");
+//#region dep.js
+var dep_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ useDep: () => useDep });
+var useDep;
+var init_dep = require_rolldown_runtime.__esmMin((() => {
+	require_hub.init_hub();
+	useDep = () => require_hub.extend({}, {});
+}));
+//#endregion
+Object.defineProperty(exports, "dep_exports", {
+	enumerable: true,
+	get: function() {
+		return dep_exports;
+	}
+});
+Object.defineProperty(exports, "init_dep", {
+	enumerable: true,
+	get: function() {
+		return init_dep;
+	}
+});
+Object.defineProperty(exports, "useDep", {
+	enumerable: true,
+	get: function() {
+		return useDep;
+	}
+});
+
+```
+
+### hub.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_dep = require("./dep.js");
+var extend;
+var init_shared = require_rolldown_runtime.__esmMin((() => {
+	extend = Object.assign;
+}));
+//#endregion
+//#region interop.cjs
+var require_interop = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin((() => {
+	init_shared();
+	require_dep.init_dep();
+}));
+var init_hub = require_rolldown_runtime.__esmMin((() => {
+	require_interop();
+	init_shared();
+	init_dep();
+}));
+//#endregion
+init_hub();
+exports.extend = extend;
+Object.defineProperty(exports, "init_hub", {
+	enumerable: true,
+	get: function() {
+		return init_hub;
+	}
+});
+Object.defineProperty(exports, "init_shared", {
+	enumerable: true,
+	get: function() {
+		return init_shared;
+	}
+});
+exports.useDep = require_dep.useDep;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_dep = require("./dep.js");
+const require_hub = require("./hub.js");
+//#region main.js
+var go;
+//#endregion
+require_rolldown_runtime.__esmMin((() => {
+	require_hub.init_hub();
+	go = () => [require_dep.useDep, require_hub.extend];
+}))();
+exports.go = go;
+
+```
+
+### rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__exportAll", {
+	enumerable: true,
+	get: function() {
+		return __exportAll;
+	}
+});
+
+```
+
+# Variant: cjs-wrap-all: [format: Cjs] [on_demand_wrapping: false]
+
+## Assets
+
+### dep.js
+
+```js
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_hub = require("./hub.js");
+//#region dep.js
+var dep_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ useDep: () => useDep });
+var useDep;
+var init_dep = require_rolldown_runtime.__esmMin((() => {
+	require_hub.init_hub();
+	useDep = () => require_hub.extend({}, {});
+}));
+//#endregion
+Object.defineProperty(exports, "dep_exports", {
+	enumerable: true,
+	get: function() {
+		return dep_exports;
+	}
+});
+Object.defineProperty(exports, "init_dep", {
+	enumerable: true,
+	get: function() {
+		return init_dep;
+	}
+});
+Object.defineProperty(exports, "useDep", {
+	enumerable: true,
+	get: function() {
+		return useDep;
+	}
+});
+
+```
+
+### hub.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_dep = require("./dep.js");
+var extend;
+var init_shared = require_rolldown_runtime.__esmMin((() => {
+	extend = Object.assign;
+}));
+//#endregion
+//#region interop.cjs
+var require_interop = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin((() => {
+	init_shared();
+	require_dep.init_dep();
+}));
+var init_hub = require_rolldown_runtime.__esmMin((() => {
+	require_interop();
+	init_shared();
+	init_dep();
+}));
+//#endregion
+init_hub();
+exports.extend = extend;
+Object.defineProperty(exports, "init_hub", {
+	enumerable: true,
+	get: function() {
+		return init_hub;
+	}
+});
+Object.defineProperty(exports, "init_shared", {
+	enumerable: true,
+	get: function() {
+		return init_shared;
+	}
+});
+exports.useDep = require_dep.useDep;
+
+```
+
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
+const require_dep = require("./dep.js");
+const require_hub = require("./hub.js");
+//#region main.js
+var go;
+//#endregion
+require_rolldown_runtime.__esmMin((() => {
+	require_hub.init_hub();
+	go = () => [require_dep.useDep, require_hub.extend];
+}))();
+exports.go = go;
+
+```
+
+### rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__exportAll", {
+	enumerable: true,
+	get: function() {
+		return __exportAll;
+	}
+});
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### dep.js
+
+```js
+import { n as __esmMin, r as __exportAll } from "./rolldown-runtime.js";
+import { extend, t as init_hub } from "./hub.js";
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ useDep: () => useDep });
+var useDep;
+var init_dep = __esmMin((() => {
+	init_hub();
+	useDep = () => extend({}, {});
+}));
+//#endregion
+export { init_dep as n, useDep as r, dep_exports as t };
+
+```
+
+### hub.js
+
+```js
+import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as init_dep, r as useDep } from "./dep.js";
+var extend;
+var init_shared = __esmMin((() => {
+	extend = Object.assign;
+}));
+//#endregion
+//#region interop.cjs
+var require_interop = /* @__PURE__ */ __commonJSMin((() => {
+	init_shared();
+	init_dep();
+}));
+var init_hub = __esmMin((() => {
+	require_interop();
+	init_shared();
+	init_dep();
+}));
+//#endregion
+init_hub();
+export { extend, init_shared as n, init_hub as t, useDep };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { r as useDep } from "./dep.js";
+import { extend, t as init_hub } from "./hub.js";
+//#region main.js
+var go;
+//#endregion
+__esmMin((() => {
+	init_hub();
+	go = () => [useDep, extend];
+}))();
+export { go };
+
+```
+
+### rolldown-runtime.js
+
+```js
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+export { __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/_config.json
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/_config.json
@@ -1,12 +1,16 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["TypeError: init_m29 is not a function"]
   },
   "configName": "on-demand",
   "config": {
-    "input": [{ "name": "e0", "import": "./e0.js" }],
+    "input": [
+      {
+        "name": "e0",
+        "import": "./e0.js"
+      }
+    ],
     "preserveEntrySignatures": "allow-extension",
     "strictExecutionOrder": true,
     "experimental": {

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/artifacts.snap
@@ -1,0 +1,130 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## e0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_m13 } from "./gb.js";
+//#region e0.js
+var reg;
+//#endregion
+__esmMin((() => {
+	init_m13();
+	reg = globalThis.__dyn ??= {};
+	reg.dyn2 = () => import("./m29.js");
+}))();
+
+```
+
+## gb.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_m31 } from "./m29.js";
+//#region m13.js
+var init_m13 = __esmMin((() => {
+	console.log("sfx-m13-0");
+}));
+//#endregion
+//#region m29.js
+function cf_m29(x) {
+	return x + 9;
+}
+var init_m29 = __esmMin((() => {
+	init_m31();
+}));
+//#endregion
+export { init_m29 as n, init_m13 as r, cf_m29 as t };
+
+```
+
+## m29.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m29, t as cf_m29 } from "./gb.js";
+//#region m31.js
+var init_m31 = __esmMin((() => {
+	console.log("sfx-m31-0");
+}));
+//#endregion
+init_m29();
+export { cf_m29, init_m31 as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### e0.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_m13 } from "./gb.js";
+//#region e0.js
+var reg;
+//#endregion
+__esmMin((() => {
+	init_m13();
+	reg = globalThis.__dyn ??= {};
+	reg.dyn2 = () => import("./m29.js");
+}))();
+
+```
+
+### gb.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { t as init_m31 } from "./m29.js";
+//#region m13.js
+var init_m13 = __esmMin((() => {
+	console.log("sfx-m13-0");
+}));
+//#endregion
+//#region m29.js
+function cf_m29(x) {
+	return x + 9;
+}
+var init_m29 = __esmMin((() => {
+	init_m31();
+}));
+//#endregion
+export { init_m29 as n, init_m13 as r, cf_m29 as t };
+
+```
+
+### m29.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as init_m29, t as cf_m29 } from "./gb.js";
+//#region m31.js
+var init_m31 = __esmMin((() => {
+	console.log("sfx-m31-0");
+}));
+//#endregion
+init_m29();
+export { cf_m29, init_m31 as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/_config.json
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "expectExecutionFailure": {
     "reason": "Expected to fail until rolldown#10104 is applied.",
     "outputContains": ["the dynamic target must initialize before the chunk checkpoint"]
@@ -7,8 +6,14 @@
   "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./a.js" },
-      { "name": "b", "import": "./b.js" }
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
     ],
     "banner": "if (import.meta.url.endsWith('/dyn.js')) queueMicrotask(() => (globalThis.events ??= []).push('checkpoint:' + Boolean(globalThis.ready)));",
     "strictExecutionOrder": true,

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
@@ -1,0 +1,138 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var targetPromise;
+//#endregion
+__esmMin((() => {
+	globalThis.events = [];
+	targetPromise = import("./dyn.js").then((n) => (n.t(), n.n));
+	console.log("a done");
+}))();
+export { targetPromise };
+
+```
+
+## b.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_observer } from "./dyn.js";
+//#endregion
+__esmMin((() => {
+	init_observer();
+	console.log("b done");
+}))();
+
+```
+
+## dyn.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region observer.js
+var init_observer = __esmMin((() => {
+	globalThis.events ??= [];
+	globalThis.events.push("observer:" + Boolean(globalThis.ready));
+	console.log("observer eval", Boolean(globalThis.ready));
+}));
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+var init_target = __esmMin((() => {
+	globalThis.events ??= [];
+	globalThis.events.push("target");
+	globalThis.ready = true;
+	console.log("target eval");
+}));
+//#endregion
+export { target_exports as n, init_observer as r, init_target as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var targetPromise;
+//#endregion
+__esmMin((() => {
+	globalThis.events = [];
+	targetPromise = import("./dyn.js").then((n) => (n.t(), n.n));
+	console.log("a done");
+}))();
+export { targetPromise };
+
+```
+
+### b.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { r as init_observer } from "./dyn.js";
+//#endregion
+__esmMin((() => {
+	init_observer();
+	console.log("b done");
+}))();
+
+```
+
+### dyn.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region observer.js
+var init_observer = __esmMin((() => {
+	globalThis.events ??= [];
+	globalThis.events.push("observer:" + Boolean(globalThis.ready));
+	console.log("observer eval", Boolean(globalThis.ready));
+}));
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+var init_target = __esmMin((() => {
+	globalThis.events ??= [];
+	globalThis.events.push("target");
+	globalThis.ready = true;
+	console.log("target eval");
+}));
+//#endregion
+export { target_exports as n, init_observer as r, init_target as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10013/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10013/_config.json
@@ -1,15 +1,22 @@
 {
   "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/10013 - two entries both import the re-exported `other` from `leaf`. `other`'s canonical lives in `helper.js`, so it bypasses `leaf` entirely, and `leaf`'s own `value = first(second)` is never used. Under `strictExecutionOrder`, the shared chunk must not keep `leaf`'s dead `value = first(second)` body or its external `dep` import. `dep` remains external for bundling, while the local node_modules package throws if runtime ever reaches it.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./entry-a.js" },
-      { "name": "b", "import": "./entry-b.js" }
+      {
+        "name": "a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "b",
+        "import": "./entry-b.js"
+      }
     ],
     "external": ["dep"],
     "strictExecutionOrder": true,
     "experimental": {
-      "lazyBarrel": true
+      "lazyBarrel": true,
+      "onDemandWrapping": true
     },
     "treeshake": {
       "moduleSideEffects": false
@@ -17,9 +24,8 @@
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
 //#endregion
 __esmMin((() => {
 	init_leaf();
@@ -18,7 +18,7 @@ __esmMin((() => {
 ## b.js
 
 ```js
-import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
 //#endregion
 __esmMin((() => {
 	init_leaf();
@@ -28,6 +28,48 @@ __esmMin((() => {
 ```
 
 ## leaf.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region helper.js
+const other = "other";
+//#endregion
+//#region leaf.js
+var init_leaf = __esmMin((() => {}));
+//#endregion
+export { other as n, __esmMin as r, init_leaf as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### b.js
+
+```js
+import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### leaf.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -43,47 +85,5 @@ var init_leaf = __esmMin((() => {
 }));
 //#endregion
 export { __esmMin as i, init_helper as n, other as r, init_leaf as t };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### a.js
-
-```js
-import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
-//#endregion
-__esmMin((() => {
-	init_leaf();
-	console.log(other);
-}))();
-
-```
-
-### b.js
-
-```js
-import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
-//#endregion
-__esmMin((() => {
-	init_leaf();
-	console.log(other);
-}))();
-
-```
-
-### leaf.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region helper.js
-const other = "other";
-//#endregion
-//#region leaf.js
-var init_leaf = __esmMin((() => {}));
-//#endregion
-export { other as n, __esmMin as r, init_leaf as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10048/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10048/_config.json
@@ -1,6 +1,6 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/10048 - with `experimental.lazyBarrel` + `strictExecutionOrder`, theming.js imports helper-only bindings (`__commonJS` / `__toESM`) and calls them at the top level, while also re-exporting a passthrough `themes` value from data.js. The entry uses only that passthrough, so theming's helper-dependent body must not be retained without helpers.js. Executing the compiled entry via `_test.mjs` must not throw.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -11,14 +11,14 @@
     "format": "esm",
     "strictExecutionOrder": true,
     "experimental": {
-      "lazyBarrel": true
+      "lazyBarrel": true,
+      "onDemandWrapping": true
     }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
@@ -8,6 +8,38 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region data.js
+const themes = {
+	light: {
+		base: "light",
+		appBg: "#ffffff"
+	},
+	dark: {
+		base: "dark",
+		appBg: "#000000"
+	}
+};
+//#endregion
+function getProjectAnnotations() {
+	return [globalThis.__themes];
+}
+__esmMin((() => {
+	//#region entry.js
+	globalThis.__themes = themes;
+	//#endregion
+}))();
+export { getProjectAnnotations };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region data.js
 var themes;
 var init_data = __esmMin((() => {
 	themes = {
@@ -35,38 +67,6 @@ function getProjectAnnotations() {
 __esmMin((() => {
 	init_theming();
 	globalThis.__themes = themes;
-}))();
-export { getProjectAnnotations };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### entry.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region data.js
-const themes = {
-	light: {
-		base: "light",
-		appBg: "#ffffff"
-	},
-	dark: {
-		base: "dark",
-		appBg: "#000000"
-	}
-};
-//#endregion
-function getProjectAnnotations() {
-	return [globalThis.__themes];
-}
-__esmMin((() => {
-	//#region entry.js
-	globalThis.__themes = themes;
-	//#endregion
 }))();
 export { getProjectAnnotations };
 

--- a/crates/rolldown/tests/rolldown/issues/3650/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3650/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "strictExecutionOrder": true,
     "codeSplitting": {
@@ -14,13 +14,15 @@
           "test": "[\\\\/]second\\.js$|^\\0rolldown/runtime\\.js$"
         }
       ]
+    },
+    "experimental": {
+      "onDemandWrapping": true
     }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -75,7 +75,7 @@ export { second_exports as n, value as r, init_second as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## warnings
 

--- a/crates/rolldown/tests/rolldown/issues/5870/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5870/_config.json
@@ -1,10 +1,15 @@
 {
-  "config": {},
+  "configName": "on-demand",
+  "config": {
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -12,31 +12,6 @@ import assert from "node:assert";
 var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => 1 });
 var init_lib = __esmMin((() => {}));
 //#endregion
-//#region reexport.js
-init_lib();
-//#endregion
-//#region log.js
-assert.strictEqual(1, 1);
-(/* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = (init_lib(), __toCommonJS(lib_exports));
-})))();
-//#endregion
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import assert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-//#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => 1 });
-var init_lib = __esmMin((() => {}));
-//#endregion
 //#region commonjs.cjs
 var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_lib(), __toCommonJS(lib_exports));
@@ -51,6 +26,42 @@ __esmMin((() => {
 	//#region main.js
 	require_commonjs();
 	//#endregion
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => 1 });
+var init_lib = __esmMin((() => {}));
+//#endregion
+//#region reexport.js
+var init_reexport = __esmMin((() => {
+	init_lib();
+}));
+//#endregion
+//#region log.js
+var init_log = __esmMin((() => {
+	init_reexport();
+	assert.strictEqual(1, 1);
+}));
+//#endregion
+//#region commonjs.cjs
+var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = (init_lib(), __toCommonJS(lib_exports));
+}));
+//#endregion
+__esmMin((() => {
+	init_log();
+	require_commonjs();
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7286/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7286/_config.json
@@ -1,13 +1,15 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
@@ -19,7 +19,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 

--- a/crates/rolldown/tests/rolldown/issues/9028/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9028/_config.json
@@ -1,13 +1,15 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
@@ -7,6 +7,18 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var init_lib = __esmMin((() => {}));
 //#endregion
@@ -18,18 +30,6 @@ var init_barrel = __esmMin((() => {
 __esmMin((() => {
 	init_barrel();
 	console.log(42);
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9083/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9083/_config.json
@@ -1,9 +1,13 @@
 {
   "configVariants": [
     {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    },
+    {
       "_configName": "wrap-all",
       "strictExecutionOrder": true
-    },
-    { "_configName": "on-demand", "strictExecutionOrder": true, "onDemandWrapping": true }
+    }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -28,6 +28,45 @@ export { manager };
 
 ```
 
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function setup() {
+	manager.ready = true;
+}
+var value, manager;
+var init_middle = __esmMin((async () => {
+	//#region deep.js
+	await sleep(100);
+	value = "hello";
+	//#endregion
+	//#region middle.js
+	manager = {
+		value,
+		ready: false
+	};
+	//#endregion
+}));
+await __esmMin((async () => {
+	//#region barrel.js
+	await init_middle();
+	//#endregion
+	//#region main.js
+	setup();
+	//#endregion
+}))();
+export { manager };
+
+```
+
 # Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
@@ -67,45 +106,6 @@ var init_barrel = __esmMin((async () => {
 await __esmMin((async () => {
 	await init_barrel();
 	setup();
-}))();
-export { manager };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-function sleep(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-function setup() {
-	manager.ready = true;
-}
-var value, manager;
-var init_middle = __esmMin((async () => {
-	//#region deep.js
-	await sleep(100);
-	value = "hello";
-	//#endregion
-	//#region middle.js
-	manager = {
-		value,
-		ready: false
-	};
-	//#endregion
-}));
-await __esmMin((async () => {
-	//#region barrel.js
-	await init_middle();
-	//#endregion
-	//#region main.js
-	setup();
-	//#endregion
 }))();
 export { manager };
 

--- a/crates/rolldown/tests/rolldown/issues/9374/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9374/_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/9374 - a star re-export chain that ends at an external module (`entry_a` -> `entry_b` -> `external`) is representable as chunk-level `export * from 'external'` statements, so no runtime helper is needed. The runtime module used to be included anyway (tree-shaking ran before the entry-level-external walk-back), shipping a dead rolldown-runtime chunk imported by both entries. The output must contain no runtime chunk and no runtime imports.",
+  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/9374 - a star re-export chain that ends at an external module (`entry_a` -> `entry_b` -> `external`) is representable as chunk-level `export * from 'external'` statements, so no runtime helper is needed. The runtime module used to be included anyway (tree-shaking ran before the entry-level-external walk-back), shipping a dead rolldown-runtime chunk imported by both entries. The strict-on-demand variant also has an empty order-wrap plan and must remain byte-identical, proving the post-order runtime sweep still runs when strict mode adds no synthetic runtime demand. The output must contain no runtime chunk and no runtime imports.",
   "config": {
     "input": [
       {
@@ -14,5 +14,16 @@
     "external": ["external"],
     "minify": false
   },
+  "configVariants": [
+    {
+      "_configName": "strict-on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
+    }
+  ],
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
@@ -28,3 +28,101 @@ const b = "b";
 //#endregion
 export { b };
 ```
+
+# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### entry_a.js
+
+```js
+import { n as __exportAll, r as __reExport, t as __esmMin } from "./rolldown-runtime.js";
+import { b, t as init_entry_b } from "./entry_b.js";
+
+export * from "external"
+
+//#region entry_a.js
+var a;
+var init_entry_a = __esmMin((() => {
+	init_entry_b();
+	a = "a";
+}));
+
+//#endregion
+init_entry_a();
+export { a, b };
+```
+
+### entry_b.js
+
+```js
+import { n as __exportAll, r as __reExport, t as __esmMin } from "./rolldown-runtime.js";
+
+export * from "external"
+
+//#region entry_b.js
+var b;
+var init_entry_b = __esmMin((() => {
+	b = "b";
+}));
+
+//#endregion
+init_entry_b();
+export { b, init_entry_b as t };
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __reExport as r, __esmMin as t };
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### entry_a.js
+
+```js
+import { n as __exportAll, r as __reExport, t as __esmMin } from "./rolldown-runtime.js";
+import { b, t as init_entry_b } from "./entry_b.js";
+
+export * from "external"
+
+//#region entry_a.js
+var a;
+var init_entry_a = __esmMin((() => {
+	init_entry_b();
+	a = "a";
+}));
+
+//#endregion
+init_entry_a();
+export { a, b };
+```
+
+### entry_b.js
+
+```js
+import { n as __exportAll, r as __reExport, t as __esmMin } from "./rolldown-runtime.js";
+
+export * from "external"
+
+//#region entry_b.js
+var b;
+var init_entry_b = __esmMin((() => {
+	b = "b";
+}));
+
+//#endregion
+init_entry_b();
+export { b, init_entry_b as t };
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __reExport as r, __esmMin as t };
+```

--- a/crates/rolldown/tests/rolldown/issues/9463/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463/_config.json
@@ -1,14 +1,21 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 - With `strictExecutionOrder`, a `codeSplitting` group (here `entriesAware` + a large `entriesAwareMergeThreshold`) lumps both entry modules and the shared module into one chunk. `chunkOptimization` then folded that chunk into entry `a`, so executing entry `b` (`import \"./a.js\"; init_b()`) eagerly ran `init_a()` and triggered entry `a`'s side effect. Each entry must run only its own `init_*`.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./a.js" },
-      { "name": "b", "import": "./b.js" }
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
     ],
     "strictExecutionOrder": true,
     "experimental": {
-      "chunkOptimization": true
+      "chunkOptimization": true,
+      "onDemandWrapping": true
     },
     "codeSplitting": {
       "groups": [
@@ -22,9 +29,8 @@
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -37,11 +37,9 @@ var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
-var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
-	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
@@ -49,7 +47,7 @@ var init_a = __esmMin((() => {
 //#region b.js
 var init_b = __esmMin((() => {
 	(globalThis.sideEffectLog ??= []).push("b");
-	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
+	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 		foo();
 	});
 }));
@@ -58,7 +56,7 @@ export { init_a as n, init_b as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## warnings
 
@@ -96,9 +94,11 @@ var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
+var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
+	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
@@ -106,7 +106,7 @@ var init_a = __esmMin((() => {
 //#region b.js
 var init_b = __esmMin((() => {
 	(globalThis.sideEffectLog ??= []).push("b");
-	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
+	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
 		foo();
 	});
 }));

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/_config.json
@@ -1,20 +1,35 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 — same execution-isolation guard must hold for a PLAIN (non-entriesAware) codeSplitting group, which unions the bits of every matched module (including both entry modules) into one chunk.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./a.js" },
-      { "name": "b", "import": "./b.js" }
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
     ],
     "strictExecutionOrder": true,
-    "experimental": { "chunkOptimization": true },
-    "codeSplitting": { "groups": [{ "name": "common", "entriesAwareMergeThreshold": 10000 }] }
+    "experimental": {
+      "chunkOptimization": true,
+      "onDemandWrapping": true
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "common",
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -37,11 +37,9 @@ var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
-var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
-	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
@@ -49,7 +47,7 @@ var init_a = __esmMin((() => {
 //#region b.js
 var init_b = __esmMin((() => {
 	(globalThis.sideEffectLog ??= []).push("b");
-	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
+	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 		foo();
 	});
 }));
@@ -58,7 +56,7 @@ export { init_a as n, init_b as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## warnings
 
@@ -96,9 +94,11 @@ var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
+var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
+	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
@@ -106,7 +106,7 @@ var init_a = __esmMin((() => {
 //#region b.js
 var init_b = __esmMin((() => {
 	(globalThis.sideEffectLog ??= []).push("b");
-	Promise.resolve().then(() => shared_exports).then(({ foo }) => {
+	Promise.resolve().then(() => (init_shared(), shared_exports)).then(({ foo }) => {
 		foo();
 	});
 }));

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/_config.json
@@ -1,23 +1,40 @@
 {
   "_comment": "https://github.com/rolldown/rolldown/issues/9463 — execution isolation must hold with more than two entries: a catch-all entriesAware group merges all three entry modules into one chunk; loading any one entry must run only its own init.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./a.js" },
-      { "name": "b", "import": "./b.js" },
-      { "name": "c", "import": "./c.js" }
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      },
+      {
+        "name": "c",
+        "import": "./c.js"
+      }
     ],
     "strictExecutionOrder": true,
-    "experimental": { "chunkOptimization": true },
+    "experimental": {
+      "chunkOptimization": true,
+      "onDemandWrapping": true
+    },
     "codeSplitting": {
-      "groups": [{ "name": "common", "entriesAware": true, "entriesAwareMergeThreshold": 10000 }]
+      "groups": [
+        {
+          "name": "common",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
     }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
@@ -35,25 +35,21 @@ init_c();
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
-var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
-	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
 //#endregion
 //#region b.js
 var init_b = __esmMin((() => {
-	init_shared();
 	(globalThis.sideEffectLog ??= []).push("b");
 	foo();
 }));
 //#endregion
 //#region c.js
 var init_c = __esmMin((() => {
-	init_shared();
 	(globalThis.sideEffectLog ??= []).push("c");
 	foo();
 }));
@@ -62,7 +58,7 @@ export { init_b as n, init_a as r, init_c as t };
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -98,21 +94,25 @@ init_c();
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }
+var init_shared = __esmMin((() => {}));
 //#endregion
 //#region a.js
 var init_a = __esmMin((() => {
+	init_shared();
 	(globalThis.sideEffectLog ??= []).push("a");
 	foo();
 }));
 //#endregion
 //#region b.js
 var init_b = __esmMin((() => {
+	init_shared();
 	(globalThis.sideEffectLog ??= []).push("b");
 	foo();
 }));
 //#endregion
 //#region c.js
 var init_c = __esmMin((() => {
+	init_shared();
 	(globalThis.sideEffectLog ??= []).push("c");
 	foo();
 }));

--- a/crates/rolldown/tests/rolldown/issues/9806/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9806/_config.json
@@ -8,13 +8,13 @@
   },
   "configVariants": [
     {
-      "_configName": "wrap-all",
-      "strictExecutionOrder": true
-    },
-    {
       "_configName": "on-demand",
       "strictExecutionOrder": true,
       "onDemandWrapping": true
+    },
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -19,6 +19,32 @@ nodeAssert.equal(import_other.default, "other-value");
 
 ```
 
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region pkg-barrel/other.cjs
+var require_other = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "other-value";
+}));
+//#endregion
+var import_other;
+__esmMin((() => {
+	//#region pkg-barrel/index.mjs
+	import_other = /* @__PURE__ */ __toESM(require_other(), 1);
+	//#endregion
+	//#region main.js
+	nodeAssert.equal(import_other.default, "other-value");
+	//#endregion
+}))();
+
+```
+
 # Variant: wrap-all: [strict_execution_order: true]
 
 ## Assets
@@ -42,32 +68,6 @@ var init_pkg_barrel = __esmMin((() => {
 __esmMin((() => {
 	init_pkg_barrel();
 	nodeAssert.equal(import_other.default, "other-value");
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
-//#region pkg-barrel/other.cjs
-var require_other = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	module.exports = "other-value";
-}));
-//#endregion
-var import_other;
-__esmMin((() => {
-	//#region pkg-barrel/index.mjs
-	import_other = /* @__PURE__ */ __toESM(require_other(), 1);
-	//#endregion
-	//#region main.js
-	nodeAssert.equal(import_other.default, "other-value");
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -7,23 +7,24 @@
         "import": "entry.js"
       }
     ],
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "cjs-wrap-all",
+      "_configName": "cjs-on-demand",
       "format": "cjs"
     },
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "cjs-wrap-all",
+      "format": "cjs",
+      "onDemandWrapping": false
     },
     {
-      "_configName": "cjs-on-demand",
-      "format": "cjs",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -19,11 +19,9 @@ import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
-var init_lib = __esmMin((() => {}));
 //#endregion
 __esmMin((() => {
-	init_lib();
-	Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
+	Promise.resolve().then(() => lib_exports).then((mod) => {
 		assert.strictEqual(mod.a, 123);
 		assert.strictEqual(123, 123);
 	});
@@ -31,7 +29,38 @@ __esmMin((() => {
 
 ```
 
-# Variant: cjs-wrap-all: [format: Cjs]
+# Variant: cjs-on-demand: [format: Cjs]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] lib.js is dynamically imported by entry.js but also statically imported by entry.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
+//#endregion
+__esmMin((() => {
+	Promise.resolve().then(() => lib_exports).then((mod) => {
+		node_assert.default.strictEqual(mod.a, 123);
+		node_assert.default.strictEqual(123, 123);
+	});
+}))();
+
+```
+
+# Variant: cjs-wrap-all: [format: Cjs] [on_demand_wrapping: false]
 
 ## warnings
 
@@ -64,7 +93,7 @@ __esmMin((() => {
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## warnings
 
@@ -84,42 +113,13 @@ import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
+var init_lib = __esmMin((() => {}));
 //#endregion
 __esmMin((() => {
-	Promise.resolve().then(() => lib_exports).then((mod) => {
+	init_lib();
+	Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
 		assert.strictEqual(mod.a, 123);
 		assert.strictEqual(123, 123);
-	});
-}))();
-
-```
-
-# Variant: cjs-on-demand: [format: Cjs] [on_demand_wrapping: true] [strict_execution_order: true]
-
-## warnings
-
-### INEFFECTIVE_DYNAMIC_IMPORT
-
-```text
-[INEFFECTIVE_DYNAMIC_IMPORT] lib.js is dynamically imported by entry.js but also statically imported by entry.js, dynamic import will not move module into another chunk.
-
-```
-
-## Assets
-
-### entry.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
-//#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
-//#endregion
-__esmMin((() => {
-	Promise.resolve().then(() => lib_exports).then((mod) => {
-		node_assert.default.strictEqual(mod.a, 123);
-		node_assert.default.strictEqual(123, 123);
 	});
 }))();
 

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
       {
@@ -7,13 +7,15 @@
         "import": "./main.js"
       }
     ],
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
@@ -7,6 +7,35 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+	//#region foo.js
+	{
+		const foo = "foo" + globalThis.foo;
+		setTimeout(() => {
+			globalThis.array.push(foo);
+		}, 100);
+	}
+	//#endregion
+	//#region bar.js
+	{
+		const foo = "bar" + globalThis.bar;
+		globalThis.array.push(foo);
+	}
+	//#endregion
+	//#region main.js
+	console.log(globalThis.array);
+	//#endregion
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region init.js
 var init_init = __esmMin((() => {
 	globalThis.array = [];
@@ -35,35 +64,6 @@ __esmMin((() => {
 	init_foo();
 	init_bar();
 	console.log(globalThis.array);
-}))();
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### entry.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-	//#region foo.js
-	{
-		const foo = "foo" + globalThis.foo;
-		setTimeout(() => {
-			globalThis.array.push(foo);
-		}, 100);
-	}
-	//#endregion
-	//#region bar.js
-	{
-		const foo = "bar" + globalThis.bar;
-		globalThis.array.push(foo);
-	}
-	//#endregion
-	//#region main.js
-	console.log(globalThis.array);
-	//#endregion
 }))();
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
@@ -1,5 +1,5 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "format": "cjs",
     "strictExecutionOrder": true,
@@ -10,14 +10,16 @@
           "test": "shared"
         }
       ]
+    },
+    "experimental": {
+      "onDemandWrapping": true
     }
   },
   "_comment": "Tests Common chunk + Esm WrapKind + Named OutputExports + named export access",
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
@@ -6,6 +6,23 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(42, 42);
+}))();
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### main.js
+
+```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_shared = require("./shared.js");
 let node_assert = require("node:assert");
@@ -18,7 +35,7 @@ require_rolldown_runtime.__esmMin((() => {
 
 ```
 
-## rolldown-runtime.js
+### rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -37,7 +54,7 @@ Object.defineProperty(exports, "__toESM", {
 
 ```
 
-## shared.js
+### shared.js
 
 ```js
 //#region shared.js
@@ -49,22 +66,5 @@ Object.defineProperty(exports, "init_shared", {
 		return init_shared;
 	}
 });
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### main.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
-//#endregion
-__esmMin((() => {
-	node_assert.default.strictEqual(42, 42);
-}))();
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/_config.json
@@ -1,20 +1,28 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "main", "import": "./main.js" },
-      { "name": "lib", "import": "./lib.js" }
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "lib",
+        "import": "./lib.js"
+      }
     ],
     "format": "cjs",
     "exports": "named",
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + default export access",
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
@@ -10,6 +10,42 @@ Object.defineProperties(exports, {
 	__esModule: { value: true },
 	[Symbol.toStringTag]: { value: "Module" }
 });
+//#region lib.js
+var lib_default = { value: 42 };
+const named = "named_value";
+//#endregion
+exports.default = lib_default;
+exports.named = named;
+
+```
+
+## main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.default.value, 42);
+}))();
+exports.lib = require_lib.default;
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperties(exports, {
+	__esModule: { value: true },
+	[Symbol.toStringTag]: { value: "Module" }
+});
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
 var lib_default, named;
@@ -30,7 +66,7 @@ exports.named = named;
 
 ```
 
-## main.js
+### main.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
@@ -47,7 +83,7 @@ exports.lib = require_lib.default;
 
 ```
 
-## rolldown-runtime.js
+### rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -63,41 +99,5 @@ Object.defineProperty(exports, "__toESM", {
 		return __toESM;
 	}
 });
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### lib.js
-
-```js
-Object.defineProperties(exports, {
-	__esModule: { value: true },
-	[Symbol.toStringTag]: { value: "Module" }
-});
-//#region lib.js
-var lib_default = { value: 42 };
-const named = "named_value";
-//#endregion
-exports.default = lib_default;
-exports.named = named;
-
-```
-
-### main.js
-
-```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
-const require_lib = require("./lib.js");
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
-//#endregion
-__esmMin((() => {
-	node_assert.default.strictEqual(require_lib.default.value, 42);
-}))();
-exports.lib = require_lib.default;
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/_config.json
@@ -1,20 +1,28 @@
 {
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "main", "import": "./main.js" },
-      { "name": "lib", "import": "./lib.js" }
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "lib",
+        "import": "./lib.js"
+      }
     ],
     "format": "cjs",
     "exports": "named",
-    "strictExecutionOrder": true
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "_comment": "Tests Entry + Esm WrapKind + Named OutputExports + named export access",
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
@@ -7,6 +7,41 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region lib.js
+const foo = "foo_value";
+const bar = 42;
+//#endregion
+exports.bar = bar;
+exports.foo = foo;
+
+```
+
+## main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.foo, "foo_value");
+	node_assert.default.strictEqual(42, 42);
+}))();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### lib.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
 var foo, bar;
@@ -27,7 +62,7 @@ Object.defineProperty(exports, "init_lib", {
 
 ```
 
-## main.js
+### main.js
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
@@ -46,7 +81,7 @@ exports.foo = require_lib.foo;
 
 ```
 
-## rolldown-runtime.js
+### rolldown-runtime.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -62,40 +97,5 @@ Object.defineProperty(exports, "__toESM", {
 		return __toESM;
 	}
 });
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### lib.js
-
-```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-//#region lib.js
-const foo = "foo_value";
-const bar = 42;
-//#endregion
-exports.bar = bar;
-exports.foo = foo;
-
-```
-
-### main.js
-
-```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
-const require_lib = require("./lib.js");
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
-//#endregion
-__esmMin((() => {
-	node_assert.default.strictEqual(require_lib.foo, "foo_value");
-	node_assert.default.strictEqual(42, 42);
-}))();
-exports.bar = require_lib.bar;
-exports.foo = require_lib.foo;
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/_config.json
@@ -1,27 +1,39 @@
 {
-  "_comment": "Two entries where `main` reads `lib`'s exports and independently pulls runtime helpers. The runtime-merge signature guard must respect `preserveEntrySignatures`: `strict` (and the default `exports-only`, since lib declares exports) keeps runtime helpers out of lib's public exports, while `allow-extension` permits but does not require a merge. Both wrapping modes are explicit variants, so auto-generated extended variants are unnecessary.",
-  "configName": "wrap-all",
+  "_comment": "Two entries where `main` reads `lib`'s exports, and both entries pull runtime helpers via interop. The runtime-merge signature guard must respect `preserveEntrySignatures`: `strict` (and the default `exports-only`, since lib declares exports) must keep runtime helpers out of lib's public exports. `allow-extension` permits a runtime merge: the on-demand layout merges it and exposes helper extension exports, while wrap-all may validly keep a separate runtime chunk. The cases are explicit config variants, so their auto-generated extended-test variants are disabled.",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "main", "import": "./main.js" },
-      { "name": "lib", "import": "./lib.js" }
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "lib",
+        "import": "./lib.js"
+      }
     ],
     "format": "cjs",
     "exports": "named",
     "strictExecutionOrder": true,
     "minifyInternalExports": false,
-    "preserveEntrySignatures": "strict"
+    "preserveEntrySignatures": "strict",
+    "experimental": {
+      "onDemandWrapping": true
+    }
   },
   "configVariants": [
-    { "_configName": "allow-extension-wrap-all", "preserveEntrySignatures": "allow-extension" },
-    {
-      "_configName": "on-demand",
-      "onDemandWrapping": true
-    },
     {
       "_configName": "allow-extension-on-demand",
+      "preserveEntrySignatures": "allow-extension"
+    },
+    {
+      "_configName": "allow-extension-wrap-all",
       "preserveEntrySignatures": "allow-extension",
-      "onDemandWrapping": true
+      "onDemandWrapping": false
+    },
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
@@ -7,23 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
-var foo, bar;
-var init_lib = require_rolldown_runtime.__esmMin((() => {
-	foo = "foo_value";
-	bar = 42;
-}));
+const foo = "foo_value";
+const bar = 42;
 //#endregion
-init_lib();
 exports.bar = bar;
 exports.foo = foo;
-Object.defineProperty(exports, "init_lib", {
-	enumerable: true,
-	get: function() {
-		return init_lib;
-	}
-});
 
 ```
 
@@ -31,13 +20,12 @@ Object.defineProperty(exports, "init_lib", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_rolldown_runtime = require("./rolldown-runtime.js");
+// HIDDEN [\0rolldown/runtime.js]
 const require_lib = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = require_rolldown_runtime.__toESM(node_assert);
+node_assert = __toESM(node_assert);
 //#endregion
-require_rolldown_runtime.__esmMin((() => {
-	require_lib.init_lib();
+__esmMin((() => {
 	node_assert.default.strictEqual(require_lib.foo, "foo_value");
 	node_assert.default.strictEqual(42, 42);
 }))();
@@ -46,26 +34,42 @@ exports.foo = require_lib.foo;
 
 ```
 
-## rolldown-runtime.js
+# Variant: allow-extension-on-demand: [preserve_entry_signatures: AllowExtension]
+
+## Assets
+
+### lib.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-Object.defineProperty(exports, "__esmMin", {
-	enumerable: true,
-	get: function() {
-		return __esmMin;
-	}
-});
-Object.defineProperty(exports, "__toESM", {
-	enumerable: true,
-	get: function() {
-		return __toESM;
-	}
-});
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region lib.js
+const foo = "foo_value";
+const bar = 42;
+//#endregion
+exports.bar = bar;
+exports.foo = foo;
 
 ```
 
-# Variant: allow-extension-wrap-all: [preserve_entry_signatures: AllowExtension]
+### main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+const require_lib = require("./lib.js");
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#endregion
+__esmMin((() => {
+	node_assert.default.strictEqual(require_lib.foo, "foo_value");
+	node_assert.default.strictEqual(42, 42);
+}))();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
+
+```
+
+# Variant: allow-extension-wrap-all: [on_demand_wrapping: false] [preserve_entry_signatures: AllowExtension]
 
 ## Assets
 
@@ -113,7 +117,7 @@ exports.foo = require_lib.foo;
 
 ```
 
-# Variant: on-demand: [on_demand_wrapping: true]
+# Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
 
@@ -121,12 +125,23 @@ exports.foo = require_lib.foo;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region lib.js
-const foo = "foo_value";
-const bar = 42;
+var foo, bar;
+var init_lib = require_rolldown_runtime.__esmMin((() => {
+	foo = "foo_value";
+	bar = 42;
+}));
 //#endregion
+init_lib();
 exports.bar = bar;
 exports.foo = foo;
+Object.defineProperty(exports, "init_lib", {
+	enumerable: true,
+	get: function() {
+		return init_lib;
+	}
+});
 
 ```
 
@@ -134,12 +149,13 @@ exports.foo = foo;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib = require("./lib.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#endregion
-__esmMin((() => {
+require_rolldown_runtime.__esmMin((() => {
+	require_lib.init_lib();
 	node_assert.default.strictEqual(require_lib.foo, "foo_value");
 	node_assert.default.strictEqual(42, 42);
 }))();
@@ -148,37 +164,21 @@ exports.foo = require_lib.foo;
 
 ```
 
-# Variant: allow-extension-on-demand: [on_demand_wrapping: true] [preserve_entry_signatures: AllowExtension]
-
-## Assets
-
-### lib.js
+### rolldown-runtime.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-//#region lib.js
-const foo = "foo_value";
-const bar = 42;
-//#endregion
-exports.bar = bar;
-exports.foo = foo;
-
-```
-
-### main.js
-
-```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
-const require_lib = require("./lib.js");
-let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
-//#endregion
-__esmMin((() => {
-	node_assert.default.strictEqual(require_lib.foo, "foo_value");
-	node_assert.default.strictEqual(42, 42);
-}))();
-exports.bar = require_lib.bar;
-exports.foo = require_lib.foo;
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configVariants": [
     {
       "_configName": "wrap-all",

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
@@ -1,0 +1,73 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region ring-b.js
+globalThis.__ringB = "b";
+//#endregion
+//#region main.js
+const value = await Promise.resolve("a");
+//#endregion
+export { value };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region ring-b.js
+var init_ring_b = __esmMin((async () => {
+	await init_ring_a();
+	globalThis.__ringB = "b";
+}));
+//#endregion
+//#region ring-a.js
+var a;
+var init_ring_a = __esmMin((async () => {
+	await init_ring_b();
+	a = await Promise.resolve("a");
+}));
+//#endregion
+//#region main.js
+var value;
+//#endregion
+await __esmMin((async () => {
+	await init_ring_a();
+	value = a;
+}))();
+export { value };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+var a, value;
+await __esmMin((async () => {
+	//#region ring-b.js
+	globalThis.__ringB = "b";
+	//#endregion
+	//#region ring-a.js
+	a = await Promise.resolve("a");
+	//#endregion
+	//#region main.js
+	value = a;
+	//#endregion
+}))();
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "configVariants": [
     {
       "_configName": "wrap-all",

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/artifacts.snap
@@ -1,0 +1,104 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+const loaded = import("./tla-target.js").then((mod) => mod.value);
+//#endregion
+export { loaded };
+
+```
+
+## tla-target.js
+
+```js
+//#region tla-target.js
+const value = await Promise.resolve("tla");
+//#endregion
+export { value };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var loaded;
+//#endregion
+__esmMin((() => {
+	loaded = import("./tla-target.js").then((mod) => mod.value);
+}))();
+export { loaded };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### tla-target.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region tla-target.js
+var value;
+//#endregion
+await __esmMin((async () => {
+	value = await Promise.resolve("tla");
+}))();
+export { value };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var loaded;
+//#endregion
+__esmMin((() => {
+	loaded = import("./tla-target.js").then((mod) => mod.value);
+}))();
+export { loaded };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### tla-target.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region tla-target.js
+var value;
+//#endregion
+await __esmMin((async () => {
+	value = await Promise.resolve("tla");
+}))();
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/artifacts.snap
@@ -1,0 +1,135 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { t as value } from "./entry-a.js";
+export { value };
+
+```
+
+## b.js
+
+```js
+import { t as value } from "./entry-a.js";
+//#region entry-b.js
+const combined = `b:${value}`;
+//#endregion
+export { combined };
+
+```
+
+## entry-a.js
+
+```js
+//#region entry-a.js
+const value = await Promise.resolve("a");
+//#endregion
+export { value as t };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { n as value, t as init_entry_a } from "./entry-a.js";
+await init_entry_a();
+export { value };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as value, t as init_entry_a } from "./entry-a.js";
+//#region entry-b.js
+var combined;
+//#endregion
+await __esmMin((async () => {
+	await init_entry_a();
+	combined = `b:${value}`;
+}))();
+export { combined };
+
+```
+
+### entry-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region entry-a.js
+var value;
+var init_entry_a = __esmMin((async () => {
+	value = await Promise.resolve("a");
+}));
+//#endregion
+export { value as n, init_entry_a as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { n as value, t as init_entry_a } from "./entry-a.js";
+await init_entry_a();
+export { value };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as value, t as init_entry_a } from "./entry-a.js";
+//#region entry-b.js
+var combined;
+//#endregion
+await __esmMin((async () => {
+	await init_entry_a();
+	combined = `b:${value}`;
+}))();
+export { combined };
+
+```
+
+### entry-a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region entry-a.js
+var value;
+var init_entry_a = __esmMin((async () => {
+	value = await Promise.resolve("a");
+}));
+//#endregion
+export { value as n, init_entry_a as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/_config.json
@@ -1,5 +1,4 @@
 {
-  "snapshot": false,
   "config": {
     "input": [
       {

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/artifacts.snap
@@ -1,0 +1,152 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { t as shared } from "./shared.js";
+//#region a.js
+const a = `a:${shared}`;
+//#endregion
+export { a };
+
+```
+
+## b.js
+
+```js
+import { t as shared } from "./shared.js";
+//#region b.js
+const b = `b:${shared}`;
+//#endregion
+export { b };
+
+```
+
+## shared.js
+
+```js
+//#region shared.js
+const shared = await Promise.resolve("shared");
+//#endregion
+export { shared as t };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as shared, t as init_shared } from "./shared.js";
+//#region a.js
+var a;
+//#endregion
+await __esmMin((async () => {
+	await init_shared();
+	a = `a:${shared}`;
+}))();
+export { a };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as shared, t as init_shared } from "./shared.js";
+//#region b.js
+var b;
+//#endregion
+await __esmMin((async () => {
+	await init_shared();
+	b = `b:${shared}`;
+}))();
+export { b };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### shared.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
+var shared;
+var init_shared = __esmMin((async () => {
+	shared = await Promise.resolve("shared");
+}));
+//#endregion
+export { shared as n, init_shared as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### a.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as shared, t as init_shared } from "./shared.js";
+//#region a.js
+var a;
+//#endregion
+await __esmMin((async () => {
+	await init_shared();
+	a = `a:${shared}`;
+}))();
+export { a };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as shared, t as init_shared } from "./shared.js";
+//#region b.js
+var b;
+//#endregion
+await __esmMin((async () => {
+	await init_shared();
+	b = `b:${shared}`;
+}))();
+export { b };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### shared.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
+var shared;
+var init_shared = __esmMin((async () => {
+	shared = await Promise.resolve("shared");
+}));
+//#endregion
+export { shared as n, init_shared as t };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/_config.json
@@ -1,15 +1,22 @@
 {
   "_comment": "A top-level pure dynamic import of side-effect-free leaf.js with unused exports must not load leaf.js's body (it is modeled as importing an empty namespace), so leaf.js must not be exempt from on-demand side-effect pruning just because it appeared in the dynamic entry set. The entries only use leaf's re-exported `other`; leaf's own `value = first(second)` body must stay dropped even when strictExecutionOrder wraps the re-export path.",
-  "configName": "wrap-all",
+  "configName": "on-demand",
   "config": {
     "input": [
-      { "name": "a", "import": "./entry-a.js" },
-      { "name": "b", "import": "./entry-b.js" }
+      {
+        "name": "a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "b",
+        "import": "./entry-b.js"
+      }
     ],
     "external": ["dep"],
     "strictExecutionOrder": true,
     "experimental": {
-      "lazyBarrel": true
+      "lazyBarrel": true,
+      "onDemandWrapping": true
     },
     "treeshake": {
       "moduleSideEffects": false
@@ -17,9 +24,8 @@
   },
   "configVariants": [
     {
-      "_configName": "on-demand",
-      "strictExecutionOrder": true,
-      "onDemandWrapping": true
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
 //#endregion
 __esmMin((() => {
 	init_leaf();
@@ -19,7 +19,7 @@ __esmMin((() => {
 ## b.js
 
 ```js
-import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
 //#endregion
 __esmMin((() => {
 	init_leaf();
@@ -29,6 +29,49 @@ __esmMin((() => {
 ```
 
 ## leaf.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region helper.js
+const other = "other";
+//#endregion
+//#region leaf.js
+var init_leaf = __esmMin((() => {}));
+//#endregion
+export { other as n, __esmMin as r, init_leaf as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+	console.log(other);
+}))();
+
+```
+
+### b.js
+
+```js
+import { i as __esmMin, n as init_helper, r as other, t as init_leaf } from "./leaf.js";
+//#endregion
+__esmMin((() => {
+	init_leaf();
+	console.log(other);
+}))();
+
+```
+
+### leaf.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -44,48 +87,5 @@ var init_leaf = __esmMin((() => {
 }));
 //#endregion
 export { __esmMin as i, init_helper as n, other as r, init_leaf as t };
-
-```
-
-# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
-
-## Assets
-
-### a.js
-
-```js
-import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
-//#endregion
-__esmMin((() => {
-	init_leaf();
-	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
-	console.log(other);
-}))();
-
-```
-
-### b.js
-
-```js
-import { n as other, r as __esmMin, t as init_leaf } from "./leaf.js";
-//#endregion
-__esmMin((() => {
-	init_leaf();
-	console.log(other);
-}))();
-
-```
-
-### leaf.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-//#region helper.js
-const other = "other";
-//#endregion
-//#region leaf.js
-var init_leaf = __esmMin((() => {}));
-//#endregion
-export { other as n, __esmMin as r, init_leaf as t };
 
 ```


### PR DESCRIPTION
## Summary

This PR isolates the review-only test layout changes requested for #10104.

- Apply the final base/variant ordering and explicit names used by the implementation PR.
- Remove 44 temporary `snapshot: false` gates and record the current `main` output in those positions.
- Keep all 44 expected-execution-failure markers attached to the same semantic configuration cells. No known failure is fixed in this layer.

Only `_config.json` and `artifacts.snap` files change: 86 configs and 85 snapshots. There are no production-code, test-input, harness, or runtime-assertion changes.

## Why this is separate

The previous #10104 diff changed variant order while also changing generated output. GitHub's positional diff then compared wrap-all output on one side with on-demand output on the other, which made unchanged behavior look like a large regression.

With this PR as the base, #10104 compares the same named configurations in the same order. Its config diff only removes expected-failure markers, and its snapshot diff shows the implementation result at the corresponding positions.

## Test-first sequence

The earlier test-first layers are already merged into `main`:

1. #10253 added the fail-closed runtime-failure harness and core integration regressions.
2. #10252 added the later hardening fixtures and paired-mode coverage.

The remaining Graphite stack is:

1. #10287 (this PR) establishes the final review layout and current-`main` snapshots while preserving every known failure.
2. #10104 adds the implementation, removes the failure markers, and records the implementation output.

## Validation

Validation ran on `main` at `c4e25974b8ff7598bf507ae4a2d7602cbcbc86fd`.

- All 86 changed fixture configs passed twice on the old implementation.
- The second pass was snapshot-stable.
- Structural audit: 96 strict-enabled fixture configs, 200 named strict executions, no missing or duplicate names, and 44 expected-failure cells preserved.
- Layout audit: all 87 target config layouts match the final #10104 layout after ignoring names and expected-failure metadata.
- `just lint-repo` passed.
