### PR TITLE
test(vite-tests): reuse the shared root vite checkout

### DIFF
--- a/docs/development-guide/repo-structure.md
+++ b/docs/development-guide/repo-structure.md
@@ -17,11 +17,11 @@ We store all the Node.js packages in this directory.
 - `/rolldown` Node.js package for the project.
 - `/bench` Benchmark programs for Node.js side of the project.
 - `/rollup-tests` Adapter for running rollup tests with rolldown.
-- `/vite-tests` Script to run Vite's own test suite with local rolldown, on a throwaway clone of [vitejs/vite](https://github.com/vitejs/vite) at the latest `rolldown-canary` rebased onto the latest `main`.
+- `/vite-tests` Script to run Vite's own test suite with local rolldown, on a throwaway clone of the shared root `/vite` checkout.
 
 # `/vite`
 
-The Vite checkout used by the dev-server test harness (`packages/test-dev-server`): a gitignored clone of [vitejs/vite](https://github.com/vitejs/vite) at the latest `rolldown-canary` rebased onto the latest `main`, created by `just setup-vite`. It must stay unpatched: never edit Vite source files inside it.
+The single Vite checkout shared by the dev-server test harness (`packages/test-dev-server`) and `packages/vite-tests`: a gitignored clone of [vitejs/vite](https://github.com/vitejs/vite) at the latest `rolldown-canary` rebased onto the latest `main`, created by `just setup-vite`. It must stay unpatched: never edit Vite source files inside it.
 
 # `/examples`
 

--- a/docs/development-guide/testing.md
+++ b/docs/development-guide/testing.md
@@ -264,7 +264,7 @@ just build-rolldown
 pnpm --filter @rolldown/test-dev-server build
 ```
 
-The browser suite also needs the Vite checkout set up once (clone vitejs/vite `rolldown-canary` rebased onto `main` + install + build + link the workspace rolldown into it). The setup builds an existing checkout as-is and never moves it, so updating it is a manual git step inside `vite/`. Re-run it after updating the checkout or after running an install inside it (an install resets the rolldown link):
+The browser suite also needs the Vite checkout set up (clone or update vitejs/vite `rolldown-canary` rebased onto `main`, then install + build + link the workspace rolldown into it). A checkout you took over (dirty, or switched to another branch) is built as-is. Re-run the setup after running an install inside the checkout (an install resets the rolldown link):
 
 ```sh
 just setup-vite

--- a/internal-docs/dev-server-test-harness/implementation.md
+++ b/internal-docs/dev-server-test-harness/implementation.md
@@ -149,11 +149,12 @@ serving. What the harness does own lives in `src/vite-server.ts`:
 Fixes and test adjustments belong on the vitejs/vite `rolldown-canary` branch,
 which both this harness and `packages/vite-tests` track. Everything
 environment-specific happens in untracked files, via the
-`scripts/src/setup-vite/` script (`just setup-vite`, idempotent, `vp`-only):
+`scripts/src/setup-vite/` script (`just setup-vite`, idempotent, `vp`-only;
+its checkout step is also reused by `packages/vite-tests`):
 
-1. clone vitejs/vite `rolldown-canary` rebased onto `main` if `vite/` is
-   missing; an existing checkout is built exactly as-is, the script never
-   moves it, so updating it is always a manual git step inside `vite/`,
+1. ensure `vite/` is at the latest `rolldown-canary` rebased onto `main`
+   (clone if missing, update otherwise); a checkout taken over by the
+   developer (dirty, or off `rolldown-canary`) is built exactly as-is,
 2. `vp install --frozen-lockfile` (vp delegates to the checkout's pinned
    pnpm; this also resets a previous step-4 swap, so the build always uses
    Vite's own pinned rolldown),
@@ -166,11 +167,10 @@ environment-specific happens in untracked files, via the
 Repo-wide tools ignore `vite/**` (a `.gitignore`
 entry covers gitignore-respecting walkers like oxfmt, plus `.typos.toml` and
 `.ls-lint.json` entries) — a repo-wide `vp fmt --write` must never touch
-files inside `vite/`. On CI, only the dev-server workflow creates the checkout
-(via the setup step); every other job needs no Vite checkout. The vite-tests
-jobs run Vite's own suite on a separate throwaway clone of vitejs/vite, at the
-same latest `rolldown-canary` rebased onto the latest `main` (see
-`packages/vite-tests/run.ts`).
+files inside `vite/`. On CI, the checkout is created on demand: the dev-server
+workflow via the setup step, the vite-tests jobs via `run.ts` (which clones
+the checkout locally to run Vite's own suite); every other job needs no Vite
+checkout.
 
 ### Server entry point (`src/`)
 

--- a/justfile
+++ b/justfile
@@ -223,7 +223,8 @@ build-test-dev-server:
 
 # Set up the Vite checkout at `vite/` (clone vitejs/vite rolldown-canary
 # rebased onto main, link the workspace rolldown into it, install + build
-# vite). It backs the `@rolldown/test-dev-server` browser tests. Requires
+# vite). It backs the `@rolldown/test-dev-server` browser tests, and
+# `packages/vite-tests` clones the same checkout. Requires
 # `just build-rolldown` first.
 setup-vite:
   vp run --filter @rolldown-internal/scripts setup-vite

--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { styleText } from 'node:util';
 import { x } from 'tinyexec';
+import { ensureViteCheckout, viteDir } from '../../scripts/src/setup-vite/checkout.js';
 
 const REPO_PATH = path.resolve(import.meta.dirname, './repo');
 const OVERRIDES = [
@@ -44,16 +45,18 @@ async function runCmdAndPipeOrExit(title: string, cmdOptions: Parameters<typeof 
 
 fs.rmSync(REPO_PATH, { recursive: true, force: true });
 
-// Test the latest `rolldown-canary` rebased onto the latest `main`, so that
-// test adjustments landing on `rolldown-canary` take effect right away and
-// new tests from Vite `main` surface incompatibilities with rolldown early.
+// Reuse the shared `vite/` checkout at the repo root (kept at the latest
+// `rolldown-canary` rebased onto the latest `main`, see
+// scripts/src/setup-vite/checkout.ts), the same code the dev-server tests
+// run on. The tests run on a throwaway LOCAL clone of it, never on the
+// checkout itself: this suite edits tracked files (pnpm overrides) and the
+// checkout must stay unpatched. The clone shares objects via hardlinks, so
+// no network is needed beyond the checkout itself.
+printTitle('# Ensuring the vite checkout...');
+ensureViteCheckout();
 await runCmdAndPipeOrExit(
-  '# Cloning vite repo (rolldown-canary branch)...',
-  ['git', ['clone', '--branch', 'rolldown-canary', 'https://github.com/vitejs/vite.git', REPO_PATH]],
-);
-await runCmdAndPipeOrExit(
-  '# Rebasing rolldown-canary onto main...',
-  ['git', ['rebase', 'origin/main'], { nodeOptions: { cwd: REPO_PATH } }],
+  '# Cloning the local vite checkout...',
+  ['git', ['clone', viteDir, REPO_PATH]],
 );
 
 printTitle('# Updating pnpm-workspace.yaml to link to local rolldown...');

--- a/packages/vite-tests/tsconfig.json
+++ b/packages/vite-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["run.ts"],
+  "include": ["run.ts", "../../scripts/src/setup-vite/checkout.ts"],
   "compilerOptions": {
     "composite": true,
     "resolveJsonModule": true,

--- a/scripts/src/setup-vite/checkout.ts
+++ b/scripts/src/setup-vite/checkout.ts
@@ -1,8 +1,10 @@
-// Handling of the Vite checkout (`vite/` at the repo root, gitignored), used
-// by the dev-server test harness (`packages/test-dev-server`, see `main.ts`).
-// It is a plain clone of vitejs/vite on the `rolldown-canary` branch rebased
-// onto the latest `main`, the same code `packages/vite-tests` runs on, so
-// both harnesses track the canary line instead of a pinned commit.
+// Handling of the Vite checkout (`vite/` at the repo root, gitignored), the
+// single Vite checkout shared by the dev-server test harness
+// (`packages/test-dev-server`, see `main.ts`) and Vite's own test suite
+// (`packages/vite-tests/run.ts`, which clones this checkout locally). It is
+// a plain clone of vitejs/vite on the `rolldown-canary` branch rebased onto
+// the latest `main`, so both harnesses track the canary line instead of a
+// pinned commit.
 
 import { execSync } from 'node:child_process';
 import nodeFs from 'node:fs';
@@ -23,19 +25,40 @@ export const run = (cmd: string, cwd: string): void => {
 const capture = (cmd: string, cwd: string): string =>
   execSync(cmd, { cwd, encoding: 'utf8' }).trim();
 
-// Ensure `vite/` has a checkout, and use that checkout exactly as-is.
+// Ensure `vite/` has a checkout at the latest `rolldown-canary` rebased onto
+// the latest `main`, so canary-side fixes take effect right away and the
+// newest Vite changes surface incompatibilities early.
 //
-//   - Missing (fresh clone / CI): clone the `rolldown-canary` branch and
-//     rebase it onto `origin/main`, so canary-side fixes take effect right
-//     away and the newest Vite changes surface incompatibilities early.
-//   - Already present: the checkout is never moved. Updating it, to a newer
-//     `rolldown-canary` or to any other commit, is always a manual git step
-//     inside `vite/`.
+//   - Missing (fresh clone / CI): clone `rolldown-canary` and rebase it.
+//   - Clean and on `rolldown-canary`: update to the latest upstream state
+//     (kept as-is when the fetch fails, e.g. offline).
+//   - Dirty or not on `rolldown-canary`: taken over by the developer, used
+//     exactly as-is so local experiments are never trampled.
 export function ensureViteCheckout(): void {
   if (!nodeFs.existsSync(nodePath.join(viteDir, 'package.json'))) {
     run('git clone --branch rolldown-canary https://github.com/vitejs/vite.git vite', repoRoot);
     run('git rebase origin/main', viteDir);
+  } else {
+    updateViteCheckout();
   }
   const head = capture('git rev-parse --short HEAD', viteDir);
   console.log(`[setup-vite] using vite ${head}`);
+}
+
+function updateViteCheckout(): void {
+  const dirty = capture('git status --porcelain', viteDir) !== '';
+  if (dirty || capture('git rev-parse --abbrev-ref HEAD', viteDir) !== 'rolldown-canary') {
+    console.log(
+      `[setup-vite] vite/ ${dirty ? 'has local changes' : 'is not on rolldown-canary'}, using it as-is`,
+    );
+    return;
+  }
+  try {
+    run('git fetch origin main rolldown-canary', viteDir);
+  } catch {
+    console.log('[setup-vite] fetch failed, using the existing checkout as-is');
+    return;
+  }
+  run('git checkout -B rolldown-canary origin/rolldown-canary', viteDir);
+  run('git rebase origin/main', viteDir);
 }

--- a/scripts/src/setup-vite/main.ts
+++ b/scripts/src/setup-vite/main.ts
@@ -2,9 +2,9 @@
 // tests run on Vite's full bundle mode backed by the workspace's local
 // rolldown, WITHOUT modifying anything in the Vite repo:
 //
-//   1. clone vitejs/vite (`rolldown-canary` rebased onto `main`) if needed
-//      and build the checkout exactly as-is (updating an existing checkout
-//      is always a manual git step, see checkout.ts),
+//   1. ensure the checkout is at the latest `rolldown-canary` rebased onto
+//      `main` (a checkout taken over by the developer is built as-is, see
+//      checkout.ts),
 //   2. `pnpm install --frozen-lockfile` (no manifest or lockfile writes),
 //   3. build the `vite` package with its own pinned dependencies,
 //   4. swap the `packages/vite/node_modules/rolldown` symlink to point at the
@@ -35,8 +35,8 @@ if (!nodeFs.existsSync(nodePath.join(localRolldownDir, 'dist', 'index.mjs'))) {
   process.exit(1);
 }
 
-// 1. Ensure `vite/` has a checkout (see checkout.ts), then build whatever
-// commit is checked out.
+// 1. Ensure `vite/` has an up-to-date checkout (see checkout.ts), then
+// build whatever commit is checked out.
 ensureViteCheckout();
 
 // 2. Install Vite's workspace deps exactly as pinned upstream, via vp. It


### PR DESCRIPTION
Follow-up to the review comments on #10318 and #10319: both test projects should be set up from the single `vite/` checkout at the workspace root, via the `just setup-vite` checkout step.

## Change

`packages/vite-tests/run.ts` no longer clones vitejs/vite from GitHub on its own. It now:

1. calls `ensureViteCheckout()` from `scripts/src/setup-vite/checkout.ts` (the checkout step of `just setup-vite`), which guarantees the root `vite/` checkout exists and is at the latest `rolldown-canary` rebased onto the latest `main`, exactly what #10319 set up for the dev-server tests.
2. clones that checkout locally into `./repo` and runs Vite's test suite there. The local clone shares objects via hardlinks, so no extra network download. It stays a throwaway copy because this suite must edit tracked files (rewrite the pnpm overrides to point `rolldown` at the workspace package, which also rewrites the lockfile on install), while `vite/` itself must stay unpatched: the dev-server setup installs it with `--frozen-lockfile` and builds it with Vite's own pinned rolldown, so the two harnesses would corrupt each other's state if they shared one working copy.

Both harnesses therefore run on exactly the same Vite code: one checkout, one rebase result, no chance of the two suites drifting apart because `rolldown-canary` or `main` moved between two independent clones.

Per the review discussion on #10319, an existing checkout is kept up to date as well: when it is clean and on `rolldown-canary` (the managed state), every setup fetches and re-derives the latest `rolldown-canary` rebased onto `main` (kept as-is when the fetch fails, e.g. offline). A checkout taken over by the developer (dirty, or switched to another branch) is used exactly as-is, with a notice, so local experiments inside `vite/` are never trampled and can still be tested through both harnesses.

Also restores the `checkout.ts` include in `packages/vite-tests/tsconfig.json` and updates the docs accordingly.

## Verification

- Local smoke run: `run.ts` picks up the shared checkout, clones it locally, and proceeds through install, build, and into the test suites.
- All three checkout states exercised live: a clean checkout on `rolldown-canary` was updated to the latest upstream state; a dirty checkout and a detached HEAD were left as-is with a notice.
- `just lint` fully green.
