### PR TITLE
fix(code-splitting): keep eager entries out of group chunks in cjs output

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -9,8 +9,9 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  Chunk, ChunkKind, ChunkingContext, EntryPoint, ManualCodeSplittingOptions, MatchGroup,
-  MatchGroupTest, Module, ModuleIdx, ModuleTable, ModuleTagBitSet, ModuleTagRegistry,
+  Chunk, ChunkKind, ChunkingContext, EntryPoint, ExportsKind, ManualCodeSplittingOptions,
+  MatchGroup, MatchGroupTest, Module, ModuleIdx, ModuleTable, ModuleTagBitSet, ModuleTagRegistry,
+  OutputFormat,
 };
 use rolldown_error::BuildResult;
 use rolldown_plugin::SharedPluginDriver;
@@ -118,6 +119,41 @@ impl ManualSplitter<'_> {
     let metas = &self.link_output.metas;
     let mut module_groups: IndexVec<ModuleGroupIdx, ModuleGroup> = IndexVec::default();
     let mut group_idx_by_id: FxHashMap<ModuleGroupId, ModuleGroupIdx> = FxHashMap::default();
+
+    // A user-defined entry whose body executes eagerly must stay in its entry chunk in cjs
+    // output: captured into a group chunk, its body runs while the entry chunk's top-of-file
+    // `require` of the group chunk is still executing, so it reads the entry chunk's
+    // `require_*`/`init_*` wrapper exports before they are installed. A CommonJS entry is pinned
+    // in every mode — unwrapped, its bare body also carries the chunk's `module.exports`, and
+    // wrapped, its facade runs `module.exports = require_main()` before the facade's own wrapper
+    // exports exist and then clobbers the entry's exports (see the
+    // `code_splitting/entry_group_*` fixtures). Other entries are pinned only while unwrapped and
+    // outside strict execution order, whose post-chunking lowering legalizes captured entries
+    // itself. Dynamic-import entries are safe to capture: their cjs lowering defers the chunk
+    // require into `Promise.resolve().then(...)`, which runs only after the exporting chunk
+    // finished executing. ESM output is unaffected — hoisted live-bound import cycles tolerate
+    // the ordering.
+    let pinned_entries: FxHashSet<ModuleIdx> = if matches!(self.options.format, OutputFormat::Cjs) {
+      self
+        .link_output
+        .entries
+        .iter()
+        .filter(|(idx, entry_points)| {
+          if !entry_points.iter().any(|entry_point| entry_point.kind.is_user_defined()) {
+            return false;
+          }
+          let Some(module) = self.link_output.module_table[**idx].as_normal() else {
+            return false;
+          };
+          matches!(module.exports_kind, ExportsKind::CommonJs)
+            || (self.link_output.metas[**idx].wrap_kind().is_none()
+              && !self.options.is_strict_execution_order_enabled())
+        })
+        .map(|(idx, _)| *idx)
+        .collect()
+    } else {
+      FxHashSet::default()
+    };
 
     let mut entries_aware_groups: Vec<ModuleGroup> = Vec::new();
     let mut entries_aware_idx_by_id: FxHashMap<ModuleGroupId, usize> = FxHashMap::default();
@@ -239,13 +275,15 @@ impl ManualSplitter<'_> {
           &mut module_groups[idx]
         };
 
+        // Seeding `visited` with the pinned entries makes the capture walk treat them as already
+        // handled: they are neither added to the group nor traversed through.
         add_module_and_dependencies_to_group_recursively(
           group,
           normal_module.idx,
           &self.link_output.metas,
           &self.link_output.module_table,
           self.module_to_assigned,
-          &mut FxHashSet::default(),
+          &mut pinned_entries.clone(),
           include_dependencies_recursively,
         );
       }

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/_config.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "format": "cjs",
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "entry-group",
+          "test": "[\\\\/]main\\.js$",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  },
+  "_comment": "The unwrapped-ESM-entry arm of the same family: outside strict execution order an ESM entry stays unwrapped, and captured into the group chunk its eager body read the entry chunk's require_* wrapper (CJS leaf) and live-binding getters (ESM leaf) before the entry chunk installed them."
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+var import_leaf = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+})))());
+if (import_leaf.default.ok !== true) throw new Error(`cjs leaf not initialized: ${JSON.stringify(import_leaf.default)}`);
+const done = true;
+//#endregion
+exports.done = done;
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/leaf-esm.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/leaf-esm.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/leaf.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/leaf.js
@@ -1,0 +1,1 @@
+module.exports = { ok: true };

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/main.js
@@ -1,5 +1,5 @@
-import leaf from "./leaf.js";
-import { value } from "./leaf-esm.js";
+import leaf from './leaf.js';
+import { value } from './leaf-esm.js';
 if (leaf.ok !== true) {
   throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_esm_entry_eager_body/main.js
@@ -1,0 +1,9 @@
+import leaf from "./leaf.js";
+import { value } from "./leaf-esm.js";
+if (leaf.ok !== true) {
+  throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+}
+if (value !== 42) {
+  throw new Error(`esm leaf value wrong: ${value}`);
+}
+export const done = true;

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/_config.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "A code-splitting group captures only the CJS entry while its required leaves stay outside. The unwrapped entry must stay in its entry chunk: moved into the group chunk, its bare body called the leaves' `require_*`/`init_*` wrapper exports through a require cycle before the entry chunk installed them, and its `module.exports` landed on the wrong chunk. ESM output keeps the entry wrapped and is unaffected.",
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "format": "cjs",
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "entry-group",
+          "test": "[\\\\/]main\\.js$",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "strict-wrap-all",
+      "strictExecutionOrder": true
+    },
+    {
+      "_configName": "strict-on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    },
+    {
+      "_configName": "esm-format-control",
+      "format": "esm"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/artifacts.snap
@@ -1,0 +1,130 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf.js
+var require_leaf = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+}));
+//#endregion
+//#region leaf-esm.js
+var leaf_esm_exports = /* @__PURE__ */ __exportAll({ ok: () => true });
+var init_leaf_esm = __esmMin((() => {}));
+//#endregion
+//#region main.js
+const leaf = require_leaf();
+const leafEsm = (init_leaf_esm(), __toCommonJS(leaf_esm_exports));
+if (leaf.ok !== true) throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+if (leafEsm.ok !== true) throw new Error(`esm leaf not initialized: ${JSON.stringify(leafEsm)}`);
+module.exports = { ok: leaf.ok && leafEsm.ok };
+//#endregion
+
+```
+
+# Variant: strict-wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf.js
+var require_leaf = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+}));
+//#endregion
+//#region leaf-esm.js
+var leaf_esm_exports = /* @__PURE__ */ __exportAll({ ok: () => true });
+var init_leaf_esm = __esmMin((() => {}));
+//#endregion
+//#region main.js
+const leaf = require_leaf();
+const leafEsm = (init_leaf_esm(), __toCommonJS(leaf_esm_exports));
+if (leaf.ok !== true) throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+if (leafEsm.ok !== true) throw new Error(`esm leaf not initialized: ${JSON.stringify(leafEsm)}`);
+module.exports = { ok: leaf.ok && leafEsm.ok };
+//#endregion
+
+```
+
+# Variant: strict-on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf.js
+var require_leaf = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+}));
+//#endregion
+//#region leaf-esm.js
+var leaf_esm_exports = /* @__PURE__ */ __exportAll({ ok: () => true });
+var init_leaf_esm = __esmMin((() => {}));
+//#endregion
+//#region main.js
+const leaf = require_leaf();
+const leafEsm = (init_leaf_esm(), __toCommonJS(leaf_esm_exports));
+if (leaf.ok !== true) throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+if (leafEsm.ok !== true) throw new Error(`esm leaf not initialized: ${JSON.stringify(leafEsm)}`);
+module.exports = { ok: leaf.ok && leafEsm.ok };
+//#endregion
+
+```
+
+# Variant: esm-format-control: [format: Esm]
+
+## Assets
+
+### entry-group.js
+
+```js
+import { i as __toCommonJS, t as __commonJSMin } from "./rolldown-runtime.js";
+import { n as leaf_esm_exports, r as require_leaf, t as init_leaf_esm } from "./main.js";
+//#region main.js
+var require_main = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const leaf = require_leaf();
+	const leafEsm = (init_leaf_esm(), __toCommonJS(leaf_esm_exports));
+	if (leaf.ok !== true) throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+	if (leafEsm.ok !== true) throw new Error(`esm leaf not initialized: ${JSON.stringify(leafEsm)}`);
+	module.exports = { ok: leaf.ok && leafEsm.ok };
+}));
+//#endregion
+export { require_main as t };
+
+```
+
+### main.js
+
+```js
+import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as require_main } from "./entry-group.js";
+//#region leaf.js
+var require_leaf = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+}));
+//#endregion
+//#region leaf-esm.js
+var leaf_esm_exports = /* @__PURE__ */ __exportAll({ ok: () => true });
+var init_leaf_esm = __esmMin((() => {}));
+//#endregion
+export default require_main();
+export { leaf_esm_exports as n, require_leaf as r, init_leaf_esm as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/leaf-esm.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/leaf-esm.js
@@ -1,0 +1,1 @@
+export const ok = true;

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/leaf.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/leaf.js
@@ -1,0 +1,1 @@
+module.exports = { ok: true };

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/main.js
@@ -1,5 +1,5 @@
-const leaf = require("./leaf.js");
-const leafEsm = require("./leaf-esm.js");
+const leaf = require('./leaf.js');
+const leafEsm = require('./leaf-esm.js');
 
 if (leaf.ok !== true) {
   throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_facade_wrapper_cycle/main.js
@@ -1,0 +1,11 @@
+const leaf = require("./leaf.js");
+const leafEsm = require("./leaf-esm.js");
+
+if (leaf.ok !== true) {
+  throw new Error(`cjs leaf not initialized: ${JSON.stringify(leaf)}`);
+}
+if (leafEsm.ok !== true) {
+  throw new Error(`esm leaf not initialized: ${JSON.stringify(leafEsm)}`);
+}
+
+module.exports = { ok: leaf.ok && leafEsm.ok };

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/_config.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "other",
+        "import": "./other.js"
+      }
+    ],
+    "format": "cjs",
+    "preserveEntrySignatures": "allow-extension",
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "entry-group",
+          "test": "[\\\\/]main\\.js$",
+          "includeDependenciesRecursively": false
+        }
+      ]
+    }
+  },
+  "_comment": "Same shape as entry_group_facade_wrapper_cycle, but the CJS entry is also required by a second entry, so it gets a require_* wrapper. A wrapped CJS entry captured by a group chunk is equally unsafe in cjs output: the facade ran `module.exports = require_main()` before its own wrapper exports existed and then clobbered the entry's exports with the re-export assignment."
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region leaf.js
+var require_leaf = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { ok: true };
+}));
+//#endregion
+//#region main.js
+var require_main = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const leaf = require_leaf();
+	if (leaf.ok !== true) throw new Error(`leaf not initialized: ${JSON.stringify(leaf)}`);
+	module.exports = { ok: leaf.ok };
+}));
+//#endregion
+module.exports = require_main();
+
+```
+
+## other.js
+
+```js
+//#region other.js
+const m = require("./main.js");
+if (m.ok !== true) throw new Error(`entry exports not visible: ${JSON.stringify(m)}`);
+module.exports = { ok: true };
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/leaf.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/leaf.js
@@ -1,0 +1,1 @@
+module.exports = { ok: true };

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/main.js
@@ -1,0 +1,5 @@
+const leaf = require("./leaf.js");
+if (leaf.ok !== true) {
+  throw new Error(`leaf not initialized: ${JSON.stringify(leaf)}`);
+}
+module.exports = { ok: leaf.ok };

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/main.js
@@ -1,4 +1,4 @@
-const leaf = require("./leaf.js");
+const leaf = require('./leaf.js');
 if (leaf.ok !== true) {
   throw new Error(`leaf not initialized: ${JSON.stringify(leaf)}`);
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/other.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/other.js
@@ -1,4 +1,4 @@
-const m = require("./main.js");
+const m = require('./main.js');
 if (m.ok !== true) {
   throw new Error(`entry exports not visible: ${JSON.stringify(m)}`);
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/other.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/entry_group_required_cjs_entry/other.js
@@ -1,0 +1,5 @@
+const m = require("./main.js");
+if (m.ok !== true) {
+  throw new Error(`entry exports not visible: ${JSON.stringify(m)}`);
+}
+module.exports = { ok: true };


### PR DESCRIPTION
> **Closed by decision.** The only affected configuration — a `codeSplitting` group capturing a user-defined entry module itself, in `cjs` output — is fuzzer-generated and has no known real-world use, and this fix would silently override the user's group directive for such entries. The analysis, executed red/green fixtures, and the correct long-term direction (wrap captured entries, keep entry facades free of co-hosted modules, cycle-safe CJS chunk layout) are preserved here for whenever a real-world report appears. Tracked in #10294.

## Summary

A `codeSplitting` group could capture a user-defined entry module into a group chunk in `cjs` output while the entry's body still executes eagerly. The entry chunk requires the group chunk at its top, the group chunk requires the entry chunk back, and the entry's body then reads the entry chunk's `require_*`/`init_*` wrapper exports before that chunk has installed them:

- Unwrapped CommonJS entry (the default in cjs output): `TypeError: require(...).require_leaf is not a function`, and the entry's `module.exports` lands on the group chunk instead of the entry file.
- Wrapped CommonJS entry (also `require`d, e.g. by a second entry): the facade runs `module.exports = require_main()` before its own wrapper exports exist, and the trailing re-export assignment then clobbers the entry's exports.
- Unwrapped ESM entry outside strict execution order: its eager body hits the same cycle through `__toESM(require_leaf())` and cross-chunk live-binding getters.

Manual group capture now pins such entries to their entry chunks in cjs output: CommonJS entries in every mode, other entries while unwrapped outside strict execution order. Their dependencies follow ordinary assignment alongside them. Three adjacent shapes deliberately keep their existing grouping behavior:

- Dynamic-import entries stay capturable: their cjs lowering defers the chunk require into `Promise.resolve().then(...)`, which runs only after the exporting chunk finished executing (pinned by the existing `optimization/chunk_merging/dynamic_entry_merged_in_common_chunk*` fixtures, whose output is unchanged).
- Under strict execution order, non-CommonJS entries remain capturable: the post-chunking order lowering legalizes captured entries itself (pinned by the existing strict fixtures that capture ESM entries in cjs output).
- ESM output is unaffected — hoisted live-bound import cycles tolerate the ordering (pinned by a fixture control cell).

Reduced from the order-fuzzer finding tracked in #10294.

## Tests

All three fixtures execute their output under node and fail on current main:

- `code_splitting/entry_group_facade_wrapper_cycle` — unwrapped CJS entry requiring a CJS leaf and an ESM leaf. On main `4930a00b` the group chunk calls both `require_leaf()` and `init_leaf_esm()` through the partially initialized facade and throws; with this change the plain, strict wrap-all, and strict on-demand cells pass, and an esm-format control cell pins the already-correct ESM shape.
- `code_splitting/entry_group_required_cjs_entry` — the wrapped-entry arm: a second entry requires the CJS entry, giving it a `require_*` wrapper; on main its captured facade throws the same way and loses the entry's exports.
- `code_splitting/entry_group_esm_entry_eager_body` — the unwrapped-ESM-entry arm: an ESM entry importing a CJS leaf and an ESM leaf; on main its captured eager body throws through the same cycle.

A recursive-capture probe (`includeDependenciesRecursively: true`) collapses back to a single chunk with the pin and stays correct.

## Validation

- `cargo test --workspace --exclude rolldown_binding` — full Rust suite with no snapshot changes outside the new fixtures
- `cargo clippy --workspace --all-targets -- --deny warnings`, `cargo fmt`
