### PR TITLE
fix(magic-string): count positional inserts at index 0 on an empty source

### DIFF
--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -320,24 +320,27 @@ impl<'text> MagicString<'text> {
     Ok(())
   }
 
+  /// Returns the chunk starting at `text_index`, or `None` if no chunk does — in which case
+  /// the caller sends the content to the global outro.
+  ///
+  /// Do not short-circuit on `text_index == self.source.len()`: for an empty source the sole
+  /// `[0, 0)` chunk both starts *and* ends at 0, so index 0 has a chunk even though it is also
+  /// the end of the source. The map lookup already answers this correctly for both cases, and
+  /// matches the reference `magic-string`, which does a plain `byStart[index]` lookup.
   fn by_start_mut(&mut self, text_index: u32) -> Result<Option<&mut Chunk<'text>>, String> {
-    if text_index as usize == self.source.len() {
-      Ok(None)
-    } else {
-      self.split_at(text_index)?;
-      let idx = self.chunk_by_start.get(&text_index);
-      Ok(idx.map(|idx| &mut self.chunks[*idx]))
-    }
+    self.split_at(text_index)?;
+    let idx = self.chunk_by_start.get(&text_index);
+    Ok(idx.map(|idx| &mut self.chunks[*idx]))
   }
 
+  /// Returns the chunk ending at `text_index`, or `None` if no chunk does — in which case the
+  /// caller sends the content to the global intro.
+  ///
+  /// Do not short-circuit on `text_index == 0`: see [`Self::by_start_mut`].
   fn by_end_mut(&mut self, text_index: u32) -> Result<Option<&mut Chunk<'text>>, String> {
-    if text_index == 0 {
-      Ok(None)
-    } else {
-      self.split_at(text_index)?;
-      let idx = self.chunk_by_end.get(&text_index);
-      Ok(idx.map(|idx| &mut self.chunks[*idx]))
-    }
+    self.split_at(text_index)?;
+    let idx = self.chunk_by_end.get(&text_index);
+    Ok(idx.map(|idx| &mut self.chunks[*idx]))
   }
 }
 

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -42,6 +42,56 @@ describe('length', () => {
     s.append('🤷');
     assert.strictEqual(s.length(), 3);
   });
+
+  // An empty source still has one `[0, 0)` chunk, and index 0 is both its start and its end —
+  // so a positional insert there belongs *on the chunk* and counts, exactly as it does in
+  // magic-string. `by_start_mut`/`by_end_mut` used to short-circuit on `index == source.len()`
+  // / `index == 0` and push the content to the global intro/outro instead, where `length()`
+  // cannot see it.
+  describe('positional inserts at index 0 on an empty source', () => {
+    for (const method of ['appendLeft', 'appendRight', 'prependLeft', 'prependRight'] as const) {
+      it(`${method}(0, ...) is counted`, () => {
+        const s = new MagicString('');
+        s[method](0, 'é');
+        assert.strictEqual(s.toString(), 'é');
+        assert.strictEqual(s.length(), 1);
+        assert.strictEqual(s.isEmpty(), false);
+      });
+    }
+
+    it('counts UTF-16 code units, not bytes, for the inserted content', () => {
+      const s = new MagicString('');
+      s.appendLeft(0, '🤷');
+      assert.strictEqual(s.length(), 2);
+    });
+
+    // The contrast: `append`/`prepend` are not positional, so they land in the global
+    // intro/outro and stay excluded — on an empty source as anywhere else.
+    for (const method of ['append', 'prepend'] as const) {
+      it(`${method}(...) stays excluded`, () => {
+        const s = new MagicString('');
+        s[method]('é');
+        assert.strictEqual(s.toString(), 'é');
+        assert.strictEqual(s.length(), 0);
+        assert.strictEqual(s.isEmpty(), true);
+      });
+    }
+  });
+
+  // The short-circuits were right for a non-empty source: nothing ends at 0 and nothing starts
+  // at `source.len()`, so those inserts do belong in the global intro/outro. Removing them must
+  // not change that.
+  it('keeps out-of-chunk-range inserts on a non-empty source excluded', () => {
+    const left = new MagicString('abc');
+    left.appendLeft(0, 'X');
+    assert.strictEqual(left.toString(), 'Xabc');
+    assert.strictEqual(left.length(), 3);
+
+    const right = new MagicString('abc');
+    right.appendRight(3, 'X');
+    assert.strictEqual(right.toString(), 'abcX');
+    assert.strictEqual(right.length(), 3);
+  });
 });
 
 describe('offset', () => {


### PR DESCRIPTION
> Stacked on #10295 — review that first; this PR's diff is just the second commit.
>
> Reported by @hyfdev in https://github.com/rolldown/rolldown/pull/10295#discussion_r3588401894. Split out of #10295 rather than folded into it: the cause is unrelated (chunk placement, not unit conversion) and it also changes `isEmpty()`, so it deserves its own entry in the history. It can't sit *below* #10295 though — see "Why it stacks here".

### What this solves

A positional insert at index 0 on an **empty** source is not counted:

```js
const s = new RolldownMagicString('');
s.appendLeft(0, 'é');
s.toString();  // 'é'
s.length();    // 0  — magic-string returns 1
s.isEmpty();   // true — magic-string returns false
```

All four positional methods reproduce it, and an emoji returns `0` instead of `2`. Pre-existing: `main` returns `0` here too, since `length()` there also walks chunks only.

### Root cause

`by_start_mut` and `by_end_mut` answered *before* consulting the chunk maps:

```rust
fn by_start_mut(..) { if text_index as usize == self.source.len() { Ok(None) } .. }
fn by_end_mut(..)   { if text_index == 0 { Ok(None) } .. }
```

Both are shortcuts for "no chunk at this index". That holds for a non-empty source — nothing ends at 0, nothing starts at `len`. It is false for an empty source: its sole `[0, 0)` chunk both **starts and ends at 0**, and the constructor registers it under `chunk_by_start[0]` *and* `chunk_by_end[0]`. The guard fired first, so the content was routed to the global intro/outro, which `length()` and `isEmpty()` deliberately exclude.

`magic-string` has no such special case — `appendLeft` is a plain `byEnd[index]` lookup, `appendRight` a plain `byStart[index]` lookup, and on an empty source both hit the zero-length chunk.

### The fix

Delete both shortcuts and let the map answer. Correct for both cases — on `'abc'`, `chunk_by_end.get(0)` returns `None` anyway, so out-of-chunk-range inserts still go to the global intro/outro exactly as before.

### Why it stacks here and not below #10295

On its own this fix would still be wrong. With the guards gone but no UTF-16 change, `''` + `appendLeft(0, 'é')` puts `é` on the chunk and `len()` counts its **2 bytes** — so `length()` returns 2, not 1. The correct answer only appears with both changes, which is why this sits directly on top of the `length()` UTF-16 fix.

### Tests

Eight cases. **Five fail without this change**: the four positional methods at index 0, plus the emoji UTF-16 case.

The other three are the contrast @hyfdev asked for, and they pass either way by design:

- `append('é')` / `prepend('é')` on an empty source stay **excluded** (`length() === 0`) — they are not positional, so they belong in the global intro/outro.
- Non-empty out-of-range inserts (`'abc'` + `appendLeft(0, 'X')` / `appendRight(3, 'X')`) stay **excluded**.

They earn their place: the tempting alternative fix is to make `len_utf16` count the global intro/outro, which would satisfy all five failing tests while breaking exactly these three.

### Verification

Differential run against `magic-string@0.30.21` over 11 cases (`toString`, `length`, `isEmpty`): **0 divergences**, down from 5 before this change. The 199-test vendored upstream conformance suite still passes.
