### PR TITLE
fix(binding): forward all missing parallel JS plugin hooks

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -95,6 +95,10 @@ impl Plugin for ParallelJsPlugin {
     Ok(())
   }
 
+  fn build_start_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::build_start_meta(self.first_plugin())
+  }
+
   async fn resolve_id(
     &self,
     ctx: &rolldown_plugin::PluginContext,
@@ -105,6 +109,27 @@ impl Plugin for ParallelJsPlugin {
     } else {
       Ok(None)
     }
+  }
+
+  fn resolve_id_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::resolve_id_meta(self.first_plugin())
+  }
+
+  #[expect(deprecated)]
+  async fn resolve_dynamic_import(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookResolveIdArgs<'_>,
+  ) -> rolldown_plugin::HookResolveIdReturn {
+    if self.first_plugin().resolve_dynamic_import.is_some() {
+      self.run_single(|plugin| Box::pin(Plugin::resolve_dynamic_import(plugin, ctx, args))).await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn resolve_dynamic_import_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::resolve_dynamic_import_meta(self.first_plugin())
   }
 
   async fn load(
@@ -119,6 +144,10 @@ impl Plugin for ParallelJsPlugin {
     }
   }
 
+  fn load_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::load_meta(self.first_plugin())
+  }
+
   async fn transform(
     &self,
     ctx: rolldown_plugin::SharedTransformPluginContext,
@@ -129,6 +158,10 @@ impl Plugin for ParallelJsPlugin {
     } else {
       Ok(None)
     }
+  }
+
+  fn transform_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::transform_meta(self.first_plugin())
   }
 
   async fn module_parsed(
@@ -147,6 +180,10 @@ impl Plugin for ParallelJsPlugin {
     Ok(())
   }
 
+  fn module_parsed_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::module_parsed_meta(self.first_plugin())
+  }
+
   async fn build_end(
     &self,
     ctx: &rolldown_plugin::PluginContext,
@@ -156,6 +193,10 @@ impl Plugin for ParallelJsPlugin {
       self.run_all(|plugin| Box::pin(Plugin::build_end(plugin, ctx, args))).await?;
     }
     Ok(())
+  }
+
+  fn build_end_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::build_end_meta(self.first_plugin())
   }
 
   async fn render_chunk(
@@ -170,7 +211,123 @@ impl Plugin for ParallelJsPlugin {
     }
   }
 
+  fn render_chunk_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::render_chunk_meta(self.first_plugin())
+  }
+
   // --- Output hooks ---
+
+  async fn render_start(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookRenderStartArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().render_start.is_some() {
+      self.run_all(|plugin| Box::pin(Plugin::render_start(plugin, ctx, args))).await?;
+    }
+    Ok(())
+  }
+
+  fn render_start_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::render_start_meta(self.first_plugin())
+  }
+
+  async fn banner(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookAddonArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if self.first_plugin().banner.is_some() {
+      self.run_single(|plugin| Box::pin(Plugin::banner(plugin, ctx, args))).await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn banner_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::banner_meta(self.first_plugin())
+  }
+
+  async fn intro(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookAddonArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if self.first_plugin().intro.is_some() {
+      self.run_single(|plugin| Box::pin(Plugin::intro(plugin, ctx, args))).await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn intro_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::intro_meta(self.first_plugin())
+  }
+
+  async fn outro(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookAddonArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if self.first_plugin().outro.is_some() {
+      self.run_single(|plugin| Box::pin(Plugin::outro(plugin, ctx, args))).await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn outro_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::outro_meta(self.first_plugin())
+  }
+
+  async fn footer(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookAddonArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if self.first_plugin().footer.is_some() {
+      self.run_single(|plugin| Box::pin(Plugin::footer(plugin, ctx, args))).await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn footer_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::footer_meta(self.first_plugin())
+  }
+
+  async fn augment_chunk_hash(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    chunk: Arc<rolldown_common::RollupRenderedChunk>,
+  ) -> rolldown_plugin::HookAugmentChunkHashReturn {
+    if self.first_plugin().augment_chunk_hash.is_some() {
+      self
+        .run_single(|plugin| Box::pin(Plugin::augment_chunk_hash(plugin, ctx, Arc::clone(&chunk))))
+        .await
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn augment_chunk_hash_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::augment_chunk_hash_meta(self.first_plugin())
+  }
+
+  async fn render_error(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookRenderErrorArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().render_error.is_some() {
+      self.run_all(|plugin| Box::pin(Plugin::render_error(plugin, ctx, args))).await?;
+    }
+    Ok(())
+  }
+
+  fn render_error_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::render_error_meta(self.first_plugin())
+  }
 
   async fn generate_bundle(
     &self,
@@ -182,6 +339,10 @@ impl Plugin for ParallelJsPlugin {
     } else {
       Ok(())
     }
+  }
+
+  fn generate_bundle_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::generate_bundle_meta(self.first_plugin())
   }
 
   async fn write_bundle(
@@ -196,7 +357,56 @@ impl Plugin for ParallelJsPlugin {
     }
   }
 
+  fn write_bundle_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::write_bundle_meta(self.first_plugin())
+  }
+
+  async fn close_bundle(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    args: Option<&rolldown_plugin::HookCloseBundleArgs<'_>>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().close_bundle.is_some() {
+      self.run_all(|plugin| Box::pin(Plugin::close_bundle(plugin, ctx, args))).await?;
+    }
+    Ok(())
+  }
+
+  fn close_bundle_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::close_bundle_meta(self.first_plugin())
+  }
+
+  async fn watch_change(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+    path: &str,
+    event: rolldown_common::WatcherChangeKind,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().watch_change.is_some() {
+      self.run_all(|plugin| Box::pin(Plugin::watch_change(plugin, ctx, path, event))).await?;
+    }
+    Ok(())
+  }
+
+  fn watch_change_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::watch_change_meta(self.first_plugin())
+  }
+
+  async fn close_watcher(
+    &self,
+    ctx: &rolldown_plugin::PluginContext,
+  ) -> rolldown_plugin::HookNoopReturn {
+    if self.first_plugin().close_watcher.is_some() {
+      self.run_all(|plugin| Box::pin(Plugin::close_watcher(plugin, ctx))).await?;
+    }
+    Ok(())
+  }
+
+  fn close_watcher_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Plugin::close_watcher_meta(self.first_plugin())
+  }
+
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::all()
+    Plugin::register_hook_usage(self.first_plugin())
   }
 }


### PR DESCRIPTION
### Summary

Extracted from #10268 as a standalone fix (part of the breakup of that PR).

`ParallelJsPlugin` (the wrapper behind `parallelPluginFromPaths`) only forwarded a subset of the `Plugin` trait surface to its worker plugins. Every hook it did not override fell through to the trait's no-op default, so parallel JS plugins silently never received:

- `renderStart`, `banner`, `intro`, `outro`, `footer`
- `augmentChunkHash`, `renderError`
- `closeBundle`, `watchChange`, `closeWatcher`
- `resolveDynamicImport`

In addition, none of the `*_meta` (order/filter metadata) getters were forwarded for any hook, and `register_hook_usage` claimed `HookUsage::all()` instead of the plugin's real usage.

### Changes

- Forward all missing hooks using the same `run_single` / `run_all` dispatch pattern as the existing ones (`run_all` for the noop-return broadcast hooks, `run_single` for value-returning hooks).
- Forward every hook's `*_meta` to the first worker plugin (all workers are instances of the same plugin, so the first one's metadata is representative — same convention `name()` already uses).
- `register_hook_usage` now delegates to the first plugin's real hook usage instead of `HookUsage::all()`, so the bundler no longer schedules hooks the plugin does not implement.

This is a Rollup-parity fix confined to `crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs`; no options or runtime types change.

### Verification

- `cargo check -p rolldown_binding`, `cargo clippy -p rolldown_binding --all-targets`, `cargo fmt --check -p rolldown_binding`: clean
- `cargo test -p rolldown_binding --lib`: 2 passed
- `cargo run --bin generator && git diff --exit-code`: clean (independent of the generated-code fix extracted separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core plugin dispatch for parallel JS plugins across build/output/watch hooks; behavior changes for plugins that relied on the previous silent no-ops, but scope is limited to the parallel wrapper in rolldown_binding.
> 
> **Overview**
> **`ParallelJsPlugin`** (used by `parallelPluginFromPaths`) now fully implements the `Plugin` trait instead of leaving many hooks as trait no-ops, so parallel JS plugins actually receive the same lifecycle calls as single-threaded plugins.
> 
> Missing **hook implementations** are added for output/render (`renderStart`, `banner`, `intro`, `outro`, `footer`, `augmentChunkHash`, `renderError`), bundle/watch (`closeBundle`, `watchChange`, `closeWatcher`), and **`resolveDynamicImport`**, using the existing **`run_single`** vs **`run_all`** pattern (value-returning vs broadcast hooks).
> 
> Every hook’s **`*_meta`** getter is forwarded from the first worker plugin (same convention as **`name()`**), and **`register_hook_usage`** now reports the real hook bitmask from that plugin instead of **`HookUsage::all()`**, so the bundler does not schedule hooks the plugin does not implement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa9f39e1eff8c32dd25e8830e67ebd38ff681b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->