### PR TITLE
perf: reuse relative path buffers for sourcemaps

### DIFF
--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -6,7 +6,7 @@ use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
 use rolldown_error::{BuildResult, ResultExt};
 use rolldown_sourcemap::SourceMap;
 use rolldown_std_utils::relative_path_to_slash;
-use sugar_path::SugarPath;
+use sugar_path::{SugarPath, SugarPathBuf};
 use url::Url;
 
 use super::uuid::uuid_v4_string_from_u128;
@@ -100,7 +100,7 @@ pub async fn prepare_sourcemap(
     map.set_sources(
       map
         .get_sources()
-        .map(|x| x.as_path().relative(file_dir).to_string_lossy().into_owned())
+        .map(|x| x.as_path().relative(file_dir).into_owned().into_slash_lossy())
         .collect::<Vec<_>>(),
     );
   }


### PR DESCRIPTION
## Summary

- consume the owned result of sourcemap source relativization into the final slash-separated `String`
- preserve lossy handling of arbitrary native encoding
- leave the Windows runtime branch unchanged

## Why

For upward or sibling sources, `relative()` already allocates an owned `PathBuf`. The previous `to_string_lossy().into_owned()` chain copied that buffer into a second allocation. `into_slash_lossy()` consumes and reuses the existing buffer on non-Windows hosts.

This removes one temporary allocation from owned relative results. Borrowable descendant results still require exactly one final allocation, so that path does not regress.

No timed benchmark is added here: SugarPath's existing allocation contract already covers the exact borrowed conversion and consuming conversion.

## Validation

- `cargo check -p rolldown --lib --locked`
- `just t-run crates/rolldown/tests/rolldown/sourcemap/inline_url_relative_to_file/_config.json`
- existing `sourcemap/live_binding` fixture
- `cargo fmt --all -- --check`
- `git diff --check`
- independent adversarial review of valid and invalid encoding, absolute and relative inputs, platform dispatch, and allocation behavior
