### PR TITLE
perf: pass string literals to AST builder methods

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -2499,7 +2499,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
   }
 
-  #[expect(clippy::too_many_lines)]
   fn try_rewrite_import_expression(&self, node: &mut ast::Expression<'ast>) -> bool {
     let ast::Expression::ImportExpression(expr) = node else {
       return false;
@@ -2695,11 +2694,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             [ast::FormalParameter::new(
               SPAN,
               [],
-              ast::BindingPattern::new_binding_identifier(
-                SPAN,
-                oxc::ast::ast::Str::from_str_in("m", &self.ast_builder),
-                &self.ast_builder,
-              ),
+              ast::BindingPattern::new_binding_identifier(SPAN, "m", &self.ast_builder),
               NONE,
               NONE,
               false,

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -130,12 +130,8 @@ pub trait ExpressionFactoryExt<'ast> {
           SPAN,
           Expression::new_static_member_expression(
             SPAN,
-            Expression::new_identifier(
-              SPAN,
-              oxc::ast::ast::Str::from_str_in("Promise", builder),
-              builder,
-            ),
-            IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("resolve", builder), builder),
+            Expression::new_identifier(SPAN, "Promise", builder),
+            IdentifierName::new(SPAN, "resolve", builder),
             false,
             builder,
           ),
@@ -144,7 +140,7 @@ pub trait ExpressionFactoryExt<'ast> {
           false,
           builder,
         ),
-        IdentifierName::new(SPAN, oxc::ast::ast::Str::from_str_in("then", builder), builder),
+        IdentifierName::new(SPAN, "then", builder),
         false,
         builder,
       ),
@@ -907,11 +903,7 @@ fn then_with_arrow_callback<'ast, B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
       [FormalParameter::new(
         SPAN,
         [],
-        BindingPattern::new_binding_identifier(
-          SPAN,
-          oxc::ast::ast::Str::from_str_in("n", builder),
-          builder,
-        ),
+        BindingPattern::new_binding_identifier(SPAN, "n", builder),
         NONE,
         NONE,
         false,

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -45,11 +45,7 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
         [ObjectPropertyKind::new_object_property(
           SPAN,
           oxc::ast::ast::PropertyKind::Init,
-          oxc::ast::ast::PropertyKey::new_static_identifier(
-            SPAN,
-            oxc::ast::ast::Str::from_str_in("url", &self.ast_builder),
-            &self.ast_builder,
-          ),
+          oxc::ast::ast::PropertyKey::new_static_identifier(SPAN, "url", &self.ast_builder),
           self.create_self_location_href_expr(),
           false,
           false,


### PR DESCRIPTION
Follow-on after #10018.

AST builder methods accept any type which is `Into<Str<'ast>>` for `Str` fields. This includes `&'static str`s. Where we have a `&'static str`, pass it directly to the builder method, rather than via `Str::from_str_in`.

This avoids unnecessarily allocating the string into the arena. As a side effect, it also makes the code shorter and more readable.

Before:

```rust
ast::BindingPattern::new_binding_identifier(
  SPAN,
  ast::Str::from_str_in("m", &self.ast_builder),
  &self.ast_builder,
)
```

After:

```rust
ast::BindingPattern::new_binding_identifier(SPAN, "m", &self.ast_builder)
```