### PR TITLE
fix: pair tokio runtime acquire and release on wasm to prevent premature shutdown

### DIFF
--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -53,11 +53,18 @@ pub mod worker_manager;
 pub use oxc_parser_napi;
 pub use oxc_resolver_napi;
 
+/// Number of live holders of the shared tokio runtime.
+///
+/// Starts at 0 so the runtime is torn down exactly when the last holder releases it.
+/// Every JS object that outlives a single call and spawns onto the runtime
+/// (`RolldownBuild`, `Watcher`, `DevEngine`, the `scan` bundler) must acquire on
+/// create and release on close. An unpaired release drops the runtime out from
+/// under the remaining holders (#8411, #8747).
 #[cfg(all(target_family = "wasm", tokio_unstable))]
-pub static ACTIVE_TASK_COUNT: LazyLock<AtomicU32> = LazyLock::new(|| AtomicU32::new(1));
+pub static ACTIVE_TASK_COUNT: LazyLock<AtomicU32> = LazyLock::new(|| AtomicU32::new(0));
 
 #[napi]
-/// Shutdown the tokio runtime manually.
+/// Release one holder of the tokio runtime, shutting it down once none are left.
 ///
 /// This is required for the wasm target with `tokio_unstable` cfg.
 /// In the wasm runtime, the `park` threads will hang there until the tokio::Runtime is shutdown.
@@ -73,10 +80,7 @@ pub fn shutdown_async_runtime() {
 }
 
 #[napi]
-/// Start the async runtime manually.
-///
-/// This is required when the async runtime is shutdown manually.
-/// Usually it's used in test.
+/// Acquire one holder of the tokio runtime, starting it if it is not running.
 pub fn start_async_runtime() {
   #[cfg(all(target_family = "wasm", tokio_unstable))]
   {

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -6,6 +6,8 @@ import {
   type BindingLazyChunkOutput,
   BindingRebuildStrategy,
   type BindingResult,
+  shutdownAsyncRuntime,
+  startAsyncRuntime,
 } from '../../binding.cjs';
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
@@ -19,6 +21,7 @@ import type { DevOptions } from './dev-options';
 export class DevEngine {
   #inner: BindingDevEngine;
   #cachedBuildFinishPromise: Promise<void> | null = null;
+  #asyncRuntimeReleased = false;
 
   static async create(
     inputOptions: InputOptions,
@@ -88,6 +91,8 @@ export class DevEngine {
 
     const inner = new BindingDevEngine(options.bundlerOptions, bindingDevOptions);
 
+    startAsyncRuntime();
+
     return new DevEngine(inner);
   }
 
@@ -143,7 +148,13 @@ export class DevEngine {
   }
 
   async close(): Promise<void> {
+    // Claim the release before the first await so a second `close` cannot release twice.
+    const shouldRelease = !this.#asyncRuntimeReleased;
+    this.#asyncRuntimeReleased = true;
     await this.#inner.close();
+    if (shouldRelease) {
+      shutdownAsyncRuntime();
+    }
   }
 
   /**

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -4,7 +4,6 @@ import { PluginDriver } from '../plugin/plugin-driver';
 import { createBundlerOptions } from '../utils/create-bundler-option';
 import { unwrapBindingResult } from '../utils/error';
 import { validateOption } from '../utils/validator';
-import { RolldownBuild } from './rolldown/rolldown-build';
 
 export { freeExternalMemory } from '../types/external-memory-handle';
 
@@ -36,15 +35,16 @@ export const scan = async (
 
   const bundler = new BindingBundler();
 
-  if (RolldownBuild.asyncRuntimeShutdown) {
-    startAsyncRuntime();
-  }
+  startAsyncRuntime();
 
+  // On the error path `cleanup` runs from both `catch` and `finally`, so it must be idempotent.
+  let cleanedUp = false;
   async function cleanup() {
+    if (cleanedUp) return;
+    cleanedUp = true;
     await bundler.close();
     await ret.stopWorkers?.();
     shutdownAsyncRuntime();
-    RolldownBuild.asyncRuntimeShutdown = true;
   }
 
   let cleanupPromise = Promise.resolve();

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -24,14 +24,13 @@ export class RolldownBuild {
   #inputOptions: InputOptions;
   #bundler: BindingBundler;
   #stopWorkers?: () => Promise<void>;
-
-  /** @internal */
-  static asyncRuntimeShutdown = false;
+  #asyncRuntimeReleased = false;
 
   /** @hidden should not be used directly */
   constructor(inputOptions: InputOptions) {
     this.#inputOptions = inputOptions;
     this.#bundler = new BindingBundler();
+    startAsyncRuntime();
   }
 
   /**
@@ -91,11 +90,16 @@ export class RolldownBuild {
    * ```
    */
   async close(): Promise<void> {
+    // Claim the release before the first await so a second `close` cannot release twice.
+    const shouldRelease = !this.#asyncRuntimeReleased;
+    this.#asyncRuntimeReleased = true;
     await this.#stopWorkers?.();
+    // `BindingBundler.close` spawns onto the runtime, so release only after it settles.
     await this.#bundler.close();
-    shutdownAsyncRuntime();
-    RolldownBuild.asyncRuntimeShutdown = true;
     this.#stopWorkers = void 0;
+    if (shouldRelease) {
+      shutdownAsyncRuntime();
+    }
   }
 
   /** @hidden documented in close method */
@@ -118,10 +122,6 @@ export class RolldownBuild {
     validateOption('output', outputOptions);
     await this.#stopWorkers?.();
     const option = await createBundlerOptions(this.#inputOptions, outputOptions, false);
-
-    if (RolldownBuild.asyncRuntimeShutdown) {
-      startAsyncRuntime();
-    }
 
     try {
       this.#stopWorkers = option.stopWorkers;

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -1,4 +1,9 @@
-import { type BindingWatcherEvent, BindingWatcher, shutdownAsyncRuntime } from '../../binding.cjs';
+import {
+  type BindingWatcherEvent,
+  BindingWatcher,
+  shutdownAsyncRuntime,
+  startAsyncRuntime,
+} from '../../binding.cjs';
 import { LOG_LEVEL_WARN } from '../../log/logging';
 import { logMultipleWatcherOption } from '../../log/logs';
 import { aggregateBindingErrorsIntoJsError } from '../../utils/error';
@@ -69,6 +74,7 @@ class Watcher {
     this.closed = false;
     this.inner = inner;
     this.emitter = emitter;
+    startAsyncRuntime();
     const originClose = emitter.close.bind(emitter);
     emitter.close = async () => {
       await this.close();

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3062,19 +3062,14 @@ export declare function registerPlugins(id: number, plugins: Array<BindingPlugin
 export declare function resolveTsconfig(filename: string, cache: TsconfigCache | undefined | null, yarnPnp: boolean): BindingTsconfigResult | null
 
 /**
- * Shutdown the tokio runtime manually.
+ * Release one holder of the tokio runtime, shutting it down once none are left.
  *
  * This is required for the wasm target with `tokio_unstable` cfg.
  * In the wasm runtime, the `park` threads will hang there until the tokio::Runtime is shutdown.
  */
 export declare function shutdownAsyncRuntime(): void
 
-/**
- * Start the async runtime manually.
- *
- * This is required when the async runtime is shutdown manually.
- * Usually it's used in test.
- */
+/** Acquire one holder of the tokio runtime, starting it if it is not running. */
 export declare function startAsyncRuntime(): void
 
 export interface ViteImportGlobMeta {


### PR DESCRIPTION
### Description

Fixes #8411. Fixes #8747.

On the wasm target the binding keeps a refcount (`ACTIVE_TASK_COUNT`) over the shared tokio runtime, and the runtime is torn down when the count reaches zero. The count was seeded at `1` and released by `RolldownBuild.close()`, `Watcher.close()` and `scan()` without any matching acquire, while `DevEngine` never touched it at all. As a result, the first `close()` in the process (for example Vite bundling `vite.config.ts` or the dep optimizer) dropped the count to zero and shut the runtime down under every remaining consumer. The next spawn then panicked with `Access tokio runtime failed in spawn`, which surfaces on StackBlitz as `RuntimeError: unreachable`.

This PR makes the refcount strictly paired. Every JS object that outlives a single call and spawns onto the runtime now acquires on create and releases on close:

- `ACTIVE_TASK_COUNT` is seeded at `0`, so the runtime lives exactly as long as its holders.
- `RolldownBuild` acquires in the constructor and releases in `close()`. The `asyncRuntimeShutdown` static flag and the conditional re-start in `#build` are removed since they only existed to work around the unbalanced count.
- `Watcher` acquires in the constructor. It previously only released.
- `DevEngine` acquires in `create()` and releases in `close()`. It previously did neither, which is the direct cause of #8411.
- `scan()` acquires before scanning and releases in `cleanup()`, which is now idempotent because the error path reaches it from both `catch` and `finally`.

Double release is also guarded. `RolldownBuild.close()` and `DevEngine.close()` claim the release before their first await, so a second or concurrent `close()` cannot release twice, and the release happens only after `BindingBundler.close()` settles because that call itself spawns onto the runtime.

All of this is a no-op on native targets, where `startAsyncRuntime` and `shutdownAsyncRuntime` compile to empty functions. `binding.d.cts` is regenerated from the updated doc comments.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

