### PR TITLE
fix(magic-string): don't report a change when edits cancel out

### DIFF
--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -122,6 +122,14 @@ impl<'text> MagicString<'text> {
       .sum()
   }
 
+  /// Returns the length in UTF-8 bytes of the whole generated output, including the global
+  /// intro/outro. Equivalent to `self.to_string().len()` without the allocation.
+  fn output_len(&self) -> usize {
+    self.intro.iter().map(|f| f.len()).sum::<usize>()
+      + self.len()
+      + self.outro.iter().map(|f| f.len()).sum::<usize>()
+  }
+
   /// Returns `true` if all chunk content (intro + content + outro) is whitespace or empty.
   /// This aligns with the reference `magic-string` behavior where `isEmpty()` uses `.trim()`.
   pub fn is_empty(&self) -> bool {
@@ -129,8 +137,13 @@ impl<'text> MagicString<'text> {
   }
 
   /// Indicates if the string has been changed.
+  ///
+  /// The length check is only a fast path for "definitely changed", so it has to measure the
+  /// same span as the string comparison below it: the whole output, global intro/outro
+  /// included. Comparing against [`Self::len`] instead would report a change for edits that
+  /// cancel out, e.g. `remove(0, 1)` followed by `prepend("a")`.
   pub fn has_changed(&self) -> bool {
-    self.source.len() != self.len() || self.source.as_ref() != self.to_string()
+    self.output_len() != self.source.len() || self.source.as_ref() != self.to_string()
   }
 
   /// Returns the last character of the generated string, or `None` if empty.

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -94,6 +94,37 @@ describe('length', () => {
   });
 });
 
+// One case per branch of `has_changed`'s two-clause condition. The `is true` cases are not
+// redundant with the bug case: this change *removes* a fast path, and a suite that only pinned
+// the `false` result would accept a `has_changed()` that always returns false.
+describe('hasChanged', () => {
+  // The fast path compared `source.len()` against `len()`, but `len()` excludes the global
+  // intro/outro that `to_string()` includes, so edits that cancel out reported a change.
+  // Here the lengths match and the strings match: no change.
+  it('is false when edits cancel out to the original string', () => {
+    const s = new MagicString('abc');
+    s.remove(0, 1);
+    s.prepend('a');
+    assert.strictEqual(s.toString(), 'abc');
+    assert.strictEqual(s.hasChanged(), false);
+  });
+
+  // Lengths match, so the fast path defers to the string comparison, which differs.
+  it('is true for a real change', () => {
+    const s = new MagicString('abc');
+    s.overwrite(0, 3, 'XYZ');
+    assert.strictEqual(s.hasChanged(), true);
+  });
+
+  // The only case where the fast path itself fires: the global intro makes the output longer
+  // than the source, which the old `len()` comparison could not see.
+  it('is true when only the global intro changed', () => {
+    const s = new MagicString('abc');
+    s.prepend('x');
+    assert.strictEqual(s.hasChanged(), true);
+  });
+});
+
 describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {


### PR DESCRIPTION
> Stacked on #10295 — review that first; this PR's diff is just the second commit.

### What this solves

`hasChanged()` reports `true` for edits that cancel out, i.e. when the generated output is byte-identical to the source:

```js
const s = new RolldownMagicString('abc');
s.remove(0, 1);
s.prepend('a');
s.toString();     // 'abc'  — identical to the original
s.hasChanged();   // true   — magic-string says false
```

Plugins commonly gate on `hasChanged()` to decide whether to hand back a transformed result and a sourcemap at all, so a false positive means pointless downstream work for a module that wasn't really touched.

### Root cause

```rust
self.source.len() != self.len() || self.source.as_ref() != self.to_string()
```

The first clause is meant to be a cheap "definitely changed" fast path for the string comparison after it — but the two measure different spans. `len()` counts **only chunk content**, while `to_string()` also includes the global intro/outro from `prepend`/`append`.

So any edit that shifts bytes between the chunks and the global intro/outro trips the fast path even when the two sides balance out. Above: `remove(0, 1)` drops a byte from the chunks (`len()` 3 → 2) and `prepend("a")` puts it back in the intro, which `len()` cannot see — `3 != 2` short-circuits to `true`.

`magic-string` has no fast path at all; it is just `original !== toString()`.

### The fix

Compare the whole output — global intro/outro included — so the fast path covers the same span as the comparison it short-circuits. Kept as a length check rather than dropped entirely, since it still avoids the `to_string()` allocation in the common "definitely changed" case.

### Tests

Three cases, one per branch of the resulting condition:

| case | branch exercised |
| --- | --- |
| `remove(0,1)` + `prepend("a")` → `false` | lengths match, strings match — **the bug** |
| `overwrite(0,3,"XYZ")` → `true` | lengths match, falls through to the string comparison |
| `prepend("x")` → `true` | the fast path itself fires (output longer than source) |

Only the first fails without this change. The two `is true` cases are deliberate: this PR *removes* a fast path, and a suite pinning only the bug case would equally accept a `has_changed()` that always returns `false` — I verified that by mutation, and those two are what catch it.
