### PR TITLE
fix(code-splitting): make strict transitive init registration deterministic and constant-time

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -67,10 +67,27 @@ impl ChunkGraph {
   }
 
   /// The module is assigned to a live chunk that still contains it.
+  ///
+  /// O(1) on purpose: this is called for every canonical referenced symbol of every included
+  /// statement under strict execution order (`add_depended_symbol_with_wrapped_esm_init`), so the
+  /// former `chunk.modules.contains(&module_idx)` linear scan made the pass quadratic on large
+  /// chunks. Dropping the scan is sound because of this invariant:
+  ///
+  ///   whenever `module_to_chunk[m] == Some(c)` and `c` is live, `c.modules` contains `m`.
+  ///
+  /// `add_module_to_chunk` establishes it (it sets `module_to_chunk[m]` and pushes `m` onto
+  /// `c.modules` together). Every site that later removes a module from a chunk's `modules` list
+  /// preserves it by pairing the removal with one of:
+  ///   - clearing `module_to_chunk[m]` to `None` (unused-runtime sweep, `sweep_unused_runtime_module`);
+  ///   - reassigning `module_to_chunk[m]` to the destination chunk via `add_module_to_chunk`
+  ///     (runtime relocation in `ensure_runtime_module_for_order_wraps`, the runtime→target merge,
+  ///     and `apply_common_chunk_merges`);
+  ///   - marking the emptied source chunk `Removed` (so `chunk_is_live` returns false).
+  ///
+  /// No site removes a module while leaving `module_to_chunk[m]` pointed at a still-live chunk, so
+  /// there is no residual case that would need a separate removed-module set.
   pub fn module_is_in_live_chunk(&self, module_idx: ModuleIdx) -> bool {
-    self.module_to_chunk[module_idx].is_some_and(|chunk_idx| {
-      self.chunk_is_live(chunk_idx) && self.chunk_table[chunk_idx].modules.contains(&module_idx)
-    })
+    self.module_to_chunk[module_idx].is_some_and(|chunk_idx| self.chunk_is_live(chunk_idx))
   }
 
   /// Render order: user-defined entry chunks first (stable by index), everything else by

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -620,7 +620,19 @@ impl GenerateStage<'_> {
     module_idx: ModuleIdx,
   ) {
     let meta = &self.link_output.metas[module_idx];
-    for targets in order_state.transitive_init_targets(module_idx, meta).values() {
+    // Iterate the targets in a deterministic, cross-target-stable order. The map is an
+    // `FxHashMap<StmtInfoIdx, _>`, and its `values()` order follows FxHash bucket layout. FxHash is
+    // unseeded but hashes differently on 32-bit vs 64-bit, so `values()` visits buckets in a
+    // different order on native (64-bit) than on wasm32/WASI. That order flows straight into
+    // `depended_symbols` (an `FxIndexSet`), whose insertion order drives the chunk's imported-symbol
+    // rename order (the `$1`/`$2` suffixes) in `deconflict_chunk_symbols` — so a hash-ordered walk
+    // here makes native and WASI builds resolve rename collisions differently. Sorting by the owning
+    // `StmtInfoIdx` pins one order for every target.
+    for (_, targets) in order_state
+      .transitive_init_targets(module_idx, meta)
+      .iter()
+      .sorted_unstable_by_key(|(stmt_info_idx, _)| **stmt_info_idx)
+    {
       for &target_idx in targets {
         let meta = &self.link_output.metas[target_idx];
         if let Some(target) = order_state.esm_init_target(target_idx, meta)


### PR DESCRIPTION
## Summary

Two independent, cheap fixes to the strict-execution-order cross-chunk link pass (review items 3 and 4):

- **Cross-target determinism.** `add_transitive_esm_init_depended_symbols` iterated an `FxHashMap` via `.values()`, whose bucket order follows FxHash layout. FxHash is unseeded but hashes differently on 32-bit vs 64-bit, so that order — which flows into the chunk's `depended_symbols` `FxIndexSet` and thence into imported-symbol rename order (the `$1`/`$2` suffixes) in `deconflict_chunk_symbols` — could diverge between native and wasm32/WASI builds. Now iterated sorted by the owning `StmtInfoIdx`, pinning one order everywhere. It is the single hash-ordered site three review passes converged on; every other hash-ordered effect is already sorted before use.
- **Quadratic strict-mode hot loop.** `module_is_in_live_chunk` did a linear `chunk.modules.contains` scan, called for every canonical referenced symbol of every included statement under strict — quadratic on large chunks. Replaced with an O(1) `module_to_chunk` + liveness check.

The O(1) rewrite is verified semantically equivalent: `add_module_to_chunk` sets `module_to_chunk[m]` and pushes `m` onto `c.modules` together, and every site that later removes a module from a chunk's `modules` list preserves the invariant (`module_to_chunk[m] == Some(c) && c live ⟹ c.modules ∋ m`) by pairing the removal with clearing `module_to_chunk[m]` (unused-runtime sweep), reassigning it to the destination chunk via `add_module_to_chunk` (runtime relocation, runtime→target merge, `apply_common_chunk_merges`), or marking the emptied chunk `Removed`. No site leaves `module_to_chunk` pointed at a still-live chunk that no longer contains the module, so no removed-module set is needed. The invariant is documented in the function's doc comment.

## Behavior / snapshot impact

**None.** Zero fixture snapshot changes. The determinism fix is invisible on native 64-bit (its value is native-vs-wasm parity, which the native suite cannot exercise); the O(1) change is a pure performance rewrite with identical results.

## Validation

- `cargo test -p rolldown` — 1868 passed; snapshot-stable (zero deltas). The only failures are 5 pre-existing environmental ones unrelated to this change (`cjs_module_lexer_compat` ×3 and `npm_packages/util_deprecate` need an installed `cjs-module-lexer`; `test262` needs the test262 submodule).
- `cargo fmt --all --check` — clean.
- `cargo clippy -p rolldown --all-targets -- -D warnings` — clean.

---

Follow-up to #10104; addresses the two "cheap pre-merge fixes" (items 3 and 4) from the review discussion: https://github.com/rolldown/rolldown/pull/10104#issuecomment-4992442574
