### PR TITLE
refactor: implement `GetAstBuilder` on visitor/pass types

### DIFF
--- a/crates/rolldown/src/ast_scanner/const_eval.rs
+++ b/crates/rolldown/src/ast_scanner/const_eval.rs
@@ -23,17 +23,19 @@ pub struct ConstEvalCtx<'me, 'ast: 'me> {
 
 impl<'ast> ConstantEvaluationCtx<'ast> for ConstEvalCtx<'_, 'ast> {}
 
-impl<'ast> GetAllocator<'ast> for ConstEvalCtx<'_, 'ast> {
-  fn allocator(&self) -> &'ast Allocator {
-    self.ast.allocator()
-  }
-}
-
 impl<'ast> GetAstBuilder<'ast> for ConstEvalCtx<'_, 'ast> {
   type Builder = oxc::ast::builder::AstBuilder<'ast>;
 
+  #[inline]
   fn builder(&self) -> &oxc::ast::builder::AstBuilder<'ast> {
     &self.ast
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for ConstEvalCtx<'_, 'ast> {
+  #[inline]
+  fn allocator(&self) -> &'ast Allocator {
+    self.ast.allocator()
   }
 }
 

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -13,7 +13,7 @@ use oxc::{
   span::{SPAN, Span},
 };
 
-use oxc::ast::builder::AstBuilder;
+use oxc::ast::builder::{AstBuilder, GetAstBuilder};
 use rolldown_common::{
   ExternalModule, ImportRecordIdx, ImportRecordMeta, IndexModules, Module, ModuleIdx, NormalModule,
 };
@@ -241,8 +241,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               &self.ast_builder,
             ));
           } else {
-            function.id =
-              Some(BindingIdentifier::new(SPAN, "__rolldown_default__", &self.ast_builder));
+            function.id = Some(BindingIdentifier::new(SPAN, "__rolldown_default__", self));
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
               Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
@@ -261,8 +260,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               &self.ast_builder,
             ));
           } else {
-            class.id =
-              Some(BindingIdentifier::new(SPAN, "__rolldown_default__", &self.ast_builder));
+            class.id = Some(BindingIdentifier::new(SPAN, "__rolldown_default__", self));
             self.exports.push(ObjectPropertyKind::new_lazy_export_property(
               "default",
               Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
@@ -275,11 +273,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         expr @ ast::match_expression!(ExportDefaultDeclarationKind) => {
           let expr = expr.into_expression();
           // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
-          program_body.push(Statement::new_var_decl(
-            "__rolldown_default__",
-            expr,
-            &self.ast_builder,
-          ));
+          program_body.push(Statement::new_var_decl("__rolldown_default__", expr, self));
           self.exports.push(ObjectPropertyKind::new_lazy_export_property(
             "default",
             Expression::new_identifier(SPAN, "__rolldown_default__", &self.ast_builder),
@@ -375,8 +369,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           [self.module.hmr_info.module_request_to_import_record_idx[string_literal.value.as_str()]];
         let Some(module_idx) = import_record.resolved_module else { return };
         // Use stable module ID for consistent runtime lookup
-        string_literal.value =
-          Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_builder);
+        string_literal.value = Str::from_str_in(self.modules[module_idx].stable_id(), self);
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -387,8 +380,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
                 [string_literal.value.as_str()]];
             let Some(module_idx) = import_record.resolved_module else { return };
             // Use stable module ID for consistent runtime lookup
-            string_literal.value =
-              Str::from_str_in(self.modules[module_idx].stable_id(), &self.ast_builder);
+            string_literal.value = Str::from_str_in(self.modules[module_idx].stable_id(), self);
           }
         });
       }
@@ -399,7 +391,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
   pub fn rewrite_import_meta_hot(&self, expr: &mut ast::Expression<'ast>) {
     if expr.is_import_meta_hot() {
       let hot_name = format!("hot_{}", self.module.repr_name);
-      *expr = Expression::new_id_ref_expr(SPAN, &hot_name, &self.ast_builder);
+      *expr = Expression::new_id_ref_expr(SPAN, &hot_name, self);
     }
   }
 
@@ -421,15 +413,10 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       Module::External(_) => None,
     };
     let call_expr = Expression::new_call_with_arg(
-      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", &self.ast_builder),
-      ast::Expression::new_string_literal(
-        SPAN,
-        Str::from_str_in(id, &self.ast_builder),
-        None,
-        &self.ast_builder,
-      ),
+      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", self),
+      ast::Expression::new_string_literal(SPAN, Str::from_str_in(id, self), None, self),
       false,
-      &self.ast_builder,
+      self,
     );
 
     // var [binding_name] = [__toESM-wrapped loadExports call];
@@ -441,21 +428,21 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         ast::VariableDeclarationKind::Var,
         ast::BindingPattern::new_binding_identifier(
           SPAN,
-          Str::from_str_in(binding_name, &self.ast_builder),
-          &self.ast_builder,
+          Str::from_str_in(binding_name, self),
+          self,
         ),
         NONE,
         Some(Expression::new_to_esm_call_with_interop(
           "__rolldown_runtime__.__toESM",
           call_expr,
           interop,
-          &self.ast_builder,
+          self,
         )),
         false,
-        &self.ast_builder,
+        self,
       )],
       false,
-      &self.ast_builder,
+      self,
     );
     Some(stmt)
   }
@@ -473,7 +460,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let module_request = &importee.id;
 
     // import * as [binding_name] from 'external';
-    let stmt = Statement::new_import_star_stmt(module_request, binding_name, &self.ast_builder);
+    let stmt = Statement::new_import_star_stmt(module_request, binding_name, self);
 
     self.generated_static_import_stmts_from_external.insert(importee.idx, stmt);
   }
@@ -493,20 +480,20 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     let call_expr = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_member_access_expr("__rolldown_runtime__", "__reExport", &self.ast_builder),
+      Expression::new_member_access_expr("__rolldown_runtime__", "__reExport", self),
       NONE,
       oxc::allocator::Vec::from_iter_in(
         [
-          ast::Argument::from(Expression::new_id_ref_expr(SPAN, self_exports, &self.ast_builder)),
-          ast::Argument::from(Expression::new_id_ref_expr(SPAN, binding_name, &self.ast_builder)),
+          ast::Argument::from(Expression::new_id_ref_expr(SPAN, self_exports, self)),
+          ast::Argument::from(Expression::new_id_ref_expr(SPAN, binding_name, self)),
         ],
-        &self.ast_builder,
+        self,
       ),
       false,
-      &self.ast_builder,
+      self,
     );
 
-    Some(ast::Statement::new_expression_statement(span, call_expr, &self.ast_builder))
+    Some(ast::Statement::new_expression_statement(span, call_expr, self))
   }
 
   fn generate_declaration_of_module_namespace_object(
@@ -519,39 +506,36 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // construct `{ prop_name: () => returned, ... }`
     let mut arg_obj_expr = ast::ObjectExpression::boxed(
       SPAN,
-      oxc::allocator::Vec::with_capacity_in(self.exports.len(), &self.ast_builder),
-      &self.ast_builder,
+      oxc::allocator::Vec::with_capacity_in(self.exports.len(), self),
+      self,
     );
     arg_obj_expr.properties.extend(self.exports.drain(..));
     arg_obj_expr.properties.extend(self.named_exports.iter().map(|(exported, named_export)| {
       let expr = if let Some(local_binding) = self.import_bindings.get(&named_export.local_binding)
       {
-        Expression::new_id_ref_expr(SPAN, local_binding, &self.ast_builder)
+        Expression::new_id_ref_expr(SPAN, local_binding, self)
       } else {
         let name = scoping.symbol_name(named_export.local_binding);
-        Expression::new_id_ref_expr(SPAN, name, &self.ast_builder)
+        Expression::new_id_ref_expr(SPAN, name, self)
       };
       // Use computed property syntax for non-identifier export names (e.g., 'rolldown:exports')
       let computed = !is_validate_identifier_name(exported.as_str());
-      ObjectPropertyKind::new_lazy_export_property(exported, expr, computed, &self.ast_builder)
+      ObjectPropertyKind::new_lazy_export_property(exported, expr, computed, self)
     }));
 
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
     let export_call_expr = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_identifier(SPAN, "__rolldown_runtime__.__exportAll", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.__exportAll", self),
       NONE,
       [ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.ast_builder.allocator()))],
       false,
-      &self.ast_builder,
+      self,
     );
 
     // construct `var [binding_name_for_namespace_object_ref] = __exportAll({ prop_name: () => returned, ... })`
-    let decl_stmt = Statement::new_var_decl(
-      binding_name_for_namespace_object_ref,
-      export_call_expr,
-      &self.ast_builder,
-    );
+    let decl_stmt =
+      Statement::new_var_decl(binding_name_for_namespace_object_ref, export_call_expr, self);
     vec![decl_stmt]
   }
 
@@ -598,16 +582,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       // Build: encodeURIComponent(importee.id)
       let encode_call = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_identifier(SPAN, "encodeURIComponent", &self.ast_builder),
+        Expression::new_identifier(SPAN, "encodeURIComponent", self),
         NONE,
-        [ast::Argument::new_string_literal(
-          SPAN,
-          Str::from_str_in(&importee.id, &self.ast_builder),
-          None,
-          &self.ast_builder,
-        )],
+        [ast::Argument::new_string_literal(SPAN, Str::from_str_in(&importee.id, self), None, self)],
         false,
-        &self.ast_builder,
+        self,
       );
 
       // Build template literal: `/@vite/lazy?id=${encodeURIComponent(importee.id)}&clientId=${__rolldown_runtime__.clientId}`
@@ -618,54 +597,49 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               SPAN,
               ast::TemplateElementValue { raw: Str::from("/@vite/lazy?id="), cooked: None },
               false,
-              &self.ast_builder,
+              self,
             ),
             ast::TemplateElement::new(
               SPAN,
               ast::TemplateElementValue { raw: Str::from("&clientId="), cooked: None },
               false,
-              &self.ast_builder,
+              self,
             ),
             ast::TemplateElement::new(
               SPAN,
               ast::TemplateElementValue { raw: Str::from(""), cooked: None },
               true,
-              &self.ast_builder,
+              self,
             ),
           ],
-          &self.ast_builder,
+          self,
         );
         let expressions = oxc::allocator::Vec::from_iter_in(
           [
             encode_call,
-            Expression::new_member_access_expr(
-              "__rolldown_runtime__",
-              "clientId",
-              &self.ast_builder,
-            ),
+            Expression::new_member_access_expr("__rolldown_runtime__", "clientId", self),
           ],
-          &self.ast_builder,
+          self,
         );
-        ast::Expression::new_template_literal(SPAN, quasis, expressions, &self.ast_builder)
+        ast::Expression::new_template_literal(SPAN, quasis, expressions, self)
       };
 
       // Build: import(`/@vite/lazy?id=...&clientId=...`)
-      let import_expr =
-        ast::Expression::new_import_expression(SPAN, url_expr, None, None, &self.ast_builder);
+      let import_expr = ast::Expression::new_import_expression(SPAN, url_expr, None, None, self);
 
       // Build: __rolldown_runtime__.loadExports("<stable_proxy_id>")
       let load_exports_call = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
+        Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", self),
         NONE,
         [ast::Argument::new_string_literal(
           SPAN,
-          Str::from_str_in(&importee.stable_id, &self.ast_builder),
+          Str::from_str_in(&importee.stable_id, self),
           None,
-          &self.ast_builder,
+          self,
         )],
         false,
-        &self.ast_builder,
+        self,
       );
 
       // Build: () => __rolldown_runtime__.loadExports("<stable_proxy_id>")
@@ -679,25 +653,25 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ast::FormalParameterKind::ArrowFormalParameters,
           [],
           NONE,
-          &self.ast_builder,
+          self,
         ),
         NONE,
         ast::FunctionBody::new(
           SPAN,
           [],
-          [ast::Statement::new_expression_statement(SPAN, load_exports_call, &self.ast_builder)],
-          &self.ast_builder,
+          [ast::Statement::new_expression_statement(SPAN, load_exports_call, self)],
+          self,
         ),
-        &self.ast_builder,
+        self,
       );
 
       // Build: import(...).then(() => __rolldown_runtime__.loadExports("..."))
       let then_callee = Expression::new_static_member_expression(
         SPAN,
         import_expr,
-        ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
+        ast::IdentifierName::new(SPAN, "then", self),
         false,
-        &self.ast_builder,
+        self,
       );
 
       *it = ast::Expression::new_call_expression(
@@ -706,7 +680,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         NONE,
         [ast::Argument::from(arrow_fn)],
         false,
-        &self.ast_builder,
+        self,
       );
       return;
     }
@@ -718,47 +692,41 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // Use stable module ID for consistent runtime lookup
     let mut load_exports_call_expr = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.loadExports", self),
       NONE,
       [ast::Argument::new_string_literal(
         SPAN,
-        Str::from_str_in(&importee.stable_id, &self.ast_builder),
+        Str::from_str_in(&importee.stable_id, self),
         None,
-        &self.ast_builder,
+        self,
       )],
       false,
-      &self.ast_builder,
+      self,
     );
 
     if is_importee_cjs {
       let is_node_cjs = importee.def_format.is_commonjs();
 
-      let mut args = oxc::allocator::Vec::from_value_in(
-        ast::Argument::from(load_exports_call_expr),
-        &self.ast_builder,
-      );
+      let mut args =
+        oxc::allocator::Vec::from_value_in(ast::Argument::from(load_exports_call_expr), self);
       if is_node_cjs {
         args.push(ast::Argument::new_numeric_literal(
           SPAN,
           1.0,
           None,
           ast::NumberBase::Decimal,
-          &self.ast_builder,
+          self,
         ));
       }
 
       // __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports('./foo.js'), node_mode)
       load_exports_call_expr = ast::Expression::new_call_expression(
         SPAN,
-        Expression::new_identifier(
-          SPAN,
-          "__rolldown_runtime__.__toDynamicImportESM",
-          &self.ast_builder,
-        ),
+        Expression::new_identifier(SPAN, "__rolldown_runtime__.__toDynamicImportESM", self),
         NONE,
         args,
         false,
-        &self.ast_builder,
+        self,
       );
     }
 
@@ -772,11 +740,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // `(__rolldown_runtime__.initModule('./foo.js'), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))`
     let init_call = self.make_init_module_call(&self.modules[importee_idx]);
     let promise_resolve_then_load_exports =
-      Expression::new_promise_resolve_then(load_exports_call_expr, &self.ast_builder);
+      Expression::new_promise_resolve_then(load_exports_call_expr, self);
     *it = ast::Expression::new_sequence_expression(
       SPAN,
       [init_call, promise_resolve_then_load_exports],
-      &self.ast_builder,
+      self,
     );
   }
 
@@ -793,11 +761,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       && id_ref.is_global_reference(scoping)
       && !ctx.parent().is_call_expression()
     {
-      *it = Expression::new_member_access_expr(
-        "__rolldown_runtime__",
-        "loadExports",
-        &self.ast_builder,
-      );
+      *it = Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", self);
     }
 
     // Rewrite `require(...)` to `(require_xxx(), __rolldown_runtime__.loadExports())` or keep it as is for external module importee.
@@ -831,15 +795,15 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     // Use stable module ID for consistent runtime lookup
     let load_exports_call = Expression::new_call_with_arg(
-      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", &self.ast_builder),
+      Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", self),
       ast::Expression::new_string_literal(
         SPAN,
-        Str::from_str_in(&importee.stable_id, &self.ast_builder),
+        Str::from_str_in(&importee.stable_id, self),
         None,
-        &self.ast_builder,
+        self,
       ),
       false,
-      &self.ast_builder,
+      self,
     );
 
     let load_exports_expr = if importee.meta.has_lazy_export() || is_importee_cjs {
@@ -870,32 +834,24 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     } else if rec.meta.contains(ImportRecordMeta::JsonModule) {
       // Vite-mode JSON: ESM-wrapped at runtime, unwrap to the JSON value.
       let to_commonjs_call = Expression::new_call_with_arg(
-        Expression::new_member_access_expr(
-          "__rolldown_runtime__",
-          "__toCommonJS",
-          &self.ast_builder,
-        ),
+        Expression::new_member_access_expr("__rolldown_runtime__", "__toCommonJS", self),
         load_exports_call,
         false,
-        &self.ast_builder,
+        self,
       );
       Expression::new_static_member_expression(
         SPAN,
         to_commonjs_call,
-        IdentifierName::new(SPAN, "default", &self.ast_builder),
+        IdentifierName::new(SPAN, "default", self),
         false,
-        &self.ast_builder,
+        self,
       )
     } else {
       Expression::new_call_with_arg(
-        Expression::new_member_access_expr(
-          "__rolldown_runtime__",
-          "__toCommonJS",
-          &self.ast_builder,
-        ),
+        Expression::new_member_access_expr("__rolldown_runtime__", "__toCommonJS", self),
         load_exports_call,
         false,
-        &self.ast_builder,
+        self,
       )
     };
 
@@ -906,23 +862,39 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     *it = Expression::new_seq_in_parens(
       self.make_init_module_call(&self.modules[importee_idx]),
       load_exports_expr,
-      &self.ast_builder,
+      self,
     );
   }
 
   /// `__rolldown_runtime__.initModule("<stable id>")`
   pub fn make_init_module_call(&self, module: &Module) -> ast::Expression<'ast> {
     Expression::new_call_with_arg(
-      Expression::new_member_access_expr("__rolldown_runtime__", "initModule", &self.ast_builder),
+      Expression::new_member_access_expr("__rolldown_runtime__", "initModule", self),
       ast::Expression::new_string_literal(
         SPAN,
-        Str::from_str_in(module.stable_id(), &self.ast_builder),
+        Str::from_str_in(module.stable_id(), self),
         None,
-        &self.ast_builder,
+        self,
       ),
       false,
-      &self.ast_builder,
+      self,
     )
+  }
+}
+
+impl<'ast> GetAstBuilder<'ast> for HmrAstFinalizer<'_, 'ast> {
+  type Builder = AstBuilder<'ast>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'ast> {
+    &self.ast_builder
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for HmrAstFinalizer<'_, 'ast> {
+  #[inline]
+  fn allocator(&self) -> &'ast oxc::allocator::Allocator {
+    self.ast_builder.allocator()
   }
 }
 

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -1,4 +1,3 @@
-use oxc::allocator::GetAllocator;
 use oxc::{
   allocator::TakeIn,
   ast::{
@@ -25,7 +24,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let taken_body = node.body.take_in(&self.ast_builder.allocator());
+    let taken_body = node.body.take_in(self);
     node.body.reserve_exact(taken_body.len());
     taken_body.into_iter().for_each(|top_level_stmt| {
       self.handle_top_level_stmt(&mut node.body, top_level_stmt, ctx.scoping());
@@ -37,7 +36,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node: &mut ast::Program<'ast>,
     ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
   ) {
-    let mut try_block = ast::BlockStatement::boxed(SPAN, [], &self.ast_builder);
+    let mut try_block = ast::BlockStatement::boxed(SPAN, [], self);
 
     // `initModule("<stable id>")` for EVERY static dep, uniformly registry-gated: a
     // co-carried factory runs, a resident module short-circuits. No payload-membership
@@ -48,11 +47,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       .filter_map(|dep| {
         let module = &self.modules[*dep];
         module.as_normal().map(|_| {
-          ast::Statement::new_expression_statement(
-            SPAN,
-            self.make_init_module_call(module),
-            &self.ast_builder,
-          )
+          ast::Statement::new_expression_statement(SPAN, self.make_init_module_call(module), self)
         })
       })
       .collect();
@@ -63,21 +58,20 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // module/exports objects become locals the body's rewritten `module`/`exports`
     // references resolve to.
     let cjs_module_locals: Vec<ast::Statement<'ast>> = if self.module.exports_kind.is_commonjs() {
-      let empty_exports_object =
-        ast::Expression::new_object_expression(SPAN, [], &self.ast_builder);
+      let empty_exports_object = ast::Expression::new_object_expression(SPAN, [], self);
       let module_object = ast::Expression::new_object_expression(
         SPAN,
         [ast::ObjectPropertyKind::new_object_property(
           SPAN,
           ast::PropertyKind::Init,
-          ast::PropertyKey::new_static_identifier(SPAN, "exports", &self.ast_builder),
+          ast::PropertyKey::new_static_identifier(SPAN, "exports", self),
           empty_exports_object,
           true,
           false,
           false,
-          &self.ast_builder,
+          self,
         )],
-        &self.ast_builder,
+        self,
       );
       vec![
         // var __rolldown_module__ = { exports: {} };
@@ -91,17 +85,17 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_MODULE_REF_IDENT,
-                &self.ast_builder,
+                self,
               ),
               NONE,
               Some(module_object),
               false,
-              &self.ast_builder,
+              self,
             ),
-            &self.ast_builder,
+            self,
           ),
           false,
-          &self.ast_builder,
+          self,
         )),
         // var __rolldown_exports__ = __rolldown_module__.exports;
         ast::Statement::from(ast::Declaration::new_variable_declaration(
@@ -114,21 +108,17 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_EXPORTS_REF_IDENT,
-                &self.ast_builder,
+                self,
               ),
               NONE,
-              Some(Expression::new_member_access_expr(
-                CJS_ROLLDOWN_MODULE_REF,
-                "exports",
-                &self.ast_builder,
-              )),
+              Some(Expression::new_member_access_expr(CJS_ROLLDOWN_MODULE_REF, "exports", self)),
               false,
-              &self.ast_builder,
+              self,
             ),
-            &self.ast_builder,
+            self,
           ),
           false,
-          &self.ast_builder,
+          self,
         )),
       ]
     } else {
@@ -146,21 +136,16 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     try_block.body.extend(runtime_module_register);
     try_block.body.extend(dependencies_init_fn_stmts);
     try_block.body.push(self.create_module_hot_context_initializer_stmt());
-    try_block.body.extend(node.body.take_in(&self.ast_builder.allocator()));
+    try_block.body.extend(node.body.take_in(self));
 
     node
       .body
       .extend(std::mem::take(&mut self.generated_static_import_stmts_from_external).into_values());
 
-    let final_block = ast::BlockStatement::boxed(SPAN, [], &self.ast_builder);
+    let final_block = ast::BlockStatement::boxed(SPAN, [], self);
 
-    let try_stmt = ast::Statement::new_try_statement(
-      SPAN,
-      try_block,
-      NONE,
-      Some(final_block),
-      &self.ast_builder,
-    );
+    let try_stmt =
+      ast::Statement::new_try_statement(SPAN, try_block, NONE, Some(final_block), self);
 
     // The runtime calls the factory with the module's stable id as its argument, so it's
     // available inside the body as `__rolldown_module_id__`. This lets registerModule /
@@ -169,21 +154,21 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     let module_id_param = ast::FormalParameter::new(
       SPAN,
       [],
-      ast::BindingPattern::new_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, &self.ast_builder),
+      ast::BindingPattern::new_binding_identifier(SPAN, MODULE_ID_PARAM_FOR_HMR, self),
       NONE,
       NONE,
       false,
       None,
       false,
       false,
-      &self.ast_builder,
+      self,
     );
     let params = ast::FormalParameters::new(
       SPAN,
       ast::FormalParameterKind::Signature,
       [module_id_param],
       NONE,
-      &self.ast_builder,
+      self,
     );
     // function () { [user code] }
     let mut user_code_wrapper = ast::Function::boxed(
@@ -197,8 +182,8 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       NONE,
       params,
       NONE,
-      Some(ast::FunctionBody::new(SPAN, [], [try_stmt], &self.ast_builder)),
-      &self.ast_builder,
+      Some(ast::FunctionBody::new(SPAN, [], [try_stmt], self)),
+      self,
     );
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
     user_code_wrapper.pife = self.use_pife_for_module_wrappers;
@@ -206,39 +191,35 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // __rolldown_runtime__.registerFactory(stable_id, kind, function (__rolldown_module_id__) { [user code] })
     // Every factory is id-addressed and registry-gated at runtime; re-execution policy
     // is runtime data (evictions), never a per-payload flag.
-    let mut register_factory_args = oxc::allocator::Vec::with_capacity_in(3, &self.ast_builder);
+    let mut register_factory_args = oxc::allocator::Vec::with_capacity_in(3, self);
     register_factory_args.push(ast::Argument::new_string_literal(
       SPAN,
-      oxc::ast::ast::Str::from_str_in(&self.module.stable_id, &self.ast_builder),
+      oxc::ast::ast::Str::from_str_in(&self.module.stable_id, self),
       None,
-      &self.ast_builder,
+      self,
     ));
     register_factory_args.push(ast::Argument::new_string_literal(
       SPAN,
       oxc::ast::ast::Str::from_str_in(
         if self.module.exports_kind.is_commonjs() { "cjs" } else { "esm" },
-        &self.ast_builder,
+        self,
       ),
       None,
-      &self.ast_builder,
+      self,
     ));
     register_factory_args
       .push(ast::Argument::from(ast::Expression::FunctionExpression(user_code_wrapper)));
 
     let register_factory_call = ast::Expression::new_call_expression(
       SPAN,
-      Expression::new_identifier(SPAN, "__rolldown_runtime__.registerFactory", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__rolldown_runtime__.registerFactory", self),
       NONE,
       register_factory_args,
       false,
-      &self.ast_builder,
+      self,
     );
 
-    node.body.push(ast::Statement::new_expression_statement(
-      SPAN,
-      register_factory_call,
-      &self.ast_builder,
-    ));
+    node.body.push(ast::Statement::new_expression_statement(SPAN, register_factory_call, self));
   }
 
   fn enter_call_expression(
@@ -260,7 +241,7 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
       && self.module.exports_kind.is_commonjs()
       && self.module.ecma_view.this_expr_replace_map.contains_key(&this_expr.node_id())
     {
-      *node = Expression::new_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF, &self.ast_builder);
+      *node = Expression::new_id_ref_expr(SPAN, CJS_ROLLDOWN_EXPORTS_REF, self);
       return;
     }
 
@@ -293,8 +274,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     let reference = ctx.scoping().get_reference(reference_id);
     if let Some(symbol_id) = reference.symbol_id() {
       if let Some(binding_name) = self.import_bindings.get(&symbol_id) {
-        ident.name =
-          oxc::ast::ast::Str::from_str_in(binding_name.as_str(), &self.ast_builder).into();
+        ident.name = oxc::ast::ast::Str::from_str_in(binding_name.as_str(), self).into();
       }
     } else if ident.name == CJS_EXPORTS_REF_STR {
       ident.name = CJS_ROLLDOWN_EXPORTS_REF_IDENT;

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -27,7 +27,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if expr.is_import_meta_hot() {
       if let Some(hmr_hot_ref) = self.ctx.module.ecma_view.hmr_hot_ref {
         let hot_name = self.canonical_name_for(hmr_hot_ref);
-        *expr = Expression::new_id_ref_expr(SPAN, hot_name, &self.ast_builder);
+        *expr = Expression::new_id_ref_expr(SPAN, hot_name, self);
       }
     }
   }
@@ -58,7 +58,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
         // Use stable module ID for consistent runtime lookup
         string_literal.value = oxc::ast::ast::Str::from_str_in(
           self.ctx.modules[import_record.into_resolved_module()].stable_id(),
-          &self.ast_builder,
+          self,
         );
       }
       ast::Argument::ArrayExpression(array_expression) => {
@@ -73,7 +73,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
             // Use stable module ID for consistent runtime lookup
             string_literal.value = oxc::ast::ast::Str::from_str_in(
               self.ctx.modules[import_record.into_resolved_module()].stable_id(),
-              &self.ast_builder,
+              self,
             );
           }
         });

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -136,8 +136,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         let canonical_name = self.canonical_name_for(*symbol_ref);
         program.body.push(Statement::new_var_decl(
           canonical_name,
-          ast::Expression::new_void_0(SPAN, &self.ast_builder),
-          &self.ast_builder,
+          ast::Expression::new_void_0(SPAN, self),
+          self,
         ));
       }
     });
@@ -159,7 +159,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
 
         let (commonjs_ref_expr, _) = self.finalized_expr_for_symbol_ref(commonjs_ref, false, false);
 
-        let mut stmts_inside_closure = allocator::Vec::new_in(&self.alloc);
+        let mut stmts_inside_closure = allocator::Vec::new_in(self);
         stmts_inside_closure.append(&mut program.body);
 
         program.body.push(Statement::new_commonjs_wrapper_stmt(
@@ -170,7 +170,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.ctx.options.profiler_names,
           &self.ctx.module.stable_id,
           self.ctx.linking_info.is_tla_or_contains_tla_dependency,
-          &self.ast_builder,
+          self,
         ));
       }
       ModuleWrapperMode::InteropEsm(target) | ModuleWrapperMode::ExecutionOrder(target) => {
@@ -178,10 +178,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.ctx.linking_info.concatenated_wrapped_module_kind,
           ConcatenateWrappedModuleKind::None
         );
-        let old_body = program.body.take_in(&self.alloc);
+        let old_body = program.body.take_in(self);
 
-        let mut fn_stmts = allocator::Vec::new_in(&self.alloc);
-        let mut stmts_inside_closure = allocator::Vec::new_in(&self.alloc);
+        let mut fn_stmts = allocator::Vec::new_in(self);
+        let mut stmts_inside_closure = allocator::Vec::new_in(self);
 
         // Hoist all top-level "var" and "function" declarations out of the closure
         old_body.into_iter().for_each(|mut stmt| match &mut stmt {
@@ -274,9 +274,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.ctx.linking_info.concatenated_wrapped_module_kind,
           ConcatenateWrappedModuleKind::Root
         ) {
-          self.rendered_concatenated_wrapped_module_parts.rendered_esm_runtime_expr = Some(
-            ast::ExpressionStatement::new(SPAN, esm_ref_expr, &self.ast_builder).to_source_string(),
-          );
+          self.rendered_concatenated_wrapped_module_parts.rendered_esm_runtime_expr =
+            Some(ast::ExpressionStatement::new(SPAN, esm_ref_expr, self).to_source_string());
           self.rendered_concatenated_wrapped_module_parts.wrap_ref_name =
             Some(CompactStr::new(wrap_ref_name));
           program.body.extend(stmts_inside_closure);
@@ -309,7 +308,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
               EsmWrapperDeclKind::Var
             },
           },
-          &self.ast_builder,
+          self,
         ));
       }
       ModuleWrapperMode::None => {
@@ -331,7 +330,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       assert!(symbol.namespace_alias.is_none());
       let canonical_name = self.canonical_name_for(symbol_ref);
       if ident.name != canonical_name {
-        ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
+        ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, self).into();
       }
       ident.symbol_id.get_mut().take();
     } else {
@@ -354,7 +353,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         self.var_declaration_to_expr_seq_and_bindings(decl, self.state)
       {
         self.top_level_var_bindings.extend(bindings);
-        *it = ast::Statement::new_expression_statement(SPAN, expr, &self.ast_builder);
+        *it = ast::Statement::new_expression_statement(SPAN, expr, self);
       }
     }
   }
@@ -408,8 +407,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let symbol_ref: SymbolRef = (self.ctx.idx, symbol_id).into();
                 let canonical_name = self.canonical_name_for(symbol_ref);
                 if id.name != canonical_name {
-                  id.name =
-                    oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
+                  id.name = oxc::ast::ast::Str::from_str_in(canonical_name, self).into();
                 }
                 // Clear symbol_id to prevent double processing:
                 // - visit_expression won't re-wrap when walker visits inner fn
@@ -425,7 +423,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                     fn_expr,
                     finalized_callee,
                     true,
-                    &self.ast_builder,
+                    self,
                   )
                 });
               }
@@ -485,17 +483,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         {
           match kind {
             ThisExprReplaceKind::Exports => {
-              *expr = ast::Expression::new_identifier(SPAN, "exports", &self.ast_builder);
+              *expr = ast::Expression::new_identifier(SPAN, "exports", self);
             }
             ThisExprReplaceKind::Context if self.ctx.options.context.is_empty() => {
-              *expr = ast::Expression::new_void_0(SPAN, &self.ast_builder);
+              *expr = ast::Expression::new_void_0(SPAN, self);
             }
             ThisExprReplaceKind::Context => {
-              *expr = Expression::new_id_ref_expr(
-                SPAN,
-                self.ctx.options.context.as_str(),
-                &self.ast_builder,
-              );
+              *expr = Expression::new_id_ref_expr(SPAN, self.ctx.options.context.as_str(), self);
             }
           }
         }
@@ -503,7 +497,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       ast::Expression::ImportMeta(import_meta) => {
         if !self.ctx.options.format.keep_esm_import_export_syntax() {
           self.record_surviving_import_meta(import_meta.span, EmptyImportMetaKind::Plain);
-          *expr = ast::Expression::new_object_expression(SPAN, [], &self.ast_builder);
+          *expr = ast::Expression::new_object_expression(SPAN, [], self);
         }
       }
       ast::Expression::ChainExpression(_) => {
@@ -538,14 +532,14 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 *expr = ast::Expression::new_chain_expression(
                   chain_span,
                   ast::ChainElement::StaticMemberExpression(member),
-                  &self.ast_builder,
+                  self,
                 );
               }
               ast::Expression::ComputedMemberExpression(member) => {
                 *expr = ast::Expression::new_chain_expression(
                   chain_span,
                   ast::ChainElement::ComputedMemberExpression(member),
-                  &self.ast_builder,
+                  self,
                 );
               }
               _ => {
@@ -602,7 +596,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             Expression::StaticMemberExpression(member_expr) => {
               *it = ast::JSXElementName::MemberExpression(oxc::allocator::Box::new_in(
                 JSXMemberExpression::from_ast(member_expr.unbox(), self.alloc).unwrap(),
-                &self.alloc,
+                self,
               ));
             }
             Expression::ThisExpression(this_expr) => {
@@ -635,7 +629,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                     // In most of scenarios, it should be enough. The ultimate solution is create
                     // an extra binding for the cjs property access then *Uppercase* the binding.
                     JSXMemberExpression::from_ast(member_expr.unbox(), self.alloc).unwrap(),
-                    &self.alloc,
+                    self,
                   )),
                 );
               }
@@ -713,17 +707,17 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             Span::default(),
             ast::AssignmentTarget::from(target),
             init,
-            &self.ast_builder,
+            self,
           )
         } else {
           ast::AssignmentTargetMaybeDefault::from(target)
         };
         *property = ast::AssignmentTargetProperty::new_assignment_target_property_property(
           Span::default(),
-          ast::PropertyKey::new_static_identifier(prop.span, prop.binding.name, &self.ast_builder),
+          ast::PropertyKey::new_static_identifier(prop.span, prop.binding.name, self),
           binding,
           false,
-          &self.ast_builder,
+          self,
         );
       } else {
         prop.binding.reference_id.get_mut().take();

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -187,11 +187,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       [],
       false,
       mark_pure_if_noop && self.ctx.final_esm_init_metadata.init_is_noop(importee_idx),
-      &self.ast_builder,
+      self,
     );
     if await_if_tla && target.tla_tainted {
       // `await init_foo()`
-      ast::Expression::new_await_expression(SPAN, init_call, &self.ast_builder)
+      ast::Expression::new_await_expression(SPAN, init_call, self)
     } else {
       init_call
     }
@@ -338,7 +338,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             NONE,
             [],
             false,
-            &self.ast_builder,
+            self,
           )
         };
 
@@ -355,7 +355,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             to_esm_fn_name,
             require_call,
             self.ctx.module.should_consider_node_esm_spec_for_static_import(),
-            &self.ast_builder,
+            self,
           )
         } else {
           require_call
@@ -363,8 +363,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
         // `import_foo`
         let binding_name_for_wrapper_call_ret = self.canonical_name_for(rec.namespace_ref);
-        *stmt =
-          Statement::new_var_decl(binding_name_for_wrapper_call_ret, init_expr, &self.ast_builder);
+        *stmt = Statement::new_var_decl(binding_name_for_wrapper_call_ret, init_expr, self);
 
         if self.transferred_import_record.contains_key(&rec_idx) {
           self.transferred_import_record.insert(rec_idx, stmt.to_source_string());
@@ -385,7 +384,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         self.generated_init_esm_importee_ids.insert(importee.idx);
         // `init_foo()` / `await init_foo()`
         let init_expr = self.wrapped_esm_init_call_expr(importee.idx, stmt.span(), false, true);
-        *stmt = ast::Statement::new_expression_statement(SPAN, init_expr, &self.ast_builder);
+        *stmt = ast::Statement::new_expression_statement(SPAN, init_expr, self);
 
         if self.transferred_import_record.contains_key(&rec_idx) {
           self.transferred_import_record.insert(rec_idx, stmt.to_source_string());
@@ -409,7 +408,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if !symbol_ref.is_declared_in_root_scope(self.ctx.symbol_db) {
       // No fancy things on none root scope symbols
       return (
-        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(symbol_ref), &self.ast_builder),
+        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(symbol_ref), self),
         FinalizedExprProcessHint::empty(),
       );
     }
@@ -440,16 +439,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       if self.ctx.module.should_consider_node_esm_spec_for_static_import() {
         if let Some(node_mode_name) = self.ctx.chunk.node_mode_external_ns_names.get(&canonical_ref)
         {
-          Expression::new_id_ref_expr(SPAN, node_mode_name.as_str(), &self.ast_builder)
+          Expression::new_id_ref_expr(SPAN, node_mode_name.as_str(), self)
         } else {
-          Expression::new_id_ref_expr(
-            SPAN,
-            self.canonical_name_for(canonical_ref),
-            &self.ast_builder,
-          )
+          Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), self)
         }
       } else {
-        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), &self.ast_builder)
+        Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), self)
       }
     } else {
       match self.ctx.options.format {
@@ -472,18 +467,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             hint.insert(extra_hint);
             expr
           } else {
-            Expression::new_id_ref_expr(
-              SPAN,
-              self.canonical_name_for(canonical_ref),
-              &self.ast_builder,
-            )
+            Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), self)
           }
         }
-        _ => Expression::new_id_ref_expr(
-          SPAN,
-          self.canonical_name_for(canonical_ref),
-          &self.ast_builder,
-        ),
+        _ => Expression::new_id_ref_expr(SPAN, self.canonical_name_for(canonical_ref), self),
       }
     };
 
@@ -492,9 +479,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         expr = ast::Expression::new_static_member_expression(
           SPAN,
           expr,
-          IdentifierName::new_id_name(SPAN, &ns_alias.property_name, &self.ast_builder),
+          IdentifierName::new_id_name(SPAN, &ns_alias.property_name, self),
           false,
-          &self.ast_builder,
+          self,
         );
       }
 
@@ -505,10 +492,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             0.0,
             Some("0".into()),
             NumberBase::Decimal,
-            &self.ast_builder,
+            self,
           ),
           expr,
-          &self.ast_builder,
+          self,
         );
       }
     }
@@ -563,11 +550,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // Cases #1-3: Entry + Cjs
       let expr = match chunk.output_exports {
         // Case #1: Entry + Cjs + Default + default → require_binding
-        OutputExports::Default => {
-          Expression::new_id_ref_expr(SPAN, require_binding, &self.ast_builder)
-        }
+        OutputExports::Default => Expression::new_id_ref_expr(SPAN, require_binding, self),
         // Cases #2-3: Entry + Cjs + Named → require_binding.default (the wrapped module)
-        _ => Expression::new_member_access_expr(require_binding, "default", &self.ast_builder),
+        _ => Expression::new_member_access_expr(require_binding, "default", self),
       };
       return (expr, FinalizedExprProcessHint::FromCjsWrapKindEntry);
     }
@@ -582,12 +567,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // See https://github.com/rolldown/rolldown/issues/7833
     let expr = match (&chunk.output_exports, is_default_export) {
       // Case #7: Entry + None + Default + default → require_binding
-      (OutputExports::Default, true) => {
-        Expression::new_id_ref_expr(SPAN, require_binding, &self.ast_builder)
-      }
+      (OutputExports::Default, true) => Expression::new_id_ref_expr(SPAN, require_binding, self),
       // Cases #5, #8, #10, #12, #14: Named + default → require_binding.default
       // Cases #6, #9, #11, #13, #15: Named + named → require_binding.exportName
-      _ => Expression::new_member_access_expr(require_binding, exported_name, &self.ast_builder),
+      _ => Expression::new_member_access_expr(require_binding, exported_name, self),
     };
 
     (expr, FinalizedExprProcessHint::empty())
@@ -749,24 +732,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return None;
     }
     let mut ret = vec![];
-    let exprs = decl.declarations.take_in(&self.alloc).into_iter().filter_map(|var_decl| {
+    let exprs = decl.declarations.take_in(self).into_iter().filter_map(|var_decl| {
       ret.extend(var_decl.id.get_binding_identifiers().iter().map(|item| item.name));
       // Turn `var ... = ...` to `... = ...`
       let init_expr = var_decl.init?;
-      let left = var_decl.id.into_assignment_target(&self.ast_builder);
+      let left = var_decl.id.into_assignment_target(self);
       Some(ast::Expression::new_assignment_expression(
         SPAN,
         ast::AssignmentOperator::Assign,
         left,
         init_expr,
-        &self.ast_builder,
+        self,
       ))
     });
     Some((
       ast::Expression::new_sequence_expression(
         SPAN,
-        oxc::allocator::Vec::from_iter_in(exprs, &self.ast_builder),
-        &self.ast_builder,
+        oxc::allocator::Vec::from_iter_in(exprs, self),
+        self,
       ),
       ret,
     ))
@@ -807,25 +790,25 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // instead of creating a property. Use computed property syntax for it.
         let key = if is_validate_identifier_name(prop_name) && prop_name != "__proto__" {
           ast::PropertyKey::StaticIdentifier(
-            IdentifierName::new_id_name(SPAN, prop_name, &self.ast_builder).into_in(self.alloc),
+            IdentifierName::new_id_name(SPAN, prop_name, self).into_in(self.alloc),
           )
         } else {
           ast::PropertyKey::new_string_literal(
             SPAN,
-            oxc::ast::ast::Str::from_str_in(prop_name, &self.ast_builder),
+            oxc::ast::ast::Str::from_str_in(prop_name, self),
             None,
-            &self.ast_builder,
+            self,
           )
         };
         Some(ast::ObjectPropertyKind::new_object_property(
           SPAN,
           ast::PropertyKind::Init,
           key,
-          Expression::new_arrow_returning(returned, &self.ast_builder),
+          Expression::new_arrow_returning(returned, self),
           false,
           false,
           prop_name == "__proto__",
-          &self.ast_builder,
+          self,
         ))
       },
     ));
@@ -834,24 +817,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // else construct `__exportAll({ prop_name: () => returned, ... })`
     let module_namespace_rhs =
       if arg_obj_expr.properties.is_empty() && !self.ctx.options.generated_code.symbols {
-        Expression::ObjectExpression(oxc::allocator::Box::new_in(arg_obj_expr, &self.ast_builder))
+        Expression::ObjectExpression(oxc::allocator::Box::new_in(arg_obj_expr, self))
       } else {
         let obj_expr = ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc));
         let args = if self.ctx.options.generated_code.symbols {
-          oxc::allocator::Vec::from_iter_in([obj_expr], &self.ast_builder)
+          oxc::allocator::Vec::from_iter_in([obj_expr], self)
         } else {
           oxc::allocator::Vec::from_iter_in(
             [
               obj_expr,
-              ast::Argument::new_numeric_literal(
-                SPAN,
-                1.0,
-                None,
-                NumberBase::Decimal,
-                &self.ast_builder,
-              ),
+              ast::Argument::new_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal, self),
             ],
-            &self.ast_builder,
+            self,
           )
         };
         ast::Expression::new_call_expression_with_pure(
@@ -861,16 +838,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           args,
           false,
           true,
-          &self.ast_builder,
+          self,
         )
       };
 
     // construct `var [binding_name_for_namespace_object_ref] = __exportAll(...)`
-    let decl_stmt = Statement::new_var_decl(
-      binding_name_for_namespace_object_ref,
-      module_namespace_rhs,
-      &self.ast_builder,
-    );
+    let decl_stmt =
+      Statement::new_var_decl(binding_name_for_namespace_object_ref, module_namespace_rhs, self);
 
     let export_all_externals_rec_ids = &self.ctx.linking_info.star_exports_from_external_modules;
 
@@ -898,27 +872,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let importee_name = &module.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
             // construct `__reExport(importer_exports, importee_exports)`
             let call_expr = CallExpression::new_re_export_call(
-              Expression::new_id_ref_expr(SPAN, re_export_name, &self.ast_builder),
-              Expression::new_id_ref_expr(
-                SPAN,
-                binding_name_for_namespace_object_ref,
-                &self.ast_builder,
-              ),
-              Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
-              &self.ast_builder,
+              Expression::new_id_ref_expr(SPAN, re_export_name, self),
+              Expression::new_id_ref_expr(SPAN, binding_name_for_namespace_object_ref, self),
+              Expression::new_id_ref_expr(SPAN, importee_namespace_name, self),
+              self,
             );
             vec![
               // Insert `import * as ns from 'ext'`external module in esm format
-              Statement::new_import_star_stmt(
-                importee_name,
-                importee_namespace_name,
-                &self.ast_builder,
-              ),
+              Statement::new_import_star_stmt(importee_name, importee_namespace_name, self),
               // Insert `__reExport(foo_exports, ns)`
               ast::Statement::new_expression_statement(
                 SPAN,
                 Expression::CallExpression(call_expr.into_in(self.alloc)),
-                &self.ast_builder,
+                self,
               ),
             ]
           });
@@ -940,23 +906,23 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.finalized_expr_for_runtime_symbol("__reExport"),
               importer_namespace_ref_expr,
               Expression::new_call_with_arg(
-                ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+                ast::Expression::new_identifier(SPAN, "require", self),
                 ast::Expression::new_string_literal(
                   SPAN,
-                  oxc::ast::ast::Str::from_str_in(importee.id().as_str(), &self.ast_builder),
+                  oxc::ast::ast::Str::from_str_in(importee.id().as_str(), self),
                   None,
-                  &self.ast_builder,
+                  self,
                 ),
                 false,
-                &self.ast_builder,
+                self,
               ),
-              &self.ast_builder,
+              self,
             );
 
             Some(ast::Statement::new_expression_statement(
               SPAN,
               Expression::CallExpression(re_export_call_expr.into_in(self.alloc)),
-              &self.ast_builder,
+              self,
             ))
           });
           re_export_external_stmts = Some(stmts.collect());
@@ -989,20 +955,20 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // require('url')
             let require_call = ast::Expression::new_call_expression(
               SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+              ast::Expression::new_identifier(SPAN, "require", self),
               NONE,
-              [ast::Argument::new_string_literal(SPAN, "url", None, &self.ast_builder)],
+              [ast::Argument::new_string_literal(SPAN, "url", None, self)],
               false,
-              &self.ast_builder,
+              self,
             );
 
             // require('url').pathToFileURL
             let require_path_to_file_url = ast::Expression::new_static_member_expression(
               SPAN,
               require_call,
-              ast::IdentifierName::new(SPAN, "pathToFileURL", &self.ast_builder),
+              ast::IdentifierName::new(SPAN, "pathToFileURL", self),
               false,
-              &self.ast_builder,
+              self,
             );
 
             // require('url').pathToFileURL(__filename)
@@ -1010,18 +976,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               SPAN,
               require_path_to_file_url,
               NONE,
-              [ast::Argument::new_identifier(SPAN, "__filename", &self.ast_builder)],
+              [ast::Argument::new_identifier(SPAN, "__filename", self)],
               false,
-              &self.ast_builder,
+              self,
             );
 
             // require('url').pathToFileURL(__filename).href
             let require_path_to_file_url_href = ast::Expression::new_static_member_expression(
               original_expr_span,
               require_path_to_file_url_call,
-              ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
+              ast::IdentifierName::new(SPAN, "href", self),
               false,
-              &self.ast_builder,
+              self,
             );
             Some(require_path_to_file_url_href)
           } else {
@@ -1040,13 +1006,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           return new_expr;
         }
         "dirname" | "filename" => {
-          let name =
-            oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), &self.ast_builder);
-          return can_polyfill_import_meta_url.then_some(ast::Expression::new_identifier(
-            SPAN,
-            name,
-            &self.ast_builder,
-          ));
+          let name = oxc::ast::ast::Str::from_str_in(&format!("__{property_name}"), self);
+          return can_polyfill_import_meta_url
+            .then_some(ast::Expression::new_identifier(SPAN, name, self));
         }
         _ => {}
       }
@@ -1138,14 +1100,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         SPAN,
         ast::Expression::new_new_expression(
           SPAN,
-          ast::Expression::new_identifier(SPAN, "URL", &self.ast_builder),
+          ast::Expression::new_identifier(SPAN, "URL", self),
           NONE,
           [
             ast::Argument::new_string_literal(
               SPAN,
-              oxc::ast::ast::Str::from_str_in(relative_asset_path, &self.ast_builder),
+              oxc::ast::ast::Str::from_str_in(relative_asset_path, self),
               None,
-              &self.ast_builder,
+              self,
             ),
             ast::Argument::new_static_member_expression(
               SPAN,
@@ -1154,18 +1116,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 // polyfilled either, the diagnostic points at the `import.meta.ROLLDOWN_FILE_URL_*`
                 // the user actually wrote.
                 original_expr_span,
-                &self.ast_builder,
+                self,
               ),
-              ast::IdentifierName::new(SPAN, "url", &self.ast_builder),
+              ast::IdentifierName::new(SPAN, "url", self),
               false,
-              &self.ast_builder,
+              self,
             ),
           ],
-          &self.ast_builder,
+          self,
         ),
-        ast::IdentifierName::new(SPAN, "href", &self.ast_builder),
+        ast::IdentifierName::new(SPAN, "href", self),
         false,
-        &self.ast_builder,
+        self,
       );
       return Some(new_expr);
     }
@@ -1212,9 +1174,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     *first_arg_expr = ast::Expression::new_string_literal(
       first_arg_expr.span(),
-      oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+      oxc::ast::ast::Str::from_str_in(&import_path, self),
       None,
-      &self.ast_builder,
+      self,
     );
     None
   }
@@ -1257,12 +1219,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // symbol, we should skip the first prop
             &props[usize::from(is_inlined_commonjs_export)..],
             span,
-            &self.ast_builder,
+            self,
           )
         })
-        .or_else(|| {
-          Some(Expression::new_member_expr_with_void_zero_object(props, span, &self.ast_builder))
-        }),
+        .or_else(|| Some(Expression::new_member_expr_with_void_zero_object(props, span, self))),
       _ => self.try_rewrite_import_meta_prop_expr(member_expr),
     }
   }
@@ -1307,13 +1267,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // Build: ns_name.default. The resolved_member_expr_refs lookup is keyed by post-semantic
     // NodeId, so this synthetic expression won't match scan-time records.
     let ns_name = self.canonical_name_for(ns_alias.namespace_ref);
-    let ns_id_ref = Expression::new_id_ref_expr(SPAN, ns_name, &self.ast_builder);
+    let ns_id_ref = Expression::new_id_ref_expr(SPAN, ns_name, self);
     let default_access = ast::Expression::new_static_member_expression(
       SPAN,
       ns_id_ref,
-      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+      ast::IdentifierName::new(SPAN, "default", self),
       false,
-      &self.ast_builder,
+      self,
     );
 
     // Create: ns_name.default.property or ns_name.default[expression]
@@ -1322,9 +1282,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let final_access = ast::SimpleAssignmentTarget::new_static_member_expression(
           SPAN,
           default_access,
-          IdentifierName::new_id_name(SPAN, property_name, &self.ast_builder),
+          IdentifierName::new_id_name(SPAN, property_name, self),
           false,
-          &self.ast_builder,
+          self,
         );
         Some(final_access)
       }
@@ -1342,7 +1302,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           default_access,
           finalized_expr,
           false,
-          &self.ast_builder,
+          self,
         );
         Some(final_access)
       }
@@ -1391,7 +1351,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // needs to rewrite to `var T = class T { static a = new T(); }`
         let mut id = id.clone();
         let new_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
-        id.name = oxc::ast::ast::Str::from_str_in(new_name, &self.ast_builder).into();
+        id.name = oxc::ast::ast::Str::from_str_in(new_name, self).into();
         class.id = Some(id);
       }
     }
@@ -1401,14 +1361,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       [ast::VariableDeclarator::new(
         SPAN,
         VariableDeclarationKind::Var,
-        ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(id, &self.ast_builder)),
+        ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(id, self)),
         NONE,
         Some(Expression::ClassExpression(class)),
         false,
-        &self.ast_builder,
+        self,
       )],
       false,
-      &self.ast_builder,
+      self,
     ))
   }
 
@@ -1451,7 +1411,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       NONE,
                       [],
                       false,
-                      &self.ast_builder,
+                      self,
                     ))
                   }
                 } else {
@@ -1465,21 +1425,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       NONE,
                       [],
                       false,
-                      &self.ast_builder,
+                      self,
                     ),
                     ast::Expression::new_static_member_expression(
                       SPAN,
-                      Expression::new_call_with_arg(
-                        to_commonjs_ref_name,
-                        ns_name,
-                        false,
-                        &self.ast_builder,
-                      ),
-                      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+                      Expression::new_call_with_arg(to_commonjs_ref_name, ns_name, false, self),
+                      ast::IdentifierName::new(SPAN, "default", self),
                       false,
-                      &self.ast_builder,
+                      self,
                     ),
-                    &self.ast_builder,
+                    self,
                   ))
                 }
               }
@@ -1505,7 +1460,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       [],
                       false,
                       self.ctx.final_esm_init_metadata.init_is_noop(importee.idx),
-                      &self.ast_builder,
+                      self,
                     )
                   };
 
@@ -1530,7 +1485,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     NONE,
                     [ast::Argument::from(namespace_object_ref_expr)],
                     false,
-                    &self.ast_builder,
+                    self,
                   );
 
                   let final_expr = if is_json_module {
@@ -1538,20 +1493,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     Expression::new_static_member_expression(
                       SPAN,
                       to_commonjs_call_expr,
-                      ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+                      ast::IdentifierName::new(SPAN, "default", self),
                       false,
-                      &self.ast_builder,
+                      self,
                     )
                   } else {
                     to_commonjs_call_expr
                   };
 
                   // `(init_xxx(), __toCommonJS(xxx_exports))`
-                  Some(Expression::new_seq_in_parens(
-                    wrap_ref_call_expr,
-                    final_expr,
-                    &self.ast_builder,
-                  ))
+                  Some(Expression::new_seq_in_parens(wrap_ref_call_expr, final_expr, self))
                 }
               }
             }
@@ -1564,10 +1515,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               request_path.span(),
               oxc::ast::ast::Str::from_str_in(
                 &importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths),
-                &self.ast_builder,
+                self,
               ),
               None,
-              &self.ast_builder,
+              self,
             );
             None
           }
@@ -1590,25 +1541,25 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // `Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))`
       return Some(Expression::new_promise_resolve_then(
         Expression::new_call_with_arg(
-          Expression::new_member_access_expr("Object", "freeze", &self.ast_builder),
+          Expression::new_member_access_expr("Object", "freeze", self),
           ast::Expression::new_object_expression(
             SPAN,
             [ast::ObjectPropertyKind::new_object_property(
               SPAN,
               ast::PropertyKind::Init,
-              ast::PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast_builder),
-              ast::Expression::new_null_literal(SPAN, &self.ast_builder),
+              ast::PropertyKey::new_static_identifier(SPAN, "__proto__", self),
+              ast::Expression::new_null_literal(SPAN, self),
               false,
               false,
               false,
-              &self.ast_builder,
+              self,
             )],
-            &self.ast_builder,
+            self,
           ),
           true,
-          &self.ast_builder,
+          self,
         ),
-        &self.ast_builder,
+        self,
       ));
     }
 
@@ -1633,14 +1584,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 Some(Expression::new_callee_then_call(
                   ast::Expression::new_call_expression(
                     SPAN,
-                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
+                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, self),
                     NONE,
                     [],
                     false,
-                    &self.ast_builder,
+                    self,
                   ),
-                  Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
-                  &self.ast_builder,
+                  Expression::new_id_ref_expr(SPAN, importee_namespace_name, self),
+                  self,
                 ))
               } else {
                 //  Promise.resolve().then(function() { return (init_foo(), foo_exports) })
@@ -1648,20 +1599,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   Expression::new_seq_in_parens(
                     ast::Expression::new_call_expression(
                       SPAN,
-                      Expression::new_id_ref_expr(
-                        SPAN,
-                        importee_wrapper_ref_name,
-                        &self.ast_builder,
-                      ),
+                      Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, self),
                       NONE,
                       [],
                       false,
-                      &self.ast_builder,
+                      self,
                     ),
-                    Expression::new_id_ref_expr(SPAN, importee_namespace_name, &self.ast_builder),
-                    &self.ast_builder,
+                    Expression::new_id_ref_expr(SPAN, importee_namespace_name, self),
+                    self,
                   ),
-                  &self.ast_builder,
+                  self,
                 ))
               }
             }
@@ -1672,19 +1619,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());
               Some(Expression::new_promise_resolve_then(
                 Expression::new_to_esm_wrapper(
-                  Expression::new_id_ref_expr(SPAN, to_esm_fn_name, &self.ast_builder),
+                  Expression::new_id_ref_expr(SPAN, to_esm_fn_name, self),
                   ast::Expression::new_call_expression(
                     SPAN,
-                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, &self.ast_builder),
+                    Expression::new_id_ref_expr(SPAN, importee_wrapper_ref_name, self),
                     NONE,
                     [],
                     false,
-                    &self.ast_builder,
+                    self,
                   ),
                   self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-                  &self.ast_builder,
+                  self,
                 ),
-                &self.ast_builder,
+                self,
               ))
             }
             WrapKind::None => {
@@ -1710,7 +1657,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   fn remove_unused_top_level_stmt(&mut self, program: &mut ast::Program<'ast>) -> usize {
     let mut last_import_stmt_idx = None;
 
-    let old_body = program.body.take_in(&self.alloc);
+    let old_body = program.body.take_in(self);
     // the first statement info is the namespace variable declaration
     // skip first statement info to make sure `program.body` has same index as `stmt_infos`
     old_body.into_iter().enumerate().zip(self.ctx.stmt_infos.iter_enumerated().skip(1)).for_each(
@@ -1740,7 +1687,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 program.body.push(ast::Statement::new_expression_statement(
                   SPAN,
                   init_expr,
-                  &self.ast_builder,
+                  self,
                 ));
               }
             }
@@ -1782,12 +1729,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let call_expr = CallExpression::new_re_export_call(
               self.finalized_expr_for_runtime_symbol("__reExport"),
               importer_namespace_ref,
-              importee_namespace_ref, &self.ast_builder
+              importee_namespace_ref, self
             );
             program.body.push(ast::Statement::new_expression_statement(
               top_stmt.span(),
               Expression::CallExpression(call_expr.into_in(self.alloc)),
-              &self.ast_builder,
+              self,
             ));
           }
           return;
@@ -1856,19 +1803,19 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     NONE,
                     [],
                     false,
-                    &self.ast_builder,
+                    self,
                   );
                   if importee_linking_info.is_tla_or_contains_tla_dependency {
                     init_expr = ast::Expression::new_await_expression(
                       SPAN,
                       init_expr,
-                      &self.ast_builder,
+                      self,
                     );
                   }
                   program.body.push(ast::Statement::new_expression_statement(
                     SPAN,
                     init_expr,
-                    &self.ast_builder,
+                    self,
                   ));
                 }
 
@@ -1891,11 +1838,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       let call_expr = CallExpression::new_re_export_call(
                         self.finalized_expr_for_runtime_symbol("__reExport"),
                         importer_namespace_ref,
-                        importee_namespace_ref, &self.ast_builder
+                        importee_namespace_ref, self
                       );
-                      let call_expr = Expression::CallExpression(call_expr.into_in(self.alloc));
+                      let call_expr = Expression::CallExpression(call_expr.into_in(self.allocator()));
                       // __reExport(exports, otherExports)
-                      let stmt = ast::Statement::new_expression_statement(SPAN, call_expr, &self.ast_builder);
+                      let stmt = ast::Statement::new_expression_statement(SPAN, call_expr, self);
                       program.body.push(stmt);
                     }
                   }
@@ -1937,17 +1884,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                           NONE,
                           [],
                           false,
-                          &self.ast_builder,
+                          self,
                         ),
-                        self.ctx.module.should_consider_node_esm_spec_for_static_import(), &self.ast_builder
-                      ), &self.ast_builder
+                        self.ctx.module.should_consider_node_esm_spec_for_static_import(), self
+                      ), self
                     );
 
                     // __reExport(importer_exports, __toESM(require_foo()))
                     let stmt = ast::Statement::new_expression_statement(
                       SPAN,
                       Expression::CallExpression(call_expr.into_in(self.alloc)),
-                      &self.ast_builder,
+                      self,
                     );
                     program.body.push(stmt);
                   }
@@ -2018,13 +1965,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     init_expr,
                     finalized_callee,
                     true, // pure annotation for tree-shaking
-                    &self.ast_builder,
+                    self,
                   );
                 }
               }
 
               top_stmt =
-                Statement::new_var_decl(canonical_name_for_default_export_ref, init_expr, &self.ast_builder);
+                Statement::new_var_decl(canonical_name_for_default_export_ref, init_expr, self);
             }
             ast::ExportDefaultDeclarationKind::FunctionDeclaration(mut func) => {
               // "export default function() {}" => "function default() {}"
@@ -2033,7 +1980,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 let canonical_name_for_default_export_ref =
                   self.canonical_name_for(self.ctx.module.default_export_ref);
                 func.id =
-                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, &self.ast_builder));
+                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, self));
 
                 // When keep_names is enabled, preserve "default" as the function name
                 if self.ctx.options.keep_names {
@@ -2055,7 +2002,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 let canonical_name_for_default_export_ref =
                   self.canonical_name_for(self.ctx.module.default_export_ref);
                 class.id =
-                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, &self.ast_builder));
+                  Some(BindingIdentifier::new_id(SPAN, canonical_name_for_default_export_ref, self));
 
                 // When keep_names is enabled, preserve "default" as the class name
                 // Skip if class has static name property
@@ -2177,13 +2124,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
           expr.replace_with(|fn_expr| {
-            Expression::new_keep_name_call(
-              &original_name,
-              fn_expr,
-              finalized_callee,
-              true,
-              &self.ast_builder,
-            )
+            Expression::new_keep_name_call(&original_name, fn_expr, finalized_callee, true, self)
           });
         }
       }
@@ -2194,13 +2135,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let name_ref = self.canonical_ref_for_runtime("__name");
           let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
           expr.replace_with(|fn_expr| {
-            Expression::new_keep_name_call(
-              &original_name,
-              fn_expr,
-              finalized_callee,
-              true,
-              &self.ast_builder,
-            )
+            Expression::new_keep_name_call(&original_name, fn_expr, finalized_callee, true, self)
           });
         }
       }
@@ -2235,11 +2170,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     let name_ref = self.canonical_ref_for_runtime("__name");
     let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-    Some(ClassElement::new_static_block_keep_name(
-      &original_name,
-      finalized_callee,
-      &self.ast_builder,
-    ))
+    Some(ClassElement::new_static_block_keep_name(&original_name, finalized_callee, self))
   }
 
   /// Check if a class body has a static `name` property, method, or accessor.
@@ -2267,19 +2198,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     for (stmt_index, original_name, new_name) in self.keep_name_statement_to_insert.iter().rev() {
       let name_ref = self.canonical_ref_for_runtime("__name");
       let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
-      let target = Expression::new_id_ref_expr(SPAN, new_name, &self.ast_builder);
+      let target = Expression::new_id_ref_expr(SPAN, new_name, self);
       statements.insert(
         *stmt_index,
         ast::Statement::new_expression_statement(
           SPAN,
-          Expression::new_keep_name_call(
-            original_name,
-            target,
-            finalized_callee,
-            false,
-            &self.ast_builder,
-          ),
-          &self.ast_builder,
+          Expression::new_keep_name_call(original_name, target, finalized_callee, false, self),
+          self,
         ),
       );
     }
@@ -2334,7 +2259,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             NONE,
             [],
             false,
-            &self.ast_builder,
+            self,
           );
 
           // __toESM(require_xxx(), isNodeMode)
@@ -2342,7 +2267,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             finalized_to_esm,
             wrapper_ref_call_expr,
             self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-            &self.ast_builder,
+            self,
           )
         }
         WrapKind::Esm => {
@@ -2362,11 +2287,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             NONE,
             [],
             false,
-            &self.ast_builder,
+            self,
           );
 
           // (init_xxx(), namespace_exports)
-          Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, &self.ast_builder)
+          Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, self)
         }
         WrapKind::None => {
           // Order-wrapped dynamic entries never reach this rewrite: their eliminated facades
@@ -2384,7 +2309,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         }
       };
 
-      Some(Expression::new_promise_resolve_then(finalized_expr, &self.ast_builder))
+      Some(Expression::new_promise_resolve_then(finalized_expr, self))
     } else {
       // If the dynamic entry point is merged into another common chunk, we should
       // convert `import('./some-module.js')` to `import('./some-module.js').then(n => n.ns)`
@@ -2421,21 +2346,21 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // require('./some-module.js')
             let require_call_expr = ast::Expression::new_call_expression(
               SPAN,
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+              ast::Expression::new_identifier(SPAN, "require", self),
               NONE,
               [ast::Argument::new_string_literal(
                 expr.span,
-                oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+                oxc::ast::ast::Str::from_str_in(&import_path, self),
                 None,
-                &self.ast_builder,
+                self,
               )],
               false,
-              &self.ast_builder,
+              self,
             );
             // Promise.resolve().then(() => require('./some-module.js'))
-            Expression::new_promise_resolve_then(require_call_expr, &self.ast_builder)
+            Expression::new_promise_resolve_then(require_call_expr, self)
           } else {
-            let import_expr = expr.take_in_box(&self.ast_builder.allocator());
+            let import_expr = expr.take_in_box(self);
             Expression::ImportExpression(import_expr)
           };
 
@@ -2448,7 +2373,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 name,
                 finalized_to_esm,
                 self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-                &self.ast_builder,
+                self,
               );
               Some(Expression::CallExpression(call_expr))
             }
@@ -2456,10 +2381,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               // For ESM modules: import('./chunk.js').then(n => (n.init_xxx(), n.namespace))
               if let Some(ns_name) = namespace_export_name {
                 let call_expr = CallExpression::new_then_call_esm_wrapper_with_namespace(
-                  base_expr,
-                  name,
-                  ns_name,
-                  &self.ast_builder,
+                  base_expr, name, ns_name, self,
                 );
                 Some(Expression::CallExpression(call_expr))
               } else {
@@ -2479,8 +2401,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   .esm_init_target(importee_idx, &self.ctx.linking_infos[importee_idx])
                   .is_none()
               );
-              let call_expr =
-                CallExpression::new_then_extract_property(base_expr, name, &self.ast_builder);
+              let call_expr = CallExpression::new_then_extract_property(base_expr, name, self);
               Some(Expression::CallExpression(call_expr))
             }
           }
@@ -2518,18 +2439,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         node.replace_with(|old| {
           let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
           let require_call = Expression::new_call_with_arg(
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+            ast::Expression::new_identifier(SPAN, "require", self),
             import_expr.unbox().source,
             false,
-            &self.ast_builder,
+            self,
           );
           let wrapped = Expression::new_to_esm_wrapper(
             to_esm_fn_name,
             require_call,
             self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-            &self.ast_builder,
+            self,
           );
-          Expression::new_promise_resolve_then(wrapped, &self.ast_builder)
+          Expression::new_promise_resolve_then(wrapped, self)
         });
         return true;
       }
@@ -2546,7 +2467,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           self.ctx.chunk_graph.entry_module_to_entry_chunk.get(&importee_idx)
         else {
           // TODO: probably we should add the reason why it is replaced with `void 0`(just like webpack) when upstream support codegen with specific operation
-          *node = ast::Expression::new_void_0(SPAN, &self.ast_builder);
+          *node = ast::Expression::new_void_0(SPAN, self);
           return true;
         };
         let Some(importee_chunk) = self.ctx.chunk_graph.chunk_table.get(importee_chunk_idx) else {
@@ -2556,9 +2477,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         let import_path = self.ctx.chunk.import_path_for(importee_chunk);
         expr.source = Expression::new_string_literal(
           expr.source.span(),
-          oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+          oxc::ast::ast::Str::from_str_in(&import_path, self),
           None,
-          &self.ast_builder,
+          self,
         );
 
         if let Some(rewritten_expr) = self.rewrite_dynamic_import_for_merged_entry(
@@ -2578,16 +2499,16 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           // require('foo.mjs')
           let mut require_call_expr = ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+            ast::Expression::new_identifier(SPAN, "require", self),
             NONE,
             [ast::Argument::new_string_literal(
               expr.span,
-              oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+              oxc::ast::ast::Str::from_str_in(&import_path, self),
               None,
-              &self.ast_builder,
+              self,
             )],
             false,
-            &self.ast_builder,
+            self,
           );
 
           if importee.exports_kind.is_commonjs() {
@@ -2598,9 +2519,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             let require_default_expr = ast::Expression::new_static_member_expression(
               SPAN,
               require_call_expr,
-              ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+              ast::IdentifierName::new(SPAN, "default", self),
               false,
-              &self.ast_builder,
+              self,
             );
 
             // __toESM(require('foo.mjs').default, isNodeMode)
@@ -2608,11 +2529,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               to_esm_fn_name,
               require_default_expr,
               self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-              &self.ast_builder,
+              self,
             );
           }
 
-          *node = Expression::new_promise_resolve_then(require_call_expr, &self.ast_builder);
+          *node = Expression::new_promise_resolve_then(require_call_expr, self);
           return true;
         }
 
@@ -2623,9 +2544,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if str != import_path {
           expr.source = Expression::new_string_literal(
             expr.source.span(),
-            oxc::ast::ast::Str::from_str_in(&import_path, &self.ast_builder),
+            oxc::ast::ast::Str::from_str_in(&import_path, self),
             None,
-            &self.ast_builder,
+            self,
           );
         }
         // Convert `import("external")` to `Promise.resolve().then(() => __toESM(require("external")))`
@@ -2637,18 +2558,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           node.replace_with(|old| {
             let ast::Expression::ImportExpression(import_expr) = old else { unreachable!() };
             let require_call = Expression::new_call_with_arg(
-              ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+              ast::Expression::new_identifier(SPAN, "require", self),
               import_expr.unbox().source,
               false,
-              &self.ast_builder,
+              self,
             );
             let wrapped = Expression::new_to_esm_wrapper(
               to_esm_fn_name,
               require_call,
               self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-              &self.ast_builder,
+              self,
             );
-            Expression::new_promise_resolve_then(wrapped, &self.ast_builder)
+            Expression::new_promise_resolve_then(wrapped, self)
           });
           return true;
         }
@@ -2668,10 +2589,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // m.default
         let m_default_expr = ast::Expression::new_static_member_expression(
           SPAN,
-          ast::Expression::new_identifier(SPAN, "m", &self.ast_builder),
-          ast::IdentifierName::new(SPAN, "default", &self.ast_builder),
+          ast::Expression::new_identifier(SPAN, "m", self),
+          ast::IdentifierName::new(SPAN, "default", self),
           false,
-          &self.ast_builder,
+          self,
         );
 
         // __toESM(m.default, isNodeMode)
@@ -2679,7 +2600,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           to_esm_fn_name,
           m_default_expr,
           self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-          &self.ast_builder,
+          self,
         );
 
         // (m) => __toESM(m.default, isNodeMode)
@@ -2694,46 +2615,39 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             [ast::FormalParameter::new(
               SPAN,
               [],
-              ast::BindingPattern::new_binding_identifier(SPAN, "m", &self.ast_builder),
+              ast::BindingPattern::new_binding_identifier(SPAN, "m", self),
               NONE,
               NONE,
               false,
               None,
               false,
               false,
-              &self.ast_builder,
+              self,
             )],
             NONE,
-            &self.ast_builder,
+            self,
           ),
           NONE,
           ast::FunctionBody::new(
             SPAN,
             [],
-            [ast::Statement::new_expression_statement(SPAN, to_esm_call, &self.ast_builder)],
-            &self.ast_builder,
+            [ast::Statement::new_expression_statement(SPAN, to_esm_call, self)],
+            self,
           ),
-          &self.ast_builder,
+          self,
         );
 
         // `import('./some-cjs-module.js').then
         let callee = ast::Expression::new_static_member_expression(
           SPAN,
           original_import_expr,
-          ast::IdentifierName::new(SPAN, "then", &self.ast_builder),
+          ast::IdentifierName::new(SPAN, "then", self),
           false,
-          &self.ast_builder,
+          self,
         );
 
         // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
-        ast::Expression::new_call_expression(
-          SPAN,
-          callee,
-          NONE,
-          [arrow_fn],
-          false,
-          &self.ast_builder,
-        )
+        ast::Expression::new_call_expression(SPAN, callee, NONE, [arrow_fn], false, self)
       });
     }
 
@@ -2765,7 +2679,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .contains(&symbol_ref)
         {
           json_module_inlined_prop.insert(id, first_decl.init.take()?);
-          *it = ast::Statement::new_empty_statement(SPAN, &self.ast_builder);
+          *it = ast::Statement::new_empty_statement(SPAN, self);
         }
       }
       None => {
@@ -2799,6 +2713,22 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
 
     Some(())
+  }
+}
+
+impl<'ast> GetAstBuilder<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
+  type Builder = AstBuilder<'ast>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'ast> {
+    &self.ast_builder
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
+  #[inline]
+  fn allocator(&self) -> &'ast Allocator {
+    self.alloc
   }
 }
 

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -78,8 +78,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if let Some(ns_alias) = &symbol.namespace_alias {
       let canonical_ns_name = self.canonical_name_for(ns_alias.namespace_ref);
       let prop_name = &ns_alias.property_name;
-      let access_expr =
-        MemberExpression::new_member_access(canonical_ns_name, prop_name, &self.ast_builder);
+      let access_expr = MemberExpression::new_member_access(canonical_ns_name, prop_name, self);
 
       return Some(ast::SimpleAssignmentTarget::from(access_expr));
     }
@@ -88,8 +87,8 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     if id_ref.name != canonical_name {
       return Some(ast::SimpleAssignmentTarget::new_assignment_target_identifier(
         id_ref.span,
-        oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder),
-        &self.ast_builder,
+        oxc::ast::ast::Str::from_str_in(canonical_name, self),
+        self,
       ));
     }
 
@@ -133,13 +132,12 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           *target = ast::SimpleAssignmentTarget::from(MemberExpression::new_member_access(
             self.canonical_name_for(ns_alias.namespace_ref),
             &ns_alias.property_name,
-            &self.ast_builder,
+            self,
           ));
         } else {
           let canonical_name = self.canonical_name_for(canonical_ref);
           if target_id_ref.name != canonical_name {
-            target_id_ref.name =
-              oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
+            target_id_ref.name = oxc::ast::ast::Str::from_str_in(canonical_name, self).into();
           }
           target_id_ref.reference_id.take();
         }
@@ -168,8 +166,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name =
-                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
+              ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, self).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();
@@ -184,8 +181,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name =
-                oxc::ast::ast::Str::from_str_in(canonical_name, &self.ast_builder).into();
+              ident.name = oxc::ast::ast::Str::from_str_in(canonical_name, self).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use oxc::allocator::GetAllocator;
 use oxc::allocator::{Allocator, ReplaceWith, TakeIn};
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
-use oxc::ast::builder::{AstBuilder, NONE};
+use oxc::ast::builder::{AstBuilder, GetAstBuilder, NONE};
 use oxc::ast_visit::{VisitMut, walk_mut};
 use oxc::span::{SPAN, Span};
 use rolldown_ecmascript_utils::StatementExt;
@@ -52,7 +52,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
     if let Statement::LabeledStatement(stmt) = it
       && labels.contains(stmt.label.name.as_str())
     {
-      *it = ast::Statement::new_empty_statement(stmt.span, &self.ast_builder);
+      *it = ast::Statement::new_empty_statement(stmt.span, self);
       return true;
     }
     false
@@ -70,16 +70,16 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
     let var_decl_span = var_decl.span;
     var_decl
       .declarations
-      .take_in(&self.ast_builder.allocator())
+      .take_in(self)
       .into_iter()
       .enumerate()
       .map(|(i, declarator)| {
         let new_decl = ast::VariableDeclaration::boxed(
           if i == 0 && named_decl_span.is_none() { var_decl_span } else { SPAN },
           var_decl.kind,
-          oxc::allocator::Vec::from_iter_in([declarator], &self.ast_builder),
+          oxc::allocator::Vec::from_iter_in([declarator], self),
           var_decl.declare,
-          &self.ast_builder,
+          self,
         );
         if let Some(named_decl_span) = named_decl_span {
           Statement::new_export_named_declaration(
@@ -90,7 +90,7 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
             None,
             ImportOrExportKind::Value,
             NONE,
-            &self.ast_builder,
+            self,
           )
         } else {
           Statement::VariableDeclaration(new_decl)
@@ -163,7 +163,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   }
 
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
-    let original_body = program.body.take_in(&self.ast_builder.allocator());
+    let original_body = program.body.take_in(self);
     program.body.reserve_exact(original_body.len());
     self.top_level_stmt_temp_storage = Vec::with_capacity(
       original_body.iter().filter(|stmt| !stmt.is_module_declaration_with_source()).count(),
@@ -196,11 +196,8 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
     }
     walk_mut::walk_statement(self, it);
     if let Some(split) = self.split_multi_declarator(it, false) {
-      *it = Statement::new_block_statement(
-        SPAN,
-        oxc::allocator::Vec::from_iter_in(split, &self.ast_builder),
-        &self.ast_builder,
-      );
+      *it =
+        Statement::new_block_statement(SPAN, oxc::allocator::Vec::from_iter_in(split, self), self);
     }
   }
 
@@ -212,7 +209,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
       walk_mut::walk_statements(self, it);
       return;
     }
-    let stmts = it.take_in(&self.ast_builder.allocator());
+    let stmts = it.take_in(self);
     for mut stmt in stmts {
       if self.try_drop_labeled(&mut stmt) {
         it.push(stmt);
@@ -258,21 +255,21 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
           cond_expr.test,
           ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+            ast::Expression::new_identifier(SPAN, "require", self),
             NONE,
             [ast::Argument::from(cond_expr.consequent)],
             false,
-            &self.ast_builder,
+            self,
           ),
           ast::Expression::new_call_expression(
             SPAN,
-            ast::Expression::new_identifier(SPAN, "require", &self.ast_builder),
+            ast::Expression::new_identifier(SPAN, "require", self),
             NONE,
             [ast::Argument::from(cond_expr.alternate)],
             false,
-            &self.ast_builder,
+            self,
           ),
-          &self.ast_builder,
+          self,
         )
       });
     }
@@ -290,24 +287,28 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
         ast::Expression::new_conditional_expression(
           SPAN,
           cond_expr.test,
-          ast::Expression::new_import_expression(
-            SPAN,
-            cond_expr.consequent,
-            None,
-            None,
-            &self.ast_builder,
-          ),
-          ast::Expression::new_import_expression(
-            SPAN,
-            cond_expr.alternate,
-            None,
-            None,
-            &self.ast_builder,
-          ),
-          &self.ast_builder,
+          ast::Expression::new_import_expression(SPAN, cond_expr.consequent, None, None, self),
+          ast::Expression::new_import_expression(SPAN, cond_expr.alternate, None, None, self),
+          self,
         )
       });
     }
     walk_mut::walk_expression(self, it);
+  }
+}
+
+impl<'ast> GetAstBuilder<'ast> for PreProcessor<'ast, '_> {
+  type Builder = AstBuilder<'ast>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'ast> {
+    &self.ast_builder
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for PreProcessor<'ast, '_> {
+  #[inline]
+  fn allocator(&self) -> &'ast Allocator {
+    self.ast_builder.allocator()
   }
 }

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -1,12 +1,12 @@
 use oxc::{
-  allocator::Allocator,
+  allocator::{Allocator, GetAllocator},
   ast::{
     ast::{
       Argument, BindingIdentifier, BindingPattern, Expression, FormalParameter,
       FormalParameterKind, FormalParameters, FunctionBody, IdentifierName, Statement,
       VariableDeclarator,
     },
-    builder::{AstBuilder, NONE},
+    builder::{AstBuilder, GetAstBuilder, NONE},
   },
   ast_visit::{VisitMut, walk_mut},
   span::SPAN,
@@ -33,8 +33,7 @@ impl<'ast> VisitMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
     // Then transform import expressions
     if matches!(expr, Expression::ImportExpression(_)) {
       // Transform: import(x) -> import(x).then(__unwrap_lazy_compilation_entry)
-      let import_expr =
-        std::mem::replace(expr, Expression::new_null_literal(SPAN, &self.ast_builder));
+      let import_expr = std::mem::replace(expr, Expression::new_null_literal(SPAN, self));
 
       // Build: import_expr.then(__unwrap_lazy_compilation_entry)
       *expr = Expression::new_call_expression(
@@ -42,18 +41,34 @@ impl<'ast> VisitMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
         Expression::new_static_member_expression(
           SPAN,
           import_expr,
-          IdentifierName::new(SPAN, "then", &self.ast_builder),
+          IdentifierName::new(SPAN, "then", self),
           false,
-          &self.ast_builder,
+          self,
         ),
         NONE,
-        [Argument::new_identifier(SPAN, HELPER_NAME, &self.ast_builder)],
+        [Argument::new_identifier(SPAN, HELPER_NAME, self)],
         false,
-        &self.ast_builder,
+        self,
       );
 
       self.transformed_count += 1;
     }
+  }
+}
+
+impl<'ast> GetAstBuilder<'ast> for LazyCompilationRuntimeInjector<'ast> {
+  type Builder = AstBuilder<'ast>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'ast> {
+    &self.ast_builder
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for LazyCompilationRuntimeInjector<'ast> {
+  #[inline]
+  fn allocator(&self) -> &'ast Allocator {
+    self.ast_builder.allocator()
   }
 }
 

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -65,18 +65,18 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
             SPAN,
             [BindingProperty::new(
               SPAN,
-              PropertyKey::new_static_identifier(SPAN, key, &self.ast_builder),
-              BindingPattern::new_binding_identifier(SPAN, value, &self.ast_builder),
+              PropertyKey::new_static_identifier(SPAN, key, self),
+              BindingPattern::new_binding_identifier(SPAN, value, self),
               true,
               false,
-              &self.ast_builder,
+              self,
             )],
             NONE,
-            &self.ast_builder,
+            self,
           ),
-          await_expr.take_in(&self.ast_builder.allocator()),
+          await_expr.take_in(self),
         ),
-        &self.ast_builder,
+        self,
       );
       return true;
     }
@@ -122,11 +122,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       };
       callee.object = self.construct_vite_preload_call(
         object_pat,
-        Expression::new_await_expression(
-          SPAN,
-          callee.object.take_in(&self.ast_builder.allocator()),
-          &self.ast_builder,
-        ),
+        Expression::new_await_expression(SPAN, callee.object.take_in(self), self),
       );
       walk_arguments(self, &mut call_expr.arguments);
       return true;
@@ -134,11 +130,9 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
     // For non-destructuring: wrap the entire import().then() expression
     walk_arguments(self, &mut call_expr.arguments);
-    let import_then_expr = expr.take_in(&self.ast_builder.allocator());
-    *expr = self.vite_preload_call(Argument::from(Expression::new_arrow_returning(
-      import_then_expr,
-      &self.ast_builder,
-    )));
+    let import_then_expr = expr.take_in(self);
+    *expr = self
+      .vite_preload_call(Argument::from(Expression::new_arrow_returning(import_then_expr, self)));
     true
   }
 
@@ -146,10 +140,8 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
   /// to `__vitePreload(() => import('foo'),...)`
   pub fn rewrite_import_expr(&self, expr: &mut Expression<'a>) -> bool {
     let Expression::ImportExpression(_) = expr else { return false };
-    *expr = self.vite_preload_call(Argument::from(Expression::new_arrow_returning(
-      expr.take_in(&self.ast_builder.allocator()),
-      &self.ast_builder,
-    )));
+    *expr = self
+      .vite_preload_call(Argument::from(Expression::new_arrow_returning(expr.take_in(self), self)));
     true
   }
 
@@ -163,13 +155,13 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
       false,
       true,
       NONE,
-      FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, &self.ast_builder),
+      FormalParameters::new(SPAN, FormalParameterKind::Signature, [], NONE, self),
       NONE,
       FunctionBody::new(
         SPAN,
         [],
         {
-          let mut statements = oxc::allocator::Vec::with_capacity_in(2, &self.ast_builder);
+          let mut statements = oxc::allocator::Vec::with_capacity_in(2, self);
           statements.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Const,
@@ -180,53 +172,53 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
               NONE,
               Some(await_expr),
               false,
-              &self.ast_builder,
+              self,
             )],
             false,
-            &self.ast_builder,
+            self,
           ));
           statements.push(Statement::new_return_statement(
             SPAN,
-            Some(BindingPattern::ObjectPattern(object_pat).into_expression(&self.ast_builder)),
-            &self.ast_builder,
+            Some(BindingPattern::ObjectPattern(object_pat).into_expression(self)),
+            self,
           ));
           statements
         },
-        &self.ast_builder,
+        self,
       ),
-      &self.ast_builder,
+      self,
     ))
   }
 
   pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
     Expression::new_call_expression(
       SPAN,
-      Expression::new_identifier(SPAN, "__vitePreload", &self.ast_builder),
+      Expression::new_identifier(SPAN, "__vitePreload", self),
       NONE,
       {
         let append_import_meta_url = self.render_built_url || self.is_relative_base;
         let capacity = if append_import_meta_url { 3 } else { 2 };
-        let mut items = oxc::allocator::Vec::with_capacity_in(capacity, &self.ast_builder);
+        let mut items = oxc::allocator::Vec::with_capacity_in(capacity, self);
 
         items.push(argument);
         items.push(Argument::from(if self.is_modern {
-          Expression::new_identifier(SPAN, "__VITE_PRELOAD__", &self.ast_builder)
+          Expression::new_identifier(SPAN, "__VITE_PRELOAD__", self)
         } else {
-          Expression::new_void_0(SPAN, &self.ast_builder)
+          Expression::new_void_0(SPAN, self)
         }));
         if append_import_meta_url {
           items.push(Argument::new_static_member_expression(
             SPAN,
-            Expression::new_import_meta(SPAN, &self.ast_builder),
-            IdentifierName::new(SPAN, "url", &self.ast_builder),
+            Expression::new_import_meta(SPAN, self),
+            IdentifierName::new(SPAN, "url", self),
             false,
-            &self.ast_builder,
+            self,
           ));
         }
         items
       },
       false,
-      &self.ast_builder,
+      self,
     )
   }
 }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -1,5 +1,5 @@
-use oxc::allocator::GetAllocator;
-use oxc::ast::builder::AstBuilder;
+use oxc::allocator::{Allocator, GetAllocator};
+use oxc::ast::builder::{AstBuilder, GetAstBuilder};
 use oxc::{
   allocator::CloneIn as _,
   ast::{
@@ -40,18 +40,18 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
         Some(oxc::allocator::Vec::from_value_in(
           ImportDeclarationSpecifier::new_import_specifier(
             SPAN,
-            ModuleExportName::new_identifier_name(SPAN, PRELOAD_METHOD, &self.ast_builder),
-            BindingIdentifier::new_id(SPAN, PRELOAD_METHOD, &self.ast_builder),
+            ModuleExportName::new_identifier_name(SPAN, PRELOAD_METHOD, self),
+            BindingIdentifier::new_id(SPAN, PRELOAD_METHOD, self),
             ImportOrExportKind::Value,
-            &self.ast_builder,
+            self,
           ),
-          &self.ast_builder,
+          self,
         )),
-        StringLiteral::new(SPAN, PRELOAD_HELPER_ID, None, &self.ast_builder),
+        StringLiteral::new(SPAN, PRELOAD_HELPER_ID, None, self),
         None,
         NONE,
         ImportOrExportKind::Value,
-        &self.ast_builder,
+        self,
       ));
     }
   }
@@ -92,7 +92,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
               object_pat.clone_in(self.ast_builder.allocator()),
               decl.init.take().unwrap(),
             ),
-            &self.ast_builder,
+            self,
           ));
           self.need_prepend_helper = true;
         } else {
@@ -124,5 +124,21 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
 
   fn leave_scope(&mut self) {
     self.scope_stack.pop();
+  }
+}
+
+impl<'a> GetAstBuilder<'a> for BuildImportAnalysisVisitor<'a> {
+  type Builder = AstBuilder<'a>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'a> {
+    &self.ast_builder
+  }
+}
+
+impl<'a> GetAllocator<'a> for BuildImportAnalysisVisitor<'a> {
+  #[inline]
+  fn allocator(&self) -> &'a Allocator {
+    self.ast_builder.allocator()
   }
 }

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -1,4 +1,5 @@
-use oxc::ast::builder::AstBuilder;
+use oxc::allocator::{Allocator, GetAllocator};
+use oxc::ast::builder::{AstBuilder, GetAstBuilder};
 use oxc::{
   ast::ast::{Expression, IdentifierName, ObjectPropertyKind, Statement},
   ast_visit::VisitMut,
@@ -22,14 +23,14 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
       SPAN,
       Expression::new_static_member_expression(
         SPAN,
-        Expression::new_identifier(SPAN, "self", &self.ast_builder),
-        IdentifierName::new(SPAN, "location", &self.ast_builder),
+        Expression::new_identifier(SPAN, "self", self),
+        IdentifierName::new(SPAN, "location", self),
         false,
-        &self.ast_builder,
+        self,
       ),
-      IdentifierName::new(SPAN, "href", &self.ast_builder),
+      IdentifierName::new(SPAN, "href", self),
       false,
-      &self.ast_builder,
+      self,
     )
   }
 
@@ -42,16 +43,16 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
         [ObjectPropertyKind::new_object_property(
           SPAN,
           oxc::ast::ast::PropertyKind::Init,
-          oxc::ast::ast::PropertyKey::new_static_identifier(SPAN, "url", &self.ast_builder),
+          oxc::ast::ast::PropertyKey::new_static_identifier(SPAN, "url", self),
           self.create_self_location_href_expr(),
           false,
           false,
           false,
-          &self.ast_builder,
+          self,
         )],
-        &self.ast_builder,
+        self,
       ),
-      &self.ast_builder,
+      self,
     )
   }
 }
@@ -73,9 +74,25 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
       }
       Expression::ImportMeta(_) => {
         self.should_inject_import_meta_object = true;
-        *it = Expression::new_identifier(SPAN, "_vite_importMeta", &self.ast_builder);
+        *it = Expression::new_identifier(SPAN, "_vite_importMeta", self);
       }
       _ => oxc::ast_visit::walk_mut::walk_expression(self, it),
     }
+  }
+}
+
+impl<'ast> GetAstBuilder<'ast> for WebWorkerPostVisitor<'ast> {
+  type Builder = AstBuilder<'ast>;
+
+  #[inline]
+  fn builder(&self) -> &AstBuilder<'ast> {
+    &self.ast_builder
+  }
+}
+
+impl<'ast> GetAllocator<'ast> for WebWorkerPostVisitor<'ast> {
+  #[inline]
+  fn allocator(&self) -> &'ast Allocator {
+    self.ast_builder.allocator()
   }
 }


### PR DESCRIPTION
Follow-on after #10018 and #10353. Pure refactor.

Implement `GetAstBuilder` and `GetAllocator` on visitor/pass/context types which hold an `AstBuilder`.

AST builder methods take any `&B where B: GetAstBuilder`, so this allows removing a lot of repetitious boilerplate code at call sites.

Before:

```rust
Expression::new_string_literal(
  SPAN,
  Str::from_str_in(id, &self.ast_builder),
  None,
  &self.ast_builder,
)
```

After:

```rust
Expression::new_string_literal(SPAN, Str::from_str_in(id, self), None, self)
```