### PR TITLE
fix(magic-string): validate relocate ranges before rewiring

### DIFF
--- a/crates/string_wizard/src/magic_string/movement.rs
+++ b/crates/string_wizard/src/magic_string/movement.rs
@@ -35,6 +35,26 @@ impl MagicString<'_> {
     if to >= start && to <= end {
       return Err("Cannot move a selection inside itself".to_string());
     }
+    // A zero-width range has nothing to move. It also breaks the lookups below — the chunk
+    // ending at `start` is the one *before* the range — and used to self-cycle two chunks.
+    // Deliberately checked after the containment guard above: `relocate(n, n, n)` keeps the
+    // "inside itself" error, matching both magic-string and this method's previous behavior.
+    // Every other zero-width move is a no-op (magic-string corrupts on those, so there is no
+    // upstream behavior to mirror).
+    if start == end {
+      return Ok(self);
+    }
+    if start > end {
+      return Err(format!("end must be greater than start, got start: {start}, end: {end}"));
+    }
+    // Past-the-end positions have no chunk to look up in `chunk_by_end`; indexing the map
+    // with one was a panic.
+    if end > self.source.len() as u32 {
+      return Err(format!(
+        "Cannot move the range ({start}, {end}): it is out of bounds (source length is {})",
+        self.source.len()
+      ));
+    }
 
     self.split_at(start)?;
     self.split_at(end)?;
@@ -46,23 +66,36 @@ impl MagicString<'_> {
     let old_left_idx = self.chunks[first_idx].prev;
     let old_right_idx = self.chunks[last_idx].next;
 
-    // The moved range occupies both ends of the linked list, so lifting it out would leave no
-    // chunk to re-attach to. Reachable once an earlier move has reordered chunks — after
-    // `relocate(0, 1, 2)` on "abc" the list is B->A->C, so `relocate(1, 3, 0)` asks to move
-    // B..C, which is no longer a contiguous run.
+    // The rewiring below lifts `first..=last` out of the list as one segment and splices it
+    // back in elsewhere. That is only sound if the chunks covering `[start, end)` still sit
+    // next to each other in list order, in original order. An earlier move can break that —
+    // after `relocate(0, 2, 3)` on "abc" the list is C -> A -> B, so `relocate(1, 3, 0)`
+    // selects first = B (the list tail) and last = C (the head), with A wedged between them.
     //
-    // This has to be caught here, before the rewiring below: that rewiring is not atomic, and
-    // bailing out part-way through leaves a chunk pointing at itself, which makes `to_string`
-    // loop forever.
-    if old_left_idx.is_none() && old_right_idx.is_none() {
-      return Err("Cannot move a range that spans the entire string".to_string());
+    // This has to be caught here, before the rewiring: that rewiring is not atomic, and
+    // splicing a non-contiguous "segment" leaves a chunk pointing at itself (`to_string`
+    // then loops forever) or silently drops content. Walk the range in original order and
+    // require each step to also be the list successor.
+    let mut idx = first_idx;
+    while idx != last_idx {
+      // Chunks tile the original source and `end` is a chunk boundary, so stepping by
+      // original position from `start` always reaches `last_idx` before running off the end.
+      let next_in_original_order = self.chunk_by_start[&self.chunks[idx].end()];
+      if self.chunks[idx].next != Some(next_in_original_order) {
+        return Err(format!(
+          "Cannot move the range ({start}, {end}): an earlier move left it non-contiguous"
+        ));
+      }
+      idx = next_in_original_order;
     }
 
     let new_right_idx = self.chunk_by_start.get(&to).copied();
 
-    // `new_right_idx` is `None` means that the `to` index is at the end of the string.
-    // Moving chunks which contain the last chunk to the end is meaningless.
-    if new_right_idx.is_none() && last_idx == self.last_chunk_idx {
+    // The range already sits exactly where it would be spliced: the chunk at `to` is the
+    // range's own list successor. This also covers `to` at the end of the string with the
+    // range already ending the list (both sides `None`). Proceeding would make `new_left`
+    // the range's own last chunk and the rewiring would link the range to itself.
+    if new_right_idx == old_right_idx {
       return Ok(self);
     }
 
@@ -89,16 +122,17 @@ impl MagicString<'_> {
 
     if self.chunks[first_idx].prev.is_none() {
       // If the `first_idx` is the first chunk, then we need to update the `first_chunk_idx`.
-      // The whole-range check above guarantees a successor exists, so this cannot be `None`
-      // — but returning an error here would corrupt the list, so assert instead of `?`.
-      debug_assert!(self.chunks[last_idx].next.is_some(), "whole-range move should be rejected");
+      // A contiguous range open at both ends would be the entire list — i.e. the entire
+      // string — which the checks above reject or no-op, so a successor must exist. Returning
+      // an error here would corrupt the list, so assert instead of `?`.
+      debug_assert!(self.chunks[last_idx].next.is_some(), "open-ended move should be rejected");
       if let Some(next_idx) = self.chunks[last_idx].next {
         self.first_chunk_idx = next_idx;
       }
     }
     if self.chunks[last_idx].next.is_none() {
       // If the `last_idx` is the last chunk, then we need to update the `last_chunk_idx`.
-      debug_assert!(self.chunks[first_idx].prev.is_some(), "whole-range move should be rejected");
+      debug_assert!(self.chunks[first_idx].prev.is_some(), "open-ended move should be rejected");
       if let Some(prev_idx) = self.chunks[first_idx].prev {
         self.last_chunk_idx = prev_idx;
       }

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -270,6 +270,78 @@ mod relocate {
     // chunk pointing at itself, and this `to_string` would then never return.
     assert_eq!(s.to_string(), "bac");
   }
+
+  #[test]
+  fn errors_when_the_range_endpoints_have_swapped_list_positions() {
+    let mut s = MagicString::new("abc");
+    // Reorders the chunks to C -> A -> B.
+    s.relocate(0, 2, 3).unwrap();
+    assert_eq!(s.to_string(), "cab");
+
+    // [1,3) selects first = B (the list tail) and last = C (the head): both endpoints have a
+    // neighbor, so an endpoint-only check passes, but A is wedged between them. Accepting the
+    // move rewired A to point at itself and `to_string` never returned.
+    let err = s.relocate(1, 3, 0).unwrap_err();
+    assert!(err.contains("non-contiguous"), "unexpected error: {err}");
+    assert_eq!(s.to_string(), "cab");
+  }
+
+  #[test]
+  fn errors_when_the_range_is_broken_mid_list() {
+    let mut s = MagicString::new("abcd");
+    // Reorders the chunks to A -> C -> D -> B.
+    s.relocate(1, 2, 4).unwrap();
+    assert_eq!(s.to_string(), "acdb");
+
+    // [1,3) is B..C with the break mid-list. Accepting the move silently produced "b" —
+    // no hang, just wrong output plus orphaned chunk cycles.
+    s.relocate(1, 3, 0).unwrap_err();
+    assert_eq!(s.to_string(), "acdb");
+  }
+
+  #[test]
+  fn zero_width_relocate_is_a_noop() {
+    // Needs no earlier move: on a pristine string the chunk ending at `start` sits *before*
+    // the chunk starting at `start`, so treating them as a range self-cycled two chunks and
+    // this printed "a".
+    let mut s = MagicString::new("abc");
+    s.relocate(1, 1, 3).unwrap();
+    assert_eq!(s.to_string(), "abc");
+  }
+
+  #[test]
+  fn zero_width_relocate_to_its_own_position_still_errors() {
+    // The one zero-width case that is not a no-op: the containment guard runs first, so
+    // `relocate(n, n, n)` keeps the same "inside itself" error as magic-string and as this
+    // method before the zero-width no-op existed.
+    let mut s = MagicString::new("abc");
+    let err = s.relocate(1, 1, 1).unwrap_err();
+    assert!(err.contains("inside itself"), "unexpected error: {err}");
+    assert_eq!(s.to_string(), "abc");
+  }
+
+  #[test]
+  fn moving_a_chunk_to_the_slot_it_already_occupies_is_a_noop() {
+    let mut s = MagicString::new("abcdef");
+    // Reorders the chunks to A -> E -> B -> C -> D -> F.
+    s.relocate(4, 5, 1).unwrap();
+    assert_eq!(s.to_string(), "aebcdf");
+
+    // E already sits right before original position 1, so there is nothing to do. The splice
+    // used to link E to itself and drop it from the list, printing "abcdf".
+    s.relocate(4, 5, 1).unwrap();
+    assert_eq!(s.to_string(), "aebcdf");
+  }
+
+  #[test]
+  fn rejects_inverted_and_out_of_bounds_ranges() {
+    let mut s = MagicString::new("abc");
+    // Both used to panic indexing `chunk_by_start`/`chunk_by_end` with a position no chunk
+    // has, since `split_at` silently ignores out-of-range indices.
+    s.relocate(2, 1, 3).unwrap_err();
+    s.relocate(1, 99, 0).unwrap_err();
+    assert_eq!(s.to_string(), "abc");
+  }
 }
 
 mod indent {

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -177,7 +177,7 @@ describe('move', () => {
     const s = new MagicString('abc');
     s.move(0, 1, 2);
     assert.strictEqual(s.toString(), 'bac');
-    assert.throws(() => s.move(1, 3, 0), /spans the entire string/);
+    assert.throws(() => s.move(1, 3, 0), /non-contiguous/);
     assert.strictEqual(s.toString(), 'bac');
   });
 });


### PR DESCRIPTION
### What this solves

Follow-up to #10311, addressing [the post-merge report](https://github.com/rolldown/rolldown/pull/10311#issuecomment-4994594426): the guard added there rejects only one non-contiguous topology — `first` having no predecessor and `last` no successor. Other reachable layouts pass it and still corrupt the chunk list:

```js
const s = new RolldownMagicString('abc');
s.move(0, 2, 3); // list is C -> A -> B
s.move(1, 3, 0); // first = B (the tail), last = C (the head) — guard passes
```

The rewiring then assigns `A.next = A` and `toString()` never returns. With the break in the middle of the list instead, the failure is quieter and worse: `toString()` terminates with wrong output (`"acdb"` becomes `"b"`) and leaves orphaned chunk cycles behind.

Fixing that surfaced two more corrupting inputs that no contiguity check can catch, plus a panic:

- a zero-width range corrupts a pristine string with no prior move at all (`move(1, 1, 3)` on `"abc"` prints `"a"`): the chunk ending at `start` is the one *before* the range, so the code treats a backwards pair as a range;
- after an earlier reorder, moving a chunk to the slot it already occupies drops it (`move(4, 5, 1)` twice on `"abcdef"` prints `"abcdf"`): the splice point resolves to the range's own last chunk, which then links to itself;
- inverted or past-the-end ranges panicked on a map lookup, because `split_at` silently ignores out-of-range positions.

### The fix

Every check runs before any pointer is rewired — the rewiring is not atomic, so bailing out half-way through is exactly the corruption being removed:

- walk the selected range in original order and require each chunk's list successor to be the chunk starting at its end, else error. This subsumes the #10311 guard: a contiguous range open at both ends is the entire string, which is already rejected as moving a selection inside itself;
- treat zero-width ranges as a no-op, mirroring `remove` — with one deliberate exception: the containment guard runs first, so `relocate(n, n, n)` keeps the "inside itself" error, matching both magic-string and this method's previous behavior;
- error on inverted and out-of-bounds ranges instead of panicking;
- generalize the "moving the tail range to the end" early-return to "the chunk at `to` is already the range's list successor", which covers the already-in-position case.

### Tests

One regression test per failure class at the `string_wizard` level; each fails on the parent commit (one by hanging, two by silently wrong output, one by panicking). The #10311 JS test only needed its message regex updated: the old "spans the entire string" message described the list topology rather than the requested range, and the accurate "non-contiguous" error replaces it.
