### PR TITLE
fix(output): skip separator for empty hoisted functions

### DIFF
--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -230,7 +230,9 @@ fn render_chunk_content<'code>(
     // into `make_esm_wrapper_stmt` for the non-concatenated wrapper.
     let is_async = ctx.link_output.metas[group.entry].is_tla_or_contains_tla_dependency;
 
-    source_joiner.append_source(hoisted_fns);
+    if !hoisted_fns.is_empty() {
+      source_joiner.append_source(hoisted_fns);
+    }
     if !hoisted_vars.is_empty() {
       source_joiner.append_source(concat_string!("var ", hoisted_vars, ";"));
     }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -18,7 +18,6 @@ var init_inner = __esmMin((() => {
 //#endregion
 }));
 
-
 var init_main = __esmMin((() => {
 //#region outer.js
 	init_inner();

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/issue-7555/_config.ts
@@ -1,6 +1,8 @@
 import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
 
+let renderChunkCalls = 0;
+
 export default defineTest({
   config: {
     input: './main.js',
@@ -11,12 +13,16 @@ export default defineTest({
       {
         name: 'assert-no-empty-import-prelude',
         renderChunk(code) {
-          expect(code.startsWith('function throwError')).toBe(true);
+          renderChunkCalls++;
+          expect(code).toMatch(/^function throwError/);
         },
       },
     ],
     output: {
       format: 'cjs',
     },
+  },
+  afterTest: () => {
+    expect(renderChunkCalls).toBe(1);
   },
 });

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/render-chunk-external-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/render-chunk-external-import/_config.ts
@@ -1,12 +1,15 @@
 import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
 
+let renderChunkCalls = 0;
+
 export default defineTest({
   config: {
     plugins: [
       {
         name: 'test-plugin',
         renderChunk(_code, chunk) {
+          renderChunkCalls++;
           expect(chunk.imports).toEqual(['node:http']);
         },
         generateBundle(_opts, bundle) {
@@ -17,5 +20,8 @@ export default defineTest({
         },
       },
     ],
+  },
+  afterTest: () => {
+    expect(renderChunkCalls).toBe(1);
   },
 });


### PR DESCRIPTION
Follow-up to #10289 and the [post-merge review](https://github.com/rolldown/rolldown/pull/10289#issuecomment-4982081640).

## Why

The ESM renderer unconditionally appended the accumulated `hoisted_fns` string for an on-demand-wrapped module group. When the group had no hoisted functions, `SourceJoiner` still treated the empty string as a source slot and inserted a separator before the next source.

This is the same empty-slot behavior fixed for the generated import prelude in #10289.

## What changed

- skip `hoisted_fns` when it is empty
- update the single affected ESM snapshot, removing the extra blank line before `init_main`
- make the #7555 `renderChunk` fixture assert that the hook ran exactly once
- preserve the actual hook input in assertion failures by matching `code` directly
- add the same call-count guard to the existing external-import `renderChunk` fixture

## Scope

This keeps the fix at the caller instead of changing `SourceJoiner` globally. Empty sources can carry sourcemaps, and a class-level change would need coherent handling for `append_source_dyn` and `prepend_source` as well.

## Impact

ESM output with `onDemandWrapping` no longer contains the stray separator when a concatenated group has no hoisted functions. The affected plugin fixtures can no longer pass if `renderChunk` is never invoked.

## Validation

- `just test-rust`
- `cargo test -p rolldown --test integration strict_execution_order -- --ignored` (65 passed)
- targeted Vitest run for both changed `renderChunk` fixtures
- `vp check` for both changed TypeScript fixtures
- `cargo fmt --all --check`
- `cargo check -p rolldown --all-features --all-targets --locked`
- `git diff --check`
