### PR TITLE
fix: reject path-fragment emitted chunk names at emit time

### DIFF
--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -53,6 +53,20 @@ pub struct EmittedChunk {
   pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
 }
 
+impl EmittedChunk {
+  /// Returns true if the emitted chunk has a valid name (not an absolute or relative path).
+  /// Mirrors [`EmittedAsset::has_valid_name`] and Rollup's `hasValidName`.
+  pub fn has_valid_name(&self) -> bool {
+    let validated_name = self.file_name.as_deref().or(self.name.as_deref());
+    validated_name.is_none_or(|name| !is_path_fragment(name))
+  }
+
+  /// Returns the validated name (fileName or name) if present.
+  pub fn validated_name(&self) -> Option<&str> {
+    self.file_name.as_deref().or(self.name.as_deref())
+  }
+}
+
 pub struct EmittedChunkInfo {
   pub reference_id: ArcStr,
   pub filename: ArcStr,
@@ -121,6 +135,18 @@ impl FileEmitter {
   }
 
   pub fn emit_chunk(&self, chunk: Arc<EmittedChunk>) -> anyhow::Result<ArcStr> {
+    // Reject a path-fragment name here, like the asset path in `emit_file` and Rollup's
+    // `emitFile()`. Deferring to `FilenameTemplate::render` loses the plugin context and
+    // blames the `chunkFileNames` pattern; erroring inside the hook lets the driver
+    // attribute it to the emitting plugin. https://github.com/rolldown/rolldown/issues/9994
+    if !chunk.has_valid_name() {
+      return Err(
+        BuildDiagnostic::invalid_option(InvalidOptionType::InvalidEmittedFileName(
+          chunk.validated_name().unwrap_or_default().to_string(),
+        ))
+        .into(),
+      );
+    }
     // Must stay synchronous: making this async would force the napi binding back
     // onto `block_on`, pinning the JS thread while `send().await` waits on channel
     // capacity — but the consumer draining the channel itself needs the JS thread

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -204,6 +204,37 @@ describe('Error output format', () => {
   });
 });
 
+// https://github.com/rolldown/rolldown/issues/9994
+// Emitting a chunk with a path-fragment name is rejected at emit time and attributed
+// to the offending plugin, instead of failing late with a message that blamed the
+// `chunkFileNames` pattern and named no plugin.
+test('emitFile chunk with a path-like name is rejected and attributed to the plugin', async () => {
+  const error = await buildWithPlugin({
+    name: 'emit-invalid-chunk-name',
+    buildStart() {
+      this.emitFile({
+        type: 'chunk',
+        id: './main.js',
+        name: '../node_modules/@builder.io/qwik-city/lib/index.qwik.mjs_entry_ErrorBoundary',
+      });
+    },
+  });
+  // Keep only the plugin attribution + message; drop everything from the first stack
+  // frame onward. That is either the JS `    at …` frames (absolute paths / OS-specific
+  // separators) or the Rust `Stack backtrace:` block that `RUST_BACKTRACE=1` (set by the
+  // test scripts) inserts before them — both make the snapshot machine-dependent.
+  const rendered = removeAnsiColors(error!.message)
+    .replace(/\r\n/g, '\n')
+    .split(/\n\s*Stack backtrace:|\n\s+at /)[0]
+    .trimEnd();
+  expect(rendered).toMatchInlineSnapshot(`
+    "Build failed with 1 error:
+
+    [plugin emit-invalid-chunk-name]
+    Error: The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../node_modules/@builder.io/qwik-city/lib/index.qwik.mjs_entry_ErrorBoundary"."
+  `);
+});
+
 // oxlint-disable no-control-regex
 function removeAnsiColors(str: string) {
   return str.replace(/\x1b\[[0-9;]*m/g, '');

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk-invalid-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk-invalid-name/_config.ts
@@ -1,0 +1,45 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// https://github.com/rolldown/rolldown/issues/9994
+// `emitFile({ type: 'chunk' })` must reject a path-fragment `name`/`fileName`
+// synchronously at emit time, like the asset case in `emit-file-invalid-name`.
+const INVALID_NAME =
+  'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths';
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin',
+        buildStart() {
+          // Path-fragment `name` values are rejected synchronously.
+          for (const name of ['./relative', '../parent', '/absolute']) {
+            expect(() => {
+              this.emitFile({ type: 'chunk', id: './main.js', name });
+            }).toThrow(INVALID_NAME);
+          }
+
+          // Path-fragment `fileName` values are rejected too.
+          for (const fileName of ['../parent.js', '/absolute.js']) {
+            expect(() => {
+              this.emitFile({ type: 'chunk', id: './main.js', fileName });
+            }).toThrow(INVALID_NAME);
+          }
+
+          // Windows absolute path (only meaningful on Windows).
+          if (process.platform === 'win32') {
+            expect(() => {
+              this.emitFile({ type: 'chunk', id: './main.js', name: 'C:/windows' });
+            }).toThrow(INVALID_NAME);
+          }
+
+          // Valid names are still accepted: a bare name, and a subdirectory
+          // `fileName` (subdirectories are not path fragments).
+          this.emitFile({ type: 'chunk', id: './main.js', name: 'valid-name' });
+          this.emitFile({ type: 'chunk', id: './main.js', fileName: 'nested/dir/valid.js' });
+        },
+      },
+    ],
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk-invalid-name/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk-invalid-name/main.js
@@ -1,0 +1,1 @@
+export default 'main';


### PR DESCRIPTION
## What

Reject a plugin-emitted chunk whose `name`/`fileName` is a path fragment (absolute or relative, e.g. `../node_modules/...`) synchronously at `emitFile` time, instead of accepting it and failing later during chunk rendering.

Fixes #9994.

## Why

The reporter's Qwik build failed with:

```
[INVALID_OPTION] Invalid substitution "../node_modules/@builder.io/qwik-city/lib/index.qwik.mjs_entry_ErrorBoundary" for placeholder "[name]" in "chunkFileNames" pattern, can be neither absolute nor relative paths.
```

The message is misleading on two counts:

- **It blames the `chunkFileNames` pattern, but the pattern is innocent.** The same error fires even with a static `chunkFileNames: 'chunk-[hash].js'` that has no `[name]` placeholder — `FilenameTemplate::render` validates the name substitution regardless of whether the template references `[name]`.
- **It names no plugin.** There's no way to tell which plugin emitted the bad name. The real culprit is a plugin in the Qwik / rolldown-vite pipeline that derives a chunk name from a module path made relative to the project root, for a dependency hoisted into a parent `node_modules` — so the name comes out as `../node_modules/...`.

Rollup rejects such a name synchronously inside `emitFile()`, so its failure carries plugin/hook attribution and points at the offending call site.

## What changed

`FileEmitter::emit_chunk` now validates `name`/`fileName` up front via a new `EmittedChunk::has_valid_name` (mirroring the existing `EmittedAsset::has_valid_name`) and the existing `InvalidEmittedFileName` diagnostic — whose message already reads *"emitted chunks and assets…"*, it just wasn't wired into the chunk path. The render-time check stays as a backstop for names not derived from a plugin emit.

**No plugin identity needs to be stored.** Because `emit_chunk` always runs inside a plugin hook, the existing `CausedPlugin` hook-error machinery attributes the error to the emitting plugin automatically; for JS plugins the surfaced error also carries the module id and a stack trace pointing at the plugin's own `emitFile` call.

### Before / after (JS plugin)

Before — late, misleading, no attribution:

```
[INVALID_OPTION] Invalid substitution "../node_modules/…_entry_ErrorBoundary" for placeholder "[name]" in "chunkFileNames" pattern …
```

After — fail-fast, correct message, attributed to the plugin:

```
[plugin emit-invalid-chunk-name] …/dep.js?chunk-url
Error: The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../node_modules/…_entry_ErrorBoundary".
    at …emitFile (…)
    at …plugin transform (…)
```

## Tests

- **`tests/fixtures/plugin/context/emit-chunk-invalid-name`** — `emitFile({ type: 'chunk' })` rejects path-fragment `name`/`fileName` (`./`, `../`, `/`, and Windows `C:/`) synchronously at emit time; valid names and subdirectory `fileName`s are still accepted. Mirrors the existing asset test `emit-file-invalid-name`.
- **`tests/error/error.test.ts`** — the surfaced diagnostic is attributed to the offending plugin (cross-platform inline snapshot; the machine/OS-specific stack trace is stripped).
