### PR TITLE
fix(magic-string): reject non-contiguous moves before rewiring the chunk list

### DIFF
--- a/crates/string_wizard/src/magic_string/movement.rs
+++ b/crates/string_wizard/src/magic_string/movement.rs
@@ -46,6 +46,18 @@ impl MagicString<'_> {
     let old_left_idx = self.chunks[first_idx].prev;
     let old_right_idx = self.chunks[last_idx].next;
 
+    // The moved range occupies both ends of the linked list, so lifting it out would leave no
+    // chunk to re-attach to. Reachable once an earlier move has reordered chunks — after
+    // `relocate(0, 1, 2)` on "abc" the list is B->A->C, so `relocate(1, 3, 0)` asks to move
+    // B..C, which is no longer a contiguous run.
+    //
+    // This has to be caught here, before the rewiring below: that rewiring is not atomic, and
+    // bailing out part-way through leaves a chunk pointing at itself, which makes `to_string`
+    // loop forever.
+    if old_left_idx.is_none() && old_right_idx.is_none() {
+      return Err("Cannot move a range that spans the entire string".to_string());
+    }
+
     let new_right_idx = self.chunk_by_start.get(&to).copied();
 
     // `new_right_idx` is `None` means that the `to` index is at the end of the string.
@@ -77,11 +89,19 @@ impl MagicString<'_> {
 
     if self.chunks[first_idx].prev.is_none() {
       // If the `first_idx` is the first chunk, then we need to update the `first_chunk_idx`.
-      self.first_chunk_idx = self.chunks[last_idx].next.unwrap();
+      // The whole-range check above guarantees a successor exists, so this cannot be `None`
+      // — but returning an error here would corrupt the list, so assert instead of `?`.
+      debug_assert!(self.chunks[last_idx].next.is_some(), "whole-range move should be rejected");
+      if let Some(next_idx) = self.chunks[last_idx].next {
+        self.first_chunk_idx = next_idx;
+      }
     }
     if self.chunks[last_idx].next.is_none() {
       // If the `last_idx` is the last chunk, then we need to update the `last_chunk_idx`.
-      self.last_chunk_idx = self.chunks[first_idx].prev.unwrap();
+      debug_assert!(self.chunks[first_idx].prev.is_some(), "whole-range move should be rejected");
+      if let Some(prev_idx) = self.chunks[first_idx].prev {
+        self.last_chunk_idx = prev_idx;
+      }
       self.chunks[last_idx].next = None;
     }
 

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -255,6 +255,21 @@ mod relocate {
     s.append_left(6, "X").unwrap().relocate(3, 6, 9).unwrap();
     assert_eq!(s.to_string(), "abcghidefXjkl");
   }
+
+  #[test]
+  fn errors_without_corrupting_the_list_when_the_range_is_not_contiguous() {
+    let mut s = MagicString::new("abc");
+    // Reorders the chunks to B -> A -> C.
+    s.relocate(0, 1, 2).unwrap();
+    assert_eq!(s.to_string(), "bac");
+
+    // [1,3) is B..C, which is no longer a contiguous run, so the move has to be rejected.
+    s.relocate(1, 3, 0).unwrap_err();
+
+    // The rejected move must not have rewired anything: a half-applied move used to leave a
+    // chunk pointing at itself, and this `to_string` would then never return.
+    assert_eq!(s.to_string(), "bac");
+  }
 }
 
 mod indent {

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -169,6 +169,19 @@ describe('splitting an already-edited chunk', () => {
   });
 });
 
+describe('move', () => {
+  // A move whose range is no longer contiguous (an earlier move reordered the chunks) has to be
+  // rejected before any pointers are rewired. Bailing out mid-rewire left a chunk pointing at
+  // itself, so the next toString() spun forever.
+  it('rejects a non-contiguous range without corrupting the instance', () => {
+    const s = new MagicString('abc');
+    s.move(0, 1, 2);
+    assert.strictEqual(s.toString(), 'bac');
+    assert.throws(() => s.move(1, 3, 0), /spans the entire string/);
+    assert.strictEqual(s.toString(), 'bac');
+  });
+});
+
 describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {


### PR DESCRIPTION
### What this solves

`move()` corrupts the chunk list when the requested range is no longer contiguous:

```js
const s = new RolldownMagicString('abc');
s.move(0, 1, 2); // list is now B -> A -> C
s.move(1, 3, 0); // asks to move B..C — A sits between them
```

`relocate` assumes `[first..last]` is a contiguous run in the linked list. An earlier move can break that: in the state above, `first.prev` and `last.next` are both `None`, so lifting the range out leaves nothing to re-attach to, and the code fell off the end of the list and unwrapped a `None` — a Rust panic that aborts the whole process across the FFI boundary.

Worse than the panic itself: `relocate` rewires `next`/`prev` **before** reaching that point, so any failure there leaves a chunk pointing at itself — a caller that survives and calls `toString()` loops forever. (`magic-string` reaches the same state and TypeErrors, but its `toString()` still terminates.)

### The fix

Detect the condition up front, from the `prev`/`next` captured **before any mutation**, and return an error while the list is still intact.

The two later `unwrap` sites deliberately keep a `debug_assert` + `if let` instead of becoming `?`: the pre-check guarantees they cannot fire, and returning an error from the middle of the rewiring would be exactly the corrupting behaviour this PR removes. That is also why this can't be fixed by the blanket `expect`→`Result` conversion used in #10301 — converting a panic into a catchable error is only safe when the function hasn't already mutated shared state.

### Tests

- JS: the reproduction above throws a catchable error, and the instance stays usable (`toString()` terminates).
- Rust: unit test for the same sequence at the `string_wizard` level.

Both fail on the parent commit (the JS one by killing the vitest worker — the panic takes the process down) and pass with the fix.
