### PR TITLE
feat(magic-string): support storeName on overwrite/update

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -218,12 +218,16 @@ pub struct BindingMagicStringOptions {
 #[derive(Default)]
 pub struct BindingUpdateOptions {
   pub overwrite: Option<bool>,
+  /// Stores the replaced content in the generated sourcemap's `names` field.
+  pub store_name: Option<bool>,
 }
 
 #[napi(object)]
 #[derive(Default)]
 pub struct BindingOverwriteOptions {
   pub content_only: Option<bool>,
+  /// Stores the replaced content in the generated sourcemap's `names` field.
+  pub store_name: Option<bool>,
 }
 
 #[napi(object)]
@@ -757,14 +761,15 @@ impl BindingMagicString<'_> {
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(end)?)
       .ok_or_else(|| napi::Error::from_reason("Invalid end character index"))?;
-    let content_only = options.and_then(|o| o.content_only).unwrap_or(false);
+    let (content_only, store_name) = options
+      .map_or((false, false), |o| (o.content_only.unwrap_or(false), o.store_name.unwrap_or(false)));
     self
       .inner
       .update_with(
         start_byte,
         end_byte,
         content,
-        string_wizard::UpdateOptions { overwrite: !content_only, keep_original: false },
+        string_wizard::UpdateOptions { overwrite: !content_only, keep_original: store_name },
       )
       .map_err(napi::Error::from_reason)?;
     Ok(this)
@@ -840,14 +845,15 @@ impl BindingMagicString<'_> {
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(end)?)
       .ok_or_else(|| napi::Error::from_reason("Invalid end character index"))?;
-    let overwrite = options.and_then(|o| o.overwrite).unwrap_or(false);
+    let (overwrite, store_name) = options
+      .map_or((false, false), |o| (o.overwrite.unwrap_or(false), o.store_name.unwrap_or(false)));
     self
       .inner
       .update_with(
         start_byte,
         end_byte,
         content,
-        string_wizard::UpdateOptions { overwrite, keep_original: false },
+        string_wizard::UpdateOptions { overwrite, keep_original: store_name },
       )
       .map_err(napi::Error::from_reason)?;
     Ok(this)

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -41,6 +41,12 @@ pub struct MagicString<'s> {
   chunk_by_end: FxHashMap<u32, ChunkIdx>,
   guessed_indentor: OnceLock<String>,
 
+  /// Original text of every range replaced with `keep_original`, mapped to its position in the
+  /// generated sourcemap's `names`. Mirrors `magic-string`'s `storedNames`: the name recorded
+  /// is the *whole* requested range, independent of how that range happens to be split into
+  /// chunks, so a range that spans a split boundary still stores its full original text.
+  stored_names: FxHashMap<String, u32>,
+
   // This is used to speed up the search for the chunk that contains a given index.
   last_searched_chunk_idx: ChunkIdx,
 }
@@ -78,6 +84,7 @@ impl<'text> MagicString<'text> {
       filename: options.filename,
       ignore_list: options.ignore_list,
       guessed_indentor: OnceLock::default(),
+      stored_names: FxHashMap::default(),
       last_searched_chunk_idx: initial_chunk_idx,
     };
 
@@ -259,6 +266,25 @@ impl<'text> MagicString<'text> {
 
   pub fn append_intro(&mut self, content: impl Into<CowStr<'text>>) {
     self.intro.push_back(content.into());
+  }
+
+  /// Records `source[start..end)` as a sourcemap name, keeping first-insertion order.
+  /// See [`Self::stored_names`].
+  pub(super) fn store_name(&mut self, start: u32, end: u32) {
+    let original = &self.source[start as usize..end as usize];
+    if !self.stored_names.contains_key(original) {
+      #[expect(clippy::cast_possible_truncation, reason = "a source has < u32::MAX edits")]
+      let next_id = self.stored_names.len() as u32;
+      self.stored_names.insert(original.to_string(), next_id);
+    }
+  }
+
+  /// Stored names in `names`-array order, paired with their index.
+  pub(super) fn stored_names_ordered(&self) -> Vec<(&str, u32)> {
+    let mut ordered: Vec<(&str, u32)> =
+      self.stored_names.iter().map(|(name, &id)| (name.as_str(), id)).collect();
+    ordered.sort_unstable_by_key(|&(_, id)| id);
+    ordered
   }
 
   fn iter_chunks(&self) -> impl Iterator<Item = &Chunk<'_>> {

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -31,6 +31,16 @@ impl MagicString<'_> {
 
     let locator = Locator::new(&self.source);
 
+    // Seed `names` with every stored range up front, so the array reflects what was replaced
+    // rather than whatever chunks happen to line up. A chunk only carries a name when its own
+    // span is exactly one of those ranges — a range split across chunks stays in `names` with
+    // no mapping pointing at it, which is what magic-string does.
+    let name_ids: FxHashMap<&str, u32> = self
+      .stored_names_ordered()
+      .into_iter()
+      .map(|(name, _)| (name, source_builder.add_name(name)))
+      .collect();
+
     self.intro.iter().for_each(|frag| {
       source_builder.advance(frag);
     });
@@ -42,15 +52,16 @@ impl MagicString<'_> {
       chunk.intro.iter().for_each(|frag| {
         source_builder.advance(frag);
       });
-      let name =
-        (chunk.keep_in_mappings && chunk.is_edited()).then(|| chunk.span.text(&self.source));
+      let name_id = (chunk.keep_in_mappings && chunk.is_edited())
+        .then(|| name_ids.get(chunk.span.text(&self.source)).copied())
+        .flatten();
 
       source_builder.add_chunk(
         chunk,
         utf16_index_map[&chunk.start()],
         &locator,
         &self.source,
-        name,
+        name_id,
       );
 
       chunk.outro.iter().for_each(|frag| {

--- a/crates/string_wizard/src/magic_string/update.rs
+++ b/crates/string_wizard/src/magic_string/update.rs
@@ -51,6 +51,13 @@ impl<'text> MagicString<'text> {
     self.split_at(start)?;
     self.split_at(end)?;
 
+    // Record the *whole* replaced range, not the start chunk's span: `start..end` may cross a
+    // boundary left by an earlier split, in which case the start chunk only covers part of it.
+    // Matches magic-string, which stores `original.slice(start, end)` here.
+    if opts.keep_original {
+      self.store_name(start, end);
+    }
+
     let start_idx = self.chunk_by_start.get(&start).copied().unwrap();
     let end_idx = self.chunk_by_end.get(&end).copied().unwrap();
 

--- a/crates/string_wizard/src/source_map/sourcemap_builder.rs
+++ b/crates/string_wizard/src/source_map/sourcemap_builder.rs
@@ -40,19 +40,19 @@ impl<'a> SourcemapBuilder<'a> {
     self.source_id = self.source_map_builder.set_source_and_content(id, content);
   }
 
+  /// Registers a sourcemap name up front and returns its index in `names`.
+  pub fn add_name(&mut self, name: &'a str) -> u32 {
+    self.source_map_builder.add_name(name)
+  }
+
   pub fn add_chunk(
     &mut self,
     chunk: &Chunk,
     chunk_start_utf16: u32,
     locator: &Locator,
     source: &str,
-    name: Option<&'a str>,
+    name_id: Option<u32>,
   ) {
-    let name_id = if chunk.keep_in_mappings {
-      name.map(|name| self.source_map_builder.add_name(name))
-    } else {
-      None
-    };
     let mut loc = locator.locate(chunk_start_utf16);
     if let Some(edited_content) = &chunk.edited_content {
       if !edited_content.is_empty() {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2576,6 +2576,8 @@ export interface BindingOutputs {
 
 export interface BindingOverwriteOptions {
   contentOnly?: boolean
+  /** Stores the replaced content in the generated sourcemap's `names` field. */
+  storeName?: boolean
 }
 
 export interface BindingPluginContextResolvedId {
@@ -2812,6 +2814,8 @@ export interface BindingTsconfigResult {
 
 export interface BindingUpdateOptions {
   overwrite?: boolean
+  /** Stores the replaced content in the generated sourcemap's `names` field. */
+  storeName?: boolean
 }
 
 export interface BindingViteAliasPluginAlias {

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -366,7 +366,7 @@ describe('MagicString', () => {
       assert.deepEqual(m1, m2);
     });
 
-    it.skip('should recover original names', () => {
+    it('should recover original names', () => {
       const s = new MagicString('function Foo () {}');
 
       s.overwrite(9, 12, 'Bar', { storeName: true });

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -139,7 +139,6 @@ const SKIP_TESTS = [
   // generateMap-specific skips (features not in string_wizard)
   'should generate a correct sourcemap including correct lines', // uses generateDecodedMap which has different mappings count
   'should generate a sourcemap using specified locations', // addSourcemapLocation not implemented
-  'should recover original names', // storeName option not implemented
   'generates a map with trimmed content', // trim sourcemap behavior differs
   // Note: 'generates x_google_ignoreList' is now supported
   'generates segments per word boundary with hires "boundary" in the next line', // multiline boundary mappings differ

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -182,6 +182,84 @@ describe('move', () => {
   });
 });
 
+describe('storeName', () => {
+  // string_wizard supports `keep_original` end-to-end, but the binding hardcoded it to
+  // `false`, so `generateMap().names` was always empty regardless of the option.
+  // The basic overwrite case lives in the vendored suite ('should recover original names',
+  // MagicString.test.ts); these cover only what that test does not reach.
+
+  // `update` has its own napi options struct (`BindingUpdateOptions`) — a missing
+  // `store_name` field there is invisible to every overwrite-based test.
+  it('update({ storeName: true }) records the original name', () => {
+    const s = new MagicString('var foo = 1;');
+    s.update(4, 7, 'bar', { storeName: true });
+    assert.deepStrictEqual(s.generateMap({}).names, ['foo']);
+  });
+
+  // These two pass either way by design: an implementation with no storeName support at all
+  // satisfies them trivially. They pin the flag-gating — an implementation that stored every
+  // replaced range unconditionally would pass every positive test in this block. Omitted and
+  // explicit `false` are distinct deserialization branches (`None` vs `Some(false)`).
+  it('names stay empty when storeName is omitted', () => {
+    const s = new MagicString('var foo = 1;');
+    s.overwrite(4, 7, 'bar');
+    assert.deepStrictEqual(s.generateMap({}).names, []);
+  });
+
+  it('names stay empty when storeName is false', () => {
+    const s = new MagicString('var foo = 1;');
+    s.overwrite(4, 7, 'bar', { storeName: false });
+    assert.deepStrictEqual(s.generateMap({}).names, []);
+  });
+
+  it('contentOnly and storeName are independent', () => {
+    const s = new MagicString('var foo = 1;');
+    s.appendLeft(4, '/*x*/');
+    s.overwrite(4, 7, 'bar', { storeName: true, contentOnly: true });
+    assert.deepStrictEqual(s.generateMap({}).names, ['foo']);
+    // contentOnly preserves the surrounding intro/outro
+    assert.strictEqual(s.toString(), 'var /*x*/bar = 1;');
+  });
+
+  // The name recorded is the whole replaced range, independent of chunk boundaries. When an
+  // earlier edit has already split that range, the start chunk covers only part of it — using
+  // the chunk's own span stored 'f' instead of 'foo', and pointed the mapping at that wrong
+  // name. magic-string keys `storedNames` off `original.slice(start, end)`.
+  it('records the whole range when an earlier appendLeft split it', () => {
+    const s = new MagicString('var foo = 1;');
+    s.appendLeft(5, 'X');
+    s.overwrite(4, 7, 'bar', { storeName: true });
+    assert.deepStrictEqual(s.generateMap({}).names, ['foo']);
+  });
+
+  // A range split across chunks leaves the name in `names` with no mapping referencing it —
+  // matching magic-string, whose per-mapping lookup is `names.indexOf(chunk.original)` and so
+  // misses once the chunk is narrower than the range.
+  it('a split range leaves the mapping unnamed, like magic-string', () => {
+    const split = new MagicString('var foo = 1;');
+    split.appendLeft(5, 'X');
+    split.overwrite(4, 7, 'bar', { storeName: true });
+    assert.deepStrictEqual(split.generateDecodedMap({}).mappings, [
+      [
+        [0, 0, 0, 0],
+        [4, 0, 0, 4],
+        [7, 0, 0, 7],
+      ],
+    ]);
+
+    // Unsplit, the chunk spans the whole range, so the mapping does carry the name.
+    const whole = new MagicString('var foo = 1;');
+    whole.overwrite(4, 7, 'bar', { storeName: true });
+    assert.deepStrictEqual(whole.generateDecodedMap({}).mappings, [
+      [
+        [0, 0, 0, 0],
+        [4, 0, 0, 4, 0],
+        [7, 0, 0, 7],
+      ],
+    ]);
+  });
+});
+
 describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {


### PR DESCRIPTION
> Stacked on #10311 — review that first; this PR's diff is just the top commit.

### What this solves

`overwrite`/`update` accepted a `storeName` option in their TypeScript signatures, but it did nothing: the binding hardcoded `keep_original: false`, so `generateMap().names` was always empty regardless of the option.

```js
const s = new RolldownMagicString('var foo = 1;');
s.overwrite(4, 7, 'bar', { storeName: true });
s.generateMap({}).names; // [] — magic-string returns ['foo']
```

### An underlying bug, not just plumbing

Wiring the flag through exposed a real bug in `string_wizard`: it took the stored name from the **start chunk's span** rather than the replaced range. When an earlier edit had already split the range, the start chunk covers only part of it — `'f'` got stored instead of `'foo'`, and the mapping pointed at that wrong name. `magic-string` keys `storedNames` off `original.slice(start, end)`.

Fixed with a `stored_names` map on `MagicString` (name → insertion order), populated in `inner_update_with` from the whole `[start, end)` range — the single code path both `update` and `overwrite` converge on. The sourcemap builder seeds `names` from it in insertion order and resolves each edited chunk's name by lookup, which also reproduces magic-string's quirk that a split range leaves its name in `names` with no mapping referencing it (upstream's per-mapping lookup is `names.indexOf(chunk.original)`, which misses once the chunk is narrower than the range).

### Verification against `magic-string@0.30.21`

- **Differential run, 18 scenarios, all byte-identical** on full `generateMap()` output — raw `mappings` VLQ string, `names` content *and* order, `sourcesContent` — plus `toString()`. Covers: both edit orders, duplicate-name dedup, re-storing the same range, split ranges, `contentOnly` interaction, multiline sources, non-BMP characters before the name, stored-then-removed ranges, `hires: true` and `hires: 'boundary'`.
- **Un-skipped the vendored upstream test** `should recover original names` — its skip-list entry said *"storeName option not implemented"*, which this PR makes untrue. It passes: `SourceMapConsumer.originalPositionFor()` recovers the original name from our map.
- Rollup's test suite: 0 failed / 1213 passed at this branch.

### Tests

Six hand-written cases, consolidated against the vendored suite so nothing is covered twice (the basic overwrite case lives in the un-skipped upstream test):

- `update({ storeName: true })` — `update` has its own napi options struct (`BindingUpdateOptions`); a missing `store_name` field there is invisible to every overwrite-based test.
- names stay empty when `storeName` is omitted / `false` — flag-gating pins (pass either way by design; an implementation that stored every replaced range unconditionally would pass every positive test).
- `contentOnly` + `storeName` are independent.
- the split-range regression (`'foo'`, not `'f'`).
- a split range leaves the mapping unnamed, like magic-string — decoded-mappings assertion, split vs unsplit.

All except the two documented flag-gating pins fail on the parent commit and pass with this change.
