### PR TITLE
refactor: centralize final ESM init metadata

### DIFF
--- a/crates/rolldown/src/esm_init_obligations.rs
+++ b/crates/rolldown/src/esm_init_obligations.rs
@@ -25,8 +25,8 @@
 //!   hops whose registration flows through the metadata pass rather than the included-record path.
 //!
 //! Excluded statements are the one structural asymmetry: for Emit and Register their targets are
-//! precomputed once by `compute_wrapped_esm_init_metadata` (post-convergence, stored as
-//! `transitive_init_targets`), while Project must recompute them per fixpoint round from the
+//! precomputed once by `compute_wrapped_esm_init_metadata` (post-convergence, returned as
+//! `Sealed<FinalEsmInitMetadata>`), while Project must recompute them per fixpoint round from the
 //! current plan — both through the shared excluded-hop router
 //! [`collect_order_wrap_esm_init_targets`], so the routing itself cannot drift.
 //!

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -25,7 +25,10 @@ use crate::{
   chunk_graph::ChunkGraph,
   module_finalizers::{ScopeHoistingFinalizer, TraverseState},
   stages::{
-    generate_stage::order_wrap_state::{EsmInitOrigin, EsmInitTarget, OrderWrapState},
+    generate_stage::{
+      FinalEsmInitMetadata, Sealed,
+      order_wrap_state::{EsmInitOrigin, EsmInitTarget, OrderWrapState},
+    },
     link_stage::SafelyMergeCjsNsInfo,
   },
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
@@ -46,6 +49,7 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub linking_info: &'me LinkingMetadata,
   pub linking_infos: &'me LinkingMetadataVec,
   pub order_wrap_state: &'me OrderWrapState,
+  pub final_esm_init_metadata: &'me Sealed<FinalEsmInitMetadata>,
   pub used_symbol_refs: &'me UsedSymbolRefs,
   pub symbol_db: &'me SymbolRefDb,
   pub runtime: &'me RuntimeModuleBrief,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -209,7 +209,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         // Otherwise we'd have marked a side-effecting `init_*()` as `@__PURE__` and DCE could
         // wrongly drop it. Turns any misclassification into a loud failure across the fixtures.
         debug_assert!(
-          !target.init_is_noop || stmts_inside_closure.is_empty(),
+          !self.ctx.final_esm_init_metadata.init_is_noop(self.ctx.idx)
+            || stmts_inside_closure.is_empty(),
           "init_is_noop set but the __esm closure is non-empty for {}",
           self.ctx.module.stable_id
         );

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -186,7 +186,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       NONE,
       oxc::allocator::Vec::new_in(&self.ast_builder),
       false,
-      mark_pure_if_noop && target.init_is_noop,
+      mark_pure_if_noop && self.ctx.final_esm_init_metadata.init_is_noop(importee_idx),
       &self.ast_builder,
     );
     if await_if_tla && target.tla_tainted {
@@ -1529,11 +1529,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       NONE,
                       oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
-                      self
-                        .ctx
-                        .order_wrap_state
-                        .esm_init_target(importee.idx, importee_linking_info)
-                        .is_some_and(|target| target.init_is_noop),
+                      self.ctx.final_esm_init_metadata.init_is_noop(importee.idx),
                       &self.ast_builder,
                     ))
                   };
@@ -1759,14 +1755,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if !is_stmt_included {
           // For ESM-wrapped modules, excluded re-export statements still need init calls for
           // correct initialization order. Their targets are precomputed by the generate
-          // stage's `compute_wrapped_esm_init_metadata`; emitting the calls (with the
-          // module-wide dedup below) is all that happens here.
-          let linking_info = self.ctx.linking_info;
+          // stage's `Sealed<FinalEsmInitMetadata>`; emitting the calls (with the module-wide dedup
+          // below) is all that happens here.
           if let Some(targets) = self
             .ctx
-            .order_wrap_state
-            .transitive_init_targets(self.ctx.idx, linking_info)
-            .get(&stmt_info_idx)
+            .final_esm_init_metadata
+            .transitive_init_targets(self.ctx.idx)
+            .and_then(|targets_by_stmt| targets_by_stmt.get(&stmt_info_idx))
           {
             for &importee_idx in targets {
               if self.generated_init_esm_importee_ids.insert(importee_idx) {

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -1,4 +1,4 @@
-use super::GenerateStage;
+use super::{FinalEsmInitMetadata, GenerateStage, Sealed};
 use crate::chunk_graph::ChunkGraph;
 use crate::esm_init_obligations::{
   ObligationPurpose, WrappedEsmInitTargetContext,
@@ -41,6 +41,23 @@ struct CrossChunkLinkState {
   order_live_symbols: FxHashSet<SymbolRef>,
 }
 
+#[derive(Clone, Copy)]
+enum FinalEsmInitMetadataAvailability<'a> {
+  /// The prediction pass runs before wrapper selection and final chunk topology are fixed.
+  Unavailable,
+  /// Final cross-chunk linking can only receive metadata through the sealed boundary.
+  Sealed(&'a Sealed<FinalEsmInitMetadata>),
+}
+
+impl<'a> FinalEsmInitMetadataAvailability<'a> {
+  fn sealed(self) -> Option<&'a Sealed<FinalEsmInitMetadata>> {
+    match self {
+      Self::Unavailable => None,
+      Self::Sealed(metadata) => Some(metadata),
+    }
+  }
+}
+
 trait UsedSymbolRefsView: Sync {
   fn contains(&self, symbol_ref: &SymbolRef) -> bool;
 }
@@ -64,6 +81,7 @@ impl GenerateStage<'_> {
     chunk_graph: &mut ChunkGraph,
     used_symbol_refs: &UsedSymbolRefs,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
   ) {
     let CrossChunkLinkState {
       index_chunk_exported_symbols,
@@ -73,7 +91,12 @@ impl GenerateStage<'_> {
       index_cross_chunk_imports,
       index_cross_chunk_dynamic_imports,
       order_live_symbols,
-    } = self.compute_cross_chunk_link_state(chunk_graph, used_symbol_refs, order_state);
+    } = self.compute_cross_chunk_link_state(
+      chunk_graph,
+      used_symbol_refs,
+      order_state,
+      FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
+    );
 
     #[cfg(debug_assertions)]
     let predicted_static_import_edges: IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> =
@@ -215,10 +238,10 @@ impl GenerateStage<'_> {
   }
 
   /// Compute provisional links for order analysis. Runtime symbol placement is cleared if moved.
-  /// Uses an empty order state, so the edges are the *pre-lowering* baseline topology (value and
-  /// side-effect imports, before any wrapping adds `init_*` wrapper imports). The emergent-cycle
-  /// fixpoint layers the plan's `init_*` forwarding edges on top of this baseline
-  /// (`post_lowering_import_edges`).
+  /// Uses an empty order state and explicitly marks final-init metadata unavailable, so the edges
+  /// are the *pre-lowering* baseline topology (value and side-effect imports, before wrapping adds
+  /// `init_*` imports). The emergent-cycle fixpoint layers the plan's `init_*` forwarding edges on
+  /// top of this baseline (`post_lowering_import_edges`).
   pub(super) fn predicted_static_import_edges(
     &mut self,
     chunk_graph: &ChunkGraph,
@@ -226,7 +249,12 @@ impl GenerateStage<'_> {
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     let empty_order_state = super::order_wrap_state::OrderWrapState::default();
     self
-      .compute_cross_chunk_link_state(chunk_graph, used_symbol_refs, &empty_order_state)
+      .compute_cross_chunk_link_state(
+        chunk_graph,
+        used_symbol_refs,
+        &empty_order_state,
+        FinalEsmInitMetadataAvailability::Unavailable,
+      )
       .index_imports_from_other_chunks
       .into_iter_enumerated()
       .map(|(chunk_idx, importee_map)| {
@@ -243,6 +271,7 @@ impl GenerateStage<'_> {
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
   ) -> CrossChunkLinkState {
     let mut index_chunk_depended_symbols: IndexChunkDependedSymbols =
       index_vec![FxIndexSet::<SymbolRef>::default(); chunk_graph.chunk_table.len()];
@@ -282,6 +311,7 @@ impl GenerateStage<'_> {
       &mut index_cross_chunk_dynamic_imports,
       used_symbol_refs,
       order_state,
+      final_esm_init_metadata,
     );
 
     self.compute_chunk_imports(
@@ -310,6 +340,7 @@ impl GenerateStage<'_> {
 
   /// - Assign each symbol to the chunk it belongs to
   /// - Collect all referenced symbols and consider them potential imports
+  #[expect(clippy::too_many_arguments)]
   fn collect_depended_symbols(
     &mut self,
     chunk_graph: &ChunkGraph,
@@ -318,6 +349,7 @@ impl GenerateStage<'_> {
     index_cross_chunk_dynamic_imports: &mut IndexCrossChunkDynamicImports,
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
   ) {
     let symbols = &self.link_output.symbol_db;
     let chunk_id_to_symbols_vec = append_only_vec::AppendOnlyVec::new();
@@ -434,6 +466,7 @@ impl GenerateStage<'_> {
             chunk_graph,
             used_symbol_refs,
             order_state,
+            final_esm_init_metadata,
             depended_symbols,
             module.idx,
           );
@@ -468,12 +501,15 @@ impl GenerateStage<'_> {
           } else if let Some(target) = order_state.esm_init_target(entry.idx, entry_meta) {
             depended_symbols.insert(target.wrapper_ref);
           }
-          self.add_transitive_esm_init_depended_symbols(
-            chunk_graph,
-            order_state,
-            depended_symbols,
-            entry.idx,
-          );
+          if let Some(final_esm_init_metadata) = final_esm_init_metadata.sealed() {
+            self.add_transitive_esm_init_depended_symbols(
+              chunk_graph,
+              order_state,
+              final_esm_init_metadata,
+              depended_symbols,
+              entry.idx,
+            );
+          }
 
           if matches!(self.options.format, OutputFormat::Cjs)
             && matches!(entry.exports_kind, ExportsKind::Esm)
@@ -588,15 +624,19 @@ impl GenerateStage<'_> {
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
     depended_symbols: &mut FxIndexSet<SymbolRef>,
     module_idx: ModuleIdx,
   ) {
-    self.add_transitive_esm_init_depended_symbols(
-      chunk_graph,
-      order_state,
-      depended_symbols,
-      module_idx,
-    );
+    if let Some(final_esm_init_metadata) = final_esm_init_metadata.sealed() {
+      self.add_transitive_esm_init_depended_symbols(
+        chunk_graph,
+        order_state,
+        final_esm_init_metadata,
+        depended_symbols,
+        module_idx,
+      );
+    }
     self.add_included_import_esm_init_depended_symbols(
       chunk_graph,
       used_symbol_refs,
@@ -616,22 +656,23 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &ChunkGraph,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
     depended_symbols: &mut FxIndexSet<SymbolRef>,
     module_idx: ModuleIdx,
   ) {
-    let meta = &self.link_output.metas[module_idx];
+    let Some(targets_by_stmt) = final_esm_init_metadata.transitive_init_targets(module_idx) else {
+      return;
+    };
     // Iterate the targets in a deterministic, cross-target-stable order. The map is an
-    // `FxHashMap<StmtInfoIdx, _>`, and its `values()` order follows FxHash bucket layout. FxHash is
-    // unseeded but hashes differently on 32-bit vs 64-bit, so `values()` visits buckets in a
+    // `FxHashMap<StmtInfoIdx, _>`, and its iteration order follows FxHash bucket layout. FxHash is
+    // unseeded but hashes differently on 32-bit vs 64-bit, so iteration visits buckets in a
     // different order on native (64-bit) than on wasm32/WASI. That order flows straight into
     // `depended_symbols` (an `FxIndexSet`), whose insertion order drives the chunk's imported-symbol
     // rename order (the `$1`/`$2` suffixes) in `deconflict_chunk_symbols` — so a hash-ordered walk
     // here makes native and WASI builds resolve rename collisions differently. Sorting by the owning
     // `StmtInfoIdx` pins one order for every target.
-    for (_, targets) in order_state
-      .transitive_init_targets(module_idx, meta)
-      .iter()
-      .sorted_unstable_by_key(|(stmt_info_idx, _)| **stmt_info_idx)
+    for (_, targets) in
+      targets_by_stmt.iter().sorted_unstable_by_key(|(stmt_info_idx, _)| **stmt_info_idx)
     {
       for &target_idx in targets {
         let meta = &self.link_output.metas[target_idx];

--- a/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
@@ -1,3 +1,7 @@
+#![forbid(unsafe_code)]
+
+use std::ops::Deref;
+
 use oxc::ast::ast::{Declaration, Statement};
 use oxc_index::IndexVec;
 use rolldown_common::{
@@ -20,16 +24,66 @@ use super::{
   order_wrap_state::{EsmInitOrigin, OrderImportKey, OrderWrapState},
 };
 
+/// An artifact whose owner can only read the sealed value.
+///
+/// Construction is private to this leaf module, and the wrapper exposes neither `DerefMut` nor an
+/// unwrap operation. Once a value crosses this boundary, re-owning it cannot make it mutable again.
+#[derive(Debug)]
+pub struct Sealed<T>(T);
+
+impl<T> Sealed<T> {
+  fn new(value: T) -> Self {
+    Self(value)
+  }
+}
+
+impl<T> Deref for Sealed<T> {
+  type Target = T;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+/// Final post-chunking facts needed to emit wrapped ESM initialization.
+///
+/// This artifact is deliberately separate from both link-owned [`LinkingMetadata`] and
+/// order-lowering-owned [`OrderWrapState`]. It is computed once after chunk topology and wrapper
+/// selection are final, sealed, then shared read-only by cross-chunk linking and module
+/// finalization.
+#[derive(Debug)]
+pub struct FinalEsmInitMetadata {
+  modules: FxHashMap<ModuleIdx, ModuleEsmInitMetadata>,
+}
+
+impl FinalEsmInitMetadata {
+  pub(crate) fn init_is_noop(&self, module_idx: ModuleIdx) -> bool {
+    self.modules.get(&module_idx).is_some_and(|metadata| metadata.init_is_noop)
+  }
+
+  pub(crate) fn transitive_init_targets(
+    &self,
+    module_idx: ModuleIdx,
+  ) -> Option<&FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>> {
+    self.modules.get(&module_idx).map(|metadata| &metadata.transitive_init_targets)
+  }
+}
+
+#[derive(Debug)]
+struct ModuleEsmInitMetadata {
+  init_is_noop: bool,
+  transitive_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
+}
+
 impl GenerateStage<'_> {
-  /// Compute no-op wrappers and excluded-statement init targets after final chunk assignment.
-  /// This must finish before parallel module finalization.
+  /// Compute the immutable no-op and excluded-statement init facts after final chunk assignment.
+  /// This must finish before cross-chunk linking and parallel module finalization.
   pub(super) fn compute_wrapped_esm_init_metadata(
-    &mut self,
+    &self,
     ast_table: &IndexEcmaAst,
     chunk_graph: &ChunkGraph,
-    order_state: &mut OrderWrapState,
-  ) {
-    // Classify in parallel (read-only); the cheap write-back stays sequential.
+    order_state: &OrderWrapState,
+  ) -> Sealed<FinalEsmInitMetadata> {
     let keep_names = self.options.keep_names;
     // Off-strict, lowering never mutates the chunk graph, so the liveness guard cannot fire.
     let strict = self.options.is_strict_execution_order_enabled();
@@ -37,14 +91,13 @@ impl GenerateStage<'_> {
     let modules = &self.link_output.module_table.modules;
     let stmt_infos_vec = &self.link_output.stmt_infos;
     let module_to_chunk = &chunk_graph.module_to_chunk;
-    let order_state_view = &*order_state;
     let results = metas
       .par_iter_enumerated()
       .filter_map(|(module_idx, meta)| {
         if !meta.is_included {
           return None;
         }
-        let init_target = order_state_view.esm_init_target(module_idx, meta)?;
+        let init_target = order_state.esm_init_target(module_idx, meta)?;
         let is_noop = init_is_noop(meta, ast_table[module_idx].as_ref(), keep_names);
         let targets_by_stmt = modules[module_idx]
           .as_normal()
@@ -63,32 +116,19 @@ impl GenerateStage<'_> {
                 chunk_idx,
                 order_wrap: matches!(init_target.origin, EsmInitOrigin::ExecutionOrder),
                 execution_dependencies: &meta.execution_dependencies,
-                order_state: order_state_view,
+                order_state,
               },
             )
           })
           .unwrap_or_default();
         (is_noop || !targets_by_stmt.is_empty()).then_some((
           module_idx,
-          init_target.origin,
-          is_noop,
-          targets_by_stmt,
+          ModuleEsmInitMetadata { init_is_noop: is_noop, transitive_init_targets: targets_by_stmt },
         ))
       })
       .collect::<Vec<_>>();
 
-    for (module_idx, origin, is_noop, targets_by_stmt) in results {
-      match origin {
-        EsmInitOrigin::Interop => {
-          let meta = &mut self.link_output.metas[module_idx];
-          meta.init_is_noop = is_noop;
-          meta.transitive_esm_init_targets = targets_by_stmt;
-        }
-        EsmInitOrigin::ExecutionOrder => {
-          order_state.set_order_init_metadata(module_idx, is_noop, targets_by_stmt);
-        }
-      }
-    }
+    Sealed::new(FinalEsmInitMetadata { modules: results.into_iter().collect() })
   }
 }
 

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -11,7 +11,7 @@ use crate::{
   type_alias::IndexEcmaAst,
 };
 
-use super::{GenerateStage, resolve_file_urls::ResolvedFileUrls};
+use super::{FinalEsmInitMetadata, GenerateStage, Sealed, resolve_file_urls::ResolvedFileUrls};
 
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
@@ -22,6 +22,7 @@ impl GenerateStage<'_> {
     resolved_file_urls: &ResolvedFileUrls,
     used_symbol_refs: &UsedSymbolRefs,
     order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
   ) -> BuildResult<()> {
     let has_enum_inlining = self.link_output.has_enum_inlining;
     let has_required_order_runtime = !order_state.required_runtime_helpers().is_empty();
@@ -59,6 +60,7 @@ impl GenerateStage<'_> {
             modules: &self.link_output.module_table.modules,
             linking_infos: &self.link_output.metas,
             order_wrap_state: order_state,
+            final_esm_init_metadata,
             used_symbol_refs,
             runtime: &self.link_output.runtime,
             options: self.options,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -114,6 +114,8 @@ mod render_chunk_to_assets;
 mod resolve_file_urls;
 mod runtime_module_sweep;
 
+pub use compute_wrapped_esm_init_metadata::{FinalEsmInitMetadata, Sealed};
+
 pub struct GenerateStage<'a> {
   link_output: &'a mut LinkStageOutput,
   /// Per-module AST table threaded by value from `LinkStage::link()`. Moved out
@@ -146,7 +148,7 @@ impl<'a> GenerateStage<'a> {
     self.plugin_driver.render_start(self.options).await?;
     let mut chunk_graph = self.generate_chunks(&mut used_symbol_refs).await?;
 
-    let mut order_state = self.finalize_chunk_plan(&mut chunk_graph, &mut used_symbol_refs)?;
+    let order_state = self.finalize_chunk_plan(&mut chunk_graph, &mut used_symbol_refs)?;
 
     // Order lowering and the unused-runtime sweep have had their last chance to update liveness.
     // Sealing consumes the builder, so nothing downstream can mutate the set.
@@ -154,9 +156,15 @@ impl<'a> GenerateStage<'a> {
     self.compute_retained_export_symbols(&used_symbol_refs);
 
     let mut ast_table = std::mem::take(&mut self.ast_table);
-    self.compute_wrapped_esm_init_metadata(&ast_table, &chunk_graph, &mut order_state);
+    let final_esm_init_metadata =
+      self.compute_wrapped_esm_init_metadata(&ast_table, &chunk_graph, &order_state);
 
-    self.compute_cross_chunk_links(&mut chunk_graph, &used_symbol_refs, &order_state);
+    self.compute_cross_chunk_links(
+      &mut chunk_graph,
+      &used_symbol_refs,
+      &order_state,
+      &final_esm_init_metadata,
+    );
 
     self.ensure_lazy_module_initialization_order(&mut chunk_graph);
 
@@ -227,6 +235,7 @@ impl<'a> GenerateStage<'a> {
       &resolved_file_urls,
       &used_symbol_refs,
       &order_state,
+      &final_esm_init_metadata,
     )?;
     self.detect_ineffective_dynamic_imports(&chunk_graph);
     self.render_chunk_to_assets(&chunk_graph, ast_table, &used_symbol_refs, &order_state).await

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -484,8 +484,9 @@ impl GenerateStage<'_> {
   /// Excluded non-included-forwarder projection — a wrapped importer's re-export of a *non-included*
   /// forwarder forwards init to every wrapped module the forwarder's static imports reach, walking
   /// the forwarder itself rather than only its resolved exports. This mirrors the excluded-statement
-  /// metadata routing (`transitive_esm_init_targets` → `collect_order_wrap_esm_init_targets`) that
-  /// `add_transitive_esm_init_depended_symbols` registers. This is the edge source the
+  /// final metadata routing (`transitive_esm_init_targets` →
+  /// `collect_order_wrap_esm_init_targets`) that `add_transitive_esm_init_depended_symbols`
+  /// registers. This is the edge source the
   /// resolved-exports-only projection missed (Hole 2).
   ///
   /// The walk passes `retained_reexport_path: None` while the real metadata pass can carry `Some`

--- a/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
@@ -133,7 +133,6 @@ impl OrderWrapState {
     if matches!(meta.wrap_kind(), WrapKind::Esm) {
       return meta.wrapper_ref.map(|wrapper_ref| EsmInitTarget {
         wrapper_ref,
-        init_is_noop: meta.init_is_noop,
         tla_tainted: meta.is_tla_or_contains_tla_dependency,
         origin: EsmInitOrigin::Interop,
       });
@@ -141,7 +140,6 @@ impl OrderWrapState {
 
     self.modules.get(&module_idx).map(|module| EsmInitTarget {
       wrapper_ref: module.wrapper_ref,
-      init_is_noop: module.init_is_noop,
       tla_tainted: meta.is_tla_or_contains_tla_dependency,
       origin: EsmInitOrigin::ExecutionOrder,
     })
@@ -191,8 +189,6 @@ impl OrderWrapState {
             wrapper_statement,
             chunk: None,
             reexport_init_transparent: false,
-            init_is_noop: false,
-            transitive_init_targets: FxHashMap::default(),
           },
         )
         .is_none(),
@@ -345,33 +341,6 @@ impl OrderWrapState {
       .is_some_and(|importers| importers.iter().copied().any(importer_is_live))
   }
 
-  pub(crate) fn set_order_init_metadata(
-    &mut self,
-    module_idx: ModuleIdx,
-    init_is_noop: bool,
-    transitive_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
-  ) {
-    let module = self.modules.get_mut(&module_idx).expect("order-wrapped module should exist");
-    module.init_is_noop = init_is_noop;
-    module.transitive_init_targets = transitive_init_targets;
-  }
-
-  pub(crate) fn transitive_init_targets<'a>(
-    &'a self,
-    module_idx: ModuleIdx,
-    meta: &'a crate::types::linking_metadata::LinkingMetadata,
-  ) -> &'a FxHashMap<StmtInfoIdx, Vec<ModuleIdx>> {
-    if self
-      .esm_init_target(module_idx, meta)
-      .is_some_and(|target| matches!(target.origin, EsmInitOrigin::ExecutionOrder))
-    {
-      if let Some(module) = self.modules.get(&module_idx) {
-        return &module.transitive_init_targets;
-      }
-    }
-    &meta.transitive_esm_init_targets
-  }
-
   pub(crate) fn order_wrapper_chunk(&self, module_idx: ModuleIdx) -> Option<ChunkIdx> {
     self.modules.get(&module_idx)?.chunk
   }
@@ -438,8 +407,6 @@ pub struct OrderWrappedModule {
   /// dependency. Binding-driven consumers may therefore route through it to the leaf wrappers
   /// they consume. Side-effect-only imports still call the wrapper directly.
   pub(crate) reexport_init_transparent: bool,
-  pub(crate) init_is_noop: bool,
-  pub(crate) transitive_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -451,7 +418,6 @@ pub enum EsmInitOrigin {
 #[derive(Clone, Copy, Debug)]
 pub struct EsmInitTarget {
   pub(crate) wrapper_ref: SymbolRef,
-  pub(crate) init_is_noop: bool,
   pub(crate) tla_tainted: bool,
   pub(crate) origin: EsmInitOrigin,
 }

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -590,10 +590,11 @@ fn lower_order_state(
 /// retained-re-export-path overlay for a re-export that itself reaches the plan through a
 /// tree-shaken barrel. Split out of [`lower_order_state`] so the emergent-cycle fixpoint projector
 /// can populate an identical set of overlays on its probe state — the overlays and the nested
-/// re-export records are what let the shared `transitive_esm_init_targets` restrict a barrel's hop
-/// walk to its retained path, so projection stays byte-faithful to the real registration instead of
-/// over-approximating. Reads and writes only the [`OrderWrapState`]; it never mints symbols, so the
-/// projector can drive it with each module's namespace ref as a wrapper placeholder.
+/// re-export records are what let the final metadata pass's `transitive_esm_init_targets` restrict
+/// a barrel's hop walk to its retained path, so projection stays byte-faithful to the real
+/// registration instead of over-approximating. Reads and writes only the [`OrderWrapState`]; it
+/// never mints symbols, so the projector can drive it with each module's namespace ref as a wrapper
+/// placeholder.
 pub(super) fn populate_order_import_overlays(
   input: &OrderLoweringInput<'_>,
   reexport_usage: &FrozenReexportUsage,

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -110,16 +110,6 @@ pub struct LinkingMetadata {
   pub stmt_info_included: IndexBitSet<StmtInfoIdx>,
   /// Tracks whether the module is included after tree-shaking.
   pub is_included: bool,
-  /// Set for a standalone wrapped (`WrapKind::Esm`) module whose `__esm` closure body is empty
-  /// (every top-level statement is a hoisted function declaration or a source-less export clause,
-  /// so nothing lands inside the wrapper closure). Calling such an `init_*` is a no-op, so init
-  /// call sites are marked `@__PURE__` and the default `dce-only` minifier drops them (and the
-  /// now-unused wrapper). Computed by [`crate::stages::generate_stage`]'s
-  /// `compute_wrapped_esm_init_metadata`.
-  pub init_is_noop: bool,
-  /// Wrapped ESM targets emitted at excluded import or re-export statements.
-  /// Ordinary order-wrap imports must already be in [`Self::execution_dependencies`].
-  pub transitive_esm_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
 }
 
 impl LinkingMetadata {

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -211,8 +211,6 @@ pub struct OrderWrappedModule {
   pub wrapper_statement: Option<OrderSyntheticStmtIdx>,
   pub chunk: Option<ChunkIdx>,
   pub reexport_init_transparent: bool,
-  pub init_is_noop: bool,
-  pub transitive_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
 }
 
 pub struct OrderSyntheticStmt {
@@ -239,9 +237,9 @@ pub struct OrderImportOverlay {
 }
 ```
 
-`OrderWrapState` is the sole owner of these fields. Helper views may borrow it, but the data is not mirrored into `LinkingMetadata`.
+`OrderWrapState` is the sole owner of these order-lowering fields. Helper views may borrow it, but the data is not mirrored into `LinkingMetadata`.
 
-- wrapper symbols and init metadata belong to order state, not `LinkingMetadata`;
+- order-wrapper symbols and placement belong to order state, not `LinkingMetadata`;
 - order state does not contain mutable user-statement inclusion;
 - importer-specific references and runtime helpers belong to `import_overlays`, not the original `StmtInfo`;
 - synthetic declarations participate in chunk assignment and deconfliction through an explicit synthetic-statement API, with secondary indexes for chunk rendering;
@@ -276,6 +274,29 @@ pub struct OrderLoweringOutput<'a> {
 
 The API does not expose mutable `LinkingMetadata`, `StmtInfos`, or the chunk graph. The surrounding generate-stage pass places the synthetic wrappers, creates any entry facades, and recomputes topology-derived facts after lowering; the lowerer communicates new symbol, namespace, runtime, and re-export-routing requirements through `OrderWrapState`.
 
+### Final ESM init metadata
+
+After wrapper selection and final chunk topology are fixed, `compute_wrapped_esm_init_metadata` derives the two facts that depend on both link and order state: whether an `init_*()` call is a no-op, and which wrapped modules must be initialized at each excluded statement. Interop and execution-order wrappers share one sealed result instead of writing the same kind of final fact back into either owner's mutable state:
+
+```rust
+pub struct Sealed<T>(T); // private field and constructor; Deref only, never DerefMut or unwrap
+
+pub struct FinalEsmInitMetadata {
+  modules: FxHashMap<ModuleIdx, ModuleEsmInitMetadata>,
+}
+
+struct ModuleEsmInitMetadata {
+  init_is_noop: bool,
+  transitive_init_targets: FxHashMap<StmtInfoIdx, Vec<ModuleIdx>>,
+}
+
+fn compute_wrapped_esm_init_metadata(/* ... */) -> Sealed<FinalEsmInitMetadata>;
+```
+
+`Sealed<T>` and its private constructor live in the leaf module that computes this artifact. The result cannot be unwrapped or mutably dereferenced, so taking ownership again does not reopen mutation. Final cross-chunk linking and module finalization accept only `&Sealed<FinalEsmInitMetadata>`; an unsealed value cannot satisfy either signature.
+
+The table is sparse: a missing entry means `init_is_noop == false` and no excluded-statement targets, never that the module lacks a wrapper. Wrapper identity remains in `LinkingMetadata` or `OrderWrapState`. The earlier on-demand projection continues to recompute a conservative draft from its probe `OrderWrapState` because final metadata does not exist yet; it marks final metadata unavailable instead of manufacturing an empty sealed value.
+
 ### Shared init-target view
 
 Finalization and cross-chunk linking need to work with two sources of lazy initialization:
@@ -288,7 +309,6 @@ They use a read-only view instead of testing an effective `WrapKind`:
 ```rust
 pub struct EsmInitTarget {
   pub wrapper_ref: SymbolRef,
-  pub init_is_noop: bool,
   pub tla_tainted: bool,
   pub origin: EsmInitOrigin,
 }
@@ -299,7 +319,7 @@ pub enum EsmInitOrigin {
 }
 ```
 
-An accessor resolves at most one ESM init target for a module. Interop ESM wrapping takes precedence because an already interop-wrapped module is represented by that existing wrapper; the order planner selects an eligible carrier instead of adding a second wrapper.
+An accessor resolves at most one ESM init target for a module. Interop ESM wrapping takes precedence because an already interop-wrapped module is represented by that existing wrapper; the order planner selects an eligible carrier instead of adding a second wrapper. This view carries structural wrapper identity only; final no-op and excluded-statement facts come from `FinalEsmInitMetadata`.
 
 ### Synthetic symbol inclusion
 
@@ -329,7 +349,7 @@ The module finalizer has three explicit cases:
 - ESM interop wrapper from `WrapKind::Esm`;
 - execution-order wrapper from `OrderWrapState`.
 
-The execution-order case reuses the established hoisted `function init_*()` code shape but obtains its symbol and init facts from order state. It never observes an overridden interop kind.
+The execution-order case reuses the established hoisted `function init_*()` code shape, obtains its wrapper symbol from order state, and obtains final derived init facts from `FinalEsmInitMetadata`. It never observes an overridden interop kind.
 
 Removed user import/re-export statements are finalized with any matching `OrderImportOverlay`. The finalizer may emit a synthetic init or re-export expression in the removed statement's source position, but it does not restore the original statement.
 
@@ -349,9 +369,9 @@ link + tree shaking
   -> provisional ChunkGraph
   -> OrderAnalysis / OrderWrapPlan
   -> lower plan into OrderWrapState + final ChunkGraph
-  -> compute init metadata using LinkingMetadata + OrderWrapState
-  -> compute cross-chunk links using the shared EsmInitTarget view
-  -> finalize modules using explicit interop/order wrapper cases
+  -> compute Sealed<FinalEsmInitMetadata> using LinkingMetadata + OrderWrapState
+  -> compute cross-chunk links using EsmInitTarget + Sealed<FinalEsmInitMetadata>
+  -> finalize modules using explicit interop/order wrapper cases + Sealed<FinalEsmInitMetadata>
   -> render entry prologues using the shared EsmInitTarget view
 ```
 
@@ -366,6 +386,7 @@ link + tree shaking
 - A planned static chunk SCC includes every eligible order-sensitive module in that SCC.
 - Every ordinary-import init obligation corresponds to a link-stage execution dependency.
 - Every excluded-statement init obligation is either a retained re-export obligation or a synthetic obligation backed by an execution dependency.
+- Final cross-chunk registration and finalizer emission require the same `Sealed<FinalEsmInitMetadata>` type; pre-final projection cannot supply one and does not consume final metadata.
 - Wrap-all and on-demand preserve the same link-stage statement and binding liveness; only their wrapper plans may differ.
 - Every order-wrapped entry has an explicit entry trigger.
 - Flag-off builds create no order wrappers or strict-only entry facades.

--- a/internal-docs/code-splitting/implementation.md
+++ b/internal-docs/code-splitting/implementation.md
@@ -1,6 +1,6 @@
 # Code Splitting
 
-The rationale and target architecture are documented in [design.md](./design.md). This file describes the current implementation, where generate-stage order lowering owns wrappers and importer overlays in `OrderWrapState` without changing link-stage `WrapKind` or user statement inclusion.
+The rationale and target architecture are documented in [design.md](./design.md). This file describes the current implementation, where generate-stage order lowering owns wrappers and importer overlays in `OrderWrapState` without changing link-stage `WrapKind` or user statement inclusion, and final interop/order init facts are sealed separately in `FinalEsmInitMetadata`.
 
 ## Summary
 
@@ -72,6 +72,8 @@ ChunkGraph
     │
     ├─ used_symbol_refs.seal()                        Freeze liveness; the sweep is the last writer
     │
+    ├─ compute_wrapped_esm_init_metadata()            Produce Sealed<FinalEsmInitMetadata>
+    │
     ├─ compute_cross_chunk_links()                    Determine cross-chunk imports/exports
     │
     ├─ ensure_lazy_module_initialization_order()      Reorder wrapped module init calls
@@ -84,7 +86,8 @@ ChunkGraph
 - `crates/rolldown/src/stages/generate_stage/code_splitting.rs` — pipeline orchestration, `generate_chunks()`, `ensure_lazy_module_initialization_order()`
 - `crates/rolldown/src/stages/generate_stage/order_analysis.rs` — `strictExecutionOrder` analysis and the reasoned `OrderWrapPlan`
 - `crates/rolldown/src/stages/generate_stage/order_wrapping.rs` — applies order wrappers after chunk assignment
-- `crates/rolldown/src/stages/generate_stage/order_wrap_state.rs` — owns synthetic wrapper declarations, importer overlays, namespace/runtime requirements, and order init metadata
+- `crates/rolldown/src/stages/generate_stage/order_wrap_state.rs` — owns synthetic wrapper declarations, importer overlays, namespace/runtime requirements, and re-export routing evidence
+- `crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs` — derives the sealed final no-op and excluded-statement init facts shared by interop and order wrappers
 - `crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs` — final topology boundary before output metadata and validation
 - `crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs` — Rollup-style dynamic import already-loaded atom reduction
 - `crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs` — merge/optimization
@@ -94,6 +97,8 @@ ChunkGraph
 - `crates/rolldown/src/types/linking_metadata.rs` — immutable link-stage `wrap_kind()`
 
 Wrap-all (the default strict mode) seeds the plan from the expected orders alone and skips prediction; `experimental.onDemandWrapping` enables the selective analysis. `finalize_chunk_plan` may run two metadata passes. Namespace usage and entry-level external re-exports are first finalized on the provisional graph. They are recomputed when order wrapping or strict entry facades change topology.
+
+Once final topology and liveness are fixed, `compute_wrapped_esm_init_metadata` produces a sparse `Sealed<FinalEsmInitMetadata>`: absence of a module entry means the default no-op/empty-target values, not absence of a wrapper. `Sealed<T>` has a private field and constructor, exposes only `Deref`, and offers neither `DerefMut` nor an unwrap operation. Final cross-chunk linking and module finalization require that sealed type, so re-owning the artifact cannot reopen mutation and an unsealed result cannot reach either consumer. The earlier `predicted_static_import_edges` pass explicitly marks final metadata unavailable instead of manufacturing an empty sealed artifact; its Project-mode obligation traversal remains separate and conservative.
 
 Both modes consume the same frozen tree-shaking facts. `order_wrapper_is_reexport_transparent` identifies pure order wrappers that are only init-routing waypoints. `collect_wrapped_esm_init_targets_for_import_record` then resolves obligations per consumer: it filters named specifiers by local facade liveness, follows consumed re-export facades recorded in `OrderWrapState`, resolves static namespace-member reads from included `StmtInfo` references, expands all exports only for opaque namespace use, and applies the same constant-inline bypass as the inclusion pass. This lets wrap-all emit more wrappers without retaining or executing more user code than on-demand.
 


### PR DESCRIPTION
### Description

Centralizes final wrapped-ESM initialization facts in one narrow, read-only `FinalEsmInitMetadata` artifact.

- `compute_wrapped_esm_init_metadata` now returns the final no-op classification and excluded-statement init targets instead of mutating `LinkingMetadata` and `OrderWrapState`.
- Cross-chunk registration and module finalization consume the same artifact.
- `EsmInitTarget` remains the structural view of wrapper identity, origin, and TLA state.
- The earlier Project/probe path stays separate and passes an empty final artifact, matching the point where final metadata does not exist yet.

### Validation

- `rustfmt --edition 2024 --check` on the touched Rust files
- `git diff --check`
- Full Rust type-check and test coverage: pending GitHub CI

No new fixture was added because this is an ownership-only refactor; existing wrapped-ESM and strict-execution-order fixtures cover both interop and order wrapper paths.