### PR TITLE
ci: enable Windows CI with a PR label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,26 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      rust-changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') }}
-      node-changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}
+      # A Windows CI request runs the complete Windows suite, even for paths outside the normal filters.
+      rust-changes: "${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
+      node-changes: "${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
       # Allows opting into Windows CI per-PR by adding the `ci: windows` label.
-      run-windows: "${{ (github.event_name == 'pull_request') && contains(github.event.pull_request.labels.*.name, 'ci: windows') }}"
+      run-windows: "${{ steps.pr-labels.outputs.run-windows == 'true' }}"
     steps:
+      # Reruns keep the original event payload, so query the current labels instead.
+      - name: Read pull request labels
+        if: github.event_name == 'pull_request'
+        id: pr-labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if ! run_windows="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '[.labels[].name] | any(. == "ci: windows")')"; then
+            echo "::warning::Could not read pull request labels; running Windows CI."
+            run_windows=true
+          fi
+          echo "run-windows=${run_windows}" >> "$GITHUB_OUTPUT"
+
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -61,8 +76,8 @@ jobs:
               - 'rollup'
       - name: Show outputs
         run: |
-          echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') }}"
-          echo "Node changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}"
+          echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
+          echo "Node changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
 
   rust-validation:
     name: Rust Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@ IMPORTANT: The project uses `just` as a task runner. Always prefer `just` comman
 
 - **Open PRs as drafts and keep them that way until the user says otherwise.** When you create a pull request, always create it as a **draft** (`gh pr create --draft`). Do NOT convert a draft to "ready for review", mark a PR ready, or request/assign reviewers unless the user has explicitly told you they are ready for team review. Publishing a PR for review pings reviewers and code owners and clutters their inboxes — never trigger that on the user's behalf prematurely. If you are unsure whether the user is ready, leave the PR as a draft and ask first.
 
+# Windows CI
+
+- For Windows coverage on a PR, add the `ci: windows` label, then rerun all jobs in the latest `CI` workflow run whose event is `pull_request` and whose head SHA matches the PR. Adding the label alone does not start a workflow. Keep the label so later PR pushes also run the Windows jobs.
+
 # Common Pitfalls & Best Practices
 
 - **`AGENTS.md` is the source of truth.** `CLAUDE.md` is a symlink to it.


### PR DESCRIPTION
## Summary

`ci: windows` is a persistent opt-in for the complete Windows CI suite.

After adding the label, rerun all jobs in the latest `pull_request` CI run for the PR's current head SHA. The workflow reads the PR's current labels through the GitHub API, so the rerun sees labels added after the original event. Later pushes continue to run Windows CI while the label remains.

Adding unrelated labels does not trigger CI. If the label API is temporarily unavailable, CI conservatively runs the full Windows suite.

This workflow is documented in `AGENTS.md`.

## Testing

- `actionlint`
- YAML parse
- `git diff --check`
- Verified labeled, unlabeled, and API-failure paths
- [CI run](https://github.com/rolldown/rolldown/actions/runs/29896781112) expanded the Windows jobs
