### PR TITLE
refactor: remove AstFactory in favor of new_* construction traits

### DIFF
--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -275,7 +275,7 @@ fn render_chunk_content<'code>(
     // The concatenated closure holds the bodies of every module in the group. If the group's
     // entry is TLA-tainted (has top-level `await`, or awaits a TLA importee's `init` call), those
     // `await`s land inside this closure, so it must be `async`. This mirrors the flag threaded
-    // into `make_esm_wrapper_stmt` for the non-concatenated wrapper.
+    // into `new_esm_wrapper_stmt` for the non-concatenated wrapper.
     let is_async = ctx.link_output.metas[group.entry].is_tla_or_contains_tla_dependency;
 
     if !hoisted_fns.is_empty() {

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -3,18 +3,25 @@ use oxc::ast::ast::Str;
 use oxc::{
   allocator::IntoIn,
   ast::{
-    ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind, Statement},
+    ast::{
+      self, BindingIdentifier, ExportDefaultDeclarationKind, Expression, IdentifierName,
+      ObjectPropertyKind, Statement,
+    },
     builder::NONE,
   },
   semantic::{IsGlobalReference, Scoping, SymbolId},
   span::{SPAN, Span},
 };
 
+use oxc::ast::builder::AstBuilder;
 use rolldown_common::{
   ExternalModule, ImportRecordIdx, ImportRecordMeta, IndexModules, Module, ModuleIdx, NormalModule,
 };
 use rolldown_ecmascript::CJS_REQUIRE_REF_STR;
-use rolldown_ecmascript_utils::{AstFactory, ExpressionExt};
+use rolldown_ecmascript_utils::{
+  BindingIdentifierFactoryExt as _, ExpressionExt, ExpressionFactoryExt as _,
+  IdentifierNameFactoryExt as _, ObjectPropertyKindFactoryExt as _, StatementFactoryExt as _,
+};
 use rolldown_utils::{
   ecmascript::is_validate_identifier_name,
   indexmap::{FxIndexMap, FxIndexSet},
@@ -25,7 +32,7 @@ use crate::hmr::utils::{HmrAstBuilder, MODULE_EXPORTS_NAME_FOR_ESM};
 
 pub struct HmrAstFinalizer<'me, 'ast> {
   // Outside input
-  pub ast_factory: AstFactory<'ast>,
+  pub ast_builder: AstBuilder<'ast>,
   pub modules: &'me IndexModules,
   pub module: &'me NormalModule,
   pub use_pife_for_module_wrappers: bool,
@@ -137,30 +144,30 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           self.dependencies.insert(importee_idx);
           let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
           self.exports.extend(decl.specifiers.iter().map(|specifier| {
-            self.ast_factory.make_lazy_export_property(
+            ObjectPropertyKind::new_lazy_export_property(
               &specifier.exported.name(),
               match &specifier.local {
                 ast::ModuleExportName::IdentifierName(ident) => {
                   Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
                     SPAN,
-                    self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
-                    ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_factory),
+                    Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
+                    ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_builder),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ))
                 }
                 ast::ModuleExportName::StringLiteral(str) => {
                   Expression::ComputedMemberExpression(ast::ComputedMemberExpression::boxed(
                     SPAN,
-                    self.ast_factory.make_id_ref_expr(SPAN, &binding_name),
+                    Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
                     ast::Expression::new_string_literal(
                       SPAN,
                       str.value.as_str(),
                       None,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ))
                 }
                 ast::ModuleExportName::IdentifierReference(_) => {
@@ -169,7 +176,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                   )
                 }
               },
-              matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)),
+              matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)), &self.ast_builder
             )
           }));
           if let Some(stmt) = self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
@@ -183,10 +190,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               // export var { foo, bar } = { foo: 1, bar: 2 }
               self.exports.extend(var_decl.declarations.iter().flat_map(|decl| {
                 decl.id.get_binding_identifiers().into_iter().map(|ident| {
-                  self.ast_factory.make_lazy_export_property(
+                  ObjectPropertyKind::new_lazy_export_property(
                     ident.name.as_str(),
-                    self.ast_factory.make_id_ref_expr(SPAN, ident.name.as_str()),
+                    Expression::new_id_ref_expr(SPAN, ident.name.as_str(), &self.ast_builder),
                     false,
+                    &self.ast_builder,
                   )
                 })
               }));
@@ -194,19 +202,21 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             ast::Declaration::FunctionDeclaration(fn_decl) => {
               // export function foo() {}
               let id = fn_decl.id.as_ref().unwrap().name.as_str();
-              self.exports.push(self.ast_factory.make_lazy_export_property(
+              self.exports.push(ObjectPropertyKind::new_lazy_export_property(
                 id,
-                self.ast_factory.make_id_ref_expr(SPAN, id),
+                Expression::new_id_ref_expr(SPAN, id, &self.ast_builder),
                 false,
+                &self.ast_builder,
               ));
             }
             ast::Declaration::ClassDeclaration(cls_decl) => {
               // export class Foo {}
               let id = cls_decl.id.as_ref().unwrap().name.as_str();
-              self.exports.push(self.ast_factory.make_lazy_export_property(
+              self.exports.push(ObjectPropertyKind::new_lazy_export_property(
                 id,
-                self.ast_factory.make_id_ref_expr(SPAN, id),
+                Expression::new_id_ref_expr(SPAN, id, &self.ast_builder),
                 false,
+                &self.ast_builder,
               ));
             }
             _ => unreachable!("doesn't support ts now"),
@@ -228,34 +238,40 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       ast::Statement::ExportDefaultDeclaration(decl) => match decl.unbox().declaration {
         ast::ExportDefaultDeclarationKind::FunctionDeclaration(mut function) => {
           if let Some(id) = &function.id {
-            self.exports.push(self.ast_factory.make_lazy_export_property(
+            self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              self.ast_factory.make_id_ref_expr(SPAN, &id.name),
+              Expression::new_id_ref_expr(SPAN, &id.name, &self.ast_builder),
               false,
+              &self.ast_builder,
             ));
           } else {
-            function.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
-            self.exports.push(self.ast_factory.make_lazy_export_property(
+            function.id =
+              Some(BindingIdentifier::new_id(SPAN, "__rolldown_default__", &self.ast_builder));
+            self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+              Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
               false,
+              &self.ast_builder,
             ));
           }
           program_body.push(ast::Statement::FunctionDeclaration(function));
         }
         ast::ExportDefaultDeclarationKind::ClassDeclaration(mut class) => {
           if let Some(id) = &class.id {
-            self.exports.push(self.ast_factory.make_lazy_export_property(
+            self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              self.ast_factory.make_id_ref_expr(SPAN, &id.name),
+              Expression::new_id_ref_expr(SPAN, &id.name, &self.ast_builder),
               false,
+              &self.ast_builder,
             ));
           } else {
-            class.id = Some(self.ast_factory.make_id(SPAN, "__rolldown_default__"));
-            self.exports.push(self.ast_factory.make_lazy_export_property(
+            class.id =
+              Some(BindingIdentifier::new_id(SPAN, "__rolldown_default__", &self.ast_builder));
+            self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+              Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
               false,
+              &self.ast_builder,
             ));
           }
           program_body.push(ast::Statement::ClassDeclaration(class));
@@ -263,11 +279,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         expr @ ast::match_expression!(ExportDefaultDeclarationKind) => {
           let expr = expr.into_expression();
           // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
-          program_body.push(self.ast_factory.make_var_decl("__rolldown_default__", expr));
-          self.exports.push(self.ast_factory.make_lazy_export_property(
+          program_body.push(Statement::new_var_decl(
+            "__rolldown_default__",
+            expr,
+            &self.ast_builder,
+          ));
+          self.exports.push(ObjectPropertyKind::new_lazy_export_property(
             "default",
-            self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_default__"),
+            Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
             false,
+            &self.ast_builder,
           ));
         }
         unhandled_kind => {
@@ -359,7 +380,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         let Some(module_idx) = import_record.resolved_module else { return };
         // Use stable module ID for consistent runtime lookup
         string_literal.value =
-          Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_factory);
+          Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_builder);
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -371,7 +392,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             let Some(module_idx) = import_record.resolved_module else { return };
             // Use stable module ID for consistent runtime lookup
             string_literal.value =
-              Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_factory);
+              Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_builder);
           }
         });
       }
@@ -382,7 +403,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
   pub fn rewrite_import_meta_hot(&self, expr: &mut ast::Expression<'ast>) {
     if expr.is_import_meta_hot() {
       let hot_name = format!("hot_{}", self.module.repr_name);
-      *expr = self.ast_factory.make_id_ref_expr(SPAN, &hot_name);
+      *expr = Expression::new_id_ref_expr(SPAN, &hot_name, &self.ast_builder);
     }
   }
 
@@ -403,15 +424,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       Module::Normal(importee) => self.module.interop(importee),
       Module::External(_) => None,
     };
-    let call_expr = self.ast_factory.make_call_with_arg(
-      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports"),
+    let call_expr = Expression::new_call_with_arg(
+      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", &self.ast_builder),
       ast::Expression::new_string_literal(
         SPAN,
-        Str::from_str_in(id, &self.ast_factory),
+        Str::from_str_in(id, &self.ast_builder),
         None,
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
+      &self.ast_builder,
     );
 
     // var [binding_name] = [__toESM-wrapped loadExports call];
@@ -424,22 +446,23 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ast::VariableDeclarationKind::Var,
           ast::BindingPattern::new_binding_identifier(
             SPAN,
-            Str::from_str_in(binding_name, &self.ast_factory),
-            &self.ast_factory,
+            Str::from_str_in(binding_name, &self.ast_builder),
+            &self.ast_builder,
           ),
           NONE,
-          Some(self.ast_factory.make_to_esm_call_with_interop(
+          Some(Expression::new_to_esm_call_with_interop(
             "__rolldown_runtime__.__toESM",
             call_expr,
             interop,
+            &self.ast_builder,
           )),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     ));
     Some(stmt)
   }
@@ -457,7 +480,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let module_request = &importee.id;
 
     // import * as [binding_name] from 'external';
-    let stmt = self.ast_factory.make_import_star_stmt(module_request, binding_name);
+    let stmt = Statement::new_import_star_stmt(module_request, binding_name, &self.ast_builder);
 
     self.generated_static_import_stmts_from_external.insert(importee.idx, stmt);
   }
@@ -477,23 +500,23 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     let call_expr = ast::Expression::new_call_expression(
       SPAN,
-      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__reExport"),
+      Expression::new_member_access_expr("__rolldown_runtime__", "__reExport", &self.ast_builder),
       NONE,
       oxc::allocator::Vec::from_iter_in(
         [
-          ast::Argument::from(self.ast_factory.make_id_ref_expr(SPAN, self_exports)),
-          ast::Argument::from(self.ast_factory.make_id_ref_expr(SPAN, binding_name)),
+          ast::Argument::from(Expression::new_id_ref_expr(SPAN, self_exports, &self.ast_builder)),
+          ast::Argument::from(Expression::new_id_ref_expr(SPAN, binding_name, &self.ast_builder)),
         ],
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     );
 
     Some(ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
       span,
       call_expr,
-      &self.ast_factory,
+      &self.ast_builder,
     )))
   }
 
@@ -507,39 +530,42 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // construct `{ prop_name: () => returned, ... }`
     let mut arg_obj_expr = ast::ObjectExpression::boxed(
       SPAN,
-      oxc::allocator::Vec::with_capacity_in(self.exports.len(), &self.ast_factory),
-      &self.ast_factory,
+      oxc::allocator::Vec::with_capacity_in(self.exports.len(), &self.ast_builder),
+      &self.ast_builder,
     );
     arg_obj_expr.properties.extend(self.exports.drain(..));
     arg_obj_expr.properties.extend(self.named_exports.iter().map(|(exported, named_export)| {
       let expr = if let Some(local_binding) = self.import_bindings.get(&named_export.local_binding)
       {
-        self.ast_factory.make_id_ref_expr(SPAN, local_binding)
+        Expression::new_id_ref_expr(SPAN, local_binding, &self.ast_builder)
       } else {
         let name = scoping.symbol_name(named_export.local_binding);
-        self.ast_factory.make_id_ref_expr(SPAN, name)
+        Expression::new_id_ref_expr(SPAN, name, &self.ast_builder)
       };
       // Use computed property syntax for non-identifier export names (e.g., 'rolldown:exports')
       let computed = !is_validate_identifier_name(exported.as_str());
-      self.ast_factory.make_lazy_export_property(exported, expr, computed)
+      ObjectPropertyKind::new_lazy_export_property(exported, expr, computed, &self.ast_builder)
     }));
 
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
     let export_call_expr = ast::Expression::new_call_expression(
       SPAN,
-      self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.__exportAll"),
+      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.__exportAll", &self.ast_builder),
       NONE,
       oxc::allocator::Vec::from_array_in(
-        [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_factory.allocator()))],
-        &self.ast_factory,
+        [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_builder.allocator()))],
+        &self.ast_builder,
       ),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     );
 
     // construct `var [binding_name_for_namespace_object_ref] = __exportAll({ prop_name: () => returned, ... })`
-    let decl_stmt =
-      self.ast_factory.make_var_decl(binding_name_for_namespace_object_ref, export_call_expr);
+    let decl_stmt = Statement::new_var_decl(
+      binding_name_for_namespace_object_ref,
+      export_call_expr,
+      &self.ast_builder,
+    );
     vec![decl_stmt]
   }
 
@@ -586,19 +612,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Build: encodeURIComponent(importee.id)
       let encode_call = ast::Expression::CallExpression(ast::CallExpression::boxed(
         SPAN,
-        self.ast_factory.make_id_ref_expr(SPAN, "encodeURIComponent"),
+        Expression::new_id_ref_expr(SPAN, "encodeURIComponent", &self.ast_builder),
         NONE,
         oxc::allocator::Vec::from_value_in(
           ast::Argument::StringLiteral(ast::StringLiteral::boxed(
             SPAN,
-            Str::from_str_in(&importee.id, &self.ast_factory),
+            Str::from_str_in(&importee.id, &self.ast_builder),
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           )),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ));
 
       // Build template literal: `/@vite/lazy?id=${encodeURIComponent(importee.id)}&clientId=${__rolldown_runtime__.clientId}`
@@ -608,63 +634,67 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             ast::TemplateElement::new(
               SPAN,
               ast::TemplateElementValue {
-                raw: Str::from_str_in("/@vite/lazy?id=", &self.ast_factory),
+                raw: Str::from_str_in("/@vite/lazy?id=", &self.ast_builder),
                 cooked: None,
               },
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             ast::TemplateElement::new(
               SPAN,
               ast::TemplateElementValue {
-                raw: Str::from_str_in("&clientId=", &self.ast_factory),
+                raw: Str::from_str_in("&clientId=", &self.ast_builder),
                 cooked: None,
               },
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             ast::TemplateElement::new(
               SPAN,
               ast::TemplateElementValue {
-                raw: Str::from_str_in("", &self.ast_factory),
+                raw: Str::from_str_in("", &self.ast_builder),
                 cooked: None,
               },
               true,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
           ],
-          &self.ast_factory,
+          &self.ast_builder,
         );
         let expressions = oxc::allocator::Vec::from_iter_in(
           [
             encode_call,
-            self.ast_factory.make_member_access_expr("__rolldown_runtime__", "clientId"),
+            Expression::new_member_access_expr(
+              "__rolldown_runtime__",
+              "clientId",
+              &self.ast_builder,
+            ),
           ],
-          &self.ast_factory,
+          &self.ast_builder,
         );
-        ast::Expression::new_template_literal(SPAN, quasis, expressions, &self.ast_factory)
+        ast::Expression::new_template_literal(SPAN, quasis, expressions, &self.ast_builder)
       };
 
       // Build: import(`/@vite/lazy?id=...&clientId=...`)
       let import_expr =
-        ast::Expression::new_import_expression(SPAN, url_expr, None, None, &self.ast_factory);
+        ast::Expression::new_import_expression(SPAN, url_expr, None, None, &self.ast_builder);
 
       // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
       let load_exports_call = ast::Expression::CallExpression(ast::CallExpression::boxed(
         SPAN,
-        self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports"),
+        Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
         NONE,
         oxc::allocator::Vec::from_value_in(
           ast::Argument::StringLiteral(ast::StringLiteral::boxed(
             SPAN,
-            Str::from_str_in(&importee.stable_id, &self.ast_factory),
+            Str::from_str_in(&importee.stable_id, &self.ast_builder),
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           )),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ));
 
       // Build: () => __rolldown_runtime__.loadExports("<stable_proxy_id>")
@@ -676,43 +706,43 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         ast::FormalParameters::new(
           SPAN,
           ast::FormalParameterKind::ArrowFormalParameters,
-          oxc::allocator::Vec::new_in(&self.ast_factory),
+          oxc::allocator::Vec::new_in(&self.ast_builder),
           NONE,
-          &self.ast_factory,
+          &self.ast_builder,
         ),
         NONE,
         ast::FunctionBody::new(
           SPAN,
-          oxc::allocator::Vec::new_in(&self.ast_factory),
+          oxc::allocator::Vec::new_in(&self.ast_builder),
           oxc::allocator::Vec::from_value_in(
             ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
               SPAN,
               load_exports_call,
-              &self.ast_factory,
+              &self.ast_builder,
             )),
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       );
 
       // Build: import(...).then(() => __rolldown_runtime__.loadExports("..."))
       let then_callee = Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
         SPAN,
         import_expr,
-        ast::IdentifierName::new(SPAN, "then", &self.ast_factory),
+        ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ));
 
       *it = ast::Expression::new_call_expression(
         SPAN,
         then_callee,
         NONE,
-        oxc::allocator::Vec::from_value_in(ast::Argument::from(arrow_fn), &self.ast_factory),
+        oxc::allocator::Vec::from_value_in(ast::Argument::from(arrow_fn), &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       );
       return;
     }
@@ -724,19 +754,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // Use stable module ID for consistent runtime lookup
     let mut load_exports_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
       SPAN,
-      self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports"),
+      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
       NONE,
       oxc::allocator::Vec::from_value_in(
         ast::Argument::StringLiteral(ast::StringLiteral::boxed(
           SPAN,
-          Str::from_str_in(&importee.stable_id, &self.ast_factory),
+          Str::from_str_in(&importee.stable_id, &self.ast_builder),
           None,
-          &self.ast_factory,
+          &self.ast_builder,
         )),
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     ));
 
     if is_importee_cjs {
@@ -744,7 +774,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
       let mut args = oxc::allocator::Vec::from_value_in(
         ast::Argument::from(load_exports_call_expr),
-        &self.ast_factory,
+        &self.ast_builder,
       );
       if is_node_cjs {
         args.push(ast::Argument::from(ast::Expression::new_numeric_literal(
@@ -752,18 +782,22 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           1.0,
           None,
           ast::NumberBase::Decimal,
-          &self.ast_factory,
+          &self.ast_builder,
         )));
       }
 
       // __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports('./foo.js'), node_mode)
       load_exports_call_expr = ast::Expression::new_call_expression(
         SPAN,
-        self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.__toDynamicImportESM"),
+        Expression::new_id_ref_expr(
+          SPAN,
+          "__rolldown_runtime__.__toDynamicImportESM",
+          &self.ast_builder,
+        ),
         NONE,
         args,
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       );
     }
 
@@ -777,14 +811,14 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // `(__rolldown_runtime__.initModule('./foo.js'), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))`
     let init_call = self.make_init_module_call(&self.modules[importee_idx]);
     let promise_resolve_then_load_exports =
-      self.ast_factory.make_promise_resolve_then(load_exports_call_expr);
+      Expression::new_promise_resolve_then(load_exports_call_expr, &self.ast_builder);
     *it = ast::Expression::SequenceExpression(ast::SequenceExpression::boxed(
       SPAN,
       oxc::allocator::Vec::from_array_in(
         [init_call, promise_resolve_then_load_exports],
-        &self.ast_factory,
+        &self.ast_builder,
       ),
-      &self.ast_factory,
+      &self.ast_builder,
     ));
   }
 
@@ -801,7 +835,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       && id_ref.is_global_reference(scoping)
       && !ctx.parent().is_call_expression()
     {
-      *it = self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports");
+      *it = Expression::new_member_access_expr(
+        "__rolldown_runtime__",
+        "loadExports",
+        &self.ast_builder,
+      );
     }
 
     // Rewrite `require(...)` to `(require_xxx(), __rolldown_runtime__.loadExports())` or keep it as is for external module importee.
@@ -834,15 +872,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let is_importee_cjs = importee.exports_kind == rolldown_common::ExportsKind::CommonJs;
 
     // Use stable module ID for consistent runtime lookup
-    let load_exports_call = self.ast_factory.make_call_with_arg(
-      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "loadExports"),
+    let load_exports_call = Expression::new_call_with_arg(
+      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", &self.ast_builder),
       ast::Expression::new_string_literal(
         SPAN,
-        Str::from_str_in(&importee.stable_id, &self.ast_factory),
+        Str::from_str_in(&importee.stable_id, &self.ast_builder),
         None,
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
+      &self.ast_builder,
     );
 
     let load_exports_expr = if importee.meta.has_lazy_export() || is_importee_cjs {
@@ -872,23 +911,33 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       load_exports_call
     } else if rec.meta.contains(ImportRecordMeta::JsonModule) {
       // Vite-mode JSON: ESM-wrapped at runtime, unwrap to the JSON value.
-      let to_commonjs_call = self.ast_factory.make_call_with_arg(
-        self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__toCommonJS"),
+      let to_commonjs_call = Expression::new_call_with_arg(
+        Expression::new_member_access_expr(
+          "__rolldown_runtime__",
+          "__toCommonJS",
+          &self.ast_builder,
+        ),
         load_exports_call,
         false,
+        &self.ast_builder,
       );
       Expression::from(ast::MemberExpression::new_static_member_expression(
         SPAN,
         to_commonjs_call,
-        self.ast_factory.make_id_name(SPAN, "default"),
+        IdentifierName::new_id_name(SPAN, "default", &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ))
     } else {
-      self.ast_factory.make_call_with_arg(
-        self.ast_factory.make_member_access_expr("__rolldown_runtime__", "__toCommonJS"),
+      Expression::new_call_with_arg(
+        Expression::new_member_access_expr(
+          "__rolldown_runtime__",
+          "__toCommonJS",
+          &self.ast_builder,
+        ),
         load_exports_call,
         false,
+        &self.ast_builder,
       )
     };
 
@@ -896,23 +945,25 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // registry gate — a resident module short-circuits, a carried factory runs.
     // Turn `require('./foo.js')` into
     // `(__rolldown_runtime__.initModule('./foo.js'), __rolldown_runtime__.loadExports('./foo.js'))`
-    *it = self.ast_factory.make_seq_in_parens(
+    *it = Expression::new_seq_in_parens(
       self.make_init_module_call(&self.modules[importee_idx]),
       load_exports_expr,
+      &self.ast_builder,
     );
   }
 
   /// `__rolldown_runtime__.initModule("<stable id>")`
   pub fn make_init_module_call(&self, module: &Module) -> ast::Expression<'ast> {
-    self.ast_factory.make_call_with_arg(
-      self.ast_factory.make_member_access_expr("__rolldown_runtime__", "initModule"),
+    Expression::new_call_with_arg(
+      Expression::new_member_access_expr("__rolldown_runtime__", "initModule", &self.ast_builder),
       ast::Expression::new_string_literal(
         SPAN,
-        Str::from_str_in(module.stable_id(), &self.ast_factory),
+        Str::from_str_in(module.stable_id(), &self.ast_builder),
         None,
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
+      &self.ast_builder,
     )
   }
 }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use arcstr::ArcStr;
+use oxc::ast::builder::AstBuilder;
 use oxc_traverse::traverse_mut;
 use rolldown_common::{
   ClientHmrInput, ClientHmrUpdate, HmrLazyChunkOutput, HmrPatch, HmrStampTable, HmrUpdate,
   ImportKind, Module, ModuleIdx, ModuleTable, ScanMode, WatcherChangeKind,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintCommentsOptions, PrintOptions};
-use rolldown_ecmascript_utils::AstFactory;
 use rolldown_error::BuildResult;
 use rolldown_fs::FileSystem;
 use rolldown_plugin::SharedPluginDriver;
@@ -779,7 +779,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
       let mut finalizer = HmrAstFinalizer {
         modules,
-        ast_factory: AstFactory::new(fields.allocator),
+        ast_builder: AstBuilder::new(fields.allocator),
         import_bindings: FxHashMap::default(),
         module,
         exports: oxc::allocator::Vec::new_in(&fields.allocator),

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -1,7 +1,10 @@
 use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::TakeIn,
-  ast::{ast, builder::NONE},
+  ast::{
+    ast::{self, Expression},
+    builder::NONE,
+  },
   span::SPAN,
 };
 use oxc_traverse::Traverse;
@@ -9,6 +12,7 @@ use rolldown_ecmascript::{
   CJS_EXPORTS_REF_STR, CJS_MODULE_REF_STR, CJS_ROLLDOWN_EXPORTS_REF,
   CJS_ROLLDOWN_EXPORTS_REF_IDENT, CJS_ROLLDOWN_MODULE_REF, CJS_ROLLDOWN_MODULE_REF_IDENT,
 };
+use rolldown_ecmascript_utils::ExpressionFactoryExt as _;
 
 use crate::hmr::{
   hmr_ast_finalizer::HmrAstFinalizer,
@@ -21,7 +25,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let taken_body = node.body.take_in(&self.ast_factory.allocator());
+    let taken_body = node.body.take_in(&self.ast_builder.allocator());
     node.body.reserve_exact(taken_body.len());
     taken_body.into_iter().for_each(|top_level_stmt| {
       self.handle_top_level_stmt(&mut node.body, top_level_stmt, ctx.scoping());
@@ -35,8 +39,8 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
   ) {
     let mut try_block = ast::BlockStatement::boxed(
       SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_factory),
-      &self.ast_factory,
+      oxc::allocator::Vec::new_in(&self.ast_builder),
+      &self.ast_builder,
     );
 
     // `initModule("<stable id>")` for EVERY static dep, uniformly registry-gated: a
@@ -51,7 +55,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           ast::Statement::new_expression_statement(
             SPAN,
             self.make_init_module_call(module),
-            &self.ast_factory,
+            &self.ast_builder,
           )
         })
       })
@@ -65,8 +69,8 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     let cjs_module_locals: Vec<ast::Statement<'ast>> = if self.module.exports_kind.is_commonjs() {
       let empty_exports_object = ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
         SPAN,
-        oxc::allocator::Vec::new_in(&self.ast_factory),
-        &self.ast_factory,
+        oxc::allocator::Vec::new_in(&self.ast_builder),
+        &self.ast_builder,
       ));
       let module_object = ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
         SPAN,
@@ -74,16 +78,16 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           ast::ObjectPropertyKind::new_object_property(
             SPAN,
             ast::PropertyKind::Init,
-            ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.ast_factory),
+            ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.ast_builder),
             empty_exports_object,
             true,
             false,
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       ));
       vec![
         // var __rolldown_module__ = { exports: {} };
@@ -97,17 +101,17 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_MODULE_REF_IDENT,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               NONE,
               Some(module_object),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         )),
         // var __rolldown_exports__ = __rolldown_module__.exports;
         ast::Statement::from(ast::Declaration::new_variable_declaration(
@@ -120,17 +124,21 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_EXPORTS_REF_IDENT,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               NONE,
-              Some(self.ast_factory.make_member_access_expr(CJS_ROLLDOWN_MODULE_REF, "exports")),
+              Some(Expression::new_member_access_expr(
+                CJS_ROLLDOWN_MODULE_REF,
+                "exports",
+                &self.ast_builder,
+              )),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         )),
       ]
     } else {
@@ -148,7 +156,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     try_block.body.extend(runtime_module_register);
     try_block.body.extend(dependencies_init_fn_stmts);
     try_block.body.push(self.create_module_hot_context_initializer_stmt());
-    try_block.body.extend(node.body.take_in(&self.ast_factory.allocator()));
+    try_block.body.extend(node.body.take_in(&self.ast_builder.allocator()));
 
     node
       .body
@@ -156,12 +164,12 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
 
     let final_block = ast::BlockStatement::boxed(
       SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_factory),
-      &self.ast_factory,
+      oxc::allocator::Vec::new_in(&self.ast_builder),
+      &self.ast_builder,
     );
 
     let try_stmt =
-      ast::TryStatement::boxed(SPAN, try_block, NONE, Some(final_block), &self.ast_factory);
+      ast::TryStatement::boxed(SPAN, try_block, NONE, Some(final_block), &self.ast_builder);
 
     // The runtime calls the factory with the module's stable id as its argument, so it's
     // available inside the body as `__rolldown_module_id__`. This lets registerModule /
@@ -169,22 +177,22 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // string literal.
     let module_id_param = ast::FormalParameter::new(
       SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_factory),
-      ast::BindingPattern::new_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, &self.ast_factory),
+      oxc::allocator::Vec::new_in(&self.ast_builder),
+      ast::BindingPattern::new_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, &self.ast_builder),
       NONE,
       NONE,
       false,
       None,
       false,
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     );
     let params = ast::FormalParameters::new(
       SPAN,
       ast::FormalParameterKind::Signature,
-      oxc::allocator::Vec::from_value_in(module_id_param, &self.ast_factory),
+      oxc::allocator::Vec::from_value_in(module_id_param, &self.ast_builder),
       NONE,
-      &self.ast_factory,
+      &self.ast_builder,
     );
     // function () { [user code] }
     let mut user_code_wrapper = ast::Function::boxed(
@@ -200,14 +208,14 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       NONE,
       Some(ast::FunctionBody::new(
         SPAN,
-        oxc::allocator::Vec::new_in(&self.ast_factory),
+        oxc::allocator::Vec::new_in(&self.ast_builder),
         oxc::allocator::Vec::from_value_in(
           ast::Statement::TryStatement(try_stmt),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       )),
-      &self.ast_factory,
+      &self.ast_builder,
     );
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
     user_code_wrapper.pife = self.use_pife_for_module_wrappers;
@@ -215,38 +223,38 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // __rolldown_runtime__.registerFactory(stable_id, kind, function (__rolldown_module_id__) { [user code] })
     // Every factory is id-addressed and registry-gated at runtime; re-execution policy
     // is runtime data (evictions), never a per-payload flag.
-    let mut register_factory_args = oxc::allocator::Vec::with_capacity_in(3, &self.ast_factory);
+    let mut register_factory_args = oxc::allocator::Vec::with_capacity_in(3, &self.ast_builder);
     register_factory_args.push(ast::Argument::StringLiteral(ast::StringLiteral::boxed(
       SPAN,
-      oxc::ast::ast::Str::from_str_in(&self.module.stable_id, &self.ast_factory),
+      oxc::ast::ast::Str::from_str_in(&self.module.stable_id, &self.ast_builder),
       None,
-      &self.ast_factory,
+      &self.ast_builder,
     )));
     register_factory_args.push(ast::Argument::StringLiteral(ast::StringLiteral::boxed(
       SPAN,
       oxc::ast::ast::Str::from_str_in(
         if self.module.exports_kind.is_commonjs() { "cjs" } else { "esm" },
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       None,
-      &self.ast_factory,
+      &self.ast_builder,
     )));
     register_factory_args
       .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
 
     let register_factory_call = ast::CallExpression::boxed(
       SPAN,
-      self.ast_factory.make_id_ref_expr(SPAN, "__rolldown_runtime__.registerFactory"),
+      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.registerFactory", &self.ast_builder),
       NONE,
       register_factory_args,
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     );
 
     node.body.push(ast::Statement::new_expression_statement(
       SPAN,
       ast::Expression::CallExpression(register_factory_call),
-      &self.ast_factory,
+      &self.ast_builder,
     ));
   }
 
@@ -269,7 +277,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       && self.module.exports_kind.is_commonjs()
       && self.module.ecma_view.this_expr_replace_map.contains_key(&this_expr.node_id())
     {
-      *node = self.ast_factory.make_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF);
+      *node = Expression::new_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF, &self.ast_builder);
       return;
     }
 
@@ -303,7 +311,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     if let Some(symbol_id) = reference.symbol_id() {
       if let Some(binding_name) = self.import_bindings.get(&symbol_id) {
         ident.name =
-          oxc::ast::ast::Str::from_str_in(binding_name.as_str(), &self.ast_factory).into();
+          oxc::ast::ast::Str::from_str_in(binding_name.as_str(), &self.ast_builder).into();
       }
     } else if ident.name == CJS_EXPORTS_REF_STR {
       ident.name = CJS_ROLLDOWN_EXPORTS_REF_IDENT;

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -167,7 +167,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
 #[cfg(feature = "experimental")]
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
   fn builder(&self) -> AstBuilder<'ast> {
-    AstBuilder::new(self.ast_factory.allocator())
+    AstBuilder::new(self.ast_builder.allocator())
   }
 
   fn module(&self) -> &NormalModule {
@@ -201,7 +201,7 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
 
 impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for ScopeHoistingFinalizer<'any, 'ast> {
   fn builder(&self) -> AstBuilder<'ast> {
-    AstBuilder::new(self.ast_factory.allocator())
+    AstBuilder::new(self.ast_builder.allocator())
   }
 
   fn module(&self) -> &NormalModule {

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -11,10 +11,10 @@ pub type FinalizerMutableFields = (
   Vec<BuildDiagnostic>,                // diagnostics
 );
 
+use oxc::ast::builder::AstBuilder;
 use oxc::ast_visit::VisitMut as _;
 use oxc::semantic::NodeId;
 use rolldown_ecmascript::EcmaAst;
-use rolldown_ecmascript_utils::AstFactory;
 use rolldown_error::{BuildDiagnostic, CausedPlugin};
 use rolldown_plugin::HookResolveFileUrlOutput;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -133,7 +133,7 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         alloc,
         ctx: self,
         scope: ast_scope,
-        ast_factory: AstFactory::new(alloc),
+        ast_builder: AstBuilder::new(alloc),
         generated_init_esm_importee_ids: FxHashSet::default(),
         scope_stack: vec![],
         top_level_var_bindings: FxIndexSet::default(),

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -1,8 +1,8 @@
 use oxc::{
-  ast::ast::{self},
+  ast::ast::{self, Expression},
   span::SPAN,
 };
-use rolldown_ecmascript_utils::ExpressionExt;
+use rolldown_ecmascript_utils::{ExpressionExt, ExpressionFactoryExt as _};
 
 use crate::hmr::utils::HmrAstBuilder;
 
@@ -27,7 +27,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if expr.is_import_meta_hot() {
       if let Some(hmr_hot_ref) = self.ctx.module.ecma_view.hmr_hot_ref {
         let hot_name = self.canonical_name_for(hmr_hot_ref);
-        *expr = self.ast_factory.make_id_ref_expr(SPAN, hot_name);
+        *expr = Expression::new_id_ref_expr(SPAN, hot_name, &self.ast_builder);
       }
     }
   }
@@ -58,7 +58,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
         // Use stable module ID for consistent runtime lookup
         string_literal.value = oxc::ast::ast::Str::from_str_in(
           self.ctx.modules[import_record.into_resolved_module()].stable_id(),
-          &self.ast_factory,
+          &self.ast_builder,
         );
       }
       ast::Argument::ArrayExpression(array_expression) => {
@@ -73,7 +73,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
             // Use stable module ID for consistent runtime lookup
             string_literal.value = oxc::ast::ast::Str::from_str_in(
               self.ctx.modules[import_record.into_resolved_module()].stable_id(),
-              &self.ast_factory,
+              &self.ast_builder,
             );
           }
         });

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -4,7 +4,7 @@ use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::{
   allocator::{self, IntoIn, ReplaceWith, TakeIn},
   ast::{
-    ast::{self, BindingPattern, Expression, SimpleAssignmentTarget, Statement},
+    ast::{self, BindingPattern, Expression, IdentifierName, SimpleAssignmentTarget, Statement},
     builder::NONE,
     match_member_expression,
   },
@@ -16,7 +16,8 @@ use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKi
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{
   EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperDeclKind, EsmWrapperStmtOptions, ExpressionExt,
-  JsxExt, JsxMemberExpressionObjectExt,
+  ExpressionFactoryExt as _, IdentifierNameFactoryExt as _, JsxExt, JsxMemberExpressionObjectExt,
+  StatementFactoryExt as _,
 };
 use rolldown_error::EmptyImportMetaKind;
 
@@ -134,11 +135,11 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         .any(|id| self.ctx.linking_info.stmt_info_included.has_bit(*id));
       if is_included {
         let canonical_name = self.canonical_name_for(*symbol_ref);
-        program.body.push(
-          self
-            .ast_factory
-            .make_var_decl(canonical_name, ast::Expression::new_void_0(SPAN, &self.ast_factory)),
-        );
+        program.body.push(Statement::new_var_decl(
+          canonical_name,
+          ast::Expression::new_void_0(SPAN, &self.ast_builder),
+          &self.ast_builder,
+        ));
       }
     });
 
@@ -162,7 +163,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         let mut stmts_inside_closure = allocator::Vec::new_in(&self.alloc);
         stmts_inside_closure.append(&mut program.body);
 
-        program.body.push(self.ast_factory.make_commonjs_wrapper_stmt(
+        program.body.push(Statement::new_commonjs_wrapper_stmt(
           wrap_ref_name,
           commonjs_ref_expr,
           stmts_inside_closure,
@@ -170,6 +171,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.ctx.options.profiler_names,
           &self.ctx.module.stable_id,
           self.ctx.linking_info.is_tla_or_contains_tla_dependency,
+          &self.ast_builder,
         ));
       }
       ModuleWrapperMode::InteropEsm(target) | ModuleWrapperMode::ExecutionOrder(target) => {
@@ -230,24 +232,24 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
 
         if !is_concatenated_wrapped_module && !self.top_level_var_bindings.is_empty() {
-          let ast_factory = &self.ast_factory;
+          let ast_builder = &self.ast_builder;
           let decorations = self.top_level_var_bindings.iter().map(|var_name| {
             ast::VariableDeclarator::new(
               SPAN,
               ast::VariableDeclarationKind::Var,
-              ast::BindingPattern::new_binding_identifier(SPAN, *var_name, ast_factory),
+              ast::BindingPattern::new_binding_identifier(SPAN, *var_name, ast_builder),
               NONE,
               None,
               false,
-              ast_factory,
+              ast_builder,
             )
           });
           program.body.push(Statement::VariableDeclaration(ast::VariableDeclaration::boxed(
             SPAN,
             ast::VariableDeclarationKind::Var,
-            oxc::allocator::Vec::from_iter_in(decorations, ast_factory),
+            oxc::allocator::Vec::from_iter_in(decorations, ast_builder),
             false,
-            ast_factory,
+            ast_builder,
           )));
         }
 
@@ -273,7 +275,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           ConcatenateWrappedModuleKind::Root
         ) {
           self.rendered_concatenated_wrapped_module_parts.rendered_esm_runtime_expr = Some(
-            ast::ExpressionStatement::new(SPAN, esm_ref_expr, &self.ast_factory).to_source_string(),
+            ast::ExpressionStatement::new(SPAN, esm_ref_expr, &self.ast_builder).to_source_string(),
           );
           self.rendered_concatenated_wrapped_module_parts.wrap_ref_name =
             Some(CompactStr::new(wrap_ref_name));
@@ -281,28 +283,34 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           return;
         }
 
-        program.body.push(self.ast_factory.make_esm_wrapper_stmt(EsmWrapperStmtOptions {
-          binding_name: wrap_ref_name,
-          esm_fn_expr: esm_ref_expr,
-          statements: stmts_inside_closure,
-          profiler_name:
-            self.ctx.options.profiler_names.then_some(self.ctx.module.stable_id.as_str()),
-          call_kind: if self.ctx.options.optimization.is_pife_for_module_wrappers_enabled() {
-            EsmWrapperCallKind::Pife
-          } else {
-            EsmWrapperCallKind::Plain
+        program.body.push(Statement::new_esm_wrapper_stmt(
+          EsmWrapperStmtOptions {
+            binding_name: wrap_ref_name,
+            esm_fn_expr: esm_ref_expr,
+            statements: stmts_inside_closure,
+            profiler_name: self
+              .ctx
+              .options
+              .profiler_names
+              .then_some(self.ctx.module.stable_id.as_str()),
+            call_kind: if self.ctx.options.optimization.is_pife_for_module_wrappers_enabled() {
+              EsmWrapperCallKind::Pife
+            } else {
+              EsmWrapperCallKind::Plain
+            },
+            body_kind: if self.ctx.linking_info.is_tla_or_contains_tla_dependency {
+              EsmWrapperBodyKind::Async
+            } else {
+              EsmWrapperBodyKind::Sync
+            },
+            decl_kind: if matches!(wrapper_mode, ModuleWrapperMode::ExecutionOrder(_)) {
+              EsmWrapperDeclKind::HoistedFunction
+            } else {
+              EsmWrapperDeclKind::Var
+            },
           },
-          body_kind: if self.ctx.linking_info.is_tla_or_contains_tla_dependency {
-            EsmWrapperBodyKind::Async
-          } else {
-            EsmWrapperBodyKind::Sync
-          },
-          decl_kind: if matches!(wrapper_mode, ModuleWrapperMode::ExecutionOrder(_)) {
-            EsmWrapperDeclKind::HoistedFunction
-          } else {
-            EsmWrapperDeclKind::Var
-          },
-        }));
+          &self.ast_builder,
+        ));
       }
       ModuleWrapperMode::None => {
         program.body.splice(0..0, declaration_of_module_namespace_object);
@@ -323,7 +331,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       assert!(symbol.namespace_alias.is_none());
       let canonical_name = self.canonical_name_for(symbol_ref);
       if ident.name != canonical_name {
-        ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory).into();
+        ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
       }
       ident.symbol_id.get_mut().take();
     } else {
@@ -349,7 +357,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         *it = ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
           SPAN,
           expr,
-          &self.ast_factory,
+          &self.ast_builder,
         ));
       }
     }
@@ -405,7 +413,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let canonical_name = self.canonical_name_for(symbol_ref);
                 if id.name != canonical_name {
                   id.name =
-                    oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory).into();
+                    oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
                 }
                 // Clear symbol_id to prevent double processing:
                 // - visit_expression won't re-wrap when walker visits inner fn
@@ -416,11 +424,12 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let (finalized_callee, _) =
                   self.finalized_expr_for_symbol_ref(name_ref, false, false);
                 expr.replace_with(|fn_expr| {
-                  self.ast_factory.make_keep_name_call(
+                  Expression::new_keep_name_call(
                     &original_name,
                     fn_expr,
                     finalized_callee,
                     true,
+                    &self.ast_builder,
                   )
                 });
               }
@@ -480,13 +489,17 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         {
           match kind {
             ThisExprReplaceKind::Exports => {
-              *expr = ast::Expression::new_identifier(SPAN, "exports", &self.ast_factory);
+              *expr = ast::Expression::new_identifier(SPAN, "exports", &self.ast_builder);
             }
             ThisExprReplaceKind::Context if self.ctx.options.context.is_empty() => {
-              *expr = ast::Expression::new_void_0(SPAN, &self.ast_factory);
+              *expr = ast::Expression::new_void_0(SPAN, &self.ast_builder);
             }
             ThisExprReplaceKind::Context => {
-              *expr = self.ast_factory.make_id_ref_expr(SPAN, self.ctx.options.context.as_str());
+              *expr = Expression::new_id_ref_expr(
+                SPAN,
+                self.ctx.options.context.as_str(),
+                &self.ast_builder,
+              );
             }
           }
         }
@@ -499,8 +512,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.record_surviving_import_meta(meta.span, EmptyImportMetaKind::Plain);
           *expr = ast::Expression::new_object_expression(
             SPAN,
-            oxc::allocator::Vec::new_in(&self.ast_factory),
-            &self.ast_factory,
+            oxc::allocator::Vec::new_in(&self.ast_builder),
+            &self.ast_builder,
           );
         }
       }
@@ -536,14 +549,14 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 *expr = ast::Expression::new_chain_expression(
                   chain_span,
                   ast::ChainElement::StaticMemberExpression(member),
-                  &self.ast_factory,
+                  &self.ast_builder,
                 );
               }
               ast::Expression::ComputedMemberExpression(member) => {
                 *expr = ast::Expression::new_chain_expression(
                   chain_span,
                   ast::ChainElement::ComputedMemberExpression(member),
-                  &self.ast_factory,
+                  &self.ast_builder,
                 );
               }
               _ => {
@@ -712,7 +725,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
               Span::default(),
               ast::AssignmentTarget::from(target),
               init,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
           )
         } else {
@@ -722,11 +735,12 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           ast::AssignmentTargetPropertyProperty::boxed(
             Span::default(),
             ast::PropertyKey::StaticIdentifier(
-              self.ast_factory.make_id_name(prop.span, &prop.binding.name).into_in(self.alloc),
+              IdentifierName::new_id_name(prop.span, &prop.binding.name, &self.ast_builder)
+                .into_in(self.alloc),
             ),
             binding,
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
         );
       } else {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use oxc::allocator::GetAllocator;
-use oxc::ast::ast::ObjectPropertyKind;
-use oxc::ast::builder::{GetAstBuilder, NONE};
+use oxc::ast::ast::{BindingIdentifier, CallExpression, IdentifierName, ObjectPropertyKind};
+use oxc::ast::builder::{AstBuilder, GetAstBuilder, NONE};
 use oxc::semantic::{NodeId, ReferenceId, ScopeFlags, SymbolId};
 use oxc::{
   allocator::{self, Allocator, CloneIn, Dummy, IntoIn, ReplaceWith, TakeIn},
@@ -19,7 +19,9 @@ use rolldown_common::{
 };
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{
-  AstFactory, BindingPatternExt, CallExpressionExt, ExpressionExt, StatementExt,
+  BindingIdentifierFactoryExt as _, BindingPatternExt, CallExpressionExt,
+  CallExpressionFactoryExt as _, ClassElementFactoryExt as _, ExpressionExt,
+  ExpressionFactoryExt as _, IdentifierNameFactoryExt as _, StatementExt, StatementFactoryExt as _,
   parse_injected_expression,
 };
 use rolldown_error::EmptyImportMetaKind;
@@ -89,7 +91,7 @@ pub struct ScopeHoistingFinalizer<'me, 'ast: 'me> {
   pub ctx: ScopeHoistingFinalizerContext<'me>,
   pub scope: &'me AstScopes,
   pub alloc: &'ast Allocator,
-  pub ast_factory: AstFactory<'ast>,
+  pub ast_builder: AstBuilder<'ast>,
   /// Wrapped-ESM importees whose `init_*()` call was already emitted while finalizing this
   /// module, so the various init-emission paths don't emit duplicates.
   pub generated_init_esm_importee_ids: FxHashSet<ModuleIdx>,
@@ -182,17 +184,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       call_span,
       wrapper_ref_expr,
       NONE,
-      oxc::allocator::Vec::new_in(&self.ast_factory),
+      oxc::allocator::Vec::new_in(&self.ast_builder),
       false,
       mark_pure_if_noop && target.init_is_noop,
-      &self.ast_factory,
+      &self.ast_builder,
     );
     if await_if_tla && target.tla_tainted {
       // `await init_foo()`
       ast::Expression::AwaitExpression(ast::AwaitExpression::boxed(
         SPAN,
         init_call,
-        &self.ast_factory,
+        &self.ast_builder,
       ))
     } else {
       init_call
@@ -220,12 +222,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     &mut self,
     rec_idx: ImportRecordIdx,
   ) -> Option<Statement<'ast>> {
-    // A fresh `AstFactory` (a free wrapper over the arena reference) lets the `&mut self` iterator
-    // below stay borrowed while we still construct nodes through `factory`. That decouples node
+    // A fresh `AstBuilder` (a free wrapper over the arena reference) lets the `&mut self` iterator
+    // below stay borrowed while we still construct nodes through `ast_builder`. That decouples node
     // construction from the borrow without the throwaway heap `Vec` the previous `.collect()`
     // needed: the common 0/1 cases now allocate nothing, and only the rare sequence case
     // allocates — straight in the arena.
-    let factory = AstFactory::new(self.alloc);
+    let ast_builder = AstBuilder::new(self.alloc);
     let targets = collect_wrapped_esm_init_targets_for_import_record(
       &WrappedEsmInitTargetContext {
         importer: self.ctx.module,
@@ -258,16 +260,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // them) regardless of how many statements we end up emitting.
     let first = init_exprs.next()?;
     let Some(second) = init_exprs.next() else {
-      return Some(ast::Statement::new_expression_statement(SPAN, first, &factory));
+      return Some(ast::Statement::new_expression_statement(SPAN, first, &ast_builder));
     };
-    let mut exprs = oxc::allocator::Vec::with_capacity_in(2, &factory);
+    let mut exprs = oxc::allocator::Vec::with_capacity_in(2, &ast_builder);
     exprs.push(first);
     exprs.push(second);
     exprs.extend(init_exprs);
     Some(ast::Statement::new_expression_statement(
       SPAN,
-      ast::Expression::new_sequence_expression(SPAN, exprs, &factory),
-      &factory,
+      ast::Expression::new_sequence_expression(SPAN, exprs, &ast_builder),
+      &ast_builder,
     ))
   }
 
@@ -338,9 +340,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             importee_wrapper_ref_name,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::new_in(&self.ast_builder),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           )
         };
 
@@ -353,10 +355,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let init_expr = if needs_toesm {
           // `__toESM`
           let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
-          self.ast_factory.make_to_esm_wrapper(
+          Expression::new_to_esm_wrapper(
             to_esm_fn_name,
             require_call,
             self.ctx.module.should_consider_node_esm_spec_for_static_import(),
+            &self.ast_builder,
           )
         } else {
           require_call
@@ -364,7 +367,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
         // `import_foo`
         let binding_name_for_wrapper_call_ret = self.canonical_name_for(rec.namespace_ref);
-        *stmt = self.ast_factory.make_var_decl(binding_name_for_wrapper_call_ret, init_expr);
+        *stmt =
+          Statement::new_var_decl(binding_name_for_wrapper_call_ret, init_expr, &self.ast_builder);
 
         if self.transferred_import_record.contains_key(&rec_idx) {
           self.transferred_import_record.insert(rec_idx, stmt.to_source_string());
@@ -385,7 +389,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         self.generated_init_esm_importee_ids.insert(importee.idx);
         // `init_foo()` / `await init_foo()`
         let init_expr = self.wrapped_esm_init_call_expr(importee.idx, stmt.span(), false, true);
-        *stmt = ast::Statement::new_expression_statement(SPAN, init_expr, &self.ast_factory);
+        *stmt = ast::Statement::new_expression_statement(SPAN, init_expr, &self.ast_builder);
 
         if self.transferred_import_record.contains_key(&rec_idx) {
           self.transferred_import_record.insert(rec_idx, stmt.to_source_string());
@@ -409,7 +413,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if !symbol_ref.is_declared_in_root_scope(self.ctx.symbol_db) {
       // No fancy things on none root scope symbols
       return (
-        self.ast_factory.make_id_ref_expr(SPAN, self.canonical_name_for(symbol_ref)),
+        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(symbol_ref), &self.ast_builder),
         FinalizedExprProcessHint::empty(),
       );
     }
@@ -429,7 +433,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         || (self.state.contains(TraverseState::SmartInlineConst) || meta.safe_to_inline)
       {
         return (
-          meta.value.to_expression(self.ast_factory.builder()),
+          meta.value.to_expression(self.ast_builder.builder()),
           FinalizedExprProcessHint::empty(),
         );
       }
@@ -440,12 +444,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       if self.ctx.module.should_consider_node_esm_spec_for_static_import() {
         if let Some(node_mode_name) = self.ctx.chunk.node_mode_external_ns_names.get(&canonical_ref)
         {
-          self.ast_factory.make_id_ref_expr(SPAN, node_mode_name.as_str())
+          Expression::new_id_ref_expr(SPAN, node_mode_name.as_str(), &self.ast_builder)
         } else {
-          self.ast_factory.make_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref))
+          Expression::new_id_ref_expr(
+            SPAN,
+            self.canonical_name_for(canonical_ref),
+            &self.ast_builder,
+          )
         }
       } else {
-        self.ast_factory.make_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref))
+        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), &self.ast_builder)
       }
     } else {
       match self.ctx.options.format {
@@ -468,10 +476,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             hint.insert(extra_hint);
             expr
           } else {
-            self.ast_factory.make_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref))
+            Expression::new_id_ref_expr(
+              SPAN,
+              self.canonical_name_for(canonical_ref),
+              &self.ast_builder,
+            )
           }
         }
-        _ => self.ast_factory.make_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref)),
+        _ => Expression::new_id_ref_expr(
+          SPAN,
+          self.canonical_name_for(canonical_ref),
+          &self.ast_builder,
+        ),
       }
     };
 
@@ -480,22 +496,23 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         expr = ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
           SPAN,
           expr,
-          self.ast_factory.make_id_name(SPAN, &ns_alias.property_name),
+          IdentifierName::new_id_name(SPAN, &ns_alias.property_name, &self.ast_builder),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         ));
       }
 
       if preserve_this_semantic_if_needed {
-        expr = self.ast_factory.make_seq_in_parens(
+        expr = Expression::new_seq_in_parens(
           ast::Expression::new_numeric_literal(
             SPAN,
             0.0,
             Some("0".into()),
             NumberBase::Decimal,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           expr,
+          &self.ast_builder,
         );
       }
     }
@@ -550,9 +567,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // Cases #1-3: Entry + Cjs
       let expr = match chunk.output_exports {
         // Case #1: Entry + Cjs + Default + default → require_binding
-        OutputExports::Default => self.ast_factory.make_id_ref_expr(SPAN, require_binding),
+        OutputExports::Default => {
+          Expression::new_id_ref_expr(SPAN, require_binding, &self.ast_builder)
+        }
         // Cases #2-3: Entry + Cjs + Named → require_binding.default (the wrapped module)
-        _ => self.ast_factory.make_member_access_expr(require_binding, "default"),
+        _ => Expression::new_member_access_expr(require_binding, "default", &self.ast_builder),
       };
       return (expr, FinalizedExprProcessHint::FromCjsWrapKindEntry);
     }
@@ -567,10 +586,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // See https://github.com/rolldown/rolldown/issues/7833
     let expr = match (&chunk.output_exports, is_default_export) {
       // Case #7: Entry + None + Default + default → require_binding
-      (OutputExports::Default, true) => self.ast_factory.make_id_ref_expr(SPAN, require_binding),
+      (OutputExports::Default, true) => {
+        Expression::new_id_ref_expr(SPAN, require_binding, &self.ast_builder)
+      }
       // Cases #5, #8, #10, #12, #14: Named + default → require_binding.default
       // Cases #6, #9, #11, #13, #15: Named + named → require_binding.exportName
-      _ => self.ast_factory.make_member_access_expr(require_binding, exported_name),
+      _ => Expression::new_member_access_expr(require_binding, exported_name, &self.ast_builder),
     };
 
     (expr, FinalizedExprProcessHint::empty())
@@ -614,7 +635,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
     Some((
-      constant_meta.value.to_expression(self.ast_factory.builder()),
+      constant_meta.value.to_expression(self.ast_builder.builder()),
       FinalizedExprProcessHint::empty(),
     ))
   }
@@ -667,7 +688,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   ///
   /// This is separate from `try_rewrite_member_expr` because `resolved_member_expr_refs` resolves
   /// `ns.c` → identifier `c` with `.x` as a remaining prop. The post-rewrite enum check only
-  /// matches `Identifier.property` patterns, so by the time `make_member_expr_or_ident_ref` rebuilds
+  /// matches `Identifier.property` patterns, so by the time `new_member_expr_or_ident_ref` rebuilds
   /// `c.x`, the inlining window has passed. This method resolves all three levels in one pass.
   fn try_inline_chained_enum_member(
     &self,
@@ -718,7 +739,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let symbol_name = canonical_ref.name(self.ctx.symbol_db);
     let member_map = module.ecma_view.enum_member_value_map.get(symbol_name)?;
     let meta = member_map.get(property_name)?;
-    Some(meta.value.to_expression(self.ast_factory.builder()))
+    Some(meta.value.to_expression(self.ast_builder.builder()))
   }
 
   fn var_declaration_to_expr_seq_and_bindings(
@@ -736,20 +757,20 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       ret.extend(var_decl.id.get_binding_identifiers().iter().map(|item| item.name));
       // Turn `var ... = ...` to `... = ...`
       let init_expr = var_decl.init?;
-      let left = var_decl.id.into_assignment_target(&self.ast_factory);
+      let left = var_decl.id.into_assignment_target(&self.ast_builder);
       Some(ast::Expression::AssignmentExpression(ast::AssignmentExpression::boxed(
         SPAN,
         ast::AssignmentOperator::Assign,
         left,
         init_expr,
-        &self.ast_factory,
+        &self.ast_builder,
       )))
     });
     Some((
       ast::Expression::new_sequence_expression(
         SPAN,
-        oxc::allocator::Vec::from_iter_in(exprs, &self.ast_factory),
-        &self.ast_factory,
+        oxc::allocator::Vec::from_iter_in(exprs, &self.ast_builder),
+        &self.ast_builder,
       ),
       ret,
     ))
@@ -790,25 +811,25 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // instead of creating a property. Use computed property syntax for it.
         let key = if is_validate_identifier_name(prop_name) && prop_name != "__proto__" {
           ast::PropertyKey::StaticIdentifier(
-            self.ast_factory.make_id_name(SPAN, prop_name).into_in(self.alloc),
+            IdentifierName::new_id_name(SPAN, prop_name, &self.ast_builder).into_in(self.alloc),
           )
         } else {
           ast::PropertyKey::StringLiteral(ast::StringLiteral::boxed(
             SPAN,
-            oxc::ast::ast::Str::from_str_in(prop_name, &self.ast_factory),
+            oxc::ast::ast::Str::from_str_in(prop_name, &self.ast_builder),
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           ))
         };
         Some(ast::ObjectPropertyKind::ObjectProperty(ast::ObjectProperty::boxed(
           SPAN,
           ast::PropertyKind::Init,
           key,
-          self.ast_factory.make_arrow_returning(returned),
+          Expression::new_arrow_returning(returned, &self.ast_builder),
           false,
           false,
           prop_name == "__proto__",
-          &self.ast_factory,
+          &self.ast_builder,
         )))
       },
     ));
@@ -817,11 +838,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // else construct `__exportAll({ prop_name: () => returned, ... })`
     let module_namespace_rhs =
       if arg_obj_expr.properties.is_empty() && !self.ctx.options.generated_code.symbols {
-        Expression::ObjectExpression(oxc::allocator::Box::new_in(arg_obj_expr, &self.ast_factory))
+        Expression::ObjectExpression(oxc::allocator::Box::new_in(arg_obj_expr, &self.ast_builder))
       } else {
         let obj_expr = ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc));
         let args = if self.ctx.options.generated_code.symbols {
-          oxc::allocator::Vec::from_iter_in([obj_expr], &self.ast_factory)
+          oxc::allocator::Vec::from_iter_in([obj_expr], &self.ast_builder)
         } else {
           oxc::allocator::Vec::from_iter_in(
             [
@@ -831,10 +852,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 1.0,
                 None,
                 NumberBase::Decimal,
-                &self.ast_factory,
+                &self.ast_builder,
               )),
             ],
-            &self.ast_factory,
+            &self.ast_builder,
           )
         };
         ast::Expression::new_call_expression_with_pure(
@@ -844,13 +865,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           args,
           false,
           true,
-          &self.ast_factory,
+          &self.ast_builder,
         )
       };
 
     // construct `var [binding_name_for_namespace_object_ref] = __exportAll(...)`
-    let decl_stmt =
-      self.ast_factory.make_var_decl(binding_name_for_namespace_object_ref, module_namespace_rhs);
+    let decl_stmt = Statement::new_var_decl(
+      binding_name_for_namespace_object_ref,
+      module_namespace_rhs,
+      &self.ast_builder,
+    );
 
     let export_all_externals_rec_ids = &self.ctx.linking_info.star_exports_from_external_modules;
 
@@ -877,19 +901,28 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             };
             let importee_name = &module.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
             // construct `__reExport(importer_exports, importee_exports)`
-            let call_expr = self.ast_factory.make_re_export_call(
-              self.ast_factory.make_id_ref_expr(SPAN, re_export_name),
-              self.ast_factory.make_id_ref_expr(SPAN, binding_name_for_namespace_object_ref),
-              self.ast_factory.make_id_ref_expr(SPAN, importee_namespace_name),
+            let call_expr = CallExpression::new_re_export_call(
+              Expression::new_id_ref_expr(SPAN, re_export_name, &self.ast_builder),
+              Expression::new_id_ref_expr(
+                SPAN,
+                binding_name_for_namespace_object_ref,
+                &self.ast_builder,
+              ),
+              Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
+              &self.ast_builder,
             );
             vec![
               // Insert `import * as ns from 'ext'`external module in esm format
-              self.ast_factory.make_import_star_stmt(importee_name, importee_namespace_name),
+              Statement::new_import_star_stmt(
+                importee_name,
+                importee_namespace_name,
+                &self.ast_builder,
+              ),
               // Insert `__reExport(foo_exports, ns)`
               ast::Statement::new_expression_statement(
                 SPAN,
                 Expression::CallExpression(call_expr.into_in(self.alloc)),
-                &self.ast_factory,
+                &self.ast_builder,
               ),
             ]
           });
@@ -906,26 +939,28 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let rec = &self.ctx.module.import_records[idx];
             let importee = rec.resolved_module.map(|module_idx| &self.ctx.modules[module_idx])?;
 
-            let re_export_call_expr = self.ast_factory.make_re_export_call(
+            let re_export_call_expr = CallExpression::new_re_export_call(
               // Insert `__reExport(importer_exports, require('ext'))`
               self.finalized_expr_for_runtime_symbol("__reExport"),
               importer_namespace_ref_expr,
-              self.ast_factory.make_call_with_arg(
-                ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+              Expression::new_call_with_arg(
+                ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
                 ast::Expression::new_string_literal(
                   SPAN,
-                  oxc::ast::ast::Str::from_str_in(importee.id().as_str(), &self.ast_factory),
+                  oxc::ast::ast::Str::from_str_in(importee.id().as_str(), &self.ast_builder),
                   None,
-                  &self.ast_factory,
+                  &self.ast_builder,
                 ),
                 false,
+                &self.ast_builder,
               ),
+              &self.ast_builder,
             );
 
             Some(ast::Statement::new_expression_statement(
               SPAN,
               Expression::CallExpression(re_export_call_expr.into_in(self.alloc)),
-              &self.ast_factory,
+              &self.ast_builder,
             ))
           });
           re_export_external_stmts = Some(stmts.collect());
@@ -958,28 +993,28 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // require('url')
             let require_call = ast::CallExpression::boxed(
               SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
               oxc::allocator::Vec::from_value_in(
                 ast::Argument::StringLiteral(ast::StringLiteral::boxed(
                   SPAN,
                   "url",
                   None,
-                  &self.ast_factory,
+                  &self.ast_builder,
                 )),
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             );
 
             // require('url').pathToFileURL
             let require_path_to_file_url = ast::StaticMemberExpression::boxed(
               SPAN,
               ast::Expression::CallExpression(require_call),
-              ast::IdentifierName::new(SPAN, "pathToFileURL", &self.ast_factory),
+              ast::IdentifierName::new(SPAN, "pathToFileURL", &self.ast_builder),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             );
 
             // require('url').pathToFileURL(__filename)
@@ -991,21 +1026,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 ast::Argument::Identifier(ast::IdentifierReference::boxed(
                   SPAN,
                   "__filename",
-                  &self.ast_factory,
+                  &self.ast_builder,
                 )),
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             );
 
             // require('url').pathToFileURL(__filename).href
             let require_path_to_file_url_href = ast::StaticMemberExpression::boxed(
               original_expr_span,
               ast::Expression::CallExpression(require_path_to_file_url_call),
-              ast::IdentifierName::new(SPAN, "href", &self.ast_factory),
+              ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             );
             Some(ast::Expression::StaticMemberExpression(require_path_to_file_url_href))
           } else {
@@ -1025,9 +1060,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         }
         "dirname" | "filename" => {
           let name =
-            oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), &self.ast_factory);
+            oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), &self.ast_builder);
           return can_polyfill_import_meta_url.then_some(ast::Expression::Identifier(
-            ast::IdentifierReference::boxed(SPAN, name, &self.ast_factory),
+            ast::IdentifierReference::boxed(SPAN, name, &self.ast_builder),
           ));
         }
         _ => {}
@@ -1118,15 +1153,15 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         SPAN,
         ast::Expression::new_new_expression(
           SPAN,
-          ast::Expression::new_identifier(SPAN, "URL", &self.ast_factory),
+          ast::Expression::new_identifier(SPAN, "URL", &self.ast_builder),
           NONE,
           oxc::allocator::Vec::from_array_in(
             [
               ast::Argument::StringLiteral(ast::StringLiteral::boxed(
                 SPAN,
-                oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_factory),
+                oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_builder),
                 None,
-                &self.ast_factory,
+                &self.ast_builder,
               )),
               ast::Argument::StaticMemberExpression(ast::StaticMemberExpression::boxed(
                 SPAN,
@@ -1135,22 +1170,22 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   // polyfilled either, the diagnostic points at the `import.meta.ROLLDOWN_FILE_URL_*`
                   // the user actually wrote.
                   original_expr_span,
-                  ast::IdentifierName::new(SPAN, "import", &self.ast_factory),
-                  ast::IdentifierName::new(SPAN, "meta", &self.ast_factory),
-                  &self.ast_factory,
+                  ast::IdentifierName::new(SPAN, "import", &self.ast_builder),
+                  ast::IdentifierName::new(SPAN, "meta", &self.ast_builder),
+                  &self.ast_builder,
                 ),
-                ast::IdentifierName::new(SPAN, "url", &self.ast_factory),
+                ast::IdentifierName::new(SPAN, "url", &self.ast_builder),
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               )),
             ],
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        ast::IdentifierName::new(SPAN, "href", &self.ast_factory),
+        ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ));
       return Some(new_expr);
     }
@@ -1197,9 +1232,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     *first_arg_expr = ast::Expression::new_string_literal(
       first_arg_expr.span(),
-      oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_factory),
+      oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
       None,
-      &self.ast_factory,
+      &self.ast_builder,
     );
     None
   }
@@ -1225,7 +1260,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.ctx.constant_value_map.get(&target_commonjs_exported_symbol_meta.0)
             }) {
             is_inlined_commonjs_export = true;
-            export_meta.value.to_expression(self.ast_factory.builder())
+            export_meta.value.to_expression(self.ast_builder.builder())
           } else {
             let (object_ref_expr, _) = self.finalized_expr_for_symbol_ref(
               object_ref,
@@ -1235,16 +1270,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             );
             object_ref_expr
           };
-          self.ast_factory.make_member_expr_or_ident_ref(
+          Expression::new_member_expr_or_ident_ref(
             object_ref_expr,
             // For commonjs member_expr resolving, the resolved ref is always namespace_alias,
             // so the props actually include the exported name, when inline member_expr access of commonjs exported
             // symbol, we should skip the first prop
             &props[usize::from(is_inlined_commonjs_export)..],
             span,
+            &self.ast_builder,
           )
         })
-        .or_else(|| Some(self.ast_factory.make_member_expr_with_void_zero_object(props, span))),
+        .or_else(|| {
+          Some(Expression::new_member_expr_with_void_zero_object(props, span, &self.ast_builder))
+        }),
       _ => self.try_rewrite_import_meta_prop_expr(member_expr),
     }
   }
@@ -1289,14 +1327,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // Build: ns_name.default. The resolved_member_expr_refs lookup is keyed by post-semantic
     // NodeId, so this synthetic expression won't match scan-time records.
     let ns_name = self.canonical_name_for(ns_alias.namespace_ref);
-    let ns_id_ref = self.ast_factory.make_id_ref_expr(SPAN, ns_name);
+    let ns_id_ref = Expression::new_id_ref_expr(SPAN, ns_name, &self.ast_builder);
     let default_access =
       ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
         SPAN,
         ns_id_ref,
-        ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+        ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       ));
 
     // Create: ns_name.default.property or ns_name.default[expression]
@@ -1305,9 +1343,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let final_access = ast::StaticMemberExpression::boxed(
           SPAN,
           default_access,
-          self.ast_factory.make_id_name(SPAN, property_name),
+          IdentifierName::new_id_name(SPAN, property_name, &self.ast_builder),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         );
         Some(ast::SimpleAssignmentTarget::StaticMemberExpression(final_access))
       }
@@ -1325,7 +1363,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           default_access,
           finalized_expr,
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         );
         Some(ast::SimpleAssignmentTarget::ComputedMemberExpression(final_access))
       }
@@ -1374,7 +1412,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // needs to rewrite to `var T = class T { static a = new T(); }`
         let mut id = id.clone();
         let new_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
-        id.name = oxc::ast::ast::Str::from_str_in(new_name, &self.ast_factory).into();
+        id.name = oxc::ast::ast::Str::from_str_in(new_name, &self.ast_builder).into();
         class.id = Some(id);
       }
     }
@@ -1387,17 +1425,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           VariableDeclarationKind::Var,
           ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(
             id,
-            &self.ast_factory,
+            &self.ast_builder,
           )),
           NONE,
           Some(Expression::ClassExpression(class)),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       ),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     ))
   }
 
@@ -1438,31 +1476,37 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_factory),
+                      oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     )))
                   }
                 } else {
                   let (ns_name, _) =
                     self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
                   let to_commonjs_ref_name = self.finalized_expr_for_runtime_symbol("__toCommonJS");
-                  Some(self.ast_factory.make_seq_in_parens(
+                  Some(Expression::new_seq_in_parens(
                     ast::Expression::CallExpression(ast::CallExpression::boxed(
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_factory),
+                      oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     )),
                     ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
                       SPAN,
-                      self.ast_factory.make_call_with_arg(to_commonjs_ref_name, ns_name, false),
-                      ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+                      Expression::new_call_with_arg(
+                        to_commonjs_ref_name,
+                        ns_name,
+                        false,
+                        &self.ast_builder,
+                      ),
+                      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     )),
+                    &self.ast_builder,
                   ))
                 }
               }
@@ -1485,14 +1529,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_factory),
+                      oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
                       self
                         .ctx
                         .order_wrap_state
                         .esm_init_target(importee.idx, importee_linking_info)
                         .is_some_and(|target| target.init_is_noop),
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ))
                   };
 
@@ -1518,10 +1562,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       NONE,
                       oxc::allocator::Vec::from_value_in(
                         ast::Argument::from(namespace_object_ref_expr),
-                        &self.ast_factory,
+                        &self.ast_builder,
                       ),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ));
 
                   let final_expr = if is_json_module {
@@ -1529,16 +1573,20 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     Expression::from(ast::MemberExpression::new_static_member_expression(
                       SPAN,
                       to_commonjs_call_expr,
-                      ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+                      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ))
                   } else {
                     to_commonjs_call_expr
                   };
 
                   // `(init_xxx(), __toCommonJS(xxx_exports))`
-                  Some(self.ast_factory.make_seq_in_parens(wrap_ref_call_expr, final_expr))
+                  Some(Expression::new_seq_in_parens(
+                    wrap_ref_call_expr,
+                    final_expr,
+                    &self.ast_builder,
+                  ))
                 }
               }
             }
@@ -1551,10 +1599,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               request_path.span(),
               oxc::ast::ast::Str::from_str_in(
                 &importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths),
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               None,
-              &self.ast_factory,
+              &self.ast_builder,
             ));
             None
           }
@@ -1575,28 +1623,30 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     if rec.meta.contains(ImportRecordMeta::DeadDynamicImport) {
       // `Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))`
-      return Some(self.ast_factory.make_promise_resolve_then(
-        self.ast_factory.make_call_with_arg(
-          self.ast_factory.make_member_access_expr("Object", "freeze"),
+      return Some(Expression::new_promise_resolve_then(
+        Expression::new_call_with_arg(
+          Expression::new_member_access_expr("Object", "freeze", &self.ast_builder),
           ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
             SPAN,
             oxc::allocator::Vec::from_value_in(
               ast::ObjectPropertyKind::new_object_property(
                 SPAN,
                 ast::PropertyKind::Init,
-                ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_factory),
-                ast::Expression::NullLiteral(ast::NullLiteral::boxed(SPAN, &self.ast_factory)),
+                ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_builder),
+                ast::Expression::NullLiteral(ast::NullLiteral::boxed(SPAN, &self.ast_builder)),
                 false,
                 false,
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
-            &self.ast_factory,
+            &self.ast_builder,
           )),
           true,
+          &self.ast_builder,
         ),
+        &self.ast_builder,
       ));
     }
 
@@ -1618,31 +1668,38 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
               if importee_linking_info.is_tla_or_contains_tla_dependency {
                 // `init_foo().then(function() { return foo_exports })`
-                Some(self.ast_factory.make_callee_then_call(
+                Some(Expression::new_callee_then_call(
                   ast::Expression::new_call_expression(
                     SPAN,
-                    self.ast_factory.make_id_ref_expr(SPAN, importee_wrapper_ref_name),
+                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_factory),
+                    oxc::allocator::Vec::new_in(&self.ast_builder),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ),
-                  self.ast_factory.make_id_ref_expr(SPAN, importee_namespace_name),
+                  Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
+                  &self.ast_builder,
                 ))
               } else {
                 //  Promise.resolve().then(function() { return (init_foo(), foo_exports) })
-                Some(self.ast_factory.make_promise_resolve_then(
-                  self.ast_factory.make_seq_in_parens(
+                Some(Expression::new_promise_resolve_then(
+                  Expression::new_seq_in_parens(
                     ast::Expression::new_call_expression(
                       SPAN,
-                      self.ast_factory.make_id_ref_expr(SPAN, importee_wrapper_ref_name),
+                      Expression::new_id_ref_expr(
+                        SPAN,
+                        importee_wrapper_ref_name,
+                        &self.ast_builder,
+                      ),
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_factory),
+                      oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ),
-                    self.ast_factory.make_id_ref_expr(SPAN, importee_namespace_name),
+                    Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
+                    &self.ast_builder,
                   ),
+                  &self.ast_builder,
                 ))
               }
             }
@@ -1651,19 +1708,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               let to_esm_fn_name = self.canonical_name_for_runtime("__toESM");
               let importee_wrapper_ref_name =
                 self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());
-              Some(self.ast_factory.make_promise_resolve_then(
-                self.ast_factory.make_to_esm_wrapper(
-                  self.ast_factory.make_id_ref_expr(SPAN, to_esm_fn_name),
+              Some(Expression::new_promise_resolve_then(
+                Expression::new_to_esm_wrapper(
+                  Expression::new_id_ref_expr(SPAN, to_esm_fn_name, &self.ast_builder),
                   ast::Expression::new_call_expression(
                     SPAN,
-                    self.ast_factory.make_id_ref_expr(SPAN, importee_wrapper_ref_name),
+                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_factory),
+                    oxc::allocator::Vec::new_in(&self.ast_builder),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ),
                   self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+                  &self.ast_builder,
                 ),
+                &self.ast_builder,
               ))
             }
             WrapKind::None => {
@@ -1720,7 +1779,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 program.body.push(ast::Statement::new_expression_statement(
                   SPAN,
                   init_expr,
-                  &self.ast_factory,
+                  &self.ast_builder,
                 ));
               }
             }
@@ -1759,15 +1818,15 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             );
             let (importee_namespace_ref, _) =
               self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
-            let call_expr = self.ast_factory.make_re_export_call(
+            let call_expr = CallExpression::new_re_export_call(
               self.finalized_expr_for_runtime_symbol("__reExport"),
               importer_namespace_ref,
-              importee_namespace_ref,
+              importee_namespace_ref, &self.ast_builder
             );
             program.body.push(ast::Statement::new_expression_statement(
               top_stmt.span(),
               Expression::CallExpression(call_expr.into_in(self.alloc)),
-              &self.ast_factory,
+              &self.ast_builder,
             ));
           }
           return;
@@ -1834,21 +1893,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     SPAN,
                     wrapper_ref,
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_factory),
+                    oxc::allocator::Vec::new_in(&self.ast_builder),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   );
                   if importee_linking_info.is_tla_or_contains_tla_dependency {
                     init_expr = ast::Expression::AwaitExpression(ast::AwaitExpression::boxed(
                       SPAN,
                       init_expr,
-                      &self.ast_factory,
+                      &self.ast_builder,
                     ));
                   }
                   program.body.push(ast::Statement::new_expression_statement(
                     SPAN,
                     init_expr,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ));
                 }
 
@@ -1868,17 +1927,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                         false,
                       );
 
-                      let call_expr = self.ast_factory.make_re_export_call(
+                      let call_expr = CallExpression::new_re_export_call(
                         self.finalized_expr_for_runtime_symbol("__reExport"),
                         importer_namespace_ref,
-                        importee_namespace_ref,
+                        importee_namespace_ref, &self.ast_builder
                       );
                       // __reExport(exports, otherExports)
                       let stmt =
                         ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
                           SPAN,
                           Expression::CallExpression(call_expr.into_in(self.alloc)),
-                          &self.ast_factory,
+                          &self.ast_builder,
                         ));
                       program.body.push(stmt);
                     }
@@ -1910,21 +1969,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       false,
                     );
 
-                    let call_expr = self.ast_factory.make_re_export_call(
+                    let call_expr = CallExpression::new_re_export_call(
                       re_export_fn_name,
                       importer_namespace_ref,
-                      self.ast_factory.make_to_esm_wrapper(
+                      Expression::new_to_esm_wrapper(
                         to_esm_fn_ref,
                         ast::Expression::CallExpression(ast::CallExpression::boxed(
                           SPAN,
                           importee_wrapper_ref_expr,
                           NONE,
-                          oxc::allocator::Vec::new_in(&self.ast_factory),
+                          oxc::allocator::Vec::new_in(&self.ast_builder),
                           false,
-                          &self.ast_factory,
+                          &self.ast_builder,
                         )),
-                        self.ctx.module.should_consider_node_esm_spec_for_static_import(),
-                      ),
+                        self.ctx.module.should_consider_node_esm_spec_for_static_import(), &self.ast_builder
+                      ), &self.ast_builder
                     );
 
                     // __reExport(importer_exports, __toESM(require_foo()))
@@ -1932,7 +1991,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
                         SPAN,
                         Expression::CallExpression(call_expr.into_in(self.alloc)),
-                        &self.ast_factory,
+                        &self.ast_builder,
                       ));
                     program.body.push(stmt);
                   }
@@ -1998,17 +2057,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   let name_ref = self.canonical_ref_for_runtime("__name");
                   let (finalized_callee, _) =
                     self.finalized_expr_for_symbol_ref(name_ref, false, false);
-                  init_expr = self.ast_factory.make_keep_name_call(
+                  init_expr = Expression::new_keep_name_call(
                     "default",
                     init_expr,
                     finalized_callee,
                     true, // pure annotation for tree-shaking
+                    &self.ast_builder,
                   );
                 }
               }
 
               top_stmt =
-                self.ast_factory.make_var_decl(canonical_name_for_default_export_ref, init_expr);
+                Statement::new_var_decl(canonical_name_for_default_export_ref, init_expr, &self.ast_builder);
             }
             ast::ExportDefaultDeclarationKind::FunctionDeclaration(mut func) => {
               // "export default function() {}" => "function default() {}"
@@ -2017,7 +2077,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 let canonical_name_for_default_export_ref =
                   self.canonical_name_for(self.ctx.module.default_export_ref);
                 func.id =
-                  Some(self.ast_factory.make_id(SPAN, canonical_name_for_default_export_ref));
+                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, &self.ast_builder));
 
                 // When keep_names is enabled, preserve "default" as the function name
                 if self.ctx.options.keep_names {
@@ -2039,7 +2099,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 let canonical_name_for_default_export_ref =
                   self.canonical_name_for(self.ctx.module.default_export_ref);
                 class.id =
-                  Some(self.ast_factory.make_id(SPAN, canonical_name_for_default_export_ref));
+                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, &self.ast_builder));
 
                 // When keep_names is enabled, preserve "default" as the class name
                 // Skip if class has static name property
@@ -2161,7 +2221,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
           expr.replace_with(|fn_expr| {
-            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true)
+            Expression::new_keep_name_call(
+              &original_name,
+              fn_expr,
+              finalized_callee,
+              true,
+              &self.ast_builder,
+            )
           });
         }
       }
@@ -2172,7 +2238,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
           expr.replace_with(|fn_expr| {
-            self.ast_factory.make_keep_name_call(&original_name, fn_expr, finalized_callee, true)
+            Expression::new_keep_name_call(
+              &original_name,
+              fn_expr,
+              finalized_callee,
+              true,
+              &self.ast_builder,
+            )
           });
         }
       }
@@ -2207,7 +2279,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     let name_ref = self.canonical_ref_for_runtime("__name");
     let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-    Some(self.ast_factory.make_static_block_keep_name(&original_name, finalized_callee))
+    Some(ClassElement::new_static_block_keep_name(
+      &original_name,
+      finalized_callee,
+      &self.ast_builder,
+    ))
   }
 
   /// Check if a class body has a static `name` property, method, or accessor.
@@ -2235,13 +2311,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     for (stmt_index, original_name, new_name) in self.keep_name_statement_to_insert.iter().rev() {
       let name_ref = self.canonical_ref_for_runtime("__name");
       let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-      let target = self.ast_factory.make_id_ref_expr(SPAN, new_name);
+      let target = Expression::new_id_ref_expr(SPAN, new_name, &self.ast_builder);
       statements.insert(
         *stmt_index,
         ast::Statement::new_expression_statement(
           SPAN,
-          self.ast_factory.make_keep_name_call(original_name, target, finalized_callee, false),
-          &self.ast_factory,
+          Expression::new_keep_name_call(
+            original_name,
+            target,
+            finalized_callee,
+            false,
+            &self.ast_builder,
+          ),
+          &self.ast_builder,
         ),
       );
     }
@@ -2294,16 +2376,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             finalized_importee_wrapper_ref,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::new_in(&self.ast_builder),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           );
 
           // __toESM(require_xxx(), isNodeMode)
-          self.ast_factory.make_to_esm_wrapper(
+          Expression::new_to_esm_wrapper(
             finalized_to_esm,
             wrapper_ref_call_expr,
             self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+            &self.ast_builder,
           )
         }
         WrapKind::Esm => {
@@ -2321,13 +2404,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             finalized_importee_wrapper_ref,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::new_in(&self.ast_builder),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ));
 
           // (init_xxx(), namespace_exports)
-          self.ast_factory.make_seq_in_parens(wrapper_call_expr, finalized_namespace)
+          Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, &self.ast_builder)
         }
         WrapKind::None => {
           // Order-wrapped dynamic entries never reach this rewrite: their eliminated facades
@@ -2345,7 +2428,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         }
       };
 
-      Some(self.ast_factory.make_promise_resolve_then(finalized_expr))
+      Some(Expression::new_promise_resolve_then(finalized_expr, &self.ast_builder))
     } else {
       // If the dynamic entry point is merged into another common chunk, we should
       // convert `import('./some-module.js')` to `import('./some-module.js').then(n => n.ns)`
@@ -2382,24 +2465,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // require('./some-module.js')
             let require_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
               SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
               oxc::allocator::Vec::from_value_in(
                 ast::Argument::StringLiteral(ast::StringLiteral::boxed(
                   expr.span,
-                  oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_factory),
+                  oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
                   None,
-                  &self.ast_factory,
+                  &self.ast_builder,
                 )),
-                &self.ast_factory,
+                &self.ast_builder,
               ),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ));
             // Promise.resolve().then(() => require('./some-module.js'))
-            self.ast_factory.make_promise_resolve_then(require_call_expr)
+            Expression::new_promise_resolve_then(require_call_expr, &self.ast_builder)
           } else {
-            let import_expr = expr.take_in_box(&self.ast_factory.allocator());
+            let import_expr = expr.take_in_box(&self.ast_builder.allocator());
             Expression::ImportExpression(import_expr)
           };
 
@@ -2407,20 +2490,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             WrapKind::Cjs => {
               // For CJS modules: import('./chunk.js').then(n => __toESM(n.require_xxx()))
               let finalized_to_esm = self.finalized_expr_for_runtime_symbol("__toESM");
-              let call_expr = self.ast_factory.make_then_call_cjs_wrapper_with_to_esm(
+              let call_expr = CallExpression::new_then_call_cjs_wrapper_with_to_esm(
                 base_expr,
                 name,
                 finalized_to_esm,
                 self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+                &self.ast_builder,
               );
               Some(Expression::CallExpression(call_expr))
             }
             WrapKind::Esm => {
               // For ESM modules: import('./chunk.js').then(n => (n.init_xxx(), n.namespace))
               if let Some(ns_name) = namespace_export_name {
-                let call_expr = self
-                  .ast_factory
-                  .make_then_call_esm_wrapper_with_namespace(base_expr, name, ns_name);
+                let call_expr = CallExpression::new_then_call_esm_wrapper_with_namespace(
+                  base_expr,
+                  name,
+                  ns_name,
+                  &self.ast_builder,
+                );
                 Some(Expression::CallExpression(call_expr))
               } else {
                 tracing::warn!(
@@ -2439,7 +2526,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   .esm_init_target(importee_idx, &self.ctx.linking_infos[importee_idx])
                   .is_none()
               );
-              let call_expr = self.ast_factory.make_then_extract_property(base_expr, name);
+              let call_expr =
+                CallExpression::new_then_extract_property(base_expr, name, &self.ast_builder);
               Some(Expression::CallExpression(call_expr))
             }
           }
@@ -2477,17 +2565,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
         node.replace_with(|old| {
           let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
-          let require_call = self.ast_factory.make_call_with_arg(
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+          let require_call = Expression::new_call_with_arg(
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             import_expr.unbox().source,
             false,
+            &self.ast_builder,
           );
-          let wrapped = self.ast_factory.make_to_esm_wrapper(
+          let wrapped = Expression::new_to_esm_wrapper(
             to_esm_fn_name,
             require_call,
             self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+            &self.ast_builder,
           );
-          self.ast_factory.make_promise_resolve_then(wrapped)
+          Expression::new_promise_resolve_then(wrapped, &self.ast_builder)
         });
         return true;
       }
@@ -2504,7 +2594,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           self.ctx.chunk_graph.entry_module_to_entry_chunk.get(&importee_idx)
         else {
           // TODO: probably we should add the reason why it is replaced with `void 0`(just like webpack) when upstream support codegen with specific operation
-          *node = ast::Expression::new_void_0(SPAN, &self.ast_factory);
+          *node = ast::Expression::new_void_0(SPAN, &self.ast_builder);
           return true;
         };
         let Some(importee_chunk) = self.ctx.chunk_graph.chunk_table.get(importee_chunk_idx) else {
@@ -2514,9 +2604,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let import_path = self.ctx.chunk.import_path_for(importee_chunk);
         expr.source = Expression::StringLiteral(ast::StringLiteral::boxed(
           expr.source.span(),
-          oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_factory),
+          oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
           None,
-          &self.ast_factory,
+          &self.ast_builder,
         ));
 
         if let Some(rewritten_expr) = self.rewrite_dynamic_import_for_merged_entry(
@@ -2536,19 +2626,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           // require('foo.mjs')
           let mut require_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
             oxc::allocator::Vec::from_value_in(
               ast::Argument::StringLiteral(ast::StringLiteral::boxed(
                 expr.span,
-                oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_factory),
+                oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
                 None,
-                &self.ast_factory,
+                &self.ast_builder,
               )),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ));
 
           if importee.exports_kind.is_commonjs() {
@@ -2560,20 +2650,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
                 SPAN,
                 require_call_expr,
-                ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+                ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               ));
 
             // __toESM(require('foo.mjs').default, isNodeMode)
-            require_call_expr = self.ast_factory.make_to_esm_wrapper(
+            require_call_expr = Expression::new_to_esm_wrapper(
               to_esm_fn_name,
               require_default_expr,
               self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+              &self.ast_builder,
             );
           }
 
-          *node = self.ast_factory.make_promise_resolve_then(require_call_expr);
+          *node = Expression::new_promise_resolve_then(require_call_expr, &self.ast_builder);
           return true;
         }
 
@@ -2584,9 +2675,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if str != import_path {
           expr.source = Expression::StringLiteral(ast::StringLiteral::boxed(
             expr.source.span(),
-            oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_factory),
+            oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           ));
         }
         // Convert `import("external")` to `Promise.resolve().then(() => __toESM(require("external")))`
@@ -2597,17 +2688,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
           node.replace_with(|old| {
             let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
-            let require_call = self.ast_factory.make_call_with_arg(
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            let require_call = Expression::new_call_with_arg(
+              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               import_expr.unbox().source,
               false,
+              &self.ast_builder,
             );
-            let wrapped = self.ast_factory.make_to_esm_wrapper(
+            let wrapped = Expression::new_to_esm_wrapper(
               to_esm_fn_name,
               require_call,
               self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+              &self.ast_builder,
             );
-            self.ast_factory.make_promise_resolve_then(wrapped)
+            Expression::new_promise_resolve_then(wrapped, &self.ast_builder)
           });
           return true;
         }
@@ -2628,17 +2721,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let m_default_expr =
           ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "m", &self.ast_factory),
-            ast::IdentifierName::new(SPAN, "default", &self.ast_factory),
+            ast::Expression::new_identifier(SPAN, "m", &self.ast_builder),
+            ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ));
 
         // __toESM(m.default, isNodeMode)
-        let to_esm_call = self.ast_factory.make_to_esm_wrapper(
+        let to_esm_call = Expression::new_to_esm_wrapper(
           to_esm_fn_name,
           m_default_expr,
           self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+          &self.ast_builder,
         );
 
         // (m) => __toESM(m.default, isNodeMode)
@@ -2653,11 +2747,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             oxc::allocator::Vec::from_value_in(
               ast::FormalParameter::new(
                 SPAN,
-                oxc::allocator::Vec::new_in(&self.ast_factory),
+                oxc::allocator::Vec::new_in(&self.ast_builder),
                 ast::BindingPattern::new_binding_identifier(
                   SPAN,
-                  oxc::ast::ast::Str::from_str_in("m", &self.ast_factory),
-                  &self.ast_factory,
+                  oxc::ast::ast::Str::from_str_in("m", &self.ast_builder),
+                  &self.ast_builder,
                 ),
                 NONE,
                 NONE,
@@ -2665,33 +2759,33 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 None,
                 false,
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             NONE,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           NONE,
           ast::FunctionBody::new(
             SPAN,
-            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::new_in(&self.ast_builder),
             oxc::allocator::Vec::from_value_in(
-              ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_factory),
-              &self.ast_factory,
+              ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_builder),
+              &self.ast_builder,
             ),
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         );
 
         // `import('./some-cjs-module.js').then
         let callee = ast::StaticMemberExpression::boxed(
           SPAN,
           original_import_expr,
-          ast::IdentifierName::new(SPAN, "then", &self.ast_factory),
+          ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         );
 
         // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
@@ -2701,10 +2795,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           NONE,
           oxc::allocator::Vec::from_value_in(
             ast::Argument::ArrowFunctionExpression(arrow_fn),
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           false,
-          &self.ast_factory,
+          &self.ast_builder,
         );
 
         ast::Expression::CallExpression(call_expr)
@@ -2739,7 +2833,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .contains(&symbol_ref)
         {
           json_module_inlined_prop.insert(id, first_decl.init.take()?);
-          *it = ast::Statement::new_empty_statement(SPAN, &self.ast_factory);
+          *it = ast::Statement::new_empty_statement(SPAN, &self.ast_builder);
         }
       }
       None => {

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -1,6 +1,6 @@
-use oxc::ast::ast::{self, Expression, IdentifierReference};
+use oxc::ast::ast::{self, Expression, IdentifierReference, MemberExpression};
 use rolldown_common::SymbolRef;
-use rolldown_ecmascript_utils::ExpressionExt;
+use rolldown_ecmascript_utils::{ExpressionExt, MemberExpressionFactoryExt as _};
 
 use super::ScopeHoistingFinalizer;
 
@@ -78,7 +78,8 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if let Some(ns_alias) = &symbol.namespace_alias {
       let canonical_ns_name = self.canonical_name_for(ns_alias.namespace_ref);
       let prop_name = &ns_alias.property_name;
-      let access_expr = self.ast_factory.make_member_access(canonical_ns_name, prop_name);
+      let access_expr =
+        MemberExpression::new_member_access(canonical_ns_name, prop_name, &self.ast_builder);
 
       return Some(ast::SimpleAssignmentTarget::from(access_expr));
     }
@@ -88,8 +89,8 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
       return Some(ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(
         ast::IdentifierReference::boxed(
           id_ref.span,
-          oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory),
-          &self.ast_factory,
+          oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder),
+          &self.ast_builder,
         ),
       ));
     }
@@ -131,15 +132,16 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
         let symbol = self.ctx.symbol_db.get(canonical_ref);
 
         if let Some(ns_alias) = &symbol.namespace_alias {
-          *target = ast::SimpleAssignmentTarget::from(self.ast_factory.make_member_access(
+          *target = ast::SimpleAssignmentTarget::from(MemberExpression::new_member_access(
             self.canonical_name_for(ns_alias.namespace_ref),
             &ns_alias.property_name,
+            &self.ast_builder,
           ));
         } else {
           let canonical_name = self.canonical_name_for(canonical_ref);
           if target_id_ref.name != canonical_name {
             target_id_ref.name =
-              oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory).into();
+              oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
           }
           target_id_ref.reference_id.take();
         }
@@ -169,7 +171,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
               ident.name =
-                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory).into();
+                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();
@@ -185,7 +187,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
               ident.name =
-                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_factory).into();
+                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -1,8 +1,9 @@
 use indexmap::map::Entry;
 use oxc::allocator::GetAllocator;
+use oxc::ast::builder::AstBuilder;
 use oxc::{
   allocator::{ReplaceWith, TakeIn},
-  ast::ast::{self, Expression},
+  ast::ast::{self, Expression, Statement},
   semantic::{SemanticBuilder, Stats},
   span::SPAN,
 };
@@ -13,7 +14,7 @@ use rolldown_common::{
   SymbolRefDbForModule, TaggedSymbolRef, WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_ecmascript_utils::AstFactory;
+use rolldown_ecmascript_utils::{ExpressionFactoryExt as _, StatementFactoryExt as _};
 use rolldown_utils::ecmascript::legitimize_json_local_binding_name;
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
@@ -107,14 +108,14 @@ enum LazyExportWrap {
 /// and replaces the statement with either `module.exports = expr` or `export default expr`.
 fn replace_first_expr_stmt(ecma_ast: &mut EcmaAst, kind: LazyExportWrap) {
   ecma_ast.program.with_mut(|fields| {
-    let ast_factory = AstFactory::new(fields.allocator);
+    let ast_builder = AstBuilder::new(fields.allocator);
     let Some(stmt) = fields.program.body.first_mut() else { unreachable!() };
     stmt.replace_with(|old| {
       let ast::Statement::ExpressionStatement(expr_stmt) = old else { unreachable!() };
       let expr = expr_stmt.unbox().expression;
       match kind {
-        LazyExportWrap::CjsExport => ast_factory.make_module_exports_stmt(expr),
-        LazyExportWrap::EsmDefault => ast_factory.make_export_default_stmt(expr),
+        LazyExportWrap::CjsExport => Statement::new_module_exports_stmt(expr, &ast_builder),
+        LazyExportWrap::EsmDefault => Statement::new_export_default_stmt(expr, &ast_builder),
       }
     });
   });
@@ -154,7 +155,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     FxIndexMap::default();
   let transformed = ecma_ast.program.with_mut(|fields| {
     let mut index_map = FxIndexMap::default();
-    let ast_factory = AstFactory::new(fields.allocator);
+    let ast_builder = AstBuilder::new(fields.allocator);
     let program = fields.program;
     let Some(ast::Statement::ExpressionStatement(stmt)) = program.body.first() else {
       unreachable!()
@@ -164,7 +165,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     }
     // Take the single-statement body by value; this leaves `program.body` empty.
     let Some(ast::Statement::ExpressionStatement(stmt)) =
-      program.body.take_in(&ast_factory.allocator()).into_iter().next()
+      program.body.take_in(&ast_builder.allocator()).into_iter().next()
     else {
       unreachable!();
     };
@@ -194,7 +195,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
 
           let value = std::mem::replace(
             &mut property.value,
-            ast_factory.make_id_ref_expr(SPAN, legitimized_ident.as_str()),
+            Expression::new_id_ref_expr(SPAN, legitimized_ident.as_str(), &ast_builder),
           );
           // TODO(shulaoda): Waiting for oxc transform to support the ES feature `ShorthandProperties`.
           if key == "__proto__" {
@@ -203,8 +204,8 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
             property.shorthand = is_legal_ident;
             property.key = ast::PropertyKey::StaticIdentifier(ast::IdentifierName::boxed(
               SPAN,
-              oxc::ast::ast::Str::from_str_in(legitimized_ident.as_ref(), &ast_factory),
-              &ast_factory,
+              oxc::ast::ast::Str::from_str_in(legitimized_ident.as_ref(), &ast_builder),
+              &ast_builder,
             ));
           }
           match index_map.entry(legitimized_ident) {
@@ -223,15 +224,18 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
     let stmts = index_map
       .into_iter()
       // declaration
-      .map(|(local, v)| ast_factory.make_var_decl(local.as_str(), v))
+      .map(|(local, v)| Statement::new_var_decl(local.as_str(), v, &ast_builder))
       // export default json module
-      .chain(std::iter::once(
-        ast_factory.make_export_default_stmt(Expression::ObjectExpression(obj_expr)),
-      ))
+      .chain(std::iter::once(Statement::new_export_default_stmt(
+        Expression::ObjectExpression(obj_expr),
+        &ast_builder,
+      )))
       // export all declaration
-      .chain(std::iter::once(
-        ast_factory.make_export_named_stmt(None, declaration_binding_names.iter()),
-      ));
+      .chain(std::iter::once(Statement::new_export_named_stmt(
+        None,
+        declaration_binding_names.iter(),
+        &ast_builder,
+      )));
     program.body.extend(stmts);
     true
   });

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -2,15 +2,15 @@ use itertools::Itertools;
 use oxc::allocator::GetAllocator;
 use oxc::allocator::{Allocator, ReplaceWith, TakeIn};
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
-use oxc::ast::builder::NONE;
+use oxc::ast::builder::{AstBuilder, NONE};
 use oxc::ast_visit::{VisitMut, walk_mut};
 use oxc::span::{SPAN, Span};
-use rolldown_ecmascript_utils::{AstFactory, StatementExt};
+use rolldown_ecmascript_utils::StatementExt;
 use rustc_hash::FxHashSet;
 
 /// Pre-process is a essential step to make rolldown generate correct and efficient code.
 pub struct PreProcessor<'ast, 'a> {
-  ast_factory: AstFactory<'ast>,
+  ast_builder: AstBuilder<'ast>,
   /// used to store none_hoisted statements.
   top_level_stmt_temp_storage: Vec<Statement<'ast>>,
   keep_names: bool,
@@ -32,7 +32,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
     drop_labels: Option<&'a FxHashSet<String>>,
   ) -> Self {
     Self {
-      ast_factory: AstFactory::new(alloc),
+      ast_builder: AstBuilder::new(alloc),
       top_level_stmt_temp_storage: vec![],
       keep_names,
       drop_labels: drop_labels.filter(|set| !set.is_empty()),
@@ -52,7 +52,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
     if let Statement::LabeledStatement(stmt) = it
       && labels.contains(stmt.label.name.as_str())
     {
-      *it = ast::Statement::new_empty_statement(stmt.span, &self.ast_factory);
+      *it = ast::Statement::new_empty_statement(stmt.span, &self.ast_builder);
       return true;
     }
     false
@@ -70,27 +70,27 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
     let var_decl_span = var_decl.span;
     var_decl
       .declarations
-      .take_in(&self.ast_factory.allocator())
+      .take_in(&self.ast_builder.allocator())
       .into_iter()
       .enumerate()
       .map(|(i, declarator)| {
         let new_decl = ast::VariableDeclaration::boxed(
           if i == 0 && named_decl_span.is_none() { var_decl_span } else { SPAN },
           var_decl.kind,
-          oxc::allocator::Vec::from_iter_in([declarator], &self.ast_factory),
+          oxc::allocator::Vec::from_iter_in([declarator], &self.ast_builder),
           var_decl.declare,
-          &self.ast_factory,
+          &self.ast_builder,
         );
         if let Some(named_decl_span) = named_decl_span {
           Statement::ExportNamedDeclaration(ast::ExportNamedDeclaration::boxed(
             if i == 0 { named_decl_span } else { SPAN },
             Some(Declaration::VariableDeclaration(new_decl)),
-            oxc::allocator::Vec::new_in(&self.ast_factory),
+            oxc::allocator::Vec::new_in(&self.ast_builder),
             // Since it is `export a = 1, b = 2;`, source should be `None`
             None,
             ImportOrExportKind::Value,
             NONE,
-            &self.ast_factory,
+            &self.ast_builder,
           ))
         } else {
           Statement::VariableDeclaration(new_decl)
@@ -163,7 +163,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
-    let original_body = program.body.take_in(&self.ast_factory.allocator());
+    let original_body = program.body.take_in(&self.ast_builder.allocator());
     program.body.reserve_exact(original_body.len());
     self.top_level_stmt_temp_storage = Vec::with_capacity(
       original_body.iter().filter(|stmt| !stmt.is_module_declaration_with_source()).count(),
@@ -198,8 +198,8 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
     if let Some(split) = self.split_multi_declarator(it, false) {
       *it = Statement::BlockStatement(ast::BlockStatement::boxed(
         SPAN,
-        oxc::allocator::Vec::from_iter_in(split, &self.ast_factory),
-        &self.ast_factory,
+        oxc::allocator::Vec::from_iter_in(split, &self.ast_builder),
+        &self.ast_builder,
       ));
     }
   }
@@ -212,7 +212,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
       walk_mut::walk_statements(self, it);
       return;
     }
-    let stmts = it.take_in(&self.ast_factory.allocator());
+    let stmts = it.take_in(&self.ast_builder.allocator());
     for mut stmt in stmts {
       if self.try_drop_labeled(&mut stmt) {
         it.push(stmt);
@@ -258,27 +258,27 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
           cond_expr.test,
           ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
             oxc::allocator::Vec::from_value_in(
               ast::Argument::from(cond_expr.consequent),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_factory),
+            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
             oxc::allocator::Vec::from_value_in(
               ast::Argument::from(cond_expr.alternate),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         ))
       });
     }
@@ -301,16 +301,16 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
             cond_expr.consequent,
             None,
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
           ast::Expression::new_import_expression(
             SPAN,
             cond_expr.alternate,
             None,
             None,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         )
       });
     }

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -1,5 +1,22 @@
+//! rolldown's recurring AST constructions, as `new_*` associated functions on
+//! extension traits implemented on the oxc AST types they build (`Expression`,
+//! `Statement`, ...).
+//!
+//! Every helper is generic over `B: GetAstBuilder<'ast> + GetAllocator<'ast>` and takes
+//! the builder as its **last** argument: oxc's per-type node constructors need
+//! [`GetAstBuilder`](oxc::ast::builder::GetAstBuilder), and arena allocation of
+//! `Vec`/`Str`/`Box` needs [`GetAllocator`]. oxc's
+//! [`AstBuilder`](oxc::ast::builder::AstBuilder) implements both, so it (or any
+//! rolldown/oxc context that forwards both traits) can be passed directly.
+//!
+//! Passing the builder last — rather than as a `self` receiver — is what lets a caller
+//! borrow `&mut self` in the same call, e.g.
+//! `Expression::new_id_ref_expr(SPAN, self.gen_name(), self)`.
+//!
+//! See `internal-docs/ast-construction/implementation.md`.
+
 use oxc::{
-  allocator::{self, Allocator, GetAllocator, IntoIn},
+  allocator::{self, GetAllocator, IntoIn},
   ast::{
     ast::{
       Argument, ArrowFunctionExpression, AssignmentExpression, AssignmentOperator,
@@ -13,25 +30,14 @@ use oxc::{
       Statement, StaticMemberExpression, StringLiteral, VariableDeclaration,
       VariableDeclarationKind, VariableDeclarator,
     },
-    builder::{AstBuilder, GetAstBuilder, NONE},
+    builder::{GetAstBuilder, NONE},
   },
   span::{GetSpanMut, SPAN, Span},
 };
 use rolldown_common::{EcmaModuleAstUsage, Interop, MemberExprProp};
 use rolldown_utils::ecmascript::is_validate_identifier_name;
 
-/// Rolldown's newtype wrapper around oxc's [`AstBuilder`].
-///
-/// It implements oxc's [`GetAstBuilder`] and [`GetAllocator`] traits, so it can be
-/// passed directly to oxc's per-type node constructors (`Expression::new_*`,
-/// `Foo::boxed`, `oxc::allocator::Vec::new_in`, ...). rolldown's own recurring
-/// constructions are added as inherent `make_*` methods. Routing all construction
-/// through this single type lets rolldown absorb future oxc construction-API changes
-/// at one point.
-///
-/// See `internal-docs/ast-construction/implementation.md`.
-pub struct AstFactory<'ast>(AstBuilder<'ast>);
-
+/// Options for [`StatementFactoryExt::new_esm_wrapper_stmt`].
 pub struct EsmWrapperStmtOptions<'ast, 'data> {
   pub binding_name: &'data str,
   pub esm_fn_expr: Expression<'ast>,
@@ -60,139 +66,25 @@ pub enum EsmWrapperDeclKind {
   HoistedFunction,
 }
 
-impl<'ast> AstFactory<'ast> {
-  pub fn new(allocator: &'ast Allocator) -> Self {
-    Self(AstBuilder::new(allocator))
-  }
-
-  /// `<name>` as a `BindingIdentifier`, with the name copied into the arena.
-  pub fn make_id(&self, span: Span, name: &str) -> BindingIdentifier<'ast> {
-    BindingIdentifier::new(span, oxc::ast::ast::Str::from_str_in(name, self), self)
-  }
-
+/// rolldown's recurring `Expression` constructions.
+pub trait ExpressionFactoryExt<'ast> {
   /// A reference to `<name>` as an `Expression`, with the name copied into the arena.
-  pub fn make_id_ref_expr(&self, span: Span, name: &str) -> Expression<'ast> {
-    Expression::new_identifier(span, oxc::ast::ast::Str::from_str_in(name, self), self)
-  }
-
-  /// `<name>` as an `IdentifierName`, with the name copied into the arena.
-  pub fn make_id_name(&self, span: Span, name: &str) -> IdentifierName<'ast> {
-    IdentifierName::new(span, oxc::ast::ast::Str::from_str_in(name, self), self)
-  }
-
-  /// `var <name> = <init>;`
-  pub fn make_var_decl(&self, name: &str, init: Expression<'ast>) -> Statement<'ast> {
-    let declarations = oxc::allocator::Vec::from_value_in(
-      VariableDeclarator::new(
-        SPAN,
-        VariableDeclarationKind::Var,
-        BindingPattern::new_binding_identifier(
-          SPAN,
-          oxc::ast::ast::Str::from_str_in(name, self),
-          self,
-        ),
-        NONE,
-        Some(init),
-        false,
-        self,
-      ),
-      self,
-    );
-
-    Statement::from(Declaration::VariableDeclaration(VariableDeclaration::boxed(
-      SPAN,
-      VariableDeclarationKind::Var,
-      declarations,
-      false,
-      self,
-    )))
-  }
-
-  /// `export default <expr>`
-  pub fn make_export_default_stmt(&self, expr: Expression<'ast>) -> Statement<'ast> {
-    Statement::from(ModuleDeclaration::new_export_default_declaration(
-      SPAN,
-      ExportDefaultDeclarationKind::from(expr),
-      self,
-    ))
-  }
-
-  /// `module.exports = <expr>`
-  pub fn make_module_exports_stmt(&self, expr: Expression<'ast>) -> Statement<'ast> {
-    Statement::new_expression_statement(
-      SPAN,
-      Expression::new_assignment_expression(
-        SPAN,
-        AssignmentOperator::Assign,
-        AssignmentTarget::from(SimpleAssignmentTarget::from(
-          MemberExpression::new_static_member_expression(
-            SPAN,
-            Expression::new_identifier(SPAN, "module", self),
-            IdentifierName::new(SPAN, "exports", self),
-            false,
-            self,
-          ),
-        )),
-        expr,
-        self,
-      ),
-      self,
-    )
-  }
-
-  /// `export { <local> as <exported>, ... };`, optionally with a `declaration`.
-  pub fn make_export_named_stmt<'a, T: AsRef<str> + 'a, I>(
-    &self,
-    declaration: Option<Declaration<'ast>>,
-    specifiers: I,
-  ) -> Statement<'ast>
-  where
-    I: Iterator<Item = (&'a T, &'a (T, bool))>,
-  {
-    Statement::from(ModuleDeclaration::new_export_named_declaration(
-      SPAN,
-      declaration,
-      oxc::allocator::Vec::from_iter_in(
-        specifiers.into_iter().map(|(local, (exported, legal_ident))| {
-          ExportSpecifier::new(
-            SPAN,
-            ModuleExportName::new_identifier_reference(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in(local.as_ref(), self),
-              self,
-            ),
-            if *legal_ident {
-              ModuleExportName::new_identifier_name(
-                SPAN,
-                oxc::ast::ast::Str::from_str_in(exported.as_ref(), self),
-                self,
-              )
-            } else {
-              ModuleExportName::new_string_literal(
-                SPAN,
-                oxc::ast::ast::Str::from_str_in(exported.as_ref(), self),
-                None,
-                self,
-              )
-            },
-            ImportOrExportKind::Value,
-            self,
-          )
-        }),
-        self,
-      ),
-      None,
-      ImportOrExportKind::Value,
-      NONE,
-      self,
-    ))
+  fn new_id_ref_expr<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    span: Span,
+    name: &str,
+    builder: &B,
+  ) -> Expression<'ast> {
+    Expression::new_identifier(span, oxc::ast::ast::Str::from_str_in(name, builder), builder)
   }
 
   /// `() => <expr>`
-  pub fn make_arrow_returning(&self, expr: Expression<'ast>) -> Expression<'ast> {
+  fn new_arrow_returning<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    builder: &B,
+  ) -> Expression<'ast> {
     let statements = oxc::allocator::Vec::from_value_in(
-      Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, self)),
-      self,
+      Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, builder)),
+      builder,
     );
     Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
       SPAN,
@@ -202,48 +94,44 @@ impl<'ast> AstFactory<'ast> {
       FormalParameters::new(
         SPAN,
         FormalParameterKind::Signature,
-        oxc::allocator::Vec::new_in(self),
+        oxc::allocator::Vec::new_in(builder),
         NONE,
-        self,
+        builder,
       ),
       NONE,
-      FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(self), statements, self),
-      self,
-    ))
-  }
-
-  /// `<object>.<property>` as a `MemberExpression`.
-  pub fn make_member_access(&self, object: &str, property: &str) -> MemberExpression<'ast> {
-    MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
-      SPAN,
-      self.make_id_ref_expr(SPAN, object),
-      self.make_id_name(SPAN, property),
-      false,
-      self,
+      FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder),
+      builder,
     ))
   }
 
   /// `<object>.<property>` as an `Expression`.
-  pub fn make_member_access_expr(&self, object: &str, property: &str) -> Expression<'ast> {
-    Expression::from(self.make_member_access(object, property))
+  fn new_member_access_expr<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    object: &str,
+    property: &str,
+    builder: &B,
+  ) -> Expression<'ast> {
+    Expression::from(MemberExpression::new_member_access(object, property, builder))
   }
 
   /// `<callee>(<arg>)`, optionally annotated `@__PURE__`.
-  pub fn make_call_with_arg(
-    &self,
+  fn new_call_with_arg<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     callee: Expression<'ast>,
     arg: Expression<'ast>,
     pure: bool,
+    builder: &B,
   ) -> Expression<'ast> {
     let mut call_expr =
-      CallExpression::new(SPAN, callee, NONE, oxc::allocator::Vec::new_in(self), false, self);
+      CallExpression::new(SPAN, callee, NONE, oxc::allocator::Vec::new_in(builder), false, builder);
     call_expr.pure = pure;
     call_expr.arguments.push(arg.into());
-    Expression::CallExpression(call_expr.into_in(self.allocator()))
+    Expression::CallExpression(call_expr.into_in(builder.allocator()))
   }
 
   /// `Promise.resolve().then(() => <expr>)`
-  pub fn make_promise_resolve_then(&self, expr: Expression<'ast>) -> Expression<'ast> {
+  fn new_promise_resolve_then<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    builder: &B,
+  ) -> Expression<'ast> {
     Expression::CallExpression(CallExpression::boxed(
       SPAN,
       Expression::StaticMemberExpression(StaticMemberExpression::boxed(
@@ -254,89 +142,44 @@ impl<'ast> AstFactory<'ast> {
             SPAN,
             Expression::new_identifier(
               SPAN,
-              oxc::ast::ast::Str::from_str_in("Promise", self),
-              self,
+              oxc::ast::ast::Str::from_str_in("Promise", builder),
+              builder,
             ),
-            IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("resolve", self), self),
+            IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("resolve", builder), builder),
             false,
-            self,
+            builder,
           )),
           NONE,
-          oxc::allocator::Vec::new_in(self),
+          oxc::allocator::Vec::new_in(builder),
           false,
-          self,
+          builder,
         )),
-        IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("then", self), self),
+        IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("then", builder), builder),
         false,
-        self,
+        builder,
       )),
       NONE,
-      oxc::allocator::Vec::from_value_in(Argument::from(self.make_arrow_returning(expr)), self),
+      oxc::allocator::Vec::from_value_in(
+        Argument::from(Expression::new_arrow_returning(expr, builder)),
+        builder,
+      ),
       false,
-      self,
-    ))
-  }
-
-  /// `<key>: () => <expr>` — a lazy-export object property.
-  pub fn make_lazy_export_property(
-    &self,
-    key: &str,
-    expr: Expression<'ast>,
-    computed: bool,
-  ) -> ObjectPropertyKind<'ast> {
-    ObjectPropertyKind::new_object_property(
-      SPAN,
-      PropertyKind::Init,
-      if computed {
-        PropertyKey::from(Expression::new_string_literal(
-          SPAN,
-          oxc::ast::ast::Str::from_str_in(key, self),
-          None,
-          self,
-        ))
-      } else {
-        PropertyKey::new_static_identifier(SPAN, oxc::ast::ast::Str::from_str_in(key, self), self)
-      },
-      self.make_arrow_returning(expr),
-      true,
-      false,
-      computed,
-      self,
-    )
-  }
-
-  /// `import * as <as_name> from "<source>";`
-  pub fn make_import_star_stmt(&self, source: &str, as_name: &str) -> Statement<'ast> {
-    let specifiers = oxc::allocator::Vec::from_value_in(
-      ImportDeclarationSpecifier::ImportNamespaceSpecifier(ImportNamespaceSpecifier::boxed(
-        SPAN,
-        BindingIdentifier::new(SPAN, oxc::ast::ast::Str::from_str_in(as_name, self), self),
-        self,
-      )),
-      self,
-    );
-    Statement::ImportDeclaration(ImportDeclaration::boxed(
-      SPAN,
-      Some(specifiers),
-      StringLiteral::new(SPAN, oxc::ast::ast::Str::from_str_in(source, self), None, self),
-      None,
-      NONE,
-      ImportOrExportKind::Value,
-      self,
+      builder,
     ))
   }
 
   /// `None` → `<call_expr>`; `Babel` → `__toESM(<call_expr>)`; `Node` → `__toESM(<call_expr>, 1)`.
-  #[expect(clippy::needless_pass_by_value)]
-  pub fn make_to_esm_call_with_interop(
-    &self,
+  fn new_to_esm_call_with_interop<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     to_esm_fn_name: &str,
     call_expr: Expression<'ast>,
     interop: Option<Interop>,
+    builder: &B,
   ) -> Expression<'ast> {
     let arguments = match interop {
       None => return call_expr,
-      Some(Interop::Babel) => oxc::allocator::Vec::from_value_in(Argument::from(call_expr), self),
+      Some(Interop::Babel) => {
+        oxc::allocator::Vec::from_value_in(Argument::from(call_expr), builder)
+      }
       Some(Interop::Node) => oxc::allocator::Vec::from_iter_in(
         [
           Argument::from(call_expr),
@@ -345,40 +188,48 @@ impl<'ast> AstFactory<'ast> {
             1.0,
             None,
             NumberBase::Decimal,
-            self,
+            builder,
           )),
         ],
-        self,
+        builder,
       ),
     };
     Expression::new_call_expression(
       SPAN,
-      Expression::new_identifier(SPAN, oxc::ast::ast::Str::from_str_in(to_esm_fn_name, self), self),
+      Expression::new_identifier(
+        SPAN,
+        oxc::ast::ast::Str::from_str_in(to_esm_fn_name, builder),
+        builder,
+      ),
       NONE,
       arguments,
       false,
-      self,
+      builder,
     )
   }
 
   /// `(<a>, <b>)` — a parenthesized two-element sequence expression.
-  pub fn make_seq_in_parens(&self, a: Expression<'ast>, b: Expression<'ast>) -> Expression<'ast> {
-    let mut expressions = oxc::allocator::Vec::with_capacity_in(2, self);
+  fn new_seq_in_parens<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    a: Expression<'ast>,
+    b: Expression<'ast>,
+    builder: &B,
+  ) -> Expression<'ast> {
+    let mut expressions = oxc::allocator::Vec::with_capacity_in(2, builder);
     expressions.push(a);
     expressions.push(b);
     Expression::ParenthesizedExpression(ParenthesizedExpression::boxed(
       SPAN,
-      Expression::SequenceExpression(SequenceExpression::boxed(SPAN, expressions, self)),
-      self,
+      Expression::SequenceExpression(SequenceExpression::boxed(SPAN, expressions, builder)),
+      builder,
     ))
   }
 
   /// `<object>.<prop>.<prop>...` — chains member access for each prop, then sets the span.
-  pub fn make_member_expr_or_ident_ref(
-    &self,
+  fn new_member_expr_or_ident_ref<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     object: Expression<'ast>,
     props: &[MemberExprProp],
     span: Span,
+    builder: &B,
   ) -> Expression<'ast> {
     let mut cur = object;
     for prop in props {
@@ -386,9 +237,13 @@ impl<'ast> AstFactory<'ast> {
         Expression::from(MemberExpression::new_static_member_expression(
           SPAN,
           cur,
-          IdentifierName::new(prop.span, oxc::ast::ast::Str::from_str_in(&prop.name, self), self),
+          IdentifierName::new(
+            prop.span,
+            oxc::ast::ast::Str::from_str_in(&prop.name, builder),
+            builder,
+          ),
           prop.optional,
-          self,
+          builder,
         ))
       } else {
         Expression::from(MemberExpression::new_computed_member_expression(
@@ -396,12 +251,12 @@ impl<'ast> AstFactory<'ast> {
           cur,
           Expression::new_string_literal(
             prop.span,
-            oxc::ast::ast::Str::from_str_in(&prop.name, self),
+            oxc::ast::ast::Str::from_str_in(&prop.name, builder),
             None,
-            self,
+            builder,
           ),
           prop.optional,
-          self,
+          builder,
         ))
       };
     }
@@ -411,50 +266,44 @@ impl<'ast> AstFactory<'ast> {
 
   /// The props of `foo_exports.value.a` is `["value", "a"]`; here convert it to `(void 0).a`.
   #[inline]
-  pub fn make_member_expr_with_void_zero_object(
-    &self,
+  fn new_member_expr_with_void_zero_object<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     props: &[MemberExprProp],
     span: Span,
+    builder: &B,
   ) -> Expression<'ast> {
     if props.is_empty() {
-      Expression::new_void_0(SPAN, self)
+      Expression::new_void_0(SPAN, builder)
     } else {
-      self.make_member_expr_or_ident_ref(Expression::new_void_0(SPAN, self), &props[1..], span)
+      Expression::new_member_expr_or_ident_ref(
+        Expression::new_void_0(SPAN, builder),
+        &props[1..],
+        span,
+        builder,
+      )
     }
   }
 
-  /// `__reExport(<first>, <second>)` (callee provided as `re_export_fn_ref`).
-  pub fn make_re_export_call(
-    &self,
-    re_export_fn_ref: Expression<'ast>,
-    first_arg: Expression<'ast>,
-    second_arg: Expression<'ast>,
-  ) -> CallExpression<'ast> {
-    let args = oxc::allocator::Vec::from_iter_in([first_arg.into(), second_arg.into()], self);
-    CallExpression::new(SPAN, re_export_fn_ref, NONE, args, false, self)
-  }
-
   /// `<callee>(<original_name as target>, "<original_name>")`, optionally `@__PURE__`.
-  pub fn make_keep_name_call(
-    &self,
+  fn new_keep_name_call<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     original_name: &str,
     target: Expression<'ast>,
     callee: Expression<'ast>,
     pure: bool,
+    builder: &B,
   ) -> Expression<'ast> {
     Expression::new_call_expression_with_pure(
       SPAN,
       callee,
       NONE,
       {
-        let mut items = oxc::allocator::Vec::with_capacity_in(2, self);
+        let mut items = oxc::allocator::Vec::with_capacity_in(2, builder);
         items.push(target.into());
         items.push(
           Expression::new_string_literal(
             SPAN,
-            oxc::ast::ast::Str::from_str_in(original_name, self),
+            oxc::ast::ast::Str::from_str_in(original_name, builder),
             None,
-            self,
+            builder,
           )
           .into(),
         );
@@ -462,15 +311,165 @@ impl<'ast> AstFactory<'ast> {
       },
       false,
       pure,
-      self,
+      builder,
     )
   }
 
+  /// `node_mode` ? `__toESM(<expr>, 1)` : `__toESM(<expr>)` (callee `to_esm_fn_expr`, `@__PURE__`).
+  fn new_to_esm_wrapper<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    to_esm_fn_expr: Expression<'ast>,
+    expr: Expression<'ast>,
+    node_mode: bool,
+    builder: &B,
+  ) -> Expression<'ast> {
+    let args = if node_mode {
+      oxc::allocator::Vec::from_iter_in(
+        [
+          Argument::from(expr),
+          Argument::from(Expression::new_numeric_literal(
+            SPAN,
+            1.0,
+            None,
+            NumberBase::Decimal,
+            builder,
+          )),
+        ],
+        builder,
+      )
+    } else {
+      oxc::allocator::Vec::from_value_in(Argument::from(expr), builder)
+    };
+    Expression::CallExpression(CallExpression::boxed_with_pure(
+      SPAN,
+      to_esm_fn_expr,
+      NONE,
+      args,
+      false,
+      true,
+      builder,
+    ))
+  }
+
+  /// `<call_expr>.then(() => <return_expr>)`
+  fn new_callee_then_call<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    call_expr: Expression<'ast>,
+    return_expr: Expression<'ast>,
+    builder: &B,
+  ) -> Expression<'ast> {
+    Expression::CallExpression(CallExpression::boxed(
+      SPAN,
+      Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+        SPAN,
+        call_expr,
+        IdentifierName::new(SPAN, "then", builder),
+        false,
+        builder,
+      )),
+      NONE,
+      oxc::allocator::Vec::from_value_in(
+        Argument::from(Expression::new_arrow_returning(return_expr, builder)),
+        builder,
+      ),
+      false,
+      builder,
+    ))
+  }
+}
+
+impl<'ast> ExpressionFactoryExt<'ast> for Expression<'ast> {}
+
+/// rolldown's recurring `BindingIdentifier` constructions.
+pub trait BindingIdentifierFactoryExt<'ast> {
+  /// `<name>` as a `BindingIdentifier`, with the name copied into the arena.
+  fn new_id<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    span: Span,
+    name: &str,
+    builder: &B,
+  ) -> BindingIdentifier<'ast> {
+    BindingIdentifier::new(span, oxc::ast::ast::Str::from_str_in(name, builder), builder)
+  }
+}
+
+impl<'ast> BindingIdentifierFactoryExt<'ast> for BindingIdentifier<'ast> {}
+
+/// rolldown's recurring `IdentifierName` constructions.
+pub trait IdentifierNameFactoryExt<'ast> {
+  /// `<name>` as an `IdentifierName`, with the name copied into the arena.
+  fn new_id_name<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    span: Span,
+    name: &str,
+    builder: &B,
+  ) -> IdentifierName<'ast> {
+    IdentifierName::new(span, oxc::ast::ast::Str::from_str_in(name, builder), builder)
+  }
+}
+
+impl<'ast> IdentifierNameFactoryExt<'ast> for IdentifierName<'ast> {}
+
+/// rolldown's recurring `MemberExpression` constructions.
+pub trait MemberExpressionFactoryExt<'ast> {
+  /// `<object>.<property>` as a `MemberExpression`.
+  fn new_member_access<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    object: &str,
+    property: &str,
+    builder: &B,
+  ) -> MemberExpression<'ast> {
+    MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
+      SPAN,
+      Expression::new_id_ref_expr(SPAN, object, builder),
+      IdentifierName::new_id_name(SPAN, property, builder),
+      false,
+      builder,
+    ))
+  }
+}
+
+impl<'ast> MemberExpressionFactoryExt<'ast> for MemberExpression<'ast> {}
+
+/// rolldown's recurring `ObjectPropertyKind` constructions.
+pub trait ObjectPropertyKindFactoryExt<'ast> {
+  /// `<key>: () => <expr>` — a lazy-export object property.
+  fn new_lazy_export_property<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    key: &str,
+    expr: Expression<'ast>,
+    computed: bool,
+    builder: &B,
+  ) -> ObjectPropertyKind<'ast> {
+    ObjectPropertyKind::new_object_property(
+      SPAN,
+      PropertyKind::Init,
+      if computed {
+        PropertyKey::from(Expression::new_string_literal(
+          SPAN,
+          oxc::ast::ast::Str::from_str_in(key, builder),
+          None,
+          builder,
+        ))
+      } else {
+        PropertyKey::new_static_identifier(
+          SPAN,
+          oxc::ast::ast::Str::from_str_in(key, builder),
+          builder,
+        )
+      },
+      Expression::new_arrow_returning(expr, builder),
+      true,
+      false,
+      computed,
+      builder,
+    )
+  }
+}
+
+impl<'ast> ObjectPropertyKindFactoryExt<'ast> for ObjectPropertyKind<'ast> {}
+
+/// rolldown's recurring `ClassElement` constructions.
+pub trait ClassElementFactoryExt<'ast> {
   /// `static { <callee>(this, "<name>"); }`
-  pub fn make_static_block_keep_name(
-    &self,
+  fn new_static_block_keep_name<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     name: &str,
     callee: Expression<'ast>,
+    builder: &B,
   ) -> ClassElement<'ast> {
     ClassElement::new_static_block(
       SPAN,
@@ -482,69 +481,278 @@ impl<'ast> AstFactory<'ast> {
             callee,
             NONE,
             {
-              let mut items = oxc::allocator::Vec::with_capacity_in(2, self);
-              items.push(Expression::new_this_expression(SPAN, self).into());
+              let mut items = oxc::allocator::Vec::with_capacity_in(2, builder);
+              items.push(Expression::new_this_expression(SPAN, builder).into());
               items.push(
                 Expression::new_string_literal(
                   SPAN,
-                  oxc::ast::ast::Str::from_str_in(name, self),
+                  oxc::ast::ast::Str::from_str_in(name, builder),
                   None,
-                  self,
+                  builder,
                 )
                 .into(),
               );
               items
             },
             false,
-            self,
+            builder,
           ),
-          self,
+          builder,
         ),
-        self,
+        builder,
       ),
-      self,
+      builder,
+    )
+  }
+}
+
+impl<'ast> ClassElementFactoryExt<'ast> for ClassElement<'ast> {}
+
+/// rolldown's recurring `CallExpression` constructions.
+pub trait CallExpressionFactoryExt<'ast> {
+  /// `__reExport(<first>, <second>)` (callee provided as `re_export_fn_ref`).
+  fn new_re_export_call<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    re_export_fn_ref: Expression<'ast>,
+    first_arg: Expression<'ast>,
+    second_arg: Expression<'ast>,
+    builder: &B,
+  ) -> CallExpression<'ast> {
+    let args = oxc::allocator::Vec::from_iter_in([first_arg.into(), second_arg.into()], builder);
+    CallExpression::new(SPAN, re_export_fn_ref, NONE, args, false, builder)
+  }
+
+  /// `<expr>.then(n => n.<property_name>)`
+  fn new_then_extract_property<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    property_name: &str,
+    builder: &B,
+  ) -> allocator::Box<'ast, CallExpression<'ast>> {
+    debug_assert!(is_validate_identifier_name(property_name));
+    // `n.<property_name>`
+    let member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      SPAN,
+      Expression::new_identifier(SPAN, "n", builder),
+      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, builder), builder),
+      false,
+      builder,
+    ));
+    then_with_arrow_callback(expr, member, builder)
+  }
+
+  /// `<expr>.then(n => (n.<wrapper_name>(), n.<namespace_name>))`
+  fn new_then_call_esm_wrapper_with_namespace<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    wrapper_name: &str,
+    namespace_name: &str,
+    builder: &B,
+  ) -> allocator::Box<'ast, CallExpression<'ast>> {
+    let wrapper_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      SPAN,
+      Expression::new_identifier(SPAN, "n", builder),
+      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(wrapper_name, builder), builder),
+      false,
+      builder,
+    ));
+    let wrapper_call = Expression::new_call_expression(
+      SPAN,
+      wrapper_member,
+      NONE,
+      oxc::allocator::Vec::new_in(builder),
+      false,
+      builder,
+    );
+    let namespace_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      SPAN,
+      Expression::new_identifier(SPAN, "n", builder),
+      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(namespace_name, builder), builder),
+      false,
+      builder,
+    ));
+    let seq_expr = Expression::new_seq_in_parens(wrapper_call, namespace_member, builder);
+    then_with_arrow_callback(expr, seq_expr, builder)
+  }
+
+  /// `<expr>.then(n => __toESM(n.<property_name>()))`
+  fn new_then_call_cjs_wrapper_with_to_esm<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    property_name: &str,
+    to_esm_fn_expr: Expression<'ast>,
+    node_mode: bool,
+    builder: &B,
+  ) -> allocator::Box<'ast, CallExpression<'ast>> {
+    let member_expr = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      SPAN,
+      Expression::new_identifier(SPAN, "n", builder),
+      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, builder), builder),
+      false,
+      builder,
+    ));
+    let wrapper_call = Expression::new_call_expression(
+      SPAN,
+      member_expr,
+      NONE,
+      oxc::allocator::Vec::new_in(builder),
+      false,
+      builder,
+    );
+    let to_esm_call =
+      Expression::new_to_esm_wrapper(to_esm_fn_expr, wrapper_call, node_mode, builder);
+    then_with_arrow_callback(expr, to_esm_call, builder)
+  }
+}
+
+impl<'ast> CallExpressionFactoryExt<'ast> for CallExpression<'ast> {}
+
+/// rolldown's recurring `Statement` constructions.
+pub trait StatementFactoryExt<'ast> {
+  /// `var <name> = <init>;`
+  fn new_var_decl<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    name: &str,
+    init: Expression<'ast>,
+    builder: &B,
+  ) -> Statement<'ast> {
+    let declarations = oxc::allocator::Vec::from_value_in(
+      VariableDeclarator::new(
+        SPAN,
+        VariableDeclarationKind::Var,
+        BindingPattern::new_binding_identifier(
+          SPAN,
+          oxc::ast::ast::Str::from_str_in(name, builder),
+          builder,
+        ),
+        NONE,
+        Some(init),
+        false,
+        builder,
+      ),
+      builder,
+    );
+
+    Statement::from(Declaration::VariableDeclaration(VariableDeclaration::boxed(
+      SPAN,
+      VariableDeclarationKind::Var,
+      declarations,
+      false,
+      builder,
+    )))
+  }
+
+  /// `export default <expr>`
+  fn new_export_default_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    builder: &B,
+  ) -> Statement<'ast> {
+    Statement::from(ModuleDeclaration::new_export_default_declaration(
+      SPAN,
+      ExportDefaultDeclarationKind::from(expr),
+      builder,
+    ))
+  }
+
+  /// `module.exports = <expr>`
+  fn new_module_exports_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    expr: Expression<'ast>,
+    builder: &B,
+  ) -> Statement<'ast> {
+    Statement::new_expression_statement(
+      SPAN,
+      Expression::new_assignment_expression(
+        SPAN,
+        AssignmentOperator::Assign,
+        AssignmentTarget::from(SimpleAssignmentTarget::from(
+          MemberExpression::new_static_member_expression(
+            SPAN,
+            Expression::new_identifier(SPAN, "module", builder),
+            IdentifierName::new(SPAN, "exports", builder),
+            false,
+            builder,
+          ),
+        )),
+        expr,
+        builder,
+      ),
+      builder,
     )
   }
 
-  /// `node_mode` ? `__toESM(<expr>, 1)` : `__toESM(<expr>)` (callee `to_esm_fn_expr`, `@__PURE__`).
-  pub fn make_to_esm_wrapper(
-    &self,
-    to_esm_fn_expr: Expression<'ast>,
-    expr: Expression<'ast>,
-    node_mode: bool,
-  ) -> Expression<'ast> {
-    let args = if node_mode {
-      oxc::allocator::Vec::from_iter_in(
-        [
-          Argument::from(expr),
-          Argument::from(Expression::new_numeric_literal(
-            SPAN,
-            1.0,
-            None,
-            NumberBase::Decimal,
-            self,
-          )),
-        ],
-        self,
-      )
-    } else {
-      oxc::allocator::Vec::from_value_in(Argument::from(expr), self)
-    };
-    Expression::CallExpression(CallExpression::boxed_with_pure(
+  /// `export { <local> as <exported>, ... };`, optionally with a `declaration`.
+  fn new_export_named_stmt<'a, T, I, B>(
+    declaration: Option<Declaration<'ast>>,
+    specifiers: I,
+    builder: &B,
+  ) -> Statement<'ast>
+  where
+    T: AsRef<str> + 'a,
+    I: Iterator<Item = (&'a T, &'a (T, bool))>,
+    B: GetAstBuilder<'ast> + GetAllocator<'ast>,
+  {
+    Statement::from(ModuleDeclaration::new_export_named_declaration(
       SPAN,
-      to_esm_fn_expr,
+      declaration,
+      oxc::allocator::Vec::from_iter_in(
+        specifiers.into_iter().map(|(local, (exported, legal_ident))| {
+          ExportSpecifier::new(
+            SPAN,
+            ModuleExportName::new_identifier_reference(
+              SPAN,
+              oxc::ast::ast::Str::from_str_in(local.as_ref(), builder),
+              builder,
+            ),
+            if *legal_ident {
+              ModuleExportName::new_identifier_name(
+                SPAN,
+                oxc::ast::ast::Str::from_str_in(exported.as_ref(), builder),
+                builder,
+              )
+            } else {
+              ModuleExportName::new_string_literal(
+                SPAN,
+                oxc::ast::ast::Str::from_str_in(exported.as_ref(), builder),
+                None,
+                builder,
+              )
+            },
+            ImportOrExportKind::Value,
+            builder,
+          )
+        }),
+        builder,
+      ),
+      None,
+      ImportOrExportKind::Value,
       NONE,
-      args,
-      false,
-      true,
-      self,
+      builder,
+    ))
+  }
+
+  /// `import * as <as_name> from "<source>";`
+  fn new_import_star_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    source: &str,
+    as_name: &str,
+    builder: &B,
+  ) -> Statement<'ast> {
+    let specifiers = oxc::allocator::Vec::from_value_in(
+      ImportDeclarationSpecifier::ImportNamespaceSpecifier(ImportNamespaceSpecifier::boxed(
+        SPAN,
+        BindingIdentifier::new(SPAN, oxc::ast::ast::Str::from_str_in(as_name, builder), builder),
+        builder,
+      )),
+      builder,
+    );
+    Statement::ImportDeclaration(ImportDeclaration::boxed(
+      SPAN,
+      Some(specifiers),
+      StringLiteral::new(SPAN, oxc::ast::ast::Str::from_str_in(source, builder), None, builder),
+      None,
+      NONE,
+      ImportOrExportKind::Value,
+      builder,
     ))
   }
 
   /// `var <binding_name> = __commonJS(... (exports, module) => { <statements> } ...)`
   #[expect(clippy::too_many_arguments)]
-  pub fn make_commonjs_wrapper_stmt(
-    &self,
+  fn new_commonjs_wrapper_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     binding_name: &str,
     commonjs_expr: Expression<'ast>,
     statements: allocator::Vec<'ast, Statement<'ast>>,
@@ -552,54 +760,55 @@ impl<'ast> AstFactory<'ast> {
     profiler_names: bool,
     stable_id: &str,
     is_async: bool,
+    builder: &B,
   ) -> Statement<'ast> {
     let mut params = FormalParameters::new(
       SPAN,
       FormalParameterKind::Signature,
-      oxc::allocator::Vec::with_capacity_in(1, self),
+      oxc::allocator::Vec::with_capacity_in(1, builder),
       NONE,
-      self,
+      builder,
     );
-    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(self), statements, self);
+    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder);
     if ast_usage.intersects(EcmaModuleAstUsage::ModuleOrExports) {
       params.items.push(FormalParameter::new(
         SPAN,
-        oxc::allocator::Vec::new_in(self),
-        BindingPattern::new_binding_identifier(SPAN, "exports", self),
+        oxc::allocator::Vec::new_in(builder),
+        BindingPattern::new_binding_identifier(SPAN, "exports", builder),
         NONE,
         NONE,
         false,
         None,
         false,
         false,
-        self,
+        builder,
       ));
     }
     if ast_usage.contains(EcmaModuleAstUsage::ModuleRef) {
       params.items.push(FormalParameter::new(
         SPAN,
-        oxc::allocator::Vec::new_in(self),
-        BindingPattern::new_binding_identifier(SPAN, "module", self),
+        oxc::allocator::Vec::new_in(builder),
+        BindingPattern::new_binding_identifier(SPAN, "module", builder),
         NONE,
         NONE,
         false,
         None,
         false,
         false,
-        self,
+        builder,
       ));
     }
     let mut commonjs_call_expr = CallExpression::new_with_pure(
       SPAN,
       commonjs_expr,
       NONE,
-      oxc::allocator::Vec::new_in(self),
+      oxc::allocator::Vec::new_in(builder),
       false,
       true,
-      self,
+      builder,
     );
     let mut arrow_expr =
-      ArrowFunctionExpression::boxed(SPAN, false, is_async, NONE, params, NONE, body, self);
+      ArrowFunctionExpression::boxed(SPAN, false, is_async, NONE, params, NONE, body, builder);
     arrow_expr.pife = true;
     if profiler_names {
       let obj_expr = ObjectExpression::boxed(
@@ -610,34 +819,38 @@ impl<'ast> AstFactory<'ast> {
             PropertyKind::Init,
             PropertyKey::from(Expression::new_string_literal(
               SPAN,
-              oxc::ast::ast::Str::from_str_in(stable_id, self),
+              oxc::ast::ast::Str::from_str_in(stable_id, builder),
               None,
-              self,
+              builder,
             )),
             Expression::ArrowFunctionExpression(arrow_expr),
             true,
             false,
             false,
-            self,
+            builder,
           ),
-          self,
+          builder,
         ),
-        self,
+        builder,
       );
       commonjs_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
     } else {
       commonjs_call_expr.arguments.push(Argument::ArrowFunctionExpression(arrow_expr));
     }
-    self.make_var_decl(
+    Statement::new_var_decl(
       binding_name,
-      Expression::CallExpression(commonjs_call_expr.into_in(self.allocator())),
+      Expression::CallExpression(commonjs_call_expr.into_in(builder.allocator())),
+      builder,
     )
   }
 
   /// `var <binding_name> = __esm(... () => { <statements> } ...)`
   /// or, for order wrappers that must be callable across chunk cycles before assignment:
   /// `function <binding_name>() { return (<binding_name> = __esm(... () => { <statements> } ...))(); }`
-  pub fn make_esm_wrapper_stmt(&self, options: EsmWrapperStmtOptions<'ast, '_>) -> Statement<'ast> {
+  fn new_esm_wrapper_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    options: EsmWrapperStmtOptions<'ast, '_>,
+    builder: &B,
+  ) -> Statement<'ast> {
     let EsmWrapperStmtOptions {
       binding_name,
       esm_fn_expr,
@@ -650,13 +863,19 @@ impl<'ast> AstFactory<'ast> {
     let params = FormalParameters::new(
       SPAN,
       FormalParameterKind::Signature,
-      oxc::allocator::Vec::new_in(self),
+      oxc::allocator::Vec::new_in(builder),
       NONE,
-      self,
+      builder,
     );
-    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(self), statements, self);
-    let mut esm_call_expr =
-      CallExpression::new(SPAN, esm_fn_expr, NONE, oxc::allocator::Vec::new_in(self), false, self);
+    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder);
+    let mut esm_call_expr = CallExpression::new(
+      SPAN,
+      esm_fn_expr,
+      NONE,
+      oxc::allocator::Vec::new_in(builder),
+      false,
+      builder,
+    );
     let mut arrow_expr = ArrowFunctionExpression::boxed(
       SPAN,
       false,
@@ -665,7 +884,7 @@ impl<'ast> AstFactory<'ast> {
       params,
       NONE,
       body,
-      self,
+      builder,
     );
     arrow_expr.pife = matches!(call_kind, EsmWrapperCallKind::Pife);
     if let Some(stable_id) = profiler_name {
@@ -677,28 +896,29 @@ impl<'ast> AstFactory<'ast> {
             PropertyKind::Init,
             PropertyKey::from(Expression::new_string_literal(
               SPAN,
-              oxc::ast::ast::Str::from_str_in(stable_id, self),
+              oxc::ast::ast::Str::from_str_in(stable_id, builder),
               None,
-              self,
+              builder,
             )),
             Expression::ArrowFunctionExpression(arrow_expr),
             false,
             false,
             false,
-            self,
+            builder,
           ),
-          self,
+          builder,
         ),
-        self,
+        builder,
       );
       esm_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
     } else {
       esm_call_expr.arguments.push(Argument::ArrowFunctionExpression(arrow_expr));
     }
     if matches!(decl_kind, EsmWrapperDeclKind::Var) {
-      return self.make_var_decl(
+      return Statement::new_var_decl(
         binding_name,
-        Expression::CallExpression(esm_call_expr.into_in(self.allocator())),
+        Expression::CallExpression(esm_call_expr.into_in(builder.allocator())),
+        builder,
       );
     }
     let assignment_expr = Expression::AssignmentExpression(AssignmentExpression::boxed(
@@ -706,24 +926,28 @@ impl<'ast> AstFactory<'ast> {
       AssignmentOperator::Assign,
       AssignmentTarget::AssignmentTargetIdentifier(IdentifierReference::boxed(
         SPAN,
-        oxc::ast::ast::Str::from_str_in(binding_name, self),
-        self,
+        oxc::ast::ast::Str::from_str_in(binding_name, builder),
+        builder,
       )),
-      Expression::CallExpression(esm_call_expr.into_in(self.allocator())),
-      self,
+      Expression::CallExpression(esm_call_expr.into_in(builder.allocator())),
+      builder,
     ));
     let call_expr = Expression::new_call_expression(
       SPAN,
       assignment_expr,
       NONE,
-      oxc::allocator::Vec::new_in(self),
+      oxc::allocator::Vec::new_in(builder),
       false,
-      self,
+      builder,
     );
     Statement::FunctionDeclaration(Function::boxed(
       SPAN,
       FunctionType::FunctionDeclaration,
-      Some(BindingIdentifier::new(SPAN, oxc::ast::ast::Str::from_str_in(binding_name, self), self)),
+      Some(BindingIdentifier::new(
+        SPAN,
+        oxc::ast::ast::Str::from_str_in(binding_name, builder),
+        builder,
+      )),
       false,
       false,
       false,
@@ -732,277 +956,91 @@ impl<'ast> AstFactory<'ast> {
       FormalParameters::new(
         SPAN,
         FormalParameterKind::Signature,
-        oxc::allocator::Vec::new_in(self),
+        oxc::allocator::Vec::new_in(builder),
         NONE,
-        self,
+        builder,
       ),
       NONE,
       Some(FunctionBody::new(
         SPAN,
-        oxc::allocator::Vec::new_in(self),
+        oxc::allocator::Vec::new_in(builder),
         oxc::allocator::Vec::from_value_in(
-          Statement::ReturnStatement(ReturnStatement::boxed(SPAN, Some(call_expr), self)),
-          self,
+          Statement::ReturnStatement(ReturnStatement::boxed(SPAN, Some(call_expr), builder)),
+          builder,
         ),
-        self,
+        builder,
       )),
-      self,
-    ))
-  }
-
-  /// `n => n.<property_name>`
-  fn arrow_function_extract_property(
-    &self,
-    property_name: &str,
-  ) -> allocator::Box<'ast, ArrowFunctionExpression<'ast>> {
-    debug_assert!(is_validate_identifier_name(property_name));
-    ArrowFunctionExpression::boxed(
-      SPAN,
-      true,
-      false,
-      NONE,
-      FormalParameters::new(
-        SPAN,
-        FormalParameterKind::ArrowFormalParameters,
-        oxc::allocator::Vec::from_value_in(
-          FormalParameter::new(
-            SPAN,
-            oxc::allocator::Vec::new_in(self),
-            BindingPattern::new_binding_identifier(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in("n", self),
-              self,
-            ),
-            NONE,
-            NONE,
-            false,
-            None,
-            false,
-            false,
-            self,
-          ),
-          self,
-        ),
-        NONE,
-        self,
-      ),
-      NONE,
-      FunctionBody::new(
-        SPAN,
-        oxc::allocator::Vec::new_in(self),
-        oxc::allocator::Vec::from_value_in(
-          Statement::ExpressionStatement(ExpressionStatement::boxed(
-            SPAN,
-            Expression::StaticMemberExpression(StaticMemberExpression::boxed(
-              SPAN,
-              Expression::new_identifier(SPAN, "n", self),
-              IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, self), self),
-              false,
-              self,
-            )),
-            self,
-          )),
-          self,
-        ),
-        self,
-      ),
-      self,
-    )
-  }
-
-  /// `<expr>.then(n => <return_expr>)`
-  fn then_with_arrow_callback(
-    &self,
-    expr: Expression<'ast>,
-    return_expr: Expression<'ast>,
-  ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let arrow_fn = ArrowFunctionExpression::boxed(
-      SPAN,
-      true,
-      false,
-      NONE,
-      FormalParameters::new(
-        SPAN,
-        FormalParameterKind::ArrowFormalParameters,
-        oxc::allocator::Vec::from_value_in(
-          FormalParameter::new(
-            SPAN,
-            oxc::allocator::Vec::new_in(self),
-            BindingPattern::new_binding_identifier(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in("n", self),
-              self,
-            ),
-            NONE,
-            NONE,
-            false,
-            None,
-            false,
-            false,
-            self,
-          ),
-          self,
-        ),
-        NONE,
-        self,
-      ),
-      NONE,
-      FunctionBody::new(
-        SPAN,
-        oxc::allocator::Vec::new_in(self),
-        oxc::allocator::Vec::from_value_in(
-          Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, return_expr, self)),
-          self,
-        ),
-        self,
-      ),
-      self,
-    );
-    let callee = StaticMemberExpression::boxed(
-      SPAN,
-      expr,
-      IdentifierName::new(SPAN, "then", self),
-      false,
-      self,
-    );
-    CallExpression::boxed(
-      SPAN,
-      Expression::StaticMemberExpression(callee),
-      NONE,
-      oxc::allocator::Vec::from_value_in(
-        Expression::ArrowFunctionExpression(arrow_fn).into(),
-        self,
-      ),
-      false,
-      self,
-    )
-  }
-
-  /// `<expr>.then(n => n.<property_name>)`
-  pub fn make_then_extract_property(
-    &self,
-    expr: Expression<'ast>,
-    property_name: &str,
-  ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let callee = StaticMemberExpression::boxed(
-      SPAN,
-      expr,
-      IdentifierName::new(SPAN, "then", self),
-      false,
-      self,
-    );
-    CallExpression::boxed(
-      SPAN,
-      Expression::StaticMemberExpression(callee),
-      NONE,
-      oxc::allocator::Vec::from_value_in(
-        Expression::ArrowFunctionExpression(self.arrow_function_extract_property(property_name))
-          .into(),
-        self,
-      ),
-      false,
-      self,
-    )
-  }
-
-  /// `<expr>.then(n => (n.<wrapper_name>(), n.<namespace_name>))`
-  pub fn make_then_call_esm_wrapper_with_namespace(
-    &self,
-    expr: Expression<'ast>,
-    wrapper_name: &str,
-    namespace_name: &str,
-  ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let wrapper_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
-      SPAN,
-      Expression::new_identifier(SPAN, "n", self),
-      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(wrapper_name, self), self),
-      false,
-      self,
-    ));
-    let wrapper_call = Expression::new_call_expression(
-      SPAN,
-      wrapper_member,
-      NONE,
-      oxc::allocator::Vec::new_in(self),
-      false,
-      self,
-    );
-    let namespace_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
-      SPAN,
-      Expression::new_identifier(SPAN, "n", self),
-      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(namespace_name, self), self),
-      false,
-      self,
-    ));
-    let seq_expr = self.make_seq_in_parens(wrapper_call, namespace_member);
-    self.then_with_arrow_callback(expr, seq_expr)
-  }
-
-  /// `<expr>.then(n => __toESM(n.<property_name>()))`
-  pub fn make_then_call_cjs_wrapper_with_to_esm(
-    &self,
-    expr: Expression<'ast>,
-    property_name: &str,
-    to_esm_fn_expr: Expression<'ast>,
-    node_mode: bool,
-  ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let member_expr = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
-      SPAN,
-      Expression::new_identifier(SPAN, "n", self),
-      IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, self), self),
-      false,
-      self,
-    ));
-    let wrapper_call = Expression::new_call_expression(
-      SPAN,
-      member_expr,
-      NONE,
-      oxc::allocator::Vec::new_in(self),
-      false,
-      self,
-    );
-    let to_esm_call = self.make_to_esm_wrapper(to_esm_fn_expr, wrapper_call, node_mode);
-    self.then_with_arrow_callback(expr, to_esm_call)
-  }
-
-  /// `<call_expr>.then(() => <return_expr>)`
-  pub fn make_callee_then_call(
-    &self,
-    call_expr: Expression<'ast>,
-    return_expr: Expression<'ast>,
-  ) -> Expression<'ast> {
-    Expression::CallExpression(CallExpression::boxed(
-      SPAN,
-      Expression::StaticMemberExpression(StaticMemberExpression::boxed(
-        SPAN,
-        call_expr,
-        IdentifierName::new(SPAN, "then", self),
-        false,
-        self,
-      )),
-      NONE,
-      oxc::allocator::Vec::from_value_in(
-        Argument::from(self.make_arrow_returning(return_expr)),
-        self,
-      ),
-      false,
-      self,
+      builder,
     ))
   }
 }
 
-impl<'ast> GetAllocator<'ast> for AstFactory<'ast> {
-  #[inline]
-  fn allocator(&self) -> &'ast Allocator {
-    self.0.allocator()
-  }
-}
+impl<'ast> StatementFactoryExt<'ast> for Statement<'ast> {}
 
-impl<'ast> GetAstBuilder<'ast> for AstFactory<'ast> {
-  type Builder = AstBuilder<'ast>;
-
-  #[inline]
-  fn builder(&self) -> &AstBuilder<'ast> {
-    &self.0
-  }
+/// `<expr>.then(n => <return_expr>)`
+fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+  expr: Expression<'ast>,
+  return_expr: Expression<'ast>,
+  builder: &B,
+) -> allocator::Box<'ast, CallExpression<'ast>> {
+  let arrow_fn = ArrowFunctionExpression::boxed(
+    SPAN,
+    true,
+    false,
+    NONE,
+    FormalParameters::new(
+      SPAN,
+      FormalParameterKind::ArrowFormalParameters,
+      oxc::allocator::Vec::from_value_in(
+        FormalParameter::new(
+          SPAN,
+          oxc::allocator::Vec::new_in(builder),
+          BindingPattern::new_binding_identifier(
+            SPAN,
+            oxc::ast::ast::Str::from_str_in("n", builder),
+            builder,
+          ),
+          NONE,
+          NONE,
+          false,
+          None,
+          false,
+          false,
+          builder,
+        ),
+        builder,
+      ),
+      NONE,
+      builder,
+    ),
+    NONE,
+    FunctionBody::new(
+      SPAN,
+      oxc::allocator::Vec::new_in(builder),
+      oxc::allocator::Vec::from_value_in(
+        Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, return_expr, builder)),
+        builder,
+      ),
+      builder,
+    ),
+    builder,
+  );
+  let callee = StaticMemberExpression::boxed(
+    SPAN,
+    expr,
+    IdentifierName::new(SPAN, "then", builder),
+    false,
+    builder,
+  );
+  CallExpression::boxed(
+    SPAN,
+    Expression::StaticMemberExpression(callee),
+    NONE,
+    oxc::allocator::Vec::from_value_in(
+      Expression::ArrowFunctionExpression(arrow_fn).into(),
+      builder,
+    ),
+    false,
+    builder,
+  )
 }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -1,51 +1,58 @@
 use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::TakeIn as _,
-  ast::ast::{
-    ArrayAssignmentTarget, ArrayExpression, ArrayExpressionElement, AssignmentTarget,
-    AssignmentTargetMaybeDefault, AssignmentTargetRest, AssignmentTargetWithDefault,
-    BindingPattern, Elision, Expression, IdentifierReference, ObjectAssignmentTarget,
-    ObjectExpression, ObjectProperty, ObjectPropertyKind, PropertyKind, SpreadElement,
+  ast::{
+    ast::{
+      ArrayAssignmentTarget, ArrayExpression, ArrayExpressionElement, AssignmentTarget,
+      AssignmentTargetMaybeDefault, AssignmentTargetRest, AssignmentTargetWithDefault,
+      BindingPattern, Elision, Expression, IdentifierReference, ObjectAssignmentTarget,
+      ObjectExpression, ObjectProperty, ObjectPropertyKind, PropertyKind, SpreadElement,
+    },
+    builder::GetAstBuilder,
   },
   span::SPAN,
 };
 
-use crate::AstFactory;
-
 use super::binding_property_ext::BindingPropertyExt as _;
 
 pub trait BindingPatternExt<'ast> {
-  fn into_assignment_target(self, ast_factory: &AstFactory<'ast>) -> AssignmentTarget<'ast>;
+  fn into_assignment_target<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    self,
+    builder: &B,
+  ) -> AssignmentTarget<'ast>;
 
-  fn into_expression(self, ast_factory: &AstFactory<'ast>) -> Expression<'ast>;
+  fn into_expression<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    self,
+    builder: &B,
+  ) -> Expression<'ast>;
 }
 
 impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
-  fn into_assignment_target(self, ast_factory: &AstFactory<'ast>) -> AssignmentTarget<'ast> {
+  fn into_assignment_target<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    self,
+    builder: &B,
+  ) -> AssignmentTarget<'ast> {
     match self {
       // Turn `var a = 1` into `a = 1`
       BindingPattern::BindingIdentifier(id) => AssignmentTarget::AssignmentTargetIdentifier(
-        IdentifierReference::boxed(id.span, id.name, ast_factory),
+        IdentifierReference::boxed(id.span, id.name, builder),
       ),
       // Turn `var { a, b = 2 } = ...` to `{a, b = 2} = ...`
       BindingPattern::ObjectPattern(mut obj_pat) => {
         let rest = obj_pat.rest.take().map(|rest| {
           AssignmentTargetRest::boxed(
             rest.span,
-            rest.unbox().argument.into_assignment_target(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_assignment_target(builder),
+            builder,
           )
         });
         let mut properties =
-          oxc::allocator::Vec::with_capacity_in(obj_pat.properties.len(), ast_factory);
-        obj_pat.properties.take_in(&ast_factory.allocator()).into_iter().for_each(|binding_prop| {
-          properties.push(binding_prop.into_assignment_target_property(ast_factory));
+          oxc::allocator::Vec::with_capacity_in(obj_pat.properties.len(), builder);
+        obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|binding_prop| {
+          properties.push(binding_prop.into_assignment_target_property(builder));
         });
         AssignmentTarget::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
-          SPAN,
-          properties,
-          rest,
-          ast_factory,
+          SPAN, properties, rest, builder,
         ))
       }
       // Turn `var [a, ,c = 1] = ...` to `[a, ,c = 1] = ...`
@@ -53,35 +60,32 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
         let rest = arr_pat.rest.take().map(|rest| {
           AssignmentTargetRest::boxed(
             rest.span,
-            rest.unbox().argument.into_assignment_target(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_assignment_target(builder),
+            builder,
           )
         });
-        let mut elements =
-          oxc::allocator::Vec::with_capacity_in(arr_pat.elements.len(), ast_factory);
-        arr_pat.elements.take_in(&ast_factory.allocator()).into_iter().for_each(|binding_pat| {
+        let mut elements = oxc::allocator::Vec::with_capacity_in(arr_pat.elements.len(), builder);
+        arr_pat.elements.take_in(&builder.allocator()).into_iter().for_each(|binding_pat| {
           elements.push(binding_pat.map(|binding_pat| match binding_pat {
             BindingPattern::AssignmentPattern(assign_pat) => {
               let assign_pat = assign_pat.unbox();
               AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
                 AssignmentTargetWithDefault::boxed(
                   assign_pat.span,
-                  assign_pat.left.into_assignment_target(ast_factory),
+                  assign_pat.left.into_assignment_target(builder),
                   assign_pat.right,
-                  ast_factory,
+                  builder,
                 ),
               )
             }
-            _ => {
-              AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(ast_factory))
-            }
+            _ => AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(builder)),
           }));
         });
         AssignmentTarget::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
           arr_pat.span,
           elements,
           rest,
-          ast_factory,
+          builder,
         ))
       }
       BindingPattern::AssignmentPattern(_) => {
@@ -90,55 +94,56 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
     }
   }
 
-  fn into_expression(self, ast_factory: &AstFactory<'ast>) -> Expression<'ast> {
+  fn into_expression<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    self,
+    builder: &B,
+  ) -> Expression<'ast> {
     match self {
-      BindingPattern::BindingIdentifier(id) => {
-        Expression::new_identifier(SPAN, id.name, ast_factory)
-      }
+      BindingPattern::BindingIdentifier(id) => Expression::new_identifier(SPAN, id.name, builder),
       BindingPattern::ObjectPattern(mut obj_pat) => {
         let capacity = obj_pat.properties.len() + usize::from(obj_pat.rest.is_some());
-        let mut properties = oxc::allocator::Vec::with_capacity_in(capacity, ast_factory);
-        obj_pat.properties.take_in(&ast_factory.allocator()).into_iter().for_each(|binding_prop| {
+        let mut properties = oxc::allocator::Vec::with_capacity_in(capacity, builder);
+        obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|binding_prop| {
           properties.push(ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
             SPAN,
             PropertyKind::Init,
             binding_prop.key,
-            binding_prop.value.into_expression(ast_factory),
+            binding_prop.value.into_expression(builder),
             false,
             binding_prop.shorthand,
             binding_prop.computed,
-            ast_factory,
+            builder,
           )));
         });
         if let Some(rest) = obj_pat.rest.take() {
           properties.push(ObjectPropertyKind::SpreadProperty(SpreadElement::boxed(
             SPAN,
-            rest.unbox().argument.into_expression(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_expression(builder),
+            builder,
           )));
         }
-        Expression::ObjectExpression(ObjectExpression::boxed(SPAN, properties, ast_factory))
+        Expression::ObjectExpression(ObjectExpression::boxed(SPAN, properties, builder))
       }
       BindingPattern::ArrayPattern(mut arg_pat) => {
         let capacity = arg_pat.elements.len() + usize::from(arg_pat.rest.is_some());
-        let mut elements = oxc::allocator::Vec::with_capacity_in(capacity, ast_factory);
-        arg_pat.elements.take_in(&ast_factory.allocator()).into_iter().for_each(|binding_pat| {
+        let mut elements = oxc::allocator::Vec::with_capacity_in(capacity, builder);
+        arg_pat.elements.take_in(&builder.allocator()).into_iter().for_each(|binding_pat| {
           elements.push(binding_pat.map_or(
-            ArrayExpressionElement::Elision(Elision::boxed(SPAN, ast_factory)),
-            |binding_pat| ArrayExpressionElement::from(binding_pat.into_expression(ast_factory)),
+            ArrayExpressionElement::Elision(Elision::boxed(SPAN, builder)),
+            |binding_pat| ArrayExpressionElement::from(binding_pat.into_expression(builder)),
           ));
         });
         if let Some(rest) = arg_pat.rest.take() {
           elements.push(ArrayExpressionElement::SpreadElement(SpreadElement::boxed(
             SPAN,
-            rest.unbox().argument.into_expression(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_expression(builder),
+            builder,
           )));
         }
-        Expression::ArrayExpression(ArrayExpression::boxed(SPAN, elements, ast_factory))
+        Expression::ArrayExpression(ArrayExpression::boxed(SPAN, elements, builder))
       }
       BindingPattern::AssignmentPattern(mut assign_pat) => {
-        assign_pat.left.take_in(&ast_factory.allocator()).into_expression(ast_factory)
+        assign_pat.left.take_in(&builder.allocator()).into_expression(builder)
       }
     }
   }
@@ -148,12 +153,15 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
 mod tests {
   use oxc::{
     allocator::{Allocator, CloneIn},
-    ast::ast::{ArrayExpressionElement, Expression, ObjectPropertyKind, Statement},
+    ast::{
+      ast::{ArrayExpressionElement, Expression, ObjectPropertyKind, Statement},
+      builder::AstBuilder,
+    },
     parser::Parser,
     span::SourceType,
   };
 
-  use crate::{AstFactory, BindingPatternExt as _};
+  use crate::BindingPatternExt as _;
 
   /// Round-trips the first declarator's binding pattern back to an expression via
   /// `into_expression`. `source` must be a single `const <pattern> = x;` statement.
@@ -163,7 +171,7 @@ mod tests {
       unreachable!("expected a variable declaration")
     };
     let pattern = decl.declarations[0].id.clone_in(allocator);
-    pattern.into_expression(&AstFactory::new(allocator))
+    pattern.into_expression(&AstBuilder::new(allocator))
   }
 
   #[test]

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
@@ -1,27 +1,30 @@
 use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::{IntoIn as _, TakeIn},
-  ast::ast::{
-    ArrayAssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
-    AssignmentTargetPropertyIdentifier, AssignmentTargetPropertyProperty, AssignmentTargetRest,
-    AssignmentTargetWithDefault, BindingPattern, BindingProperty, IdentifierReference,
-    ObjectAssignmentTarget,
+  ast::{
+    ast::{
+      ArrayAssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
+      AssignmentTargetPropertyIdentifier, AssignmentTargetPropertyProperty, AssignmentTargetRest,
+      AssignmentTargetWithDefault, BindingPattern, BindingProperty, IdentifierReference,
+      ObjectAssignmentTarget,
+    },
+    builder::GetAstBuilder,
   },
 };
 
-use crate::{AstFactory, BindingPatternExt as _};
+use crate::BindingPatternExt as _;
 
 pub trait BindingPropertyExt<'ast> {
-  fn into_assignment_target_property(
+  fn into_assignment_target_property<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     self,
-    ast_factory: &AstFactory<'ast>,
+    builder: &B,
   ) -> AssignmentTargetProperty<'ast>;
 }
 
 impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
-  fn into_assignment_target_property(
+  fn into_assignment_target_property<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     self,
-    ast_factory: &AstFactory<'ast>,
+    builder: &B,
   ) -> AssignmentTargetProperty<'ast> {
     match self.value {
       BindingPattern::AssignmentPattern(assign_pat) => {
@@ -31,9 +34,9 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
           AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
             AssignmentTargetPropertyIdentifier::boxed(
               self.span,
-              IdentifierReference::new(binding_id.span, binding_id.name, ast_factory),
+              IdentifierReference::new(binding_id.span, binding_id.name, builder),
               Some(assign_pat.right),
-              ast_factory,
+              builder,
             ),
           )
         } else {
@@ -44,16 +47,16 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
               AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
                 AssignmentTargetWithDefault::boxed(
                   assign_pat.span,
-                  assign_pat.left.into_assignment_target(ast_factory),
+                  assign_pat.left.into_assignment_target(builder),
                   assign_pat.right,
-                  ast_factory,
+                  builder,
                 ),
               ),
               self.computed,
-              ast_factory,
+              builder,
             ),
           )
-          .into_in(ast_factory.allocator())
+          .into_in(builder.allocator())
         }
       }
       BindingPattern::BindingIdentifier(ref id) => {
@@ -61,9 +64,9 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
           AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
             AssignmentTargetPropertyIdentifier::boxed(
               self.span,
-              IdentifierReference::new(id.span, id.name, ast_factory),
+              IdentifierReference::new(id.span, id.name, builder),
               None,
-              ast_factory,
+              builder,
             ),
           )
         } else {
@@ -71,12 +74,12 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
             AssignmentTargetPropertyProperty::boxed(
               self.span,
               self.key,
-              AssignmentTargetMaybeDefault::from(self.value.into_assignment_target(ast_factory)),
+              AssignmentTargetMaybeDefault::from(self.value.into_assignment_target(builder)),
               self.computed,
-              ast_factory,
+              builder,
             ),
           )
-          .into_in(ast_factory.allocator())
+          .into_in(builder.allocator())
         }
       }
       BindingPattern::ArrayPattern(arr_pat) => {
@@ -84,15 +87,14 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
         let rest = arr_pat.rest.take().map(|rest| {
           AssignmentTargetRest::boxed(
             rest.span,
-            rest.unbox().argument.into_assignment_target(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_assignment_target(builder),
+            builder,
           )
         });
-        let mut elements =
-          oxc::allocator::Vec::with_capacity_in(arr_pat.elements.len(), ast_factory);
-        arr_pat.elements.take_in(&ast_factory.allocator()).into_iter().for_each(|element| {
+        let mut elements = oxc::allocator::Vec::with_capacity_in(arr_pat.elements.len(), builder);
+        arr_pat.elements.take_in(&builder.allocator()).into_iter().for_each(|element| {
           elements.push(element.map(|binding_pat| {
-            AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(ast_factory))
+            AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(builder))
           }));
         });
         AssignmentTargetProperty::AssignmentTargetPropertyProperty(
@@ -103,27 +105,27 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
               arr_pat.span,
               elements,
               rest,
-              ast_factory,
+              builder,
             )),
             self.computed,
-            ast_factory,
+            builder,
           ),
         )
-        .into_in(ast_factory.allocator())
+        .into_in(builder.allocator())
       }
       BindingPattern::ObjectPattern(obj_pat) => {
         let mut obj_pat = obj_pat.unbox();
         let rest = obj_pat.rest.take().map(|rest| {
           AssignmentTargetRest::boxed(
             rest.span,
-            rest.unbox().argument.into_assignment_target(ast_factory),
-            ast_factory,
+            rest.unbox().argument.into_assignment_target(builder),
+            builder,
           )
         });
         let mut properties =
-          oxc::allocator::Vec::with_capacity_in(obj_pat.properties.len(), ast_factory);
-        obj_pat.properties.take_in(&ast_factory.allocator()).into_iter().for_each(|property| {
-          properties.push(property.into_assignment_target_property(ast_factory));
+          oxc::allocator::Vec::with_capacity_in(obj_pat.properties.len(), builder);
+        obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|property| {
+          properties.push(property.into_assignment_target_property(builder));
         });
         AssignmentTargetProperty::AssignmentTargetPropertyProperty(
           AssignmentTargetPropertyProperty::boxed(
@@ -133,13 +135,13 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
               obj_pat.span,
               properties,
               rest,
-              ast_factory,
+              builder,
             )),
             self.computed,
-            ast_factory,
+            builder,
           ),
         )
-        .into_in(ast_factory.allocator())
+        .into_in(builder.allocator())
       }
     }
   }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/mod.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/mod.rs
@@ -1,4 +1,4 @@
-mod binding_property_ext;
+pub mod binding_property_ext;
 
 pub mod binding_pattern_ext;
 pub mod call_expression_ext;

--- a/crates/rolldown_ecmascript_utils/src/lib.rs
+++ b/crates/rolldown_ecmascript_utils/src/lib.rs
@@ -6,10 +6,14 @@ mod source_utils;
 
 pub use crate::{
   ast_factory::{
-    AstFactory, EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperDeclKind, EsmWrapperStmtOptions,
+    BindingIdentifierFactoryExt, CallExpressionFactoryExt, ClassElementFactoryExt,
+    EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperDeclKind, EsmWrapperStmtOptions,
+    ExpressionFactoryExt, IdentifierNameFactoryExt, MemberExpressionFactoryExt,
+    ObjectPropertyKindFactoryExt, StatementFactoryExt,
   },
   extensions::ast_ext::{
     binding_pattern_ext::BindingPatternExt,
+    binding_property_ext::BindingPropertyExt,
     call_expression_ext::CallExpressionExt,
     expression_ext::ExpressionExt,
     function::FunctionExt,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -1,10 +1,11 @@
 use oxc::allocator::GetAllocator;
+use oxc::ast::builder::AstBuilder;
 use oxc::{
   allocator::{CloneIn as _, TakeIn as _},
   ast::{
     ast::{
       Argument, ArrowFunctionExpression, AwaitExpression, BindingPattern, BindingProperty,
-      Declaration, Expression, FormalParameterKind, FormalParameters, FunctionBody,
+      Declaration, Expression, FormalParameterKind, FormalParameters, FunctionBody, IdentifierName,
       MemberExpression, ObjectPattern, PropertyKey, ReturnStatement, Statement,
       StaticMemberExpression, VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
     },
@@ -14,21 +15,23 @@ use oxc::{
   semantic::ScopeFlags,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::{AstFactory, BindingPatternExt as _};
+use rolldown_ecmascript_utils::{
+  BindingPatternExt as _, ExpressionFactoryExt as _, IdentifierNameFactoryExt as _,
+};
 
 use super::ast_visit::BuildImportAnalysisVisitor;
 
 impl<'a> BuildImportAnalysisVisitor<'a> {
   #[expect(clippy::fn_params_excessive_bools)]
   pub fn new(
-    ast_factory: AstFactory<'a>,
+    ast_builder: AstBuilder<'a>,
     insert_preload: bool,
     render_built_url: bool,
     is_relative_base: bool,
     is_modern: bool,
   ) -> Self {
     Self {
-      ast_factory,
+      ast_builder,
       is_modern,
       insert_preload,
       render_built_url,
@@ -66,20 +69,20 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
             oxc::allocator::Vec::from_value_in(
               BindingProperty::new(
                 SPAN,
-                PropertyKey::new_static_identifier(SPAN, key, &self.ast_factory),
-                BindingPattern::new_binding_identifier(SPAN, value, &self.ast_factory),
+                PropertyKey::new_static_identifier(SPAN, key, &self.ast_builder),
+                BindingPattern::new_binding_identifier(SPAN, value, &self.ast_builder),
                 true,
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
-              &self.ast_factory,
+              &self.ast_builder,
             ),
             NONE,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          await_expr.take_in(&self.ast_factory.allocator()),
+          await_expr.take_in(&self.ast_builder.allocator()),
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       ));
       return true;
     }
@@ -112,7 +115,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       };
       match &params.items.first()?.pattern {
         BindingPattern::ObjectPattern(object_pat) => {
-          Some(object_pat.clone_in(self.ast_factory.allocator()))
+          Some(object_pat.clone_in(self.ast_builder.allocator()))
         }
         _ => None,
       }
@@ -127,8 +130,8 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         object_pat,
         Expression::new_await_expression(
           SPAN,
-          callee.object.take_in(&self.ast_factory.allocator()),
-          &self.ast_factory,
+          callee.object.take_in(&self.ast_builder.allocator()),
+          &self.ast_builder,
         ),
       );
       walk_arguments(self, &mut call_expr.arguments);
@@ -137,9 +140,11 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
     // For non-destructuring: wrap the entire import().then() expression
     walk_arguments(self, &mut call_expr.arguments);
-    let import_then_expr = expr.take_in(&self.ast_factory.allocator());
-    *expr = self
-      .vite_preload_call(Argument::from(self.ast_factory.make_arrow_returning(import_then_expr)));
+    let import_then_expr = expr.take_in(&self.ast_builder.allocator());
+    *expr = self.vite_preload_call(Argument::from(Expression::new_arrow_returning(
+      import_then_expr,
+      &self.ast_builder,
+    )));
     true
   }
 
@@ -147,9 +152,10 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   /// to `__vitePreload(() => import('foo'),...)`
   pub fn rewrite_import_expr(&self, expr: &mut Expression<'a>) -> bool {
     let Expression::ImportExpression(_) = expr else { return false };
-    *expr = self.vite_preload_call(Argument::from(
-      self.ast_factory.make_arrow_returning(expr.take_in(&self.ast_factory.allocator())),
-    ));
+    *expr = self.vite_preload_call(Argument::from(Expression::new_arrow_returning(
+      expr.take_in(&self.ast_builder.allocator()),
+      &self.ast_builder,
+    )));
     true
   }
 
@@ -167,16 +173,16 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         FormalParameters::new(
           SPAN,
           FormalParameterKind::Signature,
-          oxc::allocator::Vec::new_in(&self.ast_factory),
+          oxc::allocator::Vec::new_in(&self.ast_builder),
           NONE,
-          &self.ast_factory,
+          &self.ast_builder,
         ),
         NONE,
         FunctionBody::new(
           SPAN,
-          oxc::allocator::Vec::new_in(&self.ast_factory),
+          oxc::allocator::Vec::new_in(&self.ast_builder),
           {
-            let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_factory);
+            let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_builder);
             statements.push(Statement::from(Declaration::VariableDeclaration(
               VariableDeclaration::boxed(
                 SPAN,
@@ -186,29 +192,29 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
                     SPAN,
                     VariableDeclarationKind::Const,
                     BindingPattern::ObjectPattern(
-                      object_pat.clone_in(self.ast_factory.allocator()),
+                      object_pat.clone_in(self.ast_builder.allocator()),
                     ),
                     NONE,
                     Some(await_expr),
                     false,
-                    &self.ast_factory,
+                    &self.ast_builder,
                   ),
-                  &self.ast_factory,
+                  &self.ast_builder,
                 ),
                 false,
-                &self.ast_factory,
+                &self.ast_builder,
               ),
             )));
             statements.push(Statement::ReturnStatement(ReturnStatement::boxed(
               SPAN,
-              Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_factory)),
-              &self.ast_factory,
+              Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_builder)),
+              &self.ast_builder,
             )));
             statements
           },
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       ),
     )))
   }
@@ -216,18 +222,18 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
     Expression::new_call_expression(
       SPAN,
-      self.ast_factory.make_id_ref_expr(SPAN, "__vitePreload"),
+      Expression::new_id_ref_expr(SPAN, "__vitePreload", &self.ast_builder),
       NONE,
       {
         let append_import_meta_url = self.render_built_url || self.is_relative_base;
         let capacity = if append_import_meta_url { 3 } else { 2 };
-        let mut items = oxc::allocator::Vec::with_capacity_in(capacity, &self.ast_factory);
+        let mut items = oxc::allocator::Vec::with_capacity_in(capacity, &self.ast_builder);
 
         items.push(argument);
         items.push(Argument::from(if self.is_modern {
-          self.ast_factory.make_id_ref_expr(SPAN, "__VITE_PRELOAD__")
+          Expression::new_id_ref_expr(SPAN, "__VITE_PRELOAD__", &self.ast_builder)
         } else {
-          Expression::new_void_0(SPAN, &self.ast_factory)
+          Expression::new_void_0(SPAN, &self.ast_builder)
         }));
         if append_import_meta_url {
           items.push(Argument::from(Expression::from(
@@ -235,20 +241,20 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
               SPAN,
               Expression::new_meta_property(
                 SPAN,
-                self.ast_factory.make_id_name(SPAN, "import"),
-                self.ast_factory.make_id_name(SPAN, "meta"),
-                &self.ast_factory,
+                IdentifierName::new_id_name(SPAN, "import", &self.ast_builder),
+                IdentifierName::new_id_name(SPAN, "meta", &self.ast_builder),
+                &self.ast_builder,
               ),
-              self.ast_factory.make_id_name(SPAN, "url"),
+              IdentifierName::new_id_name(SPAN, "url", &self.ast_builder),
               false,
-              &self.ast_factory,
+              &self.ast_builder,
             ),
           )));
         }
         items
       },
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     )
   }
 }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -1,10 +1,12 @@
 use oxc::allocator::GetAllocator;
+use oxc::ast::builder::AstBuilder;
 use oxc::{
   allocator::CloneIn as _,
   ast::{
     ast::{
-      BindingPattern, Expression, ImportDeclarationSpecifier, ImportOrExportKind,
-      ModuleDeclaration, ModuleExportName, Statement, StringLiteral, VariableDeclaration,
+      BindingIdentifier, BindingPattern, Expression, ImportDeclarationSpecifier,
+      ImportOrExportKind, ModuleDeclaration, ModuleExportName, Statement, StringLiteral,
+      VariableDeclaration,
     },
     builder::NONE,
   },
@@ -12,7 +14,7 @@ use oxc::{
   semantic::ScopeFlags,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::AstFactory;
+use rolldown_ecmascript_utils::BindingIdentifierFactoryExt as _;
 
 use super::PRELOAD_HELPER_ID;
 
@@ -20,7 +22,7 @@ const PRELOAD_METHOD: &str = "__vitePreload";
 
 #[expect(clippy::struct_excessive_bools)]
 pub struct BuildImportAnalysisVisitor<'a> {
-  pub ast_factory: AstFactory<'a>,
+  pub ast_builder: AstBuilder<'a>,
   pub scope_stack: Vec<ScopeFlags>,
   pub insert_preload: bool,
   pub has_inserted_helper: bool,
@@ -39,18 +41,18 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
         Some(oxc::allocator::Vec::from_value_in(
           ImportDeclarationSpecifier::new_import_specifier(
             SPAN,
-            ModuleExportName::new_identifier_name(SPAN, PRELOAD_METHOD, &self.ast_factory),
-            self.ast_factory.make_id(SPAN, PRELOAD_METHOD),
+            ModuleExportName::new_identifier_name(SPAN, PRELOAD_METHOD, &self.ast_builder),
+            BindingIdentifier::new_id(SPAN, PRELOAD_METHOD, &self.ast_builder),
             ImportOrExportKind::Value,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         )),
-        StringLiteral::new(SPAN, PRELOAD_HELPER_ID, None, &self.ast_factory),
+        StringLiteral::new(SPAN, PRELOAD_HELPER_ID, None, &self.ast_builder),
         None,
         NONE,
         ImportOrExportKind::Value,
-        &self.ast_factory,
+        &self.ast_builder,
       )));
     }
   }
@@ -88,10 +90,10 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
           decl.init = Some(Expression::new_await_expression(
             SPAN,
             self.construct_vite_preload_call(
-              object_pat.clone_in(self.ast_factory.allocator()),
+              object_pat.clone_in(self.ast_builder.allocator()),
               decl.init.take().unwrap(),
             ),
-            &self.ast_factory,
+            &self.ast_builder,
           ));
           self.need_prepend_helper = true;
         } else {

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -4,9 +4,9 @@ mod ast_visit;
 use std::borrow::Cow;
 
 use arcstr::ArcStr;
+use oxc::ast::builder::AstBuilder;
 use oxc::ast_visit::VisitMut;
 use rolldown_common::side_effects::HookSideEffects;
-use rolldown_ecmascript_utils::AstFactory;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
   HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, HookUsage, Plugin,
@@ -60,9 +60,9 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
   ) -> HookTransformAstReturn {
     let mut ast = args.ast;
     ast.program.with_mut(|fields| {
-      let ast_factory = AstFactory::new(fields.allocator);
+      let ast_builder = AstBuilder::new(fields.allocator);
       let mut visitor = BuildImportAnalysisVisitor::new(
-        ast_factory,
+        ast_builder,
         self.insert_preload,
         self.render_built_url,
         self.is_relative_base,

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -1,20 +1,25 @@
+use oxc::ast::builder::AstBuilder;
 use oxc::{
   ast::ast::{
-    Expression, IdentifierName, ObjectExpression, ObjectPropertyKind, StaticMemberExpression,
+    Expression, IdentifierName, ObjectExpression, ObjectPropertyKind, Statement,
+    StaticMemberExpression,
   },
   ast_visit::VisitMut,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::{AstFactory, ExpressionExt as _};
+use rolldown_ecmascript_utils::{
+  ExpressionExt as _, ExpressionFactoryExt as _, IdentifierNameFactoryExt as _,
+  StatementFactoryExt as _,
+};
 
 pub struct WebWorkerPostVisitor<'ast> {
-  pub ast_factory: AstFactory<'ast>,
+  pub ast_builder: AstBuilder<'ast>,
   pub should_inject_import_meta_object: bool,
 }
 
 impl<'ast> WebWorkerPostVisitor<'ast> {
-  pub fn new(ast_factory: AstFactory<'ast>) -> Self {
-    Self { ast_factory, should_inject_import_meta_object: false }
+  pub fn new(ast_builder: AstBuilder<'ast>) -> Self {
+    Self { ast_builder, should_inject_import_meta_object: false }
   }
 
   #[inline]
@@ -23,20 +28,20 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
       SPAN,
       Expression::StaticMemberExpression(StaticMemberExpression::boxed(
         SPAN,
-        self.ast_factory.make_id_ref_expr(SPAN, "self"),
-        self.ast_factory.make_id_name(SPAN, "location"),
+        Expression::new_id_ref_expr(SPAN, "self", &self.ast_builder),
+        IdentifierName::new_id_name(SPAN, "location", &self.ast_builder),
         false,
-        &self.ast_factory,
+        &self.ast_builder,
       )),
-      self.ast_factory.make_id_name(SPAN, "href"),
+      IdentifierName::new_id_name(SPAN, "href", &self.ast_builder),
       false,
-      &self.ast_factory,
+      &self.ast_builder,
     ))
   }
 
   #[inline]
   fn create_import_meta_object_decl(&self) -> oxc::ast::ast::Statement<'ast> {
-    self.ast_factory.make_var_decl(
+    Statement::new_var_decl(
       "_vite_importMeta",
       Expression::ObjectExpression(ObjectExpression::boxed(
         SPAN,
@@ -46,19 +51,20 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
             oxc::ast::ast::PropertyKind::Init,
             oxc::ast::ast::PropertyKey::StaticIdentifier(IdentifierName::boxed(
               SPAN,
-              oxc::ast::ast::Str::from_str_in("url", &self.ast_factory),
-              &self.ast_factory,
+              oxc::ast::ast::Str::from_str_in("url", &self.ast_builder),
+              &self.ast_builder,
             )),
             self.create_self_location_href_expr(),
             false,
             false,
             false,
-            &self.ast_factory,
+            &self.ast_builder,
           ),
-          &self.ast_factory,
+          &self.ast_builder,
         ),
-        &self.ast_factory,
+        &self.ast_builder,
       )),
+      &self.ast_builder,
     )
   }
 }
@@ -82,7 +88,7 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
         if meta.meta.name == "import" && meta.property.name == "meta" =>
       {
         self.should_inject_import_meta_object = true;
-        *it = self.ast_factory.make_id_ref_expr(SPAN, "_vite_importMeta");
+        *it = Expression::new_id_ref_expr(SPAN, "_vite_importMeta", &self.ast_builder);
       }
       _ => oxc::ast_visit::walk_mut::walk_expression(self, it),
     }

--- a/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
@@ -2,8 +2,8 @@ mod ast_visitor;
 
 use std::borrow::Cow;
 
+use oxc::ast::builder::AstBuilder;
 use oxc::ast_visit::VisitMut;
-use rolldown_ecmascript_utils::AstFactory;
 use rolldown_plugin::{HookUsage, Plugin, PluginHookMeta, PluginOrder};
 
 use crate::ast_visitor::WebWorkerPostVisitor;
@@ -26,8 +26,8 @@ impl Plugin for ViteWebWorkerPostPlugin {
     mut args: rolldown_plugin::HookTransformAstArgs<'_>,
   ) -> rolldown_plugin::HookTransformAstReturn {
     args.ast.program.with_mut(|fields| {
-      let ast_factory = AstFactory::new(fields.allocator);
-      let mut visitor = WebWorkerPostVisitor::new(ast_factory);
+      let ast_builder = AstBuilder::new(fields.allocator);
+      let mut visitor = WebWorkerPostVisitor::new(ast_builder);
       visitor.visit_program(fields.program);
     });
     Ok(args.ast)

--- a/internal-docs/ast-construction/implementation.md
+++ b/internal-docs/ast-construction/implementation.md
@@ -2,120 +2,116 @@
 
 ## Summary
 
-Rolldown synthesizes oxc AST nodes in many places — module finalizers, the scanner's pre-processing, HMR, and plugins. Historically it did so through several competing idioms (a hand-maintained `AstSnippet` facade, raw `oxc::ast::AstBuilder`, construction-flavored extension traits, and `..Foo::dummy(alloc)` struct-update literals). oxc has since made `AstBuilder` the single sanctioned construction path (`#[non_exhaustive]` on every `NodeId`-bearing node, oxc 0.135 / [oxc#23046](https://github.com/oxc-project/oxc/pull/23046)), which deleted the struct-literal idiom outright.
+Rolldown synthesizes oxc AST nodes in many places — module finalizers, the scanner's pre-processing, HMR, and plugins. Historically it did so through several competing idioms (a hand-maintained `AstSnippet` facade, raw `oxc::ast::AstBuilder`, construction-flavored extension traits, and `..Foo::dummy(alloc)` struct-update literals). oxc has since made `AstBuilder` the single sanctioned construction path (`#[non_exhaustive]` on every `NodeId`-bearing node, oxc 0.135 / [oxc#23046](https://github.com/oxc-project/oxc/pull/23046)), which deleted the struct-literal idiom outright, and then ([oxc#23043](https://github.com/oxc-project/oxc/issues/23043), oxc 0.138) moved construction onto the AST types themselves as per-type associated functions that take the builder/allocator as their **last** argument.
 
-Going forward rolldown routes **all** construction through a single rolldown-owned newtype, **`AstFactory`**, which wraps oxc's `AstBuilder` (implementing `GetAstBuilder` / `GetAllocator` so it can be passed to oxc's per-type node constructors) and adds rolldown's own recurring constructions as inherent `make_*` methods. Funnelling everything through one rolldown type — rather than calling oxc's `AstBuilder` directly at each site — is what let rolldown absorb the oxc `AstBuilder` redesign ([oxc#23043](https://github.com/oxc-project/oxc/issues/23043), oxc 0.138) at a single point. This document records that decision and the reasoning.
+Rolldown now follows that same shape end to end:
+
+- **Generic nodes** are built with oxc's per-type constructors directly — `Expression::new_identifier(SPAN, name, builder)`, `StaticMemberExpression::boxed(.., builder)`, `oxc::allocator::Vec::new_in(builder)` — passing an `AstBuilder` (or any `GetAstBuilder` + `GetAllocator` holder) as the last argument.
+- **Rolldown's own recurring constructions** are `new_*` associated functions on rolldown-owned **extension traits**, one per node type they produce (`ExpressionFactoryExt`, `StatementFactoryExt`, `MemberExpressionFactoryExt`, `CallExpressionFactoryExt`, `BindingIdentifierFactoryExt`, `IdentifierNameFactoryExt`, `ObjectPropertyKindFactoryExt`, `ClassElementFactoryExt`). They too take the builder last: `Expression::new_id_ref_expr(SPAN, name, builder)`, `Statement::new_commonjs_wrapper_stmt(.., builder)`.
+
+There is no rolldown wrapper type around `AstBuilder` anymore. Rolldown holds and passes oxc's `AstBuilder` directly. This document records that decision and the reasoning.
+
+See also `internal-docs/ast-mutation/implementation.md` for the span/`NodeId`-as-identity contract that constrains synthesized nodes.
 
 ## Prior state
 
 Before this convention, the same kind of node could be built four different ways, and the entry points overlapped:
 
-- **`AstSnippet`** (`crates/rolldown_ecmascript_utils/src/ast_snippet.rs`, ~1030 lines, ~50 methods). A wrapper around `AstBuilder` that mixes two unrelated jobs: thin renames of single `AstBuilder` calls (`id_ref_expr`, the `call_expr_with_*` family, `string_literal_expr`, …) and genuine multi-node rolldown patterns (`wrap_with_to_esm`, `commonjs_wrapper_stmt`, the `.then` chains). Its naming is sprawling and undiscoverable — the call-expression family alone encodes arg-count/return-shape into a suffix matrix (`call_expr_with_arg_expr` vs `_with_arg_expr_expr` vs `_with_2arg_expr_expr` …). The author already flagged the type name as a compromise:
+- **`AstSnippet`** (`crates/rolldown_ecmascript_utils/src/ast_snippet.rs`, ~1030 lines, ~50 methods). A wrapper around `AstBuilder` that mixed two unrelated jobs: thin renames of single `AstBuilder` calls (`id_ref_expr`, the `call_expr_with_*` family, `string_literal_expr`, …) and genuine multi-node rolldown patterns (`wrap_with_to_esm`, `commonjs_wrapper_stmt`, the `.then` chains). Its naming was sprawling and undiscoverable — the call-expression family alone encoded arg-count/return-shape into a suffix matrix (`call_expr_with_arg_expr` vs `_with_arg_expr_expr` vs `_with_2arg_expr_expr` …). The author already flagged the type name as a compromise:
 
   ```rust
-  // crates/rolldown_ecmascript_utils/src/ast_snippet.rs
   // `AstBuilder` is more suitable name, but it's already used in oxc.
   pub struct AstSnippet<'ast> {
     pub builder: AstBuilder<'ast>,
   }
   ```
 
-- **The `pub builder` escape hatch.** Because `AstSnippet::builder` is public, roughly half of all AstSnippet interactions bypass the helpers and reach straight through to raw `AstBuilder` (~219 `snippet.builder.*` call sites vs. ~196 named-helper calls). The facade coexists with the thing it wraps instead of encapsulating it.
+- **The `pub builder` escape hatch.** Because `AstSnippet::builder` was public, roughly half of all AstSnippet interactions bypassed the helpers and reached straight through to raw `AstBuilder` (~219 `snippet.builder.*` call sites vs. ~196 named-helper calls). The facade coexisted with the thing it wrapped instead of encapsulating it.
 
-- **Ad-hoc `AstBuilder` access.** Construction-flavored extension traits (`crates/rolldown_ecmascript_utils/src/extensions/ast_ext/`) that only receive `&Allocator` build a fresh `AstBuilder::new(alloc)` inline — a third way to obtain a builder, alongside `self.ast`-style fields and `snippet.builder`.
+- **Ad-hoc `AstBuilder` access.** Construction-flavored extension traits (`crates/rolldown_ecmascript_utils/src/extensions/ast_ext/`) that only receive `&Allocator` built a fresh `AstBuilder::new(alloc)` inline — a third way to obtain a builder, alongside `self.ast`-style fields and `snippet.builder`.
 
-- **`..Foo::dummy(alloc)` struct-update literals.** Previously the most direct way to spell a node. oxc 0.135's `#[non_exhaustive]` makes this uncompilable for any `NodeId`-bearing node; [#9670](https://github.com/rolldown/rolldown/pull/9670) migrated the ~26 affected sites (in `module_finalizers/` and the `ast_ext` traits) onto `AstBuilder` constructors. The remaining `::dummy()` sites are on non-node types (options/config) and are unaffected.
+- **`..Foo::dummy(alloc)` struct-update literals.** Previously the most direct way to spell a node. oxc 0.135's `#[non_exhaustive]` made this uncompilable for any `NodeId`-bearing node; [#9670](https://github.com/rolldown/rolldown/pull/9670) migrated the ~26 affected sites onto `AstBuilder` constructors. The remaining `::dummy()` sites are on non-node types (options/config) and are unaffected.
 
-- **Parse-from-source-string.** Not all AST is built — some is authored as JS source and parsed via `EcmaCompiler::parse` (`crates/rolldown_ecmascript/src/ecma_compiler.rs`), which parses a source string into a standalone `EcmaAst` with its own allocator. On the output side this is essentially just the runtime module (`crates/rolldown/src/module_loader/runtime_module_task.rs:226`). The ~35 direct oxc `Parser::new` sites in plugins and scanner sub-analyzers parse _input_ source to analyze or transform it — a different activity from constructing rolldown's own AST.
+- **Parse-from-source-string.** Not all AST is built — some is authored as JS source and parsed via `EcmaCompiler::parse` (`crates/rolldown_ecmascript/src/ecma_compiler.rs`), which parses a source string into a standalone `EcmaAst` with its own allocator. On the output side this is essentially just the runtime module (`crates/rolldown/src/module_loader/runtime_module_task.rs`). The direct oxc `Parser::new` sites in plugins and scanner sub-analyzers parse _input_ source to analyze or transform it — a different activity from constructing rolldown's own AST.
+
+The `AstSnippet` facade was first replaced (oxc#23043 cutover, oxc 0.138) by a thin rolldown newtype, `AstFactory`, wrapping `AstBuilder`. That newtype has since been removed too (see [Migration](#migration)); construction now lives on the AST types, matching oxc.
 
 Two facts constrain every choice and are documented in [ast-mutation](../ast-mutation/implementation.md): synthesized nodes must carry the reserved synthetic span (`SPAN`, `0..0`) — the cross-pass side tables are `NodeId`-keyed now, so the span no longer prevents false matches, but `span.is_unspanned()` checks (such as the global-`require` rewrite guard in `crates/rolldown/src/module_finalizers/mod.rs`) still use it to tell synthesized nodes from scanned ones — and rolldown does not re-run semantic after finalize, so synthesized nodes keep a dummy `NodeId` for life; that dummy id is what keeps them from matching scan-time records.
 
 ## The convention
 
-Everything goes through one handle, `ast_factory: AstFactory<'a>` — rolldown's newtype over `oxc::ast::builder::AstBuilder`. Pick the tool by what you are building:
+Pick the tool by what you are building. In both cases the thing you build _through_ is a value implementing oxc's `GetAstBuilder` + `GetAllocator` — an `AstBuilder`, or any context that holds one — passed as the **last** argument.
 
-### Generic nodes → oxc's per-type constructors, passing the `ast_factory` handle
+### Generic nodes → oxc's per-type constructors
 
-Since oxc#23043 (oxc 0.138), construction lives on the AST types themselves as per-type associated functions that take the builder/allocator as the **last** argument: `Expression::new_call_expression(.., gen)`, `StaticMemberExpression::boxed(.., gen)`, `oxc::allocator::Vec::new_in(gen)`, `oxc::ast::ast::Str::from_str_in(s, gen)`. `AstFactory` implements oxc's `GetAstBuilder` and `GetAllocator`, so the `ast_factory` handle _is_ the generator you pass:
-
-```rust
-// before (pre-0.138): a method on the builder, reached through Deref
-let member = ast_factory.alloc_static_member_expression(SPAN, object, property, false);
-
-// after: the per-type constructor, with the handle passed last
-let member = StaticMemberExpression::boxed(SPAN, object, property, false, &ast_factory);
-```
-
-Inside an `&self` method that holds the handle, pass `self` directly (it implements the traits); from a value handle pass `&ast_factory` / `&self.ast_factory`. The naming maps mechanically: `alloc_X` → `X::boxed`, a plain value constructor `x` → `X::new`, and an enum constructor → `Enum::new_<variant>` (e.g. `expression_call` built `Expression::CallExpression`, so it is `Expression::new_call_expression`). Don't construct an `AstFactory` / `AstBuilder` ad hoc when a handle is already in scope. oxc's constructors are positional; preface a verbose chunk with a comment showing the JS it produces, as oxc itself recommends.
-
-### Rolldown-specific patterns → inherent `make_*` methods on `AstFactory`
-
-For constructions that compose several nodes into a recurring rolldown convention (CJS/ESM interop wrappers, `__toESM` / `__toCommonJS` calls, `.then` chains, …), add an inherent `make_*` method to the `AstFactory` newtype rather than open-coding it at the call site:
+Since oxc#23043 (oxc 0.138), construction lives on the AST types themselves as per-type associated functions: `Expression::new_call_expression(.., builder)`, `StaticMemberExpression::boxed(.., builder)`, `oxc::allocator::Vec::new_in(builder)`, `oxc::ast::ast::Str::from_str_in(s, builder)`.
 
 ```rust
-pub struct AstFactory<'a>(oxc::ast::builder::AstBuilder<'a>);
-
-// generic oxc constructors reach the handle through these traits
-impl<'a> GetAllocator<'a> for AstFactory<'a> {
-  fn allocator(&self) -> &'a Allocator { self.0.allocator() }
-}
-impl<'a> GetAstBuilder<'a> for AstFactory<'a> {
-  type Builder = AstBuilder<'a>;
-  fn builder(&self) -> &AstBuilder<'a> { &self.0 }
-}
-
-impl<'a> AstFactory<'a> {                     // rolldown's own patterns
-  pub fn make_to_esm_wrapper(&self, namespace: Expression<'a>) -> Expression<'a> { /* ... */ }
-  pub fn make_commonjs_wrapper(&self, /* ... */) -> Statement<'a> { /* ... */ }
-}
+// A member expression, built with oxc's per-type constructor, builder passed last.
+let member = StaticMemberExpression::boxed(SPAN, object, property, false, builder);
 ```
 
-These methods:
+The naming maps mechanically: `alloc_X` → `X::boxed`, a plain value constructor `x` → `X::new`, and an enum constructor → `Enum::new_<variant>` (e.g. `Expression::new_call_expression` builds `Expression::CallExpression`). oxc's constructors are positional; preface a verbose chunk with a comment showing the JS it produces, as oxc itself recommends.
 
-- are prefixed **`make_`** and named after the **operation** (`make_to_esm_wrapper`), never after a bare AST node;
-- mirror oxc's builder signature style: positional args, `make_<x>` returns a value and `make_alloc_<x>` returns a boxed node. A caller-provided `span` comes first as in oxc, but most `make_*` patterns synthesize nodes with the reserved `SPAN` internally and take no span. They take **`&self`** and pass `self` as the generator to oxc's per-type constructors (`self` implements `GetAstBuilder` / `GetAllocator`). `&self` keeps the **call sites** independent of `Copy` — the handle is borrowed, never moved, so reusing it after a `make_*` call always compiles.
+### Rolldown-specific patterns → `new_*` associated functions on extension traits
 
-A method earns a place here only if it encodes a multi-step rolldown convention that is wrong-by-default when open-coded — not merely to shorten one oxc call.
+For constructions that compose several nodes into a recurring rolldown convention (CJS/ESM interop wrappers, `__toESM` / `__toCommonJS` calls, `.then` chains, …), add a `new_*` associated function to the extension trait for the node type it produces, rather than open-coding it at the call site. All the traits live in one module (`crates/rolldown_ecmascript_utils/src/ast_factory.rs`) and are re-exported from the crate root, so a call site pulls in the ones it needs with a single `use`, imported `as _`:
+
+```rust
+use rolldown_ecmascript_utils::{ExpressionFactoryExt as _, StatementFactoryExt as _};
+
+let stmt = Statement::new_commonjs_wrapper_stmt(binding_name, /* … */, builder);
+let id_ref = Expression::new_id_ref_expr(SPAN, name, builder);
+```
+
+Rolldown can't add inherent methods to oxc's foreign types, so these live on traits. They're imported `as _` — the `new_*` methods are all a call site needs, the trait name never appears — which also keeps them from clashing with the same-typed inspection traits (`ExpressionExt`, …).
+
+These functions:
+
+- are prefixed **`new_`** and named after the **operation** (`new_to_esm_wrapper`), never after a bare AST node;
+- are **associated functions** (no `self`) generic over `B: GetAstBuilder<'ast> + GetAllocator<'ast>`, taking the builder as the **last** argument, exactly like oxc's own per-type constructors. A caller-provided `span` comes first as in oxc, but most `new_*` patterns synthesize nodes with the reserved `SPAN` internally and take no span;
+- live on the extension trait for the node type they **return** (`Expression::new_*` on `ExpressionFactoryExt`, `Statement::new_*` on `StatementFactoryExt`, …). Private multi-step helpers that don't warrant a public entry point are free functions in the same module.
+
+A function earns a place here only if it encodes a multi-step rolldown convention that is wrong-by-default when open-coded — not merely to shorten one oxc call.
 
 ### Build programmatically by default; parsing source is an exception
 
-Construct nodes through the `ast_factory` handle (oxc per-type constructors taking the handle, rolldown patterns via `make_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
+Construct nodes programmatically (oxc per-type constructors, rolldown patterns via `new_*`). This is the default for **all** node construction, including code rolldown emits, because direct construction has no runtime cost whereas parsing a source string pays lexing + parsing overhead on every build.
 
-Authoring code as JS source and parsing it (`EcmaCompiler::parse`) is reserved for a large, fixed body of code where maintaining it as real JS clearly outweighs the one-time parse cost. In practice that is the **runtime module** (`crates/rolldown/src/module_loader/runtime_module_task.rs:226`) and essentially nothing else on the output side — treat it as a special case, not a tool to reach for. Never parse for nodes that splice into an existing AST and need a synthetic `SPAN` + dummy `NodeId` — build those programmatically, per the constraint above.
+Authoring code as JS source and parsing it (`EcmaCompiler::parse`) is reserved for a large, fixed body of code where maintaining it as real JS clearly outweighs the one-time parse cost. In practice that is the **runtime module** (`crates/rolldown/src/module_loader/runtime_module_task.rs`) and essentially nothing else on the output side. Never parse for nodes that splice into an existing AST and need a synthetic `SPAN` + dummy `NodeId` — build those programmatically, per the constraint above.
 
 ### Read-only inspection → `as_*` / `is_*`
 
-Keep read-only inspection helpers separate from construction; they are not methods on `AstFactory`.
+Keep read-only inspection helpers (on `ExpressionExt`, `CallExpressionExt`, `StatementExt`, …) separate from construction. Construction traits are named `*FactoryExt` and carry only `new_*`; inspection traits carry only `as_*` / `is_*`.
 
-## Why `make_` + operation names
+## Naming: `new_` + operation, never variant
 
-The prefix is not decoration — it does two jobs:
+rolldown's constructors share oxc's `new_` prefix — they read as constructors and match oxc's own convention (the oxc maintainer who proposed this shape uses it too). Two rules keep them coherent:
 
-- **Every call site self-identifies.** A generic node is an oxc per-type constructor (`Expression::new_call_expression(.., &ast_factory)`); a `make_*` name (`ast_factory.make_to_esm_wrapper(..)`) is a rolldown method on `AstFactory`. The distinction is carried by naming: oxc constructors are named after the node they produce (nouns), rolldown's after the operation they perform (verbs).
-- **It keeps rolldown's additions in their own namespace.** The `make_` prefix means an inherent `AstFactory` method never collides with an oxc constructor name, and a reader always knows whether a construction is a generic oxc node or a rolldown convention.
+- **Name after the operation, not the node.** An oxc per-type constructor is named after the node it produces (`Expression::new_call_expression`, a noun); a rolldown convention is named after the operation it performs (`Expression::new_to_esm_wrapper`, a verb). A reader tells them apart by the noun-vs-verb name — and rolldown's are the ones reached through an imported `*FactoryExt` trait.
+- **The operation names are what keep the two disjoint.** rolldown's functions are trait associated functions on oxc's types, so a name that collided with an oxc _inherent_ constructor would be silently shadowed by oxc's. Sharing the `new_` prefix, rolldown relies on the operation-vs-variant split to stay clear: no rolldown operation name (`new_keep_name_call`, `new_re_export_call`, …) matches an oxc variant name. This is a discipline, not the guarantee the old `make_` prefix gave — when adding a `new_*` helper pick a name oxc won't use; a signature-incompatible clash fails to compile, and the snapshot suite catches anything subtler.
 
-The handle is spelled out as `ast_factory` rather than a bare `ast`: it reads unambiguously as an instance of `AstFactory`, and isn't visually confused with oxc's `ast` module that some files import.
+## Why methods-on-types, and no wrapper
 
-## Forward compatibility: one chokepoint for oxc's construction API
+The earlier design funnelled all construction through a single rolldown newtype (`AstFactory`) wrapping `AstBuilder`, on the theory that it would be an insulation boundary around oxc's construction API. In practice that insulation was thin — generic-node construction already names oxc's types at every call site (`Expression::new_call_expression`, `StaticMemberExpression::boxed`, …), so the newtype only ever centralized the `new_*` patterns and the handle _type_. Adopting oxc's own methods-on-types shape gives that up and buys more than it costs:
 
-The deeper reason to do this — independent of any specific oxc change — is that funnelling all construction through a single rolldown-owned newtype (`AstFactory`, wrapping oxc's `AstBuilder`) turns that type into an **insulation boundary** around oxc's construction API. oxc's construction surface has moved repeatedly: `#[non_exhaustive]` landed in 0.135 (oxc#23046, itself part of a stack of AST-macro reorganizations), and oxc#23043 redesigned `AstBuilder` wholesale in 0.138. Whatever oxc does next, the blast radius is confined to that one layer instead of being smeared across hundreds of call sites. (This insulates the _construction API_ — method names, signatures, the builder type — not oxc's AST node types themselves, which flow through rolldown everywhere and can't be wrapped away.)
+- **It matches oxc.** Construction lives in the same place for oxc and rolldown nodes — on the AST types, builder passed last. The only rolldown-visible difference is that rolldown's helpers are operation-named and reached through `use … as _` trait imports. The `new_*` patterns still live in one module, so the "single place to absorb an oxc construction-API change" property is preserved for the part that actually needs it.
+- **Builder-last unblocks `&mut` construction.** oxc intends to switch builder methods to take `&mut AstBuilder` (to drop the `Cell`s from `Allocator` — a hot-path win — and to enable stateful builders that assign unique `NodeId`s automatically). Passing the builder as an argument rather than as a `self` receiver is what makes that ergonomic: `Expression::new_id_ref_expr(SPAN, self.gen_name(), self)` borrow-checks where the old receiver form `self.ast_factory.make_id_ref_expr(SPAN, self.gen_name())` would not, because the argument is evaluated before the trailing `self` borrow. The old newtype-as-receiver design was the specific blocker here.
+- **Statefulness is deferred, not lost.** If rolldown later needs a stateful builder (e.g. to auto-assign `NodeId`s), it reintroduces a wrapper type that implements `GetAstBuilder` + `GetAllocator` and threads it as the builder argument. Because every `new_*` and every oxc constructor is generic over the builder, that swap costs **zero** call-site changes — strictly more flexible than the `&self`-newtype it replaced.
 
-Concretely:
-
-- **oxc#23043 landed cheaply (oxc 0.138).** It moved construction from `builder.alloc_foo(span, …)` to per-type constructors taking the generator last (`Foo::boxed(span, …, gen)`), with automatic `NodeId` assignment — explicitly citing rolldown [#9609](https://github.com/rolldown/rolldown/pull/9609). Because one rolldown newtype was already threaded everywhere, adopting it was a localized change: `AstFactory` implements `GetAstBuilder` + `GetAllocator`, the per-type `Foo::new(.., &ast_factory)` / `Foo::boxed(..)` constructors take it directly, the `make_*` bodies pass `self`, and the `Deref` to oxc's `AstBuilder` was dropped. (The generic-node call sites did change spelling — `ast_factory.alloc_foo(..)` → `Foo::boxed(.., &ast_factory)` — but each is the same node, and the `make_*` call sites were untouched.)
-- **Even removing `AstBuilder` stays contained.** If oxc ever drops or reshapes the builder entirely, rolldown re-hosts construction at this single point — `AstFactory` provides the surface itself (or impls whatever new generator trait oxc introduces) — and the call sites, all typed through `AstFactory`, stay put. The unification is precisely what makes that possible: you cannot absorb an upstream change at one point when construction is spread across four idioms and hundreds of direct sites bound to oxc's type.
-
-So the unification is what limited the cost of oxc's flux. The one ergonomic problem oxc's redesign does **not** solve is the verbosity of positional arguments, which is the remaining justification for a thin local layer: kept to genuine rolldown patterns and aligned with oxc's style rather than diverging into its own taxonomy.
+So the move is toward oxc's shape, keeping the one genuinely useful property of the old design (rolldown patterns in one module) while shedding the property that actively blocked oxc's next steps.
 
 ## Migration
 
-The convention arrived incrementally, but the oxc#23043 cutover (oxc 0.138) was a single sweep:
+The convention arrived in two steps:
 
-- `AstSnippet` became the `AstFactory` newtype: its `pub builder` field became the wrapped `AstBuilder`; the thin renames were dropped in favor of oxc constructors; the genuine patterns became inherent `make_*` methods. The awkward `AstSnippet` name disappears — rolldown now owns a properly-named builder.
-- The oxc 0.138 builder redesign was migrated in one pass: every generic-node call site moved from the (then-deprecated) `ast_factory.<builder_method>(..)` form to the per-type constructors (`Foo::new(.., &ast_factory)` / `Foo::boxed(..)` / `oxc::allocator::Vec::new_in(..)` / `Str::from_str_in(..)`), `AstFactory` gained the `GetAstBuilder` / `GetAllocator` impls, and the `Deref` was removed. New code follows the per-type convention directly.
-- With every call site on the new API, oxc_ast's **`disable_old_builder`** cargo feature is now enabled, completing the oxc#23043 migration. It removes the deprecated `AstBuilder` methods, drops `AstBuilder`'s `Clone`/`Copy` (so `AstFactory` is not `Copy` either — borrow the handle, or reconstruct one with `AstFactory::new(alloc)` where a detached handle is needed), and removes the top-level `oxc::ast::{AstBuilder, NONE}` re-exports — import from `oxc::ast::builder::` instead. The umbrella `oxc` crate has no passthrough for the feature, so it is enabled via a direct `oxc_ast` dependency carried by `crates/rolldown_ecmascript/Cargo.toml` (cargo-shear-ignored; cargo feature unification applies it to the copy the umbrella re-exports). Keep that pin in lockstep with the `oxc` version when upgrading.
+1. **`AstSnippet` → `AstFactory` newtype (oxc#23043 cutover, oxc 0.138).** `AstSnippet` became a newtype over `AstBuilder`: its `pub builder` field became the wrapped builder, the thin renames were dropped in favor of oxc's per-type constructors, and the genuine patterns became inherent `make_*` methods. Every generic-node call site moved to the per-type constructors, and oxc_ast's **`disable_old_builder`** cargo feature was enabled, removing the deprecated `AstBuilder` methods (and dropping `AstBuilder`'s `Clone`/`Copy`, and the top-level `oxc::ast::{AstBuilder, NONE}` re-exports — import from `oxc::ast::builder::` instead).
+
+2. **`AstFactory` newtype → `new_*` on extension traits (this change).** The inherent `make_*` methods on `AstFactory` became `new_*` associated functions on per-node-type `*FactoryExt` traits, generic over `B: GetAstBuilder + GetAllocator`, taking the builder last; the private multi-step helpers became free functions in the same module. The two construction-flavored binding ext traits (`BindingPatternExt`, `BindingPropertyExt`) were made generic over the builder the same way, decoupling them from the deleted type. Every holder struct's `ast_factory: AstFactory` field became `ast_builder: AstBuilder`, and every `self.ast_factory.make_x(..)` call site became `Type::new_x(.., &self.ast_builder)`. The `AstFactory` newtype was deleted.
+
+`disable_old_builder` remains enabled and pinned via a direct `oxc_ast` dependency in `crates/rolldown_ecmascript/Cargo.toml` (cargo-shear-ignored; feature unification applies it to the copy the umbrella re-exports). Keep that pin in lockstep with the `oxc` version when upgrading.
 
 ## Related
 
 - [ast-mutation](../ast-mutation/implementation.md) — the span/`NodeId`-as-identity contract that constrains synthesized nodes
-- [runtime-helpers](../runtime-helpers/implementation.md) — the runtime functions that `make_*` interop constructors emit calls to
+- [runtime-helpers](../runtime-helpers/implementation.md) — the runtime functions that `new_*` interop constructors emit calls to


### PR DESCRIPTION
Removes the `AstFactory` newtype (rolldown's wrapper over oxc's `AstBuilder`) and moves rolldown's recurring AST constructions onto per-node-type extension traits, matching oxc's own methods-on-types construction shape. Rolldown now holds and passes oxc's `AstBuilder` directly.

## What

- `AstFactory`'s ~28 inherent `make_*` methods become `new_*` associated functions on `*FactoryExt` traits — `ExpressionFactoryExt`, `StatementFactoryExt`, `MemberExpressionFactoryExt`, `CallExpressionFactoryExt`, `BindingIdentifierFactoryExt`, `IdentifierNameFactoryExt`, `ObjectPropertyKindFactoryExt`, `ClassElementFactoryExt` — each generic over `B: GetAstBuilder<'ast> + GetAllocator<'ast>` and taking the builder as its **last** argument (e.g. `Expression::new_id_ref_expr(SPAN, name, builder)`).
- `BindingPatternExt` / `BindingPropertyExt` are made generic over the builder the same way, decoupling them from the deleted type.
- Every holder struct's `ast_factory: AstFactory` field becomes `ast_builder: AstBuilder`; call sites go from `self.ast_factory.make_x(..)` to `Type::new_x(.., &self.ast_builder)`.
- `internal-docs/ast-construction/implementation.md` is updated to describe the new convention.

## Why

- **Matches oxc.** Construction lives on the AST types for both oxc and rolldown nodes, builder passed last.
- **Builder-last unblocks `&mut` construction.** Passing the builder as an argument rather than a `self` receiver is what lets oxc later switch builder methods to `&mut AstBuilder` — dropping the `Cell`s from `Allocator` (a hot-path win) and enabling stateful builders that auto-assign unique `NodeId`s.
- **Statefulness stays reintroducible.** Because every constructor is generic over the builder, a future stateful wrapper (`impl GetAstBuilder + GetAllocator`) can be threaded through with zero call-site changes.

## Notes vs the proposal

Two intentional differences from the sketch in the issue:

- Method names keep the operation suffix (`new_id_ref_expr`, not `new_id_ref`); the `new_*` names are operation-based (`new_keep_name_call`), disjoint from oxc's variant-based constructors (`new_call_expression`), so none collide.
- Holder structs keep an `ast_builder` field and pass `&self.ast_builder`, rather than implementing `GetAstBuilder` themselves to pass `self`. The borrow-check benefit still holds via argument evaluation order; the shorter `self` call syntax is a possible follow-up.

Closes #10328
