### PR TITLE
perf: reduce string allocations

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -151,7 +151,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                   Expression::new_static_member_expression(
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
-                    ast::IdentifierName::new(SPAN, ident.name.as_str(), &self.ast_builder),
+                    ast::IdentifierName::new(SPAN, ident.name, &self.ast_builder),
                     false,
                     &self.ast_builder,
                   )
@@ -160,12 +160,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                   Expression::new_computed_member_expression(
                     SPAN,
                     Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
-                    ast::Expression::new_string_literal(
-                      SPAN,
-                      str.value.as_str(),
-                      None,
-                      &self.ast_builder,
-                    ),
+                    ast::Expression::new_string_literal(SPAN, str.value, None, &self.ast_builder),
                     false,
                     &self.ast_builder,
                   )
@@ -193,7 +188,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                 decl.id.get_binding_identifiers().into_iter().map(|ident| {
                   ObjectPropertyKind::new_lazy_export_property(
                     ident.name.as_str(),
-                    Expression::new_id_ref_expr(SPAN, ident.name.as_str(), &self.ast_builder),
+                    Expression::new_identifier(SPAN, ident.name, &self.ast_builder),
                     false,
                     &self.ast_builder,
                   )
@@ -202,20 +197,20 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             }
             ast::Declaration::FunctionDeclaration(fn_decl) => {
               // export function foo() {}
-              let id = fn_decl.id.as_ref().unwrap().name.as_str();
+              let id = fn_decl.id.as_ref().unwrap().name;
               self.exports.push(ObjectPropertyKind::new_lazy_export_property(
-                id,
-                Expression::new_id_ref_expr(SPAN, id, &self.ast_builder),
+                id.as_str(),
+                Expression::new_identifier(SPAN, id, &self.ast_builder),
                 false,
                 &self.ast_builder,
               ));
             }
             ast::Declaration::ClassDeclaration(cls_decl) => {
               // export class Foo {}
-              let id = cls_decl.id.as_ref().unwrap().name.as_str();
+              let id = cls_decl.id.as_ref().unwrap().name;
               self.exports.push(ObjectPropertyKind::new_lazy_export_property(
-                id,
-                Expression::new_id_ref_expr(SPAN, id, &self.ast_builder),
+                id.as_str(),
+                Expression::new_identifier(SPAN, id, &self.ast_builder),
                 false,
                 &self.ast_builder,
               ));
@@ -241,7 +236,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           if let Some(id) = &function.id {
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              Expression::new_id_ref_expr(SPAN, &id.name, &self.ast_builder),
+              Expression::new_identifier(SPAN, id.name, &self.ast_builder),
               false,
               &self.ast_builder,
             ));
@@ -261,7 +256,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           if let Some(id) = &class.id {
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
-              Expression::new_id_ref_expr(SPAN, &id.name, &self.ast_builder),
+              Expression::new_identifier(SPAN, id.name, &self.ast_builder),
               false,
               &self.ast_builder,
             ));

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -2,9 +2,9 @@ use itertools::Itertools;
 use oxc::ast::AstType;
 use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::{
-  allocator::{self, IntoIn, ReplaceWith, TakeIn},
+  allocator::{self, ReplaceWith, TakeIn},
   ast::{
-    ast::{self, BindingPattern, Expression, IdentifierName, SimpleAssignmentTarget, Statement},
+    ast::{self, BindingPattern, Expression, SimpleAssignmentTarget, Statement},
     builder::NONE,
     match_member_expression,
   },
@@ -16,8 +16,7 @@ use rolldown_common::{ConcatenateWrappedModuleKind, SymbolRef, ThisExprReplaceKi
 use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{
   EsmWrapperBodyKind, EsmWrapperCallKind, EsmWrapperDeclKind, EsmWrapperStmtOptions, ExpressionExt,
-  ExpressionFactoryExt as _, IdentifierNameFactoryExt as _, JsxExt, JsxMemberExpressionObjectExt,
-  StatementFactoryExt as _,
+  ExpressionFactoryExt as _, JsxExt, JsxMemberExpressionObjectExt, StatementFactoryExt as _,
 };
 use rolldown_error::EmptyImportMetaKind;
 
@@ -721,10 +720,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         };
         *property = ast::AssignmentTargetProperty::new_assignment_target_property_property(
           Span::default(),
-          ast::PropertyKey::StaticIdentifier(
-            IdentifierName::new_id_name(prop.span, &prop.binding.name, &self.ast_builder)
-              .into_in(self.alloc),
-          ),
+          ast::PropertyKey::new_static_identifier(prop.span, prop.binding.name, &self.ast_builder),
           binding,
           false,
           &self.ast_builder,


### PR DESCRIPTION
Follow-on after #10018, continuation of #10420 and #10421.

Where we already have a `Str<'ast>` or `Ident<'ast>`, avoid converting it into a `&str` and then allocating it back into arena again to convert back to `Str` or `Ident`. Just re-use the existing `Str` / `Ident`. This avoids unnecessary arena allocations, and in the case of `Ident`, it avoids re-hashing the string too.