### PR TITLE
fix(dev): sourcemaps of lazily compiled chunks

### DIFF
--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -29,9 +29,15 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sugar_path::SugarPath;
 
 use crate::{
-  SharedOptions, SharedResolver, hmr::hmr_ast_finalizer::HmrAstFinalizer,
-  module_loader::ModuleLoader, type_alias::IndexEcmaAst, types::scan_stage_cache::ScanStageCache,
-  utils::process_code_and_sourcemap::process_code_and_sourcemap,
+  SharedOptions, SharedResolver,
+  hmr::hmr_ast_finalizer::HmrAstFinalizer,
+  module_loader::ModuleLoader,
+  type_alias::IndexEcmaAst,
+  types::scan_stage_cache::ScanStageCache,
+  utils::{
+    process_code_and_sourcemap::process_code_and_sourcemap,
+    render_ecma_module::collapse_module_sourcemap,
+  },
 };
 
 pub struct HmrStageInput<'a, Fs: FileSystem + Clone + 'static> {
@@ -810,10 +816,34 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       },
     );
 
-    match codegen.map {
+    // The codegen map is the last element of the module's sourcemap chain, so on its
+    // own it maps back to what the plugins produced rather than to the original file.
+    // Collapsing the chain is what lets a position in a patch or a lazy chunk resolve
+    // to the source the user wrote, the same way `render_ecma_module` does for a
+    // module rendered into a chunk.
+    //
+    // Warnings are dropped: a module rendered here was rendered by the full build too,
+    // which reports a broken chain for it already.
+    let (code, codegen_map) = match codegen.map {
       Some(map) => (codegen.code, Some(map.into_owned())),
       None => (codegen.code, None),
-    }
+    };
+
+    // Guarded, because a chain collapses to a map even when the codegen step
+    // contributed none — which would hand back a sourcemap for a render that asked
+    // not to have one.
+    let map = enable_sourcemap
+      .then(|| {
+        collapse_module_sourcemap(
+          &module.sourcemap_chain,
+          codegen_map,
+          module.id.as_str(),
+          &mut Vec::new(),
+        )
+      })
+      .flatten();
+
+    (code, map)
   }
 }
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -599,7 +599,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
     let file_dir = self.options.cwd.as_path().join(&self.options.out_dir);
 
-    if let Some(map) = map.as_mut() {
+    let sourcemap_asset = if let Some(map) = map.as_mut() {
       process_code_and_sourcemap(
         &self.options,
         &mut code,
@@ -610,8 +610,10 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
         /*is_css*/ false,
         None,
       )
-      .await?;
-    }
+      .await?
+    } else {
+      None
+    };
 
     let carried = modules_to_be_updated
       .iter()
@@ -621,7 +623,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
       })
       .collect();
 
-    Ok(HmrLazyChunkOutput { code, filename, carried })
+    Ok(HmrLazyChunkOutput {
+      code,
+      filename,
+      sourcemap_filename: sourcemap_asset.as_ref().map(|asset| asset.filename.to_string()),
+      sourcemap: sourcemap_asset.map(|asset| asset.source.try_into_string()).transpose()?,
+      carried,
+    })
   }
 
   async fn render_hmr_patch(

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -65,7 +65,7 @@ pub fn render_ecma_module(
 ///
 /// A `SOURCEMAP_BROKEN` warning is pushed onto `warnings` for every plugin that
 /// omitted its sourcemap, since that breaks the mapping chain for `module_id`.
-fn collapse_module_sourcemap(
+pub fn collapse_module_sourcemap(
   sourcemap_chain: &[SourcemapChainElement],
   codegen_map: Option<SourceMap>,
   module_id: &str,

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -301,7 +301,12 @@ impl BindingDevEngine {
       inner
         .compile_lazy_entry(module_id, client_id)
         .await
-        .map(|output| BindingLazyChunkOutput { code: output.code, filename: output.filename })
+        .map(|output| BindingLazyChunkOutput {
+          code: output.code,
+          filename: output.filename,
+          sourcemap: output.sourcemap,
+          sourcemap_filename: output.sourcemap_filename,
+        })
         .map_err(|e| napi::Error::from_reason(format!("Failed to compile lazy entry: {e:#?}")))
     })
   }
@@ -313,6 +318,11 @@ impl BindingDevEngine {
 pub struct BindingLazyChunkOutput {
   pub code: String,
   pub filename: String,
+  /// The chunk's sourcemap, when `sourcemap` is `File` or `Hidden`. Serve it
+  /// under `sourcemapFilename`, which is what the chunk's `sourceMappingURL`
+  /// refers to.
+  pub sourcemap: Option<String>,
+  pub sourcemap_filename: Option<String>,
 }
 
 #[napi(object)]

--- a/crates/rolldown_common/src/hmr/lazy_chunk_output.rs
+++ b/crates/rolldown_common/src/hmr/lazy_chunk_output.rs
@@ -4,6 +4,11 @@ use arcstr::ArcStr;
 pub struct HmrLazyChunkOutput {
   pub code: String,
   pub filename: String,
+  /// The chunk's sourcemap, when `sourcemap` is `File` or `Hidden`. The consumer
+  /// serves it under `sourcemap_filename`, which is what the chunk's
+  /// `sourceMappingURL` refers to.
+  pub sourcemap: Option<String>,
+  pub sourcemap_filename: Option<String>,
   /// `(stable id, render-time stamp)` for every module this chunk carries — the
   /// pending-payload entry that the delivery-time ship-map write consumes when the
   /// serving middleware observes the response complete.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2456,6 +2456,13 @@ export interface BindingJsWatchChangeEvent {
 export interface BindingLazyChunkOutput {
   code: string
   filename: string
+  /**
+   * The chunk's sourcemap, when `sourcemap` is `File` or `Hidden`. Serve it
+   * under `sourcemapFilename`, which is what the chunk's `sourceMappingURL`
+   * refers to.
+   */
+  sourcemap?: string
+  sourcemapFilename?: string
 }
 
 export interface BindingLog {

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import type { InputOptions, OutputOptions } from 'rolldown';
 import type { DevEngine, DevOptions } from 'rolldown/experimental';
 import { dev as _dev } from 'rolldown/experimental';
+import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
 import { expect, test } from 'vitest';
 
 const TEST_TIMEOUT = 60_000;
@@ -123,5 +124,99 @@ test(
     const coldChunk = await engine.compileEntry(lazyProxyId, 'client-without-session');
     expect(coldChunk.code).toMatch(lazyFactory);
     expect(coldChunk.code).toMatch(sharedFactory);
+  },
+);
+
+/**
+ * Writes `main.js` and a `lazy.js` whose `throw` sits on line 2, and returns a
+ * plugin that pushes that line down — the shape of any transform that removes or
+ * inserts lines, such as TypeScript type stripping.
+ */
+function setupShiftedLazyModule(dir: string) {
+  const lazyPath = path.join(dir, 'lazy.js');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'main.js'), `globalThis.load = () => import('./lazy.js');\n`);
+  const original = `export function boom() {\n  throw new Error('from lazy');\n}\n`;
+  fs.writeFileSync(lazyPath, original);
+
+  const shiftBy = 3;
+  const plugin = {
+    name: 'shift-lines',
+    transform(code: string, id: string) {
+      if (!id.endsWith('lazy.js')) {
+        return;
+      }
+      const generator = new SourceMapGenerator({ file: id });
+      code.split('\n').forEach((_, index) => {
+        generator.addMapping({
+          source: id,
+          original: { line: index + 1, column: 0 },
+          generated: { line: index + 1 + shiftBy, column: 0 },
+        });
+      });
+      generator.setSourceContent(id, code);
+      return { code: '\n'.repeat(shiftBy) + code, map: generator.toJSON() };
+    },
+  };
+
+  return { lazyPath, lazyProxyId: `${lazyPath}?rolldown-lazy=1`, plugin };
+}
+
+/** Line/column of the only `throw` in `code`, as a sourcemap consumer wants it. */
+function throwPosition(code: string) {
+  const lines = code.split('\n');
+  const index = lines.findIndex((line) => line.includes('from lazy'));
+  return { line: index + 1, column: lines[index].indexOf('throw') };
+}
+
+function inlineSourceMap(code: string) {
+  const match = /sourceMappingURL=data:application\/json[^,]+base64,([\w+/=]+)\s*$/.exec(code);
+  expect(match, 'the lazy chunk should carry an inline sourcemap').not.toBeNull();
+  return JSON.parse(Buffer.from(match![1], 'base64').toString());
+}
+
+// A module's sourcemap chain is what maps the rendered output back to the file
+// the user wrote; the oxc codegen map is only its last element and on its own
+// points at what the plugins produced. A lazy chunk collapses the whole chain,
+// the same way a module rendered into a chunk does — otherwise every position in
+// a lazily compiled module is off by whatever the transforms shifted, which is
+// every stack frame and every devtools jump inside it.
+test(
+  'lazy chunk sourcemap maps through the plugin sourcemap chain',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-sourcemap-${uniqueId}`);
+    const { lazyPath, lazyProxyId, plugin } = setupShiftedLazyModule(dir);
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        plugins: [plugin],
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist'), sourcemap: 'inline' },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await engine.ensureCurrentBuildFinish();
+    await engine.registerClient('c1');
+
+    const chunk = await engine.compileEntry(lazyProxyId, 'c1');
+    const position = await SourceMapConsumer.with(inlineSourceMap(chunk.code), null, (consumer) =>
+      consumer.originalPositionFor(throwPosition(chunk.code)),
+    );
+
+    // Line 2 of the file on disk, not line 5 of what the plugin handed the bundler.
+    expect(position.line).toBe(2);
+    expect(path.resolve(path.join(dir, 'dist'), position.source!)).toBe(lazyPath);
   },
 );

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -220,3 +220,48 @@ test(
     expect(path.resolve(path.join(dir, 'dist'), position.source!)).toBe(lazyPath);
   },
 );
+
+// With `sourcemap: true` the chunk gets a `sourceMappingURL`, so the map it names
+// has to be reachable: a lazy chunk is not written to disk, which leaves the
+// return value as the only way for the consumer to serve it.
+test(
+  'lazy chunk returns the sourcemap its sourceMappingURL names',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-sourcemap-file-${uniqueId}`);
+    const { lazyProxyId, plugin } = setupShiftedLazyModule(dir);
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        plugins: [plugin],
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist'), sourcemap: true },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await engine.ensureCurrentBuildFinish();
+    await engine.registerClient('c1');
+
+    const chunk = await engine.compileEntry(lazyProxyId, 'c1');
+
+    const referenced = /\/\/# sourceMappingURL=(.+)$/.exec(chunk.code.trimEnd())?.[1];
+    expect(chunk.sourcemapFilename).toBe(referenced);
+    expect(chunk.sourcemap).toBeTypeOf('string');
+
+    const position = await SourceMapConsumer.with(JSON.parse(chunk.sourcemap!), null, (consumer) =>
+      consumer.originalPositionFor(throwPosition(chunk.code)),
+    );
+    expect(position.line).toBe(2);
+  },
+);


### PR DESCRIPTION
Fixes #10378.

Two bugs, both about the sourcemap of a chunk produced by `DevEngine::compile_entry` (lazy compilation). The eagerly bundled output of the same build is correct in both cases, which is what makes them look like bugs rather than missing features.

## 1. Input sourcemaps were dropped

`render_module_code` returned the oxc codegen map as-is. That map is only the last element of a module's `sourcemap_chain`, so on its own it points at what the plugins produced rather than at the file the user wrote. `render_ecma_module` collapses the whole chain for a module rendered into a chunk; this path did not.

The practical effect: any transform that shifts positions — TypeScript type stripping, JSX, an SFC compiler — made every stack frame and every devtools jump inside a lazily compiled module land on the wrong line.

```
before                              after
EAGER -> { line: 2 }  ✅            EAGER -> { line: 2 }  ✅
LAZY  -> { line: 5 }  ❌            LAZY  -> { line: 2 }  ✅
```

`render_module_code` serves both the lazy-chunk and the HMR-patch path, so this fixes HMR patches as well.

The collapse is guarded on `enable_sourcemap`, matching `render_ecma_module`. Without the guard a render that asked for no sourcemap could still come back with one, since a non-empty chain collapses to a map even when the codegen step contributed none.

## 2. The `sourceMappingURL` named a map nobody could reach

`process_code_and_sourcemap` returns the sourcemap as an output asset, and `render_hmr_patch` carries it on `HmrPatch` so the consumer can serve it. The lazy-chunk path dropped that asset while still emitting a `sourceMappingURL` naming it — and a lazy chunk is never written to disk, so nothing could produce the file.

With `sourcemap: true` this left a dangling `sourceMappingURL=lazy_compile_N.js.map` and the browser could not map the module at all. `HmrLazyChunkOutput` now carries `sourcemap` / `sourcemap_filename` the way `HmrPatch` already does.

## Tests

Two tests in `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`, one per bug. They drive `dev()` + `compileEntry` directly (no browser) and use a plugin that shifts lines and returns a sourcemap — the shape of a real type-stripping transform.

Both fail without this PR:

```
lazy chunk sourcemap maps through the plugin sourcemap chain
  → expected 2, received 5

lazy chunk returns the sourcemap its sourceMappingURL names
  → expected 'lazy_compile_0.js.map', received undefined
```

`cargo test --workspace` and the Node.js suite pass. No snapshot updates were needed.

I also verified the fix end to end by building the first commit on top of `v1.1.5` and dropping the binding into a dev-server integration that runs on Vite's `experimental.bundledDev`: a TypeScript test file whose failure was reported one line off now reports the exact line and column, with no other behavior change across its suites.

## Alternatives considered

- **Turning lazy compilation off.** Not an option for consumers that rely on it: lazy compilation is what keeps module boundaries intact, since every cross-module read goes through `loadExports(id)`.
- **`sourcemap: 'inline'` as a workaround for the second bug.** It does make the map reachable, but it is not what a consumer configuring `sourcemap: true` would expect, and Vite's bundled dev mode hard-codes `output.sourcemap = true`.

## Worth a closer look

- **`HmrLazyChunkOutput` and `BindingLazyChunkOutput` gain two fields.** Additive, and `binding.d.cts` is regenerated, but it is a binding-surface change.
- **The first commit changes HMR patch sourcemaps too**, not just lazy chunks, since both render through `render_module_code`. That is intentional — the same bug affected both. No repository snapshot changed, because the affected tests do not enable sourcemaps.
- **Collapse warnings are dropped** in `render_module_code` (`&mut Vec::new()`). The reasoning is that a module rendered here was rendered by the full build as well, which already reports a broken chain for it. Happy to thread them through if you would rather they surface.