### PR TITLE
refactor: descriptor-based parallel-plugin detection (getParallelPluginInfo)

### DIFF
--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -5,6 +5,7 @@ import { getLogger, getOnLog } from '../log/logger';
 import { LOG_LEVEL_INFO, type LogLevelOption } from '../log/logging';
 import { normalizeHook } from '../utils/normalize-hook';
 import { normalizePluginOption } from '../utils/normalize-plugin-option';
+import { getParallelPluginInfo } from '../utils/parallel-plugin';
 import type { Plugin } from './';
 import { MinimalPluginContextImpl } from './minimal-plugin-context';
 
@@ -73,7 +74,7 @@ export function getObjectPlugins(plugins: RolldownPlugin[]): Plugin[] {
     if (!plugin) {
       return undefined;
     }
-    if ('_parallel' in plugin) {
+    if (getParallelPluginInfo(plugin)) {
       return undefined;
     }
     if (plugin instanceof BuiltinPlugin) {

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -18,7 +18,7 @@ import type { LogHandler } from '../log/log-handler';
 import type { LogLevelOption } from '../log/logging';
 import type { AttachDebugOptions, DevModeOptions, InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
-import type { RolldownPlugin } from '../plugin';
+import type { Plugin, RolldownPlugin } from '../plugin';
 import { bindingifyPlugin } from '../plugin/bindingify-plugin';
 import type { PluginContextData } from '../plugin/plugin-context-data';
 import { arraify } from './misc';
@@ -27,6 +27,7 @@ import {
   type NormalizedTransformOptions,
   normalizeTransformOptions,
 } from './normalize-transform-options';
+import { getParallelPluginInfo } from './parallel-plugin';
 
 export function bindingifyInputOptions(
   rawPlugins: RolldownPlugin[],
@@ -39,7 +40,7 @@ export function bindingifyInputOptions(
   watchMode: boolean,
 ): BindingInputOptions {
   const plugins = rawPlugins.map((plugin) => {
-    if ('_parallel' in plugin) {
+    if (getParallelPluginInfo(plugin)) {
       return undefined;
     }
     if (plugin instanceof BuiltinPlugin) {
@@ -51,7 +52,7 @@ export function bindingifyInputOptions(
       }
     }
     return bindingifyPlugin(
-      plugin,
+      plugin as Plugin,
       inputOptions,
       outputOptions,
       pluginContextData,

--- a/packages/rolldown/src/utils/initialize-parallel-plugins.ts
+++ b/packages/rolldown/src/utils/initialize-parallel-plugins.ts
@@ -2,6 +2,7 @@ import os from 'node:os';
 import { Worker } from 'node:worker_threads';
 import { ParallelJsPluginRegistry } from '../binding.cjs';
 import type { RolldownPlugin } from '../plugin';
+import { getParallelPluginInfo } from './parallel-plugin';
 
 export type WorkerData = {
   registryId: number;
@@ -24,8 +25,9 @@ export async function initializeParallelPlugins(plugins: RolldownPlugin[]): Prom
 > {
   const pluginInfos: ParallelPluginInfo[] = [];
   for (const [index, plugin] of plugins.entries()) {
-    if ('_parallel' in plugin) {
-      const { fileUrl, options } = plugin._parallel;
+    const parallel = getParallelPluginInfo(plugin);
+    if (parallel) {
+      const { fileUrl, options } = parallel;
       pluginInfos.push({ index, fileUrl, options });
     }
   }

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -5,8 +5,9 @@ import { LOG_LEVEL_WARN } from '../log/logging';
 import { logInputHookInOutputPlugin } from '../log/logs';
 import type { InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
-import type { RolldownOutputPlugin, RolldownPlugin } from '../plugin';
+import type { Plugin, RolldownOutputPlugin, RolldownPlugin } from '../plugin';
 import { asyncFlatten } from './async-flatten';
+import { getParallelPluginInfo } from './parallel-plugin';
 
 export const normalizePluginOption: {
   (plugins: OutputOptions['plugins']): Promise<RolldownOutputPlugin[]>;
@@ -36,14 +37,15 @@ export function normalizePlugins<T extends RolldownPlugin>(
   anonymousPrefix: string,
 ): T[] {
   for (const [index, plugin] of plugins.entries()) {
-    if ('_parallel' in plugin) {
+    if (getParallelPluginInfo(plugin)) {
       continue;
     }
     if (plugin instanceof BuiltinPlugin) {
       continue;
     }
-    if (!plugin.name) {
-      plugin.name = `${anonymousPrefix}${index + 1}`;
+    const objectPlugin = plugin as Plugin;
+    if (!objectPlugin.name) {
+      objectPlugin.name = `${anonymousPrefix}${index + 1}`;
     }
   }
   return plugins;

--- a/packages/rolldown/src/utils/parallel-plugin.ts
+++ b/packages/rolldown/src/utils/parallel-plugin.ts
@@ -1,0 +1,30 @@
+import type { ParallelPlugin } from '../plugin/parallel-plugin';
+
+/**
+ * Returns the `_parallel` marker of a parallel plugin, or `undefined` if the
+ * given plugin is not one.
+ *
+ * Detection is descriptor-based instead of using the `in` operator: only an
+ * own data property named `_parallel` with the expected shape counts. This
+ * avoids false positives from inherited or accessor `_parallel` properties on
+ * regular plugins, and guarantees that callers can safely read `fileUrl` and
+ * `options` from the returned value.
+ */
+export function getParallelPluginInfo(plugin: unknown): ParallelPlugin['_parallel'] | undefined {
+  if (plugin === null || typeof plugin !== 'object') {
+    return undefined;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(plugin, '_parallel');
+  if (!descriptor || !('value' in descriptor)) {
+    return undefined;
+  }
+  const parallel: unknown = descriptor.value;
+  if (
+    parallel === null ||
+    typeof parallel !== 'object' ||
+    typeof (parallel as { fileUrl?: unknown }).fileUrl !== 'string'
+  ) {
+    return undefined;
+  }
+  return parallel as ParallelPlugin['_parallel'];
+}


### PR DESCRIPTION
### Description

Standalone extraction from #10268 (part of breaking that PR into reviewable pieces).

Replaces the `'_parallel' in plugin` sniffing at all four call sites with one shared helper, `getParallelPluginInfo` (new `packages/rolldown/src/utils/parallel-plugin.ts`). Detection is descriptor-based: only an **own data property** named `_parallel` whose value is an object with a string `fileUrl` counts as a parallel plugin marker, and the helper returns the validated payload so callers never re-read it unchecked.

Why the `in` operator is a problem (both reproduced on main):

- A regular plugin carrying a malformed own `_parallel` (e.g. `_parallel: null`) crashes `initializeParallelPlugins`:
  `TypeError: Cannot destructure property 'fileUrl' of 'plugin._parallel' as it is null.`
- A plugin that merely *inherits* `_parallel` from its prototype chain is silently routed into the parallel worker registry (its real hooks are dropped and the workers try to import a bogus `fileUrl`).

Converted call sites (all of main's occurrences, so every site agrees on one predicate):

- `src/plugin/plugin-driver.ts` (`getObjectPlugins`)
- `src/utils/normalize-plugin-option.ts` (`normalizePlugins`)
- `src/utils/bindingify-input-options.ts`
- `src/utils/initialize-parallel-plugins.ts`

Compared to the #10268 version, the helper here is trimmed to the clean detection refactor: no `try/catch` proxy paranoia, no per-field descriptor walking of the marker payload, and none of the runtime-branch capability gates.

### Test Plan

- `tsc -p tsconfig.check.json` — passes
- `vitest run fixture.test.ts fixtures-concurrent.test.ts error/error.test.ts` — 427 passed
- `pnpm run test:cli` — 61 passed, 1 skipped
- `vitest run exports-consistency.test.ts validate-option.test.ts` — 5 passed
- Manual end-to-end smoke (no vitest suite covers parallel plugins today):
  - a genuine `defineParallelPlugin` plugin is still routed into the worker registry exactly as on main
  - a plugin with own `_parallel: null` now builds and runs as a regular plugin (crashed with the destructuring `TypeError` on main)
  - a plugin inheriting `_parallel` from its prototype now runs as a regular plugin (was misrouted to workers on main)

Note: while smoking this on Node 24 I hit a pre-existing failure in the parallel worker flow itself (`napi` ThreadsafeFunction `code: 'Closing'` errors once the unref'd workers exit). It reproduces identically with unmodified main and with the published `rolldown@1.2.0` from npm, so it is unrelated to this refactor — flagging it since parallel plugins have no CI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plugin routing and parallel worker initialization; behavior changes for edge-case plugins but genuine `defineParallelPlugin` markers should behave the same.
> 
> **Overview**
> Centralizes how Rolldown recognizes **parallel plugins** by introducing `getParallelPluginInfo` and using it everywhere that used to check `'_parallel' in plugin`.
> 
> Detection now requires an **own data** `_parallel` property whose value is an object with a string `fileUrl`, instead of treating any inherited or malformed `_parallel` as parallel. That fixes crashes when `_parallel` is `null` and stops regular plugins with a prototype `_parallel` from being sent to worker threads.
> 
> Call sites updated: `getObjectPlugins`, `normalizePlugins`, `bindingify-input-options`, and `initializeParallel-plugins` (which now destructures the validated payload from the helper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7a3e6df1f8feedf1fdb19bae9eee243b0e260c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->