### PR TITLE
test(plugin): cover chunk fileName, absolute chunk name, and Windows drive names

### DIFF
--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
@@ -66,6 +66,39 @@ export default defineTest({
             'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../node_modules/some-lib/entry".',
           );
 
+          // Chunk `fileName` is validated the same way as `name`
+          expect(() => {
+            this.emitFile({
+              type: 'chunk',
+              id: './main.js',
+              fileName: '../out/entry.js',
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../out/entry.js".',
+          );
+
+          // Absolute chunk name
+          expect(() => {
+            this.emitFile({
+              type: 'chunk',
+              id: './main.js',
+              name: '/abs-entry',
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "/abs-entry".',
+          );
+
+          // Windows drive-letter names are rejected regardless of the host OS
+          expect(() => {
+            this.emitFile({
+              type: 'asset',
+              name: 'F:\\win.txt',
+              source: 'content',
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "F:\\win.txt".',
+          );
+
           // Prebuilt chunk file names are validated too, with a prebuilt-specific message
           expect(() => {
             this.emitFile({


### PR DESCRIPTION
Stacked on #10399. Tests only — no behavior change.

The `plugin/context/emit-file-invalid-name` fixture added in #10377 covers asset `name`, asset `fileName` and chunk `name`, which leaves the branches most likely to regress unexercised. Three cases added:

- **Chunk `fileName`** — only chunk `name` was covered; `emitFile({ type: 'chunk', fileName: '../out/entry.js' })` went through an untested path.
- **Absolute chunk `name`** (`/abs-entry`) — the existing chunk case uses a relative `../…` name, so the `name[0] === '/'` branch was only covered for assets.
- **Windows drive-letter name** (`F:\win.txt`), asserted on **every** host OS. The existing drive-letter case is wrapped in `if (process.platform === 'win32')`, so on Linux CI it never ran — which is exactly how the OS-dependent Rust implementation fixed in #10398 stayed unnoticed. Since `isPathFragment` is a pure string predicate on both sides, there is no reason to gate it by platform; asserting it unconditionally means a future OS-dependent implementation fails on CI rather than only on a contributor's Windows machine.
