### PR TITLE
perf: preserve borrowed module-relative paths

### DIFF
--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -2,7 +2,7 @@ use std::{
   borrow::{Borrow, Cow},
   cmp::Ordering,
   hash::{Hash, Hasher},
-  path::{Path, PathBuf},
+  path::Path,
 };
 
 use arcstr::ArcStr;
@@ -140,8 +140,8 @@ impl ModuleId {
     Path::new(self.as_str()).representative_file_name()
   }
 
-  pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
-    Path::new(self.as_str()).relative(root).into_owned()
+  pub fn relative_path(&self, root: impl AsRef<Path>) -> Cow<'_, Path> {
+    Path::new(self.as_str()).relative(root)
   }
 
   pub fn stabilize(&self, cwd: &Path) -> StableModuleId {
@@ -239,5 +239,39 @@ impl From<ArcStr> for ModuleId {
 impl Borrow<str> for ModuleId {
   fn borrow(&self) -> &str {
     self.as_str()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn relative_path_preserves_borrowed_and_owned_results() {
+    #[cfg(not(windows))]
+    let (target, descendant_base, sibling_base, descendant, sibling) = (
+      "/workspace/package/src/index.js",
+      "/workspace/package",
+      "/workspace/package/dist",
+      "src/index.js",
+      "../src/index.js",
+    );
+    #[cfg(windows)]
+    let (target, descendant_base, sibling_base, descendant, sibling) = (
+      r"C:\workspace\package\src\index.js",
+      r"C:\workspace\package",
+      r"C:\workspace\package\dist",
+      r"src\index.js",
+      r"..\src\index.js",
+    );
+
+    let module_id = ModuleId::new(target);
+    let relative = module_id.relative_path(descendant_base);
+    assert_eq!(relative, Path::new(descendant));
+    assert!(matches!(relative, Cow::Borrowed(_)));
+
+    let relative = module_id.relative_path(sibling_base);
+    assert_eq!(relative, Path::new(sibling));
+    assert!(matches!(relative, Cow::Owned(_)));
   }
 }

--- a/crates/rolldown_plugin_vite_manifest/src/utils.rs
+++ b/crates/rolldown_plugin_vite_manifest/src/utils.rs
@@ -36,7 +36,7 @@ impl ViteManifestPlugin {
   pub fn get_chunk_name(&self, chunk: &OutputChunk, is_legacy: bool) -> String {
     match &chunk.facade_module_id {
       Some(module_id) => {
-        let mut name = module_id.relative_path(&self.root);
+        let mut name = module_id.relative_path(&self.root).into_owned();
         if is_legacy && !chunk.name.contains("-legacy") {
           let extension = OsString::from(name.extension().unwrap_or_default());
           if let Some(stem) = name.file_stem() {

--- a/internal-docs/path-manipulation/style-guide.md
+++ b/internal-docs/path-manipulation/style-guide.md
@@ -18,6 +18,8 @@ Implementation: `crates/rolldown_std_utils/src/path_ext.rs`. Module-id identity:
 
 sugar_path 3: `relative` returns `Cow<Path>` (empty when equal); `normalize` preserves a trailing separator; slash conversion is strict by default. Explicit cwd arguments must be absolute. Keep workspace feature `cached_current_dir`.
 
+`ModuleId::relative_path` preserves that `Cow<Path>` result. Only call `.into_owned()` when the caller needs to mutate or retain a `PathBuf`.
+
 When a `PathBuf` was just created by `join` or another owned operation and the final value is a slash-separated `String`, consume it with `normalize_path_buf_to_slash`. Calling non-consuming `normalize()` first produces a `Cow<Path>` and forces the later `String` conversion to copy the normalized buffer.
 
 When the destination is `ArcStr`, pass `to_slash()` directly instead of calling `into_owned()` first; `ArcStr` copies strings into its own allocation.


### PR DESCRIPTION
## Summary

- return SugarPath's `Cow<Path>` from `ModuleId::relative_path` instead of forcing a `PathBuf`
- keep package `sideEffects` matching borrowed for clean descendant module IDs
- materialize an owned path only in the Vite manifest caller that mutates it
- document the ownership rule for future path call sites

## Why

SugarPath 3 can borrow the target suffix when a module ID is a clean descendant of the package root. The existing wrapper immediately called `.into_owned()`, discarding that result even though package `sideEffects` matching only needs a temporary string view.

A pinned Rolldown trace recorded 4,888 borrowable descendants out of 4,890 `ModuleId::relative_path` calls. Preserving the `Cow` removes one non-empty `PathBuf` allocation from each borrowable call. Virtual, bare, sibling, and outside-root paths keep their existing owned result.

No timed benchmark is added here: SugarPath's existing allocation contract already covers the exact borrowed-versus-forced-owned composition.

## Validation

- `cargo test -p rolldown_common relative_path_preserves_borrowed_and_owned_results --locked`
- `cargo check -p rolldown -p rolldown_plugin_vite_manifest --tests --locked`
- targeted Clippy with all targets and warnings denied
- `cargo fmt --all --check`
- `git diff --check`
- independent adversarial review of lifetime, platform, caller, and allocation behavior
