### PR TITLE
test(vite-tests): track the latest rolldown-canary rebased onto vite main

### DIFF
--- a/docs/development-guide/repo-structure.md
+++ b/docs/development-guide/repo-structure.md
@@ -17,11 +17,11 @@ We store all the Node.js packages in this directory.
 - `/rolldown` Node.js package for the project.
 - `/bench` Benchmark programs for Node.js side of the project.
 - `/rollup-tests` Adapter for running rollup tests with rolldown.
-- `/vite-tests` Script to run Vite's own test suite with local rolldown, on a throwaway clone of the root `/vite` submodule.
+- `/vite-tests` Script to run Vite's own test suite with local rolldown, on a throwaway clone of [vitejs/vite](https://github.com/vitejs/vite) at the latest `rolldown-canary` rebased onto the latest `main`.
 
 # `/vite`
 
-The vendored [vitejs/vite](https://github.com/vitejs/vite) submodule — the single Vite checkout shared by the dev-server test harness (`packages/test-dev-server`) and by `packages/vite-tests`. It must stay pristine: never edit tracked files inside it.
+The vendored [vitejs/vite](https://github.com/vitejs/vite) submodule used by the dev-server test harness (`packages/test-dev-server`). It must stay pristine: never edit tracked files inside it.
 
 # `/examples`
 

--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { styleText } from 'node:util';
 import { x } from 'tinyexec';
-import { ensureViteCheckout, viteDir } from '../../scripts/src/setup-vite/checkout.js';
 
 const REPO_PATH = path.resolve(import.meta.dirname, './repo');
 const OVERRIDES = [
@@ -45,16 +44,16 @@ async function runCmdAndPipeOrExit(title: string, cmdOptions: Parameters<typeof 
 
 fs.rmSync(REPO_PATH, { recursive: true, force: true });
 
-// The tests run on a throwaway LOCAL clone of the shared `vite/` submodule,
-// never on the submodule itself: this suite edits tracked files (pnpm
-// overrides, spec patches) and the submodule must stay pristine. The clone
-// shares objects via hardlinks (no network) and checks out the submodule's
-// current HEAD — the same commit the dev-server tests run on.
-printTitle('# Ensuring the vite submodule checkout...');
-ensureViteCheckout();
+// Test the latest `rolldown-canary` rebased onto the latest `main`, so that
+// test adjustments landing on `rolldown-canary` take effect right away and
+// new tests from Vite `main` surface incompatibilities with rolldown early.
 await runCmdAndPipeOrExit(
-  '# Cloning the local vite checkout...',
-  ['git', ['clone', viteDir, REPO_PATH]],
+  '# Cloning vite repo (rolldown-canary branch)...',
+  ['git', ['clone', '--branch', 'rolldown-canary', 'https://github.com/vitejs/vite.git', REPO_PATH]],
+);
+await runCmdAndPipeOrExit(
+  '# Rebasing rolldown-canary onto main...',
+  ['git', ['rebase', 'origin/main'], { nodeOptions: { cwd: REPO_PATH } }],
 );
 
 printTitle('# Updating pnpm-workspace.yaml to link to local rolldown...');
@@ -78,46 +77,6 @@ await runCmdAndPipeOrExit(
   '# Running `pnpm run build`...',
   ['pnpm', ['run', 'build'], { nodeOptions: { cwd: REPO_PATH } }],
 );
-
-// Skip known failing tests
-// https://github.com/rolldown/rolldown/issues/8839
-const assetsSpecPath = path.resolve(REPO_PATH, 'playground/assets/__tests__/assets.spec.ts');
-const assetsSpec = fs.readFileSync(assetsSpecPath, 'utf-8');
-fs.writeFileSync(assetsSpecPath, assetsSpec.replace(
-  "test('import with raw query'",
-  "test.skip('import with raw query'"
-), 'utf-8');
-
-// Rolldown keeps the deduplicated CSS file under the `style2-*` name, not
-// `style-*` (same adjustment as vitejs/vite@d716106b5 on the old rolldown-canary branch).
-const cssCodesplitSpecPath = path.resolve(
-  REPO_PATH,
-  'playground/css-codesplit/__tests__/css-codesplit-consistent.spec.ts',
-);
-const cssCodesplitSpec = fs.readFileSync(cssCodesplitSpecPath, 'utf-8');
-fs.writeFileSync(cssCodesplitSpecPath, cssCodesplitSpec.replaceAll(
-  `      expect(findAssetFile(/style2-.+\\.css/)).toBeUndefined()
-      expect(findAssetFile(/style-.+\\.css/)).toMatch('h2{color:#00f}')`,
-  `      expect(findAssetFile(/style-.+\\.css/)).toBeUndefined()
-      expect(findAssetFile(/style2-.+\\.css/)).toMatch('h2{color:#00f}')`,
-), 'utf-8');
-
-// With client-side HMR, `import.meta.hot.invalidate()` is handled inside the
-// client and never reaches the server, so there is no "hmr invalidate" server
-// log anymore. Assert the user-visible result instead.
-const fbmHmrSpecPath = path.resolve(
-  REPO_PATH,
-  'playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts',
-);
-const fbmHmrSpec = fs.readFileSync(fbmHmrSpecPath, 'utf-8');
-fs.writeFileSync(fbmHmrSpecPath, fbmHmrSpec.replace(
-  `    await expect
-      .poll(() => serverLogs.slice(logIndex).join('\\n'))
-      .toContain('hmr invalidate')`,
-  `    await expect
-      .poll(() => page.textContent('.invalidation-parent'))
-      .toBe('child updated')`,
-), 'utf-8');
 
 // Remove VITE_PLUS_* env vars to prevent leaking into loadEnv() test snapshots
 for (const key of Object.keys(process.env)) {

--- a/packages/vite-tests/tsconfig.json
+++ b/packages/vite-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["run.ts", "../../scripts/src/setup-vite/checkout.ts"],
+  "include": ["run.ts"],
   "compilerOptions": {
     "composite": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Problem

Since #10164 (and #10293 which unified the checkouts), `packages/vite-tests/run.ts` ran Vite's test suite on the commit pinned by the vite submodule gitlink. The `rolldown-canary` branch of vitejs/vite is regularly rebased and force-pushed, so any pinned commit rots quickly: the current pin `4d1480ca` is no longer on any branch. Worse, test adjustments landing on `rolldown-canary` cannot reach rolldown CI without a manual pin bump. That is exactly why CI on `main` is red right now: the `js-sourcemap` inline snapshot was updated on `rolldown-canary` on 2026-07-15 (for the output change from #10249), but the pin predates that update.

## Change

Restore the pre-#10164 approach from #7633. `run.ts` now does:

```
git clone --branch rolldown-canary https://github.com/vitejs/vite.git
git rebase origin/main
```

so test adjustments landing on `rolldown-canary` take effect right away, and new tests from Vite `main` surface incompatibilities with rolldown early. The rebase identity comes from the existing "Configure Git" step in the vite-test CI jobs.

All inline spec patches are removed from `run.ts`. Test adjustments belong on the `rolldown-canary` branch itself, not in a patch layer inside this repo:

- The `css-codesplit` style-/style2- patch was already dead code: upstream Vite `main` has had the swapped assertions since vitejs/vite#22922.
- The `assets` raw-query skip (#8839) is obsolete: the test passes on current rolldown `main`, in both serve and build.
- The `hmr-full-bundle-mode` invalidate patch is removed. This one still needs a spec fix on `rolldown-canary`: with client-side HMR there is no "hmr invalidate" server log anymore, so the spec should assert that `.invalidation-parent` becomes `child updated` instead. Until that lands on the canary branch, `test-serve` fails this single test.

Also reverts the `tsconfig.json` include added for the now-removed `checkout.ts` import, and updates the `repo-structure.md` description.

## Verification

Full local run against current rolldown `main` (debug build):

| Suite | Result |
| --- | --- |
| test-unit | 65 files passed |
| test-serve | 1 real failure: `hmr-full-bundle-mode > invalidate` (expected, see above) |
| test-build | 93 files passed, `js-sourcemap` snapshot green again |

`environment-react-ssr > deps reload` failed once under full-suite load but passes in isolation (timing flake with the slow debug binding, not a regression).

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

