### PR TITLE
perf(hmr): remove unnecessary string allocations

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -621,28 +621,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           [
             ast::TemplateElement::new(
               SPAN,
-              ast::TemplateElementValue {
-                raw: Str::from_str_in("/@vite/lazy?id=", &self.ast_builder),
-                cooked: None,
-              },
+              ast::TemplateElementValue { raw: Str::from("/@vite/lazy?id="), cooked: None },
               false,
               &self.ast_builder,
             ),
             ast::TemplateElement::new(
               SPAN,
-              ast::TemplateElementValue {
-                raw: Str::from_str_in("&clientId=", &self.ast_builder),
-                cooked: None,
-              },
+              ast::TemplateElementValue { raw: Str::from("&clientId="), cooked: None },
               false,
               &self.ast_builder,
             ),
             ast::TemplateElement::new(
               SPAN,
-              ast::TemplateElementValue {
-                raw: Str::from_str_in("", &self.ast_builder),
-                cooked: None,
-              },
+              ast::TemplateElementValue { raw: Str::from(""), cooked: None },
               true,
               &self.ast_builder,
             ),

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -149,7 +149,7 @@ impl<'any, 'ast> HmrAstBuilder<'any, 'ast> for HmrAstFinalizer<'any, 'ast> {
   }
 
   fn binding_name_for_namespace_object_ref_atom(&self) -> ast::Str<'ast> {
-    ast::Str::from_str_in(MODULE_EXPORTS_NAME_FOR_ESM, &self.builder())
+    ast::Str::from(MODULE_EXPORTS_NAME_FOR_ESM)
   }
 
   fn alias_name_for_import_meta_hot(&self) -> ast::Str<'ast> {


### PR DESCRIPTION
Follow-on after #10018, continuation of #10420 and #10421.

When converting `&'static str`s to `Str`s, use `Str::from` instead of `Str::from_str_in`. The difference is that `from_str_in` performs an allocation (in arena), whereas `from` is a zero-cost no-op conversion at runtime. When the `&str` already has a `'static` lifetime, it's unnecessary to extend it by allocating it into arena.

Before:

```rs
TemplateElementValue {
  raw: Str::from_str_in("/@vite/lazy?id=", &self.ast_builder),
  cooked: None,
}
```

After:

```rs
TemplateElementValue { raw: Str::from("/@vite/lazy?id="), cooked: None }
```