### PR TITLE
test(dev): expect preserved hot.data in hmr-whole-chain-dispose

### DIFF
--- a/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/__tests__/hmr-whole-chain-dispose.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/__tests__/hmr-whole-chain-dispose.spec.ts
@@ -3,14 +3,15 @@ import { editFile, page, waitForBuildStable } from '~utils';
 
 // On a hot update EVERY re-executed module's `hot.dispose(cb)` runs — the
 // whole evicted chain (baz, bar, AND the boundary foo), not just the accepted
-// module. Each disposer receives a FRESH data bag; the next generation reads
-// it via `hot.data`, and a generation's own direct writes into `hot.data` do
-// NOT leak into the next generation's bag.
+// module. `import.meta.hot.data` is PRESERVED across a module's generations
+// (Vite's documented contract, https://vite.dev/guide/api-hmr#hot-data): the
+// disposer receives the existing bag, and a generation's own direct writes
+// into `hot.data` remain visible to the next generation.
 
 interface HotState {
   id: string;
   gen: number | null;
-  leak: string | null;
+  own: string | null;
 }
 
 const readDisposed = () =>
@@ -19,18 +20,19 @@ const readHotStates = () =>
   page.evaluate(() => (window as unknown as { __hotStates?: HotState[] }).__hotStates ?? []);
 
 describe('hmr-whole-chain-dispose', () => {
-  test('every re-executed module disposes, each generation gets a fresh data bag', async () => {
+  test('every re-executed module disposes and carries its hot.data forward', async () => {
     // Let any spurious startup rebuild/reload settle before the un-polled
     // window reads below (a reload mid-read destroys the evaluate context).
     await waitForBuildStable();
     await expect.poll(() => page.textContent('.chain')).toBe('bar(baz-v1)');
 
-    // Generation 0 saw empty bags: no `gen` from a previous disposer, no leak.
+    // Generation 0 saw empty bags: no `gen` from a previous disposer, and no
+    // own-write yet (this generation records BEFORE writing it).
     await expect.poll(async () => (await readHotStates()).length).toBe(3);
     const gen0 = await readHotStates();
     for (const state of gen0) {
       expect(state.gen).toBe(null);
-      expect(state.leak).toBe(null);
+      expect(state.own).toBe(null);
     }
 
     // --- First edit: the whole chain re-executes ---------------------------
@@ -42,15 +44,14 @@ describe('hmr-whole-chain-dispose', () => {
     expect(disposedOnce).toHaveLength(3);
     expect(disposedOnce).toEqual(expect.arrayContaining(['foo', 'bar', 'baz']));
 
-    // Generation 1 reads what generation 0's disposers wrote (`gen: 1`), and
-    // does NOT see generation 0's direct `hot.data.leak` writes — the bag is
-    // fresh, only the disposer's writes travel forward.
+    // Generation 1 reads back the SAME preserved bag: the disposer's `gen: 1`,
+    // and generation 0's own direct `hot.data` write survives intact.
     const gen1 = (await readHotStates()).slice(3);
     expect(gen1).toHaveLength(3);
     expect(gen1.map((s) => s.id)).toEqual(expect.arrayContaining(['foo', 'bar', 'baz']));
     for (const state of gen1) {
       expect(state.gen).toBe(1);
-      expect(state.leak).toBe(null);
+      expect(state.own).toBe(`${state.id}-own-write`);
     }
 
     await waitForBuildStable();
@@ -66,7 +67,7 @@ describe('hmr-whole-chain-dispose', () => {
     expect(gen2).toHaveLength(3);
     for (const state of gen2) {
       expect(state.gen).toBe(2);
-      expect(state.leak).toBe(null);
+      expect(state.own).toBe(`${state.id}-own-write`);
     }
 
     await waitForBuildStable();

--- a/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/bar.js
+++ b/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/bar.js
@@ -5,11 +5,11 @@ export const bar = `bar(${baz})`;
 (window.__hotStates ??= []).push({
   id: 'bar',
   gen: import.meta.hot?.data.gen ?? null,
-  leak: import.meta.hot?.data.leak ?? null,
+  own: import.meta.hot?.data.own ?? null,
 });
 
 if (import.meta.hot) {
-  import.meta.hot.data.leak = 'bar-own-write';
+  import.meta.hot.data.own = 'bar-own-write';
 }
 
 import.meta.hot?.dispose((data) => {

--- a/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/baz.js
+++ b/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/baz.js
@@ -3,11 +3,11 @@ export const baz = 'baz-v1';
 (window.__hotStates ??= []).push({
   id: 'baz',
   gen: import.meta.hot?.data.gen ?? null,
-  leak: import.meta.hot?.data.leak ?? null,
+  own: import.meta.hot?.data.own ?? null,
 });
 
 if (import.meta.hot) {
-  import.meta.hot.data.leak = 'baz-own-write';
+  import.meta.hot.data.own = 'baz-own-write';
 }
 
 import.meta.hot?.dispose((data) => {

--- a/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/foo.js
+++ b/packages/test-dev-server/tests/playground/hmr-whole-chain-dispose/foo.js
@@ -3,21 +3,25 @@ import { bar } from './bar.js';
 document.querySelector('.chain').textContent = bar;
 
 // Record what this generation sees in its `hot.data` bag AT EXECUTION time.
+// `import.meta.hot.data` is PRESERVED across a module's HMR generations (the
+// bag is the same object), so both the disposer's write (`gen`) and this
+// generation's own direct write (`own`) are visible to the next generation.
 (window.__hotStates ??= []).push({
   id: 'foo',
   gen: import.meta.hot?.data.gen ?? null,
-  leak: import.meta.hot?.data.leak ?? null,
+  own: import.meta.hot?.data.own ?? null,
 });
 
-// An own write into the live bag — a FRESH bag per generation means this must
-// NOT be visible to the next generation.
+// A direct write into the live bag — because the bag persists, the NEXT
+// generation must read this value back (not a fresh, empty bag).
 if (import.meta.hot) {
-  import.meta.hot.data.leak = 'foo-own-write';
+  import.meta.hot.data.own = 'foo-own-write';
 }
 
 import.meta.hot?.dispose((data) => {
   (window.__disposed ??= []).push('foo');
-  // Read the OLD generation's bag via hot.data, write into the FRESH bag.
+  // `data` is the same preserved bag as `import.meta.hot.data`; bump the
+  // generation counter that the next execution reads back.
   data.gen = (import.meta.hot.data.gen ?? 0) + 1;
 });
 


### PR DESCRIPTION
### Description

The `hmr-whole-chain-dispose` browser fixture runs on Vite's full-bundle client (the provisioned `vite/` checkout, `vitejs/vite` `rolldown-canary`), not rolldown's native runtime — see the note in `full-bundle-dev-environment.ts`. That client's `handleModuleCacheRemoval` was recently fixed to **preserve** `import.meta.hot.data` across a module's HMR generations, matching Vite's documented contract:

> The `import.meta.hot.data` object is persisted across different instances of the same updated module.
> — https://vite.dev/guide/api-hmr#hot-data (see vitejs/vite#23001)

On `rolldown-canary` the client (renamed to `bundledDevHmrClient.ts`) now does:

```ts
handleModuleCacheRemoval(id: string): void {
  const disposer = this.disposeMap.get(id)
  if (disposer) {
    disposer(this.dataMap.get(id))   // existing bag, not a fresh {}
  }
}
```

But this test + fixtures still asserted the **old** "each generation gets a fresh data bag" behavior, so once the client started preserving, CI failed:

```
FAIL playground/hmr-whole-chain-dispose/__tests__/hmr-whole-chain-dispose.spec.ts
  > every re-executed module disposes, each generation gets a fresh data bag
AssertionError: expected 'baz-own-write' to be null
```

(`'baz-own-write'` is a direct `hot.data` write from generation 0 that correctly survived into generation 1.)

### Change

Align the fixtures and assertions with the preserved-data contract:

- Rename the `leak` probe (which meant "a direct write that must NOT survive") to `own`, and assert each module's own direct `hot.data` write **is** read back by the next generation (`own === \`${id}-own-write\``).
- `gen0` bags are still empty (`gen: null`, `own: null`); the disposer-written `gen` counter still advances `1 → 2` — those were already passing and are unchanged.
- **Whole-chain dispose** coverage is untouched: every re-executed module in the evicted chain (baz, bar, and the boundary foo) still disposes each generation (3, then 6).

### Validation

- `vp check` (lint/format) via the commit hook.
- The browser E2E itself is verified by CI (`node-dev-server-test`); it requires the provisioned `vite/` checkout + native build, so it was not run locally. Expectations were derived from the preserved-data semantics and confirmed against `rolldown-canary`'s current `bundledDevHmrClient.ts` and the exact CI failure value.

Note: the separate `Vite Test` job failing on the same runs is the Vite-side manifestation of the same behavior change and is not addressed here (it lives in the `vite/` checkout, not this repo).