### PR TITLE
test(sourcemap): fix Windows-only failures in composition fixtures

### DIFF
--- a/packages/rolldown/tests/fixtures/plugin/transform/coarse-sourcemap-composition-issue-6399/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/coarse-sourcemap-composition-issue-6399/_config.ts
@@ -46,7 +46,7 @@ export default defineTest({
       {
         name: 'load-detailed-source-map',
         load(id) {
-          if (!id.endsWith('/main.js')) {
+          if (!id.endsWith('main.js')) {
             return;
           }
           return {
@@ -67,7 +67,7 @@ export default defineTest({
       {
         name: 'replace-define-component',
         transform(_code, id) {
-          if (!id.endsWith('/main.js')) {
+          if (!id.endsWith('main.js')) {
             return;
           }
           return {

--- a/packages/rolldown/tests/fixtures/plugin/transform/explicit-unmapped-boundary/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/explicit-unmapped-boundary/_config.ts
@@ -21,7 +21,7 @@ export default defineTest({
       {
         name: 'explicit-unmapped-boundary',
         transform(code, id) {
-          if (!id.endsWith('/main.js')) {
+          if (!id.endsWith('main.js')) {
             return;
           }
           return {


### PR DESCRIPTION
### Description

The `node-test-windows` job has been failing on every `main` run since 2026-07-15 (for example [this run](https://github.com/rolldown/rolldown/actions/runs/29795703407/job/88527096422)). The two fixtures added in #10249 and #10254 guard their `load` and `transform` hooks with `id.endsWith('/main.js')`. On Windows, module ids use backslashes, so the guard never matches and the hooks are silently skipped.

With the hooks skipped, `coarse-sourcemap-composition-issue-6399` bundles the on-disk comment-only `main.js` into an empty chunk whose `map` is `null`, so `new TraceMap(null)` throws `Cannot read properties of null (reading '_decodedMemo')`. In `explicit-unmapped-boundary`, the transform never injects `injected()`, so `code.indexOf('injected()')` returns -1 and the assertion fails.

This PR drops the leading slash so the checks become `id.endsWith('main.js')`, which is the pattern every other fixture in the repo already uses and works with both path separators. No production code is touched.
