### PR TITLE
fix(sourcemap): map wrapped imported callees

### DIFF
--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -4,6 +4,18 @@ use rolldown_ecmascript_utils::ExpressionExt;
 
 use super::ScopeHoistingFinalizer;
 
+fn finalized_reference_expr_mut<'a, 'ast>(
+  expr: &'a mut Expression<'ast>,
+) -> &'a mut Expression<'ast> {
+  match expr {
+    Expression::ParenthesizedExpression(expr) => finalized_reference_expr_mut(&mut expr.expression),
+    Expression::SequenceExpression(expr) => finalized_reference_expr_mut(
+      expr.expressions.last_mut().expect("sequence expression should not be empty"),
+    ),
+    expr => expr,
+  }
+}
+
 impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
   /// return `None` if
   /// - the reference is for a global variable/the reference doesn't have a `SymbolId`
@@ -25,7 +37,10 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
 
     // See https://github.com/oxc-project/oxc/issues/4606
 
-    match &mut expr {
+    // A namespace member used as a callee is wrapped as `(0, namespace.member)` to avoid
+    // binding `this`. Apply the original identifier's span to the member expression inside
+    // that wrapper so codegen can map the generated callee back to the import reference.
+    match finalized_reference_expr_mut(&mut expr) {
       ast::Expression::Identifier(it) => {
         it.span = id_ref.span;
       }

--- a/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/_config.json
+++ b/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/_config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Regression test for a wrapped imported CommonJS callee losing its producer mapping after finalization.",
+  "visualizeSourcemap": true,
+  "expectExecuted": false,
+  "config": {
+    "minify": false
+  },
+  "configVariants": [
+    {
+      "_configName": "minified",
+      "minify": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/artifacts.snap
@@ -1,0 +1,107 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region client.cjs
+var require_client = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports.createRoot = function createRoot(element) {
+		return { render() {
+			element.textContent = "rendered";
+		} };
+	};
+}));
+
+//#endregion
+//#region main.js
+var import_client = require_client();
+(0, import_client.createRoot)(document.getElementById("root")).render();
+
+//#endregion
+//# sourceMappingURL=main.js.map
+```
+
+# Sourcemap Visualizer
+
+```
+- ../client.cjs
+(0:0) "module." --> (6:1) "module."
+(0:7) "exports." --> (6:8) "exports."
+(0:15) "createRoot = " --> (6:16) "createRoot = "
+(0:28) "function " --> (6:29) "function "
+(0:37) "createRoot(" --> (6:38) "createRoot("
+(0:48) "element) " --> (6:49) "element) "
+(0:57) "{\n" --> (6:58) "{\n"
+(1:2) "return " --> (7:2) "return "
+(1:9) "{\n" --> (7:9) "{ "
+(2:4) "render() " --> (7:11) "render() "
+(2:13) "{\n" --> (7:20) "{\n"
+(3:6) "element." --> (8:3) "element."
+(3:14) "textContent = " --> (8:11) "textContent = "
+(3:28) "'rendered';\n" --> (8:25) "\"rendered\";\n"
+(4:4) "},\n" --> (9:2) "} "
+(5:2) "};\n" --> (9:4) "};\n"
+(6:0) "};\n" --> (10:1) "};\n"
+- ../main.js
+(2:0) "createRoot(" --> (16:4) "import_client.createRoot)("
+(2:11) "document." --> (16:30) "document."
+(2:20) "getElementById(" --> (16:39) "getElementById("
+(2:35) "'root'" --> (16:54) "\"root\""
+(2:41) ")" --> (16:60) ")"
+(2:42) ")" --> (16:61) ")"
+(2:43) "." --> (16:62) "."
+(2:44) "render(" --> (16:63) "render("
+(2:51) ");\n" --> (16:70) ");\n"
+```
+
+# Variant: minified: [minify: true]
+
+## Assets
+
+### main.js
+
+```js
+(0,((e,t)=>()=>(t||(e((t={exports:{}}).exports,t),e=null),t.exports))(((e,t)=>{t.exports.createRoot=function(e){return{render(){e.textContent=`rendered`}}}}))().createRoot)(document.getElementById(`root`)).render();
+//# sourceMappingURL=main.js.map
+```
+
+## Sourcemap Visualizer
+
+```
+- ../main.js
+(2:0) "createRoot(document.getElementById('root')).render();\n" --> (0:1) "0,((e,t)=>()=>(t||(e((t={exports:{}}).exports,t),e=null),t.exports))(((e,t)=>{"
+- ../client.cjs
+(0:0) "module." --> (0:79) "t."
+(0:7) "exports." --> (0:81) "exports."
+(0:15) "createRoot = " --> (0:89) "createRoot="
+(0:28) "function createRoot(" --> (0:100) "function("
+(0:48) "element) " --> (0:109) "e)"
+(0:57) "{\n" --> (0:111) "{"
+(1:2) "return " --> (0:112) "return"
+(1:9) "{\n" --> (0:118) "{"
+(2:4) "render() " --> (0:119) "render()"
+(2:13) "{\n" --> (0:127) "{"
+(3:6) "element." --> (0:128) "e."
+(3:14) "textContent = " --> (0:130) "textContent="
+(3:28) "'rendered';\n" --> (0:142) "`rendered`"
+(4:4) "},\n" --> (0:152) "}"
+(5:2) "};\n" --> (0:153) "}"
+(6:0) "};\n" --> (0:154) "}}))("
+- ../main.js
+(2:0) "createRoot(" --> (0:159) ")"
+(2:0) "createRoot(" --> (0:160) "."
+(2:0) "createRoot(" --> (0:161) "createRoot)"
+(2:0) "createRoot(" --> (0:172) "("
+(2:11) "document." --> (0:173) "document."
+(2:20) "getElementById(" --> (0:182) "getElementById("
+(2:35) "'root'" --> (0:197) "`root`"
+(2:41) ")" --> (0:203) ")"
+(2:42) ")" --> (0:204) ")"
+(2:43) "." --> (0:205) "."
+(2:44) "render(" --> (0:206) "render("
+(2:51) ");\n" --> (0:213) ");\n"
+```

--- a/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/client.cjs
+++ b/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/client.cjs
@@ -1,0 +1,7 @@
+module.exports.createRoot = function createRoot(element) {
+  return {
+    render() {
+      element.textContent = 'rendered';
+    },
+  };
+};

--- a/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/main.js
+++ b/crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/main.js
@@ -1,0 +1,3 @@
+import { createRoot } from './client.cjs';
+
+createRoot(document.getElementById('root')).render();


### PR DESCRIPTION
Fixes the broken `createRoot` mapping reported in https://github.com/rolldown/rolldown/issues/10070#issuecomment-4976660399.

The defect was found while inspecting https://github.com/vitejs/vite/issues/19819. It is separate from that issue's two original exhibits, which already did not reproduce on Vite 8.1.4 before this change.

## Problem

In this case, the named import from a CommonJS module is finalized as an unbound namespace call:

```js
// source
createRoot(document.getElementById('root')).render();

// generated
(0, import_client.createRoot)(document.getElementById("root")).render();
```

The finalized callee is wrapped as `ParenthesizedExpression → SequenceExpression → StaticMemberExpression`. Existing source-location propagation only handled an `Identifier` or `StaticMemberExpression` at the outermost level, so it did not reach the member inside this wrapper. The generated `createRoot` therefore had no producer mapping.

Coordinates below use one-based lines and zero-based columns.

```mermaid
flowchart TB
  subgraph before["Before"]
    direction LR
    B1["generated createRoot"] --> B2["no producer mapping"]
    B3["generated document"] --> B4["main.js 3:11"]
  end

  subgraph after["After"]
    direction LR
    A1["generated createRoot"] --> A2["main.js 3:0"]
    A3["generated document"] --> A4["main.js 3:11"]
  end
```

Without this mapping, consumers could not directly resolve the generated `createRoot` back to its source position.

## Fix

- follow parenthesized and sequence wrappers to the actual finalized reference
- reuse the existing identifier/member span propagation on the unwrapped reference
- do not assign the original span to the synthetic `0` or leading wrapper syntax

## Validation

- the regression fixture covers both unminified and Oxc-minified output
- in the Vite 8.1.4 project used during the investigation, both unminified output and output produced by Vite's default Oxc minifier map `createRoot` to `src/main.tsx:5:0` and keep `document` at `src/main.tsx:5:11`
- `cargo run -p rolldown_testing --bin run-fixture -- crates/rolldown/tests/rolldown/sourcemap/imported_cjs_callee/_config.json`
- `cargo test -p rolldown --lib`
- `cargo clippy -p rolldown --lib --tests -- --deny warnings`
