### PR TITLE
test(test-dev-server): drop the vite submodule, track rolldown-canary

### DIFF
--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -44,11 +44,18 @@ jobs:
       - name: Build `@rolldown/test-dev-server`
         run: vp run --filter '@rolldown/test-dev-server' build
 
+      # The rebase in setup-vite needs a committer identity.
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
       # The browser-platform tests run on Vite's full bundle mode, served from
-      # the vendored Vite submodule (kept pristine — no rolldown-side patches).
-      # setup-vite inits the submodule, installs its pinned deps, builds vite,
-      # and points its runtime `rolldown` resolution at packages/rolldown.
-      - name: Setup Vite submodule (browser-platform backend)
+      # a clone of vitejs/vite at the latest rolldown-canary rebased onto the
+      # latest main (kept unpatched, no rolldown-side edits). setup-vite
+      # creates the checkout, installs its pinned deps, builds vite, and
+      # points its runtime `rolldown` resolution at packages/rolldown.
+      - name: Setup Vite checkout (browser-platform backend)
         run: vp run --filter '@rolldown-internal/scripts' setup-vite
 
       - name: Install Playwright

--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ nul
 # Zed local config
 .zed
 
-# Vendored Vite submodule (test-dev-server browser backend): the gitlink is
-# tracked, but repo tools must not lint/format the submodule contents.
+# Vite checkout (test-dev-server browser backend): a plain clone of
+# vitejs/vite created by `just setup-vite`, never tracked, and repo tools
+# must not lint/format its contents.
 /vite/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "test262"]
 	path = test262
 	url = https://github.com/tc39/test262.git
-[submodule "packages/test-dev-server/vite"]
-	path = vite
-	url = https://github.com/vitejs/vite.git

--- a/docs/development-guide/repo-structure.md
+++ b/docs/development-guide/repo-structure.md
@@ -21,7 +21,7 @@ We store all the Node.js packages in this directory.
 
 # `/vite`
 
-The vendored [vitejs/vite](https://github.com/vitejs/vite) submodule used by the dev-server test harness (`packages/test-dev-server`). It must stay pristine: never edit tracked files inside it.
+The Vite checkout used by the dev-server test harness (`packages/test-dev-server`): a gitignored clone of [vitejs/vite](https://github.com/vitejs/vite) at the latest `rolldown-canary` rebased onto the latest `main`, created by `just setup-vite`. It must stay unpatched: never edit Vite source files inside it.
 
 # `/examples`
 

--- a/docs/development-guide/testing.md
+++ b/docs/development-guide/testing.md
@@ -205,7 +205,7 @@ To run the `tests/fixtures/resolve/alias` test, you could use `just test-node-ro
 | **browser**  | `browser` | A real Chromium page against an **in-process Vite full-bundle-mode dev server**. Most dev-engine tests live here. |
 | **fixtures** | `node`    | A custom dev server building to **disk**, with the built artifact run as a `node` child process.                  |
 
-The browser suite runs on Vite itself (`experimental.bundledDev`), served from the vendored Vite submodule at `vite/` (repo root) with its `rolldown` dependency linked to the workspace's `packages/rolldown` — so the tests exercise the local rolldown binding through the real Vite integration. The architecture and the reasoning behind the harness are captured in the [Dev Server Test Harness design doc](https://github.com/rolldown/rolldown/blob/main/internal-docs/dev-server-test-harness/implementation.md) — read it before changing the harness itself.
+The browser suite runs on Vite itself (`experimental.bundledDev`), served from the Vite checkout at `vite/` (repo root, a gitignored clone of vitejs/vite `rolldown-canary` rebased onto `main`) with its `rolldown` dependency linked to the workspace's `packages/rolldown`, so the tests exercise the local rolldown binding through the real Vite integration. The architecture and the reasoning behind the harness are captured in the [Dev Server Test Harness design doc](https://github.com/rolldown/rolldown/blob/main/internal-docs/dev-server-test-harness/implementation.md). Read it before changing the harness itself.
 
 ### Browser playgrounds
 
@@ -264,7 +264,7 @@ just build-rolldown
 pnpm --filter @rolldown/test-dev-server build
 ```
 
-The browser suite also needs the Vite submodule set up once (init + install + build + link the workspace rolldown into it). The setup builds the checkout as-is and never moves it — after a pin bump, run `git submodule update vite` first. Re-run it after updating the checkout or after running an install inside it (an install resets the rolldown link):
+The browser suite also needs the Vite checkout set up once (clone vitejs/vite `rolldown-canary` rebased onto `main` + install + build + link the workspace rolldown into it). The setup builds an existing checkout as-is and never moves it, so updating it is a manual git step inside `vite/`. Re-run it after updating the checkout or after running an install inside it (an install resets the rolldown link):
 
 ```sh
 just setup-vite

--- a/internal-docs/dev-server-test-harness/implementation.md
+++ b/internal-docs/dev-server-test-harness/implementation.md
@@ -5,7 +5,8 @@
 The `@rolldown/test-dev-server` browser suite drives a real Chromium page against
 the rolldown dev engine (HMR, lazy compilation, error overlay). The server is
 **Vite's full bundle mode** (`experimental.bundledDev`), loaded at runtime from
-the vendored submodule at `vite/` (repo root) with its `rolldown`
+the Vite checkout at `vite/` (repo root, a gitignored clone of vitejs/vite
+`rolldown-canary` rebased onto `main`) with its `rolldown`
 resolution linked to the workspace's `packages/rolldown` — the harness adds only
 test instrumentation on top (see [The Vite backend](#the-vite-backend)). It runs
 **in-process**: each spec file starts the dev server inside its own vitest worker
@@ -119,9 +120,9 @@ serving. What the harness does own lives in `src/vite-server.ts`:
   assertions, `treeshake` forwarded. Full bundle mode forces
   `devMode.lazy: true`, so lazy compilation is always on in browser runs.
 - **`vite` is not a package dependency.** It is dynamic-imported by file URL
-  from the submodule's built dist (`loadVite()`), with local structural types
+  from the checkout's built dist (`loadVite()`), with local structural types
   for the API slice the harness touches. Node-platform fixtures and CI jobs
-  that never run browser tests work without the submodule; a missing dist
+  that never run browser tests work without the checkout; a missing dist
   fails with a "run `just setup-vite`" hint.
 - **Test instrumentation** (`createHarnessPlugin`): the `/_dev/status`
   middleware; `buildSeq` counts `buildStart` plus broadcast
@@ -144,28 +145,32 @@ serving. What the harness does own lives in `src/vite-server.ts`:
     `vite:client:connect` listener (registered before Vite's own replay
     listener) drops the stale error when the tracked build state is healthy.
 
-**The submodule stays byte-pristine.** No tracked-file edits, no patches —
-bumping it is a plain pointer update. Everything environment-specific happens
-in untracked files, via the shared `scripts/src/setup-vite/` script
-(`just setup-vite`, idempotent, `vp`-only; its checkout step is also reused by
-`packages/vite-tests`):
+**The checkout stays unpatched.** No Vite source edits on the rolldown side.
+Fixes and test adjustments belong on the vitejs/vite `rolldown-canary` branch,
+which both this harness and `packages/vite-tests` track. Everything
+environment-specific happens in untracked files, via the
+`scripts/src/setup-vite/` script (`just setup-vite`, idempotent, `vp`-only):
 
-1. init the submodule if needed; an existing checkout is built exactly as-is — the script never moves it, so after a pin bump run `git submodule update vite` yourself before re-running,
-2. `vp install --frozen-lockfile` (vp delegates to the submodule's pinned
+1. clone vitejs/vite `rolldown-canary` rebased onto `main` if `vite/` is
+   missing; an existing checkout is built exactly as-is, the script never
+   moves it, so updating it is always a manual git step inside `vite/`,
+2. `vp install --frozen-lockfile` (vp delegates to the checkout's pinned
    pnpm; this also resets a previous step-4 swap, so the build always uses
    Vite's own pinned rolldown),
 3. build `packages/vite` via its own `build` script (`vp run build`),
 4. swap `vite/packages/vite/node_modules/rolldown` to a symlink at the
    workspace's `packages/rolldown`, so Vite's dist resolves the local binding
-   at runtime. Any install inside the submodule resets this — re-run the
-   script.
+   at runtime. Any install inside the checkout resets this, so re-run the
+   script after such an install.
 
 Repo-wide tools ignore `vite/**` (a `.gitignore`
 entry covers gitignore-respecting walkers like oxfmt, plus `.typos.toml` and
 `.ls-lint.json` entries) — a repo-wide `vp fmt --write` must never touch
-submodule files. On CI, the submodule is initialized on demand: the dev-server
-workflow via the setup step, the vite-tests jobs via `run.ts` (which clones the
-checkout locally to run Vite's own suite); every other job needs no submodule.
+files inside `vite/`. On CI, only the dev-server workflow creates the checkout
+(via the setup step); every other job needs no Vite checkout. The vite-tests
+jobs run Vite's own suite on a separate throwaway clone of vitejs/vite, at the
+same latest `rolldown-canary` rebased onto the latest `main` (see
+`packages/vite-tests/run.ts`).
 
 ### Server entry point (`src/`)
 
@@ -285,7 +290,7 @@ in the `tests` workspace.
 
 - **Upstream the two Vite bundled-dev fixes.** The recovery reload and the
   stale-error replay (see [The Vite backend](#the-vite-backend)) are genuine
-  upstream gaps; once fixed in vitejs/vite and the submodule is bumped, delete
+  upstream gaps; once the fixes land on vitejs/vite `rolldown-canary`, delete
   the `WORKAROUND` blocks in `src/vite-server.ts`.
 - **Client-reconnect gate after reloads.** Add
   `untilBrowserLogAfter(() => page.reload(), [/\[vite\] connected\./])` so an

--- a/justfile
+++ b/justfile
@@ -221,10 +221,10 @@ build-browser-release:
 build-test-dev-server:
   vp run --filter @rolldown/test-dev-server build
 
-# Set up the vendored Vite submodule at `vite/` (init the submodule, link the
-# workspace rolldown into it, install + build vite). It backs the
-# `@rolldown/test-dev-server` browser tests; `packages/vite-tests` shares the
-# same checkout. Requires `just build-rolldown` first.
+# Set up the Vite checkout at `vite/` (clone vitejs/vite rolldown-canary
+# rebased onto main, link the workspace rolldown into it, install + build
+# vite). It backs the `@rolldown/test-dev-server` browser tests. Requires
+# `just build-rolldown` first.
 setup-vite:
   vp run --filter @rolldown-internal/scripts setup-vite
 

--- a/packages/test-dev-server/src/vite-server.ts
+++ b/packages/test-dev-server/src/vite-server.ts
@@ -15,12 +15,12 @@ import { getDevWatchOptionsForCi } from './utils/get-dev-watch-options-for-ci.js
  * (`experimental.bundledDev`).
  *
  * In-memory serving, HMR fan-out, the lazy-bundling endpoint, the error
- * overlay, and the fallback spinner all come from Vite itself. The vendored
- * submodule at `vite/` (repo root) resolves `rolldown` to the
- * workspace's `packages/rolldown` via a node_modules symlink swap (see
- * `just setup-vite`; the submodule itself stays pristine), so running
- * these tests exercises the local rolldown binding through the real Vite
- * integration.
+ * overlay, and the fallback spinner all come from Vite itself. The Vite
+ * checkout at `vite/` (repo root, vitejs/vite `rolldown-canary` rebased onto
+ * `main`) resolves `rolldown` to the workspace's `packages/rolldown` via a
+ * node_modules symlink swap (see `just setup-vite`; the checkout itself
+ * stays unpatched), so running these tests exercises the local rolldown
+ * binding through the real Vite integration.
  *
  * What this file adds on top of Vite is only the test-harness surface the
  * specs rely on and Vite doesn't provide:
@@ -39,9 +39,9 @@ import { getDevWatchOptionsForCi } from './utils/get-dev-watch-options-for-ci.js
 // with (poll watcher + content comparison so same-second rewrites aren't
 // missed — see get-dev-watch-options-for-ci.ts), reopening exactly the blind
 // spot that made the recovery specs hang on CI before rolldown#9736. The
-// vendored submodule stays pristine, so merge the options here instead:
+// Vite checkout stays unpatched, so merge the options here instead:
 // Vite's `dev()` helper looks up `DevEngine.create` at call time, and the
-// vendored dist resolves `rolldown` to this same workspace package (see
+// checkout's dist resolves `rolldown` to this same workspace package (see
 // `just setup-vite`), so wrapping the static covers Vite's engine too.
 // Vite's own options win the merge, keeping its `skipWrite: true`.
 const originalDevEngineCreate = DevEngine.create.bind(DevEngine);
@@ -55,11 +55,11 @@ DevEngine.create = ((...args: Parameters<typeof DevEngine.create>) => {
 
 // --- Vite loading -------------------------------------------------------------
 // `vite` is deliberately NOT a package.json dependency: it is loaded at
-// runtime from the vendored submodule's built dist. The node-platform
+// runtime from the Vite checkout's built dist. The node-platform
 // fixtures — and every CI job that never runs browser tests — must work
-// without the submodule being initialized or built, so nothing here may make
+// without the checkout being cloned or built, so nothing here may make
 // `pnpm install` or `tsc` depend on it (a `link:` dependency dangles when the
-// submodule is absent and breaks both). The interfaces below are minimal
+// checkout is absent and breaks both). The interfaces below are minimal
 // structural types for the slice of Vite's API the harness touches.
 
 interface ViteDevServerLike {
@@ -106,7 +106,7 @@ const packageRoot = nodePath.resolve(
   nodePath.dirname(nodeUrl.fileURLToPath(import.meta.url)),
   '..',
 );
-// The vendored Vite submodule lives at the repo root: packages/test-dev-server → ../../vite.
+// The Vite checkout lives at the repo root: packages/test-dev-server resolves it via ../../vite.
 const viteDistEntry = nodePath.join(
   packageRoot,
   '..',
@@ -124,7 +124,7 @@ async function loadVite(): Promise<{
 }> {
   if (!nodeFs.existsSync(viteDistEntry)) {
     throw new Error(
-      `Vite dist not found at ${viteDistEntry} — the browser platform runs on the vendored Vite submodule. Run \`just setup-vite\` first.`,
+      `Vite dist not found at ${viteDistEntry}. The browser platform runs on the Vite checkout at vite/. Run \`just setup-vite\` first.`,
     );
   }
   return import(nodeUrl.pathToFileURL(viteDistEntry).href) as Promise<{
@@ -205,8 +205,8 @@ function createHarnessPlugin(counters: HarnessCounters): VitePluginLike {
   // `error` payloads. Backs the two error-recovery workarounds below — see
   // the `configureServer`/`generateBundle` comments. Vite's own bundled-dev
   // state (`BundledDev.lastBuildError`) is `private`, so the workarounds
-  // reach it with a cast; the vendored submodule pins the Vite version, so
-  // this stays stable until the submodule is bumped.
+  // reach it with a cast; the checkout tracks vitejs/vite `rolldown-canary`,
+  // so a canary update can move these internals.
   let sawBroadcastError = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let getBundledDev: () => any = () => undefined;
@@ -411,7 +411,7 @@ export async function createViteDevServer(
     const bundledDev = (server.environments.client as any).bundledDev;
     if (!bundledDev || !('initialBuildCompleted' in bundledDev)) {
       throw new Error(
-        'vite internals moved: expected `environments.client.bundledDev.initialBuildCompleted` — re-check vite-server.ts against the new submodule pin',
+        'vite internals moved: expected `environments.client.bundledDev.initialBuildCompleted`. Re-check vite-server.ts against the current Vite checkout',
       );
     }
     while (!bundledDev.initialBuildCompleted) {

--- a/packages/test-dev-server/tests/AGENTS.md
+++ b/packages/test-dev-server/tests/AGENTS.md
@@ -3,7 +3,7 @@
 ## Testing dev-server behavior
 
 The guide for writing these tests — browser playgrounds vs. node fixtures, the
-playground layout, the required Vite submodule setup, the assertion signals,
+playground layout, the required Vite checkout setup, the assertion signals,
 the synchronize-don't-`sleep` rule, when to split specs, the shared-`page`
 reliability rules, cold-start playgrounds, and the build/run commands — lives
 in the **Dev server tests** section of the testing docs. Read it before adding
@@ -13,5 +13,5 @@ or changing a test here:
   (published at <https://rolldown.rs/development-guide/testing>)
 
 The harness architecture (the Vite full-bundle-mode backend, the node
-transport, the submodule policy) is in
+transport, the Vite checkout policy) is in
 [`internal-docs/dev-server-test-harness/implementation.md`](../../../internal-docs/dev-server-test-harness/implementation.md).

--- a/scripts/src/setup-vite/checkout.ts
+++ b/scripts/src/setup-vite/checkout.ts
@@ -1,14 +1,15 @@
-// Shared handling of the vendored Vite submodule (`vite/` at the repo root) —
-// the single Vite checkout used by both the dev-server test harness
-// (`packages/test-dev-server`, see `main.ts`) and Vite's own test suite
-// (`packages/vite-tests/run.ts`, which clones this checkout locally).
+// Handling of the Vite checkout (`vite/` at the repo root, gitignored), used
+// by the dev-server test harness (`packages/test-dev-server`, see `main.ts`).
+// It is a plain clone of vitejs/vite on the `rolldown-canary` branch rebased
+// onto the latest `main`, the same code `packages/vite-tests` runs on, so
+// both harnesses track the canary line instead of a pinned commit.
 
 import { execSync } from 'node:child_process';
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
 import nodeUrl from 'node:url';
 
-// scripts/src/setup-vite/checkout.ts → repo root is three levels up.
+// scripts/src/setup-vite/checkout.ts sits three levels below the repo root.
 export const repoRoot = nodePath.resolve(
   nodePath.dirname(nodeUrl.fileURLToPath(import.meta.url)),
   '../../..',
@@ -22,30 +23,19 @@ export const run = (cmd: string, cwd: string): void => {
 const capture = (cmd: string, cwd: string): string =>
   execSync(cmd, { cwd, encoding: 'utf8' }).trim();
 
-// Ensure the submodule has a checkout, and use that checkout exactly as-is.
+// Ensure `vite/` has a checkout, and use that checkout exactly as-is.
 //
-//   - Uninitialized (fresh clone / CI): `git submodule update --init` checks
-//     out the pinned commit from the superproject index.
-//   - Already initialized: the checkout is never moved. Updating it — after a
-//     pin bump, or to a different branch/commit — is always a manual git step
-//     (e.g. `git submodule update vite`, or a checkout inside `vite/`).
-//
-// (Pathspec is repo-root-relative, so run git from the repo root.)
+//   - Missing (fresh clone / CI): clone the `rolldown-canary` branch and
+//     rebase it onto `origin/main`, so canary-side fixes take effect right
+//     away and the newest Vite changes surface incompatibilities early.
+//   - Already present: the checkout is never moved. Updating it, to a newer
+//     `rolldown-canary` or to any other commit, is always a manual git step
+//     inside `vite/`.
 export function ensureViteCheckout(): void {
-  const isInitialized =
-    nodeFs.existsSync(nodePath.join(viteDir, '.git')) &&
-    nodeFs.existsSync(nodePath.join(viteDir, 'package.json'));
-  if (!isInitialized) {
-    // Full (non-shallow) clone: this Vite submodule is developed in-tree, so the
-    // complete history is needed (branching, rebasing, blame, making commits). A
-    // shallow `--depth 1` clone would leave the checkout grafted with no
-    // ancestry — fine for a one-off build, but not for development.
-    run('git submodule update --init vite', repoRoot);
+  if (!nodeFs.existsSync(nodePath.join(viteDir, 'package.json'))) {
+    run('git clone --branch rolldown-canary https://github.com/vitejs/vite.git vite', repoRoot);
+    run('git rebase origin/main', viteDir);
   }
-  const head = capture('git rev-parse HEAD', viteDir).slice(0, 12);
-  const pinned = capture('git ls-files -s -- vite', repoRoot).split(/\s+/)[1];
-  console.log(
-    `[setup-vite] using vite ${head}` +
-      (pinned.startsWith(head) ? '' : ` (superproject pins ${pinned.slice(0, 12)})`),
-  );
+  const head = capture('git rev-parse --short HEAD', viteDir);
+  console.log(`[setup-vite] using vite ${head}`);
 }

--- a/scripts/src/setup-vite/main.ts
+++ b/scripts/src/setup-vite/main.ts
@@ -1,19 +1,19 @@
-// Set up the vendored Vite submodule (`vite/` at the repo root) so the
-// browser-platform tests run on Vite's full bundle mode backed by the
-// workspace's local rolldown — WITHOUT modifying anything in the Vite repo:
+// Set up the Vite checkout (`vite/` at the repo root) so the browser-platform
+// tests run on Vite's full bundle mode backed by the workspace's local
+// rolldown, WITHOUT modifying anything in the Vite repo:
 //
-//   1. init the submodule if needed and build the checkout exactly as-is
-//      (the superproject's pinned commit after a fresh init; updating an
-//      existing checkout is always a manual git step — see checkout.ts),
+//   1. clone vitejs/vite (`rolldown-canary` rebased onto `main`) if needed
+//      and build the checkout exactly as-is (updating an existing checkout
+//      is always a manual git step, see checkout.ts),
 //   2. `pnpm install --frozen-lockfile` (no manifest or lockfile writes),
 //   3. build the `vite` package with its own pinned dependencies,
 //   4. swap the `packages/vite/node_modules/rolldown` symlink to point at the
 //      workspace's `packages/rolldown`, so Vite's dist resolves the local
 //      rolldown (and its native binding) at runtime.
 //
-// node_modules is untracked, so the submodule stays pristine in git. The swap
-// is undone by any `pnpm install` inside the submodule — re-run this script
-// after that (it is idempotent).
+// The Vite source files are never patched. The swap is undone by any
+// `pnpm install` inside the checkout, so re-run this script after that (it is
+// idempotent).
 //
 // Requires `packages/rolldown` to be built first (`just build-rolldown`).
 //
@@ -35,19 +35,18 @@ if (!nodeFs.existsSync(nodePath.join(localRolldownDir, 'dist', 'index.mjs'))) {
   process.exit(1);
 }
 
-// 1. Ensure the submodule has a checkout (see checkout.ts), then build
-// whatever commit is checked out.
+// 1. Ensure `vite/` has a checkout (see checkout.ts), then build whatever
+// commit is checked out.
 ensureViteCheckout();
 
-// 2. Install Vite's workspace deps exactly as pinned upstream, via vp — it
-// delegates to the submodule's pinned pnpm itself, so no pnpm needs to be
-// installed separately. (The simple-git-hooks postinstall warns inside a
-// submodule — harmless.) This also resets any previous symlink swap from
+// 2. Install Vite's workspace deps exactly as pinned upstream, via vp. It
+// delegates to the checkout's pinned pnpm itself, so no pnpm needs to be
+// installed separately. This also resets any previous symlink swap from
 // step 4, so the build below always uses Vite's own pinned rolldown.
 run('vp install --frozen-lockfile', viteDir);
 
 // 3. Build the vite package (dist/node + dist/client, plus its type build)
-// via its own `build` script. vp delegates to the submodule's pinned package
+// via its own `build` script. vp delegates to the checkout's pinned package
 // manager, so no pnpm needs to be installed separately.
 const vitePkgDir = nodePath.join(viteDir, 'packages', 'vite');
 run('vp run build', vitePkgDir);
@@ -80,4 +79,4 @@ if (!resolvedRolldown.startsWith(nodeFs.realpathSync(localRolldownDir) + nodePat
   process.exit(1);
 }
 
-console.log('[setup-vite] done — vite/packages/vite/dist is ready, submodule left pristine');
+console.log('[setup-vite] done, vite/packages/vite/dist is ready');


### PR DESCRIPTION
Stacked on the vite-tests PR. Together they make both Vite harnesses run on the same code: the latest `rolldown-canary` rebased onto the latest `main`.

## Problem

The dev-server test harness built the vite submodule at its pinned commit. Same pin-rot problem as vite-tests: `rolldown-canary` is force-pushed on every update, so a pinned commit ends up on no branch, and canary-side fixes need a manual pin bump to reach CI. The pin mechanism fundamentally conflicts with tracking a rebased branch.

## Change

- **Remove the vite git submodule entirely**: the `.gitmodules` entry and the `vite` gitlink are gone. `vite/` at the repo root is now a plain, gitignored clone.
- **`scripts/src/setup-vite/checkout.ts`**: when `vite/` is missing (fresh clone, CI), it clones vitejs/vite `rolldown-canary` and rebases it onto `origin/main`. An existing checkout is never moved: updating it stays a manual git step inside `vite/`, so local work in the checkout is never trampled.
- **`reusable-node-dev-server-test.yml`**: adds a "Configure Git" step, since the rebase needs a committer identity in CI (the vite-test jobs in ci.yml already had one).
- Wording updates everywhere the submodule or the pin was mentioned: `setup-vite` scripts, `vite-server.ts` comments and error messages, `.gitignore`, `justfile`, `testing.md`, `repo-structure.md`, `implementation.md`, `tests/AGENTS.md`.

Fixes and test adjustments for the Vite side now always belong on the vitejs/vite `rolldown-canary` branch, for both harnesses.

Jobs that check out with `submodules: true` are unaffected: only the `rollup` and `test262` submodules remain.

## Verification

- Fresh `just setup-vite` end to end: clone `rolldown-canary`, rebase onto `main`, `vp install`, vite build, rolldown symlink swap and resolution check all pass.
- Dev-server browser suite smoke (`hmr-client-invalidate`, 4 tests) passes on the resulting checkout with a current rolldown `main` build.
- `just lint` fully green (fmt, oxlint/tsc, knip, publint, ls-lint).
- A repo-wide sweep found no remaining references to the submodule or the pin mechanism.