### PR TITLE
fix:  prevent being merged different entry into  a chunk without strictExecutionOrder

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -309,6 +309,7 @@ impl ManualSplitter<'_> {
           &keys,
           merge_threshold,
           &self.link_output.module_table,
+          &self.options,
         );
       }
 
@@ -552,6 +553,7 @@ fn merge_entries_aware_subgroups(
   group_keys: &[u32],
   threshold: f64,
   module_table: &ModuleTable,
+  options: &SharedOptions,
 ) {
   let mut version_by_key: FxHashMap<u32, u32> = FxHashMap::default();
   let mut unqualified_heap: BinaryHeap<Reverse<(OrderedSize, u32, u32)>> = BinaryHeap::new();
@@ -609,6 +611,14 @@ fn merge_entries_aware_subgroups(
       continue;
     };
 
+    let candidate = subgroups.get(&candidate_key).unwrap();
+    let target = subgroups.get(&target_key).unwrap();
+    if !options.is_strict_execution_order_enabled()
+      && !options.experimental.is_on_demand_wrapping_enabled()
+      && candidate.bits != target.bits
+    {
+      continue;
+    }
     merge_subgroups(subgroups, candidate_key, target_key, module_table);
     bump_version(&mut version_by_key, candidate_key);
     bump_version(&mut version_by_key, target_key);

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_shared_deps/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_shared_deps/_test.mjs
@@ -8,17 +8,17 @@ const files = fs
   .filter((f) => f !== 'package.json')
   .sort();
 
-// lib-a and lib-b are small (~40 bytes each), below merge threshold (50).
-// shared-dep is large (~110 bytes), above threshold.
-//
-// Correct: lib-a and lib-b subgroups merge → no separate vendor~entry-a/b.
-// Bug (main): shared-dep duplicated into each subgroup → inflated sizes
-// (lib-a + shared-dep ≈ 150 > 50) → merge skipped → separate chunks.
+//when ertriesAware:true+ eentriesAwareMergeThreshold,lib-a and lib-b are small (~40 bytes each), below merge threshold (50).
+// shared-dep is large (~110 bytes), above threshold,it will merged large chunks vendor~entry-a~entry-b.js
+
+// However, entry-a and entry-b both have side effects, so loading entry-a would trigger entry-b.
+// To isolate these side effects, extra vendor~entry-a and vendor~entry-b chunks are generated,
+// ensuring that loading entry-a will not trigger entry-b.
 assert.ok(
-  !files.includes('vendor~entry-a.js'),
-  'lib-a subgroup should have merged (shared-dep must not inflate its size)',
+  files.includes('vendor~entry-a.js'),
+  'lib-a subgroup should not merged (entry-a has side effect)',
 );
 assert.ok(
-  !files.includes('vendor~entry-b.js'),
-  'lib-b subgroup should have merged (shared-dep must not inflate its size)',
+  files.includes('vendor~entry-b.js'),
+  'lib-b subgroup should not merged (entry-b has side effect)',
 );

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_shared_deps/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_shared_deps/artifacts.snap
@@ -6,14 +6,24 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-import "./vendor~entry-a~entry-b.js";
+import "./vendor~entry-a.js";
 
 ```
 
 ## entry-b.js
 
 ```js
+import "./vendor~entry-b.js";
+
+```
+
+## vendor~entry-a.js
+
+```js
 import "./vendor~entry-a~entry-b.js";
+//#region lib-a.js
+console.log("lib-a");
+//#endregion
 
 ```
 
@@ -23,9 +33,13 @@ import "./vendor~entry-a~entry-b.js";
 //#region shared-dep.js
 console.log("shared-dependency-padding-to-make-this-module-large-enough-to-exceed-merge-threshold-when-duplicated");
 //#endregion
-//#region lib-a.js
-console.log("lib-a");
-//#endregion
+
+```
+
+## vendor~entry-b.js
+
+```js
+import "./vendor~entry-a~entry-b.js";
 //#region lib-b.js
 console.log("lib-b");
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/_config.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/9463 - With `strictExecutionOrder`, a `codeSplitting` group (here `entriesAware` + a large `entriesAwareMergeThreshold`) lumps both entry modules and the shared module into one chunk. `chunkOptimization` then folded that chunk into entry `a`, so executing entry `b` (`import \"./a.js\"; init_b()`) eagerly ran `init_a()` and triggered entry `a`'s side effect. Each entry must run only its own `init_*`.",
+  "config": {
+    "input": [
+      { "name": "a", "import": "./a.js" },
+      { "name": "b", "import": "./b.js" }
+    ],
+    "experimental": {
+      "chunkOptimization": true
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "common",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 10000
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/_test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+
+// Behavioral regression test for https://github.com/rolldown/rolldown/issues/9463.
+//
+// Each module records its top-level side effect in `globalThis.sideEffectLog`.
+// Executing entry `b` (which reaches `shared.js` only via a dynamic import) must
+// run ONLY b's own side effects — never entry `a`'s. Before the fix, entry `b`'s
+// chunk imported entry `a`'s chunk and eagerly ran `init_a()`, so loading `b`
+// pushed `'a'`.
+
+globalThis.sideEffectLog = [];
+
+// Load ONLY entry `b`.
+await import(new URL('./dist/b.js', import.meta.url));
+// Let the dynamic `import('./shared.js')` continuation settle.
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+assert.ok(
+  !globalThis.sideEffectLog.includes('a'),
+  `executing entry "b" must not trigger entry "a"'s side effect; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+assert.deepStrictEqual(
+  globalThis.sideEffectLog,
+  ['b', 'shared-foo'],
+  `entry "b" should run only its own side effect plus its dynamic import; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);
+
+// Sanity: entry `a`'s side effect is not dead — it runs when `a` itself is loaded.
+await import(new URL('./dist/a.js', import.meta.url));
+assert.ok(
+  globalThis.sideEffectLog.includes('a'),
+  `entry "a"'s side effect should run when entry "a" is executed; got ${JSON.stringify(globalThis.sideEffectLog)}`,
+);

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/a.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/a.js
@@ -1,0 +1,6 @@
+import { foo } from './shared.js';
+
+// Top-level side effect of entry `a` (an observable global mutation, like the
+// `addEventListener` in the original report). Executing entry `b` must NOT run it.
+(globalThis.sideEffectLog ??= []).push('a');
+foo();

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { t as foo } from "./common~a~shared.js";
+//#region a.js
+(globalThis.sideEffectLog ??= []).push("a");
+foo();
+//#endregion
+
+```
+
+## b.js
+
+```js
+//#region b.js
+(globalThis.sideEffectLog ??= []).push("b");
+import("./common~a~shared.js").then((n) => n.n).then(({ foo }) => {
+	foo();
+});
+//#endregion
+
+```
+
+## common~a~shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	(globalThis.sideEffectLog ??= []).push("shared-foo");
+}
+//#endregion
+export { shared_exports as n, foo as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/b.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/b.js
@@ -1,0 +1,7 @@
+// Entry `b` reaches `shared.js` only through a dynamic import, so executing `b`
+// must not trigger entry `a`'s top-level side effect.
+(globalThis.sideEffectLog ??= []).push('b');
+
+import('./shared.js').then(({ foo }) => {
+  foo();
+});

--- a/crates/rolldown/tests/rolldown/issues/9463_without_strict/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/9463_without_strict/shared.js
@@ -1,0 +1,3 @@
+export function foo() {
+  (globalThis.sideEffectLog ??= []).push('shared-foo');
+}


### PR DESCRIPTION

related #9998
# Summary
Because manualCodeSplitting lacks strictExecutionOrder, entry-a, entry-b, and shared are merged into a single common chunk. Without wrappers to isolate these three modules (entry-a, entry-b, and shared), loading one entry will inevitably trigger the other. This same issue also occurs in the crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_shared_deps/ test. Therefore, adding a condition before merging the chunks can prevent this merge from happening.