### PR TITLE
test(code-splitting): cover entries-aware strict init cycle

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/10259/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10259/_config.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "https://github.com/rolldown/rolldown/issues/10259 — an entries-aware manual group merges three entry-private app modules while leaving app-personal's private dependency in the personal entry chunk. The resulting common-chunk/entry-chunk cycle must keep every strict init wrapper callable regardless of which entry is loaded first.",
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "personal",
+        "import": "./personal.js"
+      },
+      {
+        "name": "admin",
+        "import": "./admin.js"
+      },
+      {
+        "name": "theming",
+        "import": "./theming.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "apps",
+          "test": "[\\\\/]app-(?:personal|admin|theming)\\.js$",
+          "includeDependenciesRecursively": false,
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 102400
+        }
+      ]
+    },
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/10259/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/10259/_test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+
+globalThis.sideEffectLog = [];
+
+await import('./dist/admin.js');
+assert.deepStrictEqual(globalThis.sideEffectLog, ['app-admin', 'admin']);
+
+await import('./dist/theming.js');
+assert.deepStrictEqual(globalThis.sideEffectLog, ['app-admin', 'admin', 'app-theming', 'theming']);
+
+await import('./dist/personal.js');
+assert.deepStrictEqual(globalThis.sideEffectLog, [
+  'app-admin',
+  'admin',
+  'app-theming',
+  'theming',
+  'palette-icon',
+  'app-personal:PaletteIcon',
+  'personal',
+]);

--- a/crates/rolldown/tests/rolldown/issues/10259/admin.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/admin.js
@@ -1,0 +1,3 @@
+import './app-admin.js';
+
+(globalThis.sideEffectLog ??= []).push('admin');

--- a/crates/rolldown/tests/rolldown/issues/10259/app-admin.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/app-admin.js
@@ -1,0 +1,1 @@
+(globalThis.sideEffectLog ??= []).push('app-admin');

--- a/crates/rolldown/tests/rolldown/issues/10259/app-personal.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/app-personal.js
@@ -1,0 +1,3 @@
+import { PaletteIcon } from './palette-icon.js';
+
+(globalThis.sideEffectLog ??= []).push(`app-personal:${PaletteIcon}`);

--- a/crates/rolldown/tests/rolldown/issues/10259/app-theming.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/app-theming.js
@@ -1,0 +1,1 @@
+(globalThis.sideEffectLog ??= []).push('app-theming');

--- a/crates/rolldown/tests/rolldown/issues/10259/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10259/artifacts.snap
@@ -1,0 +1,260 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## admin.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_admin } from "./admin2.js";
+init_admin();
+
+```
+
+## admin2.js
+
+```js
+import { n as init_app_admin } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region admin.js
+function init_admin() {
+	return (init_admin = __esmMin((() => {
+		init_app_admin();
+		(globalThis.sideEffectLog ??= []).push("admin");
+	})))();
+}
+//#endregion
+export { init_admin as t };
+
+```
+
+## apps~personal~admin~theming.js
+
+```js
+import { n as PaletteIcon, r as init_palette_icon } from "./personal2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region app-personal.js
+function init_app_personal() {
+	return (init_app_personal = __esmMin((() => {
+		init_palette_icon();
+		(globalThis.sideEffectLog ??= []).push(`app-personal:${PaletteIcon}`);
+	})))();
+}
+//#endregion
+//#region app-admin.js
+function init_app_admin() {
+	return (init_app_admin = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("app-admin");
+	})))();
+}
+//#endregion
+//#region app-theming.js
+function init_app_theming() {
+	return (init_app_theming = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("app-theming");
+	})))();
+}
+//#endregion
+export { init_app_admin as n, init_app_personal as r, init_app_theming as t };
+
+```
+
+## personal.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_personal } from "./personal2.js";
+init_personal();
+
+```
+
+## personal2.js
+
+```js
+import { r as init_app_personal } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region palette-icon.js
+var PaletteIcon;
+function init_palette_icon() {
+	return (init_palette_icon = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("palette-icon");
+		PaletteIcon = "PaletteIcon";
+	})))();
+}
+//#endregion
+//#region personal.js
+function init_personal() {
+	return (init_personal = __esmMin((() => {
+		init_app_personal();
+		(globalThis.sideEffectLog ??= []).push("personal");
+	})))();
+}
+//#endregion
+export { PaletteIcon as n, init_palette_icon as r, init_personal as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+## theming.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_theming } from "./theming2.js";
+init_theming();
+
+```
+
+## theming2.js
+
+```js
+import { t as init_app_theming } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region theming.js
+function init_theming() {
+	return (init_theming = __esmMin((() => {
+		init_app_theming();
+		(globalThis.sideEffectLog ??= []).push("theming");
+	})))();
+}
+//#endregion
+export { init_theming as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### admin.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_admin } from "./admin2.js";
+init_admin();
+
+```
+
+### admin2.js
+
+```js
+import { n as init_app_admin } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region admin.js
+function init_admin() {
+	return (init_admin = __esmMin((() => {
+		init_app_admin();
+		(globalThis.sideEffectLog ??= []).push("admin");
+	})))();
+}
+//#endregion
+export { init_admin as t };
+
+```
+
+### apps~personal~admin~theming.js
+
+```js
+import { n as PaletteIcon, r as init_palette_icon } from "./personal2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region app-personal.js
+function init_app_personal() {
+	return (init_app_personal = __esmMin((() => {
+		init_palette_icon();
+		(globalThis.sideEffectLog ??= []).push(`app-personal:${PaletteIcon}`);
+	})))();
+}
+//#endregion
+//#region app-admin.js
+function init_app_admin() {
+	return (init_app_admin = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("app-admin");
+	})))();
+}
+//#endregion
+//#region app-theming.js
+function init_app_theming() {
+	return (init_app_theming = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("app-theming");
+	})))();
+}
+//#endregion
+export { init_app_admin as n, init_app_personal as r, init_app_theming as t };
+
+```
+
+### personal.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_personal } from "./personal2.js";
+init_personal();
+
+```
+
+### personal2.js
+
+```js
+import { r as init_app_personal } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region palette-icon.js
+var PaletteIcon;
+function init_palette_icon() {
+	return (init_palette_icon = __esmMin((() => {
+		(globalThis.sideEffectLog ??= []).push("palette-icon");
+		PaletteIcon = "PaletteIcon";
+	})))();
+}
+//#endregion
+//#region personal.js
+function init_personal() {
+	return (init_personal = __esmMin((() => {
+		init_app_personal();
+		(globalThis.sideEffectLog ??= []).push("personal");
+	})))();
+}
+//#endregion
+export { PaletteIcon as n, init_palette_icon as r, init_personal as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### theming.js
+
+```js
+import "./apps~personal~admin~theming.js";
+import { t as init_theming } from "./theming2.js";
+init_theming();
+
+```
+
+### theming2.js
+
+```js
+import { t as init_app_theming } from "./apps~personal~admin~theming.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region theming.js
+function init_theming() {
+	return (init_theming = __esmMin((() => {
+		init_app_theming();
+		(globalThis.sideEffectLog ??= []).push("theming");
+	})))();
+}
+//#endregion
+export { init_theming as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10259/palette-icon.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/palette-icon.js
@@ -1,0 +1,3 @@
+(globalThis.sideEffectLog ??= []).push('palette-icon');
+
+export const PaletteIcon = 'PaletteIcon';

--- a/crates/rolldown/tests/rolldown/issues/10259/personal.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/personal.js
@@ -1,0 +1,3 @@
+import './app-personal.js';
+
+(globalThis.sideEffectLog ??= []).push('personal');

--- a/crates/rolldown/tests/rolldown/issues/10259/theming.js
+++ b/crates/rolldown/tests/rolldown/issues/10259/theming.js
@@ -1,0 +1,3 @@
+import './app-theming.js';
+
+(globalThis.sideEffectLog ??= []).push('theming');

--- a/crates/rolldown/tests/rolldown/issues/10265/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10265/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "strictExecutionOrder": true
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/10265/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/10265/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { result } from './dist/main.js';
+
+assert.strictEqual(result, 'a');

--- a/crates/rolldown/tests/rolldown/issues/10265/a.js
+++ b/crates/rolldown/tests/rolldown/issues/10265/a.js
@@ -1,0 +1,6 @@
+import { getB } from './b.js';
+import { leaf } from './leaf.js';
+
+export function getA() {
+  return getB && leaf ? 'a' : 'unreachable';
+}

--- a/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
@@ -1,0 +1,106 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { n as result, t as init_main } from "./main2.js";
+init_main();
+export { result };
+
+```
+
+## main2.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+function getB() {
+	return getA ? "b" : "unreachable";
+}
+var init_b = __esmMin((() => {
+	init_a();
+}));
+//#endregion
+//#region leaf.js
+function leaf() {
+	return "leaf";
+}
+var init_leaf = __esmMin((() => {}));
+function getA() {
+	return getB && leaf ? "a" : "unreachable";
+}
+var init_a = __esmMin((() => {
+	init_b();
+	init_leaf();
+}));
+//#endregion
+//#region main.js
+var result;
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_a();
+		init_a();
+		result = getA();
+	})))();
+}
+//#endregion
+export { result as n, init_main as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+//#endregion
+//#region b.js
+function getB() {
+	return getA ? "b" : "unreachable";
+}
+var init_b = __esmMin((() => {
+	init_a();
+}));
+//#endregion
+//#region leaf.js
+function leaf() {
+	return "leaf";
+}
+var init_leaf = __esmMin((() => {}));
+function getA() {
+	return getB && leaf ? "a" : "unreachable";
+}
+var init_a = __esmMin((() => {
+	init_b();
+	init_leaf();
+}));
+//#endregion
+//#region main.js
+init_a();
+init_a();
+const result = getA();
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10265/b.js
+++ b/crates/rolldown/tests/rolldown/issues/10265/b.js
@@ -1,0 +1,5 @@
+import { getA } from './a.js';
+
+export function getB() {
+  return getA ? 'b' : 'unreachable';
+}

--- a/crates/rolldown/tests/rolldown/issues/10265/leaf.js
+++ b/crates/rolldown/tests/rolldown/issues/10265/leaf.js
@@ -1,0 +1,3 @@
+export function leaf() {
+  return 'leaf';
+}

--- a/crates/rolldown/tests/rolldown/issues/10265/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10265/main.js
@@ -1,0 +1,4 @@
+import { getA } from './a.js';
+require('./a.js');
+
+export const result = getA();


### PR DESCRIPTION
## Summary

- Add a three-entry regression fixture for the `strictExecutionOrder` failure caused by entries-aware manual code splitting.
- Exercise both strict modes: on-demand planning and the wrap-all control.
- Execute the generated `admin`, `theming`, and `personal` entries and assert entry isolation, dependency side-effect order, and the imported `PaletteIcon` value.

## What this proves

The source module graph is acyclic:

```text
personal -> app-personal -> palette-icon
admin    -> app-admin
theming  -> app-theming
```

The manual group selects only the three `app-*` modules. `entriesAware` first separates them by entry reachability, then the large merge threshold combines those small subgroups into one common chunk. `palette-icon` remains in the personal entry implementation chunk because recursive dependency capture is disabled.

That placement creates a static output cycle: the common app chunk imports `PaletteIcon` from the personal chunk, while the personal chunk imports `app-personal` from the common chunk. Starting with `admin` or `theming` therefore enters the personal chunk before the common chunk has finished evaluating.

The previous strict wrapper form assigned `init_app_personal` from a `var` initializer, so the cycle could call it while it was still `undefined`. The new strict implementation emits a callable declaration-form wrapper. This fixture keeps the output cycle intact and verifies that both on-demand and wrap-all execute all three entries with the original source semantics.

## Validation

- `CARGO_TARGET_DIR=/tmp/codex-rolldown-pr10104-target just t-run crates/rolldown/tests/rolldown/issues/10259/_config.json` (twice; snapshot-stable)
- The same fixture fails on the pre-implementation `main` baseline in both strict modes with `init_app_personal is not a function`
- `just lint-node`
- `just lint-repo`
- `git diff --check`

Closes #10259.
