### PR TITLE
fix(magic-string): refuse repeated sendMagicString on a consumed instance

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -37,8 +37,10 @@ impl BindingTransformPluginContext {
     &self,
     magic_string: &mut BindingMagicString<'static>,
   ) -> napi::Result<Option<String>> {
-    // This moves the contents out, leaving `magic_string` unusable from JS onwards.
-    let internal_magic_string = magic_string.take_inner();
+    // This moves the contents out, leaving `magic_string` unusable from JS onwards —
+    // including for a repeated send, which errors here instead of queueing the empty
+    // leftover into the sourcemap channel.
+    let internal_magic_string = magic_string.take_inner()?;
 
     self.inner.send_magic_string(internal_magic_string).map_err(|_| {
       napi::Error::from_reason(

--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -418,10 +418,13 @@ pub struct BindingMagicString<'a> {
 
 impl<'a> BindingMagicString<'a> {
   /// Moves the inner `MagicString` out for delivery to the sourcemap worker, marking this
-  /// instance unusable. See [`Self::consumed`].
-  pub(crate) fn take_inner(&mut self) -> MagicString<'a> {
+  /// instance unusable. Errors if the instance was already consumed: repeating the transfer
+  /// would hand the empty `MagicString` left behind by the first move to the sourcemap
+  /// channel, silently replacing the real map. See [`Self::consumed`].
+  pub(crate) fn take_inner(&mut self) -> napi::Result<MagicString<'a>> {
+    self.ensure_live()?;
     self.consumed = true;
-    std::mem::take(&mut self.inner)
+    Ok(std::mem::take(&mut self.inner))
   }
 
   /// Errors if this instance was already consumed by `sendMagicString`.

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-double-send/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-double-send/_config.ts
@@ -1,0 +1,52 @@
+import { defineTest } from 'rolldown-tests';
+import type { RolldownMagicString } from 'rolldown';
+import { expect } from 'vitest';
+
+// `sendMagicString` moves the MagicString's contents out to the native sourcemap channel.
+// Every read and edit on the consumed instance refuses, but the transfer itself was left
+// unguarded: a second send returned normally and queued the empty MagicString left behind
+// by the first move, silently replacing the real map in the channel.
+export default defineTest({
+  config: {
+    input: ['main.js'],
+    experimental: {
+      nativeMagicString: true,
+    },
+    output: {
+      sourcemap: true,
+    },
+    plugins: [
+      {
+        name: 'test-magic-string-double-send',
+        transform(code, id, meta) {
+          if (id.startsWith('\0') || !meta?.magicString) {
+            return null;
+          }
+          const ms = meta.magicString;
+          ms.append('\nconsole.log("appended");');
+          const out = ms.toString();
+          // `sendMagicString` is public on the context impl but not on the declared
+          // interface; any JS plugin can reach it, so the runtime path is what matters.
+          const ctx = this as unknown as {
+            sendMagicString(s: RolldownMagicString): void;
+          };
+          // First transfer: the legitimate handoff to the native sourcemap channel.
+          ctx.sendMagicString(ms);
+          // Repeating the transfer must refuse like every other consumed-instance API.
+          expect(() => ctx.sendMagicString(ms)).toThrow(/already passed to `sendMagicString/);
+          // `map: null` signals the map was delivered out-of-band via the channel;
+          // omitting it would mark this transform Omitted and wipe the channel map.
+          return { code: out, map: null };
+        },
+      },
+    ],
+  },
+  afterTest: function (output) {
+    // The first send and the transform result itself still work.
+    const chunk = output.output[0];
+    expect(chunk.code).toContain('appended');
+    // The first transfer's map survived the rejected second one.
+    expect(chunk.map).toBeTruthy();
+    expect(chunk.map!.mappings).not.toBe('');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-double-send/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-double-send/main.js
@@ -1,0 +1,1 @@
+console.log('hello');


### PR DESCRIPTION
### What this solves

Follow-up to #10326, addressing [the post-merge report](https://github.com/rolldown/rolldown/pull/10326#issuecomment-4994986476): the consumed-state guard missed the one entry point it exists to protect — repeating the ownership transfer itself. `take_inner` set `consumed = true` but never checked it, and the `sendMagicString` binding called it without `ensure_live()`. A second send on the same instance returned normally, took the empty `MagicString` left behind by `std::mem::take`, and queued it into the native sourcemap channel — silently replacing the real map (final map `mappings: ""`).

The other double-consumption route was already covered: returning `{ code: ms }` after a manual send throws at the wrapper's `magicString.toString()` read. The direct repeated send was the single unguarded entry.

### The fix

`take_inner` now runs `ensure_live()?` before consuming and returns `napi::Result`; the `sendMagicString` binding propagates it. A repeated send fails with the same consumed-state error as every other API on a consumed instance, and the guard lives at the transfer point itself, so any future caller is covered as well.

### Tests

New fixture `plugin/native-magic-string-double-send` drives the real plugin flow with `experimental.nativeMagicString` and `sourcemap: true`: the first send works, the second throws, and the final chunk map still carries the first transfer's non-empty `mappings`. The transform returns `map: null` (the "delivered out-of-band" signal) — omitting the map marks the transform `Omitted` and wipes the channel-delivered map, which the map assertion also pins down.

On the parent build the fixture fails at the second `toThrow` — the repeated send returns normally — and the map assertion pins the corruption the report measured (double-send leaves `mappings: ""`). With the fix, all six native-magic-string fixtures pass, including the exact-mappings snapshot in `output/sourcemap/native-magic-string-true` that pins the one legitimate send. In the full `test:main` run the only failures are the two sourcemap-composition fixtures already failing on `main`.
