### PR TITLE
test: make `just setup-vite` the only entry point that touches `vite/`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,12 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
+      # `just setup-vite` is the only entry point that touches `vite/`;
+      # run.ts only clones the prepared checkout.
+      - name: Setup Vite checkout
+        if: ${{ needs.changes.outputs.node-changes == 'true' }}
+        run: vp run --filter '@rolldown-internal/scripts' setup-vite
+
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}
         run: vp run --filter vite-tests test
@@ -259,6 +265,12 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      # `just setup-vite` is the only entry point that touches `vite/`;
+      # run.ts only clones the prepared checkout.
+      - name: Setup Vite checkout
+        if: ${{ needs.changes.outputs.node-changes == 'true' }}
+        run: vp run --filter '@rolldown-internal/scripts' setup-vite
 
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}

--- a/internal-docs/dev-server-test-harness/implementation.md
+++ b/internal-docs/dev-server-test-harness/implementation.md
@@ -149,8 +149,10 @@ serving. What the harness does own lives in `src/vite-server.ts`:
 Fixes and test adjustments belong on the vitejs/vite `rolldown-canary` branch,
 which both this harness and `packages/vite-tests` track. Everything
 environment-specific happens in untracked files, via the
-`scripts/src/setup-vite/` script (`just setup-vite`, idempotent, `vp`-only;
-its checkout step is also reused by `packages/vite-tests`):
+`scripts/src/setup-vite/` script (`just setup-vite`, idempotent, `vp`-only).
+It is the only entry point that touches `vite/`: the command that moves the
+commit also rebuilds everything right after, so the checkout and the built
+dist never drift apart. The steps:
 
 1. ensure `vite/` is at the latest `rolldown-canary` rebased onto `main`
    (clone if missing, update otherwise); a checkout taken over by the
@@ -167,10 +169,9 @@ its checkout step is also reused by `packages/vite-tests`):
 Repo-wide tools ignore `vite/**` (a `.gitignore`
 entry covers gitignore-respecting walkers like oxfmt, plus `.typos.toml` and
 `.ls-lint.json` entries) — a repo-wide `vp fmt --write` must never touch
-files inside `vite/`. On CI, the checkout is created on demand: the dev-server
-workflow via the setup step, the vite-tests jobs via `run.ts` (which clones
-the checkout locally to run Vite's own suite); every other job needs no Vite
-checkout.
+files inside `vite/`. On CI, both the dev-server workflow and the vite-tests
+jobs prepare the checkout via a setup-vite step (`run.ts` then clones it
+locally to run Vite's own suite); every other job needs no Vite checkout.
 
 ### Server entry point (`src/`)
 

--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { styleText } from 'node:util';
 import { x } from 'tinyexec';
-import { ensureViteCheckout, viteDir } from '../../scripts/src/setup-vite/checkout.js';
 
+const VITE_DIR = path.resolve(import.meta.dirname, '../../vite');
 const REPO_PATH = path.resolve(import.meta.dirname, './repo');
 const OVERRIDES = [
   `  rolldown: ${path.resolve(import.meta.dirname, '../rolldown')}`,
@@ -45,18 +45,23 @@ async function runCmdAndPipeOrExit(title: string, cmdOptions: Parameters<typeof 
 
 fs.rmSync(REPO_PATH, { recursive: true, force: true });
 
-// Reuse the shared `vite/` checkout at the repo root (kept at the latest
-// `rolldown-canary` rebased onto the latest `main`, see
-// scripts/src/setup-vite/checkout.ts), the same code the dev-server tests
-// run on. The tests run on a throwaway LOCAL clone of it, never on the
-// checkout itself: this suite edits tracked files (pnpm overrides) and the
-// checkout must stay unpatched. The clone shares objects via hardlinks, so
-// no network is needed beyond the checkout itself.
-printTitle('# Ensuring the vite checkout...');
-ensureViteCheckout();
+// Reuse the shared `vite/` checkout at the repo root, prepared by
+// `just setup-vite` (the latest `rolldown-canary` rebased onto the latest
+// `main`), the same code the dev-server tests run on. Setup happens only
+// there, never here, so the checkout and the dev-server's built vite dist
+// cannot drift apart. The tests run on a throwaway LOCAL clone of the
+// checkout, never on the checkout itself: this suite edits tracked files
+// (pnpm overrides) and the checkout must stay unpatched. The clone shares
+// objects via hardlinks, so it needs no network.
+if (!fs.existsSync(path.join(VITE_DIR, 'package.json'))) {
+  console.error(
+    styleText(['red', 'bold'], `Vite checkout not found at ${VITE_DIR}. Run \`just setup-vite\` first.`),
+  );
+  process.exit(1);
+}
 await runCmdAndPipeOrExit(
   '# Cloning the local vite checkout...',
-  ['git', ['clone', viteDir, REPO_PATH]],
+  ['git', ['clone', VITE_DIR, REPO_PATH]],
 );
 
 printTitle('# Updating pnpm-workspace.yaml to link to local rolldown...');

--- a/packages/vite-tests/tsconfig.json
+++ b/packages/vite-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["run.ts", "../../scripts/src/setup-vite/checkout.ts"],
+  "include": ["run.ts"],
   "compilerOptions": {
     "composite": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Fixes the staleness window pointed out in https://github.com/rolldown/rolldown/pull/10325#issuecomment-4998953145: `run.ts` called `ensureViteCheckout()`, which can move `vite/` to a new commit, but nothing rebuilds the dev-server side afterwards. `loadVite()` in test-dev-server only checks that `vite/packages/vite/dist` exists, not that it matches the checkout, so a vite-tests run could silently invalidate the dev-server test results.

## Change

**`just setup-vite`** **is the only entry point that touches** **`vite/`.** It sets the commit (the latest `rolldown-canary` rebased onto the latest `main`) and finishes the whole setup (install, vite build, rolldown link) in one pass, so the checkout and the built vite dist can never drift apart.

**`packages/vite-tests/run.ts`** **does no setup anymore.** It clones the prepared `vite/` checkout locally and goes straight to testing; when the checkout is missing it fails with a "run `just setup-vite` first" hint, like `loadVite()` already does. The `checkout.ts` import and the tsconfig include are reverted.

On CI, the vite-test jobs gain a setup-vite step before `run.ts`, like the dev-server workflow already has.

## Verification

- Missing checkout: `run.ts` fails with the "run `just setup-vite` first" hint.
- Normal path: `run.ts` clones the prepared checkout and proceeds through install, build, and into the test suites.
- `ci.yml` parses, both vite-test jobs have the setup step, and `just lint` is fully green.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

