### PR TITLE
refactor: enable oxc_ast's `disable_old_builder` feature

### DIFF
--- a/.claude/skills/upgrade-oxc/SKILL.md
+++ b/.claude/skills/upgrade-oxc/SKILL.md
@@ -15,8 +15,8 @@ CRITICAL: Run each step sequentially ONE AT A TIME. Wait for each command to FUL
 4. Edit `pnpm-workspace.yaml`: update `@oxc-project/runtime`, `@oxc-project/types`, `oxc-minify`, `oxc-parser`, `oxc-transform` to the version from step 3 (use `=x.y.z` format)
 5. `cargo search oxc_allocator --limit 1` - note the version
 6. `cargo search oxc_resolver --limit 1` - note the version
-7. Edit `Cargo.toml`: update `oxc`, `oxc_allocator`, `oxc_ecmascript`, `oxc_minify_napi`, `oxc_parser_napi`, `oxc_transform_napi`, `oxc_traverse` to version from step 5; update `oxc_resolver`, `oxc_resolver_napi` to version from step 6
-8. `cargo update oxc oxc_allocator oxc_ecmascript oxc_minify_napi oxc_parser_napi oxc_transform_napi oxc_traverse oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index`
+7. Edit `Cargo.toml`: update `oxc`, `oxc_allocator`, `oxc_ast`, `oxc_ecmascript`, `oxc_minify_napi`, `oxc_parser_napi`, `oxc_transform_napi`, `oxc_traverse` to version from step 5; update `oxc_resolver`, `oxc_resolver_napi` to version from step 6
+8. `cargo update oxc oxc_allocator oxc_ast oxc_ecmascript oxc_minify_napi oxc_parser_napi oxc_transform_napi oxc_traverse oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index`
 9. `pnpm install` - install updated npm packages
 10. `cargo check` - if there are errors, fix all breaking changes before proceeding. Common breaking changes include renamed types, changed method signatures, or removed APIs. Study the error messages carefully and update the code accordingly.
 11. `just update-generated-code`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ version = "1.2.0"
 dependencies = [
  "arcstr",
  "oxc",
+ "oxc_ast",
  "oxc_sourcemap",
  "oxc_str",
  "rolldown_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,6 +274,9 @@ oxc = { version = "0.140.0", features = [
   "regular_expression",
 ] }
 oxc_allocator = { version = "0.140.0", features = ["pool"] }
+# Depended on directly only to enable `disable_old_builder` (removes oxc's deprecated
+# old AstBuilder API); the `oxc` umbrella crate has no passthrough feature for it.
+oxc_ast = { version = "0.140.0", features = ["disable_old_builder"] }
 oxc_ecmascript = { version = "0.140.0" }
 oxc_napi = { version = "0.140.0" }
 oxc_str = { version = "0.140.0" }

--- a/crates/rolldown/src/ast_scanner/const_eval.rs
+++ b/crates/rolldown/src/ast_scanner/const_eval.rs
@@ -13,7 +13,7 @@ use rolldown_common::{ConstExportMeta, ConstantValue};
 use rustc_hash::FxHashMap;
 
 pub struct ConstEvalCtx<'me, 'ast: 'me> {
-  pub ast: oxc::ast::AstBuilder<'ast>,
+  pub ast: oxc::ast::builder::AstBuilder<'ast>,
   pub scope: &'me Scoping,
   pub constant_map: &'me FxHashMap<SymbolId, ConstExportMeta>,
   pub overrode_get_constant_value_from_reference_id: Option<
@@ -30,9 +30,9 @@ impl<'ast> GetAllocator<'ast> for ConstEvalCtx<'_, 'ast> {
 }
 
 impl<'ast> GetAstBuilder<'ast> for ConstEvalCtx<'_, 'ast> {
-  type Builder = oxc::ast::AstBuilder<'ast>;
+  type Builder = oxc::ast::builder::AstBuilder<'ast>;
 
-  fn builder(&self) -> &oxc::ast::AstBuilder<'ast> {
+  fn builder(&self) -> &oxc::ast::builder::AstBuilder<'ast> {
     &self.ast
   }
 }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -1099,7 +1099,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   #[inline]
   pub fn create_constant_eval_ctx(&'me self) -> ConstEvalCtx<'me, 'ast> {
     ConstEvalCtx {
-      ast: oxc::ast::AstBuilder::new(self.immutable_ctx.allocator),
+      ast: oxc::ast::builder::AstBuilder::new(self.immutable_ctx.allocator),
       scope: self.result.symbol_ref_db.scoping(),
       constant_map: &self.result.constant_export_map,
       overrode_get_constant_value_from_reference_id: None,

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -3,8 +3,8 @@ use oxc::ast::ast::Str;
 use oxc::{
   allocator::IntoIn,
   ast::{
-    NONE,
     ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind, Statement},
+    builder::NONE,
   },
   semantic::{IsGlobalReference, Scoping, SymbolId},
   span::{SPAN, Span},

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -1,7 +1,7 @@
 use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::TakeIn,
-  ast::{NONE, ast},
+  ast::{ast, builder::NONE},
   span::SPAN,
 };
 use oxc_traverse::Traverse;

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -1,8 +1,6 @@
-use oxc::ast::builder::GetAstBuilder;
-use oxc::{
-  ast::{NONE, ast},
-  span::SPAN,
-};
+use oxc::allocator::GetAllocator;
+use oxc::ast::builder::{AstBuilder, NONE};
+use oxc::{ast::ast, span::SPAN};
 use rolldown_common::NormalModule;
 use rolldown_ecmascript::CJS_MODULE_REF;
 #[cfg(feature = "experimental")]
@@ -18,7 +16,7 @@ pub static MODULE_EXPORTS_NAME_FOR_ESM: &str = "__rolldown_exports__";
 pub static MODULE_ID_PARAM_FOR_HMR: &str = "__rolldown_module_id__";
 
 pub trait HmrAstBuilder<'any, 'ast> {
-  fn builder(&self) -> oxc::ast::AstBuilder<'ast>;
+  fn builder(&self) -> AstBuilder<'ast>;
 
   fn module(&self) -> &NormalModule;
 
@@ -168,8 +166,8 @@ pub trait HmrAstBuilder<'any, 'ast> {
 
 #[cfg(feature = "experimental")]
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
-  fn builder(&self) -> oxc::ast::AstBuilder<'ast> {
-    *self.ast_factory.builder()
+  fn builder(&self) -> AstBuilder<'ast> {
+    AstBuilder::new(self.ast_factory.allocator())
   }
 
   fn module(&self) -> &NormalModule {
@@ -202,8 +200,8 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
 }
 
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for ScopeHoistingFinalizer<'any, 'ast> {
-  fn builder(&self) -> oxc::ast::AstBuilder<'ast> {
-    *self.ast_factory.builder()
+  fn builder(&self) -> AstBuilder<'ast> {
+    AstBuilder::new(self.ast_factory.allocator())
   }
 
   fn module(&self) -> &NormalModule {

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -4,8 +4,8 @@ use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::{
   allocator::{self, IntoIn, ReplaceWith, TakeIn},
   ast::{
-    NONE,
     ast::{self, BindingPattern, Expression, SimpleAssignmentTarget, Statement},
+    builder::NONE,
     match_member_expression,
   },
   ast_visit::{VisitMut, walk_mut},
@@ -227,24 +227,24 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
 
         if !is_concatenated_wrapped_module && !self.top_level_var_bindings.is_empty() {
-          let ast_factory = self.ast_factory;
+          let ast_factory = &self.ast_factory;
           let decorations = self.top_level_var_bindings.iter().map(|var_name| {
             ast::VariableDeclarator::new(
               SPAN,
               ast::VariableDeclarationKind::Var,
-              ast::BindingPattern::new_binding_identifier(SPAN, *var_name, &ast_factory),
+              ast::BindingPattern::new_binding_identifier(SPAN, *var_name, ast_factory),
               NONE,
               None,
               false,
-              &ast_factory,
+              ast_factory,
             )
           });
           program.body.push(Statement::VariableDeclaration(ast::VariableDeclaration::boxed(
             SPAN,
             ast::VariableDeclarationKind::Var,
-            oxc::allocator::Vec::from_iter_in(decorations, &ast_factory),
+            oxc::allocator::Vec::from_iter_in(decorations, ast_factory),
             false,
-            &ast_factory,
+            ast_factory,
           )));
         }
 

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1,16 +1,13 @@
 use bitflags::bitflags;
 use oxc::allocator::GetAllocator;
 use oxc::ast::ast::ObjectPropertyKind;
-use oxc::ast::builder::GetAstBuilder;
+use oxc::ast::builder::{GetAstBuilder, NONE};
 use oxc::semantic::{ReferenceId, ScopeFlags, SymbolId};
 use oxc::{
   allocator::{self, Allocator, CloneIn, Dummy, IntoIn, ReplaceWith, TakeIn},
-  ast::{
-    NONE,
-    ast::{
-      self, ClassElement, Expression, IdentifierReference, ImportExpression, NumberBase, Statement,
-      VariableDeclarationKind,
-    },
+  ast::ast::{
+    self, ClassElement, Expression, IdentifierReference, ImportExpression, NumberBase, Statement,
+    VariableDeclarationKind,
   },
   span::{GetSpan, GetSpanMut, SPAN, Span},
 };
@@ -288,11 +285,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
 
-    // `AstFactory` is `Copy`, so copying it out lets the `&mut self` iterator below stay borrowed
-    // while we still construct nodes through `factory`. That decouples node construction from the
-    // borrow without the throwaway heap `Vec` the previous `.collect()` needed: the common 0/1
-    // cases now allocate nothing, and only the rare sequence case allocates — straight in the arena.
-    let factory = self.ast_factory;
+    // A fresh `AstFactory` (a free wrapper over the arena reference) lets the `&mut self` iterator
+    // below stay borrowed while we still construct nodes through `factory`. That decouples node
+    // construction from the borrow without the throwaway heap `Vec` the previous `.collect()`
+    // needed: the common 0/1 cases now allocate nothing, and only the rare sequence case
+    // allocates — straight in the arena.
+    let factory = AstFactory::new(self.alloc);
     let mut init_exprs = self
       .collect_wrapped_esm_init_modules_for_import_record(rec_idx)
       .into_iter()
@@ -469,7 +467,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         || (self.state.contains(TraverseState::SmartInlineConst) || meta.safe_to_inline)
       {
         return (
-          meta.value.to_expression(*self.ast_factory.builder()),
+          meta.value.to_expression(self.ast_factory.builder()),
           FinalizedExprProcessHint::empty(),
         );
       }
@@ -654,7 +652,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
     Some((
-      constant_meta.value.to_expression(*self.ast_factory.builder()),
+      constant_meta.value.to_expression(self.ast_factory.builder()),
       FinalizedExprProcessHint::empty(),
     ))
   }
@@ -758,7 +756,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let symbol_name = canonical_ref.name(self.ctx.symbol_db);
     let member_map = module.ecma_view.enum_member_value_map.get(symbol_name)?;
     let meta = member_map.get(property_name)?;
-    Some(meta.value.to_expression(*self.ast_factory.builder()))
+    Some(meta.value.to_expression(self.ast_factory.builder()))
   }
 
   fn var_declaration_to_expr_seq_and_bindings(
@@ -1002,7 +1000,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let require_call = ast::CallExpression::boxed(
               SPAN,
               ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
-              oxc::ast::NONE,
+              NONE,
               oxc::allocator::Vec::from_value_in(
                 ast::Argument::StringLiteral(ast::StringLiteral::boxed(
                   SPAN,
@@ -1029,7 +1027,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let require_path_to_file_url_call = ast::CallExpression::boxed(
               SPAN,
               ast::Expression::StaticMemberExpression(require_path_to_file_url),
-              oxc::ast::NONE,
+              NONE,
               oxc::allocator::Vec::from_value_in(
                 ast::Argument::Identifier(ast::IdentifierReference::boxed(
                   SPAN,
@@ -1203,7 +1201,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.ctx.constant_value_map.get(&target_commonjs_exported_symbol_meta.0)
             }) {
             is_inlined_commonjs_export = true;
-            export_meta.value.to_expression(*self.ast_factory.builder())
+            export_meta.value.to_expression(self.ast_factory.builder())
           } else {
             let (object_ref_expr, _) = self.finalized_expr_for_symbol_ref(
               object_ref,

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -1,10 +1,11 @@
 use oxc::{
   ast::{
-    AstBuilder, AstKind,
+    AstKind,
     ast::{
       BindingIdentifier, BindingPattern, Declaration, ExportDefaultDeclaration,
       ExportDefaultDeclarationKind, ExportNamedDeclaration, Expression,
     },
+    builder::AstBuilder,
   },
   ast_visit::{Visit, walk},
   semantic::{NodeId, SymbolId},

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use oxc::allocator::GetAllocator;
 use oxc::allocator::{Allocator, ReplaceWith, TakeIn};
-use oxc::ast::NONE;
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
+use oxc::ast::builder::NONE;
 use oxc::ast_visit::{VisitMut, walk_mut};
 use oxc::span::{SPAN, Span};
 use rolldown_ecmascript_utils::{AstFactory, StatementExt};

--- a/crates/rolldown_common/src/ecmascript/json_to_program.rs
+++ b/crates/rolldown_common/src/ecmascript/json_to_program.rs
@@ -1,7 +1,7 @@
 use arcstr::ArcStr;
 use oxc::{
   allocator::Allocator,
-  ast::AstBuilder,
+  ast::builder::AstBuilder,
   span::{SPAN, SourceType},
 };
 use rolldown_ecmascript::EcmaAst;
@@ -32,7 +32,7 @@ pub fn json_value_to_ecma_ast(value: &Value) -> EcmaAst {
 
   EcmaAst::from_allocator_and_source(source, allocator, |allocator| {
     let builder = AstBuilder::new(allocator);
-    let expr = json_value_to_expression(value, builder);
+    let expr = json_value_to_expression(value, &builder);
     let stmt = oxc::ast::ast::Statement::new_expression_statement(SPAN, expr, &builder);
 
     oxc::ast::ast::Program::new(
@@ -60,12 +60,12 @@ pub fn json_value_to_ecma_ast(value: &Value) -> EcmaAst {
 /// An `Expression` representing the JSON value
 pub fn json_value_to_expression<'a>(
   value: &Value,
-  builder: AstBuilder<'a>,
+  builder: &AstBuilder<'a>,
 ) -> oxc::ast::ast::Expression<'a> {
   match value {
-    Value::Null => oxc::ast::ast::Expression::new_null_literal(SPAN, &builder),
+    Value::Null => oxc::ast::ast::Expression::new_null_literal(SPAN, builder),
 
-    Value::Bool(b) => oxc::ast::ast::Expression::new_boolean_literal(SPAN, *b, &builder),
+    Value::Bool(b) => oxc::ast::ast::Expression::new_boolean_literal(SPAN, *b, builder),
 
     Value::Number(n) => {
       // A JSON number string is always a valid f64 literal, so parsing it never fails:
@@ -79,15 +79,15 @@ pub fn json_value_to_expression<'a>(
         f,
         None,
         oxc::ast::ast::NumberBase::Decimal,
-        &builder,
+        builder,
       )
     }
 
     Value::String(s) => oxc::ast::ast::Expression::new_string_literal(
       SPAN,
-      oxc::ast::ast::Str::from_str_in(s, &builder),
+      oxc::ast::ast::Str::from_str_in(s, builder),
       None,
-      &builder,
+      builder,
     ),
 
     Value::Array(arr) => {
@@ -96,9 +96,9 @@ pub fn json_value_to_expression<'a>(
           let expr = json_value_to_expression(item, builder);
           oxc::ast::ast::ArrayExpressionElement::from(expr)
         }),
-        &builder,
+        builder,
       );
-      oxc::ast::ast::Expression::new_array_expression(SPAN, elements, &builder)
+      oxc::ast::ast::Expression::new_array_expression(SPAN, elements, builder)
     }
 
     Value::Object(obj) => {
@@ -106,9 +106,9 @@ pub fn json_value_to_expression<'a>(
         obj.iter().map(|(key, val)| {
           let key_expr = oxc::ast::ast::Expression::new_string_literal(
             SPAN,
-            oxc::ast::ast::Str::from_str_in(key, &builder),
+            oxc::ast::ast::Str::from_str_in(key, builder),
             None,
-            &builder,
+            builder,
           );
           let value_expr = json_value_to_expression(val, builder);
 
@@ -117,15 +117,15 @@ pub fn json_value_to_expression<'a>(
             oxc::ast::ast::PropertyKind::Init,
             oxc::ast::ast::PropertyKey::from(key_expr),
             value_expr,
+            false, // method
             false, // shorthand
             false, // computed
-            false, // method
-            &builder,
+            builder,
           )
         }),
-        &builder,
+        builder,
       );
-      oxc::ast::ast::Expression::new_object_expression(SPAN, properties, &builder)
+      oxc::ast::ast::Expression::new_object_expression(SPAN, properties, builder)
     }
   }
 }

--- a/crates/rolldown_common/src/types/constant_value.rs
+++ b/crates/rolldown_common/src/types/constant_value.rs
@@ -64,24 +64,24 @@ impl From<&ConstantValue> for constant_evaluation::ConstantValue<'_> {
 }
 
 impl ConstantValue {
-  pub fn to_expression<'ast>(&self, ast: oxc::ast::AstBuilder<'ast>) -> Expression<'ast> {
+  pub fn to_expression<'ast>(&self, ast: &oxc::ast::builder::AstBuilder<'ast>) -> Expression<'ast> {
     match self {
       ConstantValue::Number(n) => {
-        Expression::new_numeric_literal(SPAN, *n, None, oxc::ast::ast::NumberBase::Decimal, &ast)
+        Expression::new_numeric_literal(SPAN, *n, None, oxc::ast::ast::NumberBase::Decimal, ast)
       }
       ConstantValue::BigInt(b) => Expression::new_big_int_literal(
         SPAN,
-        oxc::ast::ast::Str::from_str_in(&b.to_string(), &ast),
+        oxc::ast::ast::Str::from_str_in(&b.to_string(), ast),
         None,
         oxc::ast::ast::BigintBase::Decimal,
-        &ast,
+        ast,
       ),
       ConstantValue::String(s) => {
-        Expression::new_string_literal(SPAN, oxc::ast::ast::Str::from_str_in(s, &ast), None, &ast)
+        Expression::new_string_literal(SPAN, oxc::ast::ast::Str::from_str_in(s, ast), None, ast)
       }
-      ConstantValue::Boolean(b) => Expression::new_boolean_literal(SPAN, *b, &ast),
-      ConstantValue::Undefined => Expression::new_void_0(SPAN, &ast),
-      ConstantValue::Null => Expression::new_null_literal(SPAN, &ast),
+      ConstantValue::Boolean(b) => Expression::new_boolean_literal(SPAN, *b, ast),
+      ConstantValue::Undefined => Expression::new_void_0(SPAN, ast),
+      ConstantValue::Null => Expression::new_null_literal(SPAN, ast),
     }
   }
 }

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 arcstr = { workspace = true }
 oxc = { workspace = true }
+oxc_ast = { workspace = true }
 oxc_sourcemap = { workspace = true }
 oxc_str = { workspace = true }
 rolldown_error = { workspace = true }
@@ -23,3 +24,9 @@ self_cell = { workspace = true }
 
 [lib]
 doctest = false
+
+[package.metadata.cargo-shear]
+# `oxc_ast` is depended on directly only to enable its `disable_old_builder` feature
+# on the copy re-exported by the `oxc` umbrella crate (which has no passthrough
+# feature). Code imports it via `oxc::ast::…`.
+ignored = ["oxc_ast"]

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -99,8 +99,8 @@ unsafe impl Send for EcmaAst {}
 // This invariant is *not* fully enforced by the type system: `EcmaAst.program`
 // is `pub`, and `ProgramCell::borrow_owner` / `with_dependent` expose
 // `&ProgramCellOwner`, whose `allocator` field is `pub` — so safe code
-// holding `&EcmaAst` can construct an `oxc::ast::AstBuilder` that allocates
-// into the arena.
+// holding `&EcmaAst` can construct an `oxc::ast::builder::AstBuilder` that
+// allocates into the arena.
 //
 // [`ProgramCell::with_mut`] is the preferred access pattern because its
 // `&mut self` receiver makes the invariant statically checkable. Code that

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -4,8 +4,8 @@ use arcstr::ArcStr;
 use oxc::{
   allocator::Allocator,
   ast::{
-    AstBuilder,
     ast::{Program, Statement},
+    builder::AstBuilder,
   },
   codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions, LegalComment},
   minifier::{Minifier, MinifierOptions},

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -1,7 +1,6 @@
 use oxc::{
   allocator::{self, Allocator, GetAllocator, IntoIn},
   ast::{
-    AstBuilder, NONE,
     ast::{
       Argument, ArrowFunctionExpression, AssignmentOperator, AssignmentTarget, BindingIdentifier,
       BindingPattern, CallExpression, ClassElement, Declaration, ExportDefaultDeclarationKind,
@@ -13,7 +12,7 @@ use oxc::{
       SimpleAssignmentTarget, Statement, StaticMemberExpression, StringLiteral,
       VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
     },
-    builder::GetAstBuilder,
+    builder::{AstBuilder, GetAstBuilder, NONE},
   },
   span::{GetSpanMut, SPAN, Span},
 };
@@ -30,7 +29,6 @@ use rolldown_utils::ecmascript::is_validate_identifier_name;
 /// at one point.
 ///
 /// See `internal-docs/ast-construction/implementation.md`.
-#[derive(Clone, Copy)]
 pub struct AstFactory<'ast>(AstBuilder<'ast>);
 
 /// Options for [`AstFactory::make_esm_wrapper_stmt`], grouping the wrapper's binding, body and

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
@@ -1,8 +1,8 @@
 use oxc::allocator::Box;
-use oxc::ast::AstBuilder;
 use oxc::ast::ast::{
   Expression, JSXIdentifier, JSXMemberExpression, JSXMemberExpressionObject, StaticMemberExpression,
 };
+use oxc::ast::builder::AstBuilder;
 
 pub trait JsxExt<'ast> {
   type AstKind;

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -1,12 +1,12 @@
 use oxc::{
   allocator::Allocator,
   ast::{
-    AstBuilder, NONE,
     ast::{
       Argument, BindingIdentifier, BindingPattern, Declaration, Expression, FormalParameter,
       FormalParameterKind, FormalParameters, Function, FunctionBody, IdentifierName,
       MemberExpression, Statement, VariableDeclarator,
     },
+    builder::{AstBuilder, NONE},
   },
   ast_visit::{VisitMut, walk_mut},
   span::SPAN,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -2,13 +2,13 @@ use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::{CloneIn as _, TakeIn as _},
   ast::{
-    NONE,
     ast::{
       Argument, ArrowFunctionExpression, AwaitExpression, BindingPattern, BindingProperty,
       Declaration, Expression, FormalParameterKind, FormalParameters, FunctionBody,
       MemberExpression, ObjectPattern, PropertyKey, ReturnStatement, Statement,
       StaticMemberExpression, VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
     },
+    builder::NONE,
   },
   ast_visit::walk_mut::walk_arguments,
   semantic::ScopeFlags,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -2,11 +2,11 @@ use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::CloneIn as _,
   ast::{
-    NONE,
     ast::{
       BindingPattern, Expression, ImportDeclarationSpecifier, ImportOrExportKind,
       ModuleDeclaration, ModuleExportName, Statement, StringLiteral, VariableDeclaration,
     },
+    builder::NONE,
   },
   ast_visit::{VisitMut, walk_mut},
   semantic::ScopeFlags,

--- a/internal-docs/ast-construction/implementation.md
+++ b/internal-docs/ast-construction/implementation.md
@@ -32,7 +32,7 @@ Two facts constrain every choice and are documented in [ast-mutation](../ast-mut
 
 ## The convention
 
-Everything goes through one handle, `ast_factory: AstFactory<'a>` — rolldown's newtype over `oxc::ast::AstBuilder`. Pick the tool by what you are building:
+Everything goes through one handle, `ast_factory: AstFactory<'a>` — rolldown's newtype over `oxc::ast::builder::AstBuilder`. Pick the tool by what you are building:
 
 ### Generic nodes → oxc's per-type constructors, passing the `ast_factory` handle
 
@@ -53,8 +53,7 @@ Inside an `&self` method that holds the handle, pass `self` directly (it impleme
 For constructions that compose several nodes into a recurring rolldown convention (CJS/ESM interop wrappers, `__toESM` / `__toCommonJS` calls, `.then` chains, …), add an inherent `make_*` method to the `AstFactory` newtype rather than open-coding it at the call site:
 
 ```rust
-#[derive(Clone, Copy)]
-pub struct AstFactory<'a>(oxc::ast::AstBuilder<'a>);
+pub struct AstFactory<'a>(oxc::ast::builder::AstBuilder<'a>);
 
 // generic oxc constructors reach the handle through these traits
 impl<'a> GetAllocator<'a> for AstFactory<'a> {
@@ -80,7 +79,7 @@ A method earns a place here only if it encodes a multi-step rolldown convention 
 
 ### Build programmatically by default; parsing source is an exception
 
-Construct nodes through the `ast_factory` handle (oxc constructors via `Deref`, rolldown patterns via `make_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
+Construct nodes through the `ast_factory` handle (oxc per-type constructors taking the handle, rolldown patterns via `make_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
 
 Authoring code as JS source and parsing it (`EcmaCompiler::parse`) is reserved for a large, fixed body of code where maintaining it as real JS clearly outweighs the one-time parse cost. In practice that is the **runtime module** (`crates/rolldown/src/module_loader/runtime_module_task.rs:226`) and essentially nothing else on the output side — treat it as a special case, not a tool to reach for. Never parse for nodes that splice into an existing AST and need a synthetic `SPAN` + dummy `NodeId` — build those programmatically, per the constraint above.
 
@@ -114,6 +113,7 @@ The convention arrived incrementally, but the oxc#23043 cutover (oxc 0.138) was 
 
 - `AstSnippet` became the `AstFactory` newtype: its `pub builder` field became the wrapped `AstBuilder`; the thin renames were dropped in favor of oxc constructors; the genuine patterns became inherent `make_*` methods. The awkward `AstSnippet` name disappears — rolldown now owns a properly-named builder.
 - The oxc 0.138 builder redesign was migrated in one pass: every generic-node call site moved from the (then-deprecated) `ast_factory.<builder_method>(..)` form to the per-type constructors (`Foo::new(.., &ast_factory)` / `Foo::boxed(..)` / `oxc::allocator::Vec::new_in(..)` / `Str::from_str_in(..)`), `AstFactory` gained the `GetAstBuilder` / `GetAllocator` impls, and the `Deref` was removed. New code follows the per-type convention directly.
+- With every call site on the new API, oxc_ast's **`disable_old_builder`** cargo feature is now enabled, completing the oxc#23043 migration. It removes the deprecated `AstBuilder` methods, drops `AstBuilder`'s `Clone`/`Copy` (so `AstFactory` is not `Copy` either — borrow the handle, or reconstruct one with `AstFactory::new(alloc)` where a detached handle is needed), and removes the top-level `oxc::ast::{AstBuilder, NONE}` re-exports — import from `oxc::ast::builder::` instead. The umbrella `oxc` crate has no passthrough for the feature, so it is enabled via a direct `oxc_ast` dependency carried by `crates/rolldown_ecmascript/Cargo.toml` (cargo-shear-ignored; cargo feature unification applies it to the copy the umbrella re-exports). Keep that pin in lockstep with the `oxc` version when upgrading.
 
 ## Related
 


### PR DESCRIPTION
Enables oxc_ast's `disable_old_builder` cargo feature — the endgame of the oxc#23043 `AstBuilder` redesign, ahead of oxc removing the old builder methods entirely. All construction call sites were already on the new per-type-constructor API, so this is the enforcement pass; it also stops compiling the deprecated 599 KB `generated/ast_builder.rs`.

The `oxc` umbrella crate has no passthrough for the feature, so it is enabled through a direct `oxc_ast` dependency carried by `rolldown_ecmascript`; cargo feature unification applies it to the copy the umbrella re-exports. The dep is cargo-shear-ignored — no code references `oxc_ast::` paths directly, and without the ignore, CI autofix would remove the dep and silently disable the feature.

Changes forced by the feature:

- `AstBuilder` is no longer `Copy`/`Clone`, so `AstFactory` isn't either. The two by-value copy sites now reconstruct a handle (`AstFactory::new(alloc)` is a free wrapper over the arena reference) or borrow it.
- `ConstantValue::to_expression` and `json_value_to_expression` take `&AstBuilder`; the `HmrAstBuilder::builder` impls construct a fresh `AstBuilder::new(allocator())` instead of deref-copying, leaving their call sites untouched.
- The top-level `oxc::ast::{AstBuilder, NONE}` re-exports are removed by the feature; imports now use `oxc::ast::builder::{AstBuilder, NONE}`.

Also updates `internal-docs/ast-construction/implementation.md` (migration completion note, corrected sample) and adds `oxc_ast` to the `upgrade-oxc` skill's version-bump lists so the pin moves in lockstep on future upgrades.

A cleaner follow-up on the oxc side would be an umbrella passthrough feature (`disable_old_builder = ["oxc_ast/disable_old_builder"]`), after which the direct dep here can be dropped.