### PR TITLE
fix(magic-string): return UTF-16 code units from length()

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -745,10 +745,11 @@ impl BindingMagicString<'_> {
 
   #[napi]
   pub fn length(&self) -> u32 {
-    // MagicString::len() returns usize (length of generated output)
+    // JS measures string length in UTF-16 code units, so this must use `len_utf16` rather
+    // than `len`, which counts UTF-8 bytes and over-reports for any non-ASCII source.
     #[expect(clippy::cast_possible_truncation, reason = "files are < 4GB")]
     {
-      self.inner.len() as u32
+      self.inner.len_utf16() as u32
     }
   }
 

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -99,11 +99,27 @@ impl<'text> MagicString<'text> {
     self.ignore_list
   }
 
-  /// Returns the length of the content within chunks (intro + content + outro per chunk),
-  /// excluding the global intro/outro from `prepend`/`append`.
+  /// Returns the length in UTF-8 bytes of the content within chunks (intro + content + outro
+  /// per chunk), excluding the global intro/outro from `prepend`/`append`.
   /// This aligns with the reference `magic-string` behavior.
+  ///
+  /// Note this counts *bytes*. Callers that need the length JavaScript would report (UTF-16
+  /// code units, as the reference `magic-string` returns) must use [`Self::len_utf16`].
   pub fn len(&self) -> usize {
     self.iter_chunks().flat_map(|c| c.fragments(&self.source)).map(|f| f.len()).sum()
+  }
+
+  /// Returns the length in UTF-16 code units of the content within chunks, excluding the
+  /// global intro/outro — the same range [`Self::len`] covers.
+  ///
+  /// This is what the reference `magic-string` `length()` returns, since JavaScript string
+  /// length is measured in UTF-16 code units.
+  pub fn len_utf16(&self) -> usize {
+    self
+      .iter_chunks()
+      .flat_map(|c| c.fragments(&self.source))
+      .map(|f| f.chars().map(char::len_utf16).sum::<usize>())
+      .sum()
   }
 
   /// Returns `true` if all chunk content (intro + content + outro) is whitespace or empty.

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -15,6 +15,35 @@ import { describe, it } from 'vitest';
  * tests stay in Rust.
  */
 
+describe('length', () => {
+  // `MagicString::len()` sums UTF-8 byte lengths, but JS measures string length in UTF-16
+  // code units. The binding used to return the byte count, so every non-ASCII source
+  // over-reported (`'é'` -> 2, `'🤷'` -> 4). The upstream suite only covers ASCII, where
+  // the two happen to agree, so nothing caught it.
+  it('counts UTF-16 code units, not UTF-8 bytes', () => {
+    assert.strictEqual(new MagicString('abc').length(), 3);
+    assert.strictEqual(new MagicString('é').length(), 1);
+    assert.strictEqual(new MagicString('🤷').length(), 2);
+    assert.strictEqual(new MagicString('中文').length(), 2);
+    assert.strictEqual(new MagicString('abc™def').length(), 7);
+  });
+
+  it('counts UTF-16 code units after edits', () => {
+    const s = new MagicString('abc');
+    s.overwrite(1, 2, '🤷');
+    // 'a' + '🤷' (2 units) + 'c'
+    assert.strictEqual(s.length(), 4);
+    assert.strictEqual(s.length(), s.toString().length);
+  });
+
+  it('excludes global intro/outro, matching magic-string', () => {
+    const s = new MagicString('abc');
+    s.prepend('🤷');
+    s.append('🤷');
+    assert.strictEqual(s.length(), 3);
+  });
+});
+
 describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {


### PR DESCRIPTION
### What this solves

`RolldownMagicString.length()` returns the UTF-8 **byte** count instead of the UTF-16 code unit count that JavaScript — and `magic-string` — report. Any non-ASCII source over-reports:

| input | `length()` before | `magic-string` |
| --- | --- | --- |
| `"abc"` | 3 | 3 |
| `"é"` | **2** | 1 |
| `"🤷"` | **4** | 2 |
| `"中文"` | **6** | 2 |
| `"abc™def"` | **9** | 7 |

There is no panic and no warning — just a silently wrong number, so a plugin doing arithmetic on `length()` (bounds checks, slicing decisions) quietly misbehaves on any file containing an accented character, CJK text, or an emoji.

### Root cause

`MagicString::len()` sums `&str::len()` over the chunk fragments, which is UTF-8 bytes. The binding returned it unconverted:

```rust
pub fn length(&self) -> u32 {
  self.inner.len() as u32
}
```

`length()` was the only index-based method that skipped the `Utf16ToByteMapper` the binding already builds for every other position API (`appendLeft`, `overwrite`, `slice`, …), so the UTF-16 boundary was handled everywhere except here.

### The fix

Add `MagicString::len_utf16`, covering exactly the same span as `len` — chunk content only, global `prepend`/`append` intro/outro excluded, matching `magic-string`'s `length()` — and use it from the binding. `len()` keeps its byte semantics for Rust callers and now documents that explicitly.

### Why this wasn't caught

The vendored upstream conformance suite (`packages/rolldown/tests/magic-string/MagicString.test.ts`) exercises `length` only with ASCII, where bytes and code units coincide. The new tests live next to the other hand-written binding cases in `rolldown-magic-string.test.ts`, which is where the UTF-16↔UTF-8 boundary coverage already sits.

### Tests

Three cases in `packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts`: the non-ASCII table above, `length()` after an edit that inserts a surrogate pair (asserted against `toString().length`), and a guard that the global intro/outro stays excluded. All three fail on `main` and pass here.
