### PR TITLE
fix(types): add undefined to ExistingRawSourceMap optional properties

### DIFF
--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -3,14 +3,14 @@ import type { SourceMap } from './rolldown-output';
 
 /** @category Plugin APIs */
 export interface ExistingRawSourceMap {
-  file?: string | null;
+  file?: string | null | undefined;
   mappings: string;
-  names?: string[];
-  sources?: (string | null)[];
-  sourcesContent?: (string | null | undefined)[];
-  sourceRoot?: string;
-  version?: number; // make it optional to compat { mappings: '' }
-  x_google_ignoreList?: number[];
+  names?: string[] | undefined;
+  sources?: (string | null)[] | undefined;
+  sourcesContent?: (string | null | undefined)[] | undefined;
+  sourceRoot?: string | undefined;
+  version?: number | undefined; // make it optional to compat { mappings: '' }
+  x_google_ignoreList?: number[] | undefined;
 }
 
 /** @inline @category Plugin APIs */


### PR DESCRIPTION
Fixes #10354

Adds `| undefined` to the optional properties of `ExistingRawSourceMap` so that source maps whose properties include explicit `undefined` (for example `SourceMap` from magic-string v1, where `file` is `string | undefined`) are assignable to `SourceMapInput` in projects that enable `exactOptionalPropertyTypes`.

This is a type-only change.