### PR TITLE
refactor: pass arrays to AST builder methods

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -441,27 +441,24 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let stmt = Statement::new_variable_declaration(
       span,
       ast::VariableDeclarationKind::Var,
-      oxc::allocator::Vec::from_value_in(
-        ast::VariableDeclarator::new(
+      [ast::VariableDeclarator::new(
+        SPAN,
+        ast::VariableDeclarationKind::Var,
+        ast::BindingPattern::new_binding_identifier(
           SPAN,
-          ast::VariableDeclarationKind::Var,
-          ast::BindingPattern::new_binding_identifier(
-            SPAN,
-            Str::from_str_in(binding_name, &self.ast_builder),
-            &self.ast_builder,
-          ),
-          NONE,
-          Some(Expression::new_to_esm_call_with_interop(
-            "__rolldown_runtime__.__toESM",
-            call_expr,
-            interop,
-            &self.ast_builder,
-          )),
-          false,
+          Str::from_str_in(binding_name, &self.ast_builder),
           &self.ast_builder,
         ),
+        NONE,
+        Some(Expression::new_to_esm_call_with_interop(
+          "__rolldown_runtime__.__toESM",
+          call_expr,
+          interop,
+          &self.ast_builder,
+        )),
+        false,
         &self.ast_builder,
-      ),
+      )],
       false,
       &self.ast_builder,
     );
@@ -549,10 +546,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       SPAN,
       Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.__exportAll", &self.ast_builder),
       NONE,
-      oxc::allocator::Vec::from_array_in(
-        [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_builder.allocator()))],
-        &self.ast_builder,
-      ),
+      [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_builder.allocator()))],
       false,
       &self.ast_builder,
     );
@@ -611,15 +605,12 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         SPAN,
         Expression::new_id_ref_expr(SPAN, "encodeURIComponent", &self.ast_builder),
         NONE,
-        oxc::allocator::Vec::from_value_in(
-          ast::Argument::new_string_literal(
-            SPAN,
-            Str::from_str_in(&importee.id, &self.ast_builder),
-            None,
-            &self.ast_builder,
-          ),
+        [ast::Argument::new_string_literal(
+          SPAN,
+          Str::from_str_in(&importee.id, &self.ast_builder),
+          None,
           &self.ast_builder,
-        ),
+        )],
         false,
         &self.ast_builder,
       );
@@ -681,15 +672,12 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         SPAN,
         Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
         NONE,
-        oxc::allocator::Vec::from_value_in(
-          ast::Argument::new_string_literal(
-            SPAN,
-            Str::from_str_in(&importee.stable_id, &self.ast_builder),
-            None,
-            &self.ast_builder,
-          ),
+        [ast::Argument::new_string_literal(
+          SPAN,
+          Str::from_str_in(&importee.stable_id, &self.ast_builder),
+          None,
           &self.ast_builder,
-        ),
+        )],
         false,
         &self.ast_builder,
       );
@@ -703,18 +691,15 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         ast::FormalParameters::new(
           SPAN,
           ast::FormalParameterKind::ArrowFormalParameters,
-          oxc::allocator::Vec::new_in(&self.ast_builder),
+          [],
           NONE,
           &self.ast_builder,
         ),
         NONE,
         ast::FunctionBody::new(
           SPAN,
-          oxc::allocator::Vec::new_in(&self.ast_builder),
-          oxc::allocator::Vec::from_value_in(
-            ast::Statement::new_expression_statement(SPAN, load_exports_call, &self.ast_builder),
-            &self.ast_builder,
-          ),
+          [],
+          [ast::Statement::new_expression_statement(SPAN, load_exports_call, &self.ast_builder)],
           &self.ast_builder,
         ),
         &self.ast_builder,
@@ -733,7 +718,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         SPAN,
         then_callee,
         NONE,
-        oxc::allocator::Vec::from_value_in(ast::Argument::from(arrow_fn), &self.ast_builder),
+        [ast::Argument::from(arrow_fn)],
         false,
         &self.ast_builder,
       );
@@ -749,15 +734,12 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       SPAN,
       Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
       NONE,
-      oxc::allocator::Vec::from_value_in(
-        ast::Argument::new_string_literal(
-          SPAN,
-          Str::from_str_in(&importee.stable_id, &self.ast_builder),
-          None,
-          &self.ast_builder,
-        ),
+      [ast::Argument::new_string_literal(
+        SPAN,
+        Str::from_str_in(&importee.stable_id, &self.ast_builder),
+        None,
         &self.ast_builder,
-      ),
+      )],
       false,
       &self.ast_builder,
     );
@@ -807,10 +789,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       Expression::new_promise_resolve_then(load_exports_call_expr, &self.ast_builder);
     *it = ast::Expression::new_sequence_expression(
       SPAN,
-      oxc::allocator::Vec::from_array_in(
-        [init_call, promise_resolve_then_load_exports],
-        &self.ast_builder,
-      ),
+      [init_call, promise_resolve_then_load_exports],
       &self.ast_builder,
     );
   }

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -37,11 +37,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let mut try_block = ast::BlockStatement::boxed(
-      SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_builder),
-      &self.ast_builder,
-    );
+    let mut try_block = ast::BlockStatement::boxed(SPAN, [], &self.ast_builder);
 
     // `initModule("<stable id>")` for EVERY static dep, uniformly registry-gated: a
     // co-carried factory runs, a resident module short-circuits. No payload-membership
@@ -67,26 +63,20 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // module/exports objects become locals the body's rewritten `module`/`exports`
     // references resolve to.
     let cjs_module_locals: Vec<ast::Statement<'ast>> = if self.module.exports_kind.is_commonjs() {
-      let empty_exports_object = ast::Expression::new_object_expression(
-        SPAN,
-        oxc::allocator::Vec::new_in(&self.ast_builder),
-        &self.ast_builder,
-      );
+      let empty_exports_object =
+        ast::Expression::new_object_expression(SPAN, [], &self.ast_builder);
       let module_object = ast::Expression::new_object_expression(
         SPAN,
-        oxc::allocator::Vec::from_value_in(
-          ast::ObjectPropertyKind::new_object_property(
-            SPAN,
-            ast::PropertyKind::Init,
-            ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.ast_builder),
-            empty_exports_object,
-            true,
-            false,
-            false,
-            &self.ast_builder,
-          ),
+        [ast::ObjectPropertyKind::new_object_property(
+          SPAN,
+          ast::PropertyKind::Init,
+          ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.ast_builder),
+          empty_exports_object,
+          true,
+          false,
+          false,
           &self.ast_builder,
-        ),
+        )],
         &self.ast_builder,
       );
       vec![
@@ -162,11 +152,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       .body
       .extend(std::mem::take(&mut self.generated_static_import_stmts_from_external).into_values());
 
-    let final_block = ast::BlockStatement::boxed(
-      SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_builder),
-      &self.ast_builder,
-    );
+    let final_block = ast::BlockStatement::boxed(SPAN, [], &self.ast_builder);
 
     let try_stmt = ast::Statement::new_try_statement(
       SPAN,
@@ -182,7 +168,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // string literal.
     let module_id_param = ast::FormalParameter::new(
       SPAN,
-      oxc::allocator::Vec::new_in(&self.ast_builder),
+      [],
       ast::BindingPattern::new_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, &self.ast_builder),
       NONE,
       NONE,
@@ -195,7 +181,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     let params = ast::FormalParameters::new(
       SPAN,
       ast::FormalParameterKind::Signature,
-      oxc::allocator::Vec::from_value_in(module_id_param, &self.ast_builder),
+      [module_id_param],
       NONE,
       &self.ast_builder,
     );
@@ -211,12 +197,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       NONE,
       params,
       NONE,
-      Some(ast::FunctionBody::new(
-        SPAN,
-        oxc::allocator::Vec::new_in(&self.ast_builder),
-        oxc::allocator::Vec::from_value_in(try_stmt, &self.ast_builder),
-        &self.ast_builder,
-      )),
+      Some(ast::FunctionBody::new(SPAN, [], [try_stmt], &self.ast_builder)),
       &self.ast_builder,
     );
     // mark the callback as PIFE because the callback is executed when this chunk is loaded

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -58,19 +58,16 @@ pub trait HmrAstBuilder<'any, 'ast> {
         // { exports: namespace }
         ast::Argument::new_object_expression(
           SPAN,
-          oxc::allocator::Vec::from_value_in(
-            ast::ObjectPropertyKind::new_object_property(
-              SPAN,
-              ast::PropertyKind::Init,
-              ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.builder()),
-              namespace_object_ref_expr,
-              true,
-              false,
-              false,
-              &self.builder(),
-            ),
+          [ast::ObjectPropertyKind::new_object_property(
+            SPAN,
+            ast::PropertyKind::Init,
+            ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.builder()),
+            namespace_object_ref_expr,
+            true,
+            false,
+            false,
             &self.builder(),
-          ),
+          )],
           &self.builder(),
         )
       }
@@ -80,28 +77,18 @@ pub trait HmrAstBuilder<'any, 'ast> {
       }
       rolldown_common::ExportsKind::None => {
         // `{}`
-        ast::Argument::new_object_expression(
-          SPAN,
-          oxc::allocator::Vec::new_in(&self.builder()),
-          &self.builder(),
-        )
+        ast::Argument::new_object_expression(SPAN, [], &self.builder())
       }
     };
 
-    // ...(moduleId, module)
+    // __rolldown_runtime__.registerModule(moduleId, module)
     // moduleId is either `__rolldown_module_id__` (HMR/lazy path) or the stable-id
     // string literal (main-bundle path).
-    let arguments = oxc::allocator::Vec::from_array_in(
-      [self.module_id_argument(), module_exports],
-      &self.builder(),
-    );
-
-    // __rolldown_runtime__.registerModule(moduleId, module)
     let register_call = ast::Expression::new_call_expression(
       SPAN,
       ast::Expression::new_identifier(SPAN, "__rolldown_runtime__.registerModule", &self.builder()),
       NONE,
-      arguments,
+      [self.module_id_argument(), module_exports],
       false,
       &self.builder(),
     );
@@ -136,7 +123,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
               &self.builder(),
             ),
             NONE,
-            oxc::allocator::Vec::from_value_in(self.module_id_argument(), &self.builder()),
+            [self.module_id_argument()],
             false,
             &self.builder(),
           )),

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -504,11 +504,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       ast::Expression::ImportMeta(import_meta) => {
         if !self.ctx.options.format.keep_esm_import_export_syntax() {
           self.record_surviving_import_meta(import_meta.span, EmptyImportMetaKind::Plain);
-          *expr = ast::Expression::new_object_expression(
-            SPAN,
-            oxc::allocator::Vec::new_in(&self.ast_builder),
-            &self.ast_builder,
-          );
+          *expr = ast::Expression::new_object_expression(SPAN, [], &self.ast_builder);
         }
       }
       ast::Expression::ChainExpression(_) => {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -184,7 +184,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       call_span,
       wrapper_ref_expr,
       NONE,
-      oxc::allocator::Vec::new_in(&self.ast_builder),
+      [],
       false,
       mark_pure_if_noop && self.ctx.final_esm_init_metadata.init_is_noop(importee_idx),
       &self.ast_builder,
@@ -336,7 +336,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             importee_wrapper_ref_name,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_builder),
+            [],
             false,
             &self.ast_builder,
           )
@@ -991,10 +991,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               SPAN,
               ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
-              oxc::allocator::Vec::from_value_in(
-                ast::Argument::new_string_literal(SPAN, "url", None, &self.ast_builder),
-                &self.ast_builder,
-              ),
+              [ast::Argument::new_string_literal(SPAN, "url", None, &self.ast_builder)],
               false,
               &self.ast_builder,
             );
@@ -1013,10 +1010,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               SPAN,
               require_path_to_file_url,
               NONE,
-              oxc::allocator::Vec::from_value_in(
-                ast::Argument::new_identifier(SPAN, "__filename", &self.ast_builder),
-                &self.ast_builder,
-              ),
+              [ast::Argument::new_identifier(SPAN, "__filename", &self.ast_builder)],
               false,
               &self.ast_builder,
             );
@@ -1146,30 +1140,27 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           SPAN,
           ast::Expression::new_identifier(SPAN, "URL", &self.ast_builder),
           NONE,
-          oxc::allocator::Vec::from_array_in(
-            [
-              ast::Argument::new_string_literal(
-                SPAN,
-                oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_builder),
-                None,
+          [
+            ast::Argument::new_string_literal(
+              SPAN,
+              oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_builder),
+              None,
+              &self.ast_builder,
+            ),
+            ast::Argument::new_static_member_expression(
+              SPAN,
+              ast::Expression::new_import_meta(
+                // Carry the source span, so that if this generated `import.meta.url` cannot be
+                // polyfilled either, the diagnostic points at the `import.meta.ROLLDOWN_FILE_URL_*`
+                // the user actually wrote.
+                original_expr_span,
                 &self.ast_builder,
               ),
-              ast::Argument::new_static_member_expression(
-                SPAN,
-                ast::Expression::new_import_meta(
-                  // Carry the source span, so that if this generated `import.meta.url` cannot be
-                  // polyfilled either, the diagnostic points at the `import.meta.ROLLDOWN_FILE_URL_*`
-                  // the user actually wrote.
-                  original_expr_span,
-                  &self.ast_builder,
-                ),
-                ast::IdentifierName::new(SPAN, "url", &self.ast_builder),
-                false,
-                &self.ast_builder,
-              ),
-            ],
-            &self.ast_builder,
-          ),
+              ast::IdentifierName::new(SPAN, "url", &self.ast_builder),
+              false,
+              &self.ast_builder,
+            ),
+          ],
           &self.ast_builder,
         ),
         ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
@@ -1407,21 +1398,15 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     Ok(ast::Declaration::new_variable_declaration(
       class.span,
       VariableDeclarationKind::Var,
-      oxc::allocator::Vec::from_value_in(
-        ast::VariableDeclarator::new(
-          SPAN,
-          VariableDeclarationKind::Var,
-          ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(
-            id,
-            &self.ast_builder,
-          )),
-          NONE,
-          Some(Expression::ClassExpression(class)),
-          false,
-          &self.ast_builder,
-        ),
+      [ast::VariableDeclarator::new(
+        SPAN,
+        VariableDeclarationKind::Var,
+        ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(id, &self.ast_builder)),
+        NONE,
+        Some(Expression::ClassExpression(class)),
+        false,
         &self.ast_builder,
-      ),
+      )],
       false,
       &self.ast_builder,
     ))
@@ -1464,7 +1449,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_builder),
+                      [],
                       false,
                       &self.ast_builder,
                     ))
@@ -1478,7 +1463,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_builder),
+                      [],
                       false,
                       &self.ast_builder,
                     ),
@@ -1517,7 +1502,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       SPAN,
                       wrap_ref_expr,
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_builder),
+                      [],
                       false,
                       self.ctx.final_esm_init_metadata.init_is_noop(importee.idx),
                       &self.ast_builder,
@@ -1543,10 +1528,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     SPAN,
                     to_commonjs_expr,
                     NONE,
-                    oxc::allocator::Vec::from_value_in(
-                      ast::Argument::from(namespace_object_ref_expr),
-                      &self.ast_builder,
-                    ),
+                    [ast::Argument::from(namespace_object_ref_expr)],
                     false,
                     &self.ast_builder,
                   );
@@ -1611,19 +1593,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           Expression::new_member_access_expr("Object", "freeze", &self.ast_builder),
           ast::Expression::new_object_expression(
             SPAN,
-            oxc::allocator::Vec::from_value_in(
-              ast::ObjectPropertyKind::new_object_property(
-                SPAN,
-                ast::PropertyKind::Init,
-                ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_builder),
-                ast::Expression::new_null_literal(SPAN, &self.ast_builder),
-                false,
-                false,
-                false,
-                &self.ast_builder,
-              ),
+            [ast::ObjectPropertyKind::new_object_property(
+              SPAN,
+              ast::PropertyKind::Init,
+              ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_builder),
+              ast::Expression::new_null_literal(SPAN, &self.ast_builder),
+              false,
+              false,
+              false,
               &self.ast_builder,
-            ),
+            )],
             &self.ast_builder,
           ),
           true,
@@ -1656,7 +1635,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_builder),
+                    [],
                     false,
                     &self.ast_builder,
                   ),
@@ -1675,7 +1654,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                         &self.ast_builder,
                       ),
                       NONE,
-                      oxc::allocator::Vec::new_in(&self.ast_builder),
+                      [],
                       false,
                       &self.ast_builder,
                     ),
@@ -1698,7 +1677,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_builder),
+                    [],
                     false,
                     &self.ast_builder,
                   ),
@@ -1875,7 +1854,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     SPAN,
                     wrapper_ref,
                     NONE,
-                    oxc::allocator::Vec::new_in(&self.ast_builder),
+                    [],
                     false,
                     &self.ast_builder,
                   );
@@ -1956,7 +1935,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                           SPAN,
                           importee_wrapper_ref_expr,
                           NONE,
-                          oxc::allocator::Vec::new_in(&self.ast_builder),
+                          [],
                           false,
                           &self.ast_builder,
                         ),
@@ -2353,7 +2332,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             finalized_importee_wrapper_ref,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_builder),
+            [],
             false,
             &self.ast_builder,
           );
@@ -2381,7 +2360,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             finalized_importee_wrapper_ref,
             NONE,
-            oxc::allocator::Vec::new_in(&self.ast_builder),
+            [],
             false,
             &self.ast_builder,
           );
@@ -2444,15 +2423,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               SPAN,
               ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
               NONE,
-              oxc::allocator::Vec::from_value_in(
-                ast::Argument::new_string_literal(
-                  expr.span,
-                  oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
-                  None,
-                  &self.ast_builder,
-                ),
+              [ast::Argument::new_string_literal(
+                expr.span,
+                oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+                None,
                 &self.ast_builder,
-              ),
+              )],
               false,
               &self.ast_builder,
             );
@@ -2605,15 +2581,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             SPAN,
             ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
-            oxc::allocator::Vec::from_value_in(
-              ast::Argument::new_string_literal(
-                expr.span,
-                oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
-                None,
-                &self.ast_builder,
-              ),
+            [ast::Argument::new_string_literal(
+              expr.span,
+              oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+              None,
               &self.ast_builder,
-            ),
+            )],
             false,
             &self.ast_builder,
           );
@@ -2719,36 +2692,30 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           ast::FormalParameters::new(
             SPAN,
             ast::FormalParameterKind::ArrowFormalParameters,
-            oxc::allocator::Vec::from_value_in(
-              ast::FormalParameter::new(
+            [ast::FormalParameter::new(
+              SPAN,
+              [],
+              ast::BindingPattern::new_binding_identifier(
                 SPAN,
-                oxc::allocator::Vec::new_in(&self.ast_builder),
-                ast::BindingPattern::new_binding_identifier(
-                  SPAN,
-                  oxc::ast::ast::Str::from_str_in("m", &self.ast_builder),
-                  &self.ast_builder,
-                ),
-                NONE,
-                NONE,
-                false,
-                None,
-                false,
-                false,
+                oxc::ast::ast::Str::from_str_in("m", &self.ast_builder),
                 &self.ast_builder,
               ),
+              NONE,
+              NONE,
+              false,
+              None,
+              false,
+              false,
               &self.ast_builder,
-            ),
+            )],
             NONE,
             &self.ast_builder,
           ),
           NONE,
           ast::FunctionBody::new(
             SPAN,
-            oxc::allocator::Vec::new_in(&self.ast_builder),
-            oxc::allocator::Vec::from_value_in(
-              ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_builder),
-              &self.ast_builder,
-            ),
+            [],
+            [ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_builder)],
             &self.ast_builder,
           ),
           &self.ast_builder,
@@ -2768,7 +2735,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           SPAN,
           callee,
           NONE,
-          oxc::allocator::Vec::from_value_in(arrow_fn, &self.ast_builder),
+          [arrow_fn],
           false,
           &self.ast_builder,
         )

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -85,7 +85,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
           Statement::new_export_named_declaration(
             if i == 0 { named_decl_span } else { SPAN },
             Some(Declaration::VariableDeclaration(new_decl)),
-            oxc::allocator::Vec::new_in(&self.ast_builder),
+            [],
             // Since it is `export a = 1, b = 2;`, source should be `None`
             None,
             ImportOrExportKind::Value,
@@ -260,10 +260,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
             SPAN,
             ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
-            oxc::allocator::Vec::from_value_in(
-              ast::Argument::from(cond_expr.consequent),
-              &self.ast_builder,
-            ),
+            [ast::Argument::from(cond_expr.consequent)],
             false,
             &self.ast_builder,
           ),
@@ -271,10 +268,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
             SPAN,
             ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
             NONE,
-            oxc::allocator::Vec::from_value_in(
-              ast::Argument::from(cond_expr.alternate),
-              &self.ast_builder,
-            ),
+            [ast::Argument::from(cond_expr.alternate)],
             false,
             &self.ast_builder,
           ),

--- a/crates/rolldown_common/src/ecmascript/json_to_program.rs
+++ b/crates/rolldown_common/src/ecmascript/json_to_program.rs
@@ -39,10 +39,10 @@ pub fn json_value_to_ecma_ast(value: &Value) -> EcmaAst {
       SPAN,
       SourceType::default().with_module(true),
       "",
-      oxc::allocator::Vec::new_in(&builder),
+      [],
       None,
-      oxc::allocator::Vec::new_in(&builder),
-      oxc::allocator::Vec::from_value_in(stmt, &builder),
+      [],
+      [stmt],
       &builder,
     )
   })

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -67,13 +67,10 @@ impl EcmaCompiler {
               SPAN,
               SourceType::default().with_module(true),
               owner.source.as_str(),
-              oxc::allocator::Vec::new_in(&builder),
+              [],
               None,
-              oxc::allocator::Vec::new_in(&builder),
-              oxc::allocator::Vec::from_value_in(
-                Statement::new_expression_statement(SPAN, expr, &builder),
-                &builder,
-              ),
+              [],
+              [Statement::new_expression_statement(SPAN, expr, &builder)],
               &builder,
             );
             Ok(ProgramCellDependent { program })

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -88,15 +88,9 @@ pub trait ExpressionFactoryExt<'ast> {
       true,
       false,
       NONE,
-      FormalParameters::new(
-        SPAN,
-        FormalParameterKind::Signature,
-        oxc::allocator::Vec::new_in(builder),
-        NONE,
-        builder,
-      ),
+      FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, builder),
       NONE,
-      FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder),
+      FunctionBody::new(SPAN, [], statements, builder),
       builder,
     )
   }
@@ -117,8 +111,7 @@ pub trait ExpressionFactoryExt<'ast> {
     pure: bool,
     builder: &B,
   ) -> Expression<'ast> {
-    let mut call_expr =
-      CallExpression::new(SPAN, callee, NONE, oxc::allocator::Vec::new_in(builder), false, builder);
+    let mut call_expr = CallExpression::new(SPAN, callee, NONE, [], false, builder);
     call_expr.pure = pure;
     call_expr.arguments.push(arg.into());
     Expression::CallExpression(call_expr.into_in(builder.allocator()))
@@ -147,7 +140,7 @@ pub trait ExpressionFactoryExt<'ast> {
             builder,
           ),
           NONE,
-          oxc::allocator::Vec::new_in(builder),
+          [],
           false,
           builder,
         ),
@@ -156,10 +149,7 @@ pub trait ExpressionFactoryExt<'ast> {
         builder,
       ),
       NONE,
-      oxc::allocator::Vec::from_value_in(
-        Argument::from(Expression::new_arrow_returning(expr, builder)),
-        builder,
-      ),
+      [Argument::from(Expression::new_arrow_returning(expr, builder))],
       false,
       builder,
     )
@@ -351,10 +341,7 @@ pub trait ExpressionFactoryExt<'ast> {
         builder,
       ),
       NONE,
-      oxc::allocator::Vec::from_value_in(
-        Argument::from(Expression::new_arrow_returning(return_expr, builder)),
-        builder,
-      ),
+      [Argument::from(Expression::new_arrow_returning(return_expr, builder))],
       false,
       builder,
     )
@@ -458,34 +445,31 @@ pub trait ClassElementFactoryExt<'ast> {
   ) -> ClassElement<'ast> {
     ClassElement::new_static_block(
       SPAN,
-      oxc::allocator::Vec::from_value_in(
-        Statement::new_expression_statement(
+      [Statement::new_expression_statement(
+        SPAN,
+        Expression::new_call_expression(
           SPAN,
-          Expression::new_call_expression(
-            SPAN,
-            callee,
-            NONE,
-            {
-              let mut items = oxc::allocator::Vec::with_capacity_in(2, builder);
-              items.push(Expression::new_this_expression(SPAN, builder).into());
-              items.push(
-                Expression::new_string_literal(
-                  SPAN,
-                  oxc::ast::ast::Str::from_str_in(name, builder),
-                  None,
-                  builder,
-                )
-                .into(),
-              );
-              items
-            },
-            false,
-            builder,
-          ),
+          callee,
+          NONE,
+          {
+            let mut items = oxc::allocator::Vec::with_capacity_in(2, builder);
+            items.push(Expression::new_this_expression(SPAN, builder).into());
+            items.push(
+              Expression::new_string_literal(
+                SPAN,
+                oxc::ast::ast::Str::from_str_in(name, builder),
+                None,
+                builder,
+              )
+              .into(),
+            );
+            items
+          },
+          false,
           builder,
         ),
         builder,
-      ),
+      )],
       builder,
     )
   }
@@ -538,14 +522,8 @@ pub trait CallExpressionFactoryExt<'ast> {
       false,
       builder,
     );
-    let wrapper_call = Expression::new_call_expression(
-      SPAN,
-      wrapper_member,
-      NONE,
-      oxc::allocator::Vec::new_in(builder),
-      false,
-      builder,
-    );
+    let wrapper_call =
+      Expression::new_call_expression(SPAN, wrapper_member, NONE, [], false, builder);
     let namespace_member = Expression::new_static_member_expression(
       SPAN,
       Expression::new_identifier(SPAN, "n", builder),
@@ -572,14 +550,7 @@ pub trait CallExpressionFactoryExt<'ast> {
       false,
       builder,
     );
-    let wrapper_call = Expression::new_call_expression(
-      SPAN,
-      member_expr,
-      NONE,
-      oxc::allocator::Vec::new_in(builder),
-      false,
-      builder,
-    );
+    let wrapper_call = Expression::new_call_expression(SPAN, member_expr, NONE, [], false, builder);
     let to_esm_call =
       Expression::new_to_esm_wrapper(to_esm_fn_expr, wrapper_call, node_mode, builder);
     then_with_arrow_callback(expr, to_esm_call, builder)
@@ -752,11 +723,11 @@ pub trait StatementFactoryExt<'ast> {
       NONE,
       builder,
     );
-    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder);
+    let body = FunctionBody::new(SPAN, [], statements, builder);
     if ast_usage.intersects(EcmaModuleAstUsage::ModuleOrExports) {
       params.items.push(FormalParameter::new(
         SPAN,
-        oxc::allocator::Vec::new_in(builder),
+        [],
         BindingPattern::new_binding_identifier(SPAN, "exports", builder),
         NONE,
         NONE,
@@ -770,7 +741,7 @@ pub trait StatementFactoryExt<'ast> {
     if ast_usage.contains(EcmaModuleAstUsage::ModuleRef) {
       params.items.push(FormalParameter::new(
         SPAN,
-        oxc::allocator::Vec::new_in(builder),
+        [],
         BindingPattern::new_binding_identifier(SPAN, "module", builder),
         NONE,
         NONE,
@@ -781,39 +752,29 @@ pub trait StatementFactoryExt<'ast> {
         builder,
       ));
     }
-    let mut commonjs_call_expr = CallExpression::new_with_pure(
-      SPAN,
-      commonjs_expr,
-      NONE,
-      oxc::allocator::Vec::new_in(builder),
-      false,
-      true,
-      builder,
-    );
+    let mut commonjs_call_expr =
+      CallExpression::new_with_pure(SPAN, commonjs_expr, NONE, [], false, true, builder);
     let mut arrow_expr =
       ArrowFunctionExpression::boxed(SPAN, false, is_async, NONE, params, NONE, body, builder);
     arrow_expr.pife = true;
     if profiler_names {
       let obj_expr = ObjectExpression::boxed(
         SPAN,
-        oxc::allocator::Vec::from_value_in(
-          ObjectPropertyKind::new_object_property(
+        [ObjectPropertyKind::new_object_property(
+          SPAN,
+          PropertyKind::Init,
+          PropertyKey::new_string_literal(
             SPAN,
-            PropertyKind::Init,
-            PropertyKey::new_string_literal(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in(stable_id, builder),
-              None,
-              builder,
-            ),
-            Expression::ArrowFunctionExpression(arrow_expr),
-            true,
-            false,
-            false,
+            oxc::ast::ast::Str::from_str_in(stable_id, builder),
+            None,
             builder,
           ),
+          Expression::ArrowFunctionExpression(arrow_expr),
+          true,
+          false,
+          false,
           builder,
-        ),
+        )],
         builder,
       );
       commonjs_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
@@ -843,22 +804,9 @@ pub trait StatementFactoryExt<'ast> {
       body_kind,
       decl_kind,
     } = options;
-    let params = FormalParameters::new(
-      SPAN,
-      FormalParameterKind::Signature,
-      oxc::allocator::Vec::new_in(builder),
-      NONE,
-      builder,
-    );
-    let body = FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(builder), statements, builder);
-    let mut esm_call_expr = CallExpression::new(
-      SPAN,
-      esm_fn_expr,
-      NONE,
-      oxc::allocator::Vec::new_in(builder),
-      false,
-      builder,
-    );
+    let params = FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, builder);
+    let body = FunctionBody::new(SPAN, [], statements, builder);
+    let mut esm_call_expr = CallExpression::new(SPAN, esm_fn_expr, NONE, [], false, builder);
     let mut arrow_expr = ArrowFunctionExpression::boxed(
       SPAN,
       false,
@@ -873,24 +821,21 @@ pub trait StatementFactoryExt<'ast> {
     if let Some(stable_id) = profiler_name {
       let obj_expr = ObjectExpression::boxed(
         SPAN,
-        oxc::allocator::Vec::from_value_in(
-          ObjectPropertyKind::new_object_property(
+        [ObjectPropertyKind::new_object_property(
+          SPAN,
+          PropertyKind::Init,
+          PropertyKey::new_string_literal(
             SPAN,
-            PropertyKind::Init,
-            PropertyKey::new_string_literal(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in(stable_id, builder),
-              None,
-              builder,
-            ),
-            Expression::ArrowFunctionExpression(arrow_expr),
-            false,
-            false,
-            false,
+            oxc::ast::ast::Str::from_str_in(stable_id, builder),
+            None,
             builder,
           ),
+          Expression::ArrowFunctionExpression(arrow_expr),
+          false,
+          false,
+          false,
           builder,
-        ),
+        )],
         builder,
       );
       esm_call_expr.arguments.push(Argument::ObjectExpression(obj_expr));
@@ -915,14 +860,8 @@ pub trait StatementFactoryExt<'ast> {
       Expression::CallExpression(esm_call_expr.into_in(builder.allocator())),
       builder,
     );
-    let call_expr = Expression::new_call_expression(
-      SPAN,
-      assignment_expr,
-      NONE,
-      oxc::allocator::Vec::new_in(builder),
-      false,
-      builder,
-    );
+    let call_expr =
+      Expression::new_call_expression(SPAN, assignment_expr, NONE, [], false, builder);
     Statement::new_function_declaration(
       SPAN,
       FunctionType::FunctionDeclaration,
@@ -936,21 +875,12 @@ pub trait StatementFactoryExt<'ast> {
       false,
       NONE,
       NONE,
-      FormalParameters::new(
-        SPAN,
-        FormalParameterKind::Signature,
-        oxc::allocator::Vec::new_in(builder),
-        NONE,
-        builder,
-      ),
+      FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, builder),
       NONE,
       Some(FunctionBody::new(
         SPAN,
-        oxc::allocator::Vec::new_in(builder),
-        oxc::allocator::Vec::from_value_in(
-          Statement::new_return_statement(SPAN, Some(call_expr), builder),
-          builder,
-        ),
+        [],
+        [Statement::new_return_statement(SPAN, Some(call_expr), builder)],
         builder,
       )),
       builder,
@@ -974,36 +904,30 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     FormalParameters::new(
       SPAN,
       FormalParameterKind::ArrowFormalParameters,
-      oxc::allocator::Vec::from_value_in(
-        FormalParameter::new(
+      [FormalParameter::new(
+        SPAN,
+        [],
+        BindingPattern::new_binding_identifier(
           SPAN,
-          oxc::allocator::Vec::new_in(builder),
-          BindingPattern::new_binding_identifier(
-            SPAN,
-            oxc::ast::ast::Str::from_str_in("n", builder),
-            builder,
-          ),
-          NONE,
-          NONE,
-          false,
-          None,
-          false,
-          false,
+          oxc::ast::ast::Str::from_str_in("n", builder),
           builder,
         ),
+        NONE,
+        NONE,
+        false,
+        None,
+        false,
+        false,
         builder,
-      ),
+      )],
       NONE,
       builder,
     ),
     NONE,
     FunctionBody::new(
       SPAN,
-      oxc::allocator::Vec::new_in(builder),
-      oxc::allocator::Vec::from_value_in(
-        Statement::new_expression_statement(SPAN, return_expr, builder),
-        builder,
-      ),
+      [],
+      [Statement::new_expression_statement(SPAN, return_expr, builder)],
       builder,
     ),
     builder,
@@ -1015,12 +939,5 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     false,
     builder,
   );
-  CallExpression::boxed(
-    SPAN,
-    callee,
-    NONE,
-    oxc::allocator::Vec::from_value_in(arrow_fn, builder),
-    false,
-    builder,
-  )
+  CallExpression::boxed(SPAN, callee, NONE, [arrow_fn], false, builder)
 }

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -47,10 +47,7 @@ impl<'ast> VisitMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
           &self.ast_builder,
         ),
         NONE,
-        oxc::allocator::Vec::from_value_in(
-          Argument::new_identifier(SPAN, HELPER_NAME, &self.ast_builder),
-          &self.ast_builder,
-        ),
+        [Argument::new_identifier(SPAN, HELPER_NAME, &self.ast_builder)],
         false,
         &self.ast_builder,
       );
@@ -74,21 +71,18 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
   let params = FormalParameters::new(
     SPAN,
     FormalParameterKind::FormalParameter,
-    oxc::allocator::Vec::from_value_in(
-      FormalParameter::new(
-        SPAN,
-        oxc::allocator::Vec::new_in(&ast_builder),
-        BindingPattern::new_binding_identifier(SPAN, "m", &ast_builder),
-        NONE,
-        NONE,
-        false,
-        None,
-        false,
-        false,
-        &ast_builder,
-      ),
+    [FormalParameter::new(
+      SPAN,
+      [],
+      BindingPattern::new_binding_identifier(SPAN, "m", &ast_builder),
+      NONE,
+      NONE,
+      false,
+      None,
+      false,
+      false,
       &ast_builder,
-    ),
+    )],
     NONE,
     &ast_builder,
   );
@@ -97,24 +91,21 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
   let var_decl_stmt = Statement::new_variable_declaration(
     SPAN,
     oxc::ast::ast::VariableDeclarationKind::Var,
-    oxc::allocator::Vec::from_value_in(
-      VariableDeclarator::new(
+    [VariableDeclarator::new(
+      SPAN,
+      oxc::ast::ast::VariableDeclarationKind::Var,
+      BindingPattern::new_binding_identifier(SPAN, "e", &ast_builder),
+      NONE,
+      Some(Expression::new_computed_member_expression(
         SPAN,
-        oxc::ast::ast::VariableDeclarationKind::Var,
-        BindingPattern::new_binding_identifier(SPAN, "e", &ast_builder),
-        NONE,
-        Some(Expression::new_computed_member_expression(
-          SPAN,
-          Expression::new_identifier(SPAN, "m", &ast_builder),
-          Expression::new_string_literal(SPAN, "rolldown:exports", None, &ast_builder),
-          false,
-          &ast_builder,
-        )),
+        Expression::new_identifier(SPAN, "m", &ast_builder),
+        Expression::new_string_literal(SPAN, "rolldown:exports", None, &ast_builder),
         false,
         &ast_builder,
-      ),
+      )),
+      false,
       &ast_builder,
-    ),
+    )],
     false,
     &ast_builder,
   );
@@ -136,8 +127,7 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
   let mut body_stmts = oxc::allocator::Vec::with_capacity_in(2, &ast_builder);
   body_stmts.push(var_decl_stmt);
   body_stmts.push(return_stmt);
-  let body =
-    FunctionBody::new(SPAN, oxc::allocator::Vec::new_in(&ast_builder), body_stmts, &ast_builder);
+  let body = FunctionBody::new(SPAN, [], body_stmts, &ast_builder);
 
   // function __unwrap_lazy_compilation_entry(m) { ... }
   Statement::new_function_declaration(

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -65,17 +65,14 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         self.construct_vite_preload_call(
           ObjectPattern::boxed(
             SPAN,
-            oxc::allocator::Vec::from_value_in(
-              BindingProperty::new(
-                SPAN,
-                PropertyKey::new_static_identifier(SPAN, key, &self.ast_builder),
-                BindingPattern::new_binding_identifier(SPAN, value, &self.ast_builder),
-                true,
-                false,
-                &self.ast_builder,
-              ),
+            [BindingProperty::new(
+              SPAN,
+              PropertyKey::new_static_identifier(SPAN, key, &self.ast_builder),
+              BindingPattern::new_binding_identifier(SPAN, value, &self.ast_builder),
+              true,
+              false,
               &self.ast_builder,
-            ),
+            )],
             NONE,
             &self.ast_builder,
           ),
@@ -168,34 +165,25 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       false,
       true,
       NONE,
-      FormalParameters::new(
-        SPAN,
-        FormalParameterKind::Signature,
-        oxc::allocator::Vec::new_in(&self.ast_builder),
-        NONE,
-        &self.ast_builder,
-      ),
+      FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, &self.ast_builder),
       NONE,
       FunctionBody::new(
         SPAN,
-        oxc::allocator::Vec::new_in(&self.ast_builder),
+        [],
         {
           let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_builder);
           statements.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Const,
-            oxc::allocator::Vec::from_value_in(
-              VariableDeclarator::new(
-                SPAN,
-                VariableDeclarationKind::Const,
-                BindingPattern::ObjectPattern(object_pat.clone_in(self.ast_builder.allocator())),
-                NONE,
-                Some(await_expr),
-                false,
-                &self.ast_builder,
-              ),
+            [VariableDeclarator::new(
+              SPAN,
+              VariableDeclarationKind::Const,
+              BindingPattern::ObjectPattern(object_pat.clone_in(self.ast_builder.allocator())),
+              NONE,
+              Some(await_expr),
+              false,
               &self.ast_builder,
-            ),
+            )],
             false,
             &self.ast_builder,
           ));

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -42,23 +42,20 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
       "_vite_importMeta",
       Expression::new_object_expression(
         SPAN,
-        oxc::allocator::Vec::from_value_in(
-          ObjectPropertyKind::new_object_property(
+        [ObjectPropertyKind::new_object_property(
+          SPAN,
+          oxc::ast::ast::PropertyKind::Init,
+          oxc::ast::ast::PropertyKey::new_static_identifier(
             SPAN,
-            oxc::ast::ast::PropertyKind::Init,
-            oxc::ast::ast::PropertyKey::new_static_identifier(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in("url", &self.ast_builder),
-              &self.ast_builder,
-            ),
-            self.create_self_location_href_expr(),
-            false,
-            false,
-            false,
+            oxc::ast::ast::Str::from_str_in("url", &self.ast_builder),
             &self.ast_builder,
           ),
+          self.create_self_location_href_expr(),
+          false,
+          false,
+          false,
           &self.ast_builder,
-        ),
+        )],
         &self.ast_builder,
       ),
       &self.ast_builder,


### PR DESCRIPTION
Follow-on after #10018.

The new AST builder methods allow passing arrays where a `Vec` is required. Use this facility to remove a lot of repetitious boilerplate.

Before:

```rust
FunctionBody::new(
  SPAN,
  oxc::allocator::Vec::new_in(&self.ast_builder),
  oxc::allocator::Vec::from_value_in(try_stmt, &self.ast_builder),
  &self.ast_builder,
)
```

After:

```rust
FunctionBody::new(SPAN, [], [try_stmt], &self.ast_builder)
```

Note: Like #10418, diff is quite large, but these changes were almost entirely produced using the same [deterministic codemod](https://github.com/oxc-project/oxc/tree/overlookmotel/ast-builder-codemod) we used to migrate Oxc repo to new AST builder, with only some final tweaks by an LLM. I've reviewed it all and, even though I'm unfamiliar with Rolldown's codebase, I'm pretty confident it looks correct.