### PR TITLE
fix(output): skip separator for empty import prelude

### DIFF
--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -144,7 +144,11 @@ pub fn render_modules_with_peek_runtime_module_at_first<'a>(
     _ => {}
   }
 
-  source_joiner.append_source(import_code);
+  // An empty import prelude is not a source slot. Appending it would make `SourceJoiner` insert a
+  // separator line before the modules.
+  if !import_code.is_empty() {
+    source_joiner.append_source(import_code);
+  }
 
   // chunk content
   module_sources_peekable.for_each(

--- a/crates/rolldown/tests/rolldown/function/extend/iife/namespace_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/namespace_default/artifacts.snap
@@ -12,7 +12,6 @@ class A {
 this.test = this.test || {};
 this.test.module = (function() {
 
-
 //#region main.js
 	var main_default = "default";
 

--- a/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
@@ -13,7 +13,6 @@ this.test = this.test || {};
 (function(exports) {
 
 Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-
 //#region main.js
 	const a = 1;
 	const b = 2;

--- a/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_default/artifacts.snap
@@ -11,7 +11,6 @@ class A {
   constructor() {
 this.module = (function() {
 
-
 //#region main.js
 	var main_default = "default";
 

--- a/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
@@ -12,7 +12,6 @@ class A {
 (function(exports) {
 
 Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-
 //#region main.js
 	const a = 1;
 	const b = 2;

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
@@ -13,7 +13,6 @@ this.namespace = this.namespace || {};
 this.namespace.module = (function(exports) {
 
 Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-
 //#region foo.js
 	const value = 1;
 

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
@@ -13,7 +13,6 @@ this["1"] = this["1"] || {};
 this["1"]["2"] = (function(exports) {
 
 Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-
 //#region foo.js
 	const value = 1;
 

--- a/crates/rolldown/tests/rolldown/issues/8670/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8670/artifacts.snap
@@ -27,7 +27,6 @@ export default require_main();
 var myLib = (function() {
 
 // HIDDEN [\0rolldown/runtime.js]
-
 //#region main.cjs
 	var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
 		exports.foo = "foo";
@@ -53,7 +52,6 @@ module.exports = myLib;
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, (global.myLib = factory()));
 })(this, function() {
 // HIDDEN [\0rolldown/runtime.js]
-
 //#region main.cjs
 	var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
 		exports.foo = "foo";

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/_config.ts
@@ -1,0 +1,22 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    experimental: {
+      attachDebugInfo: 'none',
+    },
+    plugins: [
+      {
+        name: 'assert-no-empty-import-prelude',
+        renderChunk(code) {
+          expect(code.startsWith('function throwError')).toBe(true);
+        },
+      },
+    ],
+    output: {
+      format: 'cjs',
+    },
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/main.js
@@ -1,0 +1,5 @@
+function throwError() {
+  throw new Error('TEST_ERROR');
+}
+
+throwError();


### PR DESCRIPTION
Refs #7555.

## Why

The wrapped-format renderer appended `import_code` to `SourceJoiner` even when the generated import prelude was empty. `SourceJoiner` treats every appended value as a source slot and inserts a separator between slots, so an empty prelude still caused an unwanted separator: before the first module in the CJS reproduction and at the corresponding module boundary in affected IIFE and UMD output.

## What changed

- skip the generated import prelude when it is empty
- update the affected IIFE and UMD snapshots
- add a CJS `renderChunk` fixture that verifies the hook input starts with the first module, without a separator from an empty prelude

## Source-map scope

The final composed map observed in #7555 was wrong, but Rolldown's producer map and composition were correct for the inputs they received. Rolldown's producer map correctly described the exact `renderChunk` input, including the leading separator. JavaScript Obfuscator trimmed that input before parsing and returned a map for the trimmed code without representing the trim relative to the hook input ([source](https://github.com/javascript-obfuscator/javascript-obfuscator/blob/35860ec7087b1e53e89233419f91336f6d4f0bd5/src/code-transformers/preparing-transformers/HashbangOperatorTransformer.ts#L54-L63)).

This PR does not change Rolldown's source-map generation or composition logic; there was no bug in either for this reproduction. It removes the unintended output separator. As a consequence, the exact #7555 reproduction no longer triggers the coordinate mismatch in the plugin-returned map. Plugins remain responsible for returning maps relative to the exact code passed to `renderChunk`.

The regression fixture intentionally checks the hook input rather than source-map composition. A valid plugin map constructed from the token's actual hook position composes to the correct original position both before and after this change, so that assertion would not detect this regression.

## Before and after

For the CJS reproduction, the `renderChunk` input changes from:

```text
Before: "\nfunction throwError() { ..."
After:  "function throwError() { ..."
```

For affected IIFE and UMD output, the removed separator is at the wrapper or factory boundary rather than necessarily at the start of the whole chunk.

## Validation

- targeted `plugin/render-chunk/issue-7555` Node fixture
- `vp check packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/_config.ts`
- all seven affected Rust fixtures
- `cargo fmt --all --check`
- `cargo check -p rolldown --all-features --all-targets --locked`
