### PR TITLE
feat: `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>` support to pass context to `resolveFileUrl` hook

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -297,12 +297,13 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_member_expression(&mut self, it: &ast::MemberExpression<'ast>) {
     if it.object().is_import_meta()
       && let Some(property_name) = it.static_property_name()
-      && let Some(reference_id) = utils::file_url::strip_file_url_prefix(property_name)
+      && let Some(file_url) = utils::file_url::strip_file_url_prefix(property_name)
     {
       self.result.rolldown_file_url_references.push(RolldownFileUrlReference {
         node_id: it.node_id(),
         stmt_info_idx: self.current_stmt_idx,
-        reference_id: CompactStr::from(reference_id),
+        reference_id: CompactStr::from(file_url.reference_id),
+        url_id: file_url.url_id.map(CompactStr::from),
       });
     }
     walk::walk_member_expression(self, it);

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -115,7 +115,7 @@ pub struct ScanResult {
   pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
   /// `new URL('...', import.meta.url)`
   pub new_url_references: FxHashMap<NodeId, ImportRecordIdx>,
-  /// `import.meta.ROLLDOWN_FILE_URL_<referenceId>`, one entry per occurrence.
+  /// `import.meta.ROLLDOWN_FILE_URL_<referenceId>[_<urlId>]`, one entry per occurrence.
   pub rolldown_file_url_references: Vec<RolldownFileUrlReference>,
   pub this_expr_replace_map: FxHashMap<NodeId, ThisExprReplaceKind>,
   pub hmr_info: HmrInfo,

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -1249,6 +1249,9 @@ mod test {
     assert!(!has_side_effect_for_tree_shaking("import.meta?.['url']"));
     assert!(!has_side_effect_for_tree_shaking("import.meta.ROLLDOWN_FILE_URL_abc123"));
     assert!(!has_side_effect_for_tree_shaking("import.meta?.ROLLDOWN_FILE_URL_abc123"));
+    assert!(!has_side_effect_for_tree_shaking(
+      "import.meta.ROLLDOWN_FILE_URL_aaaaaaaaaaaaaaaaaaaaaa_myUrlId"
+    ));
     assert!(!has_side_effect_for_tree_shaking("import.meta['ROLLDOWN_FILE_URL_abc123']"));
     assert!(!has_side_effect_for_tree_shaking("import.meta?.['ROLLDOWN_FILE_URL_abc123']"));
     assert!(!has_side_effect_for_tree_shaking("import.meta.ROLLUP_FILE_URL_abc123"));

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1096,8 +1096,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     original_expr_span: Span,
     node_id: NodeId,
   ) -> Option<Expression<'ast>> {
-    // rewrite `import.meta.ROLLDOWN_FILE_URL_<referenceId>`
-    if let Some(reference_id) = utils::file_url::strip_file_url_prefix(property_name) {
+    // rewrite `import.meta.ROLLDOWN_FILE_URL_<referenceId>[_<urlId>]`
+    if let Some(reference_id) =
+      utils::file_url::strip_file_url_prefix(property_name).map(|file_url| file_url.reference_id)
+    {
       // A plugin's `resolveFileUrl` result wins over the default. Copy the `&'me`
       // reference out of `ctx` first, so the lookup does not borrow `self` and the
       // error path below can borrow it mutably.

--- a/crates/rolldown/src/stages/generate_stage/resolve_file_urls.rs
+++ b/crates/rolldown/src/stages/generate_stage/resolve_file_urls.rs
@@ -59,7 +59,7 @@ impl GenerateStage<'_> {
           continue;
         }
 
-        for RolldownFileUrlReference { node_id, stmt_info_idx, reference_id } in
+        for RolldownFileUrlReference { node_id, stmt_info_idx, reference_id, url_id } in
           &module.ecma_view.rolldown_file_url_references
         {
           if !self.link_output.metas[module.idx].stmt_info_included.has_bit(*stmt_info_idx) {
@@ -81,6 +81,7 @@ impl GenerateStage<'_> {
               module_id: module.id.as_str(),
               reference_id,
               relative_path: &relative_path,
+              url_id: url_id.as_deref(),
             };
             self.plugin_driver.resolve_file_url(&args).await?
           } else {

--- a/crates/rolldown/src/utils/file_url.rs
+++ b/crates/rolldown/src/utils/file_url.rs
@@ -1,14 +1,105 @@
 /// Prefixes recognized on `import.meta.<prefix><referenceId>` file URL references.
 ///
 /// `ROLLDOWN_FILE_URL_` is a rolldown-specific alias of Rollup's `ROLLUP_FILE_URL_`.
-pub const FILE_URL_PREFIXES: [&str; 2] = ["ROLLDOWN_FILE_URL_", "ROLLUP_FILE_URL_"];
+const ROLLDOWN_FILE_URL_PREFIX: &str = "ROLLDOWN_FILE_URL_";
+const ROLLUP_FILE_URL_PREFIX: &str = "ROLLUP_FILE_URL_";
 
-/// Returns the `<referenceId>` when `name` begins with a recognized file URL prefix.
-pub fn strip_file_url_prefix(name: &str) -> Option<&str> {
-  FILE_URL_PREFIXES.iter().find_map(|prefix| name.strip_prefix(prefix))
+/// Reference ids are produced by `FileEmitter::assign_reference_id` as the base64url
+/// encoding of a 128-bit xxhash (with `-` swapped for `$`), so they are always exactly
+/// this many characters. The optional `_<urlId>` part of
+/// `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>` therefore begins right after them.
+const REFERENCE_ID_LEN: usize = 22;
+
+/// A parsed `import.meta.<prefix><referenceId>[_<urlId>]` reference.
+#[derive(Debug, PartialEq, Eq)]
+pub struct FileUrlReference<'a> {
+  pub reference_id: &'a str,
+  pub url_id: Option<&'a str>,
+}
+
+/// Parses `name` when it begins with a recognized file URL prefix.
+///
+/// For `ROLLDOWN_FILE_URL_<referenceId>`, an optional `_<urlId>` suffix is split off and
+/// exposed as [`FileUrlReference::url_id`]. The `ROLLUP_FILE_URL_` alias is parsed for
+/// backward compatibility with Rollup and never carries a `urlId`.
+pub fn strip_file_url_prefix(name: &str) -> Option<FileUrlReference<'_>> {
+  if let Some(rest) = name.strip_prefix(ROLLDOWN_FILE_URL_PREFIX) {
+    // Reference ids are fixed-length, so the `_<urlId>` suffix (if any) begins right after
+    // them. `rest` is ASCII (base64url + `$`), so byte indexing lands on char boundaries.
+    if rest.len() > REFERENCE_ID_LEN && rest.as_bytes()[REFERENCE_ID_LEN] == b'_' {
+      let url_id = &rest[REFERENCE_ID_LEN + 1..];
+      return Some(FileUrlReference {
+        reference_id: &rest[..REFERENCE_ID_LEN],
+        url_id: if url_id.is_empty() { None } else { Some(url_id) },
+      });
+    }
+    return Some(FileUrlReference { reference_id: rest, url_id: None });
+  }
+  name
+    .strip_prefix(ROLLUP_FILE_URL_PREFIX)
+    .map(|reference_id| FileUrlReference { reference_id, url_id: None })
 }
 
 /// Whether `name` begins with a recognized file URL prefix.
 pub fn starts_with_file_url_prefix(name: &str) -> bool {
   strip_file_url_prefix(name).is_some()
+}
+
+#[cfg(test)]
+mod test {
+  use super::{FileUrlReference, starts_with_file_url_prefix, strip_file_url_prefix};
+
+  #[test]
+  fn strips_rolldown_prefix_without_url_id() {
+    // A 22-char reference id with no `_<urlId>` suffix.
+    let reference_id = "aaaaaaaaaaaaaaaaaaaaaa";
+    assert_eq!(
+      strip_file_url_prefix(&format!("ROLLDOWN_FILE_URL_{reference_id}")),
+      Some(FileUrlReference { reference_id, url_id: None })
+    );
+    assert_eq!(
+      strip_file_url_prefix(&format!("ROLLDOWN_FILE_URL_{reference_id}_")),
+      Some(FileUrlReference { reference_id, url_id: None })
+    );
+  }
+
+  #[test]
+  fn strips_rolldown_prefix_with_url_id() {
+    let reference_id = "aaaaaaaaaaaaaaaaaaaaaa";
+    assert_eq!(
+      strip_file_url_prefix(&format!("ROLLDOWN_FILE_URL_{reference_id}_myUrlId")),
+      Some(FileUrlReference { reference_id, url_id: Some("myUrlId") })
+    );
+    // A `urlId` may itself contain underscores.
+    assert_eq!(
+      strip_file_url_prefix(&format!("ROLLDOWN_FILE_URL_{reference_id}_a_b_c")),
+      Some(FileUrlReference { reference_id, url_id: Some("a_b_c") })
+    );
+  }
+
+  #[test]
+  fn rollup_prefix_never_carries_url_id() {
+    let reference_id = "aaaaaaaaaaaaaaaaaaaaaa_myUrlId";
+    assert_eq!(
+      strip_file_url_prefix(&format!("ROLLUP_FILE_URL_{reference_id}")),
+      Some(FileUrlReference { reference_id, url_id: None })
+    );
+  }
+
+  #[test]
+  fn shorter_reference_ids_have_no_url_id() {
+    // Reference ids shorter than the fixed length (e.g. in unit tests) are taken verbatim.
+    assert_eq!(
+      strip_file_url_prefix("ROLLDOWN_FILE_URL_abc123"),
+      Some(FileUrlReference { reference_id: "abc123", url_id: None })
+    );
+  }
+
+  #[test]
+  fn ignores_unrecognized_names() {
+    assert!(strip_file_url_prefix("url").is_none());
+    assert!(!starts_with_file_url_prefix("url"));
+    assert!(starts_with_file_url_prefix("ROLLDOWN_FILE_URL_abc123"));
+    assert!(starts_with_file_url_prefix("ROLLUP_FILE_URL_abc123"));
+  }
 }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -538,6 +538,7 @@ impl Plugin for JsPlugin {
               module_id: args.module_id.to_string(),
               reference_id: args.reference_id.to_string(),
               relative_path: args.relative_path.to_string(),
+              url_id: args.url_id.map(str::to_string),
             },
           )
             .into(),

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_file_url_args.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_file_url_args.rs
@@ -13,4 +13,7 @@ pub struct BindingHookResolveFileUrlArgs {
   pub reference_id: String,
   /// Path from the chunk to the emitted file.
   pub relative_path: String,
+  /// The `<urlId>` of `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>`, if present.
+  /// Only the rolldown-specific form carries it; the `ROLLUP_FILE_URL_` alias never does.
+  pub url_id: Option<String>,
 }

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -44,6 +44,8 @@ pub struct RolldownFileUrlReference {
   pub stmt_info_idx: StmtInfoIdx,
   /// The `<referenceId>` suffix, as handed out by `emitFile`.
   pub reference_id: CompactStr,
+  /// Optional `urlId`
+  pub url_id: Option<CompactStr>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -147,7 +149,7 @@ pub struct EcmaView {
   pub mutations: Vec<ArcSourceMutation>,
   /// `NodeId` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
   pub new_url_references: FxHashMap<NodeId, ImportRecordIdx>,
-  /// Occurrences of `import.meta.ROLLDOWN_FILE_URL_<referenceId>`, in source order.
+  /// Occurrences of `import.meta.ROLLDOWN_FILE_URL_<referenceId>[_<urlId>]`, in source order.
   /// One entry per occurrence: the `resolveFileUrl` hook is called per occurrence,
   /// matching Rollup, so duplicates are meaningful.
   pub rolldown_file_url_references: Vec<RolldownFileUrlReference>,

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -458,3 +458,31 @@ impl FileEmitter {
 }
 
 pub type SharedFileEmitter = Arc<FileEmitter>;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Reference ids are the base64url encoding of a 128-bit xxhash (with `-` remapped to `$`),
+  /// which is always 22 characters. The `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>`
+  /// parser depends on this: because a reference id can contain any identifier character
+  /// (`[A-Za-z0-9_$]`, including `$` and `_`), the `urlId` cannot be found by searching for a
+  /// separator, so it is split off by this fixed length instead.
+  ///
+  /// If this length ever changes, `REFERENCE_ID_LEN` in `rolldown/src/utils/file_url.rs` must
+  /// be updated in lockstep or urlId parsing will silently corrupt reference ids.
+  #[test]
+  fn assign_reference_id_is_always_22_chars() {
+    let emitter = FileEmitter::new(Arc::new(NormalizedBundlerOptions::default()));
+
+    // Counter-based ids: assets emitted without an explicit file name.
+    for _ in 0..1000 {
+      assert_eq!(emitter.assign_reference_id(None).len(), 22);
+    }
+
+    // Name/file-name-based ids: chunks and explicitly named files, including edge-case inputs.
+    for name in ["a", "index.js", "assets/deeply/nested/asset.name.txt", ""] {
+      assert_eq!(emitter.assign_reference_id(Some(ArcStr::from(name))).len(), 22, "name={name:?}");
+    }
+  }
+}

--- a/crates/rolldown_plugin/src/types/hook_resolve_file_url_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_file_url_args.rs
@@ -12,4 +12,9 @@ pub struct HookResolveFileUrlArgs<'a> {
   pub reference_id: &'a str,
   /// Path from the chunk to the emitted file.
   pub relative_path: &'a str,
+  /// The `<urlId>` of `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>`, if present.
+  /// Only the rolldown-specific form carries it; the `ROLLUP_FILE_URL_` alias never does.
+  ///
+  /// This API is experimental and may change in minor versions.
+  pub url_id: Option<&'a str>,
 }

--- a/docs/apis/plugin-api/file-urls.md
+++ b/docs/apis/plugin-api/file-urls.md
@@ -116,3 +116,46 @@ export const size = 6;
 :::
 
 If you build this code, both the main chunk and the worklet will share the code from `config.js` via a shared chunk. This enables us to make use of the browser cache to reduce transmitted data and speed up loading the worklet.
+
+## Passing a `urlId`
+
+::: warning Experimental
+
+The `urlId` API is experimental and may change in minor versions.
+
+:::
+
+Rolldown extends the syntax with an optional `urlId` (`import.meta.ROLLDOWN_FILE_URL_referenceId_urlId`). The `urlId` is an arbitrary identifier that is forwarded to the [`resolveFileUrl`](/reference/Interface.Plugin#resolvefileurl) hook as `args.urlId`, so a single plugin can resolve the same emitted file differently depending on where it is referenced from:
+
+```js [rolldown-plugin-svg-resolver.js]
+import path from 'node:path';
+import fs from 'node:fs';
+
+function svgResolverPlugin() {
+  return {
+    name: 'svg-resolver',
+    load: {
+      filter: { id: /\.svg$/ },
+      handler(id) {
+        const referenceId = this.emitFile({
+          type: 'asset',
+          name: path.basename(id),
+          source: fs.readFileSync(id),
+        });
+        // Append a `urlId` so `resolveFileUrl` can special-case this reference.
+        return `export default import.meta.ROLLDOWN_FILE_URL_${referenceId}_inline;`;
+      },
+    },
+    resolveFileUrl({ referenceId, relativePath, urlId }) {
+      if (urlId === 'inline') {
+        // resolve inlined references differently
+      }
+      // ...
+    },
+  };
+}
+```
+
+The `urlId` is only recognized on the rolldown-specific `ROLLDOWN_FILE_URL_` prefix. The Rollup-compatible `ROLLUP_FILE_URL_` alias never carries one. The default resolution (when no plugin handles the reference) ignores `urlId`.
+
+The `urlId` can only contain ASCII identifier characters: letters (`a`-`z`, `A`-`Z`), digits (`0`-`9`), `_`, and `$`.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2321,6 +2321,11 @@ export interface BindingHookResolveFileUrlArgs {
   referenceId: string
   /** Path from the chunk to the emitted file. */
   relativePath: string
+  /**
+   * The `<urlId>` of `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>`, if present.
+   * Only the rolldown-specific form carries it; the `ROLLUP_FILE_URL_` alias never does.
+   */
+  urlId?: string
 }
 
 export interface BindingHookResolveIdExtraArgs {

--- a/packages/rolldown/src/plugin/docs/plugin-hooks-resolvefileurl.md
+++ b/packages/rolldown/src/plugin/docs/plugin-hooks-resolvefileurl.md
@@ -4,6 +4,8 @@ This hook can be used to customize the behavior of `import.meta.ROLLDOWN_FILE_UR
 
 The returned string must be a single JavaScript expression. Also the returned expression must be side-effect free. If the URL is not used in the code, Rolldown will remove it.
 
+Rolldown additionally accepts `import.meta.ROLLDOWN_FILE_URL_referenceId_urlId`, where `urlId` is an arbitrary identifier of your choosing. It is passed to this hook as `args.urlId`, letting a single plugin resolve the same emitted file differently depending on the reference. The `urlId` API is experimental and may change in minor versions. The `urlId` is not available on the Rollup-compatible `ROLLUP_FILE_URL_` alias. Use only ASCII identifier characters in a `urlId`: letters, digits, `_`, and `$`.
+
 ::: tip `import.meta.url` in the returned string
 
 If the returned string contains `import.meta.url`, it will be rewritten for non-ESM formats similarly to [when `import.meta.url` is used in the code directly](/in-depth/non-esm-output-formats#well-known-import-meta-properties). Unlike Rolldown, Rollup outputs `import.meta.url` as-is.

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -207,6 +207,16 @@ export interface ResolveFileUrlArgs {
    * This path will contain no leading `./`, but may contain a leading `../`.
    */
   relativePath: string;
+  /**
+   * The `urlId` of an `import.meta.ROLLDOWN_FILE_URL_<referenceId>_<urlId>` reference,
+   * or `undefined` when the reference has no `urlId`.
+   *
+   * This is a rolldown-specific extension: the Rollup-compatible
+   * `import.meta.ROLLUP_FILE_URL_<referenceId>` form never carries a `urlId`.
+   *
+   * @experimental This API may change in minor versions.
+   */
+  urlId?: string | undefined;
 }
 
 /** @inline */

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/_config.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const seen: (string | undefined)[] = [];
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'emit-asset',
+        load(id) {
+          if (!id.endsWith('main.js')) return;
+          const referenceId = this.emitFile({
+            type: 'asset',
+            name: 'asset.txt',
+            source: fs.readFileSync(path.join(import.meta.dirname, 'asset.txt')),
+          });
+          // Only `ROLLDOWN_FILE_URL_<referenceId>_<urlId>` carries a `urlId`. The plain
+          // `ROLLDOWN_FILE_URL_<referenceId>` form and the `ROLLUP_FILE_URL_` alias do not
+          // (for the alias, a trailing `_<urlId>` would be read as part of the reference id).
+          return [
+            `export const a = import.meta.ROLLDOWN_FILE_URL_${referenceId}_myUrlId;`,
+            `export const b = import.meta.ROLLDOWN_FILE_URL_${referenceId};`,
+            `export const c = import.meta.ROLLUP_FILE_URL_${referenceId};`,
+            `export const d = import.meta.ROLLDOWN_FILE_URL_${referenceId}_defaultUrlId;`,
+          ].join('\n');
+        },
+      },
+      {
+        name: 'resolve-file-url',
+        resolveFileUrl(args) {
+          seen.push(args.urlId);
+          if (args.urlId === 'defaultUrlId') return null;
+          return JSON.stringify(args.urlId ?? null);
+        },
+      },
+    ],
+  },
+  afterTest: async (output) => {
+    // One hook call per occurrence, in source order.
+    // - `ROLLDOWN_FILE_URL_<id>_myUrlId` -> `urlId === 'myUrlId'`
+    // - `ROLLDOWN_FILE_URL_<id>`         -> `urlId === undefined`
+    // - `ROLLUP_FILE_URL_<id>`           -> `urlId === undefined` (alias never carries a urlId)
+    // - `ROLLDOWN_FILE_URL_<id>_defaultUrlId` -> `urlId === 'defaultUrlId'`
+    expect(seen).toEqual(['myUrlId', undefined, undefined, 'defaultUrlId']);
+
+    const chunk = output.output.find((o) => o.type === 'chunk')!;
+    const asset = output.output.find((o) => o.type === 'asset')!;
+    expect(chunk.code).toContain('const a = "myUrlId"');
+    expect(chunk.code).toContain('const b = null');
+    expect(chunk.code).toContain('const c = null');
+    // Declining the urlId-carrying occurrence uses the default rewrite. The urlId
+    // suffix is ignored when resolving the emitted asset's relative path.
+    expect(chunk.code).toContain(
+      `const d = new URL(${JSON.stringify(asset.fileName)}, import.meta.url).href`,
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/asset.txt
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/asset.txt
@@ -1,0 +1,1 @@
+asset contents

--- a/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-file-url/url-id/main.js
@@ -1,0 +1,2 @@
+// The `load` hook below replaces this module's source
+export const url = 'placeholder';


### PR DESCRIPTION
This PR adds a new feature to `import.meta.ROLLDOWN_FILE_URL_<referenceId>`.

Currently, these file URL references does not have a way to differentiate each references when `resolveFileUrl` hook is called. But that is sometimes needed. For example, in Vite, there are three cases:

- The wasm plugin emits the reference to the wasm binary. In SSR, this reference to the wasm binary should be rendered in a way that accesses as a relative path (as it's a file read). But in other plugins, the wasm binary should be rendered as the URL that can be accessed from the browser (this may sound strange, but it's the current behavior). So the `import.meta.ROLLDOWN_FILE_URL_<referenceId>` needs to be differentiated with type it is.
- Vite has `?inline` query which forces the asset to be output as `data` URL. The same asset can be imported with the query in some places while it can also be imported without the query in other places. This means the same asset needs to be referenced differently depending on the reference.
- Vite never inlines assets specified as the entrypoint. This information is tied to a single reference.

[rendered docs](https://github.com/rolldown/rolldown/blob/07-15-feat_import.meta.rolldown_file_url__referenceid___urlid_support_to_pass_context_to_resolvefileurl_hook/docs/apis/plugin-api/file-urls.md#passing-a-urlid)

In this PR, I made the `urlId` generated on the plugin side, but maybe that should be generated on the Rolldown side so that a conflict never happens. This can be done by adding `this.generateFileUrlId`.

The API can also be expanded to store the metadata in the Rolldown side. Currently, The metadata lives on the plugin side, so the referenceId emit and the `resolveFileUrl` hook needs to be coupled. This works for Vite's case, but won't work in general. For now, I think it's ok to go without it.

refs https://github.com/vitejs/vite/pull/22962
