### PR TITLE
fix: handle `./foo/bar` glob pattern the same as `foo/bar`

### DIFF
--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, path::Path};
 
 use crate::js_regex::HybridRegex;
 use fast_glob::glob_match;
+use sugar_path::SugarPath;
 
 #[derive(Debug, Clone)]
 pub enum StringOrRegex {
@@ -104,7 +105,8 @@ fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
   if glob.starts_with("**") || Path::new(glob).is_absolute() {
     normalize_path(glob)
   } else {
-    let final_path = Path::new(cwd).join(glob);
+    let joined = Path::new(cwd).join(glob);
+    let final_path = joined.normalize();
     Cow::Owned(normalize_path(&final_path.to_string_lossy()).into_owned())
   }
 }
@@ -301,13 +303,18 @@ mod tests {
         );
         assert_eq!(
           result, expected,
-          r"Failed at case {i}, 
+          r"Failed at case {i},
 subcase: {si},
 filter: {:?}, id: {id}",
           test_case.input_filter
         );
       }
     }
+  }
+
+  #[test]
+  fn test_get_matcher_string() {
+    assert_eq!(get_matcher_string("./foo/*.txt", "/home/rolldown"), "/home/rolldown/foo/*.txt");
   }
 
   #[test]


### PR DESCRIPTION
`./foo/bar` was treated differently from `foo/bar` for globs. This PR fixes that inconsistency.

This fixes ,https://github.com/vitejs/vite/issues/22943. The e2e test case is added in https://github.com/vitejs/vite/pull/22955.
