### PR TITLE
refactor: shorten AST builder code

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -148,16 +148,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               &specifier.exported.name(),
               match &specifier.local {
                 ast::ModuleExportName::IdentifierName(ident) => {
-                  Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+                  Expression::new_static_member_expression(
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
                     ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_builder),
                     false,
                     &self.ast_builder,
-                  ))
+                  )
                 }
                 ast::ModuleExportName::StringLiteral(str) => {
-                  Expression::ComputedMemberExpression(ast::ComputedMemberExpression::boxed(
+                  Expression::new_computed_member_expression(
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
                     ast::Expression::new_string_literal(
@@ -168,7 +168,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                     ),
                     false,
                     &self.ast_builder,
-                  ))
+                  )
                 }
                 ast::ModuleExportName::IdentifierReference(_) => {
                   unreachable!(
@@ -176,7 +176,8 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                   )
                 }
               },
-              matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)), &self.ast_builder
+              matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)),
+              &self.ast_builder,
             )
           }));
           if let Some(stmt) = self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
@@ -437,7 +438,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     );
 
     // var [binding_name] = [__toESM-wrapped loadExports call];
-    let stmt = Statement::from(ast::Declaration::new_variable_declaration(
+    let stmt = Statement::new_variable_declaration(
       span,
       ast::VariableDeclarationKind::Var,
       oxc::allocator::Vec::from_value_in(
@@ -463,7 +464,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       ),
       false,
       &self.ast_builder,
-    ));
+    );
     Some(stmt)
   }
 
@@ -513,11 +514,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       &self.ast_builder,
     );
 
-    Some(ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-      span,
-      call_expr,
-      &self.ast_builder,
-    )))
+    Some(ast::Statement::new_expression_statement(span, call_expr, &self.ast_builder))
   }
 
   fn generate_declaration_of_module_namespace_object(
@@ -610,22 +607,22 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // TODO: hyf0 should switch to a more robust way to identify lazy proxy modules
     if importee.id.contains("?rolldown-lazy=1") {
       // Build: encodeURIComponent(importee.id)
-      let encode_call = ast::Expression::CallExpression(ast::CallExpression::boxed(
+      let encode_call = ast::Expression::new_call_expression(
         SPAN,
         Expression::new_id_ref_expr(SPAN, "encodeURIComponent", &self.ast_builder),
         NONE,
         oxc::allocator::Vec::from_value_in(
-          ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+          ast::Argument::new_string_literal(
             SPAN,
             Str::from_str_in(&importee.id, &self.ast_builder),
             None,
             &self.ast_builder,
-          )),
+          ),
           &self.ast_builder,
         ),
         false,
         &self.ast_builder,
-      ));
+      );
 
       // Build template literal: `/@vite/lazy?id=${encodeURIComponent(importee.id)}&clientId=${__rolldown_runtime__.clientId}`
       let url_expr = {
@@ -680,22 +677,22 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         ast::Expression::new_import_expression(SPAN, url_expr, None, None, &self.ast_builder);
 
       // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
-      let load_exports_call = ast::Expression::CallExpression(ast::CallExpression::boxed(
+      let load_exports_call = ast::Expression::new_call_expression(
         SPAN,
         Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
         NONE,
         oxc::allocator::Vec::from_value_in(
-          ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+          ast::Argument::new_string_literal(
             SPAN,
             Str::from_str_in(&importee.stable_id, &self.ast_builder),
             None,
             &self.ast_builder,
-          )),
+          ),
           &self.ast_builder,
         ),
         false,
         &self.ast_builder,
-      ));
+      );
 
       // Build: () => __rolldown_runtime__.loadExports("<stable_proxy_id>")
       let arrow_fn = ast::Expression::new_arrow_function_expression(
@@ -715,11 +712,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           SPAN,
           oxc::allocator::Vec::new_in(&self.ast_builder),
           oxc::allocator::Vec::from_value_in(
-            ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-              SPAN,
-              load_exports_call,
-              &self.ast_builder,
-            )),
+            ast::Statement::new_expression_statement(SPAN, load_exports_call, &self.ast_builder),
             &self.ast_builder,
           ),
           &self.ast_builder,
@@ -728,13 +721,13 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       );
 
       // Build: import(...).then(() => __rolldown_runtime__.loadExports("..."))
-      let then_callee = Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+      let then_callee = Expression::new_static_member_expression(
         SPAN,
         import_expr,
         ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
         false,
         &self.ast_builder,
-      ));
+      );
 
       *it = ast::Expression::new_call_expression(
         SPAN,
@@ -752,22 +745,22 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     // __rolldown_runtime__.loadExports('./foo.js')
     // Use stable module ID for consistent runtime lookup
-    let mut load_exports_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
+    let mut load_exports_call_expr = ast::Expression::new_call_expression(
       SPAN,
       Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
       NONE,
       oxc::allocator::Vec::from_value_in(
-        ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+        ast::Argument::new_string_literal(
           SPAN,
           Str::from_str_in(&importee.stable_id, &self.ast_builder),
           None,
           &self.ast_builder,
-        )),
+        ),
         &self.ast_builder,
       ),
       false,
       &self.ast_builder,
-    ));
+    );
 
     if is_importee_cjs {
       let is_node_cjs = importee.def_format.is_commonjs();
@@ -777,13 +770,13 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         &self.ast_builder,
       );
       if is_node_cjs {
-        args.push(ast::Argument::from(ast::Expression::new_numeric_literal(
+        args.push(ast::Argument::new_numeric_literal(
           SPAN,
           1.0,
           None,
           ast::NumberBase::Decimal,
           &self.ast_builder,
-        )));
+        ));
       }
 
       // __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports('./foo.js'), node_mode)
@@ -812,14 +805,14 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let init_call = self.make_init_module_call(&self.modules[importee_idx]);
     let promise_resolve_then_load_exports =
       Expression::new_promise_resolve_then(load_exports_call_expr, &self.ast_builder);
-    *it = ast::Expression::SequenceExpression(ast::SequenceExpression::boxed(
+    *it = ast::Expression::new_sequence_expression(
       SPAN,
       oxc::allocator::Vec::from_array_in(
         [init_call, promise_resolve_then_load_exports],
         &self.ast_builder,
       ),
       &self.ast_builder,
-    ));
+    );
   }
 
   pub fn try_rewrite_require(
@@ -921,13 +914,13 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         false,
         &self.ast_builder,
       );
-      Expression::from(ast::MemberExpression::new_static_member_expression(
+      Expression::new_static_member_expression(
         SPAN,
         to_commonjs_call,
         IdentifierName::new_id_name(SPAN, "default", &self.ast_builder),
         false,
         &self.ast_builder,
-      ))
+      )
     } else {
       Expression::new_call_with_arg(
         Expression::new_member_access_expr(

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -67,12 +67,12 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // module/exports objects become locals the body's rewritten `module`/`exports`
     // references resolve to.
     let cjs_module_locals: Vec<ast::Statement<'ast>> = if self.module.exports_kind.is_commonjs() {
-      let empty_exports_object = ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
+      let empty_exports_object = ast::Expression::new_object_expression(
         SPAN,
         oxc::allocator::Vec::new_in(&self.ast_builder),
         &self.ast_builder,
-      ));
-      let module_object = ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
+      );
+      let module_object = ast::Expression::new_object_expression(
         SPAN,
         oxc::allocator::Vec::from_value_in(
           ast::ObjectPropertyKind::new_object_property(
@@ -88,7 +88,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           &self.ast_builder,
         ),
         &self.ast_builder,
-      ));
+      );
       vec![
         // var __rolldown_module__ = { exports: {} };
         ast::Statement::from(ast::Declaration::new_variable_declaration(
@@ -168,8 +168,13 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       &self.ast_builder,
     );
 
-    let try_stmt =
-      ast::TryStatement::boxed(SPAN, try_block, NONE, Some(final_block), &self.ast_builder);
+    let try_stmt = ast::Statement::new_try_statement(
+      SPAN,
+      try_block,
+      NONE,
+      Some(final_block),
+      &self.ast_builder,
+    );
 
     // The runtime calls the factory with the module's stable id as its argument, so it's
     // available inside the body as `__rolldown_module_id__`. This lets registerModule /
@@ -209,10 +214,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       Some(ast::FunctionBody::new(
         SPAN,
         oxc::allocator::Vec::new_in(&self.ast_builder),
-        oxc::allocator::Vec::from_value_in(
-          ast::Statement::TryStatement(try_stmt),
-          &self.ast_builder,
-        ),
+        oxc::allocator::Vec::from_value_in(try_stmt, &self.ast_builder),
         &self.ast_builder,
       )),
       &self.ast_builder,
@@ -224,13 +226,13 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // Every factory is id-addressed and registry-gated at runtime; re-execution policy
     // is runtime data (evictions), never a per-payload flag.
     let mut register_factory_args = oxc::allocator::Vec::with_capacity_in(3, &self.ast_builder);
-    register_factory_args.push(ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+    register_factory_args.push(ast::Argument::new_string_literal(
       SPAN,
       oxc::ast::ast::Str::from_str_in(&self.module.stable_id, &self.ast_builder),
       None,
       &self.ast_builder,
-    )));
-    register_factory_args.push(ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+    ));
+    register_factory_args.push(ast::Argument::new_string_literal(
       SPAN,
       oxc::ast::ast::Str::from_str_in(
         if self.module.exports_kind.is_commonjs() { "cjs" } else { "esm" },
@@ -238,11 +240,11 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       ),
       None,
       &self.ast_builder,
-    )));
+    ));
     register_factory_args
       .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
 
-    let register_factory_call = ast::CallExpression::boxed(
+    let register_factory_call = ast::Expression::new_call_expression(
       SPAN,
       Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.registerFactory", &self.ast_builder),
       NONE,
@@ -253,7 +255,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
 
     node.body.push(ast::Statement::new_expression_statement(
       SPAN,
-      ast::Expression::CallExpression(register_factory_call),
+      register_factory_call,
       &self.ast_builder,
     ));
   }

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -35,12 +35,12 @@ pub trait HmrAstBuilder<'any, 'ast> {
   /// by the runtime. The main-bundle path has no such wrapper, so it still needs to emit the
   /// stable id as a string literal.
   fn module_id_argument(&self) -> ast::Argument<'ast> {
-    ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+    ast::Argument::new_string_literal(
       SPAN,
       ast::Str::from_str_in(&self.module().stable_id, &self.builder()),
       None,
       &self.builder(),
-    ))
+    )
   }
 
   /// `__rolldown_runtime__.registerModule(moduleId, module)`
@@ -49,15 +49,14 @@ pub trait HmrAstBuilder<'any, 'ast> {
       rolldown_common::ExportsKind::Esm => {
         let binding_name_for_namespace_object_ref_atom =
           self.binding_name_for_namespace_object_ref_atom();
-        let namespace_object_ref_expr =
-          ast::Expression::Identifier(ast::IdentifierReference::boxed(
-            SPAN,
-            binding_name_for_namespace_object_ref_atom,
-            &self.builder(),
-          ));
+        let namespace_object_ref_expr = ast::Expression::new_identifier(
+          SPAN,
+          binding_name_for_namespace_object_ref_atom,
+          &self.builder(),
+        );
 
         // { exports: namespace }
-        ast::Argument::ObjectExpression(ast::ObjectExpression::boxed(
+        ast::Argument::new_object_expression(
           SPAN,
           oxc::allocator::Vec::from_value_in(
             ast::ObjectPropertyKind::new_object_property(
@@ -73,23 +72,19 @@ pub trait HmrAstBuilder<'any, 'ast> {
             &self.builder(),
           ),
           &self.builder(),
-        ))
+        )
       }
       rolldown_common::ExportsKind::CommonJs => {
         // `module`
-        ast::Argument::from(ast::Expression::Identifier(ast::IdentifierReference::boxed(
-          SPAN,
-          Self::cjs_module_name(),
-          &self.builder(),
-        )))
+        ast::Argument::new_identifier(SPAN, Self::cjs_module_name(), &self.builder())
       }
       rolldown_common::ExportsKind::None => {
         // `{}`
-        ast::Argument::from(ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
+        ast::Argument::new_object_expression(
           SPAN,
           oxc::allocator::Vec::new_in(&self.builder()),
           &self.builder(),
-        )))
+        )
       }
     };
 
@@ -102,31 +97,23 @@ pub trait HmrAstBuilder<'any, 'ast> {
     );
 
     // __rolldown_runtime__.registerModule(moduleId, module)
-    let register_call = ast::CallExpression::boxed(
+    let register_call = ast::Expression::new_call_expression(
       SPAN,
-      ast::Expression::Identifier(ast::IdentifierReference::boxed(
-        SPAN,
-        "__rolldown_runtime__.registerModule",
-        &self.builder(),
-      )),
+      ast::Expression::new_identifier(SPAN, "__rolldown_runtime__.registerModule", &self.builder()),
       NONE,
       arguments,
       false,
       &self.builder(),
     );
 
-    ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-      SPAN,
-      ast::Expression::CallExpression(register_call),
-      &self.builder(),
-    ))
+    ast::Statement::new_expression_statement(SPAN, register_call, &self.builder())
   }
 
   /// `var $hot_name = __rolldown_runtime__.createModuleHotContext($stable_id);`
   fn create_module_hot_context_initializer_stmt(&self) -> ast::Statement<'ast> {
     // var $hot_name = __rolldown_runtime__.createModuleHotContext($stable_id);
     // Use stable module ID for consistent lookup
-    ast::Statement::VariableDeclaration(ast::VariableDeclaration::boxed(
+    ast::Statement::new_variable_declaration(
       SPAN,
       ast::VariableDeclarationKind::Const,
       oxc::allocator::Vec::from_value_in(
@@ -141,18 +128,18 @@ pub trait HmrAstBuilder<'any, 'ast> {
           ),
           NONE,
           // __rolldown_runtime__.createModuleHotContext($stable_id)
-          Some(ast::Expression::CallExpression(ast::CallExpression::boxed(
+          Some(ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::Identifier(ast::IdentifierReference::boxed(
+            ast::Expression::new_identifier(
               SPAN,
               "__rolldown_runtime__.createModuleHotContext",
               &self.builder(),
-            )),
+            ),
             NONE,
             oxc::allocator::Vec::from_value_in(self.module_id_argument(), &self.builder()),
             false,
             &self.builder(),
-          ))),
+          )),
           false,
           &self.builder(),
         ),
@@ -160,7 +147,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
       ),
       false,
       &self.builder(),
-    ))
+    )
   }
 }
 
@@ -191,11 +178,7 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
   /// (or `createCjsInitializer(id, function (exports, module, __rolldown_module_id__) { … })`),
   /// so the id is in lexical scope as a parameter.
   fn module_id_argument(&self) -> ast::Argument<'ast> {
-    ast::Argument::Identifier(ast::IdentifierReference::boxed(
-      SPAN,
-      MODULE_ID_PARAM_FOR_HMR,
-      &self.builder(),
-    ))
+    ast::Argument::new_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, &self.builder())
   }
 }
 

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -245,13 +245,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
               ast_builder,
             )
           });
-          program.body.push(Statement::VariableDeclaration(ast::VariableDeclaration::boxed(
+          program.body.push(Statement::new_variable_declaration(
             SPAN,
             ast::VariableDeclarationKind::Var,
             oxc::allocator::Vec::from_iter_in(decorations, ast_builder),
             false,
             ast_builder,
-          )));
+          ));
         }
 
         // The wrapping would happen during the chunk codegen phase
@@ -355,11 +355,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         self.var_declaration_to_expr_seq_and_bindings(decl, self.state)
       {
         self.top_level_var_bindings.extend(bindings);
-        *it = ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-          SPAN,
-          expr,
-          &self.ast_builder,
-        ));
+        *it = ast::Statement::new_expression_statement(SPAN, expr, &self.ast_builder);
       }
     }
   }
@@ -718,28 +714,24 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         self.generate_finalized_simple_assignment_target_for_reference(&prop.binding)
       {
         let binding = if let Some(init) = prop.init.take() {
-          ast::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
-            ast::AssignmentTargetWithDefault::boxed(
-              Span::default(),
-              ast::AssignmentTarget::from(target),
-              init,
-              &self.ast_builder,
-            ),
+          ast::AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+            Span::default(),
+            ast::AssignmentTarget::from(target),
+            init,
+            &self.ast_builder,
           )
         } else {
           ast::AssignmentTargetMaybeDefault::from(target)
         };
-        *property = ast::AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-          ast::AssignmentTargetPropertyProperty::boxed(
-            Span::default(),
-            ast::PropertyKey::StaticIdentifier(
-              IdentifierName::new_id_name(prop.span, &prop.binding.name, &self.ast_builder)
-                .into_in(self.alloc),
-            ),
-            binding,
-            false,
-            &self.ast_builder,
+        *property = ast::AssignmentTargetProperty::new_assignment_target_property_property(
+          Span::default(),
+          ast::PropertyKey::StaticIdentifier(
+            IdentifierName::new_id_name(prop.span, &prop.binding.name, &self.ast_builder)
+              .into_in(self.alloc),
           ),
+          binding,
+          false,
+          &self.ast_builder,
         );
       } else {
         prop.binding.reference_id.get_mut().take();

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -191,11 +191,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     );
     if await_if_tla && target.tla_tainted {
       // `await init_foo()`
-      ast::Expression::AwaitExpression(ast::AwaitExpression::boxed(
-        SPAN,
-        init_call,
-        &self.ast_builder,
-      ))
+      ast::Expression::new_await_expression(SPAN, init_call, &self.ast_builder)
     } else {
       init_call
     }
@@ -493,13 +489,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     if let Some(ns_alias) = namespace_alias {
       if !optimize_namespace_alias_transform {
-        expr = ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+        expr = ast::Expression::new_static_member_expression(
           SPAN,
           expr,
           IdentifierName::new_id_name(SPAN, &ns_alias.property_name, &self.ast_builder),
           false,
           &self.ast_builder,
-        ));
+        );
       }
 
       if preserve_this_semantic_if_needed {
@@ -758,13 +754,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // Turn `var ... = ...` to `... = ...`
       let init_expr = var_decl.init?;
       let left = var_decl.id.into_assignment_target(&self.ast_builder);
-      Some(ast::Expression::AssignmentExpression(ast::AssignmentExpression::boxed(
+      Some(ast::Expression::new_assignment_expression(
         SPAN,
         ast::AssignmentOperator::Assign,
         left,
         init_expr,
         &self.ast_builder,
-      )))
+      ))
     });
     Some((
       ast::Expression::new_sequence_expression(
@@ -814,14 +810,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             IdentifierName::new_id_name(SPAN, prop_name, &self.ast_builder).into_in(self.alloc),
           )
         } else {
-          ast::PropertyKey::StringLiteral(ast::StringLiteral::boxed(
+          ast::PropertyKey::new_string_literal(
             SPAN,
             oxc::ast::ast::Str::from_str_in(prop_name, &self.ast_builder),
             None,
             &self.ast_builder,
-          ))
+          )
         };
-        Some(ast::ObjectPropertyKind::ObjectProperty(ast::ObjectProperty::boxed(
+        Some(ast::ObjectPropertyKind::new_object_property(
           SPAN,
           ast::PropertyKind::Init,
           key,
@@ -830,7 +826,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           false,
           prop_name == "__proto__",
           &self.ast_builder,
-        )))
+        ))
       },
     ));
 
@@ -847,13 +843,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           oxc::allocator::Vec::from_iter_in(
             [
               obj_expr,
-              ast::Argument::NumericLiteral(ast::NumericLiteral::boxed(
+              ast::Argument::new_numeric_literal(
                 SPAN,
                 1.0,
                 None,
                 NumberBase::Decimal,
                 &self.ast_builder,
-              )),
+              ),
             ],
             &self.ast_builder,
           )
@@ -991,17 +987,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // Replace it with `require('url').pathToFileURL(__filename).href`
 
             // require('url')
-            let require_call = ast::CallExpression::boxed(
+            let require_call = ast::Expression::new_call_expression(
               SPAN,
               ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
               oxc::allocator::Vec::from_value_in(
-                ast::Argument::StringLiteral(ast::StringLiteral::boxed(
-                  SPAN,
-                  "url",
-                  None,
-                  &self.ast_builder,
-                )),
+                ast::Argument::new_string_literal(SPAN, "url", None, &self.ast_builder),
                 &self.ast_builder,
               ),
               false,
@@ -1009,25 +1000,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             );
 
             // require('url').pathToFileURL
-            let require_path_to_file_url = ast::StaticMemberExpression::boxed(
+            let require_path_to_file_url = ast::Expression::new_static_member_expression(
               SPAN,
-              ast::Expression::CallExpression(require_call),
+              require_call,
               ast::IdentifierName::new(SPAN, "pathToFileURL", &self.ast_builder),
               false,
               &self.ast_builder,
             );
 
             // require('url').pathToFileURL(__filename)
-            let require_path_to_file_url_call = ast::CallExpression::boxed(
+            let require_path_to_file_url_call = ast::Expression::new_call_expression(
               SPAN,
-              ast::Expression::StaticMemberExpression(require_path_to_file_url),
+              require_path_to_file_url,
               NONE,
               oxc::allocator::Vec::from_value_in(
-                ast::Argument::Identifier(ast::IdentifierReference::boxed(
-                  SPAN,
-                  "__filename",
-                  &self.ast_builder,
-                )),
+                ast::Argument::new_identifier(SPAN, "__filename", &self.ast_builder),
                 &self.ast_builder,
               ),
               false,
@@ -1035,14 +1022,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             );
 
             // require('url').pathToFileURL(__filename).href
-            let require_path_to_file_url_href = ast::StaticMemberExpression::boxed(
+            let require_path_to_file_url_href = ast::Expression::new_static_member_expression(
               original_expr_span,
-              ast::Expression::CallExpression(require_path_to_file_url_call),
+              require_path_to_file_url_call,
               ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
               false,
               &self.ast_builder,
             );
-            Some(ast::Expression::StaticMemberExpression(require_path_to_file_url_href))
+            Some(require_path_to_file_url_href)
           } else {
             // If we don't support polyfill `import.meta.url` in this platform and format, we just keep it as it is
             // so users may handle it in their own way.
@@ -1061,8 +1048,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         "dirname" | "filename" => {
           let name =
             oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), &self.ast_builder);
-          return can_polyfill_import_meta_url.then_some(ast::Expression::Identifier(
-            ast::IdentifierReference::boxed(SPAN, name, &self.ast_builder),
+          return can_polyfill_import_meta_url.then_some(ast::Expression::new_identifier(
+            SPAN,
+            name,
+            &self.ast_builder,
           ));
         }
         _ => {}
@@ -1151,7 +1140,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
       // new URL({relative_asset_path}, import.meta.url).href
       // TODO: needs import.meta.url polyfill for non esm
-      let new_expr = ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+      let new_expr = ast::Expression::new_static_member_expression(
         SPAN,
         ast::Expression::new_new_expression(
           SPAN,
@@ -1159,13 +1148,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           NONE,
           oxc::allocator::Vec::from_array_in(
             [
-              ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+              ast::Argument::new_string_literal(
                 SPAN,
                 oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_builder),
                 None,
                 &self.ast_builder,
-              )),
-              ast::Argument::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+              ),
+              ast::Argument::new_static_member_expression(
                 SPAN,
                 ast::Expression::new_import_meta(
                   // Carry the source span, so that if this generated `import.meta.url` cannot be
@@ -1177,7 +1166,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 ast::IdentifierName::new(SPAN, "url", &self.ast_builder),
                 false,
                 &self.ast_builder,
-              )),
+              ),
             ],
             &self.ast_builder,
           ),
@@ -1186,7 +1175,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
         false,
         &self.ast_builder,
-      ));
+      );
       return Some(new_expr);
     }
     None
@@ -1328,26 +1317,25 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // NodeId, so this synthetic expression won't match scan-time records.
     let ns_name = self.canonical_name_for(ns_alias.namespace_ref);
     let ns_id_ref = Expression::new_id_ref_expr(SPAN, ns_name, &self.ast_builder);
-    let default_access =
-      ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
-        SPAN,
-        ns_id_ref,
-        ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
-        false,
-        &self.ast_builder,
-      ));
+    let default_access = ast::Expression::new_static_member_expression(
+      SPAN,
+      ns_id_ref,
+      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+      false,
+      &self.ast_builder,
+    );
 
     // Create: ns_name.default.property or ns_name.default[expression]
     match property {
       CjsMemberProperty::Static(property_name) => {
-        let final_access = ast::StaticMemberExpression::boxed(
+        let final_access = ast::SimpleAssignmentTarget::new_static_member_expression(
           SPAN,
           default_access,
           IdentifierName::new_id_name(SPAN, property_name, &self.ast_builder),
           false,
           &self.ast_builder,
         );
-        Some(ast::SimpleAssignmentTarget::StaticMemberExpression(final_access))
+        Some(final_access)
       }
       CjsMemberProperty::Computed(expr) => {
         // Finalize the computed key expression (e.g. inline constants) so that an
@@ -1358,14 +1346,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             .unwrap_or_else(|| expr.clone_in(self.alloc)),
           _ => expr.clone_in(self.alloc),
         };
-        let final_access = ast::ComputedMemberExpression::boxed(
+        let final_access = ast::SimpleAssignmentTarget::new_computed_member_expression(
           SPAN,
           default_access,
           finalized_expr,
           false,
           &self.ast_builder,
         );
-        Some(ast::SimpleAssignmentTarget::ComputedMemberExpression(final_access))
+        Some(final_access)
       }
     }
   }
@@ -1472,29 +1460,29 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   if hint.contains(FinalizedExprProcessHint::FromCjsWrapKindEntry) {
                     Some(wrap_ref_expr)
                   } else {
-                    Some(ast::Expression::CallExpression(ast::CallExpression::boxed(
+                    Some(ast::Expression::new_call_expression(
                       SPAN,
                       wrap_ref_expr,
                       NONE,
                       oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
                       &self.ast_builder,
-                    )))
+                    ))
                   }
                 } else {
                   let (ns_name, _) =
                     self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
                   let to_commonjs_ref_name = self.finalized_expr_for_runtime_symbol("__toCommonJS");
                   Some(Expression::new_seq_in_parens(
-                    ast::Expression::CallExpression(ast::CallExpression::boxed(
+                    ast::Expression::new_call_expression(
                       SPAN,
                       wrap_ref_expr,
                       NONE,
                       oxc::allocator::Vec::new_in(&self.ast_builder),
                       false,
                       &self.ast_builder,
-                    )),
-                    ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
+                    ),
+                    ast::Expression::new_static_member_expression(
                       SPAN,
                       Expression::new_call_with_arg(
                         to_commonjs_ref_name,
@@ -1505,7 +1493,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
                       false,
                       &self.ast_builder,
-                    )),
+                    ),
                     &self.ast_builder,
                   ))
                 }
@@ -1525,7 +1513,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   if hint.contains(FinalizedExprProcessHint::FromCjsWrapKindEntry) {
                     wrap_ref_expr
                   } else {
-                    ast::Expression::CallExpression(ast::CallExpression::boxed_with_pure(
+                    ast::Expression::new_call_expression_with_pure(
                       SPAN,
                       wrap_ref_expr,
                       NONE,
@@ -1533,7 +1521,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       false,
                       self.ctx.final_esm_init_metadata.init_is_noop(importee.idx),
                       &self.ast_builder,
-                    ))
+                    )
                   };
 
                 if matches!(importee.exports_kind, ExportsKind::CommonJs)
@@ -1551,28 +1539,27 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   // `__toCommonJS`
                   let to_commonjs_expr = self.finalized_expr_for_runtime_symbol("__toCommonJS");
                   // `__toCommonJS(xxx_exports)`
-                  let to_commonjs_call_expr =
-                    ast::Expression::CallExpression(ast::CallExpression::boxed(
-                      SPAN,
-                      to_commonjs_expr,
-                      NONE,
-                      oxc::allocator::Vec::from_value_in(
-                        ast::Argument::from(namespace_object_ref_expr),
-                        &self.ast_builder,
-                      ),
-                      false,
+                  let to_commonjs_call_expr = ast::Expression::new_call_expression(
+                    SPAN,
+                    to_commonjs_expr,
+                    NONE,
+                    oxc::allocator::Vec::from_value_in(
+                      ast::Argument::from(namespace_object_ref_expr),
                       &self.ast_builder,
-                    ));
+                    ),
+                    false,
+                    &self.ast_builder,
+                  );
 
                   let final_expr = if is_json_module {
                     // `__toCommonJS(xxx_exports).default`
-                    Expression::from(ast::MemberExpression::new_static_member_expression(
+                    Expression::new_static_member_expression(
                       SPAN,
                       to_commonjs_call_expr,
                       ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
                       false,
                       &self.ast_builder,
-                    ))
+                    )
                   } else {
                     to_commonjs_call_expr
                   };
@@ -1591,7 +1578,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let request_path =
               call_expr.arguments.get_mut(0).expect("require should have an argument");
             // Rewrite `require('xxx')` to `require('fs')`, if there is an alias that maps 'xxx' to 'fs'
-            *request_path = ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+            *request_path = ast::Argument::new_string_literal(
               request_path.span(),
               oxc::ast::ast::Str::from_str_in(
                 &importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths),
@@ -1599,7 +1586,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               ),
               None,
               &self.ast_builder,
-            ));
+            );
             None
           }
         };
@@ -1622,14 +1609,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return Some(Expression::new_promise_resolve_then(
         Expression::new_call_with_arg(
           Expression::new_member_access_expr("Object", "freeze", &self.ast_builder),
-          ast::Expression::ObjectExpression(ast::ObjectExpression::boxed(
+          ast::Expression::new_object_expression(
             SPAN,
             oxc::allocator::Vec::from_value_in(
               ast::ObjectPropertyKind::new_object_property(
                 SPAN,
                 ast::PropertyKind::Init,
                 ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_builder),
-                ast::Expression::NullLiteral(ast::NullLiteral::boxed(SPAN, &self.ast_builder)),
+                ast::Expression::new_null_literal(SPAN, &self.ast_builder),
                 false,
                 false,
                 false,
@@ -1638,7 +1625,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               &self.ast_builder,
             ),
             &self.ast_builder,
-          )),
+          ),
           true,
           &self.ast_builder,
         ),
@@ -1893,11 +1880,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     &self.ast_builder,
                   );
                   if importee_linking_info.is_tla_or_contains_tla_dependency {
-                    init_expr = ast::Expression::AwaitExpression(ast::AwaitExpression::boxed(
+                    init_expr = ast::Expression::new_await_expression(
                       SPAN,
                       init_expr,
                       &self.ast_builder,
-                    ));
+                    );
                   }
                   program.body.push(ast::Statement::new_expression_statement(
                     SPAN,
@@ -1927,13 +1914,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                         importer_namespace_ref,
                         importee_namespace_ref, &self.ast_builder
                       );
+                      let call_expr = Expression::CallExpression(call_expr.into_in(self.alloc));
                       // __reExport(exports, otherExports)
-                      let stmt =
-                        ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-                          SPAN,
-                          Expression::CallExpression(call_expr.into_in(self.alloc)),
-                          &self.ast_builder,
-                        ));
+                      let stmt = ast::Statement::new_expression_statement(SPAN, call_expr, &self.ast_builder);
                       program.body.push(stmt);
                     }
                   }
@@ -1969,25 +1952,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       importer_namespace_ref,
                       Expression::new_to_esm_wrapper(
                         to_esm_fn_ref,
-                        ast::Expression::CallExpression(ast::CallExpression::boxed(
+                        ast::Expression::new_call_expression(
                           SPAN,
                           importee_wrapper_ref_expr,
                           NONE,
                           oxc::allocator::Vec::new_in(&self.ast_builder),
                           false,
                           &self.ast_builder,
-                        )),
+                        ),
                         self.ctx.module.should_consider_node_esm_spec_for_static_import(), &self.ast_builder
                       ), &self.ast_builder
                     );
 
                     // __reExport(importer_exports, __toESM(require_foo()))
-                    let stmt =
-                      ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(
-                        SPAN,
-                        Expression::CallExpression(call_expr.into_in(self.alloc)),
-                        &self.ast_builder,
-                      ));
+                    let stmt = ast::Statement::new_expression_statement(
+                      SPAN,
+                      Expression::CallExpression(call_expr.into_in(self.alloc)),
+                      &self.ast_builder,
+                    );
                     program.body.push(stmt);
                   }
                   ExportsKind::None => {}
@@ -2395,14 +2377,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
 
           // init_xxx()
-          let wrapper_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
+          let wrapper_call_expr = ast::Expression::new_call_expression(
             SPAN,
             finalized_importee_wrapper_ref,
             NONE,
             oxc::allocator::Vec::new_in(&self.ast_builder),
             false,
             &self.ast_builder,
-          ));
+          );
 
           // (init_xxx(), namespace_exports)
           Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, &self.ast_builder)
@@ -2458,22 +2440,22 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let base_expr = if matches!(self.ctx.options.format, OutputFormat::Cjs) {
             let import_path = self.ctx.chunk.import_path_for(importee_chunk);
             // require('./some-module.js')
-            let require_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
+            let require_call_expr = ast::Expression::new_call_expression(
               SPAN,
               ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
               oxc::allocator::Vec::from_value_in(
-                ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+                ast::Argument::new_string_literal(
                   expr.span,
                   oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
                   None,
                   &self.ast_builder,
-                )),
+                ),
                 &self.ast_builder,
               ),
               false,
               &self.ast_builder,
-            ));
+            );
             // Promise.resolve().then(() => require('./some-module.js'))
             Expression::new_promise_resolve_then(require_call_expr, &self.ast_builder)
           } else {
@@ -2597,12 +2579,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         };
 
         let import_path = self.ctx.chunk.import_path_for(importee_chunk);
-        expr.source = Expression::StringLiteral(ast::StringLiteral::boxed(
+        expr.source = Expression::new_string_literal(
           expr.source.span(),
           oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
           None,
           &self.ast_builder,
-        ));
+        );
 
         if let Some(rewritten_expr) = self.rewrite_dynamic_import_for_merged_entry(
           expr,
@@ -2619,36 +2601,35 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // when format is CJS
         if matches!(self.ctx.options.format, OutputFormat::Cjs) {
           // require('foo.mjs')
-          let mut require_call_expr = ast::Expression::CallExpression(ast::CallExpression::boxed(
+          let mut require_call_expr = ast::Expression::new_call_expression(
             SPAN,
             ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
             oxc::allocator::Vec::from_value_in(
-              ast::Argument::StringLiteral(ast::StringLiteral::boxed(
+              ast::Argument::new_string_literal(
                 expr.span,
                 oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
                 None,
                 &self.ast_builder,
-              )),
+              ),
               &self.ast_builder,
             ),
             false,
             &self.ast_builder,
-          ));
+          );
 
           if importee.exports_kind.is_commonjs() {
             // Inline __toDynamicImportESM: __toESM(require('foo.mjs').default, isNodeMode)
             let to_esm_fn_name = self.finalized_expr_for_runtime_symbol("__toESM");
 
             // require('foo.mjs').default
-            let require_default_expr =
-              ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
-                SPAN,
-                require_call_expr,
-                ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
-                false,
-                &self.ast_builder,
-              ));
+            let require_default_expr = ast::Expression::new_static_member_expression(
+              SPAN,
+              require_call_expr,
+              ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+              false,
+              &self.ast_builder,
+            );
 
             // __toESM(require('foo.mjs').default, isNodeMode)
             require_call_expr = Expression::new_to_esm_wrapper(
@@ -2668,12 +2649,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       Module::External(importee) => {
         let import_path = importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
         if str != import_path {
-          expr.source = Expression::StringLiteral(ast::StringLiteral::boxed(
+          expr.source = Expression::new_string_literal(
             expr.source.span(),
             oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
             None,
             &self.ast_builder,
-          ));
+          );
         }
         // Convert `import("external")` to `Promise.resolve().then(() => __toESM(require("external")))`
         // when format is CJS and dynamicImportInCjs is false
@@ -2713,14 +2694,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       node.replace_with(|original_import_expr| {
         // Build arrow function: (m) => __toESM(m.default, isNodeMode)
         // m.default
-        let m_default_expr =
-          ast::Expression::StaticMemberExpression(ast::StaticMemberExpression::boxed(
-            SPAN,
-            ast::Expression::new_identifier(SPAN, "m", &self.ast_builder),
-            ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
-            false,
-            &self.ast_builder,
-          ));
+        let m_default_expr = ast::Expression::new_static_member_expression(
+          SPAN,
+          ast::Expression::new_identifier(SPAN, "m", &self.ast_builder),
+          ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+          false,
+          &self.ast_builder,
+        );
 
         // __toESM(m.default, isNodeMode)
         let to_esm_call = Expression::new_to_esm_wrapper(
@@ -2731,7 +2711,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         );
 
         // (m) => __toESM(m.default, isNodeMode)
-        let arrow_fn = ast::ArrowFunctionExpression::boxed(
+        let arrow_fn = ast::Argument::new_arrow_function_expression(
           SPAN,
           true,  // expression
           false, // async
@@ -2775,7 +2755,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         );
 
         // `import('./some-cjs-module.js').then
-        let callee = ast::StaticMemberExpression::boxed(
+        let callee = ast::Expression::new_static_member_expression(
           SPAN,
           original_import_expr,
           ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
@@ -2784,19 +2764,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         );
 
         // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
-        let call_expr = ast::CallExpression::boxed(
+        ast::Expression::new_call_expression(
           SPAN,
-          ast::Expression::StaticMemberExpression(callee),
+          callee,
           NONE,
-          oxc::allocator::Vec::from_value_in(
-            ast::Argument::ArrowFunctionExpression(arrow_fn),
-            &self.ast_builder,
-          ),
+          oxc::allocator::Vec::from_value_in(arrow_fn, &self.ast_builder),
           false,
           &self.ast_builder,
-        );
-
-        ast::Expression::CallExpression(call_expr)
+        )
       });
     }
 

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -86,12 +86,10 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
 
     let canonical_name = self.canonical_name_for(canonical_ref);
     if id_ref.name != canonical_name {
-      return Some(ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(
-        ast::IdentifierReference::boxed(
-          id_ref.span,
-          oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder),
-          &self.ast_builder,
-        ),
+      return Some(ast::SimpleAssignmentTarget::new_assignment_target_identifier(
+        id_ref.span,
+        oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder),
+        &self.ast_builder,
       ));
     }
 

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -202,11 +202,11 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
             property.computed = true;
           } else if is_legal_ident {
             property.shorthand = is_legal_ident;
-            property.key = ast::PropertyKey::StaticIdentifier(ast::IdentifierName::boxed(
+            property.key = ast::PropertyKey::new_static_identifier(
               SPAN,
               oxc::ast::ast::Str::from_str_in(legitimized_ident.as_ref(), &ast_builder),
               &ast_builder,
-            ));
+            );
           }
           match index_map.entry(legitimized_ident) {
             Entry::Occupied(mut occ) => {

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -82,7 +82,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
           &self.ast_builder,
         );
         if let Some(named_decl_span) = named_decl_span {
-          Statement::ExportNamedDeclaration(ast::ExportNamedDeclaration::boxed(
+          Statement::new_export_named_declaration(
             if i == 0 { named_decl_span } else { SPAN },
             Some(Declaration::VariableDeclaration(new_decl)),
             oxc::allocator::Vec::new_in(&self.ast_builder),
@@ -91,7 +91,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
             ImportOrExportKind::Value,
             NONE,
             &self.ast_builder,
-          ))
+          )
         } else {
           Statement::VariableDeclaration(new_decl)
         }
@@ -196,11 +196,11 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
     }
     walk_mut::walk_statement(self, it);
     if let Some(split) = self.split_multi_declarator(it, false) {
-      *it = Statement::BlockStatement(ast::BlockStatement::boxed(
+      *it = Statement::new_block_statement(
         SPAN,
         oxc::allocator::Vec::from_iter_in(split, &self.ast_builder),
         &self.ast_builder,
-      ));
+      );
     }
   }
 
@@ -253,7 +253,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
           unreachable!()
         };
         let cond_expr = cond_expr.unbox();
-        ast::Expression::ConditionalExpression(ast::ConditionalExpression::boxed(
+        ast::Expression::new_conditional_expression(
           SPAN,
           cond_expr.test,
           ast::Expression::new_call_expression(
@@ -279,7 +279,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
             &self.ast_builder,
           ),
           &self.ast_builder,
-        ))
+        )
       });
     }
     // transpose `import(test ? 'a' : 'b')` into `test ? import('a') : import('b')`

--- a/crates/rolldown_common/src/ecmascript/json_to_program.rs
+++ b/crates/rolldown_common/src/ecmascript/json_to_program.rs
@@ -104,7 +104,7 @@ pub fn json_value_to_expression<'a>(
     Value::Object(obj) => {
       let properties = oxc::allocator::Vec::from_iter_in(
         obj.iter().map(|(key, val)| {
-          let key_expr = oxc::ast::ast::Expression::new_string_literal(
+          let key_expr = oxc::ast::ast::PropertyKey::new_string_literal(
             SPAN,
             oxc::ast::ast::Str::from_str_in(key, builder),
             None,
@@ -115,7 +115,7 @@ pub fn json_value_to_expression<'a>(
           oxc::ast::ast::ObjectPropertyKind::new_object_property(
             SPAN,
             oxc::ast::ast::PropertyKind::Init,
-            oxc::ast::ast::PropertyKey::from(key_expr),
+            key_expr,
             value_expr,
             false, // method
             false, // shorthand

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -19,16 +19,13 @@ use oxc::{
   allocator::{self, GetAllocator, IntoIn},
   ast::{
     ast::{
-      Argument, ArrowFunctionExpression, AssignmentExpression, AssignmentOperator,
-      AssignmentTarget, BindingIdentifier, BindingPattern, CallExpression, ClassElement,
-      Declaration, ExportDefaultDeclarationKind, ExportSpecifier, Expression, ExpressionStatement,
-      FormalParameter, FormalParameterKind, FormalParameters, Function, FunctionBody, FunctionType,
-      IdentifierName, IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier,
-      ImportNamespaceSpecifier, ImportOrExportKind, MemberExpression, ModuleDeclaration,
-      ModuleExportName, NumberBase, ObjectExpression, ObjectPropertyKind, ParenthesizedExpression,
-      PropertyKey, PropertyKind, ReturnStatement, SequenceExpression, SimpleAssignmentTarget,
-      Statement, StaticMemberExpression, StringLiteral, VariableDeclaration,
-      VariableDeclarationKind, VariableDeclarator,
+      Argument, ArrowFunctionExpression, AssignmentOperator, AssignmentTarget, BindingIdentifier,
+      BindingPattern, CallExpression, ClassElement, Declaration, ExportDefaultDeclarationKind,
+      ExportSpecifier, Expression, FormalParameter, FormalParameterKind, FormalParameters,
+      FunctionBody, FunctionType, IdentifierName, ImportDeclarationSpecifier, ImportOrExportKind,
+      MemberExpression, ModuleExportName, NumberBase, ObjectExpression, ObjectPropertyKind,
+      PropertyKey, PropertyKind, Statement, StringLiteral, VariableDeclarationKind,
+      VariableDeclarator,
     },
     builder::{GetAstBuilder, NONE},
   },
@@ -83,10 +80,10 @@ pub trait ExpressionFactoryExt<'ast> {
     builder: &B,
   ) -> Expression<'ast> {
     let statements = oxc::allocator::Vec::from_value_in(
-      Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, expr, builder)),
+      Statement::new_expression_statement(SPAN, expr, builder),
       builder,
     );
-    Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
+    Expression::new_arrow_function_expression(
       SPAN,
       true,
       false,
@@ -101,7 +98,7 @@ pub trait ExpressionFactoryExt<'ast> {
       NONE,
       FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder),
       builder,
-    ))
+    )
   }
 
   /// `<object>.<property>` as an `Expression`.
@@ -132,13 +129,13 @@ pub trait ExpressionFactoryExt<'ast> {
     expr: Expression<'ast>,
     builder: &B,
   ) -> Expression<'ast> {
-    Expression::CallExpression(CallExpression::boxed(
+    Expression::new_call_expression(
       SPAN,
-      Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      Expression::new_static_member_expression(
         SPAN,
-        Expression::CallExpression(CallExpression::boxed(
+        Expression::new_call_expression(
           SPAN,
-          Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+          Expression::new_static_member_expression(
             SPAN,
             Expression::new_identifier(
               SPAN,
@@ -148,16 +145,16 @@ pub trait ExpressionFactoryExt<'ast> {
             IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("resolve", builder), builder),
             false,
             builder,
-          )),
+          ),
           NONE,
           oxc::allocator::Vec::new_in(builder),
           false,
           builder,
-        )),
+        ),
         IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("then", builder), builder),
         false,
         builder,
-      )),
+      ),
       NONE,
       oxc::allocator::Vec::from_value_in(
         Argument::from(Expression::new_arrow_returning(expr, builder)),
@@ -165,7 +162,7 @@ pub trait ExpressionFactoryExt<'ast> {
       ),
       false,
       builder,
-    ))
+    )
   }
 
   /// `None` → `<call_expr>`; `Babel` → `__toESM(<call_expr>)`; `Node` → `__toESM(<call_expr>, 1)`.
@@ -183,13 +180,7 @@ pub trait ExpressionFactoryExt<'ast> {
       Some(Interop::Node) => oxc::allocator::Vec::from_iter_in(
         [
           Argument::from(call_expr),
-          Argument::from(Expression::new_numeric_literal(
-            SPAN,
-            1.0,
-            None,
-            NumberBase::Decimal,
-            builder,
-          )),
+          Argument::new_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal, builder),
         ],
         builder,
       ),
@@ -217,11 +208,11 @@ pub trait ExpressionFactoryExt<'ast> {
     let mut expressions = oxc::allocator::Vec::with_capacity_in(2, builder);
     expressions.push(a);
     expressions.push(b);
-    Expression::ParenthesizedExpression(ParenthesizedExpression::boxed(
+    Expression::new_parenthesized_expression(
       SPAN,
-      Expression::SequenceExpression(SequenceExpression::boxed(SPAN, expressions, builder)),
+      Expression::new_sequence_expression(SPAN, expressions, builder),
       builder,
-    ))
+    )
   }
 
   /// `<object>.<prop>.<prop>...` — chains member access for each prop, then sets the span.
@@ -234,7 +225,7 @@ pub trait ExpressionFactoryExt<'ast> {
     let mut cur = object;
     for prop in props {
       cur = if oxc::syntax::identifier::is_identifier_name(&prop.name) {
-        Expression::from(MemberExpression::new_static_member_expression(
+        Expression::new_static_member_expression(
           SPAN,
           cur,
           IdentifierName::new(
@@ -244,9 +235,9 @@ pub trait ExpressionFactoryExt<'ast> {
           ),
           prop.optional,
           builder,
-        ))
+        )
       } else {
-        Expression::from(MemberExpression::new_computed_member_expression(
+        Expression::new_computed_member_expression(
           SPAN,
           cur,
           Expression::new_string_literal(
@@ -257,7 +248,7 @@ pub trait ExpressionFactoryExt<'ast> {
           ),
           prop.optional,
           builder,
-        ))
+        )
       };
     }
     *cur.span_mut() = span;
@@ -326,20 +317,14 @@ pub trait ExpressionFactoryExt<'ast> {
       oxc::allocator::Vec::from_iter_in(
         [
           Argument::from(expr),
-          Argument::from(Expression::new_numeric_literal(
-            SPAN,
-            1.0,
-            None,
-            NumberBase::Decimal,
-            builder,
-          )),
+          Argument::new_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal, builder),
         ],
         builder,
       )
     } else {
       oxc::allocator::Vec::from_value_in(Argument::from(expr), builder)
     };
-    Expression::CallExpression(CallExpression::boxed_with_pure(
+    Expression::new_call_expression_with_pure(
       SPAN,
       to_esm_fn_expr,
       NONE,
@@ -347,7 +332,7 @@ pub trait ExpressionFactoryExt<'ast> {
       false,
       true,
       builder,
-    ))
+    )
   }
 
   /// `<call_expr>.then(() => <return_expr>)`
@@ -356,15 +341,15 @@ pub trait ExpressionFactoryExt<'ast> {
     return_expr: Expression<'ast>,
     builder: &B,
   ) -> Expression<'ast> {
-    Expression::CallExpression(CallExpression::boxed(
+    Expression::new_call_expression(
       SPAN,
-      Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      Expression::new_static_member_expression(
         SPAN,
         call_expr,
         IdentifierName::new(SPAN, "then", builder),
         false,
         builder,
-      )),
+      ),
       NONE,
       oxc::allocator::Vec::from_value_in(
         Argument::from(Expression::new_arrow_returning(return_expr, builder)),
@@ -372,7 +357,7 @@ pub trait ExpressionFactoryExt<'ast> {
       ),
       false,
       builder,
-    ))
+    )
   }
 }
 
@@ -414,13 +399,13 @@ pub trait MemberExpressionFactoryExt<'ast> {
     property: &str,
     builder: &B,
   ) -> MemberExpression<'ast> {
-    MemberExpression::StaticMemberExpression(StaticMemberExpression::boxed(
+    MemberExpression::new_static_member_expression(
       SPAN,
       Expression::new_id_ref_expr(SPAN, object, builder),
       IdentifierName::new_id_name(SPAN, property, builder),
       false,
       builder,
-    ))
+    )
   }
 }
 
@@ -439,12 +424,12 @@ pub trait ObjectPropertyKindFactoryExt<'ast> {
       SPAN,
       PropertyKind::Init,
       if computed {
-        PropertyKey::from(Expression::new_string_literal(
+        PropertyKey::new_string_literal(
           SPAN,
           oxc::ast::ast::Str::from_str_in(key, builder),
           None,
           builder,
-        ))
+        )
       } else {
         PropertyKey::new_static_identifier(
           SPAN,
@@ -529,13 +514,13 @@ pub trait CallExpressionFactoryExt<'ast> {
   ) -> allocator::Box<'ast, CallExpression<'ast>> {
     debug_assert!(is_validate_identifier_name(property_name));
     // `n.<property_name>`
-    let member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+    let member = Expression::new_static_member_expression(
       SPAN,
       Expression::new_identifier(SPAN, "n", builder),
       IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, builder), builder),
       false,
       builder,
-    ));
+    );
     then_with_arrow_callback(expr, member, builder)
   }
 
@@ -546,13 +531,13 @@ pub trait CallExpressionFactoryExt<'ast> {
     namespace_name: &str,
     builder: &B,
   ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let wrapper_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+    let wrapper_member = Expression::new_static_member_expression(
       SPAN,
       Expression::new_identifier(SPAN, "n", builder),
       IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(wrapper_name, builder), builder),
       false,
       builder,
-    ));
+    );
     let wrapper_call = Expression::new_call_expression(
       SPAN,
       wrapper_member,
@@ -561,13 +546,13 @@ pub trait CallExpressionFactoryExt<'ast> {
       false,
       builder,
     );
-    let namespace_member = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+    let namespace_member = Expression::new_static_member_expression(
       SPAN,
       Expression::new_identifier(SPAN, "n", builder),
       IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(namespace_name, builder), builder),
       false,
       builder,
-    ));
+    );
     let seq_expr = Expression::new_seq_in_parens(wrapper_call, namespace_member, builder);
     then_with_arrow_callback(expr, seq_expr, builder)
   }
@@ -580,13 +565,13 @@ pub trait CallExpressionFactoryExt<'ast> {
     node_mode: bool,
     builder: &B,
   ) -> allocator::Box<'ast, CallExpression<'ast>> {
-    let member_expr = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+    let member_expr = Expression::new_static_member_expression(
       SPAN,
       Expression::new_identifier(SPAN, "n", builder),
       IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in(property_name, builder), builder),
       false,
       builder,
-    ));
+    );
     let wrapper_call = Expression::new_call_expression(
       SPAN,
       member_expr,
@@ -628,13 +613,13 @@ pub trait StatementFactoryExt<'ast> {
       builder,
     );
 
-    Statement::from(Declaration::VariableDeclaration(VariableDeclaration::boxed(
+    Statement::new_variable_declaration(
       SPAN,
       VariableDeclarationKind::Var,
       declarations,
       false,
       builder,
-    )))
+    )
   }
 
   /// `export default <expr>`
@@ -642,11 +627,11 @@ pub trait StatementFactoryExt<'ast> {
     expr: Expression<'ast>,
     builder: &B,
   ) -> Statement<'ast> {
-    Statement::from(ModuleDeclaration::new_export_default_declaration(
+    Statement::new_export_default_declaration(
       SPAN,
       ExportDefaultDeclarationKind::from(expr),
       builder,
-    ))
+    )
   }
 
   /// `module.exports = <expr>`
@@ -659,15 +644,13 @@ pub trait StatementFactoryExt<'ast> {
       Expression::new_assignment_expression(
         SPAN,
         AssignmentOperator::Assign,
-        AssignmentTarget::from(SimpleAssignmentTarget::from(
-          MemberExpression::new_static_member_expression(
-            SPAN,
-            Expression::new_identifier(SPAN, "module", builder),
-            IdentifierName::new(SPAN, "exports", builder),
-            false,
-            builder,
-          ),
-        )),
+        AssignmentTarget::new_static_member_expression(
+          SPAN,
+          Expression::new_identifier(SPAN, "module", builder),
+          IdentifierName::new(SPAN, "exports", builder),
+          false,
+          builder,
+        ),
         expr,
         builder,
       ),
@@ -686,7 +669,7 @@ pub trait StatementFactoryExt<'ast> {
     I: Iterator<Item = (&'a T, &'a (T, bool))>,
     B: GetAstBuilder<'ast> + GetAllocator<'ast>,
   {
-    Statement::from(ModuleDeclaration::new_export_named_declaration(
+    Statement::new_export_named_declaration(
       SPAN,
       declaration,
       oxc::allocator::Vec::from_iter_in(
@@ -722,7 +705,7 @@ pub trait StatementFactoryExt<'ast> {
       ImportOrExportKind::Value,
       NONE,
       builder,
-    ))
+    )
   }
 
   /// `import * as <as_name> from "<source>";`
@@ -732,14 +715,14 @@ pub trait StatementFactoryExt<'ast> {
     builder: &B,
   ) -> Statement<'ast> {
     let specifiers = oxc::allocator::Vec::from_value_in(
-      ImportDeclarationSpecifier::ImportNamespaceSpecifier(ImportNamespaceSpecifier::boxed(
+      ImportDeclarationSpecifier::new_import_namespace_specifier(
         SPAN,
         BindingIdentifier::new(SPAN, oxc::ast::ast::Str::from_str_in(as_name, builder), builder),
         builder,
-      )),
+      ),
       builder,
     );
-    Statement::ImportDeclaration(ImportDeclaration::boxed(
+    Statement::new_import_declaration(
       SPAN,
       Some(specifiers),
       StringLiteral::new(SPAN, oxc::ast::ast::Str::from_str_in(source, builder), None, builder),
@@ -747,7 +730,7 @@ pub trait StatementFactoryExt<'ast> {
       NONE,
       ImportOrExportKind::Value,
       builder,
-    ))
+    )
   }
 
   /// `var <binding_name> = __commonJS(... (exports, module) => { <statements> } ...)`
@@ -817,12 +800,12 @@ pub trait StatementFactoryExt<'ast> {
           ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
-            PropertyKey::from(Expression::new_string_literal(
+            PropertyKey::new_string_literal(
               SPAN,
               oxc::ast::ast::Str::from_str_in(stable_id, builder),
               None,
               builder,
-            )),
+            ),
             Expression::ArrowFunctionExpression(arrow_expr),
             true,
             false,
@@ -894,12 +877,12 @@ pub trait StatementFactoryExt<'ast> {
           ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
-            PropertyKey::from(Expression::new_string_literal(
+            PropertyKey::new_string_literal(
               SPAN,
               oxc::ast::ast::Str::from_str_in(stable_id, builder),
               None,
               builder,
-            )),
+            ),
             Expression::ArrowFunctionExpression(arrow_expr),
             false,
             false,
@@ -921,17 +904,17 @@ pub trait StatementFactoryExt<'ast> {
         builder,
       );
     }
-    let assignment_expr = Expression::AssignmentExpression(AssignmentExpression::boxed(
+    let assignment_expr = Expression::new_assignment_expression(
       SPAN,
       AssignmentOperator::Assign,
-      AssignmentTarget::AssignmentTargetIdentifier(IdentifierReference::boxed(
+      AssignmentTarget::new_assignment_target_identifier(
         SPAN,
         oxc::ast::ast::Str::from_str_in(binding_name, builder),
         builder,
-      )),
+      ),
       Expression::CallExpression(esm_call_expr.into_in(builder.allocator())),
       builder,
-    ));
+    );
     let call_expr = Expression::new_call_expression(
       SPAN,
       assignment_expr,
@@ -940,7 +923,7 @@ pub trait StatementFactoryExt<'ast> {
       false,
       builder,
     );
-    Statement::FunctionDeclaration(Function::boxed(
+    Statement::new_function_declaration(
       SPAN,
       FunctionType::FunctionDeclaration,
       Some(BindingIdentifier::new(
@@ -965,13 +948,13 @@ pub trait StatementFactoryExt<'ast> {
         SPAN,
         oxc::allocator::Vec::new_in(builder),
         oxc::allocator::Vec::from_value_in(
-          Statement::ReturnStatement(ReturnStatement::boxed(SPAN, Some(call_expr), builder)),
+          Statement::new_return_statement(SPAN, Some(call_expr), builder),
           builder,
         ),
         builder,
       )),
       builder,
-    ))
+    )
   }
 }
 
@@ -983,7 +966,7 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
   return_expr: Expression<'ast>,
   builder: &B,
 ) -> allocator::Box<'ast, CallExpression<'ast>> {
-  let arrow_fn = ArrowFunctionExpression::boxed(
+  let arrow_fn = Argument::new_arrow_function_expression(
     SPAN,
     true,
     false,
@@ -1018,14 +1001,14 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
       SPAN,
       oxc::allocator::Vec::new_in(builder),
       oxc::allocator::Vec::from_value_in(
-        Statement::ExpressionStatement(ExpressionStatement::boxed(SPAN, return_expr, builder)),
+        Statement::new_expression_statement(SPAN, return_expr, builder),
         builder,
       ),
       builder,
     ),
     builder,
   );
-  let callee = StaticMemberExpression::boxed(
+  let callee = Expression::new_static_member_expression(
     SPAN,
     expr,
     IdentifierName::new(SPAN, "then", builder),
@@ -1034,12 +1017,9 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
   );
   CallExpression::boxed(
     SPAN,
-    Expression::StaticMemberExpression(callee),
+    callee,
     NONE,
-    oxc::allocator::Vec::from_value_in(
-      Expression::ArrowFunctionExpression(arrow_fn).into(),
-      builder,
-    ),
+    oxc::allocator::Vec::from_value_in(arrow_fn, builder),
     false,
     builder,
   )

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -3,10 +3,8 @@ use oxc::{
   allocator::TakeIn as _,
   ast::{
     ast::{
-      ArrayAssignmentTarget, ArrayExpression, ArrayExpressionElement, AssignmentTarget,
-      AssignmentTargetMaybeDefault, AssignmentTargetRest, AssignmentTargetWithDefault,
-      BindingPattern, Elision, Expression, IdentifierReference, ObjectAssignmentTarget,
-      ObjectExpression, ObjectProperty, ObjectPropertyKind, PropertyKind, SpreadElement,
+      ArrayExpressionElement, AssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetRest,
+      BindingPattern, Expression, ObjectPropertyKind, PropertyKind,
     },
     builder::GetAstBuilder,
   },
@@ -34,9 +32,9 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
   ) -> AssignmentTarget<'ast> {
     match self {
       // Turn `var a = 1` into `a = 1`
-      BindingPattern::BindingIdentifier(id) => AssignmentTarget::AssignmentTargetIdentifier(
-        IdentifierReference::boxed(id.span, id.name, builder),
-      ),
+      BindingPattern::BindingIdentifier(id) => {
+        AssignmentTarget::new_assignment_target_identifier(id.span, id.name, builder)
+      }
       // Turn `var { a, b = 2 } = ...` to `{a, b = 2} = ...`
       BindingPattern::ObjectPattern(mut obj_pat) => {
         let rest = obj_pat.rest.take().map(|rest| {
@@ -51,9 +49,7 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
         obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|binding_prop| {
           properties.push(binding_prop.into_assignment_target_property(builder));
         });
-        AssignmentTarget::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
-          SPAN, properties, rest, builder,
-        ))
+        AssignmentTarget::new_object_assignment_target(SPAN, properties, rest, builder)
       }
       // Turn `var [a, ,c = 1] = ...` to `[a, ,c = 1] = ...`
       BindingPattern::ArrayPattern(mut arr_pat) => {
@@ -69,24 +65,17 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
           elements.push(binding_pat.map(|binding_pat| match binding_pat {
             BindingPattern::AssignmentPattern(assign_pat) => {
               let assign_pat = assign_pat.unbox();
-              AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
-                AssignmentTargetWithDefault::boxed(
-                  assign_pat.span,
-                  assign_pat.left.into_assignment_target(builder),
-                  assign_pat.right,
-                  builder,
-                ),
+              AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+                assign_pat.span,
+                assign_pat.left.into_assignment_target(builder),
+                assign_pat.right,
+                builder,
               )
             }
             _ => AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(builder)),
           }));
         });
-        AssignmentTarget::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
-          arr_pat.span,
-          elements,
-          rest,
-          builder,
-        ))
+        AssignmentTarget::new_array_assignment_target(arr_pat.span, elements, rest, builder)
       }
       BindingPattern::AssignmentPattern(_) => {
         unreachable!("`BindingPattern::AssignmentPattern` should be pre-handled in above")
@@ -104,7 +93,7 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
         let capacity = obj_pat.properties.len() + usize::from(obj_pat.rest.is_some());
         let mut properties = oxc::allocator::Vec::with_capacity_in(capacity, builder);
         obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|binding_prop| {
-          properties.push(ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
+          properties.push(ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
             binding_prop.key,
@@ -113,34 +102,35 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
             binding_prop.shorthand,
             binding_prop.computed,
             builder,
-          )));
+          ));
         });
         if let Some(rest) = obj_pat.rest.take() {
-          properties.push(ObjectPropertyKind::SpreadProperty(SpreadElement::boxed(
+          properties.push(ObjectPropertyKind::new_spread_property(
             SPAN,
             rest.unbox().argument.into_expression(builder),
             builder,
-          )));
+          ));
         }
-        Expression::ObjectExpression(ObjectExpression::boxed(SPAN, properties, builder))
+        Expression::new_object_expression(SPAN, properties, builder)
       }
       BindingPattern::ArrayPattern(mut arg_pat) => {
         let capacity = arg_pat.elements.len() + usize::from(arg_pat.rest.is_some());
         let mut elements = oxc::allocator::Vec::with_capacity_in(capacity, builder);
         arg_pat.elements.take_in(&builder.allocator()).into_iter().for_each(|binding_pat| {
-          elements.push(binding_pat.map_or(
-            ArrayExpressionElement::Elision(Elision::boxed(SPAN, builder)),
-            |binding_pat| ArrayExpressionElement::from(binding_pat.into_expression(builder)),
-          ));
+          elements.push(
+            binding_pat.map_or(ArrayExpressionElement::new_elision(SPAN, builder), |binding_pat| {
+              ArrayExpressionElement::from(binding_pat.into_expression(builder))
+            }),
+          );
         });
         if let Some(rest) = arg_pat.rest.take() {
-          elements.push(ArrayExpressionElement::SpreadElement(SpreadElement::boxed(
+          elements.push(ArrayExpressionElement::new_spread_element(
             SPAN,
             rest.unbox().argument.into_expression(builder),
             builder,
-          )));
+          ));
         }
-        Expression::ArrayExpression(ArrayExpression::boxed(SPAN, elements, builder))
+        Expression::new_array_expression(SPAN, elements, builder)
       }
       BindingPattern::AssignmentPattern(mut assign_pat) => {
         assign_pat.left.take_in(&builder.allocator()).into_expression(builder)

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
@@ -3,10 +3,8 @@ use oxc::{
   allocator::{IntoIn as _, TakeIn},
   ast::{
     ast::{
-      ArrayAssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
-      AssignmentTargetPropertyIdentifier, AssignmentTargetPropertyProperty, AssignmentTargetRest,
-      AssignmentTargetWithDefault, BindingPattern, BindingProperty, IdentifierReference,
-      ObjectAssignmentTarget,
+      AssignmentTargetMaybeDefault, AssignmentTargetProperty, AssignmentTargetRest, BindingPattern,
+      BindingProperty, IdentifierReference,
     },
     builder::GetAstBuilder,
   },
@@ -31,53 +29,43 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
         let assign_pat = assign_pat.unbox();
         if self.shorthand {
           let binding_id = assign_pat.left.get_binding_identifier().unwrap();
-          AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
-            AssignmentTargetPropertyIdentifier::boxed(
-              self.span,
-              IdentifierReference::new(binding_id.span, binding_id.name, builder),
-              Some(assign_pat.right),
-              builder,
-            ),
+          AssignmentTargetProperty::new_assignment_target_property_identifier(
+            self.span,
+            IdentifierReference::new(binding_id.span, binding_id.name, builder),
+            Some(assign_pat.right),
+            builder,
           )
         } else {
-          AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-            AssignmentTargetPropertyProperty::boxed(
-              self.span,
-              self.key,
-              AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(
-                AssignmentTargetWithDefault::boxed(
-                  assign_pat.span,
-                  assign_pat.left.into_assignment_target(builder),
-                  assign_pat.right,
-                  builder,
-                ),
-              ),
-              self.computed,
+          AssignmentTargetProperty::new_assignment_target_property_property(
+            self.span,
+            self.key,
+            AssignmentTargetMaybeDefault::new_assignment_target_with_default(
+              assign_pat.span,
+              assign_pat.left.into_assignment_target(builder),
+              assign_pat.right,
               builder,
             ),
+            self.computed,
+            builder,
           )
           .into_in(builder.allocator())
         }
       }
       BindingPattern::BindingIdentifier(ref id) => {
         if self.shorthand {
-          AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
-            AssignmentTargetPropertyIdentifier::boxed(
-              self.span,
-              IdentifierReference::new(id.span, id.name, builder),
-              None,
-              builder,
-            ),
+          AssignmentTargetProperty::new_assignment_target_property_identifier(
+            self.span,
+            IdentifierReference::new(id.span, id.name, builder),
+            None,
+            builder,
           )
         } else {
-          AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-            AssignmentTargetPropertyProperty::boxed(
-              self.span,
-              self.key,
-              AssignmentTargetMaybeDefault::from(self.value.into_assignment_target(builder)),
-              self.computed,
-              builder,
-            ),
+          AssignmentTargetProperty::new_assignment_target_property_property(
+            self.span,
+            self.key,
+            AssignmentTargetMaybeDefault::from(self.value.into_assignment_target(builder)),
+            self.computed,
+            builder,
           )
           .into_in(builder.allocator())
         }
@@ -97,19 +85,17 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
             AssignmentTargetMaybeDefault::from(binding_pat.into_assignment_target(builder))
           }));
         });
-        AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-          AssignmentTargetPropertyProperty::boxed(
-            self.span,
-            self.key,
-            AssignmentTargetMaybeDefault::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
-              arr_pat.span,
-              elements,
-              rest,
-              builder,
-            )),
-            self.computed,
+        AssignmentTargetProperty::new_assignment_target_property_property(
+          self.span,
+          self.key,
+          AssignmentTargetMaybeDefault::new_array_assignment_target(
+            arr_pat.span,
+            elements,
+            rest,
             builder,
           ),
+          self.computed,
+          builder,
         )
         .into_in(builder.allocator())
       }
@@ -127,19 +113,17 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
         obj_pat.properties.take_in(&builder.allocator()).into_iter().for_each(|property| {
           properties.push(property.into_assignment_target_property(builder));
         });
-        AssignmentTargetProperty::AssignmentTargetPropertyProperty(
-          AssignmentTargetPropertyProperty::boxed(
-            self.span,
-            self.key,
-            AssignmentTargetMaybeDefault::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
-              obj_pat.span,
-              properties,
-              rest,
-              builder,
-            )),
-            self.computed,
+        AssignmentTargetProperty::new_assignment_target_property_property(
+          self.span,
+          self.key,
+          AssignmentTargetMaybeDefault::new_object_assignment_target(
+            obj_pat.span,
+            properties,
+            rest,
             builder,
           ),
+          self.computed,
+          builder,
         )
         .into_in(builder.allocator())
       }

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -2,9 +2,9 @@ use oxc::{
   allocator::Allocator,
   ast::{
     ast::{
-      Argument, BindingIdentifier, BindingPattern, Declaration, Expression, FormalParameter,
-      FormalParameterKind, FormalParameters, Function, FunctionBody, IdentifierName,
-      MemberExpression, Statement, VariableDeclarator,
+      Argument, BindingIdentifier, BindingPattern, Expression, FormalParameter,
+      FormalParameterKind, FormalParameters, FunctionBody, IdentifierName, Statement,
+      VariableDeclarator,
     },
     builder::{AstBuilder, NONE},
   },
@@ -39,16 +39,16 @@ impl<'ast> VisitMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
       // Build: import_expr.then(__unwrap_lazy_compilation_entry)
       *expr = Expression::new_call_expression(
         SPAN,
-        Expression::from(MemberExpression::new_static_member_expression(
+        Expression::new_static_member_expression(
           SPAN,
           import_expr,
           IdentifierName::new(SPAN, "then", &self.ast_builder),
           false,
           &self.ast_builder,
-        )),
+        ),
         NONE,
         oxc::allocator::Vec::from_value_in(
-          Argument::from(Expression::new_identifier(SPAN, HELPER_NAME, &self.ast_builder)),
+          Argument::new_identifier(SPAN, HELPER_NAME, &self.ast_builder),
           &self.ast_builder,
         ),
         false,
@@ -94,7 +94,7 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
   );
 
   // var e = m['rolldown:exports'];
-  let var_decl_stmt = Statement::from(Declaration::new_variable_declaration(
+  let var_decl_stmt = Statement::new_variable_declaration(
     SPAN,
     oxc::ast::ast::VariableDeclarationKind::Var,
     oxc::allocator::Vec::from_value_in(
@@ -103,13 +103,13 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
         oxc::ast::ast::VariableDeclarationKind::Var,
         BindingPattern::new_binding_identifier(SPAN, "e", &ast_builder),
         NONE,
-        Some(Expression::from(MemberExpression::new_computed_member_expression(
+        Some(Expression::new_computed_member_expression(
           SPAN,
           Expression::new_identifier(SPAN, "m", &ast_builder),
           Expression::new_string_literal(SPAN, "rolldown:exports", None, &ast_builder),
           false,
           &ast_builder,
-        ))),
+        )),
         false,
         &ast_builder,
       ),
@@ -117,7 +117,7 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
     ),
     false,
     &ast_builder,
-  ));
+  );
 
   // return e ? e : m;
   let return_stmt = Statement::new_return_statement(
@@ -140,7 +140,7 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
     FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(&ast_builder), body_stmts, &ast_builder);
 
   // function __unwrap_lazy_compilation_entry(m) { ... }
-  Statement::FunctionDeclaration(Function::boxed(
+  Statement::new_function_declaration(
     SPAN,
     oxc::ast::ast::FunctionType::FunctionDeclaration,
     Some(BindingIdentifier::new(SPAN, HELPER_NAME, &ast_builder)),
@@ -153,5 +153,5 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
     NONE, // return_type
     Some(body),
     &ast_builder,
-  ))
+  )
 }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -4,10 +4,9 @@ use oxc::{
   allocator::{CloneIn as _, TakeIn as _},
   ast::{
     ast::{
-      Argument, ArrowFunctionExpression, AwaitExpression, BindingPattern, BindingProperty,
-      Declaration, Expression, FormalParameterKind, FormalParameters, FunctionBody, IdentifierName,
-      MemberExpression, ObjectPattern, PropertyKey, ReturnStatement, Statement,
-      StaticMemberExpression, VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
+      Argument, BindingPattern, BindingProperty, Expression, FormalParameterKind, FormalParameters,
+      FunctionBody, IdentifierName, ObjectPattern, PropertyKey, Statement, StaticMemberExpression,
+      VariableDeclarationKind, VariableDeclarator,
     },
     builder::NONE,
   },
@@ -61,7 +60,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         key @ "default" => (key, "__vite_default__"),
         _ => (member_expr.property.name.as_str(), member_expr.property.name.as_str()),
       };
-      *await_expr = Expression::AwaitExpression(AwaitExpression::boxed(
+      *await_expr = Expression::new_await_expression(
         SPAN,
         self.construct_vite_preload_call(
           ObjectPattern::boxed(
@@ -83,7 +82,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           await_expr.take_in(&self.ast_builder.allocator()),
         ),
         &self.ast_builder,
-      ));
+      );
       return true;
     }
     false
@@ -164,59 +163,53 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
     object_pat: oxc::allocator::Box<'a, ObjectPattern<'a>>,
     await_expr: Expression<'a>,
   ) -> Expression<'a> {
-    self.vite_preload_call(Argument::from(Expression::ArrowFunctionExpression(
-      ArrowFunctionExpression::boxed(
+    self.vite_preload_call(Argument::new_arrow_function_expression(
+      SPAN,
+      false,
+      true,
+      NONE,
+      FormalParameters::new(
         SPAN,
-        false,
-        true,
+        FormalParameterKind::Signature,
+        oxc::allocator::Vec::new_in(&self.ast_builder),
         NONE,
-        FormalParameters::new(
-          SPAN,
-          FormalParameterKind::Signature,
-          oxc::allocator::Vec::new_in(&self.ast_builder),
-          NONE,
-          &self.ast_builder,
-        ),
-        NONE,
-        FunctionBody::new(
-          SPAN,
-          oxc::allocator::Vec::new_in(&self.ast_builder),
-          {
-            let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_builder);
-            statements.push(Statement::from(Declaration::VariableDeclaration(
-              VariableDeclaration::boxed(
+        &self.ast_builder,
+      ),
+      NONE,
+      FunctionBody::new(
+        SPAN,
+        oxc::allocator::Vec::new_in(&self.ast_builder),
+        {
+          let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_builder);
+          statements.push(Statement::new_variable_declaration(
+            SPAN,
+            VariableDeclarationKind::Const,
+            oxc::allocator::Vec::from_value_in(
+              VariableDeclarator::new(
                 SPAN,
                 VariableDeclarationKind::Const,
-                oxc::allocator::Vec::from_value_in(
-                  VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Const,
-                    BindingPattern::ObjectPattern(
-                      object_pat.clone_in(self.ast_builder.allocator()),
-                    ),
-                    NONE,
-                    Some(await_expr),
-                    false,
-                    &self.ast_builder,
-                  ),
-                  &self.ast_builder,
-                ),
+                BindingPattern::ObjectPattern(object_pat.clone_in(self.ast_builder.allocator())),
+                NONE,
+                Some(await_expr),
                 false,
                 &self.ast_builder,
               ),
-            )));
-            statements.push(Statement::ReturnStatement(ReturnStatement::boxed(
-              SPAN,
-              Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_builder)),
               &self.ast_builder,
-            )));
-            statements
-          },
-          &self.ast_builder,
-        ),
+            ),
+            false,
+            &self.ast_builder,
+          ));
+          statements.push(Statement::new_return_statement(
+            SPAN,
+            Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_builder)),
+            &self.ast_builder,
+          ));
+          statements
+        },
         &self.ast_builder,
       ),
-    )))
+      &self.ast_builder,
+    ))
   }
 
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
@@ -236,15 +229,13 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           Expression::new_void_0(SPAN, &self.ast_builder)
         }));
         if append_import_meta_url {
-          items.push(Argument::from(Expression::from(
-            MemberExpression::new_static_member_expression(
-              SPAN,
-              Expression::new_import_meta(SPAN, &self.ast_builder),
-              IdentifierName::new_id_name(SPAN, "url", &self.ast_builder),
-              false,
-              &self.ast_builder,
-            ),
-          )));
+          items.push(Argument::new_static_member_expression(
+            SPAN,
+            Expression::new_import_meta(SPAN, &self.ast_builder),
+            IdentifierName::new_id_name(SPAN, "url", &self.ast_builder),
+            false,
+            &self.ast_builder,
+          ));
         }
         items
       },

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -5,8 +5,7 @@ use oxc::{
   ast::{
     ast::{
       BindingIdentifier, BindingPattern, Expression, ImportDeclarationSpecifier,
-      ImportOrExportKind, ModuleDeclaration, ModuleExportName, Statement, StringLiteral,
-      VariableDeclaration,
+      ImportOrExportKind, ModuleExportName, Statement, StringLiteral, VariableDeclaration,
     },
     builder::NONE,
   },
@@ -36,7 +35,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_program(&mut self, it: &mut oxc::ast::ast::Program<'a>) {
     walk_mut::walk_program(self, it);
     if self.need_prepend_helper && self.insert_preload && !self.has_inserted_helper {
-      it.body.push(Statement::from(ModuleDeclaration::new_import_declaration(
+      it.body.push(Statement::new_import_declaration(
         SPAN,
         Some(oxc::allocator::Vec::from_value_in(
           ImportDeclarationSpecifier::new_import_specifier(
@@ -53,7 +52,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
         NONE,
         ImportOrExportKind::Value,
         &self.ast_builder,
-      )));
+      ));
     }
   }
 

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -1,9 +1,6 @@
 use oxc::ast::builder::AstBuilder;
 use oxc::{
-  ast::ast::{
-    Expression, IdentifierName, ObjectExpression, ObjectPropertyKind, Statement,
-    StaticMemberExpression,
-  },
+  ast::ast::{Expression, IdentifierName, ObjectPropertyKind, Statement},
   ast_visit::VisitMut,
   span::SPAN,
 };
@@ -24,36 +21,36 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
 
   #[inline]
   fn create_self_location_href_expr(&self) -> Expression<'ast> {
-    Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+    Expression::new_static_member_expression(
       SPAN,
-      Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+      Expression::new_static_member_expression(
         SPAN,
         Expression::new_id_ref_expr(SPAN, "self", &self.ast_builder),
         IdentifierName::new_id_name(SPAN, "location", &self.ast_builder),
         false,
         &self.ast_builder,
-      )),
+      ),
       IdentifierName::new_id_name(SPAN, "href", &self.ast_builder),
       false,
       &self.ast_builder,
-    ))
+    )
   }
 
   #[inline]
   fn create_import_meta_object_decl(&self) -> oxc::ast::ast::Statement<'ast> {
     Statement::new_var_decl(
       "_vite_importMeta",
-      Expression::ObjectExpression(ObjectExpression::boxed(
+      Expression::new_object_expression(
         SPAN,
         oxc::allocator::Vec::from_value_in(
           ObjectPropertyKind::new_object_property(
             SPAN,
             oxc::ast::ast::PropertyKind::Init,
-            oxc::ast::ast::PropertyKey::StaticIdentifier(IdentifierName::boxed(
+            oxc::ast::ast::PropertyKey::new_static_identifier(
               SPAN,
               oxc::ast::ast::Str::from_str_in("url", &self.ast_builder),
               &self.ast_builder,
-            )),
+            ),
             self.create_self_location_href_expr(),
             false,
             false,
@@ -63,7 +60,7 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
           &self.ast_builder,
         ),
         &self.ast_builder,
-      )),
+      ),
       &self.ast_builder,
     )
   }


### PR DESCRIPTION
Follow-on after #10018.

First of a series of PRs all grouped around 2 themes:

1. Shorten code using AST builder methods.
2. Reduce string allocations.

The new AST builder methods allow shortened syntax. Utilize the shorter methods wherever possible.

Before:

```rust
ast::Statement::ExpressionStatement(ast::ExpressionStatement::boxed(span, call_expr, &self.ast_builder))
```

After:

```rust
ast::Statement::new_expression_statement(span, call_expr, &self.ast_builder)
```

Note: Diff is quite large, but these changes were almost entirely produced using the same [deterministic codemod](https://github.com/oxc-project/oxc/tree/overlookmotel/ast-builder-codemod) we used to migrate Oxc repo to new AST builder, with only some final tweaks by an LLM. I've reviewed it all and, even though I'm unfamiliar with Rolldown's codebase, I'm pretty confident it looks correct.