### PR TITLE
fix(code-splitting): initialize pure definers behind star re-export barrels under strict execution order

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
@@ -264,9 +264,18 @@ fn transitive_esm_init_targets(
       }
       let mut targets = vec![];
       if ctx.order_wrap {
-        let retained_reexport_path = overlay
-          .filter(|overlay| !overlay.retained_reexport_path.is_empty())
-          .map(|overlay| overlay.retained_reexport_path.as_slice());
+        // A recorded retained path restricts the hop walk to the chains resolved reads consumed.
+        // That is only sound when the path is the record's whole evidence: an included namespace
+        // (or forwarded dynamic exports) retains EVERY non-ambiguous export of this star record —
+        // including chains no resolved read recorded — so the walk must stay unrestricted there or
+        // the off-path pure definers lose their only init call site.
+        let retained_reexport_path = if namespace_reexport_is_retained {
+          None
+        } else {
+          overlay
+            .filter(|overlay| !overlay.retained_reexport_path.is_empty())
+            .map(|overlay| overlay.retained_reexport_path.as_slice())
+        };
         let mut retained_path_visited = FxHashSet::default();
         collect_order_wrap_esm_init_targets(
           ctx.modules,

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -687,18 +687,50 @@ pub(super) fn collect_frozen_reexport_usage(input: &OrderLoweringInput<'_>) -> F
   let mut root_paths =
     FxHashMap::<(ModuleIdx, ImportRecordIdx), Vec<(ModuleIdx, ImportRecordIdx)>>::default();
   for (imported_as_ref, paths) in input.star_reexport_records_by_imported_symbol {
+    // A namespace-keyed path (recorded for a whole consumed namespace by
+    // `record_namespace_consumed_star_reexport_paths`, or a member read resolving to a
+    // namespace-valued binding) is consumed exactly when that namespace object is materialized:
+    // an included namespace retains every non-ambiguous export, so its star chains are
+    // execution-relevant; symbol-level usedness would conflate routes (a leaf used through a
+    // direct import elsewhere must not retain a barrel path nobody consumes).
+    let key_is_namespace = input.modules[imported_as_ref.owner]
+      .as_normal()
+      .is_some_and(|module| module.namespace_object_ref == *imported_as_ref);
     for path in paths {
       let Some(root) = path.first().copied() else {
         continue;
       };
-      let consumer_is_used = input.used_symbols.contains(imported_as_ref)
-        || consumed_facades.contains(imported_as_ref)
-        || input.linking[root.0]
-          .referenced_symbols_by_entry_point_chunk
-          .iter()
-          .any(|(symbol_ref, _)| symbol_ref == imported_as_ref);
+      let consumer_is_used = if key_is_namespace {
+        // `namespace_included` here is the provisional pre-wrap value: `finalize_chunk_plan` runs
+        // `finalized_module_namespace_ref_usage` before order analysis/lowering and re-runs it
+        // only after. The skew is safe — the post-wrap refinement can only ADD namespaces
+        // demanded by import overlays (`requires_namespace`: `export *` of a dynamic-exports
+        // importee, `require` interop, splitting-disabled dynamic import), and those routes
+        // discharge their breadth at runtime through `__reExport`/`__toCommonJS` glue rather
+        // than statically routed init forwarding. An opaque `import * as` consumer — the demand
+        // this gate exists for — is a link-time fact the provisional pass already observes.
+        input.linking[imported_as_ref.owner].namespace_included
+      } else {
+        input.used_symbols.contains(imported_as_ref)
+          || consumed_facades.contains(imported_as_ref)
+          || input.linking[root.0]
+            .referenced_symbols_by_entry_point_chunk
+            .iter()
+            .any(|(symbol_ref, _)| symbol_ref == imported_as_ref)
+      };
       if consumer_is_used {
         root_paths.entry(root).or_default().extend(path.iter().copied());
+        // An ancestor's excluded-hop traversal stops at the first init-owning barrel it meets and
+        // delegates the rest of the chain to that barrel's own `init_*`
+        // (`collect_order_wrap_esm_init_targets` pushes the owning wrapper without descending).
+        // That delegation is only sound if the owning barrel itself carries the remainder as
+        // retained evidence, so record each such suffix as that barrel's own root — otherwise its
+        // interior hop forwards nothing and the chain's pure leaf is never initialized.
+        for (position, record) in path.iter().copied().enumerate().skip(1) {
+          if module_owns_reexport_init(input, record.0) {
+            root_paths.entry(record).or_default().extend(path[position..].iter().copied());
+          }
+        }
       }
     }
   }

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -245,6 +245,7 @@ impl LinkStage<'_> {
       meta.sorted_and_non_ambiguous_resolved_exports =
         FxIndexMap::from_iter(sorted_and_non_ambiguous_resolved_exports);
     });
+    self.record_namespace_consumed_star_reexport_paths();
     self.update_cjs_module_meta();
     self.resolve_member_expr_refs(&side_effects_modules, &normal_symbol_exports_chain_map);
     self.normal_symbol_exports_chain_map = normal_symbol_exports_chain_map;
@@ -413,6 +414,58 @@ impl LinkStage<'_> {
     module_stack.pop();
   }
 
+  /// Strict-execution-order only: record the star re-export paths behind every non-ambiguous
+  /// export of a statically namespace-imported module (`import * as ns`), keyed by the importee's
+  /// namespace object. Dynamic imports are deliberately NOT scanned here: `import()` consumption
+  /// flows through the entry export interface, and `create_exports_for_ecma_modules` already
+  /// records those paths per referenced entry export (keyed by the export's symbol, gated by the
+  /// entry-chunk arm of `collect_frozen_reexport_usage`).
+  ///
+  /// A namespace object consumed as a whole retains EVERY export — including bindings reached
+  /// through `export *` chains that no named import or statically resolved member read records.
+  /// Without a recorded path, an init-owning barrel on such a chain has no retained-re-export
+  /// evidence for its excluded star hop, so its `init_*` never initializes a side-effect-free
+  /// definer that only the namespace observes. `collect_frozen_reexport_usage` gates every
+  /// namespace-keyed path on the namespace object actually being included, so a namespace
+  /// tree-shaking drops retains nothing here.
+  fn record_namespace_consumed_star_reexport_paths(&mut self) {
+    if !self.options.is_strict_execution_order_enabled() {
+      return;
+    }
+    let mut namespace_consumed = FxHashSet::default();
+    for module in self.module_table.modules.iter().filter_map(|module| module.as_normal()) {
+      for named_import in module.named_imports.values() {
+        if matches!(named_import.imported, Specifier::Star)
+          && let Some(importee_idx) = module.import_records[named_import.record_idx].resolved_module
+        {
+          namespace_consumed.insert(importee_idx);
+        }
+      }
+    }
+    for importee_idx in namespace_consumed {
+      let Some(importee) = self.module_table[importee_idx].as_normal() else {
+        continue;
+      };
+      // Key every path by the importee's namespace object, not by each export's canonical symbol:
+      // an export used through a DIFFERENT route (a direct import elsewhere) must not retain a
+      // barrel path nobody consumes. `collect_frozen_reexport_usage` gates a namespace-keyed path
+      // on the namespace object actually being included — the exact breadth demand.
+      let namespace_ref = importee.namespace_object_ref;
+      let meta = &self.metas[importee_idx];
+      for export_name in meta.sorted_and_non_ambiguous_resolved_exports.keys() {
+        record_star_reexport_path(
+          importee_idx,
+          export_name,
+          namespace_ref,
+          &self.module_table.modules,
+          &self.metas,
+          &mut self.star_reexport_records_by_imported_symbol,
+          &mut FxHashSet::default(),
+        );
+      }
+    }
+  }
+
   /// Try to find the final pointed `SymbolRef` of the member expression.
   /// ```js
   /// // index.js
@@ -457,6 +510,7 @@ impl LinkStage<'_> {
     } else {
       FxHashSet::default()
     };
+    let strict_execution_order = self.options.is_strict_execution_order_enabled();
     let resolved_meta_data = self
       .module_table
       .modules
@@ -467,10 +521,16 @@ impl LinkStage<'_> {
           let mut resolved_map = FxHashMap::default();
           let mut side_effects_dependency = vec![];
           let mut written_cjs_exports: Vec<SymbolRef> = vec![];
+          let mut star_reexport_consumptions: Vec<(SymbolRef, Vec<(ModuleIdx, CompactStr)>)> =
+            vec![];
           stmt_infos.iter().for_each(|stmt_info| {
             stmt_info.referenced_symbols.iter().for_each(|symbol_ref| {
               // `depended_refs` is used to store necessary symbols that must be included once the resolved symbol gets included
               let mut depended_refs: Vec<SymbolRef> = vec![];
+              // Strict-only: every (module, export) step this member chain statically resolves
+              // through, recorded so re-export hops consumed via a namespace read retain their
+              // barrel-forwarding evidence exactly like named imports do.
+              let mut star_reexport_steps: Vec<(ModuleIdx, CompactStr)> = vec![];
 
               if let SymbolOrMemberExprRef::MemberExpr(member_expr_ref) = symbol_ref {
                 // First get the canonical ref of `foo_ns`, then we get the `NormalModule#namespace_object_ref` of `foo.js`.
@@ -559,6 +619,9 @@ impl LinkStage<'_> {
                     return;
                   }
 
+                  if strict_execution_order {
+                    star_reexport_steps.push((canonical_ref_owner.idx, name.clone()));
+                  }
                   depended_refs.push(export_symbol.symbol_ref);
                   if let Some(chains) =
                     normal_symbol_exports_chain_map.get(&export_symbol.symbol_ref)
@@ -713,6 +776,13 @@ impl LinkStage<'_> {
                 }
 
                 if cursor > 0 || target_commonjs_exported_symbol.is_some() {
+                  // Key the consumed steps by the final canonical ref: it is the symbol the
+                  // inclusion pass marks used for this read (an inlined constant never is, and
+                  // needs no init), which is exactly the usedness gate
+                  // `collect_frozen_reexport_usage` applies to this index.
+                  if !star_reexport_steps.is_empty() {
+                    star_reexport_consumptions.push((canonical_ref, star_reexport_steps));
+                  }
                   resolved_map.insert(
                     member_expr_ref.node_id,
                     MemberExprRefResolution {
@@ -729,9 +799,9 @@ impl LinkStage<'_> {
             });
           });
 
-          (resolved_map, side_effects_dependency, written_cjs_exports)
+          (resolved_map, side_effects_dependency, written_cjs_exports, star_reexport_consumptions)
         }
-        Module::External(_) => (FxHashMap::default(), vec![], vec![]),
+        Module::External(_) => (FxHashMap::default(), vec![], vec![], vec![]),
       })
       .collect::<Vec<_>>();
 
@@ -744,7 +814,7 @@ impl LinkStage<'_> {
     // `cjs[name] = value`, or writes through `ns.default`), bail out all CJS exports of the
     // target module since we can't determine which specific property is affected.
     let mut written_cjs_export_symbols: Vec<SymbolRef> = Vec::new();
-    for (meta, (_, _, written_cjs_exports)) in self.metas.iter().zip(resolved_meta_data.iter()) {
+    for (meta, (_, _, written_cjs_exports, _)) in self.metas.iter().zip(resolved_meta_data.iter()) {
       written_cjs_export_symbols.extend(written_cjs_exports);
       for (import_symbol, cjs_module_idx) in
         meta.named_import_to_cjs_module.iter().chain(meta.import_record_ns_to_cjs_module.iter())
@@ -766,8 +836,34 @@ impl LinkStage<'_> {
     for symbol_ref in &written_cjs_export_symbols {
       self.global_constant_symbol_map.remove(symbol_ref);
     }
+    // A statically resolved namespace member read consumes re-export hops exactly like a named
+    // import: without this, a side-effect-free definer reached only through an `export *` barrel
+    // by namespace readers leaves the barrel's forwarding hop without retention evidence, and the
+    // wrapped barrel's `init_*` never initializes the definer (`collect_frozen_reexport_usage`
+    // keys its retained re-export paths off this same index).
+    if strict_execution_order {
+      let mut recorded = FxHashSet::default();
+      for (_, _, _, star_reexport_consumptions) in &resolved_meta_data {
+        for (imported_as_ref, steps) in star_reexport_consumptions {
+          for (module_idx, export_name) in steps {
+            if !recorded.insert((*module_idx, export_name.clone(), *imported_as_ref)) {
+              continue;
+            }
+            record_star_reexport_path(
+              *module_idx,
+              export_name,
+              *imported_as_ref,
+              &self.module_table.modules,
+              &self.metas,
+              &mut self.star_reexport_records_by_imported_symbol,
+              &mut FxHashSet::default(),
+            );
+          }
+        }
+      }
+    }
     self.metas.iter_mut().zip(resolved_meta_data).for_each(
-      |(meta, (resolved_map, side_effects_dependency, _))| {
+      |(meta, (resolved_map, side_effects_dependency, _, _))| {
         meta.resolved_member_expr_refs = resolved_map;
         meta.dependencies.extend(side_effects_dependency);
       },

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/_config.json
@@ -1,0 +1,25 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const a = await import('./dist/a.js');
+await import('./dist/b.js');
+
+// The consumer's namespace evidence lives on the OUTER pure barrel's star record, but that record's
+// unrestricted walk stops at the init-owning MID barrel and delegates the rest of the chain. The
+// breadth demand (every export the namespace retains, including `wDef` that no resolved read
+// recorded) must survive that delegation, or the second pure definer is never initialized.
+assert.deepStrictEqual(a.defValue, { value: 7 });
+assert.deepStrictEqual(
+  a.nsObject.wDef,
+  { value: 11 },
+  `delegated breadth must initialize the opaque-only pure definer; got ${JSON.stringify(a.nsObject.wDef)} events=${JSON.stringify(globalThis.__events)}`,
+);
+assert.deepStrictEqual(a.nsObject.vDef, { value: 7 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/a.js
@@ -1,0 +1,4 @@
+import * as ns from './outer.js';
+(globalThis.__events ??= []).push('a');
+export const defValue = ns.vDef;
+export const nsObject = ns;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/artifacts.snap
@@ -1,0 +1,177 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as vDef, t as outer_exports } from "./outer.js";
+//#region a.js
+(globalThis.__events ??= []).push("a");
+const defValue = vDef;
+const nsObject = outer_exports;
+//#endregion
+export { defValue, nsObject };
+
+```
+
+## b.js
+
+```js
+import { n as vDef } from "./outer.js";
+//#region b.js
+(globalThis.__events ??= []).push("b");
+const sharedDef = vDef;
+//#endregion
+export { sharedDef };
+
+```
+
+## outer.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region definer1.js
+function build$1() {
+	return { value: 7 };
+}
+const vDef = /* @__PURE__ */ build$1();
+//#endregion
+//#region definer2.js
+function build() {
+	return { value: 11 };
+}
+const wDef = /* @__PURE__ */ build();
+//#endregion
+//#region mid.js
+(globalThis.__events ??= []).push("mid");
+//#endregion
+//#region outer.js
+var outer_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	wDef: () => wDef
+});
+//#endregion
+export { vDef as n, outer_exports as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a, r as nsObject, t as defValue } from "./a2.js";
+init_a();
+export { defValue, nsObject };
+
+```
+
+### a2.js
+
+```js
+import { i as vDef, n as outer_exports, t as init_outer } from "./outer.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var defValue, nsObject;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_outer();
+		(globalThis.__events ??= []).push("a");
+		defValue = vDef;
+		nsObject = outer_exports;
+	})))();
+}
+//#endregion
+export { init_a as n, nsObject as r, defValue as t };
+
+```
+
+### b.js
+
+```js
+import { n as sharedDef, t as init_b } from "./b2.js";
+init_b();
+export { sharedDef };
+
+```
+
+### b2.js
+
+```js
+import { i as vDef, t as init_outer } from "./outer.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var sharedDef;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_outer();
+		(globalThis.__events ??= []).push("b");
+		sharedDef = vDef;
+	})))();
+}
+//#endregion
+export { sharedDef as n, init_b as t };
+
+```
+
+### outer.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region definer1.js
+function build$1() {
+	return { value: 7 };
+}
+var vDef;
+function init_definer1() {
+	return (init_definer1 = __esmMin((() => {
+		vDef = /* @__PURE__ */ build$1();
+	})))();
+}
+//#endregion
+//#region definer2.js
+function build() {
+	return { value: 11 };
+}
+var wDef;
+function init_definer2() {
+	return (init_definer2 = __esmMin((() => {
+		wDef = /* @__PURE__ */ build();
+	})))();
+}
+//#endregion
+//#region mid.js
+function init_mid() {
+	return (init_mid = __esmMin((() => {
+		init_definer1();
+		init_definer2();
+		(globalThis.__events ??= []).push("mid");
+	})))();
+}
+//#endregion
+//#region outer.js
+var outer_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	wDef: () => wDef
+});
+function init_outer() {
+	return (init_outer = __esmMin((() => {
+		init_mid();
+	})))();
+}
+//#endregion
+export { vDef as i, outer_exports as n, init_definer1 as r, init_outer as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/b.js
@@ -1,0 +1,3 @@
+import * as ns from './outer.js';
+(globalThis.__events ??= []).push('b');
+export const sharedDef = ns.vDef;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/definer1.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/definer1.js
@@ -1,0 +1,4 @@
+function build() {
+  return { value: 7 };
+}
+export const vDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/definer2.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/definer2.js
@@ -1,0 +1,4 @@
+function build() {
+  return { value: 11 };
+}
+export const wDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/inner.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/inner.js
@@ -1,0 +1,2 @@
+export * from './definer1.js';
+export * from './definer2.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/mid.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/mid.js
@@ -1,0 +1,2 @@
+export * from './inner.js';
+(globalThis.__events ??= []).push('mid');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/outer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/outer.js
@@ -1,0 +1,1 @@
+export * from './mid.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/_config.json
@@ -1,0 +1,25 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const a = await import('./dist/a.js');
+const b = await import('./dist/b.js');
+
+// The outer barrel's retained path stops at the non-transparent inner barrel and delegates the
+// remaining star hop to it; the inner barrel's `init_*` must therefore call `init_definer` before
+// any namespace reader observes the definer's binding.
+assert.deepStrictEqual(
+  a.defValue,
+  { value: 7 },
+  `inner barrel init must initialize the pure definer; got ${JSON.stringify(a.defValue)} events=${JSON.stringify(globalThis.__events)}`,
+);
+assert.strictEqual(b.loaded, true);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/a.js
@@ -1,0 +1,6 @@
+import * as ns from './outer-barrel.js';
+
+(globalThis.__events ??= []).push('a');
+
+// Statically resolved namespace member read of the pure definer through both star hops.
+export const defValue = ns.vDef;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/artifacts.snap
@@ -1,0 +1,167 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as vDef } from "./outer-barrel.js";
+//#region a.js
+(globalThis.__events ??= []).push("a");
+const defValue = vDef;
+//#endregion
+export { defValue };
+
+```
+
+## b.js
+
+```js
+import { t as outer_barrel_exports } from "./outer-barrel.js";
+//#region b.js
+(globalThis.__events ??= []).push("b");
+const loaded = typeof outer_barrel_exports === "object";
+//#endregion
+export { loaded };
+
+```
+
+## outer-barrel.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region definer.js
+function build() {
+	return { value: 7 };
+}
+const vDef = /* @__PURE__ */ build();
+//#endregion
+//#region sibling.js
+(globalThis.__events ??= []).push("sibling");
+const vSib = { value: 3 };
+//#endregion
+//#region outer-barrel.js
+var outer_barrel_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	vSib: () => vSib
+});
+//#endregion
+export { vDef as n, outer_barrel_exports as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a, t as defValue } from "./a2.js";
+init_a();
+export { defValue };
+
+```
+
+### a2.js
+
+```js
+import { i as vDef, t as init_outer_barrel } from "./outer-barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var defValue;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_outer_barrel();
+		(globalThis.__events ??= []).push("a");
+		defValue = vDef;
+	})))();
+}
+//#endregion
+export { init_a as n, defValue as t };
+
+```
+
+### b.js
+
+```js
+import { n as loaded, t as init_b } from "./b2.js";
+init_b();
+export { loaded };
+
+```
+
+### b2.js
+
+```js
+import { n as outer_barrel_exports, t as init_outer_barrel } from "./outer-barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var loaded;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_outer_barrel();
+		(globalThis.__events ??= []).push("b");
+		loaded = typeof outer_barrel_exports === "object";
+	})))();
+}
+//#endregion
+export { loaded as n, init_b as t };
+
+```
+
+### outer-barrel.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region definer.js
+function build() {
+	return { value: 7 };
+}
+var vDef;
+function init_definer() {
+	return (init_definer = __esmMin((() => {
+		vDef = /* @__PURE__ */ build();
+	})))();
+}
+//#endregion
+//#region sibling.js
+var vSib;
+function init_sibling() {
+	return (init_sibling = __esmMin((() => {
+		(globalThis.__events ??= []).push("sibling");
+		vSib = { value: 3 };
+	})))();
+}
+//#endregion
+//#region inner-barrel.js
+function init_inner_barrel() {
+	return (init_inner_barrel = __esmMin((() => {
+		init_definer();
+		init_sibling();
+	})))();
+}
+//#endregion
+//#region outer-barrel.js
+var outer_barrel_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	vSib: () => vSib
+});
+function init_outer_barrel() {
+	return (init_outer_barrel = __esmMin((() => {
+		init_inner_barrel();
+	})))();
+}
+//#endregion
+export { vDef as i, outer_barrel_exports as n, init_definer as r, init_outer_barrel as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/b.js
@@ -1,0 +1,7 @@
+import * as ns from './outer-barrel.js';
+
+// Second entry sharing the barrel namespace without reading the definer — the split that keeps the
+// barrels in a shared chunk and the definer's init reachable only through barrel forwarding.
+(globalThis.__events ??= []).push('b');
+
+export const loaded = typeof ns === 'object';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/definer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/definer.js
@@ -1,0 +1,7 @@
+// Inferred-pure definer reached only through TWO star hops (outer-barrel -> inner-barrel -> here).
+// The value is non-inlinable so a dropped `init_*` cannot be masked by constant folding.
+function build() {
+  return { value: 7 };
+}
+
+export const vDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/inner-barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/inner-barrel.js
@@ -1,0 +1,5 @@
+// Non-transparent barrel (it owns a side-effectful execution dependency). Its own star hop to the
+// pure definer must forward `init_definer` when a consumer reads the definer's binding through the
+// outer barrel's namespace — the delegated remainder of the outer barrel's retained path.
+export * from './definer.js';
+export { vSib } from './sibling.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/outer-barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/outer-barrel.js
@@ -1,0 +1,3 @@
+// Pure star-only outer barrel: no local body and no direct execution dependency of its own, so the
+// namespace consumers reach the definer's binding through two chained `export *` hops.
+export * from './inner-barrel.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/sibling.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/sibling.js
@@ -1,0 +1,6 @@
+// Side-effectful sibling re-exported by the INNER barrel: it makes the inner barrel a
+// non-transparent init owner, so an ancestor's retained-path traversal stops there and delegates
+// the rest of the chain (the star hop to the pure definer) to the inner barrel's own `init_*`.
+(globalThis.__events ??= []).push('sibling');
+
+export const vSib = { value: 3 };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/_config.json
@@ -1,0 +1,25 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const a = await import('./dist/a.js');
+await import('./dist/b.js');
+
+// The resolved read must observe the first definer.
+assert.deepStrictEqual(a.defValue, { value: 7 });
+// The opaque namespace route must observe the second definer: a retained path recorded for the
+// resolved read must not restrict the barrel's init walk below what the included namespace
+// retains, or `wDef` would read back undefined.
+assert.deepStrictEqual(
+  a.nsObject.wDef,
+  { value: 11 },
+  `opaque namespace read must see the second pure definer; got ${JSON.stringify(a.nsObject.wDef)} events=${JSON.stringify(globalThis.__events)}`,
+);
+assert.deepStrictEqual(a.nsObject.vDef, { value: 7 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/a.js
@@ -1,0 +1,9 @@
+import * as ns from './barrel.js';
+
+(globalThis.__events ??= []).push('a');
+
+// The statically resolved read: puts definer1's chain on the record's retained path.
+export const defValue = ns.vDef;
+// The opaque namespace use: retains every export of the barrel, including definer2's `wDef`,
+// which is read only through the namespace object at runtime.
+export const nsObject = ns;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/artifacts.snap
@@ -1,0 +1,168 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as vDef, t as barrel_exports } from "./barrel.js";
+//#region a.js
+(globalThis.__events ??= []).push("a");
+const defValue = vDef;
+const nsObject = barrel_exports;
+//#endregion
+export { defValue, nsObject };
+
+```
+
+## b.js
+
+```js
+import { n as vDef } from "./barrel.js";
+//#region b.js
+(globalThis.__events ??= []).push("b");
+const sharedDef = vDef;
+//#endregion
+export { sharedDef };
+
+```
+
+## barrel.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region definer1.js
+function build$1() {
+	return { value: 7 };
+}
+const vDef = /* @__PURE__ */ build$1();
+//#endregion
+//#region definer2.js
+function build() {
+	return { value: 11 };
+}
+const wDef = /* @__PURE__ */ build();
+//#endregion
+//#region barrel.js
+var barrel_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	wDef: () => wDef
+});
+(globalThis.__events ??= []).push("barrel");
+//#endregion
+export { vDef as n, barrel_exports as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a, r as nsObject, t as defValue } from "./a2.js";
+init_a();
+export { defValue, nsObject };
+
+```
+
+### a2.js
+
+```js
+import { i as vDef, n as init_barrel, t as barrel_exports } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var defValue, nsObject;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("a");
+		defValue = vDef;
+		nsObject = barrel_exports;
+	})))();
+}
+//#endregion
+export { init_a as n, nsObject as r, defValue as t };
+
+```
+
+### b.js
+
+```js
+import { n as sharedDef, t as init_b } from "./b2.js";
+init_b();
+export { sharedDef };
+
+```
+
+### b2.js
+
+```js
+import { i as vDef, n as init_barrel } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var sharedDef;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("b");
+		sharedDef = vDef;
+	})))();
+}
+//#endregion
+export { sharedDef as n, init_b as t };
+
+```
+
+### barrel.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region definer1.js
+function build$1() {
+	return { value: 7 };
+}
+var vDef;
+function init_definer1() {
+	return (init_definer1 = __esmMin((() => {
+		vDef = /* @__PURE__ */ build$1();
+	})))();
+}
+//#endregion
+//#region definer2.js
+function build() {
+	return { value: 11 };
+}
+var wDef;
+function init_definer2() {
+	return (init_definer2 = __esmMin((() => {
+		wDef = /* @__PURE__ */ build();
+	})))();
+}
+//#endregion
+//#region barrel.js
+var barrel_exports = /* @__PURE__ */ __exportAll({
+	vDef: () => vDef,
+	wDef: () => wDef
+});
+function init_barrel() {
+	return (init_barrel = __esmMin((() => {
+		init_definer1();
+		init_definer2();
+		(globalThis.__events ??= []).push("barrel");
+	})))();
+}
+//#endregion
+export { vDef as i, init_barrel as n, init_definer1 as r, barrel_exports as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/b.js
@@ -1,0 +1,6 @@
+import * as ns from './barrel.js';
+
+// Second entry keeping the barrel in a shared chunk (the split-consumer topology).
+(globalThis.__events ??= []).push('b');
+
+export const sharedDef = ns.vDef;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/barrel.js
@@ -1,0 +1,6 @@
+// Init-owning barrel (own top-level effect). Its excluded star hop serves BOTH a resolved member
+// read (records a retained path for definer1's chain) and the opaque namespace (which retains
+// every export, including definer2's chain that no resolved read recorded).
+export * from './inner.js';
+
+(globalThis.__events ??= []).push('barrel');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/definer1.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/definer1.js
@@ -1,0 +1,7 @@
+// First pure definer: consumed through a statically RESOLVED namespace member read, so its chain
+// is on the barrel record's recorded retained path.
+function build() {
+  return { value: 7 };
+}
+
+export const vDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/definer2.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/definer2.js
@@ -1,0 +1,8 @@
+// Second pure definer: consumed ONLY through the opaque namespace object (no statically resolved
+// read records its chain). A path-restricted barrel walk would drop its init even though the
+// included namespace retains its binding.
+function build() {
+  return { value: 11 };
+}
+
+export const wDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/inner.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/inner.js
@@ -1,0 +1,3 @@
+// Pure intermediate barrel fanning out to both definers.
+export * from './definer1.js';
+export * from './definer2.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/_config.json
@@ -1,0 +1,25 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/_test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+
+const a = await import('./dist/a.js');
+const b = await import('./dist/b.js');
+
+// The pure definer is reached only through the barrel's `export *`. Under strict execution order
+// the barrel's `init_*` must forward to `init_definer`; the regression emits `init_definer` with
+// zero call sites, so `vDef` is never assigned and the namespace read observes `undefined`.
+assert.deepStrictEqual(
+  a.defValue,
+  { value: 7 },
+  `barrel init must initialize the pure definer; got ${JSON.stringify(a.defValue)} events=${JSON.stringify(globalThis.__events)}`,
+);
+assert.deepStrictEqual(b.sibValue, { value: 3 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/a.js
@@ -1,0 +1,6 @@
+import * as ns from './barrel.js';
+
+(globalThis.__events ??= []).push('a');
+
+// This entry reads the pure definer's binding through the barrel namespace.
+export const defValue = ns.vDef;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/artifacts.snap
@@ -1,0 +1,210 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { n as init_a, t as defValue } from "./a2.js";
+init_a();
+export { defValue };
+
+```
+
+## a2.js
+
+```js
+import { t as init_barrel } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region definer.js
+function build() {
+	return { value: 7 };
+}
+var vDef;
+function init_definer() {
+	return (init_definer = __esmMin((() => {
+		vDef = /* @__PURE__ */ build();
+	})))();
+}
+//#endregion
+//#region a.js
+var defValue;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("a");
+		defValue = vDef;
+	})))();
+}
+//#endregion
+export { init_a as n, init_definer as r, defValue as t };
+
+```
+
+## b.js
+
+```js
+import { n as sibValue, t as init_b } from "./b2.js";
+init_b();
+export { sibValue };
+
+```
+
+## b2.js
+
+```js
+import { r as vSib, t as init_barrel } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var sibValue;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("b");
+		sibValue = vSib;
+	})))();
+}
+//#endregion
+export { sibValue as n, init_b as t };
+
+```
+
+## barrel.js
+
+```js
+import { r as init_definer } from "./a2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region sibling.js
+var vSib;
+function init_sibling() {
+	return (init_sibling = __esmMin((() => {
+		(globalThis.__events ??= []).push("sibling");
+		vSib = { value: 3 };
+	})))();
+}
+//#endregion
+//#region barrel.js
+function init_barrel() {
+	return (init_barrel = __esmMin((() => {
+		init_definer();
+		init_sibling();
+	})))();
+}
+//#endregion
+export { init_sibling as n, vSib as r, init_barrel as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { n as init_a, t as defValue } from "./a2.js";
+init_a();
+export { defValue };
+
+```
+
+### a2.js
+
+```js
+import { t as init_barrel } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region definer.js
+function build() {
+	return { value: 7 };
+}
+var vDef;
+function init_definer() {
+	return (init_definer = __esmMin((() => {
+		vDef = /* @__PURE__ */ build();
+	})))();
+}
+//#endregion
+//#region a.js
+var defValue;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("a");
+		defValue = vDef;
+	})))();
+}
+//#endregion
+export { init_a as n, init_definer as r, defValue as t };
+
+```
+
+### b.js
+
+```js
+import { n as sibValue, t as init_b } from "./b2.js";
+init_b();
+export { sibValue };
+
+```
+
+### b2.js
+
+```js
+import { r as vSib, t as init_barrel } from "./barrel.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var sibValue;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_barrel();
+		(globalThis.__events ??= []).push("b");
+		sibValue = vSib;
+	})))();
+}
+//#endregion
+export { sibValue as n, init_b as t };
+
+```
+
+### barrel.js
+
+```js
+import { r as init_definer } from "./a2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region sibling.js
+var vSib;
+function init_sibling() {
+	return (init_sibling = __esmMin((() => {
+		(globalThis.__events ??= []).push("sibling");
+		vSib = { value: 3 };
+	})))();
+}
+//#endregion
+//#region barrel.js
+function init_barrel() {
+	return (init_barrel = __esmMin((() => {
+		init_definer();
+		init_sibling();
+	})))();
+}
+//#endregion
+export { init_sibling as n, vSib as r, init_barrel as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/b.js
@@ -1,0 +1,8 @@
+import * as ns from './barrel.js';
+
+(globalThis.__events ??= []).push('b');
+
+// This entry reads only the SIBLING binding — the split read. With both entries reading the
+// definer, on-demand wrapping stays green; the split is what makes on-demand drop `init_definer`
+// from the barrel init as well, so the case fails in both wrap modes.
+export const sibValue = ns.vSib;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/barrel.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/barrel.js
@@ -1,0 +1,5 @@
+// The star re-export is load-bearing: a NAMED re-export of the definer resolves the binding to its
+// origin and the consumer calls `init_definer` directly (green). Reaching the pure definer through
+// `export *` makes the namespace read depend on the barrel's own `init_*` forwarding to the definer.
+export * from './definer.js';
+export { vSib } from './sibling.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/definer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/definer.js
@@ -1,0 +1,9 @@
+// Inferred-pure definer: the top level is only pure statements, so tree-shaking judges this module
+// side-effect-free by inference (no `sideEffects` metadata involved). The exported value is
+// non-inlinable — an object built by a local function behind a PURE annotation — so a dropped
+// `init_*` cannot be masked by constant folding; `vDef` stays `undefined` until the init runs.
+function build() {
+  return { value: 7 };
+}
+
+export const vDef = /* @__PURE__ */ build();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/sibling.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/sibling.js
@@ -1,0 +1,5 @@
+// Side-effectful sibling re-exported by the same barrel. Its top-level event keeps the barrel a
+// real wrapped execution dependency instead of a fully flattened re-exporter.
+(globalThis.__events ??= []).push('sibling');
+
+export const vSib = { value: 3 };


### PR DESCRIPTION
### Problem

First P0 item of #10294 (Family A): under `strictExecutionOrder: true` — in both wrap modes — an inferred-pure ESM definer reached through an `export *` barrel by a split namespace consumer is never initialized. The definer's `init_*` ends up with zero call sites, its exported binding stays `undefined`, and a namespace reader observes it (NaN fold / TypeError). `strictExecutionOrder: false` is correct.

Minimal shape (now `strict_execution_order/pure_definer_star_barrel_split_readers`):

```js
// definer.js — inferred pure, non-inlinable value
export const vDef = /* @__PURE__ */ build();
// barrel.js
export * from './definer.js';          // star — essential
export { vSib } from './sibling.js';   // side-effectful sibling keeps the barrel wrapped
// entry a: import * as ns from './barrel.js';  ns.vDef   ← undefined
// entry b: import * as ns from './barrel.js';  ns.vSib   ← the split
```

### Root cause

The consumer side deliberately delegates: a non-transparent wrapped barrel is pushed as the only init target, trusting the barrel's own `init_*` to forward (the soundness comment on `wrapper_is_reachable_in_chunk` states exactly this contract). But the barrel's excluded `export *` statement only forwards with **retained-re-export evidence**, and the retention index (`star_reexport_records_by_imported_symbol`) was populated **only for named imports** (`Specifier::Literal` in `match_imports_with_exports`). A statically resolved namespace member read (`ns.vDef`) resolves through `resolve_member_expr_refs` and recorded nothing — so the hop had no evidence anywhere: statement excluded, no overlay, namespace not included. Nobody called `init_definer`.

Two adjacent holes fall out of the same evidence model:

- **Nested barrels:** `collect_order_wrap_esm_init_targets` stops a retained-path walk at the first init-owning barrel and delegates the remainder to that barrel's `init_*` — but `root_paths` was keyed only by the outermost record, so the interior owning barrel had no evidence for its own hop and the delegated remainder was silently dropped.
- **Opaque namespaces:** a whole-consumed namespace (`import * as ns` used opaquely) retains *every* export, including chains no named import or resolved read records; behind an owning barrel those chains had no evidence either (pre-existing on main, confirmed red under wrap-all).

### Fix (all strict-mode gated; flag-off output untouched)

1. **`resolve_member_expr_refs`** records the star re-export path of every statically resolved member step, keyed by the final canonical symbol — exactly the ref the inclusion pass marks used for the read, so `collect_frozen_reexport_usage`'s existing usedness gate applies unchanged (an inlined constant is never marked used and needs no init).
2. **`collect_frozen_reexport_usage`** segments each retained path at every init-owning barrel: the suffix becomes that barrel's own retained root, completing the delegation contract.
3. **`record_namespace_consumed_star_reexport_paths`** (new, link stage) records breadth paths for namespace-consumed modules, keyed by the importee's **namespace object** and gated on `namespace_included` — route-accurate, so a leaf used through a direct import elsewhere cannot retain a barrel path nobody consumes. Symmetrically, `transitive_esm_init_targets` no longer lets a recorded path restrict the walk below the record's own namespace evidence (`namespace_reexport_is_retained` ⇒ unrestricted walk) — without this, a path recorded for one resolved read would starve the definers only the opaque namespace observes.

The on-demand emergent-cycle projection consumes the same `collect_frozen_reexport_usage` / overlay population, so lowering and projection stay in lockstep by construction.

### Tests

Four new fixtures (each red without the fix, green with it, in both wrap modes — except `opaque_and_resolved_reads`, which is green on main and guards repair 3's gate against the path-restriction regression):

- `pure_definer_star_barrel_split_readers` — the minimal Family-A conjunction
- `pure_definer_nested_star_barrel_split_readers` — pure outer barrel, owning inner barrel (delegated remainder)
- `pure_definer_star_barrel_opaque_and_resolved_reads` — mixed resolved + opaque reads on one record
- `pure_definer_delegated_breadth_nested_barrels` — breadth demand crossing a delegation boundary (main is red under wrap-all)

### Validation

- Full integration suite: zero failure-list changes vs unmodified main; **zero existing `artifacts.snap` modified** (byte-identical outputs outside the new fixtures).
- Execution-order fuzzer (rolldown-order-fuzzer@77f196b) against this build: pure-ESM 100-case cell **24/100 RED → 0/100**, mixed cell **22/100 → 3/100**, identical in both wrap modes; the 3 residuals are the `sideEffects:false`-package event-reorder arm with signatures identical before and after this change (a distinct root, tracked separately in #10294). Pure-ESM seed `200004` and the shadcn transplant overlay pass in both wrap modes; the `strictExecutionOrder: false` control still passes.

Part of #10294.
