### PR TITLE
test(code-splitting): pin flag-off wrapped-esm init emission

### DIFF
--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "wrapper",
+        "import": "./wrapper.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/_test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+
+globalThis.__log = [];
+const ns = await import('./dist/main.js');
+
+// Runtime check: ambiguous x stays absent and both owners evaluate once; the snapshot pins that neither owner init is added at main's star re-export.
+assert.strictEqual('x' in ns, false, 'ambiguous names are omitted from the namespace');
+assert.deepStrictEqual(
+  globalThis.__log,
+  ['A', 'B', 'BEFORE_REQUIRE', 'MAIN'],
+  'both ambiguous owners evaluate once before the main body',
+);

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## barrel.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region mod_a.js
+var mod_a_exports = /* @__PURE__ */ __exportAll({ x: () => "ax" });
+var init_mod_a = __esmMin((() => {
+	globalThis.__log.push("A");
+}));
+//#endregion
+//#region mod_b.js
+var mod_b_exports = /* @__PURE__ */ __exportAll({ x: () => "bx" });
+var init_mod_b = __esmMin((() => {
+	globalThis.__log.push("B");
+}));
+//#endregion
+//#region dynamic.cjs
+var require_dynamic = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { dynamic: "dynamic" };
+}));
+//#endregion
+//#region barrel.js
+var barrel_exports = /* @__PURE__ */ __exportAll({});
+init_mod_a();
+init_mod_b();
+__reExport(barrel_exports, /* @__PURE__ */ __toESM(require_dynamic()));
+//#endregion
+export { mod_a_exports as a, init_mod_a as i, init_mod_b as n, __exportAll as o, mod_b_exports as r, __reExport as s, barrel_exports as t };
+
+```
+
+## main.js
+
+```js
+import { i as init_mod_a, n as init_mod_b, o as __exportAll, s as __reExport, t as barrel_exports } from "./barrel.js";
+__reExport(/* @__PURE__ */ __exportAll({}), barrel_exports);
+globalThis.__log.push("BEFORE_REQUIRE");
+init_mod_a();
+init_mod_b();
+globalThis.__log.push("MAIN");
+//#endregion
+
+```
+
+## wrapper.js
+
+```js
+import "./barrel.js";
+
+```

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/barrel.js
@@ -1,0 +1,7 @@
+// Both leaves export `x`, so `x` is an ambiguous export on the barrel (resolves to undefined). The
+// ambiguous owners still have observable side effects that must run.
+export * from './mod_a.js';
+export * from './mod_b.js';
+// Dynamic exports keep main's `export *` statement included so its IsExportStar collector path is
+// finalized; this module intentionally exports no `x` of its own.
+export * from './dynamic.cjs';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/dynamic.cjs
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/dynamic.cjs
@@ -1,0 +1,1 @@
+module.exports = { dynamic: 'dynamic' };

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/main.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/main.js
@@ -1,0 +1,10 @@
+// The barrel's dynamic exports keep this IsExportStar record included while `x` remains ambiguous
+// and is therefore absent from its sorted, non-ambiguous export map. The second entry keeps the
+// immediate barrel unwrapped and in a different chunk.
+export * from './barrel.js';
+globalThis.__log.push('BEFORE_REQUIRE');
+// These later requires wrap both owners and make both init symbols reachable in this chunk. The
+// star-export collector must not pull either call forward to the re-export position.
+require('./mod_a.js');
+require('./mod_b.js');
+globalThis.__log.push('MAIN');

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/mod_a.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/mod_a.js
@@ -1,0 +1,2 @@
+globalThis.__log.push('A');
+export const x = 'ax';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/mod_b.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/mod_b.js
@@ -1,0 +1,2 @@
+globalThis.__log.push('B');
+export const x = 'bx';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/wrapper.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/wrapper.js
@@ -1,0 +1,3 @@
+// A second entry makes the unwrapped barrel and its leaves shared with main. It is not executed by
+// the runtime assertion; its only role is to keep the immediate forwarder out of main's chunk.
+import './barrel.js';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/_config.json
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "codeSplitting": false,
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/_test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import run from './dist/main.js';
+
+globalThis.__log = [];
+delete globalThis.__ready;
+
+// Runtime regression check: the carrier observes the TLA side effect before it continues.
+assert.strictEqual(await run(), 'usedmarker');
+assert.deepStrictEqual(
+  globalThis.__log,
+  ['LEAF:before', 'LEAF:after', 'CARRIER:ready', 'BARREL:used:marker'],
+  'an excluded re-export awaits its TLA init before the carrier continues',
+);

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/artifacts.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf.js
+var used;
+var init_leaf = __esmMin((async () => {
+	globalThis.__log.push("LEAF:before");
+	await Promise.resolve();
+	globalThis.__ready = "ready";
+	globalThis.__log.push("LEAF:after");
+	used = "used";
+}));
+//#endregion
+//#region carrier.js
+var marker;
+var init_carrier = __esmMin((async () => {
+	await init_leaf();
+	globalThis.__log.push(`CARRIER:${globalThis.__ready}`);
+	marker = "marker";
+}));
+//#endregion
+//#region barrel.js
+var barrel_exports = /* @__PURE__ */ __exportAll({ result: () => result });
+var result;
+var init_barrel = __esmMin((async () => {
+	await init_carrier();
+	await init_leaf();
+	globalThis.__log.push(`BARREL:${used}:${marker}`);
+	result = used + marker;
+}));
+//#endregion
+//#region main.js
+async function run() {
+	const { result } = await init_barrel().then(() => barrel_exports);
+	return result;
+}
+//#endregion
+export { run as default };
+
+```

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/barrel.js
@@ -1,0 +1,5 @@
+import { marker } from './carrier.js';
+import { used } from './leaf.js';
+
+globalThis.__log.push(`BARREL:${used}:${marker}`);
+export const result = used + marker;

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/carrier.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/carrier.js
@@ -1,0 +1,6 @@
+// `unused` is tree-shaken, but leaf remains live through barrel's `used` import. The excluded
+// re-export still forwards init_leaf() inside this async wrapper and must await it before continuing.
+export { unused } from './leaf.js';
+
+globalThis.__log.push(`CARRIER:${globalThis.__ready}`);
+export const marker = 'marker';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/leaf.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/leaf.js
@@ -1,0 +1,7 @@
+globalThis.__log.push('LEAF:before');
+await Promise.resolve();
+globalThis.__ready = 'ready';
+globalThis.__log.push('LEAF:after');
+
+export const used = 'used';
+export const unused = 'unused';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/main.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/excluded_reexport_tla/main.js
@@ -1,0 +1,4 @@
+export default async function run() {
+  const { result } = await import('./barrel.js');
+  return result;
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/_config.json
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "wrapper",
+        "import": "./wrapper.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/_test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+
+globalThis.__log = [];
+await import('./dist/main.js');
+
+// Runtime smoke check: the namespace value remains usable and each leaf evaluates once; the snapshot pins exact init routing.
+assert.deepStrictEqual(
+  globalThis.__log,
+  ['A', 'B', 'BEFORE_REQUIRE:a', 'MAIN'],
+  'the namespace value remains usable and each leaf evaluates once',
+);

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/artifacts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## barrel.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf_a.js
+var leaf_a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+function a() {
+	return "a";
+}
+var init_leaf_a = __esmMin((() => {
+	globalThis.__log.push("A");
+}));
+//#endregion
+//#region leaf_b.js
+var leaf_b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+function b() {
+	return "b";
+}
+var init_leaf_b = __esmMin((() => {
+	globalThis.__log.push("B");
+}));
+//#endregion
+//#region barrel.js
+init_leaf_a();
+init_leaf_b();
+//#endregion
+export { leaf_a_exports as a, init_leaf_a as i, leaf_b_exports as n, a as r, init_leaf_b as t };
+
+```
+
+## main.js
+
+```js
+import { i as init_leaf_a, r as a, t as init_leaf_b } from "./barrel.js";
+//#region main.js
+init_leaf_a();
+globalThis.__log.push("BEFORE_REQUIRE:" + a());
+init_leaf_a();
+init_leaf_b();
+globalThis.__log.push("MAIN");
+//#endregion
+
+```
+
+## wrapper.js
+
+```js
+import "./barrel.js";
+
+```

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/barrel.js
@@ -1,0 +1,2 @@
+export * from './leaf_a.js';
+export * from './leaf_b.js';

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/leaf_a.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/leaf_a.js
@@ -1,0 +1,4 @@
+globalThis.__log.push('A');
+export function a() {
+  return 'a';
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/leaf_b.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/leaf_b.js
@@ -1,0 +1,4 @@
+globalThis.__log.push('B');
+export function b() {
+  return 'b';
+}

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/main.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/main.js
@@ -1,0 +1,7 @@
+import * as ns from './barrel.js';
+// The second entry keeps this forwarder in a different chunk. These later requires wrap both leaf
+// owners and make both init symbols reachable here without wrapping the immediate barrel.
+globalThis.__log.push('BEFORE_REQUIRE:' + ns.a());
+require('./leaf_a.js');
+require('./leaf_b.js');
+globalThis.__log.push('MAIN');

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/wrapper.js
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/namespace_liveness_gating/wrapper.js
@@ -1,0 +1,3 @@
+// A second entry makes the unwrapped barrel and its leaves shared with main. It is not executed by
+// the runtime assertion; its only role is to keep the immediate forwarder out of main's chunk.
+import './barrel.js';


### PR DESCRIPTION
## Summary

Adds three executable **flag-off** regression fixtures for wrapped-ESM init emission changes that landed with #10104. None enables `strictExecutionOrder`, and this PR changes no production source.

The earlier version of this PR required each barrel directly, which wrapped the immediate importee and bypassed the shared init-target collector it claimed to cover. The two collector fixtures now keep the immediate barrel at `WrapKind::None` in a shared chunk, while later `require()` calls wrap the leaf owners and make their init symbols reachable from the main chunk.

## Coverage

### Importer-local namespace liveness

`namespace_liveness_gating` imports the barrel namespace but reads only `ns.a()`. A second entry places the unwrapped barrel in a shared chunk; later requires make both wrapped leaf init symbols reachable.

- Current output emits only `init_leaf_a()` at the namespace-import position. `init_leaf_b()` stays at its later explicit require position.
- Pre-#10104 output emitted `init_leaf_a(), init_leaf_b()` together at the namespace-import position.
- The shared barrel still evaluates both leaves exactly once; runtime order is `A, B, BEFORE_REQUIRE:a, MAIN`.

### Sorted, non-ambiguous star-export routing

`ambiguous_star_reexport` has two wrapped leaves that both export `x`. The entry uses a real `export * from` record; a dynamic CommonJS re-export keeps that record included, while the second entry keeps the immediate barrel unwrapped and in another chunk.

- Current output excludes ambiguous `x` from the collector's sorted, non-ambiguous export map and emits no owner init before `__reExport(...)`.
- Pre-#10104 output selected an ambiguous owner and emitted `init_mod_a()` before `__reExport(...)`.
- Runtime confirms `x` is absent and both owners still evaluate exactly once through the shared barrel.

### Excluded re-export to a TLA wrapper

`excluded_reexport_tla` uses `codeSplitting: false`, so an inline dynamic import wraps the barrel and its static dependency chain even with strict execution order disabled. With `moduleSideEffects: false`, the carrier's unused re-export is excluded while the same TLA leaf remains live through a separate `used` import.

- Current output emits `await init_leaf()` in the carrier's async wrapper before its later statement.
- Pre-#10104 output emitted bare `init_leaf()`, producing `CARRIER:undefined` before the leaf's top-level await completed.
- Current runtime order is `LEAF:before, LEAF:after, CARRIER:ready, BARREL:used:marker`.

## Behavior / snapshot impact

Tests only: two existing fixtures are corrected, one TLA fixture is added, and their generated snapshots are pinned. No existing production code or unrelated snapshot changes.

## Validation

- Rebased onto `main` at `cccf1d0d849c71e80c02fe3ff17a97192f3bf258`.
- Generated all three fixtures with the macOS native binding from current-main CI [run 29795703407](https://github.com/rolldown/rolldown/actions/runs/29795703407); every `_test.mjs` passed under Node.
- Compared each committed snapshot byte-for-byte with those generated assets after applying the integration harness's runtime-module hiding.
- Re-ran the same sources with the pre-#10104 binding from CI [run 29559371389](https://github.com/rolldown/rolldown/actions/runs/29559371389): both collector fixtures show the obsolete extra init, and the TLA fixture logs `CARRIER:undefined`.
- `vp fmt ... --check`, `typos`, JS syntax checks, JSON parsing, and `git diff --check` pass. The pre-commit `vp check --fix` hook also completed cleanly.

- CI [run 29819995357](https://github.com/rolldown/rolldown/actions/runs/29819995357): Repo, Rust, Node, Cargo, WASI, native-build, and Node 20/22/24 test jobs passed. Vite Test Ubuntu and the three Ubuntu Dev Server jobs stopped before tests because the Vite `rolldown-canary` branch no longer rebases cleanly onto `vite/main` (`pnpm-lock.yaml` conflict); this is unrelated Vite checkout noise.

## AI usage disclosure

Per the [AI Usage Policy](https://rolldown.rs/contribution-guide/#ai-usage-policy), OpenAI Codex was used to rebase and review the PR, design the corrected regression shapes, and verify generated output. I reviewed the final diff and validation evidence.

---

Follow-up to #10104; addresses Major 2b/2c from the review discussion: https://github.com/rolldown/rolldown/pull/10104#issuecomment-4992442574
