### PR TITLE
fix(code-splitting): gate entry facades on post-lowering import edges

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -168,6 +168,40 @@ impl GenerateStage<'_> {
 
     chunk_graph.sort_chunk_modules(self.link_output, self.options);
 
+    self.assign_chunk_exec_orders(&mut chunk_graph);
+    chunk_graph.rebuild_sorted_chunk_idx_vec(false);
+
+    Ok(chunk_graph)
+  }
+
+  /// Assign each live chunk a render `exec_order` from the execution order of its lead module, so
+  /// that both `sorted_chunk_idx_vec` and the cross-chunk import sort (`compute_cross_chunk_links`)
+  /// reflect real evaluation order. A `Common` chunk keys on `modules[0]` — the lowest-`exec_order`
+  /// module after `sort_chunk_modules`.
+  ///
+  /// This keying is sensitive to chunk *membership*: the runtime module has `exec_order` 0 and
+  /// `sort_chunk_modules` always places it first, so any chunk hosting the runtime keys on 0. The
+  /// provisional call in `generate_chunks` runs before the post-chunking
+  /// `sweep_unused_runtime_module`, so a still-live chunk the sweep later strips the runtime out of
+  /// would otherwise keep an `exec_order` derived from a module it no longer contains — sorting
+  /// ahead of chunks it should follow. `finalize_chunk_plan` therefore re-runs this after such a
+  /// sweep, restoring the ordering the pre-#10104 pipeline produced by sweeping *before* assignment.
+  ///
+  /// Composition with the strict path: `renumber_live_chunks` (strict-only, after order-wrap
+  /// lowering) merely *compacts* existing `exec_order` values to close tombstone gaps; it never
+  /// re-derives them from `modules[0]`. The two compose by last-writer-wins: the re-run happens after
+  /// lowering, so when the sweep removes the runtime it re-derives every live chunk's order from its
+  /// current `modules[0]`, producing a dense, correctly-keyed order that supersedes any earlier
+  /// `renumber_live_chunks` compaction. (They rarely both fire anyway — an order wrapper or interop
+  /// facade demands a runtime helper, which keeps `required_runtime_helpers()` non-empty and skips
+  /// the sweep entirely.)
+  ///
+  /// The esbuild-style `Chunk#bits` sort is intentionally avoided: `Chunk#bits` is not stably
+  /// ordered (e.g. `BitSet(0) 00000001_00000000` > `BitSet(8) 00000000_00000001`), so it cannot fix
+  /// the relative order of dynamic and common chunks. `Chunk#exec_order` is both cheaper and stable,
+  /// and guarantees entry chunks precede others, static chunks precede dynamic ones, and every chunk
+  /// has a stable order at the per-entry-chunk level.
+  pub(super) fn assign_chunk_exec_orders(&self, chunk_graph: &mut ChunkGraph) {
     chunk_graph
       .chunk_table
       .iter_mut_enumerated()
@@ -219,19 +253,6 @@ impl GenerateStage<'_> {
       .for_each(|(i, (_chunk_idx, chunk))| {
         chunk.exec_order = i.try_into().expect("Too many chunks, u32 overflowed.");
       });
-    // The esbuild using `Chunk#bits` to sorted chunks, but the order of `Chunk#bits` is not stable, eg `BitSet(0) 00000001_00000000` > `BitSet(8) 00000000_00000001`. It couldn't ensure the order of dynamic chunks and common chunks.
-    // Consider the compare `Chunk#exec_order` should be faster than `Chunk#bits`, we use `Chunk#exec_order` to sort chunks.
-    // Note Here could be make sure the order of chunks.
-    // - entry chunks are always before other chunks
-    // - static chunks are always before dynamic chunks
-    // - other chunks has stable order at per entry chunk level
-    // i.e.
-    // EntryPoint (is_user_defined: true) < EntryPoint (is_user_defined: false) or Common
-    // [order by chunk index]               [order by exec order]
-
-    chunk_graph.rebuild_sorted_chunk_idx_vec(false);
-
-    Ok(chunk_graph)
   }
 
   /// Merge symbols that import the same binding from the same external module, now that chunk

--- a/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
@@ -46,6 +46,15 @@ impl GenerateStage<'_> {
       let runtime_chunk_before = chunk_graph.module_to_chunk[runtime_idx];
       self.sweep_unused_runtime_module(chunk_graph, used_symbol_refs);
       if runtime_chunk_before.is_some() && chunk_graph.module_to_chunk[runtime_idx].is_none() {
+        // The sweep removed the runtime from its chunk. When that chunk is still live (the runtime
+        // co-hosted with user modules), its `modules[0]` changed, so the `exec_order` the
+        // provisional `assign_chunk_exec_orders` in `generate_chunks` derived from the runtime
+        // (`exec_order` 0) is now stale and would sort the chunk ahead of chunks it should follow.
+        // Re-derive every live chunk's `exec_order` from its current lead module before rebuilding
+        // the sorted list, which restores the ordering the pre-#10104 pipeline produced by sweeping
+        // before assignment. See `assign_chunk_exec_orders` for how this composes with the
+        // strict-only `renumber_live_chunks`.
+        self.assign_chunk_exec_orders(chunk_graph);
         chunk_graph.rebuild_sorted_chunk_idx_vec(true);
       }
     }

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -180,7 +180,11 @@ impl GenerateStage<'_> {
     // The at-risk set is monotone and finite; this bound only guards against a logic error.
     let iteration_cap = self.link_output.module_table.modules.len() + 1;
     let mut iterations = 0usize;
-    loop {
+    // The converged round's post-lowering edges are the ones the facade gate must see (see the
+    // `import_edges` field return below): the fixpoint recomputes them every round and, before this
+    // change, threw them all away, so `create_order_wrap_entry_facades` gated on the pre-lowering
+    // baseline and missed edges that only lowering mints.
+    let final_post_edges = loop {
       // Project the chunk edges the current plan's lowering will add — the `init_*` forwarding
       // imports of wrapped modules — on top of the pre-lowering baseline, then find the chunk
       // cycles those emergent edges close.
@@ -214,7 +218,9 @@ impl GenerateStage<'_> {
         )
       });
       if added == 0 {
-        break;
+        // Converged: `post_edges` here already includes the final plan's lowering-added imports and
+        // closes no further cycle, so it is the exact edge set the facade gate needs.
+        break post_edges;
       }
       plan = self.build_order_wrap_plan(
         all_at_risk.clone(),
@@ -225,7 +231,7 @@ impl GenerateStage<'_> {
         &reverse_static_imports,
       );
       assert!(iterations < iteration_cap, "order-wrap emergent-cycle fixpoint did not converge");
-    }
+    };
     order_debug_trace(|| {
       format!(
         "[order] fixpoint converged in {iterations} iteration(s): {} modules planned (+{} over the one-shot plan)",
@@ -239,7 +245,16 @@ impl GenerateStage<'_> {
       planned_modules = plan.len(),
       "emergent-cycle fixpoint converged"
     );
-    Some(OrderAnalysis { plan, import_edges, on_demand: true })
+    // Return the converged *post-lowering* edges, not the pre-lowering `import_edges` baseline.
+    // The only consumer is `create_order_wrap_entry_facades`, whose gate splits an interop-wrapped
+    // entry into a facade when another chunk imports the entry's chunk. Lowering can mint the first
+    // such edge itself — e.g. an `init_*` forward through an excluded re-export hop into the entry's
+    // host chunk — and when that edge closes no cycle the fixpoint converges without revisiting the
+    // facade decision, so a baseline-only gate would leave the entry's inline trigger in place and
+    // run its whole program when the importing chunk loads. Post-lowering edges are a superset of the
+    // baseline, and more facades are always legal (wrap-all splits unconditionally), so feeding the
+    // gate the final edges only ever adds correct facades.
+    Some(OrderAnalysis { plan, import_edges: final_post_edges, on_demand: true })
   }
 
   /// Project the chunk-level static import edges the lowering of `plan` will produce, as the

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/_config.json
@@ -1,0 +1,19 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      { "name": "main", "import": "./main.js" },
+      { "name": "sec", "import": "./gs/sec.js" }
+    ],
+    "strictExecutionOrder": true,
+    "preserveEntrySignatures": "allow-extension",
+    "experimental": { "onDemandWrapping": true },
+    "codeSplitting": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        { "name": "a", "test": "[\\\\/]a[\\\\/]" },
+        { "name": "gs", "test": "[\\\\/]gs[\\\\/]" }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/_test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+// Load only the importing side (the root) and confirm `sec`'s program did not run. This asserts the
+// fixed output executes correctly with `sec` deferred behind its facade; it does not by itself
+// distinguish the bug, since the emergent A->gs edge is a conservative projection the real lowering
+// never renders (chunk `a.js` imports nothing from `sec`'s chunk), so this also holds on the unfixed
+// build. The regression guard is the SNAPSHOT: without the fix `sec.js` keeps its inline
+// `require_sec()` trigger and no `sec2.js` facade split; with the fix the gate sees the emergent
+// edge and splits the facade.
+await import('./dist/main.js');
+assert.ok(
+  !globalThis.__secRan,
+  `sec must not run when only the root is loaded; ran ${globalThis.__secRan} time(s)`,
+);
+
+// Loading `sec` directly runs its CommonJS program exactly once and yields its exports.
+const sec = await import('./dist/sec.js');
+assert.strictEqual(globalThis.__secRan, 1, 'sec runs once when loaded directly');
+assert.deepStrictEqual(sec.default, { s: 'TV' }, 'sec exports its CommonJS value');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/a/a-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/a/a-first.js
@@ -1,0 +1,3 @@
+// Earliest side-effectful member of chunk A, so the root imports chunk A first.
+(globalThis.__events ??= []).push('a-first');
+export const aFirst = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/a/wrapper.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/a/wrapper.js
@@ -1,0 +1,10 @@
+// Order-wrapped barrel in chunk A. `wv` (a pure call) keeps it order-sensitive so the root's
+// deviation wraps it; the pure body means the excluded `export * from '../f.js'` below is
+// tree-shaken and `f` dropped. Because the barrel is order-wrapped, the excluded-statement metadata
+// still forwards `init_t` through `f` — the projected, baseline-invisible chunk edge into `sec`'s
+// chunk.
+export * from '../f.js';
+function mkWv() {
+  return 'WV';
+}
+export const wv = /* @__PURE__ */ mkWv();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/artifacts.snap
@@ -1,0 +1,98 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region a/a-first.js
+(globalThis.__events ??= []).push("a-first");
+//#endregion
+//#region a/wrapper.js
+function mkWv() {
+	return "WV";
+}
+var wv;
+function init_wrapper() {
+	return (init_wrapper = __esmMin((() => {
+		wv = /* @__PURE__ */ mkWv();
+	})))();
+}
+//#endregion
+export { wv as n, init_wrapper as t };
+
+```
+
+## main.js
+
+```js
+import "./a.js";
+import { t as init_main } from "./main2.js";
+init_main();
+
+```
+
+## main2.js
+
+```js
+import { n as wv, t as init_wrapper } from "./a.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region e-first.js
+(globalThis.__events ??= []).push("e-first");
+//#endregion
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_wrapper();
+		globalThis.__mainResult = wv;
+	})))();
+}
+//#endregion
+export { init_main as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## sec.js
+
+```js
+import { t as require_sec } from "./sec2.js";
+export default require_sec();
+
+```
+
+## sec2.js
+
+```js
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region gs/t.js
+var t_exports = /* @__PURE__ */ __exportAll({
+	tv: () => tv,
+	unused: () => unused
+});
+var tv, unused;
+var init_t = __esmMin((() => {
+	tv = /* @__PURE__ */ (() => "TV")();
+	unused = "UNUSED";
+}));
+//#endregion
+//#region gs/sec.js
+var require_sec = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const { tv } = (init_t(), __toCommonJS(t_exports));
+	globalThis.__secRan = (globalThis.__secRan ?? 0) + 1;
+	(globalThis.__events ??= []).push("sec-body");
+	module.exports = { s: tv };
+}));
+//#endregion
+export { require_sec as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/e-first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/e-first.js
@@ -1,0 +1,4 @@
+// Side-effectful module in the root's own entry chunk: predicted order runs it after chunk A,
+// source order before `wrapper` — the deviation that makes `wrapper` premature.
+(globalThis.__events ??= []).push('e-first');
+export const first = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/f.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/f.js
@@ -1,0 +1,6 @@
+// Non-included forwarder: nothing consumes `forwarded`, so `f` is dropped from the output. Its
+// `import { unused } from './gs/t.js'` still resolves to the interop-wrapped `t`, and the excluded
+// re-export hop in `wrapper` forwards `init_t` through it — the cross-chunk edge the pre-lowering
+// baseline never records.
+import { unused } from './gs/t.js';
+export const forwarded = unused;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/gs/sec.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/gs/sec.js
@@ -1,0 +1,9 @@
+// Interop-wrapped entry (CommonJS -> WrapKind::Cjs). Its chunk (group `gs`) co-hosts the
+// order-wrapped `t`. The only cross-chunk edge into this chunk is the emergent `A -> gs` hop the
+// excluded forwarder projects — there is no baseline edge — so a facade gate reading pre-lowering
+// edges leaves `sec`'s inline `require_sec()` trigger in the shared chunk. Reading the post-lowering
+// edges instead splits `sec` into a facade, so evaluating the shared chunk never runs its program.
+const { tv } = require('./t.js');
+globalThis.__secRan = (globalThis.__secRan ?? 0) + 1;
+(globalThis.__events ??= []).push('sec-body');
+module.exports = { s: tv };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/gs/t.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/gs/t.js
@@ -1,0 +1,5 @@
+// Interop-wrapped (required by the CJS `sec`) and co-hosted with it. `tv` is consumed by `sec`;
+// `unused` is imported only by the excluded forwarder `f`, so only the excluded-statement metadata
+// reaches it — the projected hop the facade gate must see.
+export const tv = /* @__PURE__ */ (() => 'TV')();
+export const unused = 'UNUSED';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/facade_gate_emergent_edge/main.js
@@ -1,0 +1,13 @@
+// Facade gate must consume post-lowering edges (rolldown/rolldown#10104 review item 1).
+//
+// Source order `a-first` (chunk A), `e-first` (this entry chunk), then `wrapper` (chunk A) makes
+// `wrapper` deviate (premature) under the root, so on-demand wrapping order-wraps it. `wrapper`
+// carries a tree-shaken `export * from './f.js'`; the excluded-statement metadata walks the dropped
+// `f`'s `import { unused } from './gs/t.js'` and projects an `init_t` forward, so the analysis's
+// post-lowering edges include `chunk A -> the sec entry's chunk`. That emergent edge has no
+// baseline counterpart (f is excluded), so it is invisible to a facade gate keyed on pre-lowering
+// edges — the exact miss this fix repairs.
+import './a/a-first.js';
+import './e-first.js';
+import { wv } from './a/wrapper.js';
+globalThis.__mainResult = wv;

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      { "name": "entry_a", "import": "./entry_a.js" },
+      { "name": "entry_b", "import": "./entry_b.js" },
+      { "name": "entry_c", "import": "./entry_c.js" }
+    ],
+    "external": ["external"]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/artifacts.snap
@@ -1,0 +1,50 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_a.js
+
+```js
+import "./s_ac.js";
+import "./re.js";
+export * from "external";
+
+```
+
+## entry_b.js
+
+```js
+import "./re.js";
+export * from "external";
+
+```
+
+## entry_c.js
+
+```js
+import "./s_ac.js";
+//#region entry_c.js
+const c = "c";
+//#endregion
+export { c };
+
+```
+
+## re.js
+
+```js
+//#region re.js
+console.log("re side effect");
+//#endregion
+
+```
+
+## s_ac.js
+
+```js
+//#region s_ac.js
+console.log("s_ac side effect");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_a.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_a.js
@@ -1,0 +1,2 @@
+import './s_ac.js';
+export * from './re.js';

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_b.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_b.js
@@ -1,0 +1,1 @@
+export * from './re.js';

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_c.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/entry_c.js
@@ -1,0 +1,2 @@
+import './s_ac.js';
+export const c = 'c';

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/re.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/re.js
@@ -1,0 +1,2 @@
+export * from 'external';
+console.log('re side effect');

--- a/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/s_ac.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/sweep_shared_chunk_exec_order/s_ac.js
@@ -1,0 +1,1 @@
+console.log('s_ac side effect');


### PR DESCRIPTION
## Summary

The strict-order entry-facade gate decided whether to split an interop-wrapped entry into a facade using the **pre-lowering** chunk import edges. Lowering's own `init_*` forwarding can add the first cross-chunk edge into such an entry's chunk, and when that edge closes no cycle the fixpoint converges without revisiting the facade decision — so the gate never saw it. This routes the gate through the converged **post-lowering** edges instead, so an entry whose chunk is only reached by a lowering-added hop is still split. Over-approximation is the safe direction (more facades are always legal; wrap-all splits unconditionally).

## Verified mechanism

- `create_order_wrap_entry_facades` builds `imported_chunks` from `analysis.import_edges` (`order_wrapping.rs:214`), which `analyze_execution_order` set to the pre-lowering baseline and returned at the end.
- The emergent-cycle fixpoint recomputes `post_lowering_import_edges` every round and threw them away after cycle detection. This captures the **converged** round's `post_edges` (the round where `added == 0`) and returns those as `OrderAnalysis.import_edges`.
- `create_order_wrap_entry_facades` is the only consumer of that field (grep-verified); the wrap-all path builds empty edges and short-circuits (`on_demand == false`), so it is unchanged.

## Behavior / snapshot impact

- **Full suite: zero existing snapshots change.** Over-approximation added no facades to any existing fixture — no current fixture reaches an interop entry's chunk by an emergent-only edge, confirming the shape is novel.
- **One new fixture** `function/experimental/strict_execution_order/facade_gate_emergent_edge` (on-demand): a CommonJS entry `sec` (WrapKind::Cjs) co-hosts the interop-wrapped `t` in group `gs`; an order-wrapped `wrapper` in chunk A carries a tree-shaken `export * from './f.js'` whose dropped `f` imports `unused` from `t`, so the excluded-statement metadata projects an `init_t` forward — a post-lowering `A -> gs` edge with **no baseline counterpart**.
  - **Snapshot is the differentiator (verified against the unfixed base):** with the pre-lowering gate, `sec` keeps its inline `require_sec()` trigger in the shared chunk (no `sec2.js`); with this fix the gate sees the emergent edge and splits `sec` into a facade (`sec.js` thin trigger + `sec2.js` impl). The only diff between the two builds is the added facade chunk.
  - Executes under node (`_test.mjs`): loading only the root does not run `sec`'s program; loading `sec` directly runs it once.

## Fixture outcome — constructibility verdict

The reviewer expected a directed fixture where "evaluating the importing chunk runs the whole entry program early." I could construct the **facade-decision** difference (above) but not an **executable** early-run, and the reason is structural — established over ≥7 distinct attempts (co-hosted order-wrapped target with a TLA entry, a CJS entry, and a plain entry; the excluded forwarder targeting the entry directly vs. a co-hosted module; single- vs. two-entry; TLA vs. CJS interop). A post-lowering-only edge (absent from the baseline) comes from exactly two sources:

1. **Excluded re-export hops** (the named Hole-2 shape) — projection-only. The real lowering does not render the forward (Hole-2's own `dist/a.js` calls no `init_t`); it exists only in `post_lowering_import_edges` for cycle detection. So it never actually imports the entry's chunk at runtime — the facade the fix creates is a correct conservative guard, not a fix for a live crash.
2. **Eager re-export overlays** (Hole-1) — rendered, but retaining the re-export requires the re-exported binding to be consumed, which itself creates a baseline edge into the target's chunk. So the gate already splits in that case, with or without the fix.

A rendered, baseline-invisible edge into an interop entry's chunk therefore does not appear constructible; the executable early-run is not reachable through the facade gate. The fixture pins the facade-gate behavior change directly (snapshot differentiator) and the fix stands as the correct over-approximation the review asked for. If a rendered path is later found, it converts straight into an executed assertion on this same fixture.

## Validation

- `cargo test -p rolldown` — 1872 passed (+1 new fixture, executed under node); only the 5 known environmental failures (`cjs_module_lexer_compat` ×3 + `npm_packages/util_deprecate` need `pnpm install`; `test262_module_code` needs the submodule). No existing snapshot changed (the local `symbols_ns2` drift is pre-existing `node_modules`-resolution noise, reproducible with this change reverted, and is not committed).
- `cargo fmt --all --check` — clean; `cargo clippy -p rolldown --all-targets -- -D warnings` — clean.

---

Follow-up to #10104; addresses item 1 of https://github.com/rolldown/rolldown/pull/10104#issuecomment-4995527384
