### PR TITLE
fix(plugin): validate emitted prebuilt-chunk file names

### DIFF
--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -371,6 +371,24 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
 
   public emitFile: PluginContext['emitFile'] = (file): string => {
     if (file.type === 'prebuilt-chunk') {
+      // Rollup validates prebuilt chunks in `FileEmitter#emitPrebuiltChunk` — `code`
+      // first, then `fileName` — before either reaches the bundler. Without these the
+      // values fall through to N-API, which reports the napi `Status` (`InvalidArg`,
+      // `StringExpected`) as `pluginCode` instead of `VALIDATION_ERROR`.
+      if (typeof file.code !== 'string') {
+        return error(
+          logFailedValidation(
+            `Emitted prebuilt chunks need to have a valid string code, received "${file.code}".`,
+          ),
+        );
+      }
+      if (typeof file.fileName !== 'string' || isPathFragment(file.fileName)) {
+        return error(
+          logFailedValidation(
+            `The "fileName" property of emitted prebuilt chunks must be strings that are neither absolute nor relative paths, received "${file.fileName}".`,
+          ),
+        );
+      }
       return this.context.emitPrebuiltChunk({
         fileName: file.fileName,
         name: file.name,

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
@@ -66,6 +66,41 @@ export default defineTest({
             'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../node_modules/some-lib/entry".',
           );
 
+          // Prebuilt chunk file names are validated too, with a prebuilt-specific message
+          expect(() => {
+            this.emitFile({
+              type: 'prebuilt-chunk',
+              fileName: '../prebuilt.js',
+              code: 'export default 1;',
+            });
+          }).toThrow(
+            'The "fileName" property of emitted prebuilt chunks must be strings that are neither absolute nor relative paths, received "../prebuilt.js".',
+          );
+
+          // A missing/non-string prebuilt `fileName` is rejected by the same check, so it
+          // never reaches N-API (which would report `Missing field \`fileName\`` with a
+          // napi Status as pluginCode). Mirrors Rollup's
+          // test/function/samples/emit-file/invalid-prebuilt-chunk-filename.
+          expect(() => {
+            this.emitFile({
+              type: 'prebuilt-chunk',
+              code: 'export default 1;',
+            } as any);
+          }).toThrow(
+            'The "fileName" property of emitted prebuilt chunks must be strings that are neither absolute nor relative paths, received "undefined".',
+          );
+
+          // `code` is validated first, as in Rollup's emitPrebuiltChunk. Mirrors
+          // test/function/samples/emit-file/invalid-prebuit-chunk-code.
+          expect(() => {
+            this.emitFile({
+              type: 'prebuilt-chunk',
+              fileName: 'my-chunk.js',
+            } as any);
+          }).toThrow(
+            'Emitted prebuilt chunks need to have a valid string code, received "undefined".',
+          );
+
           // Subdirectory names are not path fragments
           this.emitFile({
             type: 'asset',


### PR DESCRIPTION
Stacked on #10398. Follow-up polish on #10377.

## Problem

#10377 added `isPathFragment` validation to `emitFile`, but the `prebuilt-chunk` branch returns before the check runs:

```ts
public emitFile: PluginContext['emitFile'] = (file): string => {
  if (file.type === 'prebuilt-chunk') {
    return this.context.emitPrebuiltChunk({ ... });   // <- returns early
  }
  // isPathFragment validation lives below this point
  ...
```

So this is accepted today:

```js
this.emitFile({
  type: 'prebuilt-chunk',
  fileName: '../prebuilt.js',
  code: 'export default 1;',
});
```

The bad name is not caught at emit time, so the plugin that emitted it is no longer on the stack when it eventually surfaces — as a write outside `outDir`, or as a later native error that doesn't name the plugin. That is the same diagnostic problem #10377 fixed for the other emit types (#9994), just on the branch it missed.

## Change

Run the same `isPathFragment` check inside the `prebuilt-chunk` branch, with a message specific to prebuilt chunks — they only carry `fileName`, no `name`, so reusing the shared message would be inaccurate:

> The "fileName" property of emitted prebuilt chunks must be strings that are neither absolute nor relative paths, received "../prebuilt.js".

The `typeof file.fileName === 'string'` guard keeps the existing behavior for a missing/non-string `fileName`, which is already reported downstream.

Covered by a new case in the existing `plugin/context/emit-file-invalid-name` fixture.
