### PR TITLE
perf: reuse normalized path buffers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Rust Core (crates/rolldown)
 - `crates/rolldown_watcher`: Watch mode coordinator. See `internal-docs/watch-mode/implementation.md` for architecture, state machine, debounce/consolidation rules, and event lifecycle.
 - `docs/`: Documentation site built with VitePress.
 - `internal-docs/`: Internal design & implementation docs — one folder per feature (`design.md` + `implementation.md`). See the "Context Engineering" section above.
+- Path manipulation: read `internal-docs/path-manipulation/style-guide.md` before composing paths, and prefer its consuming `rolldown_std_utils` helpers for owned `PathBuf` values.
 
 ## Auto-generated or Submodule Files
 

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use dashmap::{DashMap, DashSet, Entry};
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
-use rolldown_std_utils::path_buf_to_slash;
+use rolldown_std_utils::normalize_path_buf_to_slash;
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 use rolldown_utils::make_unique_name::make_unique_name;
 use rolldown_utils::xxhash::{xxhash_base64_url, xxhash_with_base};
@@ -16,7 +16,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use sugar_path::SugarPathBuf;
 
 #[derive(Debug, Default)]
 pub struct EmittedAsset {
@@ -294,7 +293,7 @@ impl FileEmitter {
       let name = path.file_stem().and_then(OsStr::to_str).map(|stem| {
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
           // Normalize to resolve ".." and "." where possible, then convert to forward slashes
-          path_buf_to_slash(parent.join(stem).into_normalized())
+          normalize_path_buf_to_slash(parent.join(stem))
         } else {
           stem.to_string()
         }

--- a/crates/rolldown_std_utils/src/lib.rs
+++ b/crates/rolldown_std_utils/src/lib.rs
@@ -9,8 +9,8 @@ pub use crate::{
   option_ext::OptionExt,
   path_buf_ext::PathBufExt,
   path_ext::{
-    PathExt, absolute_path_to_relative_slash, absolutize_path_buf, path_buf_to_slash,
-    relative_path_as_js_specifier, relative_path_to_slash,
+    PathExt, absolute_path_to_relative_slash, absolutize_path_buf, normalize_path_buf_to_slash,
+    path_buf_to_slash, relative_path_as_js_specifier, relative_path_to_slash,
     representative_file_name_for_preserve_modules, strip_path_prefix_to_slash,
   },
   pretty_type_name::pretty_type_name,

--- a/crates/rolldown_std_utils/src/path_ext.rs
+++ b/crates/rolldown_std_utils/src/path_ext.rs
@@ -4,7 +4,8 @@
 //! `Cow<Path>` from `relative` and makes slash conversion explicit; the patterns
 //! below are the ones we want in call sites so later code does not reintroduce
 //! lossy or double-allocating chains like
-//! `relative(...).to_slash_lossy().into_owned()`.
+//! `relative(...).to_slash_lossy().into_owned()` or
+//! `normalize().as_ref().expect_to_slash()`.
 
 use std::{
   borrow::Cow,
@@ -80,7 +81,7 @@ pub fn strip_path_prefix_to_slash(path: &Path, prefix: &Path) -> Option<String> 
 ///
 /// Uses sugar_path 3's intended composition for known-UTF-8 Rolldown paths:
 /// `relative` may borrow a clean descendant, then one owned buffer becomes the
-/// final slash `String` via [`SugarPathBuf::into_slash`].
+/// final slash `String` via [`sugar_path::SugarPathBuf::into_slash`].
 ///
 /// Prefer this over `relative(...).to_slash_lossy().into_owned()` or
 /// `relative(...).as_path().expect_to_slash()`.
@@ -131,6 +132,22 @@ pub fn path_buf_to_slash(path: PathBuf) -> String {
   path.into_slash()
 }
 
+/// Normalize an owned path, then consume it into a `/`-separated UTF-8 string.
+///
+/// Prefer this when `path` was just created by `join` or another owned operation.
+/// The consuming chain lets the normalized `PathBuf` become the final `String`
+/// instead of copying it through a non-consuming
+/// [`sugar_path::SugarPath::normalize`] result.
+///
+/// # Panics
+///
+/// Panics if `path` is not valid UTF-8. Rolldown module and resolver paths are
+/// required to satisfy that invariant.
+#[inline]
+pub fn normalize_path_buf_to_slash(path: PathBuf) -> String {
+  path.into_normalized().into_slash()
+}
+
 #[test]
 fn test_relative_path_helpers() {
   let workspace = std::env::current_dir().unwrap().join("path-helper-tests");
@@ -146,6 +163,12 @@ fn test_relative_path_helpers() {
   assert_eq!(absolute_path_to_relative_slash(&nested, &workspace), "src/lib/mod.js");
   assert!(absolutize_path_buf(PathBuf::from("path-helper-tests")).is_absolute());
   assert_eq!(path_buf_to_slash(PathBuf::from("src").join("lib.js")), "src/lib.js");
+  assert_eq!(
+    normalize_path_buf_to_slash(
+      PathBuf::from("src").join(".").join("nested").join("..").join("lib.js")
+    ),
+    "src/lib.js",
+  );
 }
 
 #[test]

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 
 use crate::js_regex::HybridRegex;
 use fast_glob::glob_match;
-use sugar_path::SugarPath;
+use rolldown_std_utils::normalize_path_buf_to_slash;
 
 #[derive(Debug, Clone)]
 pub enum StringOrRegex {
@@ -105,9 +105,7 @@ fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
   if glob.starts_with("**") || Path::new(glob).is_absolute() {
     normalize_path(glob)
   } else {
-    let joined = Path::new(cwd).join(glob);
-    let final_path = joined.normalize();
-    Cow::Owned(normalize_path(&final_path.to_string_lossy()).into_owned())
+    Cow::Owned(normalize_path_buf_to_slash(Path::new(cwd).join(glob)))
   }
 }
 
@@ -313,8 +311,25 @@ filter: {:?}, id: {id}",
   }
 
   #[test]
-  fn test_get_matcher_string() {
-    assert_eq!(get_matcher_string("./foo/*.txt", "/home/rolldown"), "/home/rolldown/foo/*.txt");
+  fn relative_current_dir_globs_match_like_clean_globs() {
+    #[cfg(windows)]
+    let (cwd, matching_id, nonmatching_id) =
+      (r"C:\home\rolldown", r"C:\home\rolldown\foo\file.txt", r"C:\home\rolldown\bar\file.txt");
+    #[cfg(not(windows))]
+    let (cwd, matching_id, nonmatching_id) =
+      ("/home/rolldown", "/home/rolldown/foo/file.txt", "/home/rolldown/bar/file.txt");
+
+    let dirty = get_matcher_string("./foo/*.txt", cwd);
+    let clean = get_matcher_string("foo/*.txt", cwd);
+    assert_eq!(dirty, clean);
+
+    for glob in ["./foo/*.txt", "foo/*.txt"] {
+      let pattern = [StringOrRegex::new(glob.to_string(), None).unwrap()];
+      assert_eq!(filter(None, Some(&pattern), matching_id, cwd), FilterResult::Match(true));
+      assert_eq!(filter(None, Some(&pattern), nonmatching_id, cwd), FilterResult::NoneMatch(false),);
+      assert_eq!(filter(Some(&pattern), None, matching_id, cwd), FilterResult::Match(false));
+      assert_eq!(filter(Some(&pattern), None, nonmatching_id, cwd), FilterResult::NoneMatch(true),);
+    }
   }
 
   #[test]

--- a/internal-docs/path-manipulation/style-guide.md
+++ b/internal-docs/path-manipulation/style-guide.md
@@ -6,16 +6,19 @@ Implementation: `crates/rolldown_std_utils/src/path_ext.rs`. Module-id identity:
 
 ## Use these
 
-| Helper                                        | For                                     |
-| --------------------------------------------- | --------------------------------------- |
-| `absolutize_path_buf(path)`                   | Ensure an owned path is absolute        |
-| `relative_path_to_slash(target, base)`        | Relative path as `/`-separated `String` |
-| `relative_path_as_js_specifier(target, base)` | Same, JS form: `.` / `./…` / `../…`     |
-| `absolute_path_to_relative_slash(path, cwd)`  | Absolute → cwd-relative slash string    |
-| `path_buf_to_slash(path)`                     | Owned `PathBuf` → slash `String`        |
-| `PathExt::expect_to_slash`                    | Borrowed path → slash `String`          |
+| Helper                                        | For                                                |
+| --------------------------------------------- | -------------------------------------------------- |
+| `absolutize_path_buf(path)`                   | Ensure an owned path is absolute                   |
+| `relative_path_to_slash(target, base)`        | Relative path as `/`-separated `String`            |
+| `relative_path_as_js_specifier(target, base)` | Same, JS form: `.` / `./…` / `../…`                |
+| `absolute_path_to_relative_slash(path, cwd)`  | Absolute → cwd-relative slash string               |
+| `normalize_path_buf_to_slash(path)`           | Normalize owned `PathBuf` → slash `String`         |
+| `path_buf_to_slash(path)`                     | Owned `PathBuf` → slash `String` without normalize |
+| `PathExt::expect_to_slash`                    | Borrowed path → slash `String`                     |
 
 sugar_path 3: `relative` returns `Cow<Path>` (empty when equal); `normalize` preserves a trailing separator; slash conversion is strict by default. Explicit cwd arguments must be absolute. Keep workspace feature `cached_current_dir`.
+
+When a `PathBuf` was just created by `join` or another owned operation and the final value is a slash-separated `String`, consume it with `normalize_path_buf_to_slash`. Calling non-consuming `normalize()` first produces a `Cow<Path>` and forces the later `String` conversion to copy the normalized buffer.
 
 When the destination is `ArcStr`, pass `to_slash()` directly instead of calling `into_owned()` first; `ArcStr` copies strings into its own allocation.
 
@@ -25,6 +28,7 @@ When the destination is `ArcStr`, pass `to_slash()` directly instead of calling 
 target.relative(base).to_slash_lossy().into_owned()  // lossy on known UTF-8
 path.to_slash().unwrap()                             // 2.x API
 target.relative(base).as_path().expect_to_slash()    // skip into_slash reuse
+path.normalize().as_ref().expect_to_slash()          // skip owned normalize/slash reuse
 let p: PathBuf = target.relative(base);              // not PathBuf anymore
 path.to_string_lossy().replace('\\', "/")            // hand-rolled policy
 ```


### PR DESCRIPTION
## Summary

- consume joined `PathBuf` values through a shared `normalize_path_buf_to_slash` helper
- avoid copying the normalized glob path into a second allocation before matching
- strengthen the `./foo` versus `foo` regression test through the public filter path, including a Windows drive cwd
- document the owned-path rule in the path manipulation guide and link it from `AGENTS.md`

## Why

#10313 correctly inserted lexical normalization into the existing `join -> to_string_lossy -> slash` chain. However, `join` had already produced an owned `PathBuf`; calling the non-consuming `normalize()` API converted it to `Cow<Path>`, and the following string conversion copied the normalized buffer.

The same ownership issue was caught during #10230's review in `file_emitter.rs`, but the general rule never made it into the final style guide. The guide covered consuming relative/slash conversion and exposed `path_buf_to_slash`, but it did not provide a named normalize-plus-slash helper or list the non-consuming owned-path chain as an anti-pattern.

This PR records that missing rule and centralizes the composition so future call sites do not need to reconstruct it.

## Performance

A release-mode `GlobalAlloc` counter around matcher construction reported one fewer allocation/reallocation for each non-bypass relative glob:

| Pattern | Current | This PR |
| --- | ---: | ---: |
| `foo/*.txt` | 3 | 2 |
| `./foo/*.txt` | 4 | 3 |

The probe compared exact outputs across clean, dirty, parent, trailing-separator, absolute, and `**` cases. No benchmark case is added here; if this path is added to continuous performance coverage, the benchmark should land first in a baseline-only PR and the implementation comparison should follow from that baseline.

## Validation

- `just lint-rust`
- `just lint-repo`
- `cargo test -p rolldown_std_utils -p rolldown_utils -p rolldown_common`
- `cargo check -p rolldown_std_utils -p rolldown_utils --tests --target x86_64-pc-windows-msvc --locked`
- `cargo check -p rolldown_std_utils --tests --target wasm32-wasip1 --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rolldown_std_utils --no-deps --locked`
- `just test-rust` executed the workspace suite successfully until the single `test262_module_code` test stopped on the intentionally uninitialized `test262` submodule; 1,873 integration tests had passed, with no code failure
- adversarial review passed after documenting the strict UTF-8 panic contract
