### PR TITLE
fix: don't body-demand modules from simulated facade chunk includes

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -656,7 +656,14 @@ fn handle_include_symbol(
     return;
   }
 
-  drain_body_demand_stmts(ctx, canonical_ref);
+  // A simulated-facade include only materializes the eliminated facade's namespace object
+  // as a chunk export; it is not a semantic observation of the module, so it must not
+  // body-demand it (the namespace statement's getters were already narrowed to link-time
+  // used symbols, mirroring the `WorkItem::Module` gate below). Resurrecting gated
+  // statements here would also let inclusion grow after chunk assignment finished (#10337).
+  if !include_reason.contains(SymbolIncludeReason::SimulatedFacadeChunk) {
+    drain_body_demand_stmts(ctx, canonical_ref);
+  }
 
   // Also include the symbol that points to the canonical ref.
   ctx.used_symbol_refs.insert(symbol_ref);

--- a/crates/rolldown/tests/rolldown/issues/10337/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10337/_config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Regression test for https://github.com/rolldown/rolldown/issues/10337 - a codeSplitting group pulls a dynamically imported side-effect-free package into a common chunk, so the dynamic entry's facade chunk is empty and gets eliminated. The elimination replay simulates the entry's namespace; that include must not body-demand the entry, otherwise it resurrects the deferred `shaderIntersectFunction` statement and newly includes the glsl leaf AFTER chunk assignment already finished, leaving the leaf chunk-less and panicking in `compute_cross_chunk_links` with `Symbol \"common_functions\" should belong to a chunk`.",
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "treeshake": {
+      "moduleSideEffects": false
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "three-mesh-bvh",
+          "test": "three-mesh-bvh"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/10337/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10337/artifacts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+import("./three-mesh-bvh.js").then((n) => n.t).then((res) => {
+	if (typeof res.MeshBVH !== "function") throw new Error("MeshBVH missing from dynamic namespace");
+});
+//#endregion
+
+```
+
+## three-mesh-bvh.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region three-mesh-bvh/core/MeshBVH.js
+var MeshBVH = class {
+	constructor() {
+		this.name = "MeshBVH";
+	}
+};
+//#endregion
+//#region three-mesh-bvh/index.js
+var three_mesh_bvh_exports = /* @__PURE__ */ __exportAll({ MeshBVH: () => MeshBVH });
+//#endregion
+export { three_mesh_bvh_exports as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10337/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10337/main.js
@@ -1,0 +1,8 @@
+// Only `MeshBVH` is demanded from the dynamic namespace. `common_functions` must be
+// reached exclusively through the facade-simulation replay (via the deferred
+// `shaderIntersectFunction` body), never through this import.
+import('./three-mesh-bvh/index.js').then((res) => {
+  if (typeof res.MeshBVH !== 'function') {
+    throw new Error('MeshBVH missing from dynamic namespace');
+  }
+});

--- a/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/core/MeshBVH.js
+++ b/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/core/MeshBVH.js
@@ -1,0 +1,5 @@
+export class MeshBVH {
+  constructor() {
+    this.name = 'MeshBVH';
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/index.js
+++ b/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/index.js
@@ -1,0 +1,11 @@
+export * from './core/MeshBVH.js';
+export * as BVHShaderGLSL from './webgl/BVHShaderGLSL.js';
+
+// Mirrors three-mesh-bvh's "backwards compatibility" block: a top-level statement that
+// reads through the namespace re-export chain. Under `moduleSideEffects: false` this
+// body is deferred at link time (only `MeshBVH` is demanded by the dynamic import) and
+// resurrected by the facade-chunk-elimination replay.
+import * as BVHShaderGLSL from './webgl/BVHShaderGLSL.js';
+export const shaderIntersectFunction = `
+	${BVHShaderGLSL.common_functions}
+`;

--- a/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/webgl/BVHShaderGLSL.js
+++ b/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/webgl/BVHShaderGLSL.js
@@ -1,0 +1,1 @@
+export * from './glsl/common_functions.glsl.js';

--- a/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/webgl/glsl/common_functions.glsl.js
+++ b/crates/rolldown/tests/rolldown/issues/10337/three-mesh-bvh/webgl/glsl/common_functions.glsl.js
@@ -1,0 +1,3 @@
+export const common_functions = /* glsl */ `
+  float dot2( vec3 v ) { return dot( v, v ); }
+`;


### PR DESCRIPTION
### Description

Fixes #10337.

Since 1.1.5, bundling a dynamically imported `sideEffects: false` package (three-mesh-bvh in the report) together with a `codeSplitting` group that matches the package crashes with:

```
Symbol "common_functions" in ".../three-mesh-bvh/src/webgl/glsl/common_functions.glsl.js" should belong to a chunk
```

### Root cause

Regression from #10080. When a manual code-splitting group leaves a dynamic entry's facade chunk empty, `optimize_facade_entry_chunks` eliminates the facade and re-includes the entry's namespace object (`SymbolIncludeReason::SimulatedFacadeChunk`) so the namespace becomes an export of the merge-target chunk.

That include went through `drain_body_demand_stmts`, so it counted as *body demand* for the entry module and resurrected its deferred (gated) side-effect statements. In the reproduction, three-mesh-bvh's backwards-compatibility statement

```js
export const shaderIntersectFunction = ` ... ${BVHShaderGLSL.common_functions} ... `;
```

comes back to life, and its member expression canonicalizes through the `export *` chain straight to the glsl leaf module. The leaf therefore becomes included **after** `split_chunks` already assigned every included module to a chunk, so it belongs to no chunk and `compute_cross_chunk_links` panics.

### Fix

A simulated-facade include only materializes the eliminated facade's namespace object as a chunk export; it is not a semantic observation of the module, so it must not create body demand. `handle_include_symbol` now skips `drain_body_demand_stmts` for `SimulatedFacadeChunk` includes — mirroring the existing `WorkItem::Module` gate on `is_simulated_facade_chunk` a few lines below. This is safe because the namespace statement's symbol getters were already narrowed to link-time-used symbols before the replay, so the include cannot legitimately need anything that wasn't included at link time.

This also restores the invariant that chunk-layout choices don't change tree-shaking results: with the fix, the grouped build emits exactly what the ungrouped build emits (the dead `${common_functions}` statement no longer appears).

### Alternatives considered

Instead of (or in addition to) the semantic gate, the generate stage could detect modules newly included by the replay and assign them to the merge-target chunk. That converts the panic into working output, but it ships code the ungrouped build proves dead, and it papers over inclusion growing after chunk assignment instead of preventing it — so the semantic gate alone is preferred.

### Test

`crates/rolldown/tests/rolldown/issues/10337` mirrors the three-mesh-bvh shape: dynamic `import()` → an index module with `export * as` plus the deferred template-literal statement → an `export *` barrel → the glsl leaf, with `treeshake.moduleSideEffects: false` and a `codeSplitting` group. The entry only touches `res.MeshBVH`, so the leaf is reachable exclusively through the facade-elimination replay. The fixture panics on `main` and passes with this fix; it also executes the output under node and asserts the namespace member exists.
