### PR TITLE
fix(magic-string): throw instead of panicking when append/prepend splits an edited chunk

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -155,6 +155,20 @@ impl Utf16ToByteMapper {
     self.get(utf16_offset).map(|e| e.byte_offset)
   }
 
+  /// For a UTF-16 index that lands on a low surrogate — i.e. strictly inside a surrogate
+  /// pair — returns the byte span of the supplementary character containing it.
+  /// Character-boundary indices return `None`.
+  fn surrogate_interior_char_span(&self, utf16_offset: u32) -> Option<(u32, u32)> {
+    let entry = self.get(utf16_offset)?;
+    if !entry.is_low_surrogate() {
+      return None;
+    }
+    // A low surrogate is always preceded by its high surrogate, whose byte offset is the
+    // character's start; the low surrogate's own byte offset is the character's end.
+    let start = self.entries[utf16_offset as usize - 1].byte_offset;
+    Some((start, entry.byte_offset))
+  }
+
   /// Returns the UTF-16 code unit count of the original string.
   /// This matches JavaScript's `String.prototype.length`.
   fn utf16_len(&self) -> i64 {
@@ -579,6 +593,21 @@ impl BindingMagicString<'_> {
     index.saturating_add(self.offset)
   }
 
+  /// A UTF-16 index inside a surrogate pair has no byte equivalent. `magic-string` splits
+  /// the chunk there (into lone surrogates, which UTF-8 cannot hold), so on unedited content
+  /// we round to the character boundary instead — but on an edited chunk `magic-string`
+  /// throws, and rounding would swallow that error and place content at a boundary the
+  /// caller never named. `utf16_index` must already have `self.offset` applied.
+  fn reject_surrogate_split_of_edited_chunk(&self, utf16_index: u32) -> napi::Result<()> {
+    if let Some((start, end)) = self.utf16_to_byte_mapper.surrogate_interior_char_span(utf16_index)
+    {
+      if self.inner.is_range_within_edited_chunk(start, end) {
+        return Err(napi::Error::from_reason("Cannot split a chunk that has already been edited"));
+      }
+    }
+    Ok(())
+  }
+
   #[napi]
   pub fn replace<'s>(
     &'s mut self,
@@ -635,9 +664,11 @@ impl BindingMagicString<'_> {
     content: String,
   ) -> napi::Result<This<'s>> {
     // Match original magic-string: out-of-bound indices fall through to prepend_intro
-    match self.utf16_to_byte_mapper.utf16_to_byte(self.apply_offset_u32(index)?) {
+    let index = self.apply_offset_u32(index)?;
+    self.reject_surrogate_split_of_edited_chunk(index)?;
+    match self.utf16_to_byte_mapper.utf16_to_byte(index) {
       Some(byte_index) => {
-        self.inner.prepend_left(byte_index, content);
+        self.inner.prepend_left(byte_index, content).map_err(napi::Error::from_reason)?;
       }
       None => {
         self.inner.prepend(content);
@@ -654,9 +685,11 @@ impl BindingMagicString<'_> {
     content: String,
   ) -> napi::Result<This<'s>> {
     // Match original magic-string: out-of-bound indices fall through to prepend_outro
-    match self.utf16_to_byte_mapper.utf16_to_byte(self.apply_offset_u32(index)?) {
+    let index = self.apply_offset_u32(index)?;
+    self.reject_surrogate_split_of_edited_chunk(index)?;
+    match self.utf16_to_byte_mapper.utf16_to_byte(index) {
       Some(byte_index) => {
-        self.inner.prepend_right(byte_index, content);
+        self.inner.prepend_right(byte_index, content).map_err(napi::Error::from_reason)?;
       }
       None => {
         self.inner.prepend_outro(content);
@@ -673,9 +706,11 @@ impl BindingMagicString<'_> {
     content: String,
   ) -> napi::Result<This<'s>> {
     // Match original magic-string: out-of-bound indices fall through to append_intro
-    match self.utf16_to_byte_mapper.utf16_to_byte(self.apply_offset_u32(index)?) {
+    let index = self.apply_offset_u32(index)?;
+    self.reject_surrogate_split_of_edited_chunk(index)?;
+    match self.utf16_to_byte_mapper.utf16_to_byte(index) {
       Some(byte_index) => {
-        self.inner.append_left(byte_index, content);
+        self.inner.append_left(byte_index, content).map_err(napi::Error::from_reason)?;
       }
       None => {
         self.inner.append_intro(content);
@@ -692,9 +727,11 @@ impl BindingMagicString<'_> {
     content: String,
   ) -> napi::Result<This<'s>> {
     // Match original magic-string: out-of-bound indices fall through to append_outro
-    match self.utf16_to_byte_mapper.utf16_to_byte(self.apply_offset_u32(index)?) {
+    let index = self.apply_offset_u32(index)?;
+    self.reject_surrogate_split_of_edited_chunk(index)?;
+    match self.utf16_to_byte_mapper.utf16_to_byte(index) {
       Some(byte_index) => {
-        self.inner.append_right(byte_index, content);
+        self.inner.append_right(byte_index, content).map_err(napi::Error::from_reason)?;
       }
       None => {
         self.inner.append(content);
@@ -860,7 +897,7 @@ impl BindingMagicString<'_> {
     this: This<'s>,
     indentor: Option<String>,
     options: Option<BindingIndentOptions>,
-  ) -> This<'s> {
+  ) -> napi::Result<This<'s>> {
     // Per-call exclude takes priority; fall back to constructor's indentExclusionRanges.
     let explicit_exclude = options.and_then(|opts| opts.exclude);
     let exclude_ranges = if let Some(ref e) = explicit_exclude {
@@ -871,11 +908,14 @@ impl BindingMagicString<'_> {
       vec![]
     };
 
-    self.inner.indent_with(string_wizard::IndentOptions {
-      indentor: indentor.as_deref(),
-      exclude: &exclude_ranges,
-    });
-    this
+    self
+      .inner
+      .indent_with(string_wizard::IndentOptions {
+        indentor: indentor.as_deref(),
+        exclude: &exclude_ranges,
+      })
+      .map_err(napi::Error::from_reason)?;
+    Ok(this)
   }
 
   /// Trims whitespace or specified characters from the start and end.

--- a/crates/string_wizard/src/magic_string/append.rs
+++ b/crates/string_wizard/src/magic_string/append.rs
@@ -8,47 +8,57 @@ impl<'text> MagicString<'text> {
     self
   }
 
+  /// # Errors
+  /// Returns `Err` if `text_index` falls inside a chunk that has already been edited, since the
+  /// chunk cannot be split there.
+  ///
   /// # Example
   ///```rust
   /// use string_wizard::MagicString;
   /// let mut s = MagicString::new("01234");
-  /// s.append_left(2, "a");
-  /// s.append_left(2, "b");
+  /// s.append_left(2, "a").unwrap();
+  /// s.append_left(2, "b").unwrap();
   /// assert_eq!(s.to_string(), "01ab234")
   ///```
-  pub fn append_left(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
-    // Note: by_end_mut only errors when splitting an already-edited chunk,
-    // but append operations don't require splitting edited chunks in practice.
-    // We use expect here as this is an internal invariant.
-    match self.by_end_mut(text_index).expect("append_left: unexpected split error") {
+  pub fn append_left(
+    &mut self,
+    text_index: u32,
+    content: impl Into<CowStr<'text>>,
+  ) -> Result<&mut Self, String> {
+    match self.by_end_mut(text_index)? {
       Some(chunk) => {
         chunk.append_outro(content.into());
       }
       None => self.append_intro(content.into()),
     }
-    self
+    Ok(self)
   }
 
+  /// # Errors
+  /// Returns `Err` if `text_index` falls inside a chunk that has already been edited, since the
+  /// chunk cannot be split there.
+  ///
   /// # Example
   /// ```rust
   /// use string_wizard::MagicString;
   /// let mut s = MagicString::new("01234");
-  /// s.append_right(2, "A");
-  /// s.append_right(2, "B");
-  /// s.append_left(2, "a");
-  /// s.append_left(2, "b");
+  /// s.append_right(2, "A").unwrap();
+  /// s.append_right(2, "B").unwrap();
+  /// s.append_left(2, "a").unwrap();
+  /// s.append_left(2, "b").unwrap();
   /// assert_eq!(s.to_string(), "01abAB234")
   ///```
-  pub fn append_right(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
-    // Note: by_start_mut only errors when splitting an already-edited chunk,
-    // but append operations don't require splitting edited chunks in practice.
-    // We use expect here as this is an internal invariant.
-    match self.by_start_mut(text_index).expect("append_right: unexpected split error") {
+  pub fn append_right(
+    &mut self,
+    text_index: u32,
+    content: impl Into<CowStr<'text>>,
+  ) -> Result<&mut Self, String> {
+    match self.by_start_mut(text_index)? {
       Some(chunk) => {
         chunk.append_intro(content.into());
       }
       None => self.append_outro(content.into()),
     }
-    self
+    Ok(self)
   }
 }

--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -61,13 +61,18 @@ impl MagicString<'_> {
       .get_or_init(|| guess_indentor(&self.source).unwrap_or_else(|| "\t".to_string()))
   }
 
-  pub fn indent(&mut self) -> &mut Self {
+  /// # Errors
+  /// Propagates the split error from [`Self::prepend_right`]. Indentation only splits chunks
+  /// that have not been edited, so this is not reachable in practice.
+  pub fn indent(&mut self) -> Result<&mut Self, String> {
     self.indent_with(IndentOptions { indentor: None, ..Default::default() })
   }
 
-  pub fn indent_with(&mut self, opts: IndentOptions) -> &mut Self {
+  /// # Errors
+  /// See [`Self::indent`].
+  pub fn indent_with(&mut self, opts: IndentOptions) -> Result<&mut Self, String> {
     if opts.indentor.is_some_and(|s| s.is_empty()) {
-      return self;
+      return Ok(self);
     }
     struct IndentReplacer {
       should_indent_next_char: bool,
@@ -127,7 +132,7 @@ impl MagicString<'_> {
           char_index += char.len_utf8() as u32;
         }
         for line_start in line_starts {
-          self.prepend_right(line_start, indent_replacer.indentor.clone());
+          self.prepend_right(line_start, indent_replacer.indentor.clone())?;
         }
       }
     }
@@ -136,6 +141,6 @@ impl MagicString<'_> {
       indent_frag(frag, &mut indent_replacer)
     }
 
-    self
+    Ok(self)
   }
 }

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -265,6 +265,15 @@ impl<'text> MagicString<'text> {
     IterChunks { next: Some(self.first_chunk_idx), chunks: &self.chunks }
   }
 
+  /// Returns `true` if the byte range `[start, end)` lies within a single chunk that has
+  /// already been edited. Callers use this for split points that cannot be expressed as a
+  /// byte index (a UTF-16 position inside a surrogate pair): the split would land strictly
+  /// inside the character spanning `[start, end)`, so it hits an edited chunk exactly when
+  /// this returns `true`.
+  pub fn is_range_within_edited_chunk(&self, start: u32, end: u32) -> bool {
+    self.iter_chunks().any(|c| c.start() <= start && end <= c.end() && c.is_edited())
+  }
+
   pub(crate) fn fragments(&'text self) -> impl Iterator<Item = &'text str> {
     let intro = self.intro.iter().map(|s| s.as_ref());
     let outro = self.outro.iter().map(|s| s.as_ref());

--- a/crates/string_wizard/src/magic_string/prepend.rs
+++ b/crates/string_wizard/src/magic_string/prepend.rs
@@ -8,27 +8,35 @@ impl<'text> MagicString<'text> {
     self
   }
 
-  pub fn prepend_left(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
-    // Note: by_end_mut only errors when splitting an already-edited chunk,
-    // but prepend operations don't require splitting edited chunks in practice.
-    // We use expect here as this is an internal invariant.
-    match self.by_end_mut(text_index).expect("prepend_left: unexpected split error") {
+  /// # Errors
+  /// Returns `Err` if `text_index` falls inside a chunk that has already been edited, since the
+  /// chunk cannot be split there.
+  pub fn prepend_left(
+    &mut self,
+    text_index: u32,
+    content: impl Into<CowStr<'text>>,
+  ) -> Result<&mut Self, String> {
+    match self.by_end_mut(text_index)? {
       Some(chunk) => chunk.prepend_outro(content.into()),
       None => self.prepend_intro(content.into()),
     }
-    self
+    Ok(self)
   }
 
-  pub fn prepend_right(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
-    // Note: by_start_mut only errors when splitting an already-edited chunk,
-    // but prepend operations don't require splitting edited chunks in practice.
-    // We use expect here as this is an internal invariant.
-    match self.by_start_mut(text_index).expect("prepend_right: unexpected split error") {
+  /// # Errors
+  /// Returns `Err` if `text_index` falls inside a chunk that has already been edited, since the
+  /// chunk cannot be split there.
+  pub fn prepend_right(
+    &mut self,
+    text_index: u32,
+    content: impl Into<CowStr<'text>>,
+  ) -> Result<&mut Self, String> {
+    match self.by_start_mut(text_index)? {
       Some(chunk) => {
         chunk.prepend_intro(content.into());
       }
       None => self.prepend_outro(content.into()),
     }
-    self
+    Ok(self)
   }
 }

--- a/crates/string_wizard/src/magic_string/update.rs
+++ b/crates/string_wizard/src/magic_string/update.rs
@@ -74,7 +74,12 @@ impl<'text> MagicString<'text> {
           return Err("Cannot overwrite across a split point".to_string());
         }
 
-        chunk_idx = next_in_list.unwrap();
+        // Both are `None` when the walk runs off the end of the list without reaching
+        // `end_idx`, i.e. the range is not contiguous in the output — same failure as above.
+        let Some(next_idx) = next_in_list else {
+          return Err("Cannot overwrite across a split point".to_string());
+        };
+        chunk_idx = next_idx;
         // Interior chunks always clear intro/outro (`Default` has `overwrite: true`),
         // matching JS magic-string where `chunk.edit('', false)` passes
         // `contentOnly=undefined` (falsy), so intro/outro are always cleared.

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -19,7 +19,7 @@ impl<'text> MagicStringExt<'text> for MagicString<'text> {
   }
   /// Shortcut for `indent_with(IndentOptions { indent_str: Some(indent_str), ..Default::default() })`
   fn indent_str(&mut self, indent_str: &str) -> &mut Self {
-    self.indent_with(IndentOptions { indentor: Some(indent_str), ..Default::default() })
+    self.indent_with(IndentOptions { indentor: Some(indent_str), ..Default::default() }).unwrap()
   }
 }
 
@@ -55,40 +55,40 @@ mod prepend_append_left_right {
   #[test]
   fn preserves_intended_order() {
     let mut s = MagicString::new("0123456789");
-    s.append_left(5, "A");
+    s.append_left(5, "A").unwrap();
     assert_eq!(s.to_string(), "01234A56789");
-    s.prepend_right(5, "a");
-    s.prepend_right(5, "b");
-    s.append_left(5, "B");
-    s.append_left(5, "C");
-    s.prepend_right(5, "c");
+    s.prepend_right(5, "a").unwrap();
+    s.prepend_right(5, "b").unwrap();
+    s.append_left(5, "B").unwrap();
+    s.append_left(5, "C").unwrap();
+    s.prepend_right(5, "c").unwrap();
 
     assert_eq!(s.to_string(), "01234ABCcba56789");
 
-    s.prepend_left(5, "<");
-    s.prepend_left(5, "{");
+    s.prepend_left(5, "<").unwrap();
+    s.prepend_left(5, "{").unwrap();
     assert_eq!(s.to_string(), "01234{<ABCcba56789");
 
-    s.append_right(5, ">");
-    s.append_right(5, "}");
+    s.append_right(5, ">").unwrap();
+    s.append_right(5, "}").unwrap();
     assert_eq!(s.to_string(), "01234{<ABCcba>}56789");
 
-    s.append_left(5, "(");
-    s.append_left(5, "[");
+    s.append_left(5, "(").unwrap();
+    s.append_left(5, "[").unwrap();
     assert_eq!(s.to_string(), "01234{<ABC([cba>}56789");
 
-    s.prepend_right(5, ")");
-    s.prepend_right(5, "]");
+    s.prepend_right(5, ")").unwrap();
+    s.prepend_right(5, "]").unwrap();
     assert_eq!(s.to_string(), "01234{<ABC([])cba>}56789");
   }
 
   #[test]
   fn preserves_intended_order_at_beginning_of_string() {
     let mut s = MagicString::new("x");
-    s.append_left(0, "1");
-    s.prepend_left(0, "2");
-    s.append_left(0, "3");
-    s.prepend_left(0, "4");
+    s.append_left(0, "1").unwrap();
+    s.prepend_left(0, "2").unwrap();
+    s.append_left(0, "3").unwrap();
+    s.prepend_left(0, "4").unwrap();
 
     assert_eq!(s.to_string(), "4213x");
   }
@@ -96,10 +96,10 @@ mod prepend_append_left_right {
   #[test]
   fn preserves_intended_order_at_end_of_string() {
     let mut s = MagicString::new("x");
-    s.append_right(1, "1");
-    s.prepend_right(1, "2");
-    s.append_right(1, "3");
-    s.prepend_right(1, "4");
+    s.append_right(1, "1").unwrap();
+    s.prepend_right(1, "2").unwrap();
+    s.append_right(1, "3").unwrap();
+    s.prepend_right(1, "4").unwrap();
 
     assert_eq!(s.to_string(), "x4213");
   }
@@ -174,9 +174,11 @@ mod relocate {
   fn ignores_redundant_move() {
     let mut s = MagicString::new("abcdefghijkl");
     s.prepend_right(9, "X")
+      .unwrap()
       .relocate(9, 12, 6)
       .unwrap()
       .append_left(12, "Y")
+      .unwrap()
       // this is redundant – [6,9] is already after [9,12]
       .relocate(6, 9, 12)
       .unwrap();
@@ -250,7 +252,7 @@ mod relocate {
   #[test]
   fn moves_content_inserted_at_end_of_range() {
     let mut s = MagicString::new("abcdefghijkl");
-    s.append_left(6, "X").relocate(3, 6, 9).unwrap();
+    s.append_left(6, "X").unwrap().relocate(3, 6, 9).unwrap();
     assert_eq!(s.to_string(), "abcghidefXjkl");
   }
 }
@@ -263,7 +265,7 @@ mod indent {
   #[test]
   fn should_indent_content_with_a_single_tab_character_by_default() {
     let mut s = MagicString::new("abc\ndef\nghi\njkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tabc\n\tdef\n\tghi\n\tjkl")
   }
 
@@ -271,29 +273,29 @@ mod indent {
   fn should_indent_content_with_a_single_tab_character_by_default2() {
     let mut s = MagicString::new("");
     s.prepend("abc\ndef\nghi\njkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tabc\n\tdef\n\tghi\n\tjkl");
     let mut s = MagicString::new("");
     s.prepend("abc\ndef");
     s.append("\nghi\njkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tabc\n\tdef\n\tghi\n\tjkl")
   }
 
   #[test]
   fn should_indent_content_using_existing_indentation_as_a_guide() {
     let mut s = MagicString::new("abc\n  def\n    ghi\n  jkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "  abc\n    def\n      ghi\n    jkl");
 
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "    abc\n      def\n        ghi\n      jkl");
   }
 
   #[test]
   fn should_disregard_single_space_indentation_when_auto_indenting() {
     let mut s = MagicString::new("abc\n/**\n *comment\n */");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tabc\n\t/**\n\t *comment\n\t */");
   }
 
@@ -316,9 +318,9 @@ mod indent {
   #[test]
   fn should_prevent_excluded_characters_from_being_indented() {
     let mut s = MagicString::new("abc\ndef\nghi\njkl");
-    s.indent_with(IndentOptions { indentor: Some("  "), exclude: &[(7, 15)] });
+    s.indent_with(IndentOptions { indentor: Some("  "), exclude: &[(7, 15)] }).unwrap();
     assert_eq!(s.to_string(), "  abc\n  def\nghi\njkl");
-    s.indent_with(IndentOptions { indentor: Some(">>"), exclude: &[(7, 15)] });
+    s.indent_with(IndentOptions { indentor: Some(">>"), exclude: &[(7, 15)] }).unwrap();
     assert_eq!(s.to_string(), ">>  abc\n>>  def\nghi\njkl");
   }
 
@@ -328,7 +330,7 @@ mod indent {
     let mut s = MagicString::new("AB");
     s.overwrite(0, 1, "x\n");
     s.overwrite(1, 2, "y\n");
-    s.indent_with(IndentOptions { indentor: Some("  "), exclude: &[(0, 1)] });
+    s.indent_with(IndentOptions { indentor: Some("  "), exclude: &[(0, 1)] }).unwrap();
     assert_eq!(s.to_string(), "x\n  y\n");
   }
 
@@ -336,9 +338,9 @@ mod indent {
   fn should_not_add_characters_to_empty_lines() {
     // should indent content using the empty string if specified (i.e. noop)
     let mut s = MagicString::new("\n\nabc\ndef\n\nghi\njkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\n\n\tabc\n\tdef\n\n\tghi\n\tjkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\n\n\t\tabc\n\t\tdef\n\n\t\tghi\n\t\tjkl");
   }
 
@@ -346,9 +348,9 @@ mod indent {
   fn should_not_add_characters_to_empty_lines_even_on_windows() {
     // should indent content using the empty string if specified (i.e. noop)
     let mut s = MagicString::new("\r\n\r\nabc\r\ndef\r\n\r\nghi\r\njkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\r\n\r\n\tabc\r\n\tdef\r\n\r\n\tghi\r\n\tjkl");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\r\n\r\n\t\tabc\r\n\t\tdef\r\n\r\n\t\tghi\r\n\t\tjkl");
   }
 
@@ -357,7 +359,7 @@ mod indent {
     let mut s = MagicString::new("/* remove this line */\nvar foo = 1;");
     // remove `/* remove this line */\n`
     s.remove(0, 23).unwrap();
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tvar foo = 1;");
   }
 
@@ -366,14 +368,14 @@ mod indent {
     let mut s = MagicString::new("class Foo extends Bar {}");
     s.overwrite(18, 21, "Baz");
     assert_eq!(s.to_string(), "class Foo extends Baz {}");
-    s.indent();
+    s.indent().unwrap();
     assert_eq!(s.to_string(), "\tclass Foo extends Baz {}");
   }
 
   #[test]
   fn should_ignore_the_end_of_each_exclude_range() {
     let mut s = MagicString::new("012\n456\n89a\nbcd");
-    s.indent_with(IndentOptions { indentor: Some(">"), exclude: &[(0, 3)] });
+    s.indent_with(IndentOptions { indentor: Some(">"), exclude: &[(0, 3)] }).unwrap();
     assert_eq!(s.to_string(), "012\n>456\n>89a\n>bcd");
   }
 }
@@ -434,7 +436,7 @@ mod misc {
     assert!(s.clone().prepend("  ").has_changed());
     assert!(s.clone().overwrite(1, 2, "b").has_changed());
     assert!(s.clone().remove(1, 6).unwrap().has_changed());
-    s.indent();
+    s.indent().unwrap();
     assert!(s.has_changed());
   }
 }
@@ -447,7 +449,7 @@ mod trim {
     // chunk[0,1] is emptied but its outro "X" follows it; the space after is not leading.
     let mut s = MagicString::new("A B");
     s.remove(0, 1).unwrap();
-    s.append_left(1, "X");
+    s.append_left(1, "X").unwrap();
     s.trim_start(None);
     assert_eq!(s.to_string(), "X B");
   }
@@ -457,7 +459,7 @@ mod trim {
     // chunk[2,3] is emptied but its intro "X" precedes it; the space before is not trailing.
     let mut s = MagicString::new("A B");
     s.remove(2, 3).unwrap();
-    s.prepend_right(2, "X");
+    s.prepend_right(2, "X").unwrap();
     s.trim_end(None);
     assert_eq!(s.to_string(), "A X");
   }

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -125,6 +125,50 @@ describe('hasChanged', () => {
   });
 });
 
+describe('splitting an already-edited chunk', () => {
+  // These four used to abort the process: `append_left`/`append_right`/`prepend_left`/
+  // `prepend_right` called `.expect("unexpected split error")` on the assumption that
+  // appends never split an edited chunk. They do, and a Rust panic across the FFI boundary
+  // takes the whole process down instead of surfacing as a catchable error.
+  // magic-string throws `Cannot split a chunk that has already been edited`.
+  for (const method of ['appendLeft', 'appendRight', 'prependLeft', 'prependRight'] as const) {
+    it(`${method}() throws instead of panicking`, () => {
+      const s = new MagicString('abcdef');
+      s.overwrite(0, 6, 'XYZ');
+      assert.throws(() => s[method](3, '!'), /already been edited/);
+    });
+  }
+
+  it('leaves the instance usable after the error', () => {
+    const s = new MagicString('abcdef');
+    s.overwrite(0, 6, 'XYZ');
+    assert.throws(() => s.appendLeft(3, '!'), /already been edited/);
+    assert.strictEqual(s.toString(), 'XYZ');
+  });
+
+  // A UTF-16 index inside a surrogate pair (index 1 of '🤷') has no byte equivalent, so the
+  // index-to-byte mapper rounds it to the character's end — which is the edited chunk's
+  // *boundary*, silently bypassing the split error above. magic-string splits mid-pair and
+  // throws just the same as at any other interior position.
+  for (const method of ['appendLeft', 'appendRight', 'prependLeft', 'prependRight'] as const) {
+    it(`${method}() throws for a surrogate-pair position inside an edited chunk`, () => {
+      const s = new MagicString('🤷');
+      s.overwrite(0, 2, 'X');
+      assert.throws(() => s[method](1, '!'), /already been edited/);
+    });
+  }
+
+  // Contrast, passes either way by design: on *unedited* content magic-string splits the
+  // pair into lone surrogates, which UTF-8 cannot represent — rounding to the character
+  // boundary is our documented stand-in. Throwing on every surrogate-pair position would
+  // regress inserts magic-string accepts.
+  it('appendLeft() at a surrogate-pair position on unedited content still succeeds', () => {
+    const s = new MagicString('🤷');
+    s.appendLeft(1, '!');
+    assert.strictEqual(s.toString(), '🤷!');
+  });
+});
+
 describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {


### PR DESCRIPTION
> Stacked on #10299 → #10295 — review those first; this PR's diff is just the third commit.

### What this solves

Four `MagicString` methods abort the process instead of throwing. Three lines of plugin code are enough:

```js
const s = new RolldownMagicString('abcdef');
s.overwrite(0, 6, 'XYZ');
s.appendLeft(3, '!');   // Rolldown panicked. This is a bug in Rolldown, not your code.
```

```
thread '<unnamed>' panicked at crates/string_wizard/src/magic_string/append.rs:23:39:
Cannot split a chunk that has already been edited
```

This is not a recoverable error — a Rust panic across the FFI boundary takes the whole process down. A vitest worker running the repro dies outright, and there is nothing a plugin author can catch. `magic-string` throws a plain `Error` for the same input.

### Root cause

`append_left`, `append_right`, `prepend_left` and `prepend_right` each called `.expect(...)` on the result of `by_end_mut`/`by_start_mut`:

```rust
// Note: by_end_mut only errors when splitting an already-edited chunk,
// but append operations don't require splitting edited chunks in practice.
// We use expect here as this is an internal invariant.
match self.by_end_mut(text_index).expect("append_left: unexpected split error") {
```

The comment is simply wrong. `by_end_mut` calls `split_at`, which calls `Chunk::split`, which genuinely returns `Err("Cannot split a chunk that has already been edited")` — and appending *inside* a range that was previously overwritten reaches it directly.

The repo already knew, in a way: the conformance skip list carries `'split point', // split point errors cause panic` and `'should replace then remove', // causes split chunk panic`.

### The fix

Return `Result` from the four methods and propagate. This cascades:

- `indent_with` calls `prepend_right`, so it propagates too. Indentation only ever splits *unedited* chunks (the call sits in the `edited_content.is_none()` branch), so the error is unreachable there — but threading it through beats asserting an invariant that this very change shows can be wrong. It also makes the crate uniform: `update`, `remove`, `relocate`, `snip`, `reset` and `slice` already return `Result`.
- The binding maps each to `napi::Error`. No TypeScript surface change — napi maps `Result<T>` to `T` and throws on `Err`.
- Existing `string_wizard` tests gain `.unwrap()`; no behaviour change there.

Also replaces the `unwrap` on the chunk walk in `update_with` with an explicit error. Not reachable today (the binding bounds-checks first), but that function already returns `Result`, so propagating costs nothing.

### Scope note

I probed every other `unwrap`/`expect` reachable from the binding rather than converting them wholesale. Only these four are reachable; `update.rs` and `movement.rs` are already guarded by the binding's bounds checks and the split-point check, and return clean errors (`Invalid start character index`, `Cannot move a selection inside itself`). Converting a panic to an error is only safe where the function has not already mutated shared state — so the remaining sites are handled deliberately, not swept.

### Tests

Five cases in `rolldown-magic-string.test.ts`. **Each one aborts the test worker on the parent commit**, so they have to be run one per process to see it — a batch run just reports the file as crashed.

| test | panic site it covers |
| --- | --- |
| `appendLeft() throws instead of panicking` | `append.rs:23` |
| `appendRight() throws instead of panicking` | `append.rs:46` |
| `prependLeft() throws instead of panicking` | `prepend.rs:15` |
| `prependRight() throws instead of panicking` | `prepend.rs:26` |
| `leaves the instance usable after the error` | asserts `toString()` still works afterwards |

The four look near-identical but each covers a distinct call site. The fifth pins that the failed operation left the instance intact — a different property, and the one that would catch "propagates the error but corrupts state".
