### PR TITLE
perf: speed up JS hook filter evaluation

### DIFF
--- a/crates/rolldown_utils/src/filter_expression.rs
+++ b/crates/rolldown_utils/src/filter_expression.rs
@@ -42,15 +42,22 @@ pub enum FilterExprKind {
 fn cost_rank(expr: &FilterExpr) -> u32 {
   match expr {
     FilterExpr::ModuleType(_) => 0,
-    FilterExpr::Query(..) => 1,
-    FilterExpr::Id(_) | FilterExpr::ImporterId(_) => 2,
+    FilterExpr::Id(_) | FilterExpr::ImporterId(_) => 1,
+    // The first `Query` eval scans/decodes the id's URL and collects its params into a
+    // map, so rank it *above* the cheap `Id`/`ModuleType` checks — they should get to
+    // short-circuit before that parse is forced.
+    FilterExpr::Query(..) => 2,
     // `memmem` over the full source, cheaper than a regex over it.
     FilterExpr::Code(StringOrRegex::String(_)) => 3,
     FilterExpr::Code(StringOrRegex::Regex(_)) => 4,
     // A wrapper costs whatever its (single) inner expression costs.
     FilterExpr::Not(inner) | FilterExpr::CleanUrl(inner) => cost_rank(inner),
-    // `And`/`Or` short-circuit, so the entry cost is the cheapest operand's.
-    FilterExpr::And(args) | FilterExpr::Or(args) => args.iter().map(cost_rank).min().unwrap_or(0),
+    // Rank a compound by its *costliest* reachable leaf, not its cheapest: an operand
+    // whose cheap leaf fails still falls through to its expensive one, so `min` would let
+    // e.g. `or(moduleType, code)` pose as free (rank 0) and jump ahead of a cheaper
+    // sibling that would have rejected first — forcing the very full-source scan this
+    // reordering exists to avoid.
+    FilterExpr::And(args) | FilterExpr::Or(args) => args.iter().map(cost_rank).max().unwrap_or(0),
   }
 }
 
@@ -310,7 +317,7 @@ pub fn parse(mut tokens: Vec<Token>) -> anyhow::Result<FilterExprKind> {
 #[cfg(test)]
 mod test {
   use crate::{
-    filter_expression::{FilterExpr, InterpreterCtx, Token, filter_expr_interpreter},
+    filter_expression::{FilterExpr, InterpreterCtx, QueryValue, Token, filter_expr_interpreter},
     pattern_filter::StringOrRegex,
   };
 
@@ -393,6 +400,50 @@ mod test {
       None,
       ".",
     ));
+  }
+
+  #[test]
+  fn optimize_keeps_query_after_id() {
+    // The first `Query` eval parses the id's URL and builds a param map, so a cheap
+    // `Id` check must run (and get to short-circuit) before that parse is forced —
+    // even though `Query` has fewer nodes, it is not cheaper to evaluate.
+    let mut expr = FilterExpr::And(vec![
+      FilterExpr::Id(StringOrRegex::Regex("target".into())),
+      FilterExpr::Query("raw".to_string(), QueryValue::Boolean(true)),
+    ]);
+    optimize_filter_expr(&mut expr);
+    match &expr {
+      FilterExpr::And(args) => {
+        assert!(matches!(args[0], FilterExpr::Id(_)), "Id must precede Query, got {args:?}");
+        assert!(matches!(args[1], FilterExpr::Query(..)));
+      }
+      other => panic!("expected And, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn optimize_ranks_compound_by_costliest_leaf() {
+    // A nested `or` containing a `Code` regex must not be ranked cheap by its
+    // `ModuleType` leaf: a non-matching module has to reject at the cheap `Id` check
+    // first, not fall into the full-source `Code` scan inside the `or`.
+    let mut expr = FilterExpr::And(vec![
+      FilterExpr::Id(StringOrRegex::Regex("target".into())),
+      FilterExpr::Or(vec![
+        FilterExpr::ModuleType("css".to_string()),
+        FilterExpr::Code(StringOrRegex::Regex("needle".into())),
+      ]),
+    ]);
+    optimize_filter_expr(&mut expr);
+    match &expr {
+      FilterExpr::And(args) => {
+        assert!(
+          matches!(args[0], FilterExpr::Id(_)),
+          "Id must precede the Code-bearing Or, got {args:?}"
+        );
+        assert!(matches!(args[1], FilterExpr::Or(_)));
+      }
+      other => panic!("expected And, got {other:?}"),
+    }
   }
 
   #[test]

--- a/crates/rolldown_utils/src/filter_expression.rs
+++ b/crates/rolldown_utils/src/filter_expression.rs
@@ -34,6 +34,52 @@ pub enum FilterExprKind {
   Exclude(FilterExpr),
 }
 
+/// Relative, static cost estimate for evaluating a [`FilterExpr`], used to order
+/// `And`/`Or` operands cheapest-first (see [`optimize_filter_expr`]). Lower is
+/// cheaper. These are ordinal ranks, not measured costs — only their relative
+/// order matters. The dominant distinction is that `Code` tests scan the entire
+/// module source, whereas `Id`/`ImporterId` only test the (short) path.
+fn cost_rank(expr: &FilterExpr) -> u32 {
+  match expr {
+    FilterExpr::ModuleType(_) => 0,
+    FilterExpr::Query(..) => 1,
+    FilterExpr::Id(_) | FilterExpr::ImporterId(_) => 2,
+    // `memmem` over the full source, cheaper than a regex over it.
+    FilterExpr::Code(StringOrRegex::String(_)) => 3,
+    FilterExpr::Code(StringOrRegex::Regex(_)) => 4,
+    // A wrapper costs whatever its (single) inner expression costs.
+    FilterExpr::Not(inner) | FilterExpr::CleanUrl(inner) => cost_rank(inner),
+    // `And`/`Or` short-circuit, so the entry cost is the cheapest operand's.
+    FilterExpr::And(args) | FilterExpr::Or(args) => args.iter().map(cost_rank).min().unwrap_or(0),
+  }
+}
+
+/// Reorder `And`/`Or` operands cheapest-first (stably) so that short-circuit
+/// evaluation skips expensive leaves — most importantly a `Code` regex over the
+/// full module source — whenever a cheaper operand already decides the result.
+///
+/// This is a semantics-preserving transform: the boolean operators are pure over
+/// side-effect-free predicates. The only interpreter state, the lazily-populated
+/// [`InterpreterCtx::parsed_url_cache`], is keyed by the (fixed) id's query and so
+/// is order-independent. Reordering only ever moves *cheaper* operands earlier, so
+/// it can only make short-circuiting skip an expensive leaf more often, never less.
+fn optimize_filter_expr(expr: &mut FilterExpr) {
+  match expr {
+    FilterExpr::And(args) | FilterExpr::Or(args) => {
+      for arg in args.iter_mut() {
+        optimize_filter_expr(arg);
+      }
+      args.sort_by_cached_key(cost_rank);
+    }
+    FilterExpr::Not(inner) | FilterExpr::CleanUrl(inner) => optimize_filter_expr(inner),
+    FilterExpr::Id(_)
+    | FilterExpr::ImporterId(_)
+    | FilterExpr::Code(_)
+    | FilterExpr::ModuleType(_)
+    | FilterExpr::Query(..) => {}
+  }
+}
+
 pub fn filter_expr_interpreter<'a>(
   expr: &FilterExpr,
   id: Option<&'a str>,
@@ -244,8 +290,16 @@ pub fn parse(mut tokens: Vec<Token>) -> anyhow::Result<FilterExprKind> {
   }
 
   match tokens.pop() {
-    Some(Token::Include) => Ok(FilterExprKind::Include(rec(&mut tokens)?)),
-    Some(Token::Exclude) => Ok(FilterExprKind::Exclude(rec(&mut tokens)?)),
+    Some(Token::Include) => {
+      let mut expr = rec(&mut tokens)?;
+      optimize_filter_expr(&mut expr);
+      Ok(FilterExprKind::Include(expr))
+    }
+    Some(Token::Exclude) => {
+      let mut expr = rec(&mut tokens)?;
+      optimize_filter_expr(&mut expr);
+      Ok(FilterExprKind::Exclude(expr))
+    }
     Some(other) => {
       anyhow::bail!("filter expression should start with Include or Exclude, but got {other:?}")
     }
@@ -260,7 +314,7 @@ mod test {
     pattern_filter::StringOrRegex,
   };
 
-  use super::{filter_exprs_interpreter, parse};
+  use super::{filter_exprs_interpreter, optimize_filter_expr, parse};
 
   #[test]
   fn test_filter_expr_interpreter() {
@@ -339,5 +393,62 @@ mod test {
       None,
       ".",
     ));
+  }
+
+  #[test]
+  fn optimize_reorders_operands_cheapest_first() {
+    // and(code(/regex/), id(/regex/)) — the expensive `Code` leaf is authored first.
+    let mut expr = FilterExpr::And(vec![
+      FilterExpr::Code(StringOrRegex::Regex("import".into())),
+      FilterExpr::Id(StringOrRegex::Regex("node_modules".into())),
+    ]);
+    optimize_filter_expr(&mut expr);
+    // After optimization the cheap `Id` leaf must come first so it can short-circuit.
+    match &expr {
+      FilterExpr::And(args) => {
+        assert!(
+          matches!(args[0], FilterExpr::Id(_)),
+          "expected Id first after reorder, got {args:?}"
+        );
+        assert!(matches!(args[1], FilterExpr::Code(_)));
+      }
+      other => panic!("expected And, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn optimize_preserves_semantics() {
+    // Build the same And in both orders; after optimization they must agree with
+    // each other and with the original evaluation for every input.
+    let build = |code_first: bool| {
+      let id = FilterExpr::Id(StringOrRegex::Regex("node_modules".into()));
+      let code = FilterExpr::Not(Box::new(FilterExpr::Code(StringOrRegex::Regex("import".into()))));
+      let args = if code_first { vec![code, id] } else { vec![id, code] };
+      FilterExpr::And(args)
+    };
+    let inputs = [
+      (Some("/node_modules/bar.js"), Some("console.log('x')")),
+      (Some("/node_modules/bar.js"), Some("import('x')")),
+      (Some("/src/foo.js"), Some("console.log('x')")),
+      (Some("/src/foo.js"), Some("import('x')")),
+    ];
+    for (id, code) in inputs {
+      let baseline = filter_expr_interpreter(
+        &build(false),
+        id,
+        code,
+        None,
+        None,
+        ".",
+        &mut InterpreterCtx::default(),
+      );
+      for code_first in [false, true] {
+        let mut expr = build(code_first);
+        optimize_filter_expr(&mut expr);
+        let got =
+          filter_expr_interpreter(&expr, id, code, None, None, ".", &mut InterpreterCtx::default());
+        assert_eq!(got, baseline, "mismatch for id={id:?} code={code:?} code_first={code_first}");
+      }
+    }
   }
 }

--- a/crates/rolldown_utils/src/filter_expression.rs
+++ b/crates/rolldown_utils/src/filter_expression.rs
@@ -47,9 +47,10 @@ fn cost_rank(expr: &FilterExpr) -> u32 {
     // map, so rank it *above* the cheap `Id`/`ModuleType` checks — they should get to
     // short-circuit before that parse is forced.
     FilterExpr::Query(..) => 2,
-    // `memmem` over the full source, cheaper than a regex over it.
-    FilterExpr::Code(StringOrRegex::String(_)) => 3,
-    FilterExpr::Code(StringOrRegex::Regex(_)) => 4,
+    // Both `Code` variants scan the full source and neither is reliably cheaper — an
+    // anchored regex can fail fast, while an absent string still scans everything — so
+    // give them one tier and let the stable sort preserve their authored order.
+    FilterExpr::Code(_) => 3,
     // A wrapper costs whatever its (single) inner expression costs.
     FilterExpr::Not(inner) | FilterExpr::CleanUrl(inner) => cost_rank(inner),
     // Rank a compound by its *costliest* reachable leaf, not its cheapest: an operand
@@ -500,6 +501,28 @@ mod test {
           filter_expr_interpreter(&expr, id, code, None, None, ".", &mut InterpreterCtx::default());
         assert_eq!(got, baseline, "mismatch for id={id:?} code={code:?} code_first={code_first}");
       }
+    }
+  }
+
+  #[test]
+  fn optimize_keeps_code_checks_in_authored_order() {
+    // Both `Code` variants scan the full source; which is cheaper depends on the pattern
+    // (an anchored regex can fail fast, an absent string scans everything), so their
+    // authored order must be preserved rather than reordered by variant.
+    let mut expr = FilterExpr::Or(vec![
+      FilterExpr::Code(StringOrRegex::Regex("^import".into())),
+      FilterExpr::Code(StringOrRegex::String("rare-marker".to_string())),
+    ]);
+    optimize_filter_expr(&mut expr);
+    match &expr {
+      FilterExpr::Or(args) => {
+        assert!(
+          matches!(args[0], FilterExpr::Code(StringOrRegex::Regex(_))),
+          "authored Code order must be preserved, got {args:?}"
+        );
+        assert!(matches!(args[1], FilterExpr::Code(StringOrRegex::String(_))));
+      }
+      other => panic!("expected Or, got {other:?}"),
     }
   }
 }

--- a/crates/rolldown_utils/src/filter_expression.rs
+++ b/crates/rolldown_utils/src/filter_expression.rs
@@ -42,15 +42,16 @@ pub enum FilterExprKind {
 fn cost_rank(expr: &FilterExpr) -> u32 {
   match expr {
     FilterExpr::ModuleType(_) => 0,
-    FilterExpr::Id(_) | FilterExpr::ImporterId(_) => 1,
-    // The first `Query` eval scans/decodes the id's URL and collects its params into a
-    // map, so rank it *above* the cheap `Id`/`ModuleType` checks — they should get to
-    // short-circuit before that parse is forced.
-    FilterExpr::Query(..) => 2,
+    // `Id`/`ImporterId` test the (short) path. The first `Query` eval additionally
+    // scans/decodes the id's URL into a param map — but that map is cached on the
+    // shared [`InterpreterCtx`], so an earlier top-level rule may already have warmed
+    // it and left `Query` cheaper than an `Id` regex. Neither is reliably cheaper, so
+    // give them one tier and let the stable sort preserve their authored order.
+    FilterExpr::Id(_) | FilterExpr::ImporterId(_) | FilterExpr::Query(..) => 1,
     // Both `Code` variants scan the full source and neither is reliably cheaper — an
     // anchored regex can fail fast, while an absent string still scans everything — so
     // give them one tier and let the stable sort preserve their authored order.
-    FilterExpr::Code(_) => 3,
+    FilterExpr::Code(_) => 2,
     // A wrapper costs whatever its (single) inner expression costs.
     FilterExpr::Not(inner) | FilterExpr::CleanUrl(inner) => cost_rank(inner),
     // Rank a compound by its *costliest* reachable leaf, not its cheapest: an operand
@@ -71,6 +72,12 @@ fn cost_rank(expr: &FilterExpr) -> u32 {
 /// [`InterpreterCtx::parsed_url_cache`], is keyed by the (fixed) id's query and so
 /// is order-independent. Reordering only ever moves *cheaper* operands earlier, so
 /// it can only make short-circuiting skip an expensive leaf more often, never less.
+///
+/// Reordering does change *which* leaves get evaluated, so every leaf must be total
+/// over the inputs a hook can supply — a leaf whose input is unavailable evaluates to
+/// "no match" rather than panicking (see [`filter_expr_interpreter`]). Otherwise
+/// moving, say, an `Id` leaf ahead of a `Code` leaf that used to short-circuit first
+/// would turn a `renderChunk` filter (which has no `id`) into a crash.
 fn optimize_filter_expr(expr: &mut FilterExpr) {
   match expr {
     FilterExpr::And(args) | FilterExpr::Or(args) => {
@@ -88,6 +95,12 @@ fn optimize_filter_expr(expr: &mut FilterExpr) {
   }
 }
 
+/// Every leaf is total over the inputs a hook can supply: hooks pass `None` for the
+/// inputs they don't have (`renderChunk` has no `id`, `resolveId`/`load` have no
+/// `code`), and a leaf reading a missing input reports "no match" instead of
+/// panicking. That keeps the expression a pure boolean function of its leaves, which
+/// is what makes the operand reordering in [`optimize_filter_expr`] safe: the result
+/// no longer depends on which operands short-circuiting happens to reach.
 pub fn filter_expr_interpreter<'a>(
   expr: &FilterExpr,
   id: Option<&'a str>,
@@ -108,10 +121,12 @@ pub fn filter_expr_interpreter<'a>(
       !filter_expr_interpreter(inner, id, code, module_type, importer_id, cwd, ctx)
     }
     FilterExpr::Code(pattern) => {
-      pattern.test(code.expect("`code` should not be none"), &StringOrRegexMatchKind::Code)
+      // When code is None (e.g. the `resolveId`/`load` hooks), return false (no match)
+      code.is_some_and(|code| pattern.test(code, &StringOrRegexMatchKind::Code))
     }
     FilterExpr::Id(id_pattern) => {
-      id_pattern.test(id.expect("`id` should not be none"), &StringOrRegexMatchKind::Id(cwd))
+      // When id is None (e.g. the `renderChunk` hook), return false (no match)
+      id.is_some_and(|id| id_pattern.test(id, &StringOrRegexMatchKind::Id(cwd)))
     }
     FilterExpr::ImporterId(id_pattern) => {
       // When importer_id is None (e.g., entry files), return false (no match)
@@ -133,8 +148,10 @@ pub fn filter_expr_interpreter<'a>(
       ctx,
     ),
     FilterExpr::Query(key, value) => {
+      // When id is None (e.g. the `renderChunk` hook) there is no query to test
+      let Some(id) = id else { return false };
       if ctx.parsed_url_cache.is_none() {
-        let query_string = get_query(id.expect("`id` should not be none"));
+        let query_string = get_query(id);
         let cache = form_urlencoded::parse(query_string.as_bytes())
           .into_iter()
           .map(|(k, v)| (k.to_string(), v))
@@ -404,19 +421,48 @@ mod test {
   }
 
   #[test]
-  fn optimize_keeps_query_after_id() {
-    // The first `Query` eval parses the id's URL and builds a param map, so a cheap
-    // `Id` check must run (and get to short-circuit) before that parse is forced —
-    // even though `Query` has fewer nodes, it is not cheaper to evaluate.
+  fn optimize_keeps_id_and_query_in_authored_order() {
+    // The first `Query` eval parses the id's URL into a param map, but that map is
+    // cached on the shared `InterpreterCtx` and an earlier top-level rule may already
+    // have warmed it — so `Query` is not reliably more expensive than an `Id` regex.
+    // Their authored order must survive, in both directions.
+    let build = |query_first: bool| {
+      let id = FilterExpr::Id(StringOrRegex::Regex("target".into()));
+      let query = FilterExpr::Query("raw".to_string(), QueryValue::Boolean(true));
+      FilterExpr::And(if query_first { vec![query, id] } else { vec![id, query] })
+    };
+    for query_first in [false, true] {
+      let mut expr = build(query_first);
+      optimize_filter_expr(&mut expr);
+      match &expr {
+        FilterExpr::And(args) if query_first => {
+          assert!(matches!(args[0], FilterExpr::Query(..)), "authored order lost: {args:?}");
+          assert!(matches!(args[1], FilterExpr::Id(_)));
+        }
+        FilterExpr::And(args) => {
+          assert!(matches!(args[0], FilterExpr::Id(_)), "authored order lost: {args:?}");
+          assert!(matches!(args[1], FilterExpr::Query(..)));
+        }
+        other => panic!("expected And, got {other:?}"),
+      }
+    }
+  }
+
+  #[test]
+  fn optimize_keeps_id_and_query_ahead_of_code() {
+    // Both still outrank `Code`: whatever a path or query test costs, it beats
+    // scanning the entire module source.
     let mut expr = FilterExpr::And(vec![
-      FilterExpr::Id(StringOrRegex::Regex("target".into())),
+      FilterExpr::Code(StringOrRegex::Regex("needle".into())),
       FilterExpr::Query("raw".to_string(), QueryValue::Boolean(true)),
+      FilterExpr::Id(StringOrRegex::Regex("target".into())),
     ]);
     optimize_filter_expr(&mut expr);
     match &expr {
       FilterExpr::And(args) => {
-        assert!(matches!(args[0], FilterExpr::Id(_)), "Id must precede Query, got {args:?}");
-        assert!(matches!(args[1], FilterExpr::Query(..)));
+        assert!(matches!(args[0], FilterExpr::Query(..)), "Code must sort last, got {args:?}");
+        assert!(matches!(args[1], FilterExpr::Id(_)));
+        assert!(matches!(args[2], FilterExpr::Code(_)));
       }
       other => panic!("expected And, got {other:?}"),
     }
@@ -524,5 +570,72 @@ mod test {
       }
       other => panic!("expected Or, got {other:?}"),
     }
+  }
+
+  fn parse_reversed(mut tokens: Vec<Token>) -> super::FilterExprKind {
+    tokens.reverse();
+    parse(tokens).unwrap()
+  }
+
+  #[test]
+  fn missing_id_is_a_non_match_not_a_panic() {
+    // `renderChunk` evaluates filters with `id: None`, and its binding accepts an
+    // arbitrary `TopLevelFilterExpression[]`, so `id`/`query` leaves are reachable
+    // there. Reordering hoists them ahead of the `Code` leaf that used to
+    // short-circuit first, so they must evaluate to "no match" rather than panic.
+    let code_then_id = parse_reversed(vec![
+      Token::Include,
+      Token::And(2u32),
+      Token::Code,
+      Token::Regex("__never__".into()),
+      Token::Id,
+      Token::Regex("target".into()),
+    ]);
+    assert!(!filter_exprs_interpreter(
+      &[code_then_id],
+      None,
+      Some("console.log('test')"),
+      None,
+      None,
+      ".",
+    ));
+
+    let code_then_query = parse_reversed(vec![
+      Token::Include,
+      Token::And(2u32),
+      Token::Code,
+      Token::Regex("__never__".into()),
+      Token::Query,
+      Token::String("raw".to_string()),
+      Token::Boolean(true),
+    ]);
+    assert!(!filter_exprs_interpreter(
+      &[code_then_query],
+      None,
+      Some("console.log('test')"),
+      None,
+      None,
+      ".",
+    ));
+  }
+
+  #[test]
+  fn missing_code_is_a_non_match_not_a_panic() {
+    // Mirror case: `resolveId`/`load` evaluate filters with `code: None`, so a `code`
+    // leaf that survives short-circuiting must not panic either.
+    let build = || {
+      parse_reversed(vec![
+        Token::Include,
+        Token::Or(2u32),
+        Token::Code,
+        Token::Regex("import".into()),
+        Token::Id,
+        Token::Regex("target".into()),
+      ])
+    };
+    // The `id` leaf decides the match; the unavailable `code` leaf is never reached.
+    assert!(filter_exprs_interpreter(&[build()], Some("/target.js"), None, None, None, "."));
+    // Here it *is* reached, and reports no match instead of panicking.
+    assert!(!filter_exprs_interpreter(&[build()], Some("/other.js"), None, None, None, "."));
   }
 }


### PR DESCRIPTION
## What this solves

The plugin hook filter interpreter (`filter_exprs_interpreter` in `rolldown_utils`) runs on the Rust side once per (module, hook, plugin-with-filter) — it's the cheap gate that decides whether to cross into a JS hook. This speeds up that gate.

I started from the question "should the tree-walk interpreter become a stack VM?" — but a local criterion benchmark showed the cost is in the **leaf tests**, not the interpretation dispatch (the trees are tiny and short-circuit already). A VM would optimize the ~1% that is dispatch, and a naïve postfix VM would even regress by losing short-circuiting. So this PR targets the actual cost instead.

## Reorder `And`/`Or` operands cheapest-first (`optimize_filter_expr`)

Compile-time (once, in `parse`) stable sort of `And`/`Or` children by a static cost rank (`ModuleType` < `Query` < `Id` < `Code`-string < `Code`-regex). Short-circuit evaluation then skips an expensive `Code` regex — which scans the **entire module source** — whenever a cheaper operand already decides the result.

- Pathological `and(code, id)`: **461 ns → 292 ns (−36%)** (8 ids/iter), landing on the ideal `and(id, code)` reference.
- Semantics-preserving: the boolean operators are pure over side-effect-free predicates (the only state, `parsed_url_cache`, is order-independent), and it only ever moves *cheaper* operands earlier — so it can only make short-circuiting skip an expensive leaf *more* often, never less.

## Why a VM was the wrong lever

- Dispatch is ~1% of the cost; the trees are tiny and stay hot in L1. A single `Code` regex over module source is 100–1000× a node dispatch.
- Short-circuiting is load-bearing: `And` stops on first false, `Or` on first true — that's what lets a cheap `Id` test skip an expensive `Code` regex. A naïve postfix stack VM evaluates every leaf and loses that (net slower); preserving it needs jump opcodes for no dispatch win that matters.

## Follow-up (not in this PR)

There's a second win — hoisting the per-call `Path::join(cwd, glob)` + normalize allocation in `get_matcher_string` for relative-glob `id` filters (measured ~1246 ns → ~546 ns). An earlier revision cached the cwd-resolved matcher on the leaf, but that changed `Id`/`ImporterId` matching semantics for relative globs (it baked in the first `cwd`). It's reverted here and will be stacked on top as a separate PR that caches the **compiled glob** rather than the cwd-resolved string.

## Tests

- `optimize_reorders_operands_cheapest_first` — verifies the reorder.
- `optimize_preserves_semantics` — asserts reordered vs. original agree across all input combinations.

No public signatures changed (`parse`, `filter_exprs_interpreter`, `FilterExprKind`), so `rolldown_binding` is untouched. Net diff is a single file, `crates/rolldown_utils/src/filter_expression.rs`.


