### PR TITLE
test(generated-code): mark assert external in symbols_ns2 for deterministic output

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/_config.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "format": "esm",
+    "external": ["assert"],
     "generatedCode": {
       "symbols": true
     }

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/artifacts.snap
@@ -1,21 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
-
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Could not resolve 'assert' in main.js
-   ╭─[ main.js:1:20 ]
-   │
- 1 │ import assert from 'assert';
-   │                    ────┬───  
-   │                        ╰───── Module not found, treating it as an external dependency
-───╯
-
-```
-
 # Assets
 
 ## main.js
@@ -73,19 +58,6 @@ assert.default.equal(String(lib_exports), "[object Module]");
 
 ```text
 [MISSING_GLOBAL_NAME] No name was provided for external module "assert" in "output.globals" – guessing "assert".
-
-```
-
-### UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Could not resolve 'assert' in main.js
-   ╭─[ main.js:1:20 ]
-   │
- 1 │ import assert from 'assert';
-   │                    ────┬───  
-   │                        ╰───── Module not found, treating it as an external dependency
-───╯
 
 ```
 


### PR DESCRIPTION
## Summary

`symbols_ns2` imports `assert` in its bundled entry (`main.js`) but — unlike its sibling `symbols_ns` — never declared it external. The committed snapshot was generated in an environment where `assert` was **unresolvable** (it literally carries an `[UNRESOLVED_IMPORT] Could not resolve 'assert'` warning). In any environment where an `assert` npm polyfill is resolvable somewhere up the directory tree, rolldown resolves and bundles it together with its whole transitive tree (`has-symbols`, `has-tostringtag`, `es-object-atoms`, `object.assign`, …), drifting the snapshot by ~7,200 lines.

CI has nothing up-tree, so the fixture stays green there; locally-installed worktrees drift, and the auto-update means the bloated snapshot can be committed by accident.

## Fix

Add `"external": ["assert"]` to the config, matching `symbols_ns`. The snapshot becomes a clean external passthrough (no `UNRESOLVED_IMPORT` warning, no bundled polyfill) and is deterministic regardless of what resolves up the tree. The fixture's actual intent — `Symbol.toStringTag` and `getOwnPropertyNames` on `generatedCode.symbols` namespaces — is unchanged.

## Validation

- `cargo test -p rolldown --test integration -- symbols_ns2` passes; snapshot re-generated and stable across two runs (115 → 87 lines, zero `UNRESOLVED_IMPORT` / polyfill content).