### PR TITLE
fix(code-splitting): deconflict force-included runtime helper statements

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -134,7 +134,15 @@ pub fn deconflict_chunk_symbols(
 
       link_output.stmt_infos[module.idx]
         .iter_enumerated()
-        .filter(|(idx, _)| meta.stmt_info_included.has_bit(*idx))
+        // A runtime statement tree-shaking excluded but order wrapping force-includes is rendered
+        // and symbol-assigned, so it must reach the renamer too. Mirror the overlay-aware inclusion
+        // test the other two consumers already use (`compute_cross_chunk_links` and the module
+        // finalizer's `remove_unused_top_level_stmt`); without it a user top-level binding named
+        // `__esmMin`/`__esm` co-hosted with the runtime collides with the forced helper declaration.
+        .filter(|(idx, stmt_info)| {
+          meta.stmt_info_included.has_bit(*idx)
+            || order_wrap_state.forces_runtime_stmt(&link_output.runtime, module.idx, stmt_info)
+        })
         .for_each(|(_, stmt_info)| {
           for declared_symbol in stmt_info.declared_symbols.iter().filter(|item| item.is_normal()) {
             let symbol_ref = declared_symbol.inner();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "strictExecutionOrder": true,
+    "codeSplitting": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/_test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+
+// Unfixed: the forced runtime `__esmMin` shares a root binding with helper.js's `__esmMin`; helper's
+// init overwrites it with the user string and `init_late`'s `__esmMin(...)` throws. The fix registers
+// the runtime statement with the renamer, which renames one so both survive and stay callable.
+await import('./dist/main.js');
+assert.deepStrictEqual(
+  globalThis.__result,
+  { helper: 'H:USERVAL', late: 'LATE:z' },
+  `strict single-chunk build must keep the runtime helper callable; got ${JSON.stringify(globalThis.__result)}`,
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region helper.js
+var __esmMin, helper;
+function init_helper() {
+	return (init_helper = __esmMin$1((() => {
+		__esmMin = globalThis.__x ?? "USERVAL";
+		helper = "H:" + __esmMin;
+	})))();
+}
+//#endregion
+//#region late.js
+var late;
+function init_late() {
+	return (init_late = __esmMin$1((() => {
+		late = "LATE:" + (globalThis.__y ?? "z");
+	})))();
+}
+//#endregion
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin$1((() => {
+		init_helper();
+		init_late();
+		globalThis.__result = {
+			helper,
+			late
+		};
+	})))();
+}
+//#endregion
+init_main();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/helper.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/helper.js
@@ -1,0 +1,5 @@
+// User module whose top-level `__esmMin` collides with the forced runtime helper. Reading a global
+// keeps the value materialized (not const-folded) so its order wrapper hoists a root-scope
+// `var __esmMin`; the initializer then reassigns that shared binding to the user string.
+export const __esmMin = globalThis.__x ?? 'USERVAL';
+export const helper = 'H:' + __esmMin;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/late.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/late.js
@@ -1,0 +1,3 @@
+// Ordered after `helper`, so its wrapper's `init_late = __esmMin(...)` runs after `helper` clobbered
+// the shared `__esmMin` — the call that throws on the unfixed build.
+export const late = 'LATE:' + (globalThis.__y ?? 'z');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/deconflict_forced_runtime_helper/main.js
@@ -1,0 +1,13 @@
+// Deconflict must register force-included runtime statements (rolldown/rolldown#10104 review item 2).
+//
+// A single-chunk strict build (codeSplitting disabled) places the runtime module next to user code
+// (order_wrapping.rs:451-457). Pure ESM demands no runtime helper at link time, so tree-shaking drops
+// `__esmMin`; strict order lowering then force-includes it. `helper.js` declares a top-level
+// `__esmMin` of its own, hoisted to a root-scope `var __esmMin` by its order wrapper — the same root
+// scope as the runtime's forced `__esmMin`. deconflict_chunk_symbols filtered the runtime module's
+// statements on raw `stmt_info_included`, so the force-included helper statement never reached the
+// renamer and the collision went unnoticed: `helper`'s init overwrites the shared binding with the
+// user string, and the next wrapper's `__esmMin(...)` call throws `__esmMin is not a function`.
+import { helper } from './helper.js';
+import { late } from './late.js';
+globalThis.__result = { helper, late };


### PR DESCRIPTION
## Summary

Chunk deconfliction filtered each module's statements on raw `stmt_info_included`, so a runtime helper statement that tree-shaking excluded but strict order lowering force-includes (e.g. `__esmMin`) was rendered and symbol-assigned yet never registered with the renamer. When a user module co-hosted with the runtime declares a top-level binding of the same name, the two share the chunk's root scope: the user's initializer overwrites the runtime helper and the next wrapper's `__esmMin(...)` call throws. This ORs the order overlay into deconfliction's inclusion test, matching the two other consumers.

## Verified mechanism

- `compute_cross_chunk_links.rs:438` and `module_finalizers/mod.rs:1623` both OR `order_wrap_state.forces_runtime_stmt(...)` into their inclusion test; `deconflict_chunk_symbols.rs:137` filtered on `meta.stmt_info_included.has_bit(...)` alone.
- A single-chunk strict build (`codeSplitting: false`) places the runtime next to user code (`order_wrapping.rs:451-457`). Pure ESM demands no helper at link time, so tree-shaking drops `__esmMin` and strict order lowering force-includes it — the exact statement the deconflict filter dropped.

## Fix

`deconflict_chunk_symbols` already receives `order_wrap_state` and `link_output`, so the change is a one-line mirror of the existing two sites: `has_bit(idx) || forces_runtime_stmt(&link_output.runtime, module.idx, stmt_info)` (`forces_runtime_stmt` self-guards `module_idx == runtime.id()`, so it is inert for every non-runtime module).

**Item 7 (maintainability).** I kept the inline `||` rather than extracting a shared "is this statement rendered?" accessor: `forces_runtime_stmt` is already the shared half, the other two sites use this exact inline form, and a shared method would have to take `meta` + `stmt_idx` + `stmt_info` (coupling `OrderWrapState` to `LinkingMetadata`) and rewrite two already-correct sites — a larger diff than the reviewer's "keep the diff small" guidance wants for a fix. The three sites now read identically.

## Behavior / snapshot impact

- **Full suite: zero existing snapshots change.** No current fixture co-hosts a user binding named after a force-included runtime helper, so the added disjunct fires nowhere else.
- **One new fixture** `function/experimental/strict_execution_order/deconflict_forced_runtime_helper` (strict, `codeSplitting: false`): `helper.js` declares a top-level `__esmMin` (hoisted to a root-scope `var __esmMin` by its order wrapper) co-hosted with the runtime; `late.js` is ordered after it.
  - **Broken output verified on the unfixed base:** two `var __esmMin` at root — the runtime helper and helper.js's binding. `helper`'s init reassigns the shared binding to the user string, and `init_late = __esmMin(...)` then throws `TypeError: __esmMin is not a function` (the fixture fails to execute).
  - **Fixed:** deconflict registers the runtime statement, so the renamer renames the runtime helper to `__esmMin$1`; every wrapper calls `__esmMin$1(...)` and the user's `__esmMin` keeps its name. Snapshot pins the rename; `_test.mjs` asserts the executed result `{ helper: 'H:USERVAL', late: 'LATE:z' }`.

**Note on wrap-all vs on-demand, and the co-hosting mechanism.** The reproduction is a wrap-all strict build (`strictExecutionOrder` without `onDemandWrapping`) because it deterministically co-hosts the runtime with user code in one chunk. The collision needs the runtime co-hosted with a user module *at deconflict time*. `try_merge_runtime_chunk` can co-host the standalone runtime into a user consumer chunk even in multi-chunk builds, but under strict order wrapping `ensure_runtime_module_for_order_wraps` (`order_wrapping.rs:395-457`) relocates a co-hosted runtime (`modules.len() > 1`) back to a standalone chunk unless code splitting is disabled — so at deconflict time the runtime sits next to user code only in single-chunk (`codeSplitting: false`) builds. (This stack's own multi-chunk strict on-demand fixtures, e.g. `facade_gate_emergent_edge`, confirm it — they emit a standalone `rolldown-runtime.js` chunk.) In a single chunk on-demand finds no cross-chunk execution-order hazard, so it wraps nothing and demands no `__esmMin`; wrap-all is the frame that both co-hosts the runtime and force-includes the helper. The fix itself is mode-independent: `forces_runtime_stmt` keys on `required_runtime_helpers()`, covering on-demand and wrap-all and both the `__esmMin` and `__esm` (profiler_names) variants.

## Validation

- `cargo test -p rolldown` — 1872 passed (+1 new fixture, executed under node); only the 5 known environmental failures (`cjs_module_lexer_compat` ×3 + `npm_packages/util_deprecate` need `pnpm install`; `test262_module_code` needs the submodule). No existing snapshot changed (the local `symbols_ns2` drift is pre-existing `node_modules`-resolution noise, reproducible with this change reverted, and is not committed).
- `cargo fmt --all --check` — clean; `cargo clippy -p rolldown --all-targets -- -D warnings` — clean.

---

Follow-up to #10104; addresses item 2 (and the item-7 maintainability note) of https://github.com/rolldown/rolldown/pull/10104#issuecomment-4995527384
