### PR TITLE
fix(rolldown): apply output.paths to CJS export-star of external modules

### DIFF
--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -276,7 +276,7 @@ pub fn render_chunk_exports(
           s.push('\n');
           // Only generate require statement if this external module hasn't been imported yet
           if imported_external_modules.insert(external.namespace_ref) {
-            writeln!(s, "var {} = require(\"{}\");", binding_ref_name, external.get_import_path(chunk, None)).unwrap();
+            writeln!(s, "var {} = require(\"{}\");", binding_ref_name, external.get_import_path(chunk, ctx.resolved_paths)).unwrap();
           }
           s.push_str(&import_stmt);
         });

--- a/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/_config.json
+++ b/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "external": ["ext-mod"],
+    "paths": { "ext-mod": "./mapped-ext.js" }
+  },
+  "configVariants": [
+    { "format": "esm", "_configName": "esm" },
+    { "format": "cjs", "_configName": "cjs" }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+export * from "./mapped-ext.js";
+
+```
+
+# Variant: esm: [format: Esm]
+
+## Assets
+
+### main.js
+
+```js
+export * from "./mapped-ext.js";
+
+```
+
+# Variant: cjs: [format: Cjs]
+
+## Assets
+
+### main.js
+
+```js
+var ext_mod = require("./mapped-ext.js");
+Object.keys(ext_mod).forEach(function(k) {
+	if (k !== "default" && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+		enumerable: true,
+		get: function() {
+			return ext_mod[k];
+		}
+	});
+});
+
+```

--- a/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/main.js
+++ b/crates/rolldown/tests/rolldown/function/output_paths_export_star_external/main.js
@@ -1,0 +1,1 @@
+export * from 'ext-mod';


### PR DESCRIPTION
## Summary

Fixes #10402. `output.paths` was ignored by CJS output when re-exporting an external module via `export * from '<external>'`, even though ESM output applied it correctly.

The CJS/IIFE/UMD lowering of `export * from '<external>'` renders `var ns = require("<path>")` in `render_chunk_exports.rs`, but it called `external.get_import_path(chunk, None)` — passing `None` for the pre-resolved paths, so the `paths` map was never consulted and the **original source specifier** was emitted. This was the only `get_import_path`/`get_file_name` call site passing `None`; every other one (ESM export-star, CJS direct imports, `require()` calls, dynamic imports) already threads `ctx.resolved_paths`. It's the gap left by #6923.

## Fix

```rust
// crates/rolldown/src/utils/chunk/render_chunk_exports.rs
- external.get_import_path(chunk, None)
+ external.get_import_path(chunk, ctx.resolved_paths)
```

`ctx.resolved_paths` is the correct value: `output.paths` may be an async function, and the generate stage pre-resolves it into an `FxHashMap` before sync rendering (calling the raw `Fn` variant synchronously hits a `debug_assert!`). When no `paths` option is set, `resolved_paths` is `None`, so behavior is unchanged.

## Before / after

Input: `export * from 'ext-mod'` (external), `paths: { "ext-mod": "./mapped-ext.js" }`

| Format | Before | After |
|---|---|---|
| ESM | `export * from "./mapped-ext.js"` ✅ | `export * from "./mapped-ext.js"` ✅ |
| CJS | `require("ext-mod")` ❌ | `require("./mapped-ext.js")` ✅ |

## Rollup parity

Verified against **rollup 4.62.2** with the issue's exact reproduction — Rollup applies `output.paths` in both formats, which this change now matches:

```js
// ESM
export * from './sub.mjs';
// CJS
var mod_js = require('./sub.cjs');
```

## Tests

- New regression fixture `tests/rolldown/function/output_paths_export_star_external/` snapshotting both ESM and CJS variants.
- Existing `export_star_from_external` / `cjs_module_lexer` fixtures unchanged (no `paths` ⇒ identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)