### PR TITLE
fix(code-splitting): fold the runtime chunk back after order lowering

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -29,6 +29,19 @@ use super::{
   code_splitting::IndexSplittingInfo,
 };
 
+/// Which hosts [`GenerateStage::try_merge_runtime_chunk`] may fold the runtime chunk into.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum RuntimeMergeCascade {
+  /// The full host cascade: sole consumer, then bitset hosts, then a consumer dominator.
+  Full,
+  /// Only a sole consumer. The post-order-lowering fold uses this: any other host creates or
+  /// reorders chunk-evaluation edges the order analysis never modeled — a dominator merge turns
+  /// transitive reachability into a direct import whose exec-order sort position can hoist the
+  /// host past sibling imports, and a bitset host can gain a brand-new consumer edge — while a
+  /// sole-consumer merge only removes that consumer's edge to the runtime-only chunk.
+  SingleConsumerOnly,
+}
+
 struct FacadeChunkElimination {
   reason: FacadeChunkEliminationReason,
   entry_module_idx: ModuleIdx,
@@ -1173,7 +1186,11 @@ impl GenerateStage<'_> {
       chunk_graph,
       input_base,
     );
-    self.try_merge_runtime_chunk(chunk_graph, Some(&runtime_dependent_chunks));
+    self.try_merge_runtime_chunk(
+      chunk_graph,
+      Some(&runtime_dependent_chunks),
+      RuntimeMergeCascade::Full,
+    );
   }
 
   /// Merge the standalone runtime chunk into a safe existing host. Prefer a
@@ -1183,6 +1200,7 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &mut ChunkGraph,
     additional_runtime_consumers: Option<&FxHashSet<ChunkIdx>>,
+    cascade: RuntimeMergeCascade,
   ) {
     let runtime_module_idx = self.link_output.runtime.id();
     let Some(runtime_chunk_idx) = chunk_graph.module_to_chunk[runtime_module_idx] else {
@@ -1212,46 +1230,49 @@ impl GenerateStage<'_> {
       runtime_module_idx,
       additional_runtime_consumers,
     );
-    let Some(target_chunk_idx) = self
-      .find_single_runtime_consumer(&consumer_chunks)
-      .or_else(|| {
-        self.find_single_runtime_bitset_host(
-          chunk_graph,
-          runtime_chunk_idx,
-          &runtime_chunk_bits,
-          &consumer_chunks,
-          module_table,
-        )
-      })
-      .or_else(|| {
-        self.find_runtime_bitset_host(
-          chunk_graph,
-          runtime_chunk_idx,
-          &runtime_chunk_bits,
-          &consumer_chunks,
-          module_table,
-        )
-      })
-      .or_else(|| {
-        Self::find_consumer_dominator(&consumer_chunks, chunk_graph, module_table).filter(
-          |&target_chunk_idx| {
-            Self::runtime_merge_target_is_allowed(chunk_graph, target_chunk_idx)
-              && self.runtime_target_is_tla_safe(chunk_graph, target_chunk_idx, &consumer_chunks)
-              && self.runtime_merge_preserves_target_signature(
-                chunk_graph,
-                target_chunk_idx,
-                &consumer_chunks,
-              )
-              && !Self::runtime_target_would_create_static_cycle(
-                target_chunk_idx,
-                &consumer_chunks,
-                chunk_graph,
-                module_table,
-              )
-          },
-        )
-      })
-    else {
+    let single_consumer = self.find_single_runtime_consumer(&consumer_chunks);
+    let target_chunk_idx = match cascade {
+      RuntimeMergeCascade::SingleConsumerOnly => single_consumer,
+      RuntimeMergeCascade::Full => single_consumer
+        .or_else(|| {
+          self.find_single_runtime_bitset_host(
+            chunk_graph,
+            runtime_chunk_idx,
+            &runtime_chunk_bits,
+            &consumer_chunks,
+            module_table,
+          )
+        })
+        .or_else(|| {
+          self.find_runtime_bitset_host(
+            chunk_graph,
+            runtime_chunk_idx,
+            &runtime_chunk_bits,
+            &consumer_chunks,
+            module_table,
+          )
+        })
+        .or_else(|| {
+          Self::find_consumer_dominator(&consumer_chunks, chunk_graph, module_table).filter(
+            |&target_chunk_idx| {
+              Self::runtime_merge_target_is_allowed(chunk_graph, target_chunk_idx)
+                && self.runtime_target_is_tla_safe(chunk_graph, target_chunk_idx, &consumer_chunks)
+                && self.runtime_merge_preserves_target_signature(
+                  chunk_graph,
+                  target_chunk_idx,
+                  &consumer_chunks,
+                )
+                && !Self::runtime_target_would_create_static_cycle(
+                  target_chunk_idx,
+                  &consumer_chunks,
+                  chunk_graph,
+                  module_table,
+                )
+            },
+          )
+        }),
+    };
+    let Some(target_chunk_idx) = target_chunk_idx else {
       return;
     };
     if target_chunk_idx == runtime_chunk_idx {
@@ -1267,7 +1288,13 @@ impl GenerateStage<'_> {
     );
     let target_chunk = &mut chunk_graph.chunk_table[target_chunk_idx];
     target_chunk.depended_runtime_helper.insert(runtime_chunk_helpers);
-    target_chunk.bits.union(&runtime_chunk_bits);
+    // A sole-consumer host already has exact bits: the runtime becomes internal to it, so nobody
+    // else loads it through this chunk. The post-order-lowering standalone runtime chunk carries
+    // synthetic all-live-union bits (minted as a universal source), and folding those in would
+    // widen the host's bits — visible through bits-derived chunk names.
+    if matches!(cascade, RuntimeMergeCascade::Full) {
+      target_chunk.bits.union(&runtime_chunk_bits);
+    }
     chunk_graph
       .post_chunk_optimization_operations
       .insert(runtime_chunk_idx, PostChunkOptimizationOperation::Removed);

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -2,7 +2,10 @@ use std::{borrow::Cow, cmp::Ordering, collections::VecDeque, path::Path};
 
 use crate::{
   chunk_graph::ChunkGraph,
-  stages::generate_stage::{chunk_ext::ChunkDebugExt, chunk_optimizer::ChunkOptimizationGraph},
+  stages::generate_stage::{
+    chunk_ext::ChunkDebugExt,
+    chunk_optimizer::{ChunkOptimizationGraph, RuntimeMergeCascade},
+  },
   types::linking_metadata::LinkingMetadataVec,
   utils::chunk::normalize_preserve_entry_signature,
 };
@@ -1063,7 +1066,7 @@ impl GenerateStage<'_> {
       );
     }
 
-    self.try_merge_runtime_chunk(chunk_graph, None);
+    self.try_merge_runtime_chunk(chunk_graph, None, RuntimeMergeCascade::Full);
 
     Ok(())
   }

--- a/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
@@ -41,6 +41,33 @@ impl OrderWrapState {
       .fold(synthetic_helpers, |helpers, overlay| helpers | overlay.runtime_helpers)
   }
 
+  /// The chunks whose rendered output calls a runtime helper that order lowering introduced: a
+  /// wrapper's synthetic `init_*` declaration renders in its assigned chunk, and an overlay's
+  /// lowered import/re-export glue renders at the importer's import site. Pre-lowering helper
+  /// demand is not collected here — the runtime-chunk merge proof re-scans it from chunk and
+  /// statement metadata.
+  pub(crate) fn runtime_helper_consumer_chunks(
+    &self,
+    module_to_chunk: &IndexVec<ModuleIdx, Option<ChunkIdx>>,
+  ) -> FxHashSet<ChunkIdx> {
+    let mut consumers = FxHashSet::default();
+    for stmt in &self.synthetic_statements {
+      if !stmt.runtime_helpers.is_empty()
+        && let Some(chunk_idx) = stmt.chunk
+      {
+        consumers.insert(chunk_idx);
+      }
+    }
+    for (key, overlay) in &self.import_overlays {
+      if !overlay.runtime_helpers.is_empty()
+        && let Some(chunk_idx) = module_to_chunk[key.importer]
+      {
+        consumers.insert(chunk_idx);
+      }
+    }
+    consumers
+  }
+
   pub(crate) fn requires_runtime_symbol(
     &self,
     runtime: &RuntimeModuleBrief,

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 use oxc::ast::ast::{Declaration, ExportDefaultDeclarationKind, Statement};
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, ImportKind, ImportRecordIdx, ImportRecordMeta,
-  IndexModules, ModuleIdx, PostChunkOptimizationOperation, RuntimeHelper, StmtInfoIdx, SymbolRef,
-  SymbolRefDb, UsedSymbolRefsBuilder, WrapKind,
+  IndexModules, ModuleIdx, OutputFormat, PostChunkOptimizationOperation, RuntimeHelper,
+  StmtInfoIdx, SymbolRef, SymbolRefDb, UsedSymbolRefsBuilder, WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_ecmascript_utils::StatementExt;
@@ -17,6 +17,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use super::{
   GenerateStage,
   chunk_ext::{ChunkCreationReason, ChunkDebugExt},
+  chunk_optimizer::RuntimeMergeCascade,
   order_analysis::{OrderAnalysis, OrderWrapPlan},
   order_wrap_state::{OrderImportKey, OrderImportOverlay, OrderWrapState},
 };
@@ -146,7 +147,7 @@ impl GenerateStage<'_> {
     self.place_order_wrap_modules(chunk_graph, plan, order_state);
     self.create_order_wrap_entry_facades(chunk_graph, analysis);
     self.restore_order_wrap_entry_facades(chunk_graph, plan);
-    self.ensure_runtime_module_for_order_wraps(chunk_graph);
+    self.ensure_runtime_module_for_order_wraps(chunk_graph, order_state);
     chunk_graph.sort_chunk_modules(self.link_output, self.options);
     self.renumber_live_chunks(chunk_graph);
     true
@@ -392,7 +393,19 @@ impl GenerateStage<'_> {
     }
   }
 
-  fn ensure_runtime_module_for_order_wraps(&mut self, chunk_graph: &mut ChunkGraph) {
+  /// Normalize the runtime module onto a standalone chunk, then re-run the runtime-chunk merge
+  /// proof with the post-lowering consumer set.
+  ///
+  /// The baseline `try_merge_runtime_chunk` calls run before order analysis, so a pre-lowering
+  /// merge never proved anything about the helper demand the wrappers and overlays above added.
+  /// Evicting a co-hosted runtime first restores the standalone shape that proof requires; by this
+  /// point lowering has materialized every order-introduced demand in [`OrderWrapState`], so the
+  /// re-proof sees the complete consumer set.
+  fn ensure_runtime_module_for_order_wraps(
+    &mut self,
+    chunk_graph: &mut ChunkGraph,
+    order_state: &OrderWrapState,
+  ) {
     let runtime_idx = self.link_output.runtime.id();
     if let Some(runtime_chunk_idx) = chunk_graph.module_to_chunk[runtime_idx] {
       if self.options.code_splitting.is_disabled() {
@@ -401,6 +414,9 @@ impl GenerateStage<'_> {
       let runtime_chunk = &chunk_graph.chunk_table[runtime_chunk_idx];
       if runtime_chunk.modules.len() == 1 {
         self.clear_module_symbol_chunk_indices(runtime_idx);
+        // Facade restoration above can tombstone chunks the pre-lowering merge counted as
+        // consumers, so a standalone runtime may only now have a sole consumer left.
+        self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
         return;
       }
       let mut bits = runtime_chunk.bits.clone();
@@ -440,6 +456,7 @@ impl GenerateStage<'_> {
         self.link_output.metas[runtime_idx].depended_runtime_helper,
       );
       self.clear_module_symbol_chunk_indices(runtime_idx);
+      self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
       return;
     }
 
@@ -483,6 +500,32 @@ impl GenerateStage<'_> {
       self.link_output.metas[runtime_idx].depended_runtime_helper,
     );
     self.clear_module_symbol_chunk_indices(runtime_idx);
+    self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
+  }
+
+  /// Re-run the runtime-chunk merge proof against the post-lowering consumer set: the
+  /// order-introduced consumers from [`OrderWrapState`] plus the merge's own re-scan of every
+  /// pre-lowering consumer. Restricted to a sole-consumer host — see
+  /// [`RuntimeMergeCascade::SingleConsumerOnly`].
+  ///
+  /// Esm output only. Under cjs output, `compute_cross_chunk_links` later gives every ESM-exports
+  /// entry chunk — including the zero-module facades minted above — a `__toCommonJS` demand that
+  /// is invisible here, so a fold could hand an entry chunk with no demand at all a brand-new
+  /// require edge into a user chunk. Other formats keep the standalone/evicted layout.
+  fn fold_runtime_chunk_after_order_lowering(
+    &self,
+    chunk_graph: &mut ChunkGraph,
+    order_state: &OrderWrapState,
+  ) {
+    if !matches!(self.options.format, OutputFormat::Esm) {
+      return;
+    }
+    let order_consumers = order_state.runtime_helper_consumer_chunks(&chunk_graph.module_to_chunk);
+    self.try_merge_runtime_chunk(
+      chunk_graph,
+      Some(&order_consumers),
+      RuntimeMergeCascade::SingleConsumerOnly,
+    );
   }
 
   fn update_chunk_runtime_helpers_after_module_removal(

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -43,8 +43,8 @@ export { all };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var stages;
 function init_lib() {
@@ -74,13 +74,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as n, all as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -37,7 +37,7 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region cjs.cjs
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("cjs");
@@ -64,14 +64,6 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __toESM as r, __commonJSMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
@@ -62,7 +62,7 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -82,14 +82,6 @@ export { init_setup as n, init_main as t };
 
 ```
 
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 # Variant: pife-for-module-wrappers-wrap-all: [on_demand_wrapping: false] [pife_for_module_wrappers: false]
 
 ## Assets
@@ -105,7 +97,7 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin(() => {
@@ -125,14 +117,6 @@ export { init_setup as n, init_main as t };
 
 ```
 
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 # Variant: wrap-all: [on_demand_wrapping: false]
 
 ## Assets
@@ -148,7 +132,7 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -165,13 +149,5 @@ function init_main() {
 }
 //#endregion
 export { init_setup as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -37,8 +37,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -73,13 +73,5 @@ function init_main() {
 }
 //#endregion
 export { init_foo as n, init_setup as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes_multi_entry/artifacts.snap
@@ -53,18 +53,10 @@ init_b();
 
 ```
 
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
-
-```
-
 ### shared.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -46,8 +46,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
 var value;
 function init_lib_foo() {
@@ -65,13 +65,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -30,8 +30,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
 var value;
 function init_lib_foo() {
@@ -49,13 +49,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -46,8 +46,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
 var value;
 function init_lib_foo() {
@@ -65,13 +65,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -35,8 +35,7 @@ export { inner_exports as star };
 ### main2.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
-
+// HIDDEN [\0rolldown/runtime.js]
 //#region leaf.js
 var foo;
 function init_leaf() {
@@ -65,11 +64,4 @@ function init_main() {
 
 //#endregion
 export { init_inner as n, inner_exports as r, init_main as t };
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
@@ -33,8 +33,8 @@ export { out };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import { sep } from "node:path";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
 var marker;
 function init_dep() {
@@ -54,14 +54,6 @@ function init_main() {
 }
 //#endregion
 export { out as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -39,7 +39,6 @@ nodeAssert.strictEqual(import_foo.value, "foo");
 
 ```js
 import { t as init_main } from "./main2.js";
-import "./rolldown-runtime.js";
 init_main();
 
 ```
@@ -47,8 +46,8 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 __rolldown_runtime__.registerGraph({
 	ids: ["foo.cjs", "main.js"],
 	localCount: 2,
@@ -74,13 +73,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -14,7 +14,7 @@ init_main();
 ## main2.js
 
 ```js
-import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const sideEffect = {};
@@ -38,14 +38,6 @@ function init_main() {
 }
 //#endregion
 export { init_dep_b as n, init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __commonJSMin as t };
 
 ```
 
@@ -64,7 +56,7 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const sideEffect = {};
@@ -88,13 +80,5 @@ function init_main() {
 }
 //#endregion
 export { init_dep_b as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -36,8 +36,8 @@ export { dep_default as dep };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
 function foo() {
 	globalThis.value = 1;
@@ -58,13 +58,5 @@ function init_main() {
 }
 //#endregion
 export { dep_default as n, init_dep as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -38,7 +38,7 @@ export { Foo, fooClasses, getFooUtilityClass };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region components/Foo/fooClasses.js
 function getFooUtilityClass(slot) {
 	return "MuiFoo-" + slot;
@@ -71,13 +71,5 @@ function init_main() {
 }
 //#endregion
 export { getFooUtilityClass as a, fooClasses as i, Foo as n, init_fooClasses as o, init_Foo as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
@@ -31,7 +31,7 @@ init_main();
 ## main2.js
 
 ```js
-import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const sideEffect = {};
@@ -56,14 +56,6 @@ function init_main() {
 }
 //#endregion
 export { init_dep_b as n, init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```
 
@@ -99,7 +91,7 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const sideEffect = {};
@@ -124,13 +116,5 @@ function init_main() {
 }
 //#endregion
 export { init_dep_b as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
@@ -37,8 +37,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -67,13 +67,5 @@ function init_main() {
 }
 //#endregion
 export { init_setup as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
@@ -51,8 +51,8 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region react.js
 var require_react = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.createReactElement = function() {
@@ -89,13 +89,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __toESM as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -42,8 +42,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
@@ -52,13 +52,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
@@ -24,7 +24,7 @@ init_main();
 ## main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 const setup = () => {
 	globalThis.foo = "foo";
@@ -44,14 +44,6 @@ function init_main() {
 }
 //#endregion
 export { setup as n, init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -30,7 +30,7 @@ await init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 function init_foo() {
 	return (init_foo = __esmMin((async () => {
@@ -47,13 +47,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -22,11 +22,5 @@ import{t as e}from"./main2.js";await e();
 ### main2.js
 
 ```js
-import{t as e}from"./rolldown-runtime.js";async function t(){console.log(`foo`)}function n(){return(n=e((async()=>{await t()})))()}export{n as t};
-```
-
-### rolldown-runtime.js
-
-```js
-var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};export{e as t};
+var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}function n(){return(n=e((async()=>{await t()})))()}export{n as t};
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
@@ -14,7 +14,7 @@ init_main();
 ## main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
 function init_dep() {
 	return (init_dep = __esmMin((() => {
@@ -31,14 +31,6 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
@@ -43,7 +43,7 @@ export { getProjectAnnotations };
 ### entry2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region data.js
 var themes;
 function init_data() {
@@ -73,13 +73,5 @@ function init_entry() {
 }
 //#endregion
 export { init_entry as n, getProjectAnnotations as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
@@ -15,7 +15,7 @@ export { result };
 ## main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region b.js
 function getB() {
 	return getA ? "b" : "unreachable";
@@ -50,14 +50,6 @@ function init_main() {
 }
 //#endregion
 export { result as n, init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -43,8 +43,8 @@ init_main();
 ### main2.js
 
 ```js
-import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => 1 });
 var init_lib = __esmMin((() => {}));
@@ -78,13 +78,5 @@ function init_main() {
 }
 //#endregion
 export { init_log as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
@@ -30,8 +30,8 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 var A, foo;
 function init_main() {
@@ -43,13 +43,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
@@ -27,7 +27,7 @@ init_main();
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
@@ -36,13 +36,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -73,7 +73,7 @@ export { manager };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region deep.js
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -117,13 +117,5 @@ function init_main() {
 }
 //#endregion
 export { init_middle as n, manager as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -31,7 +31,7 @@ init_b();
 ## common~a~b~shared.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
@@ -57,14 +57,6 @@ function init_b() {
 }
 //#endregion
 export { init_a as n, init_b as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 
@@ -100,7 +92,7 @@ init_b();
 ### common~a~b~shared.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
@@ -128,14 +120,6 @@ function init_b() {
 }
 //#endregion
 export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -31,7 +31,7 @@ init_b();
 ## common.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
@@ -57,14 +57,6 @@ function init_b() {
 }
 //#endregion
 export { init_a as n, init_b as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 
@@ -100,7 +92,7 @@ init_b();
 ### common.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
@@ -128,14 +120,6 @@ function init_b() {
 }
 //#endregion
 export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_three_entries/artifacts.snap
@@ -30,7 +30,7 @@ init_c();
 ## common~a~b~c.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
@@ -61,14 +61,6 @@ function init_c() {
 }
 //#endregion
 export { init_b as n, init_a as r, init_c as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 
@@ -103,7 +95,7 @@ init_c();
 ### common~a~b~c.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
@@ -134,13 +126,5 @@ function init_c() {
 }
 //#endregion
 export { init_b as n, init_a as r, init_c as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -58,8 +58,8 @@ init_main();
 ### main2.js
 
 ```js
-import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region pkg-barrel/other.cjs
 var require_other = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "other-value";
@@ -82,13 +82,5 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as n, __toESM as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
@@ -14,7 +14,7 @@ init_main();
 ## main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region core/setupWorker.js
 function setupWorker(handler) {
 	return { handler };
@@ -35,14 +35,6 @@ function init_main() {
 }
 //#endregion
 export { init_main as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -23,8 +23,8 @@ init_entry();
 ## entry2.js
 
 ```js
-import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
 //#endregion
@@ -39,14 +39,6 @@ function init_entry() {
 }
 //#endregion
 export { init_entry as t };
-
-```
-
-## rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```
 
@@ -254,8 +246,8 @@ init_entry();
 ### entry2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var a;
 function init_lib() {
@@ -285,13 +277,5 @@ export { a as n, init_lib as r, init_entry as t };
 import { n as a, r as init_lib } from "./entry2.js";
 init_lib();
 export { a };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as n, __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
@@ -44,7 +44,7 @@ init_main();
 ### main.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region init.js
 function init_init() {
 	return (init_init = __esmMin((() => {
@@ -85,13 +85,5 @@ function init_main() {
 }
 //#endregion
 export { init_init as i, init_bar as n, init_foo as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
@@ -29,7 +29,7 @@ export { foo };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var foo;
 function init_lib() {
@@ -46,14 +46,6 @@ function init_main() {
 }
 //#endregion
 export { foo as n, init_lib as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
@@ -32,7 +32,7 @@ export { foo };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var foo;
 function init_lib() {
@@ -51,14 +51,6 @@ function init_main() {
 }
 //#endregion
 export { foo as n, init_lib as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
@@ -36,7 +36,7 @@ export { value as normalLibValue, value$1 as tlaLibValue };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region normal-dep.js
 var value$3;
 function init_normal_dep() {
@@ -80,14 +80,6 @@ function init_main() {
 }
 //#endregion
 export { value$2 as a, init_normal_lib as i, init_tla_lib as n, value as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
@@ -34,7 +34,7 @@ export { value };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region ring-b.js
 function init_ring_b() {
 	return (init_ring_b = __esmMin((async () => {
@@ -62,14 +62,6 @@ function init_main() {
 }
 //#endregion
 export { value as n, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -31,7 +31,7 @@ export { value };
 ### main2.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+// HIDDEN [\0rolldown/runtime.js]
 //#region tla.js
 var value$1;
 function init_tla() {
@@ -57,14 +57,6 @@ function init_main() {
 }
 //#endregion
 export { init_lib as n, value as r, init_main as t };
-
-```
-
-### rolldown-runtime.js
-
-```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __esmMin as t };
 
 ```
 

--- a/internal-docs/code-splitting/implementation.md
+++ b/internal-docs/code-splitting/implementation.md
@@ -66,6 +66,7 @@ ChunkGraph
     │    ├─ finalize provisional namespace/external facts
     │    ├─ analyze_execution_order()                Build an OrderWrapPlan with per-module reasons
     │    ├─ apply_order_wraps()                      Lower the plan into wrappers and topology edits
+    │    │    └─ ensure_runtime_module_for_order_wraps()   Re-place the runtime, then sole-consumer fold
     │    ├─ recompute metadata if topology changed
     │    ├─ sweep_unused_runtime_module()            Drop a runtime with no source or order-state demand
     │    └─ validate final output shape
@@ -209,8 +210,10 @@ consumer_chunks = (non-removed chunks with non-empty depended_runtime_helper)
                 ∪ chunks whose included statements reference runtime-owned symbols
                 ∪ chunks containing modules that depend on the runtime module
                 ∪ chunks containing wrapped modules or side-effectful runtime dependencies
-                ∪ facade-elimination consumers added during the current pass
+                ∪ caller-supplied additional consumers
 ```
+
+The additional-consumers channel carries demand that only the caller can see: facade-elimination consumers during chunk optimization, and order-introduced consumers during the post-order-lowering fold below.
 
 Most runtime-helper dependencies are known at link time, before chunking, so this consumer set is usually complete as soon as chunks exist. Facade elimination is the exception: collapsing a facade into its target chunk can add a helper edge that did not exist during early chunking, through one of two `wrap_kind`-gated paths in `optimize_facade_entry_chunks`:
 
@@ -221,10 +224,24 @@ A `WrapKind::Esm` facade hits both paths.
 
 A chunk only _consumes_ the runtime once it carries a non-empty `depended_runtime_helper` (or references a runtime-owned symbol). So in a build that needed no helpers at link time, _no_ chunk consumed the runtime — and one of the paths above can create the very first consumer _after_ early chunking has already placed the runtime standalone. To keep that placement decision sound, the pass restores the inclusion metadata it just mutated, (re)materializes the standalone runtime chunk, and re-runs `try_merge_runtime_chunk` with these newly added consumers (the final bullet of the consumer set above).
 
-The merge target must not create a static cycle or force unrelated entry chunks to execute just to access helpers. Candidate targets are tried in compactness-preserving order: a sole runtime consumer, a sole live chunk with the runtime bitset, a live common chunk with the same runtime bitset, then a consumer-set dominator. Manual code splitting / advanced chunk group chunks may host runtime only when that chunk is the sole runtime consumer; otherwise their contents are user-directed grouping output, and absorbing the runtime would make unrelated chunks load the group for helpers. Safety is checked by following static chunk-loading edges through still-live chunks. Dynamic imports are not followed; static imports and `require()` records are both considered because either can become a static chunk import in generated output. Chunks containing top-level await, or a dependency on top-level await, are runtime hosts only when they are the sole runtime consumer; otherwise a dynamically imported chunk that statically imports its awaiting importer for helpers can produce an unsettled async module cycle.
+The merge target must not create a static cycle or force unrelated entry chunks to execute just to access helpers. Candidate targets are tried in compactness-preserving order: a sole runtime consumer, a sole live chunk with the runtime bitset, a live common chunk with the same runtime bitset, then a consumer-set dominator. The caller selects how deep this cascade may go (`RuntimeMergeCascade`): both merge attempts during chunk optimization use the full cascade, while the post-order-lowering fold below stops after the sole-consumer step. Manual code splitting / advanced chunk group chunks may host runtime only when that chunk is the sole runtime consumer; otherwise their contents are user-directed grouping output, and absorbing the runtime would make unrelated chunks load the group for helpers. Safety is checked by following static chunk-loading edges through still-live chunks. Dynamic imports are not followed; static imports and `require()` records are both considered because either can become a static chunk import in generated output. Chunks containing top-level await, or a dependency on top-level await, are runtime hosts only when they are the sole runtime consumer; otherwise a dynamically imported chunk that statically imports its awaiting importer for helpers can produce an unsettled async module cycle.
 
 - **Safe target found** → runtime moves into that chunk, and the empty standalone runtime chunk is marked removed.
 - **No safe target** → keep the standalone runtime chunk. Runtime imports that resolve only to externals are ignored for chunk-cycle checks; live internal runtime imports keep the runtime standalone instead.
+
+### Post-Order-Lowering Runtime Fold (`ensure_runtime_module_for_order_wraps`)
+
+Order lowering can invalidate the placement the merge above decided. Synthetic wrappers and importer overlays add helper demand that lives only in `OrderWrapState`, never in link-stage metadata, so a chunk with no pre-lowering demand can become a consumer — and that new consumer may sit in a static cycle with the runtime's current host. `ensure_runtime_module_for_order_wraps` therefore restores the standalone-first baseline at the end of `apply_order_wraps()` when code splitting is enabled: a runtime co-hosted in a user chunk is evicted into a fresh standalone chunk, and a runtime that was never placed is materialized standalone. (With code splitting disabled, the single-chunk placement above stands.) These (re)minted chunks carry synthetic all-live-union bits so they sort and name as a universal source; the bits are not reachability facts.
+
+Evicting unconditionally would permanently split layouts the pre-lowering merge had already proven safe (#10294). So every exit of the pass — standalone runtime kept, co-hosted runtime evicted, runtime newly materialized — re-runs `try_merge_runtime_chunk` against the post-lowering consumer set (`fold_runtime_chunk_after_order_lowering`). The order-introduced consumers come from `OrderWrapState::runtime_helper_consumer_chunks`: a synthetic `init_*` declaration consumes helpers in its assigned chunk, and an importer overlay consumes them in the importer's chunk, where its lowered import glue renders. They are passed through the additional-consumers channel; pre-lowering demand is re-scanned by the merge itself, so the proof sees the full post-lowering consumer set. The standalone-kept exit re-runs the proof too, because entry-facade restoration during lowering can tombstone chunks the pre-lowering merge counted as consumers — a sole consumer may exist only now.
+
+The fold is deliberately narrower than the optimization-time merge:
+
+- **Sole-consumer host only (`RuntimeMergeCascade::SingleConsumerOnly`).** Exec order and the order-wrap plan are already fixed. Any other host would create or reorder chunk-evaluation edges the order analysis never modeled: a dominator merge turns transitive reachability into a direct helper import whose exec-order sort position can hoist the host past sibling imports, and a bitset host can gain a brand-new consumer edge. Merging into the sole consumer only removes that consumer's edge to a runtime-only chunk — no new edges, no reordering.
+- **ESM output only.** Under CJS output, `compute_cross_chunk_links` later gives every ESM-exports entry chunk — including zero-module facades minted during lowering — a speculative `__toCommonJS` demand that is invisible at fold time, so a chunk with no visible demand could be handed a brand-new require edge into a user chunk. Other formats keep the standalone or evicted layout.
+- **No bits union.** The full cascade unions the runtime chunk's bits into the host so bits stay an exact reachability record. Here the runtime chunk's bits are the synthetic all-live union above; folding them in would widen the host's bits, which is user-visible through bits-derived chunk names. The sole-consumer host keeps its own bits.
+
+**Regression coverage:** `crates/rolldown/tests/rolldown/issues/9463/` and `issues/9463_plain_group/` — the runtime folds into the sole consumer `common~a~b~shared` instead of shipping as a helper-only chunk, in both config cells; `issues/10265/` and `optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/` — the only demand is order-introduced (synthetic `init_*` wrappers), and the runtime folds into the chunk hosting them, while the latter's cjs cells pin the ESM-only gate by keeping the standalone `rolldown-runtime.js`; the `function/experimental/strict_execution_order/` snapshots pin the folded layouts under wrap-all and on-demand wrapping (`top_level_await_syntax` pins the TLA sole-consumer case).
 
 ### Unused-Runtime Sweep (`sweep_unused_runtime_module`)
 
@@ -240,7 +257,7 @@ The sweep is **all-or-nothing and conservative**: any remaining demand — or an
 
 **Why this shape**
 
-Runtime used to be placed by normal bitset grouping and later peeled out when a cycle was detected. That made every optimizer responsible for understanding runtime-host edge cases. Standalone-first flips the default: the initial layout is always cycle-safe, and runtime-specific processing is confined to two final passes — the optional merge into a proven dominator above, then the unused-runtime sweep once the entry-level-external walk-back has settled what the finalizer will actually emit.
+Runtime used to be placed by normal bitset grouping and later peeled out when a cycle was detected. That made every optimizer responsible for understanding runtime-host edge cases. Standalone-first flips the default: the initial layout is always cycle-safe, and runtime-specific processing is confined to three final passes — the optional merge into a proven host after chunk optimization, the post-order-lowering re-placement and sole-consumer fold, then the unused-runtime sweep once the entry-level-external walk-back has settled what the finalizer will actually emit.
 
 **Regression coverage**
 


### PR DESCRIPTION
### Problem

First P1 item of #10294: `ensure_runtime_module_for_order_wraps` unconditionally evicts a co-hosted runtime module onto a standalone `rolldown-runtime` chunk (and mints one when the runtime was unplaced), even when every helper consumer lives in a single chunk. `issues/9463` ships a `rolldown-runtime.js` whose only content is two helper re-exports consumed exclusively by `common~a~b~shared.js` — one extra request per page load for nothing, in both wrap modes.

The eviction itself is justified: the baseline merge proof (`try_merge_runtime_chunk`, called from `generate_chunks` and the chunk optimizer) runs **before** order analysis, so nothing it proved covers the helper demand order lowering adds (`__esm`/`__esmMin` per wrapper, `__toCommonJS`/`__reExport` per lowered overlay). What was missing is re-running the proof afterwards: by the end of lowering the full demand is materialized in `OrderWrapState`, so the complete post-lowering consumer set is knowable.

### Fix

`ensure_runtime_module_for_order_wraps` keeps its normalize-to-standalone behavior unchanged, then re-runs the merge proof with the post-lowering consumer set:

- New `OrderWrapState::runtime_helper_consumer_chunks` collects the order-introduced consumers: each wrapper's synthetic `init_*` statement renders in its assigned chunk, and each overlay's lowered import/require glue renders in the importer's chunk. Pre-lowering demand is re-collected by `collect_runtime_consumer_chunks`'s own scan (chunk helper bits, interop wrappers, statement-level runtime symbol references), and stale/tombstoned chunks are filtered by the existing `post_chunk_optimization_operations` guard.
- `try_merge_runtime_chunk` gains a `RuntimeMergeCascade` parameter. The two pre-existing call sites use `Full` (byte-identical cascade). The post-lowering fold uses `SingleConsumerOnly`, and two deliberate restrictions apply:
  - **Sole-consumer hosts only.** A dominator merge turns transitive reachability into a direct import whose exec-order sort position can hoist the host past sibling imports, and a bitset host can gain a brand-new consumer edge — either way the chunk-evaluation order deviates from what the on-demand analysis proved against the pre-fold edge set. A sole-consumer merge only removes that consumer's edge to an inert runtime-only chunk, so evaluation order is preserved by construction (this also makes the TLA/signature/cycle guards trivially satisfied, and keeps the existing sole-consumer allowance for manual group chunks).
  - **Esm output only.** Under cjs output, `compute_cross_chunk_links` later gives every ESM-exports entry chunk — including the zero-module order facades — a `__toCommonJS` demand that is invisible at fold time; folding would hand an entry chunk with no visible demand a brand-new `require` edge into a user chunk. Every other post-fold demand source was audited to be either Esm-excluded or already represented in the fold-time consumer set.
- In `SingleConsumerOnly` mode the merge tail skips `target_chunk.bits.union(...)`: the sole consumer's own bits are already exact (the runtime becomes internal to it), while the order-time standalone chunk carries synthetic all-live-union bits whose widening would leak into bits-derived chunk names.

Non-esm formats and `strictExecutionOrder: false` builds are byte-for-byte untouched; the fold only runs from the order-wrap path (non-empty plan).

### Output shape

`issues/9463` (acceptance): `rolldown-runtime.js` disappears and the helpers inline into `common~a~b~shared.js` in both cells; same for `issues/9463_plain_group`, `issues/9463_three_entries`, and `strict_execution_order/concatenate_basic` (wrap-all cells fold into `main2.js`). 40 snapshots change, all strict-mode fixtures, all the same shape: the standalone runtime chunk is gone and its (actually demanded) helpers render inside the sole consumer — `issues/5870` and `mixed_static_dynamic_same_target` also drop a previously exported-but-unconsumed `__exportAll`, since the host renders only demanded statements.

One snapshot-cosmetic note: in fixtures where the runtime region folds ahead of a synthetic wrapper rendered without its own region markers (pre-existing quirk), the `HIDDEN [\0rolldown/runtime.js]` replacement visually swallows the following wrapper in the snapshot (`top_level_await_syntax`). The raw emitted chunk was dumped and verified correct — `init_foo` is present; only the snapshot display collapses it.

### Validation

- Full integration suite + workspace tests: failure list byte-identical to unmodified main (verified by stash-and-rerun on the same machine; the only local failures are the pre-existing css/legal-comments/esbuild-diff environment set).
- Execution-order fuzzer (rolldown-order-fuzzer) against this build, 300 cases across three cells: mixed 112/120, pure-ESM 83/100, wrap-all 71/80. The same three campaigns (same seeds and flags) were then run against an unmodified-main build of this worktree: the failing seed sets are identical and every one of the 34 failures carries a byte-identical verdict signature (the known Family-A / event-reorder arms tracked in #10294) — zero failure signatures introduced or altered by this change.

Part of #10294.
