### PR TITLE
fix(resolveId): reject string `id` filters (must be a RegExp)

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -138,6 +138,33 @@ function assertNoImporterId(
   }
 }
 
+function containsStringId(expr: FilterExpression | TopLevelFilterExpression): boolean {
+  switch (expr.kind) {
+    case 'and':
+    case 'or':
+      return expr.args.some(containsStringId);
+    case 'not':
+    case 'include':
+    case 'exclude':
+      return containsStringId(expr.expr);
+    case 'id':
+      return typeof expr.pattern === 'string';
+    default:
+      return false;
+  }
+}
+
+function assertNoStringId(
+  filterExprs: filter.TopLevelFilterExpression[] | undefined,
+  hookName: string,
+): void {
+  if (filterExprs?.some(containsStringId)) {
+    throw new Error(
+      `A string \`id\` filter is not supported for the \`${hookName}\` hook, because its \`id\` is the import specifier rather than a resolved path. Use a RegExp instead.`,
+    );
+  }
+}
+
 function bindingifyFilterExprImpl(
   expr: FilterExpression | TopLevelFilterExpression,
   list: BindingFilterToken[],
@@ -220,12 +247,20 @@ export function bindingifyResolveIdFilter(
   if (!filterOption) {
     return undefined;
   }
-  if (Array.isArray(filterOption)) {
-    return {
-      value: filterOption.map(bindingifyFilterExpr),
-    };
+  const filterExprs = Array.isArray(filterOption)
+    ? filterOption
+    : filterOption.id
+      ? generalHookFilterMatcherToFilterExprs(filterOption.id, 'id')
+      : undefined;
+  // In `resolveId`, `id` is the raw import specifier, not a resolved path, so a
+  // string (glob) `id` is meaningless there -- it must be a RegExp. (`importerId`
+  // may still be a string: it matches the importer's resolved id, which is a path.)
+  assertNoStringId(filterExprs, 'resolveId');
+  if (!filterExprs) {
+    return undefined;
   }
-  return filterOption.id ? bindingifyGeneralHookFilter('id', filterOption.id) : undefined;
+  const value = filterExprs.map(bindingifyFilterExpr);
+  return value.length > 0 ? { value } : undefined;
 }
 
 export function bindingifyLoadFilter(

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/_config.ts
@@ -22,8 +22,8 @@ export default defineTest({
   },
   catchError(e: any) {
     expect(e).toBeInstanceOf(Error);
-    expect(e.message).toContain('id');
-    expect(e.message).toContain('resolveId');
-    expect(e.message).toContain('RegExp');
+    expect(e.message).toMatchInlineSnapshot(
+      `"A string \`id\` filter is not supported for the \`resolveId\` hook, because its \`id\` is the import specifier rather than a resolved path. Use a RegExp instead."`,
+    );
   },
 });

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/_config.ts
@@ -1,0 +1,29 @@
+import { id, include } from '@rolldown/pluginutils';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        name: 'test-plugin',
+        resolveId: {
+          // A string `id` is compiled to a glob, which is meaningless for the
+          // `resolveId` specifier (it's raw import text, not a path); it must be a
+          // RegExp. This should throw at plugin-normalization time.
+          filter: [include(id('**/main.js'))],
+          handler(_id) {
+            return null;
+          },
+        },
+      },
+    ],
+  },
+  catchError(e: any) {
+    expect(e).toBeInstanceOf(Error);
+    expect(e.message).toContain('id');
+    expect(e.message).toContain('resolveId');
+    expect(e.message).toContain('RegExp');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/filter-string-id-error/main.js
@@ -1,0 +1,1 @@
+console.log('main');


### PR DESCRIPTION
> **Bottom of the stack.** Base is `main`. The filter perf PRs (#10408 reorder, #10410 glob-cache) stack on top of this.

## What this solves

In `resolveId`, the `id` given to the filter is the **raw import specifier** (`./foo`, `lodash`, `virtual:x`), not a resolved path. But a `string` `id` filter is compiled to a **glob** — which is path/cwd-oriented (`get_matcher_string` even anchors relative globs onto cwd). Matching a specifier against a cwd-anchored glob is meaningless and silently never matches the way a user expects. Per the docs, resolveId `id` filters must be a `RegExp` (`hook-filters.md:80`).

The **object form** already enforces this at the type level — `HookFilterExtension<'resolveId'>` types `id` as `GeneralHookFilter<RegExp>` (`index.ts:774`). But the **composable form** (`filter: [include(id('glob'))]`, typed `TopLevelFilterExpression[]`) is not hook-restricted: `@rolldown/pluginutils`'s `id()` accepts `string | RegExp`, and `bindingifyResolveIdFilter` passed it straight through to the Rust glob matcher.

## The fix

Add `assertNoStringId` in `bindingifyResolveIdFilter`, mirroring the existing `assertNoImporterId` guard. It walks the filter expressions and throws a clear error if any `id` node uses a string, covering **both** forms (the composable form, and the object form defensively in case the type is bypassed):

```
A string `id` filter is not supported for the `resolveId` hook, because its
`id` is the import specifier rather than a resolved path. Use a RegExp instead.
```

`importerId` is intentionally **not** rejected — for resolveId it matches the *importer's* resolved id, which is a real path, so a glob is appropriate there.

## Tests

- `tests/fixtures/plugin/resolve-id/filter-string-id-error/` — a resolveId hook with `filter: [include(id('**/main.js'))]`, asserting the build throws an error mentioning `id`, `resolveId`, and `RegExp`. Mirrors the existing `filter-importer-id-error` fixture.

Typecheck passes. (The fixture runs in CI; it wasn't run locally because no napi binding is built in this worktree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
