### PR TITLE
perf: avoid allocating static strings via custom builder methods

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -19,8 +19,8 @@ use rolldown_common::{
 };
 use rolldown_ecmascript::CJS_REQUIRE_REF_STR;
 use rolldown_ecmascript_utils::{
-  BindingIdentifierFactoryExt as _, ExpressionExt, ExpressionFactoryExt as _,
-  IdentifierNameFactoryExt as _, ObjectPropertyKindFactoryExt as _, StatementFactoryExt as _,
+  ExpressionExt, ExpressionFactoryExt as _, ObjectPropertyKindFactoryExt as _,
+  StatementFactoryExt as _,
 };
 use rolldown_utils::{
   ecmascript::is_validate_identifier_name,
@@ -247,10 +247,10 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             ));
           } else {
             function.id =
-              Some(BindingIdentifier::new_id(SPAN, "__rolldown_default__", &self.ast_builder));
+              Some(BindingIdentifier::new(SPAN, "__rolldown_default__", &self.ast_builder));
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
+              Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
               false,
               &self.ast_builder,
             ));
@@ -267,10 +267,10 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             ));
           } else {
             class.id =
-              Some(BindingIdentifier::new_id(SPAN, "__rolldown_default__", &self.ast_builder));
+              Some(BindingIdentifier::new(SPAN, "__rolldown_default__", &self.ast_builder));
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
+              Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
               false,
               &self.ast_builder,
             ));
@@ -287,7 +287,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ));
           self.exports.push(ObjectPropertyKind::new_lazy_export_property(
             "default",
-            Expression::new_id_ref_expr(SPAN, "__rolldown_default__", &self.ast_builder),
+            Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
             false,
             &self.ast_builder,
           ));
@@ -544,7 +544,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
     let export_call_expr = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.__exportAll", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.__exportAll", &self.ast_builder),
       NONE,
       [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_builder.allocator()))],
       false,
@@ -603,7 +603,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Build: encodeURIComponent(importee.id)
       let encode_call = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_id_ref_expr(SPAN, "encodeURIComponent", &self.ast_builder),
+        Expression::new_identifier(SPAN, "encodeURIComponent", &self.ast_builder),
         NONE,
         [ast::Argument::new_string_literal(
           SPAN,
@@ -670,7 +670,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
       let load_exports_call = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
+        Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
         NONE,
         [ast::Argument::new_string_literal(
           SPAN,
@@ -732,7 +732,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // Use stable module ID for consistent runtime lookup
     let mut load_exports_call_expr = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
       NONE,
       [ast::Argument::new_string_literal(
         SPAN,
@@ -764,7 +764,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports('./foo.js'), node_mode)
       load_exports_call_expr = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_id_ref_expr(
+        Expression::new_identifier(
           SPAN,
           "__rolldown_runtime__.__toDynamicImportESM",
           &self.ast_builder,
@@ -896,7 +896,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       Expression::new_static_member_expression(
         SPAN,
         to_commonjs_call,
-        IdentifierName::new_id_name(SPAN, "default", &self.ast_builder),
+        IdentifierName::new(SPAN, "default", &self.ast_builder),
         false,
         &self.ast_builder,
       )

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -227,7 +227,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
 
     let register_factory_call = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_id_ref_expr(SPAN, "__rolldown_runtime__.registerFactory", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.registerFactory", &self.ast_builder),
       NONE,
       register_factory_args,
       false,

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -14,9 +14,7 @@ use oxc::{
   semantic::ScopeFlags,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::{
-  BindingPatternExt as _, ExpressionFactoryExt as _, IdentifierNameFactoryExt as _,
-};
+use rolldown_ecmascript_utils::{BindingPatternExt as _, ExpressionFactoryExt as _};
 
 use super::ast_visit::BuildImportAnalysisVisitor;
 
@@ -203,7 +201,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
     Expression::new_call_expression(
       SPAN,
-      Expression::new_id_ref_expr(SPAN, "__vitePreload", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__vitePreload", &self.ast_builder),
       NONE,
       {
         let append_import_meta_url = self.render_built_url || self.is_relative_base;
@@ -212,7 +210,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
         items.push(argument);
         items.push(Argument::from(if self.is_modern {
-          Expression::new_id_ref_expr(SPAN, "__VITE_PRELOAD__", &self.ast_builder)
+          Expression::new_identifier(SPAN, "__VITE_PRELOAD__", &self.ast_builder)
         } else {
           Expression::new_void_0(SPAN, &self.ast_builder)
         }));
@@ -220,7 +218,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           items.push(Argument::new_static_member_expression(
             SPAN,
             Expression::new_import_meta(SPAN, &self.ast_builder),
-            IdentifierName::new_id_name(SPAN, "url", &self.ast_builder),
+            IdentifierName::new(SPAN, "url", &self.ast_builder),
             false,
             &self.ast_builder,
           ));

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -4,10 +4,7 @@ use oxc::{
   ast_visit::VisitMut,
   span::SPAN,
 };
-use rolldown_ecmascript_utils::{
-  ExpressionExt as _, ExpressionFactoryExt as _, IdentifierNameFactoryExt as _,
-  StatementFactoryExt as _,
-};
+use rolldown_ecmascript_utils::{ExpressionExt as _, StatementFactoryExt as _};
 
 pub struct WebWorkerPostVisitor<'ast> {
   pub ast_builder: AstBuilder<'ast>,
@@ -25,12 +22,12 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
       SPAN,
       Expression::new_static_member_expression(
         SPAN,
-        Expression::new_id_ref_expr(SPAN, "self", &self.ast_builder),
-        IdentifierName::new_id_name(SPAN, "location", &self.ast_builder),
+        Expression::new_identifier(SPAN, "self", &self.ast_builder),
+        IdentifierName::new(SPAN, "location", &self.ast_builder),
         false,
         &self.ast_builder,
       ),
-      IdentifierName::new_id_name(SPAN, "href", &self.ast_builder),
+      IdentifierName::new(SPAN, "href", &self.ast_builder),
       false,
       &self.ast_builder,
     )
@@ -76,7 +73,7 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
       }
       Expression::ImportMeta(_) => {
         self.should_inject_import_meta_object = true;
-        *it = Expression::new_id_ref_expr(SPAN, "_vite_importMeta", &self.ast_builder);
+        *it = Expression::new_identifier(SPAN, "_vite_importMeta", &self.ast_builder);
       }
       _ => oxc::ast_visit::walk_mut::walk_expression(self, it),
     }


### PR DESCRIPTION
Follow-on after #10018, continuation of #10420.

Custom AST builder methods (previously methods of `AstFactory`) take `&str`s. They allocate the string into arena, to obtain a `&'ast str` (allocator lifetime). Where the string is a `&'static str`, it's unnecessary to allocate into arena to extend the lifetime.

In these cases, use standard AST builder methods provided by Oxc, and skip the allocation.

Before:

```rust
BindingIdentifier::new_id(SPAN, "__rolldown_default__", &self.ast_builder)
```

After:

```rust
BindingIdentifier::new(SPAN, "__rolldown_default__", &self.ast_builder)
```