### PR TITLE
chore: publint/package-metadata fixes and small correctness fixes

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -23,6 +23,8 @@
   "files": [
     "bin",
     "dist",
+    "LICENSE",
+    "THIRD-PARTY-LICENSE",
     "!*/.tsbuildinfo"
   ],
   "type": "module",
@@ -31,6 +33,7 @@
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.mts",
       "browser": "./dist/index.browser.mjs",
       "default": "./dist/index.mjs"
     },
@@ -62,7 +65,6 @@
     "build:debug": "pnpm run --filter rolldown build-browser-pkg:debug",
     "build:release": "pnpm run --filter rolldown build-browser-pkg:release",
     "build-node": "TARGET='browser' pnpm run --filter rolldown build-node",
-    "preinstall": "npx only-allow pnpm",
     "publint": "publint ."
   },
   "dependencies": {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -24,6 +24,8 @@
     "bin",
     "cli",
     "dist",
+    "LICENSE",
+    "THIRD-PARTY-LICENSE",
     "!dist/*.node"
   ],
   "type": "module",

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -61,7 +61,8 @@ export async function bundleWithCliOptions(cliOptions: NormalizedCliOptions): Pr
 
   if (outputs.length === 0) {
     logger.error('No output generated');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   for (const file of outputs) {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -28,7 +28,7 @@ export function bindingifyRenderStart(
 
   return {
     plugin: async (ctx, opts) => {
-      handler.call(
+      await handler.call(
         new PluginContextImpl(
           args.outputOptions,
           ctx,
@@ -230,7 +230,7 @@ export function bindingifyRenderError(
 
   return {
     plugin: async (ctx, err) => {
-      handler.call(
+      await handler.call(
         new PluginContextImpl(
           args.outputOptions,
           ctx,


### PR DESCRIPTION
### Description

Standalone extraction from #10268 (part of breaking that PR into reviewable pieces). Four independent, verified-on-main fixes:

**Package metadata / publint**

- Ship `LICENSE` and `THIRD-PARTY-LICENSE` in the published `rolldown` and `@rolldown/browser` tarballs. The publish workflow (`.github/workflows/publish-to-npm.yml`) copies both files into every package directory before publishing, but they were missing from the `files` arrays — so `THIRD-PARTY-LICENSE` was silently dropped from the tarballs (`LICENSE` only survived because npm auto-includes it). Verified with `npm pack --dry-run` before/after.
- Add the missing `types` condition to `@rolldown/browser`'s `.` export so TypeScript resolves declarations for the root entry under `moduleResolution: bundler`/`node16` (the top-level `types` field is ignored once `exports` exists).
- Remove `"preinstall": "npx only-allow pnpm"` from `@rolldown/browser`. Lifecycle scripts ship with the published package, so this runs on consumers' machines and breaks `npm install` / `yarn add` of `@rolldown/browser`. The repo-level pnpm guard remains enforced by the root `packageManager` field.

**Small correctness fixes**

- `bindingify-output-hooks.ts`: `renderStart` and `renderError` handlers were called without `await` inside their async wrappers, so async hook implementations were not awaited (the bundle could proceed mid-hook) and rejections became unhandled. All other output hooks already `await`.
- `cli/commands/bundle.ts`: replace `process.exit(1)` with `process.exitCode = 1; return;` in the "No output generated" path, so the `await using build` disposer runs and stdio flushes before the process exits.

### Test Plan

- `pnpm --filter rolldown build-native:debug` (includes `tsc -p tsconfig.check.json`) — passes
- `pnpm --filter rolldown publint` — passes (only the pre-existing `sideEffects` suggestion)
- `npm pack --dry-run` with the CI license-copy step simulated: both packages now include `LICENSE` + `THIRD-PARTY-LICENSE`; on main, `THIRD-PARTY-LICENSE` is dropped
- `vitest run fixture.test.ts fixtures-concurrent.test.ts` — 415 passed
- `vitest run error/error.test.ts` — 12 passed
- `pnpm run test:cli` (`cli-e2e.test.ts`) — 61 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly packaging and small CLI/plugin-hook correctness fixes; hook awaiting slightly changes timing for async `renderStart`/`renderError` plugins but aligns with intended Rollup semantics.
> 
> **Overview**
> **Publishing** for `rolldown` and `@rolldown/browser` now explicitly includes `LICENSE` and `THIRD-PARTY-LICENSE` in the `files` list so CI-copied license files are not dropped from npm tarballs. `@rolldown/browser` adds a `types` condition on the root `.` export for modern TypeScript resolution, and drops the published `preinstall` `only-allow pnpm` script so npm/yarn consumers can install the package.
> 
> **Runtime behavior:** `renderStart` and `renderError` plugin hooks now `await` their handlers, matching other output hooks so async plugins finish before the bundle continues and rejections are handled. The CLI “no output generated” path sets `process.exitCode = 1` and returns instead of calling `process.exit(1)`, so the `await using` build disposer runs and stdio can flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075c98112783229ae327eb5a7a1d936f091a6dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->