### PR TITLE
fix(ci): fetch the pinned vite commit before checking it out

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -64,8 +64,17 @@ await runCmdAndPipeOrExit(
   ['git', ['clone', 'https://github.com/vitejs/vite.git', REPO_PATH]],
 );
 
-// The pinned commit must be pushed to vitejs/vite (same requirement as the
-// submodule itself), otherwise this checkout fails.
+// `clone` only brings down branches and their history, so a pin that no branch
+// contains never arrives, and the checkout below fails with `unable to read
+// tree`. That is what happens once the branch the pin was pushed on is
+// force-pushed or deleted. The remote still serves the commit when it is asked
+// for by sha, which is how `git submodule update` recovers the same case for
+// the submodule this pin is read from.
+await runCmdAndPipeOrExit(
+  `# Fetching pinned vite commit ${vitePin}...`,
+  ['git', ['fetch', 'origin', vitePin], { nodeOptions: { cwd: REPO_PATH } }],
+);
+
 await runCmdAndPipeOrExit(
   `# Checking out pinned vite commit ${vitePin}...`,
   ['git', ['-c', 'advice.detachedHead=false', 'checkout', vitePin], { nodeOptions: { cwd: REPO_PATH } }],


### PR DESCRIPTION
## Summary

`Vite Test Ubuntu` has been failing **during setup** on `main` and on every PR since #10164 landed at 06:52 UTC today ([example run](https://github.com/rolldown/rolldown/actions/runs/29426838433/job/87391835474)):

```
# Checking out pinned vite commit f5d4fa671808d08656f799268a2857db6a1c31e7...
fatal: unable to read tree (f5d4fa671808d08656f799268a2857db6a1c31e7)
```

`packages/vite-tests/run.ts` clones `vitejs/vite` and then checks out the commit pinned by the `packages/test-dev-server/vite` submodule. `git clone` only brings down branches and their history, so a pin that no branch contains is never fetched, and the checkout fails. The pin `f5d4fa67` sits on vite's `feat/client-side-hmr`, which has since been force-pushed, so it is now reachable from **none** of vite's 73 branches.

This PR asks the remote for the commit by sha before checking it out. The remote still serves it, and this is how `git submodule update` already recovers the same case for the submodule the pin is read from — git's own message for that path is *"Fetched in submodule path '…', but it did not contain `<sha>`. Direct fetching of that commit failed."*

**This fixes the setup crash, and that is all it fixes — CI on this PR is still red.** See below; the remaining failures are pre-existing problems with the pin that this change deliberately does not touch. They were simply invisible while setup was dying.

## Verification — the setup crash is fixed

From this PR's own CI run ([job](https://github.com/rolldown/rolldown/actions/runs/29429032532)), setup now clears end to end:

```
# Cloning vite repo...
# Fetching pinned vite commit f5d4fa671808d08656f799268a2857db6a1c31e7...
# Checking out pinned vite commit f5d4fa671808d08656f799268a2857db6a1c31e7...
HEAD is now at f5d4fa671 only full-reload when a fallback is generated in the initial build
# Updating pnpm-workspace.yaml to link to local rolldown...
# Running `pnpm install`... / playwright install / pnpm run build
# Running `pnpm test-unit`...     -> 64 passed (64)
```

The added fetch is a no-op when the pin *is* reachable (both a branch tip and an older ancestor of `main` fetch with exit 0), so healthy pins are unaffected. One `run.ts` covers both jobs, since Ubuntu and Windows both run `vp run --filter vite-tests test`.

## What is still red, and why it is a separate problem

With setup unblocked, the suite runs and two test files fail:

| suite | result | failing file |
| --- | --- | --- |
| `test-unit` | 64 passed (64) | — |
| `test-serve` | 1 failed, 1102 passed, 159 skipped | `playground/tsconfig-json-load-error` |
| `test-build` | 1 failed, 900 passed, 280 skipped | `playground/js-sourcemap` |

Both trace back to the same root: **the pin is a stale branch off vite `main`, whereas this suite used to test `rolldown-canary`.** Before #10164, `run.ts` did `git clone --branch rolldown-canary` + `git rebase origin/main`. #10164 replaced that with the submodule pin, which is based on vite `main` and therefore has neither `rolldown-canary`'s rolldown-specific test adaptations nor the last 25 commits of vite `main`.

1. **`tsconfig-json-load-error`** — a lineage problem. `rolldown-canary` deliberately relaxes this assertion for rolldown; the pin has vite `main`'s esbuild-oriented one:

   | ref | expectation |
   | --- | --- |
   | `rolldown-canary` | `/(\[TSCONFIG_ERROR\] )*Failed to load tsconfig\|JSONError/` |
   | pin (= `main`) | `/(\[TSCONFIG_ERROR\] )*Failed to load tsconfig .*: JSON parse error\|JSONError/` |

   rolldown emits `Failed to load tsconfig '…': expected value at line 4 column 1`, which matches the first but not the second. `rolldown-canary`'s `85aeb0081` touches exactly this file.

2. **`js-sourcemap`** — a staleness problem. This spec is byte-identical on the pin and on `rolldown-canary`, so it is not a lineage issue; the pin is simply 25 commits behind vite `main`, and the snapshot depends on newer vite behaviour.

## Suggested follow-up (owner's call, not done here)

`rolldown-canary` is `main + 2` and **already contains `feat(bundled-dev): client-side HMR` (`4d1480ca0`)** plus the rolldown test adaptations, and being a real branch it is always reachable. It looks like the pin the suite actually wants. The one thing it does *not* carry is `f5d4fa671` *"only full-reload when a fallback is generated in the initial build"*, so re-pointing naively would drop that — which is why this PR does not touch the pin.

cc @h-a-n-a @sapphi-red — you own #10164 and the vite side, and this overlaps #10293. Two things worth deciding: whether the pin should track `rolldown-canary` (pushing `f5d4fa671`'s change there if it is still wanted), and, longer term, that a pin which no branch contains is fragile regardless — GitHub serves the object today but may garbage-collect it, after which this fetch fails too (with a clearer error naming the sha).
