### PR TITLE
docs: add Module, Chunk, and Source Map glossary entries

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,9 +51,12 @@ const sidebarForGuide: DefaultTheme.SidebarItem[] = [
     collapsed: true,
     items: [
       { text: 'Barrel Module', link: '/glossary/barrel-module.md' },
+      { text: 'Chunk', link: '/glossary/chunk.md' },
       { text: 'Entry', link: '/glossary/entry.md' },
       { text: 'Entry Chunk', link: '/glossary/entry-chunk.md' },
       { text: 'Entry Name', link: '/glossary/entry-name.md' },
+      { text: 'Module', link: '/glossary/module.md' },
+      { text: 'Source Map', link: '/glossary/source-map.md' },
       { text: 'User-defined Entry', link: '/glossary/user-defined-entry.md' },
     ],
   },

--- a/docs/glossary/chunk.md
+++ b/docs/glossary/chunk.md
@@ -1,0 +1,11 @@
+# Chunk
+
+A **chunk** is an output file produced by the bundler. It contains one or more [modules](./module.md) and the runtime code needed to load and execute them.
+
+Rolldown creates:
+
+- [Entry chunks](./entry-chunk.md) — one per [entry](./entry.md), exporting that entry’s public API
+- Shared / common chunks — modules used by multiple entries or dynamic imports, split out to avoid duplication
+- Dynamic import chunks — loaded on demand when the corresponding `import()` runs
+
+How modules are grouped into chunks depends on entries, dynamic imports, and options such as [`codeSplitting`](/reference/OutputOptions.codeSplitting) / manual chunking. See [Automatic Code Splitting](/in-depth/automatic-code-splitting) and [Manual Code Splitting](/in-depth/manual-code-splitting).

--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -6,11 +6,23 @@ Common terms and concepts used in Rolldown documentation.
 
 - [Barrel Module](./barrel-module.md)
 
+## C
+
+- [Chunk](./chunk.md)
+
 ## E
 
 - [Entry](./entry.md)
 - [Entry Chunk](./entry-chunk.md)
 - [Entry Name](./entry-name.md)
+
+## M
+
+- [Module](./module.md)
+
+## S
+
+- [Source Map](./source-map.md)
 
 ## U
 

--- a/docs/glossary/module.md
+++ b/docs/glossary/module.md
@@ -1,0 +1,10 @@
+# Module
+
+A **module** is a single source file (or virtual unit) that Rolldown includes in the module graph — for example a `.js`, `.ts`, or `.jsx` file, or a virtual module provided by a plugin.
+
+Rolldown builds a dependency graph by starting from [entry](./entry.md) modules and following `import` / `require` / dynamic `import()` edges. Each module may be transformed (TypeScript, JSX, plugins) before it is placed into one or more [chunks](./chunk.md).
+
+Related concepts:
+
+- [Barrel Module](./barrel-module.md) — a module that re-exports many other modules
+- [Entry](./entry.md) — a module used as a graph starting point

--- a/docs/glossary/source-map.md
+++ b/docs/glossary/source-map.md
@@ -1,0 +1,7 @@
+# Source Map
+
+A **source map** maps positions in bundled (and often minified) output back to the original source files. Debuggers and browser DevTools use source maps so stack traces and breakpoints refer to your TypeScript or unminified JavaScript instead of the generated chunk.
+
+Enable them with [`output.sourcemap`](/reference/OutputOptions.sourcemap) (for example `true`, `'inline'`, or `'hidden'`).
+
+Plugins that transform code should return a map for their edits (or an empty `mappings` string when a map is not meaningful). See [Source Code Transformations](/apis/plugin-api/transformations).


### PR DESCRIPTION
## Summary
- Add glossary pages for **Module**, **Chunk**, and **Source Map**
- Wire them into the glossary index and VitePress sidebar

Related to #6089

## Test plan
- [ ] Glossary pages render on the docs preview
- [ ] Sidebar / index links resolve

Made with [Cursor](https://cursor.com)