### PR TITLE
fix(tracing): invalid RD_LOG filter and RD_LOG_OUTPUT=json no longer panic

### DIFF
--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -35,6 +35,13 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
   }
 
   let output_mode = std::env::var(LOG_OUTPUT_ENV_NAME).unwrap_or_else(|_| "stdout".to_string());
+  let targets = match Targets::from_str(&env_var) {
+    Ok(targets) => targets,
+    Err(error) => {
+      report_tracing_init_failure(&format!("invalid `{LOG_ENV_NAME}` filter: {error}"));
+      return None;
+    }
+  };
 
   // Remove events that have `devtoolsAction` field, as those events are only for devtools.
   let filter_for_removing_devtools_event = filter_fn(|metadata| {
@@ -55,7 +62,7 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         let (chrome_layer, guard) =
           ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
         tracing_subscriber::registry()
-          .with(Targets::from_str(&env_var).unwrap())
+          .with(targets)
           .with(chrome_layer.with_filter(filter_for_removing_devtools_event))
           .init();
         Some(Box::new(guard))
@@ -70,7 +77,7 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         );
         tracing_subscriber::registry()
           .with(filter_for_removing_devtools_event)
-          .with(Targets::from_str(&env_var).unwrap())
+          .with(targets)
           .with(
             fmt::layer()
               .pretty()
@@ -83,12 +90,22 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
       }
     }
     "json" => {
-      panic!("`json` output mode is not implemented yet");
+      report_tracing_init_failure(
+        "`RD_LOG_OUTPUT=json` is not implemented; falling back to readable output",
+      );
+      tracing_subscriber::registry()
+        .with(filter_for_removing_devtools_event)
+        .with(targets)
+        .with(
+          fmt::layer().pretty().with_span_events(FmtSpan::NONE).with_level(true).with_target(false),
+        )
+        .init();
+      None
     }
     "readable" => {
       tracing_subscriber::registry()
         .with(filter_for_removing_devtools_event)
-        .with(Targets::from_str(&env_var).unwrap())
+        .with(targets)
         .with(
           fmt::layer().pretty().with_span_events(FmtSpan::NONE).with_level(true).with_target(false),
         )
@@ -99,11 +116,19 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
     _ => {
       tracing_subscriber::registry()
         .with(filter_for_removing_devtools_event)
-        .with(Targets::from_str(&env_var).unwrap())
+        .with(targets)
         .with(fmt::layer().pretty().with_span_events(FmtSpan::CLOSE | FmtSpan::ENTER))
         .init();
       tracing::debug!("Tracing initialized");
       None
     }
   }
+}
+
+#[expect(
+  clippy::print_stderr,
+  reason = "tracing is unavailable for reporting its own init failure"
+)]
+fn report_tracing_init_failure(message: &str) {
+  eprintln!("Rolldown tracing disabled: {message}");
 }

--- a/crates/rolldown_tracing/tests/invalid_filter_fallback.rs
+++ b/crates/rolldown_tracing/tests/invalid_filter_fallback.rs
@@ -1,0 +1,17 @@
+// Runs as its own integration-test binary (own process) because
+// `try_init_tracing` reads env vars and guards itself with a global
+// `IS_INITIALIZED` flag, so scenarios must not share a process.
+
+#[test]
+fn invalid_rd_log_filter_disables_tracing_instead_of_panicking() {
+  // SAFETY: this test binary is single-threaded (one test) and sets the env
+  // var before any other code reads it.
+  unsafe {
+    // `not_a_level` is not a valid tracing level, so `Targets::from_str` fails.
+    // Before the fix this was `.unwrap()`ed and panicked.
+    std::env::set_var("RD_LOG", "rolldown=not_a_level");
+    std::env::remove_var("RD_LOG_OUTPUT");
+  }
+  let guard = rolldown_tracing::try_init_tracing();
+  assert!(guard.is_none(), "invalid filter should disable tracing, not panic");
+}

--- a/crates/rolldown_tracing/tests/json_output_fallback.rs
+++ b/crates/rolldown_tracing/tests/json_output_fallback.rs
@@ -1,0 +1,18 @@
+// Runs as its own integration-test binary (own process) because
+// `try_init_tracing` reads env vars and guards itself with a global
+// `IS_INITIALIZED` flag, so scenarios must not share a process.
+
+#[test]
+fn json_output_mode_falls_back_to_readable_instead_of_panicking() {
+  // SAFETY: this test binary is single-threaded (one test) and sets the env
+  // vars before any other code reads them.
+  unsafe {
+    std::env::set_var("RD_LOG", "debug");
+    // Before the fix `RD_LOG_OUTPUT=json` hit a `panic!`.
+    std::env::set_var("RD_LOG_OUTPUT", "json");
+  }
+  let guard = rolldown_tracing::try_init_tracing();
+  assert!(guard.is_none(), "json output mode falls back to readable output without a guard");
+  // The fallback installed a real subscriber.
+  assert!(tracing::dispatcher::has_been_set(), "fallback subscriber should be installed");
+}


### PR DESCRIPTION
### Description

Extracted from #10268 (standalone fix, re-derived onto `main`'s file shape).

Two panic paths in `rolldown_tracing::try_init_tracing`:

1. **Invalid `RD_LOG` filter panics.** The filter was parsed with `Targets::from_str(&env_var).unwrap()` in every output-mode arm. An invalid directive level, e.g. `RD_LOG='rolldown=not_a_level'`, panicked with:
   ```
   panicked at crates/rolldown_tracing/src/lib.rs:102:43:
   called `Result::unwrap()` on an `Err` value: ParseError { kind: Level(ParseLevelFilterError(())) }
   ```
   The filter is now parsed once up front; on error a message is printed to stderr and tracing is disabled instead of crashing the process.

2. **`RD_LOG_OUTPUT=json` panics.** The `"json"` arm was `panic!("`json` output mode is not implemented yet")`. It now reports that json output is unimplemented and falls back to the readable output layer.

Note: a filter like `RD_LOG='((('` does *not* panic on `main` — `Targets` treats any bare string as a valid target name; only invalid *levels* (and similar directive errors) hit the `unwrap`. Both panics above were reproduced on `main` with `#[should_panic]` tests before writing the fix.

Coverage: one integration-test binary per scenario (`tests/invalid_filter_fallback.rs`, `tests/json_output_fallback.rs`) — separate binaries because `try_init_tracing` reads env vars and is guarded by a global `IS_INITIALIZED` flag, so the scenarios must run in separate processes.

### Test

- `cargo test -p rolldown_tracing` (both new integration tests pass)
- `cargo check -p rolldown_tracing` (default and `--features chrome-tracing`)
- `cargo clippy -p rolldown_tracing --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect optional debug tracing startup; no bundling, auth, or data-path impact.
> 
> **Overview**
> **`try_init_tracing`** no longer crashes on bad tracing env configuration. **`RD_LOG`** is parsed once with **`Targets::from_str`**; invalid filter syntax (e.g. invalid level directives) logs **`Rolldown tracing disabled: …`** to stderr and skips tracing instead of **`unwrap`** panicking.
> 
> **`RD_LOG_OUTPUT=json`**, which was unimplemented, no longer **`panic!`s**—it emits the same stderr notice and installs the readable pretty **`fmt`** subscriber as a fallback.
> 
> Two process-isolated integration tests cover invalid filters and json output fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979eb0747a27ef5e5f29a80379d8001a6812f33e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->