### PR TITLE
fix: guarantee tokio runtime release when close rejects

### DIFF
--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -151,9 +151,12 @@ export class DevEngine {
     // Claim the release before the first await so a second `close` cannot release twice.
     const shouldRelease = !this.#asyncRuntimeReleased;
     this.#asyncRuntimeReleased = true;
-    await this.#inner.close();
-    if (shouldRelease) {
-      shutdownAsyncRuntime();
+    try {
+      await this.#inner.close();
+    } finally {
+      if (shouldRelease) {
+        shutdownAsyncRuntime();
+      }
     }
   }
 

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -42,9 +42,12 @@ export const scan = async (
   async function cleanup() {
     if (cleanedUp) return;
     cleanedUp = true;
-    await bundler.close();
-    await ret.stopWorkers?.();
-    shutdownAsyncRuntime();
+    try {
+      await bundler.close();
+      await ret.stopWorkers?.();
+    } finally {
+      shutdownAsyncRuntime();
+    }
   }
 
   let cleanupPromise = Promise.resolve();

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -93,12 +93,15 @@ export class RolldownBuild {
     // Claim the release before the first await so a second `close` cannot release twice.
     const shouldRelease = !this.#asyncRuntimeReleased;
     this.#asyncRuntimeReleased = true;
-    await this.#stopWorkers?.();
-    // `BindingBundler.close` spawns onto the runtime, so release only after it settles.
-    await this.#bundler.close();
-    this.#stopWorkers = void 0;
-    if (shouldRelease) {
-      shutdownAsyncRuntime();
+    try {
+      await this.#stopWorkers?.();
+      // `BindingBundler.close` spawns onto the runtime, so release only after it settles.
+      await this.#bundler.close();
+      this.#stopWorkers = void 0;
+    } finally {
+      if (shouldRelease) {
+        shutdownAsyncRuntime();
+      }
     }
   }
 

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -91,11 +91,14 @@ class Watcher {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    for (const stop of this.stopWorkers) {
-      await stop?.();
+    try {
+      for (const stop of this.stopWorkers) {
+        await stop?.();
+      }
+      await this.inner.close();
+    } finally {
+      shutdownAsyncRuntime();
     }
-    await this.inner.close();
-    shutdownAsyncRuntime();
   }
 
   private async run(): Promise<void> {


### PR DESCRIPTION
### Description

Follow-up to #10363, addressing [this review comment](https://github.com/rolldown/rolldown/pull/10363#issuecomment-5041768680).

#10363 made the wasm tokio runtime refcount strictly paired: acquire on create, release on close. But every release still ran as a plain statement after the awaited close calls. If any of those awaits rejects, the release is skipped and the acquire leaks. The count then stays above zero, the runtime is never torn down, and on wasm the park threads hang forever, which is the #8747 symptom in reverse. This is not a regression, the old code had the same shape, but it leaves the pairing guaranteed only on the success path.

This PR wraps each release in `try/finally` so it fires no matter how the close settles:

- `RolldownBuild.close()`
- `DevEngine.close()`
- the idempotent `cleanup()` in `scan()`
- `Watcher.close()`, which the comment did not name but has the identical pattern

The documented ordering is unchanged. `finally` runs only after the awaited close settles, whether it resolves or rejects, so the release still happens strictly after `BindingBundler.close()` is done spawning onto the runtime. The claim-before-first-await guard against double release is also untouched, and the whole change remains a no-op on native targets, where `startAsyncRuntime` and `shutdownAsyncRuntime` compile to empty functions.

One pre-existing gap is deliberately left alone: when an early step rejects (for example `stopWorkers()`), the later close calls in the same method are still skipped. This PR only guarantees the runtime release. Making every cleanup step run independently is a separate concern.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

