### PR TITLE
feat(plugin): surface output-option callbacks in [PLUGIN_TIMINGS]

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -190,7 +190,14 @@ impl ManualSplitter<'_> {
 
         let ctx = ChunkingContext::new(Arc::clone(&self.plugin_driver.module_infos));
 
-        let Some(group_name) = match_group.name.value(&ctx, &normal_module.id).await? else {
+        // Time the user's chunk `name` classifier. It is a Rust-core output-option
+        // callback that never passes through the plugin driver, so it is otherwise
+        // invisible to `[PLUGIN_TIMINGS]`. `start_timing()` is a no-op (returns `None`)
+        // unless plugin-timing collection is enabled, so this is zero-overhead by default.
+        let name_timing = self.plugin_driver.start_timing();
+        let name_result = match_group.name.value(&ctx, &normal_module.id).await;
+        self.plugin_driver.record_code_splitting_name_timing(name_timing);
+        let Some(group_name) = name_result? else {
           // Group which doesn't have a name will be ignored.
           continue;
         };

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -129,6 +129,17 @@ impl PluginDriver {
     }
   }
 
+  /// Record the elapsed time for the `output.codeSplitting` / `advancedChunks`
+  /// `groups[].name` chunk-name classifier (a user JS callback invoked directly from the
+  /// Rust core, not via a plugin hook) if timing collection is enabled.
+  #[inline]
+  pub fn record_code_splitting_name_timing(&self, start: Option<std::time::Instant>) {
+    if let (Some(collector), Some(start)) = (&self.hook_timing_collector, start) {
+      #[expect(clippy::cast_possible_truncation)]
+      collector.record_code_splitting_name(start.elapsed().as_micros() as u64);
+    }
+  }
+
   /// Set total build time from start instant
   #[inline]
   pub fn set_total_build_time(&self, start: Option<std::time::Instant>) {
@@ -148,26 +159,30 @@ impl PluginDriver {
   }
 
   /// Get plugin timings summary if timing collection is enabled and plugins are taking significant time.
-  /// Returns a list of (plugin_name, percentage) pairs for plugins at or above average time.
-  /// Only plugins with total duration >= 1 second are included.
+  /// Returns a list of (name, percentage) pairs at or above average time (min 1 second).
+  /// Includes both plugin hooks and non-plugin output-option callbacks (e.g. the
+  /// `output.codeSplitting` `groups[].name` chunk classifier), so the report is not blind
+  /// to user callbacks invoked directly from the Rust core rather than via a plugin hook.
   #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
   pub fn get_plugin_timings_info(&self) -> Option<Vec<rolldown_error::PluginTimingInfo>> {
-    const MAX_PLUGINS: usize = 5;
+    const MAX_ROWS: usize = 5;
     const ONE_SECOND_MICROS: u64 = 1_000_000;
     let collector = self.hook_timing_collector.as_ref()?;
     if !collector.plugins_are_slow() {
       return None;
     }
-    let summary = collector.get_summary();
+    let mut summary = collector.get_summary();
+    summary.extend(collector.get_output_callback_summary());
     let total_micros: u64 = summary.iter().map(|s| s.total_duration_micros).sum();
-    if total_micros == 0 {
+    if summary.is_empty() || total_micros == 0 {
       return None;
     }
+    summary.sort_by_key(|s| std::cmp::Reverse(s.total_duration_micros));
     let threshold = (total_micros / summary.len() as u64).max(ONE_SECOND_MICROS);
     let result = summary
       .iter()
       .filter(|s| s.total_duration_micros >= threshold)
-      .take(MAX_PLUGINS)
+      .take(MAX_ROWS)
       .map(|s| rolldown_error::PluginTimingInfo {
         name: s.plugin_name.to_string(),
         percent: (s.total_duration_micros as f64 / total_micros as f64 * 100.0).round() as u8,

--- a/crates/rolldown_plugin/src/types/hook_timing.rs
+++ b/crates/rolldown_plugin/src/types/hook_timing.rs
@@ -27,6 +27,13 @@ pub struct HookTimingCollector {
   total_build_micros: AtomicU64,
   /// Link stage time in microseconds (pure Rust core, no plugins)
   link_stage_micros: AtomicU64,
+  /// Accumulated time (microseconds) for the `output.codeSplitting` / `advancedChunks`
+  /// `groups[].name` chunk-name classifier — a user JS callback invoked directly from the
+  /// Rust core (NOT a plugin hook), so it is invisible to per-plugin timing yet can
+  /// dominate a build. Surfaced as its own row in the `[PLUGIN_TIMINGS]` report. The set of
+  /// such core-invoked output callbacks is known statically, so each gets a fixed field
+  /// rather than a dynamic map (precedent: `link_stage_micros`).
+  code_splitting_name_micros: AtomicU64,
 }
 
 impl HookTimingCollector {
@@ -40,6 +47,12 @@ impl HookTimingCollector {
     if let Some(data) = self.plugins.get(&plugin_idx) {
       data.duration_micros.fetch_add(micros, Ordering::Relaxed);
     }
+  }
+
+  /// Accumulate execution time (microseconds) for the `output.codeSplitting` /
+  /// `advancedChunks` `groups[].name` chunk-name classifier.
+  pub fn record_code_splitting_name(&self, micros: u64) {
+    self.code_splitting_name_micros.fetch_add(micros, Ordering::Relaxed);
   }
 
   /// Set total build time in microseconds
@@ -84,10 +97,50 @@ impl HookTimingCollector {
     summaries
   }
 
+  /// Get timing summaries for non-plugin output-option callbacks invoked from the Rust
+  /// core (reuses the `PluginTimingSummary` shape, with a stable label in `plugin_name`).
+  /// Only callbacks that actually ran are included.
+  pub fn get_output_callback_summary(&self) -> Vec<PluginTimingSummary> {
+    let mut summaries = Vec::new();
+    let code_splitting_name = self.code_splitting_name_micros.load(Ordering::Relaxed);
+    if code_splitting_name > 0 {
+      summaries.push(PluginTimingSummary {
+        plugin_name: arcstr::literal!("output.codeSplitting groups[].name"),
+        total_duration_micros: code_splitting_name,
+      });
+    }
+    summaries
+  }
+
   /// Clear all collected timings
   pub fn clear(&self) {
     for mut entry in self.plugins.iter_mut() {
       entry.value_mut().duration_micros.store(0, Ordering::Relaxed);
     }
+    self.code_splitting_name_micros.store(0, Ordering::Relaxed);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn output_callback_timing_accumulates() {
+    let collector = HookTimingCollector::default();
+
+    // Nothing ran yet → no row.
+    assert!(collector.get_output_callback_summary().is_empty());
+
+    collector.record_code_splitting_name(1_000);
+    collector.record_code_splitting_name(2_500);
+
+    let summary = collector.get_output_callback_summary();
+    assert_eq!(summary.len(), 1);
+    assert_eq!(summary[0].plugin_name.as_str(), "output.codeSplitting groups[].name");
+    assert_eq!(summary[0].total_duration_micros, 3_500);
+
+    collector.clear();
+    assert!(collector.get_output_callback_summary().is_empty());
   }
 }


### PR DESCRIPTION
Extends the `[PLUGIN_TIMINGS]` report to account for user output-option callbacks that run directly in the Rust core instead of through the plugin driver — notably the `output.codeSplitting` / `advancedChunks` `groups[].name` chunk classifier — which were previously invisible even when they dominate a build.

Records these in `HookTimingCollector` alongside the existing whole-build aggregates (precedent: `link_stage_micros`) and merges them into `get_plugin_timings_info` so they surface as rows in the same breakdown. Because the set of core-invoked callbacks is known statically, each gets a fixed `AtomicU64` field rather than a dynamic map — no per-call allocation or hashing on the hot path. Timing is recorded at the classifier call site with the existing `start_timing()` idiom, so it is zero-overhead unless `checks.pluginTimings` is enabled. Adds a unit test.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
