### PR TITLE
fix(magic-string): refuse to use a MagicString after sendMagicString consumed it

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -36,12 +36,15 @@ impl BindingTransformPluginContext {
   pub fn send_magic_string(
     &self,
     magic_string: &mut BindingMagicString<'static>,
-  ) -> Option<String> {
-    let internal_magic_string = std::mem::take(&mut magic_string.inner);
+  ) -> napi::Result<Option<String>> {
+    // This moves the contents out, leaving `magic_string` unusable from JS onwards.
+    let internal_magic_string = magic_string.take_inner();
 
-    // If the the message is not send to main thread correctly, we should panic immediately.
-    self.inner.send_magic_string(internal_magic_string).expect(
-      "TransformPluginContext: failed to send MagicString to sourcemap worker - sourcemap generation thread terminated unexpectedly during transform"
-    )
+    self.inner.send_magic_string(internal_magic_string).map_err(|_| {
+      napi::Error::from_reason(
+        "TransformPluginContext: failed to send MagicString to sourcemap worker - sourcemap \
+         generation thread terminated unexpectedly during transform",
+      )
+    })
   }
 }

--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -405,11 +405,36 @@ impl BindingDecodedMap {
 
 #[napi]
 pub struct BindingMagicString<'a> {
-  pub(crate) inner: MagicString<'a>,
+  inner: MagicString<'a>,
   utf16_to_byte_mapper: Utf16ToByteMapper,
   pub(crate) offset: i64,
   indent_exclusion_ranges: Option<IndentExclusionRanges>,
   ignore_list: bool,
+  /// Set once `sendMagicString` has moved `inner` out to the native sourcemap channel.
+  /// The JS object outlives that move, so every method that touches `inner` has to refuse
+  /// rather than silently operate on the empty `MagicString` left behind.
+  consumed: bool,
+}
+
+impl<'a> BindingMagicString<'a> {
+  /// Moves the inner `MagicString` out for delivery to the sourcemap worker, marking this
+  /// instance unusable. See [`Self::consumed`].
+  pub(crate) fn take_inner(&mut self) -> MagicString<'a> {
+    self.consumed = true;
+    std::mem::take(&mut self.inner)
+  }
+
+  /// Errors if this instance was already consumed by `sendMagicString`.
+  fn ensure_live(&self) -> napi::Result<()> {
+    if self.consumed {
+      return Err(napi::Error::from_reason(
+        "This MagicString was already passed to `sendMagicString()`, which moves its contents \
+         into the native sourcemap channel. Finish reading and editing it before returning it \
+         from the `transform` hook.",
+      ));
+    }
+    Ok(())
+  }
 }
 
 #[napi]
@@ -429,17 +454,20 @@ impl BindingMagicString<'_> {
       offset,
       indent_exclusion_ranges,
       ignore_list,
+      consumed: false,
     }
   }
 
   #[napi(getter)]
-  pub fn original(&self) -> &str {
-    self.inner.source()
+  pub fn original(&self) -> napi::Result<&str> {
+    self.ensure_live()?;
+    Ok(self.inner.source())
   }
 
   #[napi(getter)]
-  pub fn filename(&self) -> Option<&str> {
-    self.inner.filename()
+  pub fn filename(&self) -> napi::Result<Option<&str>> {
+    self.ensure_live()?;
+    Ok(self.inner.filename())
   }
 
   #[napi(getter)]
@@ -619,6 +647,7 @@ impl BindingMagicString<'_> {
     from: String,
     to: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.replace(&from, to).map_err(napi::Error::from_reason)?;
     Ok(this)
   }
@@ -630,6 +659,7 @@ impl BindingMagicString<'_> {
     from: String,
     to: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.replace_all(&from, to).map_err(napi::Error::from_reason)?;
     Ok(this)
   }
@@ -643,21 +673,24 @@ impl BindingMagicString<'_> {
     #[napi(ts_arg_type = "RegExp")] from: JsRegExp,
     to: String,
   ) -> napi::Result<i32> {
+    self.ensure_live()?;
     let last_end = self.regex_replace(&from, &to)?;
     #[expect(clippy::cast_possible_wrap)]
     Ok(last_end.map_or(-1, |v| v as i32))
   }
 
   #[napi]
-  pub fn prepend<'s>(&'s mut self, this: This<'s>, content: String) -> This<'s> {
+  pub fn prepend<'s>(&'s mut self, this: This<'s>, content: String) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.prepend(content);
-    this
+    Ok(this)
   }
 
   #[napi]
-  pub fn append<'s>(&'s mut self, this: This<'s>, content: String) -> This<'s> {
+  pub fn append<'s>(&'s mut self, this: This<'s>, content: String) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.append(content);
-    this
+    Ok(this)
   }
 
   #[napi]
@@ -667,6 +700,7 @@ impl BindingMagicString<'_> {
     index: u32,
     content: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Match original magic-string: out-of-bound indices fall through to prepend_intro
     let index = self.apply_offset_u32(index)?;
     self.reject_surrogate_split_of_edited_chunk(index)?;
@@ -688,6 +722,7 @@ impl BindingMagicString<'_> {
     index: u32,
     content: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Match original magic-string: out-of-bound indices fall through to prepend_outro
     let index = self.apply_offset_u32(index)?;
     self.reject_surrogate_split_of_edited_chunk(index)?;
@@ -709,6 +744,7 @@ impl BindingMagicString<'_> {
     index: u32,
     content: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Match original magic-string: out-of-bound indices fall through to append_intro
     let index = self.apply_offset_u32(index)?;
     self.reject_surrogate_split_of_edited_chunk(index)?;
@@ -730,6 +766,7 @@ impl BindingMagicString<'_> {
     index: u32,
     content: String,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Match original magic-string: out-of-bound indices fall through to append_outro
     let index = self.apply_offset_u32(index)?;
     self.reject_surrogate_split_of_edited_chunk(index)?;
@@ -753,6 +790,7 @@ impl BindingMagicString<'_> {
     content: String,
     options: Option<BindingOverwriteOptions>,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     let start_byte = self
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(start)?)
@@ -776,32 +814,37 @@ impl BindingMagicString<'_> {
   }
 
   #[napi]
-  pub fn to_string(&self) -> String {
-    self.inner.to_string()
+  pub fn to_string(&self) -> napi::Result<String> {
+    self.ensure_live()?;
+    Ok(self.inner.to_string())
   }
 
   #[napi]
-  pub fn has_changed(&self) -> bool {
-    self.inner.has_changed()
+  pub fn has_changed(&self) -> napi::Result<bool> {
+    self.ensure_live()?;
+    Ok(self.inner.has_changed())
   }
 
   #[napi]
-  pub fn length(&self) -> u32 {
+  pub fn length(&self) -> napi::Result<u32> {
+    self.ensure_live()?;
     // JS measures string length in UTF-16 code units, so this must use `len_utf16` rather
     // than `len`, which counts UTF-8 bytes and over-reports for any non-ASCII source.
     #[expect(clippy::cast_possible_truncation, reason = "files are < 4GB")]
     {
-      self.inner.len_utf16() as u32
+      Ok(self.inner.len_utf16() as u32)
     }
   }
 
   #[napi]
-  pub fn is_empty(&self) -> bool {
-    self.inner.is_empty()
+  pub fn is_empty(&self) -> napi::Result<bool> {
+    self.ensure_live()?;
+    Ok(self.inner.is_empty())
   }
 
   #[napi]
   pub fn remove<'s>(&'s mut self, this: This<'s>, start: i64, end: i64) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Apply offset, then handle negative indices (matching reset/slice pattern)
     let start = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(start));
     let end = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(end));
@@ -837,6 +880,7 @@ impl BindingMagicString<'_> {
     content: String,
     options: Option<BindingUpdateOptions>,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     let start_byte = self
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(start)?)
@@ -867,6 +911,7 @@ impl BindingMagicString<'_> {
     end: u32,
     to: u32,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     let start_byte = self
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(start)?)
@@ -904,6 +949,7 @@ impl BindingMagicString<'_> {
     indentor: Option<String>,
     options: Option<BindingIndentOptions>,
   ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Per-call exclude takes priority; fall back to constructor's indentExclusionRanges.
     let explicit_exclude = options.and_then(|opts| opts.exclude);
     let exclude_ranges = if let Some(ref e) = explicit_exclude {
@@ -926,30 +972,46 @@ impl BindingMagicString<'_> {
 
   /// Trims whitespace or specified characters from the start and end.
   #[napi]
-  pub fn trim<'s>(&'s mut self, this: This<'s>, char_type: Option<String>) -> This<'s> {
+  pub fn trim<'s>(
+    &'s mut self,
+    this: This<'s>,
+    char_type: Option<String>,
+  ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.trim(char_type.as_deref());
-    this
+    Ok(this)
   }
 
   /// Trims whitespace or specified characters from the start.
   #[napi]
-  pub fn trim_start<'s>(&'s mut self, this: This<'s>, char_type: Option<String>) -> This<'s> {
+  pub fn trim_start<'s>(
+    &'s mut self,
+    this: This<'s>,
+    char_type: Option<String>,
+  ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.trim_start(char_type.as_deref());
-    this
+    Ok(this)
   }
 
   /// Trims whitespace or specified characters from the end.
   #[napi]
-  pub fn trim_end<'s>(&'s mut self, this: This<'s>, char_type: Option<String>) -> This<'s> {
+  pub fn trim_end<'s>(
+    &'s mut self,
+    this: This<'s>,
+    char_type: Option<String>,
+  ) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.trim_end(char_type.as_deref());
-    this
+    Ok(this)
   }
 
   /// Trims newlines from the start and end.
   #[napi]
-  pub fn trim_lines<'s>(&'s mut self, this: This<'s>) -> This<'s> {
+  pub fn trim_lines<'s>(&'s mut self, this: This<'s>) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     self.inner.trim_lines();
-    this
+    Ok(this)
   }
 
   /// Deprecated method that throws an error directing users to use prependRight or appendLeft.
@@ -963,38 +1025,43 @@ impl BindingMagicString<'_> {
 
   /// Returns a clone of the MagicString instance.
   #[napi(js_name = "clone")]
-  #[must_use]
-  pub fn clone_instance(&self) -> Self {
-    Self {
+  pub fn clone_instance(&self) -> napi::Result<Self> {
+    self.ensure_live()?;
+    Ok(Self {
       inner: self.inner.clone(),
       utf16_to_byte_mapper: self.utf16_to_byte_mapper.clone(),
       offset: self.offset,
       indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
       ignore_list: self.ignore_list,
-    }
+      consumed: false,
+    })
   }
 
   /// Returns the last character of the generated string, or an empty string if empty.
   #[napi]
-  pub fn last_char(&self) -> String {
-    self.inner.last_char().map(|c| c.to_string()).unwrap_or_default()
+  pub fn last_char(&self) -> napi::Result<String> {
+    self.ensure_live()?;
+    Ok(self.inner.last_char().map(|c| c.to_string()).unwrap_or_default())
   }
 
   /// Returns the content after the last newline in the generated string.
   #[napi]
-  pub fn last_line(&self) -> String {
-    self.inner.last_line()
+  pub fn last_line(&self) -> napi::Result<String> {
+    self.ensure_live()?;
+    Ok(self.inner.last_line())
   }
 
   /// Returns the guessed indentation string, or `\t` if none is found.
   #[napi]
-  pub fn get_indent_string(&self) -> &str {
-    self.inner.get_indent_string()
+  pub fn get_indent_string(&self) -> napi::Result<&str> {
+    self.ensure_live()?;
+    Ok(self.inner.get_indent_string())
   }
 
   /// Returns a clone with content outside the specified range removed.
   #[napi]
   pub fn snip(&self, start: u32, end: u32) -> napi::Result<Self> {
+    self.ensure_live()?;
     let start_byte = self
       .utf16_to_byte_mapper
       .utf16_to_byte(self.apply_offset_u32(start)?)
@@ -1009,6 +1076,7 @@ impl BindingMagicString<'_> {
       offset: self.offset,
       indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
       ignore_list: self.ignore_list,
+      consumed: false,
     })
   }
 
@@ -1017,6 +1085,7 @@ impl BindingMagicString<'_> {
   /// Supports negative indices (counting from the end).
   #[napi]
   pub fn reset<'s>(&'s mut self, this: This<'s>, start: i64, end: i64) -> napi::Result<This<'s>> {
+    self.ensure_live()?;
     // Apply offset, then handle negative indices (matching original magic-string behavior)
     let start = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(start));
     let end = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(end));
@@ -1052,6 +1121,7 @@ impl BindingMagicString<'_> {
     start: Option<i64>,
     end: Option<i64>,
   ) -> napi::Result<JsString<'env>> {
+    self.ensure_live()?;
     // Apply offset to both start and end (including defaults), then normalize negatives
     let start = self.apply_offset_i64(start.unwrap_or(0));
 
@@ -1153,7 +1223,11 @@ impl BindingMagicString<'_> {
   /// Generates a source map for the transformations applied to this MagicString.
   /// Returns a BindingSourceMap object with version, file, sources, sourcesContent, names, mappings.
   #[napi]
-  pub fn generate_map(&self, options: Option<BindingSourceMapOptions>) -> BindingSourceMap {
+  pub fn generate_map(
+    &self,
+    options: Option<BindingSourceMapOptions>,
+  ) -> napi::Result<BindingSourceMap> {
+    self.ensure_live()?;
     let opts = options.unwrap_or_default();
     let hires = match &opts.hires {
       Some(Either::A(true)) => string_wizard::Hires::True,
@@ -1185,7 +1259,7 @@ impl BindingMagicString<'_> {
       source_map
     };
 
-    BindingSourceMap { json: source_map.to_json() }
+    Ok(BindingSourceMap { json: source_map.to_json() })
   }
 
   /// Generates a decoded source map for the transformations applied to this MagicString.
@@ -1194,7 +1268,8 @@ impl BindingMagicString<'_> {
   pub fn generate_decoded_map(
     &self,
     options: Option<BindingSourceMapOptions>,
-  ) -> BindingDecodedMap {
+  ) -> napi::Result<BindingDecodedMap> {
+    self.ensure_live()?;
     let opts = options.unwrap_or_default();
     let hires = match &opts.hires {
       Some(Either::A(true)) => string_wizard::Hires::True,
@@ -1227,7 +1302,7 @@ impl BindingMagicString<'_> {
     };
 
     let json = source_map.to_json();
-    BindingDecodedMap { inner: source_map, json }
+    Ok(BindingDecodedMap { inner: source_map, json })
   }
 }
 

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-consumed/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-consumed/_config.ts
@@ -1,0 +1,45 @@
+import { defineTest } from 'rolldown-tests';
+import type { RolldownMagicString } from 'rolldown';
+import { expect } from 'vitest';
+
+// Returning a MagicString from `transform` hands it to `sendMagicString`, which moves its
+// contents out to the native sourcemap channel. The JS object outlives that move, so a
+// plugin holding on to the reference used to get an empty MagicString back with no error
+// — silently producing empty code. It must refuse instead.
+let stashed: RolldownMagicString | undefined;
+
+export default defineTest({
+  config: {
+    input: ['main.js'],
+    plugins: [
+      {
+        name: 'test-magic-string-consumed',
+        transform(code, id, meta) {
+          if (id.startsWith('\0') || !meta?.magicString) {
+            return null;
+          }
+          stashed = meta.magicString;
+          stashed.append('\nconsole.log("appended");');
+          // Still live here — the handoff happens when we return it.
+          expect(stashed.toString()).toContain('appended');
+          return { code: stashed };
+        },
+        buildEnd() {
+          expect(stashed).toBeDefined();
+          const consumed = /already passed to `sendMagicString/;
+          // Reads and edits alike must throw rather than report an empty string.
+          expect(() => stashed!.toString()).toThrow(consumed);
+          expect(() => stashed!.length()).toThrow(consumed);
+          expect(() => stashed!.hasChanged()).toThrow(consumed);
+          expect(() => stashed!.generateMap({})).toThrow(consumed);
+          expect(() => stashed!.append('x')).toThrow(consumed);
+          expect(() => stashed!.overwrite(0, 1, 'x')).toThrow(consumed);
+        },
+      },
+    ],
+  },
+  afterTest: function (output) {
+    // The transform itself still worked; only post-handoff reuse is refused.
+    expect(output.output[0].code).toContain('appended');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-consumed/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-consumed/main.js
@@ -1,0 +1,1 @@
+console.log('hello');


### PR DESCRIPTION
> Stacked on #10312 — review that first; this PR's diff is just the top commit.

### What this solves

Returning a `MagicString` from the `transform` hook hands it to `sendMagicString`, which **moves** its contents out to the native sourcemap channel. The JS object outlives that move, so a plugin holding on to the reference got an empty `MagicString` back with no error — every read returned `''`, every edit silently applied to nothing:

```js
transform(code, id, meta) {
  stashed = meta.magicString;
  stashed.append('...');
  return { code: stashed };  // contents moved out here
},
buildEnd() {
  stashed.toString();  // '' — silently, no error
}
```

### The fix

`BindingMagicString` tracks a `consumed` flag: `take_inner()` (the `sendMagicString` path) sets it, and every method that touches the inner `MagicString` goes through an `ensure_live()` check first, erroring with:

> This MagicString was already passed to `sendMagicString()`, which moves its contents into the native sourcemap channel. Finish reading and editing it before returning it from the `transform` hook.

Reads and edits alike refuse — reporting `''` for a string the caller populated is worse than an error naming what happened and what to do instead.

### Tests

An integration fixture (`plugin/native-magic-string-consumed`) drives the real plugin flow: the `transform`-time use still works, the emitted chunk contains the appended code, and post-handoff reuse throws across the API surface (`toString`, `length`, `hasChanged`, `generateMap`, `append`, `overwrite`).

On the parent commit the fixture fails at the first `toThrow` — the consumed instance silently returns instead of refusing. The full JS suite at this branch shows no other change (the only failures are the two fixtures already failing on `main`).
