### PR TITLE
refactor(dev): make it easier to customize the runtime

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -63,13 +63,21 @@ impl From<BindingChunkOptimizationOptions> for rolldown_common::ChunkOptimizatio
 pub struct BindingExperimentalDevModeOptions {
   pub host: Option<String>,
   pub port: Option<u16>,
-  pub implement: Option<String>,
+  pub implement: String,
+  /// @deprecated Common runtime injection will be disabled by default in the future.
+  pub skip_common_runtime_injection: Option<bool>,
   pub lazy: Option<bool>,
 }
 
 impl From<BindingExperimentalDevModeOptions> for rolldown_common::DevModeOptions {
   fn from(value: BindingExperimentalDevModeOptions) -> Self {
-    Self { host: value.host, port: value.port, implement: value.implement, lazy: value.lazy }
+    Self {
+      host: value.host,
+      port: value.port,
+      implement: Some(value.implement),
+      skip_common_runtime_injection: value.skip_common_runtime_injection,
+      lazy: value.lazy,
+    }
   }
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/dev_mode_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/dev_mode_options.rs
@@ -16,6 +16,10 @@ pub struct DevModeOptions {
   pub port: Option<u16>,
   /// Custom dev mode runtime implementation.
   pub implement: Option<String>,
+  /// Do not inject the common dev runtime before the custom implementation.
+  ///
+  /// Deprecated: common runtime injection will be disabled by default in the future.
+  pub skip_common_runtime_injection: Option<bool>,
   /// Enable lazy compilation for dynamic imports.
   pub lazy: Option<bool>,
 }

--- a/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
+++ b/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
@@ -1,7 +1,7 @@
-use rolldown_common::{Platform, RUNTIME_MODULE_KEY, ResolvedExternal};
+use rolldown_common::RUNTIME_MODULE_KEY;
 use rolldown_plugin::{
-  HookResolveIdOutput, HookTransformArgs, HookTransformOutput, HookTransformReturn, HookUsage,
-  Plugin, SharedTransformPluginContext,
+  HookTransformArgs, HookTransformOutput, HookTransformReturn, HookUsage, Plugin,
+  SharedTransformPluginContext,
 };
 
 #[derive(Debug)]
@@ -13,28 +13,7 @@ impl Plugin for HmrPlugin {
   }
 
   fn register_hook_usage(&self) -> rolldown_plugin::HookUsage {
-    HookUsage::Transform | HookUsage::ResolveId
-  }
-
-  async fn resolve_id(
-    &self,
-    _ctx: &rolldown_plugin::PluginContext,
-    args: &rolldown_plugin::HookResolveIdArgs<'_>,
-  ) -> rolldown_plugin::HookResolveIdReturn {
-    // Only handle ws external marking for Node.js
-    if args.specifier == "ws" {
-      return Ok(Some(HookResolveIdOutput {
-        id: args.specifier.into(),
-        external: Some(ResolvedExternal::Bool(true)),
-        ..Default::default()
-      }));
-    }
-
-    Ok(None)
-  }
-
-  fn resolve_id_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
-    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
+    HookUsage::Transform
   }
 
   async fn transform(
@@ -53,23 +32,14 @@ impl Plugin for HmrPlugin {
 
     let mut hmr_source = String::new();
 
-    // Platform-specific WebSocket import
-    if matches!(bundler_options.platform, Platform::Node) {
-      hmr_source.push_str("import { WebSocket } from 'ws';\n");
+    if dev_mode_options.skip_common_runtime_injection != Some(true) {
+      hmr_source.push_str(include_str!("./runtime/runtime-extra-dev-common.js"));
     }
 
-    // Common runtime
-    hmr_source.push_str(include_str!("./runtime/runtime-extra-dev-common.js"));
-
-    // Default or custom implementation
+    // The JS API supplies the default implementation. Rust consumers must provide the
+    // complete implementation, including the common runtime when they need it.
     if let Some(implement) = dev_mode_options.implement.as_deref() {
       hmr_source.push_str(implement);
-    } else {
-      let content = include_str!("./runtime/runtime-extra-dev-default.js");
-      let host = dev_mode_options.host.as_deref().unwrap_or("localhost");
-      let port = dev_mode_options.port.unwrap_or(3000);
-      let addr = format!("{host}:{port}");
-      hmr_source.push_str(&content.replace("$ADDR", &addr));
     }
 
     // Append to runtime

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1081,6 +1081,13 @@
             "null"
           ]
         },
+        "skipCommonRuntimeInjection": {
+          "description": "Do not inject the common dev runtime before the custom implementation.\n\nDeprecated: common runtime injection will be disabled by default in the future.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "lazy": {
           "description": "Enable lazy compilation for dynamic imports.",
           "type": [

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -673,7 +673,12 @@ impl IntegrationTest {
     if let Some(experimental) = &mut options.experimental {
       if let Some(dev_mode) = &mut experimental.dev_mode {
         if dev_mode.implement.is_none() {
-          dev_mode.implement = Some(include_str!("./hmr-runtime.js").to_owned());
+          dev_mode.implement = Some(format!(
+            "{}\n{}",
+            include_str!("../../rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js"),
+            include_str!("./hmr-runtime.js")
+          ));
+          dev_mode.skip_common_runtime_injection = Some(true);
         }
       }
     }

--- a/internal-docs/dev-engine/implementation.md
+++ b/internal-docs/dev-engine/implementation.md
@@ -78,6 +78,26 @@ pub struct DevContext {
 }
 ```
 
+### Browser runtime ownership
+
+The HMR plugin appends `experimental.devMode.implement`. The Rust layer
+deliberately has no default implementation. The JavaScript API keeps its default
+client in `crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js`;
+option normalization reads the standalone common runtime from its package export,
+removes its generated first-line helper import, and reads the default runtime
+through the package-internal `#default-runtime` import. It then joins them after
+substituting the server address. Rust consumers and the integration test harness
+provide the complete implementation explicitly.
+
+The reusable runtime classes are also built as the ESM entry
+`rolldown/experimental/runtime`; its package export points at the matching
+generated declaration file so custom runtime implementations can import both
+the values and their types from one specifier. The entry imports its helpers from
+an unmodified copy of `crates/rolldown/src/runtime/runtime-base.js`, which is the
+same source the Rust core includes in generated bundles. Removing the standalone
+entry's generated helper import recovers the verbatim common runtime source for
+injection, so generated bundle output does not change.
+
 ### Threading model
 
 - The `BundleCoordinator` runs in **one** dedicated tokio task

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -31,6 +31,9 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "imports": {
+    "#default-runtime": "./dist/experimental-default-runtime.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
@@ -44,6 +47,10 @@
     },
     "./experimental/runtime-types": {
       "types": "./dist/experimental-runtime-types.d.ts"
+    },
+    "./experimental/runtime": {
+      "types": "./dist/experimental-runtime.d.ts",
+      "default": "./dist/experimental-runtime.mjs"
     },
     "./plugins": {
       "browser": "./dist/plugins-index.browser.mjs",

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -96,7 +96,7 @@ if (buildMeta.target === 'browser-pkg') {
   for (const config of configs) {
     await build(config);
   }
-  generateRuntimeTypes();
+  generateRuntimeEntry();
 })();
 
 function withShared({
@@ -233,27 +233,57 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
   };
 }
 
-function generateRuntimeTypes() {
-  const inputFile = nodePath.resolve(
+// Prefix the common runtime with its canonical compiler-helper imports for standalone ESM use.
+// The default runtime loader removes this generated first line before injecting the source into a
+// bundle, where the same helpers are already in scope.
+function generateRuntimeEntry() {
+  const commonRuntimeInputFile = nodePath.resolve(
     __dirname,
     '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js',
   );
-  const outputFile = nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime-types.d.ts');
+  const runtimeBaseInputFile = nodePath.resolve(
+    __dirname,
+    '../../crates/rolldown/src/runtime/runtime-base.js',
+  );
+  const defaultInputFile = nodePath.resolve(
+    __dirname,
+    '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js',
+  );
+  const outputFile = nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime.d.ts');
 
-  console.log(styleText('green', '[build:done]'), 'Generating dts from', inputFile);
+  console.log(styleText('green', '[build:done]'), 'Generating dts from', commonRuntimeInputFile);
 
-  const jsCode = fs.readFileSync(inputFile, 'utf-8');
-  const result = ts.transpileDeclaration(jsCode, {
+  const commonRuntimeSource = fs.readFileSync(commonRuntimeInputFile, 'utf-8');
+  const runtimeHelperImport =
+    "import { __exportAll, __reExport, __toCommonJS, __toESM } from './experimental-runtime-base.mjs';\n";
+  fs.writeFileSync(
+    nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime.mjs'),
+    runtimeHelperImport + commonRuntimeSource,
+  );
+  fs.copyFileSync(
+    runtimeBaseInputFile,
+    nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime-base.mjs'),
+  );
+  fs.copyFileSync(
+    defaultInputFile,
+    nodePath.resolve(buildMeta.buildOutputDir, 'experimental-default-runtime.mjs'),
+  );
+
+  const result = ts.transpileDeclaration(commonRuntimeSource, {
     compilerOptions: {
-      ...getTsconfigCompilerOptionsForFile(inputFile),
+      ...getTsconfigCompilerOptionsForFile(commonRuntimeInputFile),
       noEmit: false,
       emitDeclarationOnly: true,
     },
-    fileName: inputFile,
+    fileName: commonRuntimeInputFile,
   });
 
   if (result && result.outputText) {
     fs.writeFileSync(outputFile, result.outputText, 'utf-8');
+    fs.copyFileSync(
+      outputFile,
+      nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime-types.d.ts'),
+    );
   } else {
     throw new Error('Failed to generate d.ts from runtime-extra-dev.js');
   }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -33,6 +33,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "imports": {
+    "#default-runtime": "./dist/experimental-default-runtime.mjs",
     "#parallel-plugin-worker": "./dist/parallel-plugin-worker.mjs"
   },
   "exports": {
@@ -50,6 +51,10 @@
     },
     "./experimental/runtime-types": {
       "types": "./dist/experimental-runtime-types.d.ts"
+    },
+    "./experimental/runtime": {
+      "types": "./dist/experimental-runtime.d.ts",
+      "default": "./dist/experimental-runtime.mjs"
     },
     "./filter": {
       "dev": "./src/filter-index.ts",
@@ -84,6 +89,10 @@
       "./experimental": "./dist/experimental-index.mjs",
       "./experimental/runtime-types": {
         "types": "./dist/experimental-runtime-types.d.ts"
+      },
+      "./experimental/runtime": {
+        "types": "./dist/experimental-runtime.d.ts",
+        "default": "./dist/experimental-runtime.mjs"
       },
       "./filter": "./dist/filter-index.mjs",
       "./getLogFilter": "./dist/get-log-filter.mjs",

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2235,7 +2235,9 @@ export interface BindingEsmExternalRequirePluginConfig {
 export interface BindingExperimentalDevModeOptions {
   host?: string
   port?: number
-  implement?: string
+  implement: string
+  /** @deprecated Common runtime injection will be disabled by default in the future. */
+  skipCommonRuntimeInjection?: boolean
   lazy?: boolean
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -220,6 +220,13 @@ export type DevModeOptions =
       host?: string;
       port?: number;
       implement?: string;
+      /**
+       * Prevent Rolldown from prepending its common dev runtime to {@link implement}.
+       * @deprecated Common runtime injection will be disabled by default in the future.
+       * Include the common runtime in {@link implement} instead.
+       * @default false
+       */
+      skipCommonRuntimeInjection?: boolean;
       lazy?: boolean;
     };
 

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -28,6 +28,7 @@ import {
   normalizeTransformOptions,
 } from './normalize-transform-options';
 import { getParallelPluginInfo } from './parallel-plugin';
+import { getDefaultDevRuntime } from './default-dev-runtime';
 
 export function bindingifyInputOptions(
   rawPlugins: RolldownPlugin[],
@@ -119,9 +120,16 @@ export function bindingifyInputOptions(
 function bindingifyDevMode(devMode?: DevModeOptions): BindingExperimentalOptions['devMode'] {
   if (devMode) {
     if (typeof devMode === 'boolean') {
-      return devMode ? {} : undefined;
+      return devMode
+        ? { implement: getDefaultDevRuntime(), skipCommonRuntimeInjection: true }
+        : undefined;
     }
-    return devMode;
+    const usesDefaultRuntime = devMode.implement == null;
+    return {
+      ...devMode,
+      implement: devMode.implement ?? getDefaultDevRuntime(devMode.host, devMode.port),
+      skipCommonRuntimeInjection: usesDefaultRuntime ? true : devMode.skipCommonRuntimeInjection,
+    };
   }
 }
 

--- a/packages/rolldown/src/utils/default-dev-runtime.ts
+++ b/packages/rolldown/src/utils/default-dev-runtime.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// The public entry's generated first line imports helpers for standalone ESM use. Remove it before
+// appending the source to Rolldown's internal runtime module, where those helpers are already in
+// scope.
+export function getDefaultDevRuntime(host = 'localhost', port = 3000): string {
+  const runtimeEntry = fs.readFileSync(
+    fileURLToPath(import.meta.resolve('rolldown/experimental/runtime')),
+    'utf8',
+  );
+  const runtimeHelperImportEnd = runtimeEntry.indexOf('\n');
+  if (!runtimeEntry.startsWith('import ') || runtimeHelperImportEnd === -1) {
+    throw new Error('Expected the standalone runtime to start with a helper import');
+  }
+  const runtime = runtimeEntry.slice(runtimeHelperImportEnd + 1);
+  const defaultRuntime = fs.readFileSync(
+    fileURLToPath(import.meta.resolve('#default-runtime')),
+    'utf8',
+  );
+  return `${runtime}\n${defaultRuntime.replaceAll('$ADDR', `${host}:${port}`)}`;
+}

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -596,6 +596,7 @@ const DevModeSchema = v.union([
     port: v.optional(v.number()),
     host: v.optional(v.string()),
     implement: v.optional(v.string()),
+    skipCommonRuntimeInjection: v.optional(v.boolean()),
     lazy: v.optional(v.boolean()),
   }),
 ]);

--- a/packages/rolldown/tests/dev/dev-runtime.test.ts
+++ b/packages/rolldown/tests/dev/dev-runtime.test.ts
@@ -1,24 +1,48 @@
-import { beforeAll, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
 
-// The runtime references helpers that rolldown injects at build time
-// (`__toESM` etc.) from class-field initializers, so they must exist as
-// globals before a DevRuntime is constructed.
-beforeAll(() => {
-  const g = globalThis as any;
-  g.__toESM = (mod: any) => mod;
-  g.__toCommonJS = (mod: any) => mod;
-  g.__exportAll = (all: any) => all;
-  g.__reExport = () => {};
-});
+import { expect, test, vi } from 'vitest';
 
 async function createRuntime() {
-  const runtimeUrl = new URL(
-    '../../../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js',
-    import.meta.url,
-  ).href;
+  const runtimeUrl = import.meta.resolve('rolldown/experimental/runtime');
   const { DevRuntime, MissingFactoryError } = await import(runtimeUrl);
   return { runtime: new DevRuntime('test-client') as any, MissingFactoryError };
 }
+
+test('the standalone runtime uses the canonical runtime helpers', async () => {
+  const { runtime } = await createRuntime();
+  const commonJsModule = { value: 1 };
+
+  expect(runtime.__toESM(commonJsModule).default).toBe(commonJsModule);
+  const esmModule = runtime.__toCommonJS({ default: commonJsModule });
+  expect(esmModule.__esModule).toBe(true);
+  expect(esmModule.default).toBe(commonJsModule);
+});
+
+test('the packaged runtime base is byte-identical to the bundled runtime base', () => {
+  const packagedRuntimeBaseUrl = new URL(
+    './experimental-runtime-base.mjs',
+    import.meta.resolve('rolldown/experimental/runtime'),
+  );
+  const bundledRuntimeBaseUrl = new URL(
+    '../../../../crates/rolldown/src/runtime/runtime-base.js',
+    import.meta.url,
+  );
+
+  expect(fs.existsSync(packagedRuntimeBaseUrl)).toBe(true);
+  if (!fs.existsSync(packagedRuntimeBaseUrl)) return;
+  expect(fs.readFileSync(packagedRuntimeBaseUrl, 'utf8')).toBe(
+    fs.readFileSync(bundledRuntimeBaseUrl, 'utf8'),
+  );
+});
+
+test('the package does not emit a separate runtime injection source', () => {
+  const runtimeSourceUrl = new URL(
+    './experimental-runtime-source.mjs',
+    import.meta.resolve('rolldown/experimental/runtime'),
+  );
+
+  expect(fs.existsSync(runtimeSourceUrl)).toBe(false);
+});
 
 test('registerGraph maintains static + dynamic reverse indexes; getImporters unions them', async () => {
   const { runtime } = await createRuntime();

--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -186,9 +186,12 @@ async function runArtifactProcess(artifactPath: string, tmpProjectPath: string, 
   id++;
 
   const initOkFilePath = nodePath.join(tmpProjectPath, `ok-init-${thisId}`);
+  const webSocketUrl = import.meta.resolve('ws');
   const injectCode = encodeURIComponent(
     `
     import __nodeFs__ from 'node:fs';
+    import { WebSocket as __WebSocket__ } from ${JSON.stringify(webSocketUrl)};
+    globalThis.WebSocket = __WebSocket__;
     __nodeFs__.writeFileSync('ok-init-${thisId}', '');
   `.trim(),
   );

--- a/packages/test-dev-server/tests/package.json
+++ b/packages/test-dev-server/tests/package.json
@@ -14,7 +14,8 @@
     "fast-glob": "catalog:",
     "kill-port": "^1.6.1",
     "rimraf": "^6.0.1",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "ws": "catalog:"
   },
   "devDependencies": {
     "playwright": "^1.60.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.1.5(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      ws:
+        specifier: 'catalog:'
+        version: 8.21.1
     devDependencies:
       playwright:
         specifier: ^1.60.0


### PR DESCRIPTION
Export the HMR runtime from `rolldown/experimental/runtime` so that Vite can import it and construct the runtime on their own.
This will allow Vite to remove the hacky code.