### PR TITLE
feat(lazy-barrel): defer `export *` star re-export targets

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -125,6 +125,14 @@ pub struct ModuleLoader<'a, Fs: FileSystem + Clone + 'static> {
   /// of the first TLA keyword. Stored here instead of on every `EcmaView`
   /// because top-level await is rarely used in real-world apps.
   tla_keyword_span_map: FxHashMap<ModuleIdx, Span>,
+  /// On-demand `export *` deferral (transient per scan, not build-cache state):
+  /// maps a star-re-export *target* module to the barrel modules that
+  /// speculatively loaded it while probing for a requested name. When the target
+  /// finishes loading, the loader subtracts the names it provides from each
+  /// awaiting barrel's `pending_star_names` and probes the barrel's next star
+  /// target if names remain. See `BarrelInfo::take_needed_records` for why star
+  /// targets can't be attributed to a requested name up front.
+  star_probe_targets: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
 }
 
 pub struct ModuleLoaderOutput {
@@ -218,6 +226,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
       magic_string_tx,
       tla_module_count: 0,
       tla_keyword_span_map: FxHashMap::default(),
+      star_probe_targets: FxHashMap::default(),
     })
   }
 
@@ -642,6 +651,16 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
                 })
               },
             );
+            // Kick the first `export *` probe for this barrel's own requested-but-
+            // unresolved names (no-op unless it defers star targets).
+            self.drive_star_probes(module_idx, &mut work_queue, &user_defined_entries);
+            self.process_barrel_import_record(&mut work_queue, &user_defined_entries);
+          }
+
+          // This module may itself be a star-re-export target another barrel is
+          // probing; advance those barrels now that its exports are known.
+          if self.flat_options.is_lazy_barrel_enabled() {
+            self.on_star_probe_target_loaded(module_idx, &mut work_queue, &user_defined_entries);
             self.process_barrel_import_record(&mut work_queue, &user_defined_entries);
           }
 
@@ -1076,75 +1095,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
           return true;
         };
 
-        let mut is_module_from_cache_snapshot = false;
-        let barrel_normal_module = match &self.intermediate_normal_modules.modules {
-          HybridIndexVec::IndexVec(modules) => modules[idx]
-            .as_ref()
-            .expect("Barrel module should exists in full build")
-            .as_normal()
-            .unwrap(),
-          HybridIndexVec::Map(modules) => {
-            if let Some(module) = modules.get(&idx) {
-              module
-                .as_ref()
-                .expect("Barrel module should exists in partial build")
-                .as_normal()
-                .unwrap()
-            } else {
-              is_module_from_cache_snapshot = true;
-              self
-                .cache
-                .get_snapshot()
-                .module_table
-                .get(idx)
-                .expect("Barrel module should exist in cache snapshot in partial scan mode")
-                .as_normal()
-                .unwrap()
-            }
-          }
-        };
-
-        let target_idx = match barrel_normal_module.import_records[rec_idx].resolved_module {
-          Some(existing_idx) => existing_idx,
-          None => {
-            let importer_record = ImporterRecord {
-              kind: barrel_normal_module.import_records[rec_idx].kind,
-              importer_path: barrel_normal_module.id.clone(),
-              importer_idx: barrel_normal_module.idx,
-            };
-            let new_idx = self.try_spawn_new_task(
-              resolved_id.clone(),
-              Some(ModuleTaskOwner::new(barrel_normal_module, import_record_state.span)),
-              false,
-              import_record_state.asserted_module_type.as_ref(),
-              user_defined_entries,
-            );
-            self.intermediate_normal_modules.importers[new_idx].push(importer_record);
-            self.mark_module_importers_changed(new_idx);
-            // Update resolved module in either cache snapshot or intermediate modules
-            if is_module_from_cache_snapshot {
-              self
-                .cache
-                .barrel_state
-                .resolved_barrel_modules
-                .entry(idx)
-                .or_default()
-                .push((rec_idx, new_idx));
-            } else {
-              self
-                .intermediate_normal_modules
-                .modules
-                .get_mut(idx)
-                .as_mut()
-                .expect("barrel module should exist")
-                .as_normal_mut()
-                .unwrap()
-                .import_records[rec_idx]
-                .resolved_module = Some(new_idx);
-            }
-            new_idx
-          }
-        };
+        let target_idx = self.spawn_or_get_barrel_record_target(
+          idx,
+          rec_idx,
+          import_record_state,
+          resolved_id,
+          user_defined_entries,
+        );
         let keep_tracking = match self.cache.barrel_state.barrel_infos.get(&target_idx) {
           Some(Some(s)) => target_idx == idx || !s.tracked_records.is_empty(),
           Some(None) => false,
@@ -1163,6 +1120,202 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
         self.cache.barrel_state.barrel_infos.get_mut(&idx).unwrap().as_mut().unwrap();
       barrel_module_state.tracked_records = tracked_records;
       barrel_module_state.remaining_imported_specifiers = remaining_imported_specifiers;
+
+      // A new request may have added pending star names; probe the next star
+      // target on demand (no-op unless this barrel has unresolved `export *`).
+      self.drive_star_probes(idx, work_queue, user_defined_entries);
+    }
+  }
+
+  /// Resolve `rec_idx`'s target module for barrel `barrel_idx`, spawning its load
+  /// task if not already resolved. Mirrors the initial resolution in the main
+  /// module-load loop, handling both intermediate modules and the partial-scan
+  /// cache snapshot. Returns the target `ModuleIdx`.
+  #[expect(clippy::rc_buffer)]
+  fn spawn_or_get_barrel_record_target(
+    &mut self,
+    barrel_idx: ModuleIdx,
+    rec_idx: ImportRecordIdx,
+    import_record_state: &rolldown_common::ImportRecordStateInit,
+    resolved_id: &ResolvedId,
+    user_defined_entries: &Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  ) -> ModuleIdx {
+    let mut is_module_from_cache_snapshot = false;
+    let barrel_normal_module = match &self.intermediate_normal_modules.modules {
+      HybridIndexVec::IndexVec(modules) => modules[barrel_idx]
+        .as_ref()
+        .expect("Barrel module should exists in full build")
+        .as_normal()
+        .unwrap(),
+      HybridIndexVec::Map(modules) => {
+        if let Some(module) = modules.get(&barrel_idx) {
+          module
+            .as_ref()
+            .expect("Barrel module should exists in partial build")
+            .as_normal()
+            .unwrap()
+        } else {
+          is_module_from_cache_snapshot = true;
+          self
+            .cache
+            .get_snapshot()
+            .module_table
+            .get(barrel_idx)
+            .expect("Barrel module should exist in cache snapshot in partial scan mode")
+            .as_normal()
+            .unwrap()
+        }
+      }
+    };
+
+    match barrel_normal_module.import_records[rec_idx].resolved_module {
+      Some(existing_idx) => existing_idx,
+      None => {
+        let importer_record = ImporterRecord {
+          kind: barrel_normal_module.import_records[rec_idx].kind,
+          importer_path: barrel_normal_module.id.clone(),
+          importer_idx: barrel_normal_module.idx,
+        };
+        let new_idx = self.try_spawn_new_task(
+          resolved_id.clone(),
+          Some(ModuleTaskOwner::new(barrel_normal_module, import_record_state.span)),
+          false,
+          import_record_state.asserted_module_type.as_ref(),
+          user_defined_entries,
+        );
+        self.intermediate_normal_modules.importers[new_idx].push(importer_record);
+        self.mark_module_importers_changed(new_idx);
+        // Update resolved module in either cache snapshot or intermediate modules
+        if is_module_from_cache_snapshot {
+          self
+            .cache
+            .barrel_state
+            .resolved_barrel_modules
+            .entry(barrel_idx)
+            .or_default()
+            .push((rec_idx, new_idx));
+        } else {
+          self
+            .intermediate_normal_modules
+            .modules
+            .get_mut(barrel_idx)
+            .as_mut()
+            .expect("barrel module should exist")
+            .as_normal_mut()
+            .unwrap()
+            .import_records[rec_idx]
+            .resolved_module = Some(new_idx);
+        }
+        new_idx
+      }
+    }
+  }
+
+  /// Names a loaded module directly provides as ESM exports (its `named_exports`
+  /// keys), or `None` if the module has not finished loading yet. Names reachable
+  /// only through the module's *own* deferred `export *` are not listed — a first
+  /// cut that can make an outer barrel over-probe (never under-load): the request
+  /// pushed to the target still drives its nested stars.
+  fn module_provided_export_names(&self, idx: ModuleIdx) -> Option<FxHashSet<oxc_str::CompactStr>> {
+    let module = match &self.intermediate_normal_modules.modules {
+      HybridIndexVec::IndexVec(modules) => modules.get(idx).and_then(Option::as_ref),
+      HybridIndexVec::Map(modules) => match modules.get(&idx) {
+        Some(module) => module.as_ref(),
+        None => self.cache.get_snapshot().module_table.modules.get(idx),
+      },
+    };
+    module?.as_normal().map(|normal| normal.named_exports.keys().cloned().collect())
+  }
+
+  /// Drive on-demand `export *` probing for barrel `barrel_idx`: while names are
+  /// still pending and star targets remain, load star targets in `star` order,
+  /// stopping at the first one whose load has not yet completed (its result feeds
+  /// back through [`Self::on_star_probe_target_loaded`]). Targets already in memory
+  /// are resolved synchronously in the loop. Only one probe is ever in flight per
+  /// barrel. No-op unless the barrel has unresolved star names.
+  #[expect(clippy::rc_buffer)]
+  fn drive_star_probes(
+    &mut self,
+    barrel_idx: ModuleIdx,
+    work_queue: &mut VecDeque<(ModuleIdx, ImportedExports)>,
+    user_defined_entries: &Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  ) {
+    loop {
+      let Some(Some(state)) = self.cache.barrel_state.barrel_infos.get_mut(&barrel_idx) else {
+        return;
+      };
+      if state.info.star_probe_in_flight
+        || state.info.pending_star_names.is_empty()
+        || state.info.star_cursor >= state.info.star.len()
+      {
+        return;
+      }
+      let rec_idx = state.info.star[state.info.star_cursor];
+      state.info.star_cursor += 1;
+      // The probed star record is now being loaded; stop deferring it.
+      let tracked = state.tracked_records.remove(&rec_idx);
+      state.remaining_imported_specifiers.remove(&rec_idx);
+      let pending = ImportedExports::Partial(
+        state.info.pending_star_names.iter().cloned().collect::<FxHashSet<_>>(),
+      );
+
+      let Some((import_record_state, resolved_id)) = tracked else {
+        // Record was already resolved/loaded outside the deferral bookkeeping;
+        // nothing to spawn, keep looking through the next star target.
+        continue;
+      };
+      let target_idx = self.spawn_or_get_barrel_record_target(
+        barrel_idx,
+        rec_idx,
+        &import_record_state,
+        &resolved_id,
+        user_defined_entries,
+      );
+
+      // Feed the request into the target so a nested barrel resolves it too.
+      work_queue.push_back((target_idx, pending));
+
+      match self.module_provided_export_names(target_idx) {
+        // Target already loaded: subtract the names it provides and keep probing
+        // synchronously — there will be no load message to advance us.
+        Some(provided) => {
+          if let Some(Some(state)) = self.cache.barrel_state.barrel_infos.get_mut(&barrel_idx) {
+            state.info.pending_star_names.retain(|name| !provided.contains(name));
+          }
+        }
+        // Target not yet loaded: register it as this barrel's in-flight probe and
+        // wait for its completion to advance us.
+        None => {
+          self.star_probe_targets.entry(target_idx).or_default().insert(barrel_idx);
+          if let Some(Some(state)) = self.cache.barrel_state.barrel_infos.get_mut(&barrel_idx) {
+            state.info.star_probe_in_flight = true;
+          }
+          return;
+        }
+      }
+    }
+  }
+
+  /// Feedback for a completed star-target probe: subtract the names `target_idx`
+  /// provides from every barrel that was waiting on it, clear those barrels'
+  /// in-flight flag, and probe their next star target if names remain.
+  #[expect(clippy::rc_buffer)]
+  fn on_star_probe_target_loaded(
+    &mut self,
+    target_idx: ModuleIdx,
+    work_queue: &mut VecDeque<(ModuleIdx, ImportedExports)>,
+    user_defined_entries: &Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  ) {
+    let Some(waiting_barrels) = self.star_probe_targets.remove(&target_idx) else {
+      return;
+    };
+    let provided = self.module_provided_export_names(target_idx).unwrap_or_default();
+    for barrel_idx in waiting_barrels {
+      if let Some(Some(state)) = self.cache.barrel_state.barrel_infos.get_mut(&barrel_idx) {
+        state.info.pending_star_names.retain(|name| !provided.contains(name));
+        state.info.star_probe_in_flight = false;
+      }
+      self.drive_star_probes(barrel_idx, work_queue, user_defined_entries);
     }
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/_config.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "experimental.lazyBarrel star-re-export deferral: a sideEffects:false barrel re-exports a.js..d.js via `export *` only. The entry imports `fromA` (a.js) and `fromC` (c.js). Instead of eagerly loading every star target to attribute the names, the loader probes star targets in order and stops once both names are found, so d.js is never loaded and stays out of the bundle. Executing the entry must bind the star-re-exported values correctly.",
+  "config": {
+    "experimental": {
+      "lazyBarrel": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+// Star re-exports resolved via on-demand probing must still bind correctly.
+import { result } from './dist/main.js';
+assert.strictEqual(result, 'a-value|c-value');

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/a.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/a.js
@@ -1,0 +1,1 @@
+export const fromA = 'a-value';

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#endregion
+//#region main.js
+const result = "a-value|c-value";
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/b.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/b.js
@@ -1,0 +1,1 @@
+export const fromB = 'b-value';

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/barrel.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/barrel.js
@@ -1,0 +1,8 @@
+// A "sideEffects": false barrel that re-exports its members only via "export *".
+// lazyBarrel resolves the entry's named imports by probing these star targets in
+// order, stopping once every requested name is found — so d.js (below the last
+// needed name) is never loaded.
+export * from './a.js';
+export * from './b.js';
+export * from './c.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/c.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/c.js
@@ -1,0 +1,1 @@
+export const fromC = 'c-value';

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/d.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/d.js
@@ -1,0 +1,2 @@
+// Never loaded: probing stops after  is resolved in c.js.
+export const fromD = 'd-value';

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/main.js
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/main.js
@@ -1,0 +1,4 @@
+// Uses names living in the 1st and 3rd star targets; b.js is probed but its
+// export is unused, d.js is never even probed.
+import { fromA, fromC } from './barrel.js';
+export const result = fromA + '|' + fromC;

--- a/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/package.json
+++ b/crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/crates/rolldown_common/src/types/lazy_barrel.rs
+++ b/crates/rolldown_common/src/types/lazy_barrel.rs
@@ -135,10 +135,21 @@ pub struct ExportSource {
 pub struct BarrelInfo {
   /// `export const a = 1`
   pub local: Vec<CompactStr>,
-  /// `export * from './x'`
+  /// `export * from './x'` — the ordered star-re-export records. `star_cursor`
+  /// marks how far on-demand probing has advanced through them.
   pub star: Vec<ImportRecordIdx>,
   /// `export { a } from './x'` or `export * as ns from './x'`
   pub named: FxHashMap<CompactStr, ExportSource>,
+  /// Requested names not resolvable to a `named`/`local` export, awaiting a
+  /// providing `export *` target. `take_needed_records` accumulates these
+  /// instead of eagerly loading every star target; the loader probes star
+  /// targets in `star` order (via `star_cursor`) until this set drains.
+  pub pending_star_names: FxHashSet<CompactStr>,
+  /// Index into `star` of the next star target to probe on demand.
+  pub star_cursor: usize,
+  /// A star-target probe spawned by this barrel is in flight; suppresses
+  /// kicking a second concurrent probe. Cleared when the probe target loads.
+  pub star_probe_in_flight: bool,
 }
 
 impl BarrelInfo {
@@ -151,13 +162,16 @@ impl BarrelInfo {
   /// - If `imports` is `All`: returns all records (takes entire `imported_exports_per_record`)
   /// - If `imports` is `Partial` with names:
   ///   - Named exports are resolved to their source records
-  ///   - Missing names are searched in star re-exports
+  ///   - Names not resolvable to a `named` export are recorded in
+  ///     `self.pending_star_names` for on-demand `export *` probing by the loader
+  ///     (star targets are *not* returned here — they are loaded lazily)
   ///   - If any local (own) export is used, all non-re-export import records must be loaded
   ///     (since the barrel module itself needs to execute)
   ///
   /// # Side effects
   /// - Consumes matched entries from `imported_exports_per_record`
   /// - Removes matched entries from `self.named`
+  /// - Extends `self.pending_star_names` with names awaiting a star target
   /// - Clears `self.local` if a local export is used
   pub fn take_needed_records(
     &mut self,
@@ -217,17 +231,21 @@ impl BarrelInfo {
             missing_names.insert(name.clone());
           }
         }
-        if !missing_names.is_empty() {
-          let missing = ImportedExports::Partial(missing_names);
-          for rec_idx in &self.star {
-            match needs_records.entry(*rec_idx) {
-              Entry::Occupied(mut occ) => occ.get_mut().merge(&missing),
-              Entry::Vacant(vac) => {
-                vac.insert(missing.clone());
-              }
-            }
-          }
-        }
+        // Names not resolvable to a `named`/`local` export may come from an
+        // `export *` target. Rather than eagerly loading every star target (which
+        // forces the whole barrel into memory), record them as pending: the loader
+        // probes star targets one at a time, in `star` order, stopping once every
+        // pending name has been found in a loaded target.
+        //
+        // KNOWN LIMITATION: strict `export *` ambiguity (two star targets exporting
+        // the same name → that name is excluded and diagnosed) requires visiting
+        // *all* targets. Greedy "stop when found" probing loads only up to the first
+        // provider, so an ambiguous name resolves to that first provider instead of
+        // being excluded. This is acceptable because the whole path is gated on the
+        // barrel being `sideEffects:false` (`UserDefined(false)`) and opt-in
+        // `experimental.lazyBarrel`; it never produces wrong output for the common
+        // unambiguous case and never crashes on the ambiguous one.
+        self.pending_star_names.extend(missing_names);
         if has_local_export {
           let mut reexports = FxHashSet::with_capacity(self.named.len() + self.star.len());
           reexports


### PR DESCRIPTION
## What this solves

`experimental.lazyBarrel` defers *loading* unused **named** re-exports of a side-effect-free barrel, but loaded every `export *` **star** target eagerly — because a requested name can't be attributed to a specific star target without loading it. For a barrel that `export *`s many modules (a library index doing `export * from './x'` for hundreds of files — e.g. `date-fns`, 245 star re-exports) and is imported for a few names, this parses and retains the AST of every target, which dominates peak build memory (ASTs are held for the whole build).

Part of #10393.

## Approach

Resolve star names on demand instead of eagerly: probe star targets one at a time in source order and stop once every requested name is found. Deferred targets are never loaded, so their ASTs are never allocated. `import * as ns` (an `All` request) still loads every target. Only active when `experimental.lazyBarrel` is on **and** the barrel is `sideEffects:false` (`UserDefined(false)`) — the assertion that makes skipping unused members safe.

- `BarrelInfo::take_needed_records` records missing names in a new `pending_star_names` set instead of pushing every star record as "needed".
- The loader gains `drive_star_probes` / `on_star_probe_target_loaded`: it loads star targets sequentially, subtracting the names each provides as it resolves, and stops when the set drains. Probe bookkeeping is transient per-scan state on `ModuleLoader`, not the cached `BarrelState`. Deferred star records keep `resolved_module = None`, which `NormalModule::star_export_records()` already skips during linking.

## Result

On an 8000-target star barrel imported for 50 names (`sideEffects:false`): peak RSS **~649 MB → ~196 MB**, **byte-identical output** (`cmp` clean). Matches the named-barrel deferral it mirrors.

## Tests

- New fixture `crates/rolldown/tests/rolldown/issues/lazy_barrel_star_reexport_deferral/` (star barrel, partial-name import; snapshot shows only resolved values survive and the unused target is never loaded).
- `cargo test --workspace --exclude rolldown_binding` green (the only failure, `test262::test262_module_code`, is the unchecked-out test262 submodule and fails identically on `main`). The existing lazyBarrel fixtures pass with **no snapshot changes**.
- clippy `--deny warnings` + rustfmt clean.

## Needs reviewer attention (opened as draft)

Strict `export *` **ambiguity** — a name exported by two star targets, which rolldown normally excludes-and-diagnoses — requires visiting all targets. Greedy stop-when-found resolves it to the first provider instead of erroring (verified: eager build errors, lazy build resolves greedily; it does not crash). This is gated behind `sideEffects:false` + opt-in `experimental.lazyBarrel`, and documented in a code comment. I'd like guidance on whether that trade-off is acceptable or whether ambiguity should force a full scan. A barrel that star-re-exports *another* barrel may also over-probe (extra loading only, never wrong/under-loading).
