### PR TITLE
test(wasi): add tokio runtime lifecycle regression test

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Stability Test
         run: vp run --filter rolldown-tests test:stability
 
+      # Runs against the WASI binding itself (NAPI_RS_FORCE_WASI), which no
+      # other CI test does. Regression coverage for #8411 and #8747.
+      - name: Tokio Runtime Lifecycle Test
+        run: vp run --filter rolldown-tests test:wasi-runtime
+
       # `@example/typescript` is excluded because its config enables `devtools`, which currently
       # panics under WASI when the writer tries to open its log file (crates/rolldown_devtools/src/writer.rs).
       # `@example/native-magic-string` is excluded because it depends on a native-only addon.

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -19,6 +19,7 @@
     "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts dev-watch.test.ts --reporter verbose --hideSkippedTests",
     "test:cli": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run cli-e2e.test.ts --reporter verbose --hideSkippedTests",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
+    "test:wasi-runtime": "node ./wasi/runtime-lifecycle.mjs",
     "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests"
   },
   "dependencies": {

--- a/packages/rolldown/tests/wasi/runtime-lifecycle.mjs
+++ b/packages/rolldown/tests/wasi/runtime-lifecycle.mjs
@@ -1,0 +1,103 @@
+// Regression test for #8411 and #8747, WASI only.
+//
+// The wasm binding refcounts the shared tokio runtime. Before the fix,
+// `RolldownBuild.close()` and `Watcher.close()` released the runtime without a
+// matching acquire, and `DevEngine` never acquired at all. The first `close()`
+// in the process then tore the runtime down under every later consumer, and
+// the next binding call crashed with "Access tokio runtime failed in spawn".
+// On native targets the runtime functions are no-ops, so this can only be
+// caught by running against the WASI binding.
+//
+// This file is a plain node script wired into the WASI CI lane. It must set
+// NAPI_RS_FORCE_WASI before importing rolldown, and `error` mode is required:
+// with `true`, a missing wasi build silently falls back to the native binding
+// and the test would pass without testing anything.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+process.env.NAPI_RS_FORCE_WASI = 'error';
+
+const { rolldown, watch } = await import('rolldown');
+const { dev } = await import('rolldown/experimental');
+
+const require = createRequire(import.meta.url);
+if (!Object.keys(require.cache).some((k) => k.includes('rolldown-binding.wasi.cjs'))) {
+  console.error('[wasi-runtime] the WASI binding was not loaded');
+  process.exit(1);
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rolldown-wasi-runtime-'));
+function makeFixture(name) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'entry.js'), 'export const value = 1;\n');
+  return dir;
+}
+
+async function buildAndClose(dir) {
+  const bundle = await rolldown({ input: path.join(dir, 'entry.js'), cwd: dir });
+  await bundle.generate({ format: 'esm' });
+  await bundle.close();
+}
+
+// #8411: a closed build (Vite bundling vite.config.ts) followed by a DevEngine.
+{
+  const dir = makeFixture('dev-after-close');
+  await buildAndClose(dir);
+  const engine = await dev(
+    { input: path.join(dir, 'entry.js'), cwd: dir },
+    { dir: path.join(dir, 'dist') },
+    {},
+  );
+  await engine.run();
+  await engine.ensureCurrentBuildFinish();
+  await engine.close();
+  console.log('[wasi-runtime] dev engine after build close: ok');
+}
+
+// #8747: a closed build followed by watch mode.
+{
+  const dir = makeFixture('watch-after-close');
+  await buildAndClose(dir);
+  const watcher = watch({
+    input: path.join(dir, 'entry.js'),
+    cwd: dir,
+    output: { dir: path.join(dir, 'dist') },
+  });
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out waiting for BUNDLE_END')), 60_000);
+    watcher.on('event', (event) => {
+      if (event.code === 'BUNDLE_END') {
+        clearTimeout(timer);
+        resolve();
+      } else if (event.code === 'ERROR') {
+        clearTimeout(timer);
+        reject(event.error);
+      }
+    });
+  });
+  await watcher.close();
+  console.log('[wasi-runtime] watch after build close: ok');
+}
+
+// The invariant behind both fixes: closing one consumer must not tear the
+// runtime down under another consumer that is still alive.
+{
+  const dir = makeFixture('close-while-dev-alive');
+  const engine = await dev(
+    { input: path.join(dir, 'entry.js'), cwd: dir },
+    { dir: path.join(dir, 'dist') },
+    {},
+  );
+  await engine.run();
+  await buildAndClose(makeFixture('unrelated-build'));
+  await engine.ensureCurrentBuildFinish();
+  await engine.close();
+  console.log('[wasi-runtime] build close while dev engine alive: ok');
+}
+
+fs.rmSync(root, { recursive: true, force: true });
+console.log('[wasi-runtime] PASS');
+process.exit(0);


### PR DESCRIPTION
### Description

Follow-up to #10363, which must land first. Adds regression coverage for the `Access tokio runtime failed in spawn` crash class fixed there.

This bug class was invisible to every existing CI test. The runtime acquire and release functions are no-ops on native targets, and no CI test actually executed the WASI binding: the WASI workflow builds the wasm binding and runs the stability test and the examples, but those load the native binding that the same job builds for tooling. So an unbalanced runtime release could only ever crash on StackBlitz, never in CI.

The new `tests/wasi/runtime-lifecycle.mjs` is a plain node script following the `test:stability` pattern, wired into the WASI workflow right after the build step. It forces the real wasm binding and covers three sequences:

- The #8411 shape: a build that gets closed (Vite bundling `vite.config.ts`), then a `DevEngine` is created and run.
- The #8747 shape: a build that gets closed, then `watch()` runs until `BUNDLE_END`.
- The invariant behind both: closing one consumer while a `DevEngine` is still alive must not tear the runtime down under the engine.

Two details are load-bearing. `NAPI_RS_FORCE_WASI` is set to `error` inside the script before importing rolldown, because `true` silently falls back to the native binding when the wasi files are missing and the test would pass without testing anything. After the import the script also asserts via `require.cache` that `rolldown-binding.wasi.cjs` was really loaded.

### Verification

Red and green were produced under identical conditions (same machine, same stable toolchain, napi 3.11.0 on both sides, wasm binding forced and asserted). On `main` (`aa73a6848`, without #10363) the test exits 1 in the first sequence with the exact issue signature: `Access tokio runtime failed in spawn` in napi's `tokio_runtime.rs`, followed by `RuntimeError: unreachable`. On top of #10363 all three sequences pass.

To run locally: `pnpm build-wasi:debug` in `packages/rolldown` (dist only contains the wasi files when built with `TARGET=rolldown-wasi`), then `pnpm test:wasi-runtime` in `packages/rolldown/tests`.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

