### PR TITLE
perf: use VisitJs in JavaScript-only AST passes

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -6,7 +6,7 @@ use oxc::{
       JSXElementName, JSXMemberExpressionObject, JSXOpeningElement,
     },
   },
-  ast_visit::{Visit, walk},
+  ast_visit::{VisitJs, walk_js},
   semantic::{ScopeFlags, SymbolId},
   span::{GetSpan, Span},
 };
@@ -30,7 +30,7 @@ use super::{
   stmt_eval_analyzer::StmtEvalAnalyzer, top_level_import_read::TopLevelImportReadDetector,
 };
 
-impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
+impl<'me, 'ast: 'me> VisitJs<'ast> for AstScanner<'me, 'ast> {
   fn enter_scope(
     &mut self,
     flags: oxc::semantic::ScopeFlags,
@@ -115,12 +115,6 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       self.result.stmt_infos.add_stmt_info(std::mem::take(&mut self.current_stmt_info));
     }
 
-    if self.untranspiled_syntax.contains(UntranspiledSyntax::TypeScript) {
-      self.result.errors.push(BuildDiagnostic::untranspiled_syntax(
-        self.immutable_ctx.id.to_string(),
-        "TypeScript",
-      ));
-    }
     if self.untranspiled_syntax.contains(UntranspiledSyntax::Jsx) {
       self
         .result
@@ -168,14 +162,14 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     if it.r#await && self.is_valid_tla_scope() {
       self.handle_top_level_await(it.span());
     }
-    walk::walk_for_of_statement(self, it);
+    walk_js::walk_for_of_statement(self, it);
   }
 
   fn visit_await_expression(&mut self, it: &ast::AwaitExpression<'ast>) {
     if self.is_valid_tla_scope() {
       self.handle_top_level_await(it.span());
     }
-    walk::walk_await_expression(self, it);
+    walk_js::walk_await_expression(self, it);
   }
 
   fn visit_identifier_reference(&mut self, ident: &IdentifierReference) {
@@ -188,7 +182,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     if let Some(decl) = stmt.as_module_declaration() {
       self.scan_module_decl(decl);
     }
-    walk::walk_statement(self, stmt);
+    walk_js::walk_statement(self, stmt);
   }
 
   fn visit_return_statement(&mut self, stmt: &ast::ReturnStatement<'ast>) {
@@ -196,7 +190,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     if self.is_top_level {
       self.result.ast_usage.insert(EcmaModuleAstUsage::TopLevelReturn);
     }
-    walk::walk_return_statement(self, stmt);
+    walk_js::walk_return_statement(self, stmt);
   }
 
   fn visit_import_expression(&mut self, expr: &ast::ImportExpression<'ast>) {
@@ -226,7 +220,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       // No import record - either @vite-ignore or non-static dynamic import
       self.current_stmt_info.meta.insert(StmtInfoMeta::NonStaticDynamicImport);
     }
-    walk::walk_import_expression(self, expr);
+    walk_js::walk_import_expression(self, expr);
   }
 
   fn visit_assignment_expression(&mut self, node: &ast::AssignmentExpression<'ast>) {
@@ -279,14 +273,14 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       }
     }
 
-    walk::walk_assignment_expression(self, node);
+    walk_js::walk_assignment_expression(self, node);
   }
 
   fn visit_new_expression(&mut self, it: &ast::NewExpression<'ast>) {
     if self.immutable_ctx.flat_options.resolve_new_url_to_asset_enabled() {
       self.handle_new_url_with_string_literal_and_import_meta_url(it);
     }
-    walk::walk_new_expression(self, it);
+    walk_js::walk_new_expression(self, it);
   }
 
   /// Records `import.meta.ROLLDOWN_FILE_URL_<referenceId>` for the `resolveFileUrl` hook.
@@ -306,19 +300,19 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         url_id: file_url.url_id.map(CompactStr::from),
       });
     }
-    walk::walk_member_expression(self, it);
+    walk_js::walk_member_expression(self, it);
   }
   fn visit_this_expression(&mut self, it: &ast::ThisExpression) {
     if !self.is_this_nested() {
       self.top_level_this_expr_set.insert(it.node_id());
     }
-    walk::walk_this_expression(self, it);
+    walk_js::walk_this_expression(self, it);
   }
 
   fn visit_class_element(&mut self, it: &ast::ClassElement<'ast>) {
     let pre_is_nested_this_inside_class = self.is_nested_this_inside_class;
     self.is_nested_this_inside_class = true;
-    walk::walk_class_element(self, it);
+    walk_js::walk_class_element(self, it);
     self.is_nested_this_inside_class = pre_is_nested_this_inside_class;
   }
 
@@ -327,7 +321,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     if let Some(AstKind::ClassBody(_)) = self.visit_path.iter().rev().nth(1) {
       self.is_nested_this_inside_class = false;
     }
-    walk::walk_property_key(self, it);
+    walk_js::walk_property_key(self, it);
     self.is_nested_this_inside_class = pre_is_nested_this_inside_class;
   }
 
@@ -358,7 +352,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         // Handle multiple declarations in a single statement
       }
     }
-    walk::walk_variable_declaration(self, decl);
+    walk_js::walk_variable_declaration(self, decl);
   }
 
   fn visit_declaration(&mut self, it: &ast::Declaration<'ast>) {
@@ -370,7 +364,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         self.visit_class_decl(class);
       }
       _ => {
-        walk::walk_declaration(self, it);
+        walk_js::walk_declaration(self, it);
       }
     }
   }
@@ -386,77 +380,14 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     {
       self.current_stmt_info.meta.insert(StmtInfoMeta::KeepNamesType);
     }
-    walk::walk_expression(self, it);
-  }
-
-  // --- Outermost TS visitor overrides ---
-  // Empty bodies prevent the walker from descending into TS subtrees.
-  // We only record the untranspiled syntax flag so the scan stage can report the error.
-
-  fn visit_ts_enum_declaration(&mut self, _it: &ast::TSEnumDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_type_alias_declaration(&mut self, _it: &ast::TSTypeAliasDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_interface_declaration(&mut self, _it: &ast::TSInterfaceDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_module_declaration(&mut self, _it: &ast::TSModuleDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_import_equals_declaration(&mut self, _it: &ast::TSImportEqualsDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_global_declaration(&mut self, _it: &ast::TSGlobalDeclaration<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_as_expression(&mut self, _it: &ast::TSAsExpression<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_satisfies_expression(&mut self, _it: &ast::TSSatisfiesExpression<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_type_assertion(&mut self, _it: &ast::TSTypeAssertion<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_non_null_expression(&mut self, _it: &ast::TSNonNullExpression<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_instantiation_expression(&mut self, _it: &ast::TSInstantiationExpression<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_export_assignment(&mut self, _it: &ast::TSExportAssignment<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_namespace_export_declaration(
-    &mut self,
-    _it: &ast::TSNamespaceExportDeclaration<'ast>,
-  ) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-  }
-
-  fn visit_ts_index_signature(&mut self, _it: &ast::TSIndexSignature<'ast>) {
-    self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
+    walk_js::walk_expression(self, it);
   }
 
   // --- Outermost JSX visitor overrides ---
 
   fn visit_jsx_element(&mut self, it: &ast::JSXElement<'ast>) {
     if self.immutable_ctx.flat_options.jsx_preserve() {
-      walk::walk_jsx_element(self, it);
+      walk_js::walk_jsx_element(self, it);
     } else {
       self.untranspiled_syntax |= UntranspiledSyntax::Jsx;
     }
@@ -464,7 +395,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_jsx_fragment(&mut self, it: &ast::JSXFragment<'ast>) {
     if self.immutable_ctx.flat_options.jsx_preserve() {
-      walk::walk_jsx_fragment(self, it);
+      walk_js::walk_jsx_fragment(self, it);
     } else {
       self.untranspiled_syntax |= UntranspiledSyntax::Jsx;
     }
@@ -472,17 +403,17 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_call_expression(&mut self, it: &ast::CallExpression<'ast>) {
     self.try_extract_hmr_info_from_hot_accept_call(it);
-    walk::walk_call_expression(self, it);
+    walk_js::walk_call_expression(self, it);
   }
 
   fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'ast>) {
     self.visit_jsx_opening_element_for_jsx_preserve(it);
-    walk::walk_jsx_opening_element(self, it);
+    walk_js::walk_jsx_opening_element(self, it);
   }
 
   fn visit_jsx_closing_element(&mut self, it: &JSXClosingElement<'ast>) {
     self.visit_jsx_closing_element_for_jsx_preserve(it);
-    walk::walk_jsx_closing_element(self, it);
+    walk_js::walk_jsx_closing_element(self, it);
   }
 
   fn visit_export_default_declaration(&mut self, it: &ast::ExportDefaultDeclaration<'ast>) {
@@ -498,7 +429,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       }
       _ => {}
     }
-    walk::walk_export_default_declaration(self, it);
+    walk_js::walk_export_default_declaration(self, it);
   }
 }
 

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -12,7 +12,6 @@ use arcstr::ArcStr;
 use const_eval::{ConstEvalCtx, try_extract_const_literal};
 use oxc::ast::ast::{BindingPattern, Expression, ImportExpression};
 use oxc::ast::{AstKind, ast};
-use oxc::ast_visit::walk;
 use oxc::semantic::{NodeId, Reference, ScopeFlags, Scoping};
 use oxc::span::SPAN;
 use oxc::{
@@ -23,7 +22,7 @@ use oxc::{
       ImportDeclaration, ModuleDeclaration, Program,
     },
   },
-  ast_visit::Visit,
+  ast_visit::{VisitJs, walk_js},
   semantic::SymbolId,
   span::{GetSpan, Span},
 };
@@ -57,8 +56,7 @@ bitflags! {
   #[derive(Debug, Clone, Copy, Default)]
   /// Tracks untranspiled syntax encountered during scanning.
   pub(crate) struct UntranspiledSyntax: u8 {
-    const TypeScript = 1 << 0;
-    const Jsx = 1 << 1;
+    const Jsx = 1 << 0;
   }
 }
 
@@ -713,14 +711,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
   fn visit_function_decl(&mut self, it: &ast::Function<'ast>, flags: oxc::semantic::ScopeFlags) {
     self.current_stmt_info.meta.insert(StmtInfoMeta::KeepNamesType);
-    walk::walk_function(self, it, flags);
+    walk_js::walk_function(self, it, flags);
   }
 
   fn visit_class_decl(&mut self, it: &ast::Class<'ast>) {
     let previous_class_decl_id = self.cur_class_decl.take();
     self.cur_class_decl = self.get_class_id(it);
     self.current_stmt_info.meta.insert(StmtInfoMeta::KeepNamesType);
-    walk::walk_class(self, it);
+    walk_js::walk_class(self, it);
     self.cur_class_decl = previous_class_decl_id;
   }
 
@@ -819,9 +817,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             let id = cls_decl.id.as_ref().unwrap();
             self.add_local_export(id.name.as_str(), id.symbol_id(), id.span);
           }
-          _ => {
-            self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-          }
+          _ => {}
         }
       }
     }
@@ -839,7 +835,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   }
 
   fn scan_export_default_decl(&mut self, decl: &ExportDefaultDeclaration) {
-    use oxc::ast::ast::ExportDefaultDeclarationKind;
     let local_binding_for_default_export = match &decl.declaration {
       ast::ExportDefaultDeclarationKind::Identifier(id) => {
         if let Some(symbol_id) = self.resolve_symbol_from_reference(id) {
@@ -892,11 +887,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           (symbol_id, id.span)
         })
       }
-      ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
-        self.untranspiled_syntax |= UntranspiledSyntax::TypeScript;
-        None
-      }
-      oxc::ast::match_expression!(ExportDefaultDeclarationKind) => None,
+      _ => None,
     };
     let (reference, span) = local_binding_for_default_export
       .unwrap_or((self.result.default_export_ref.symbol, Span::default()));

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -6,7 +6,7 @@ use oxc::ast::ast::{
   IdentifierReference, UnaryOperator, VariableDeclarationKind,
 };
 use oxc::ast::match_member_expression;
-use oxc::ast_visit::{Visit, walk};
+use oxc::ast_visit::{VisitJs, walk_js};
 use oxc::semantic::{NodeId, ScopeFlags, SymbolId};
 use oxc::transformer::EngineTargets;
 use oxc_ecmascript::GlobalContext;
@@ -755,7 +755,7 @@ impl<'analyzer, 'ctx> DefinitionTimeOrderReasonCollector<'analyzer, 'ctx> {
   }
 }
 
-impl<'ast> Visit<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
+impl<'ast> VisitJs<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
   fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'ast>) {
     let is_global_read = ident.reference_id.get().is_some_and(|reference_id| {
       let reference = self.analyzer.scope.scoping().get_reference(reference_id);
@@ -770,7 +770,7 @@ impl<'ast> Visit<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
     if check_pure_cjs_export(self.analyzer.scope, &assignment.left).is_some() {
       self.visit_expression(&assignment.right);
     } else {
-      walk::walk_assignment_expression(self, assignment);
+      walk_js::walk_assignment_expression(self, assignment);
     }
   }
 
@@ -779,7 +779,7 @@ impl<'ast> Visit<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
       && (call.pure || self.analyzer.is_call_expr_marked_pure(call));
     self.add_reason_if(StmtOrderSensitiveReasons::PureAnnotation, is_pure_annotated);
 
-    walk::walk_call_expression(self, call);
+    walk_js::walk_call_expression(self, call);
     self.visit_immediately_invoked_function(&call.callee);
   }
 
@@ -788,7 +788,7 @@ impl<'ast> Visit<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
       StmtOrderSensitiveReasons::PureAnnotation,
       !self.analyzer.flat_options.ignore_annotations() && new_expr.pure,
     );
-    walk::walk_new_expression(self, new_expr);
+    walk_js::walk_new_expression(self, new_expr);
     self.visit_immediately_invoked_function(&new_expr.callee);
   }
 
@@ -801,9 +801,6 @@ impl<'ast> Visit<'ast> for DefinitionTimeOrderReasonCollector<'_, '_> {
   fn visit_class(&mut self, class: &ast::Class<'ast>) {
     self.visit_class_definition(class);
   }
-
-  // Types are erased before runtime.
-  fn visit_ts_type(&mut self, _ty: &ast::TSType<'ast>) {}
 }
 
 /// Bundler-specific: detect `exports.staticProp = ...` CJS export pattern.

--- a/crates/rolldown/src/ast_scanner/top_level_import_read.rs
+++ b/crates/rolldown/src/ast_scanner/top_level_import_read.rs
@@ -1,8 +1,8 @@
 use oxc::ast::ast::{
   ArrowFunctionExpression, CallExpression, ExportNamedDeclaration, Expression, Function,
-  IdentifierReference, Statement, TSType,
+  IdentifierReference, Statement,
 };
-use oxc::ast_visit::{Visit, walk};
+use oxc::ast_visit::{VisitJs, walk_js};
 use oxc::semantic::ScopeFlags;
 use rolldown_common::AstScopes;
 
@@ -76,7 +76,7 @@ impl<'scopes> TopLevelImportReadDetector<'scopes> {
   }
 }
 
-impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
+impl<'ast> VisitJs<'ast> for TopLevelImportReadDetector<'_> {
   fn visit_identifier_reference(&mut self, it: &IdentifierReference<'ast>) {
     if self.reads_import {
       return;
@@ -97,7 +97,7 @@ impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
     if self.reads_import {
       return;
     }
-    walk::walk_expression(self, it);
+    walk_js::walk_expression(self, it);
   }
 
   // Merely creating a function does not run its parameters or body.
@@ -108,7 +108,7 @@ impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
     if self.reads_import {
       return;
     }
-    walk::walk_call_expression(self, it);
+    walk_js::walk_call_expression(self, it);
     if !self.reads_import {
       self.visit_immediately_invoked_function(&it.callee);
     }
@@ -121,9 +121,6 @@ impl<'ast> Visit<'ast> for TopLevelImportReadDetector<'_> {
       self.visit_declaration(declaration);
     }
   }
-
-  // Types are erased at runtime; a type-only import reference is never a value read.
-  fn visit_ts_type(&mut self, _it: &TSType<'ast>) {}
 }
 
 #[cfg(test)]

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -7,7 +7,7 @@ use oxc::{
     },
     builder::AstBuilder,
   },
-  ast_visit::{Visit, walk},
+  ast_visit::{VisitJs, walk_js},
   semantic::{NodeId, SymbolId},
 };
 use rolldown_common::{
@@ -353,7 +353,7 @@ impl<'ast> CrossModuleOptimizationRunnerContext<'_, 'ast> {
   }
 }
 
-impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast> {
+impl<'a, 'ast: 'a> VisitJs<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast> {
   fn enter_node(&mut self, kind: AstKind<'ast>) {
     self.visit_path.push(kind);
   }
@@ -407,7 +407,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
         }
       }
     }
-    walk::walk_import_expression(self, it);
+    walk_js::walk_import_expression(self, it);
   }
 
   fn visit_call_expression(&mut self, it: &oxc::ast::ast::CallExpression<'ast>) {
@@ -444,7 +444,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
         pre_node_id = self.latest_side_effect_free_call_expr_node_id.replace(it.node_id());
       }
     }
-    walk::walk_call_expression(self, it);
+    walk_js::walk_call_expression(self, it);
     if let Some(node_id) = pre_node_id {
       self.latest_side_effect_free_call_expr_node_id = Some(node_id);
     }
@@ -482,7 +482,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
         }
       });
     }
-    walk::walk_export_named_declaration(self, it);
+    walk_js::walk_export_named_declaration(self, it);
   }
 
   fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'ast>) {
@@ -494,7 +494,7 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
     {
       return;
     }
-    walk::walk_export_default_declaration(self, it);
+    walk_js::walk_export_default_declaration(self, it);
     let Some(expr) = it.declaration.as_expression() else {
       return;
     };

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use oxc::ast::ast::CommentContent;
 use oxc::ast::ast::Program;
 use oxc::ast::ast::{Declaration, ExportDefaultDeclarationKind, Statement};
-use oxc::ast_visit::{Visit, VisitMut, walk};
+use oxc::ast_visit::{VisitJs, VisitMut, walk_js};
 use oxc::diagnostics::{LabeledSpan, Severity as OxcSeverity};
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
 use oxc::semantic::{Scoping, Stats};
@@ -208,6 +208,11 @@ impl PreProcessEcmaAst {
       })?;
     }
 
+    debug_assert!(
+      ast.program().source_type.is_javascript(),
+      "ECMAScript transform must produce a JavaScript AST"
+    );
+
     // Step 4: Run inject plugin.
     if !bundle_options.inject.is_empty() {
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
@@ -320,7 +325,7 @@ impl FunctionDeclarationStartMatcher {
   }
 }
 
-impl<'ast> Visit<'ast> for FunctionDeclarationStartMatcher {
+impl<'ast> VisitJs<'ast> for FunctionDeclarationStartMatcher {
   fn visit_program(&mut self, program: &Program<'ast>) {
     for stmt in &program.body {
       if self.remaining_target_count == 0 {
@@ -342,7 +347,7 @@ impl<'ast> Visit<'ast> for FunctionDeclarationStartMatcher {
       }
     }
     if self.remaining_target_count > 0 {
-      walk::walk_statement(self, stmt);
+      walk_js::walk_statement(self, stmt);
     }
   }
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use cow_utils::CowUtils;
 use oxc::{
   ast::{Comment, ast::Expression},
-  ast_visit::{Visit, walk},
+  ast_visit::{VisitJs, walk_js},
 };
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
 use rolldown_std_utils::relative_path_to_slash;
@@ -32,10 +32,10 @@ pub struct DynamicImportVarsVisit<'ast, 'b> {
   pub magic_string: Option<MagicString<'b>>,
 }
 
-impl<'ast> Visit<'ast> for DynamicImportVarsVisit<'ast, '_> {
+impl<'ast> VisitJs<'ast> for DynamicImportVarsVisit<'ast, '_> {
   fn visit_expression(&mut self, expr: &Expression<'ast>) {
     if self.rewrite_variable_dynamic_import(expr, None) {
-      walk::walk_expression(self, expr);
+      walk_js::walk_expression(self, expr);
     }
   }
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -4,7 +4,7 @@ mod utils;
 
 use std::{borrow::Cow, pin::Pin, sync::Arc};
 
-use oxc::ast_visit::Visit;
+use oxc::ast_visit::VisitJs;
 use rolldown_common::ModuleType;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use std::{borrow::Cow, path::PathBuf};
 
-use oxc::ast_visit::Visit;
+use oxc::ast_visit::VisitJs;
 use rolldown_common::ModuleType;
 use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
 use sugar_path::SugarPath as _;

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use oxc::ast::ast::{
   self, Argument, ArrayExpressionElement, Expression, ObjectPropertyKind, PropertyKey, PropertyKind,
 };
-use oxc::ast_visit::{Visit, walk};
+use oxc::ast_visit::{VisitJs, walk_js};
 use rolldown_ecmascript_utils::ExpressionExt;
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
 use rolldown_plugin_utils::constants::{ViteImportGlob, ViteImportGlobValue};
@@ -26,9 +26,9 @@ pub struct GlobImportVisit<'a> {
   pub errors: Vec<anyhow::Error>,
 }
 
-impl<'ast> Visit<'ast> for GlobImportVisit<'_> {
+impl<'ast> VisitJs<'ast> for GlobImportVisit<'_> {
   fn visit_program(&mut self, it: &ast::Program<'ast>) {
-    walk::walk_program(self, it);
+    walk_js::walk_program(self, it);
     if !self.import_decls.is_empty() {
       self
         .magic_string
@@ -40,7 +40,7 @@ impl<'ast> Visit<'ast> for GlobImportVisit<'_> {
     if self.transform_glob_import(expr, ImportGlobOmitType::None) {
       return;
     }
-    walk::walk_expression(self, expr);
+    walk_js::walk_expression(self, expr);
   }
 }
 


### PR DESCRIPTION
Use Oxc's `VisitJs` for AST passes that run after ECMAScript transformation, and assert in debug builds that the transformed source type is JavaScript.

Validation: `just lint-rust` and targeted Rust suites.
Binary size: −49,648 bytes (−0.304%) for the macOS arm64 release binding.