### PR TITLE
fix(dev): skip user plugin hooks for ?rolldown-lazy proxy modules

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -21,6 +21,26 @@ use rolldown_sourcemap::SourceMap;
 use rolldown_utils::{IndexBitSet, unique_arc::UniqueArc};
 use tracing::{Instrument, debug_span};
 
+const LAZY_PROXY_QUERY: &str = "?rolldown-lazy=1";
+
+#[inline]
+fn is_lazy_proxy_module_id(module_id: &str) -> bool {
+  module_id.ends_with(LAZY_PROXY_QUERY)
+}
+
+#[inline]
+fn should_skip_plugin_for_lazy_proxy(
+  should_skip_user_plugins_for_lazy_proxy_modules: bool,
+  module_id: &str,
+  plugin_idx: PluginIdx,
+  lazy_compilation_plugin_idx: Option<PluginIdx>,
+) -> bool {
+  if !should_skip_user_plugins_for_lazy_proxy_modules || !is_lazy_proxy_module_id(module_id) {
+    return false;
+  }
+  lazy_compilation_plugin_idx.is_some_and(|idx| idx != plugin_idx)
+}
+
 impl PluginDriver {
   #[tracing::instrument(
     level = "trace",
@@ -196,6 +216,14 @@ impl PluginDriver {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_load_meta)
     {
+      if should_skip_plugin_for_lazy_proxy(
+        self.should_skip_user_plugins_for_lazy_proxy_modules,
+        args.id,
+        plugin_idx,
+        self.lazy_compilation_plugin_idx,
+      ) {
+        continue;
+      }
       let ret = async {
         trace_action!(action::HookLoadCallStart {
           action: "HookLoadCallStart",
@@ -269,6 +297,14 @@ impl PluginDriver {
     {
       let call_id = tracing::enabled!(tracing::Level::TRACE).then(rolldown_utils::uuid::uuid_v4);
       let code_arc_ref = code_arc.get_or_insert_with(|| ArcStr::from(code.as_str()));
+      if should_skip_plugin_for_lazy_proxy(
+        self.should_skip_user_plugins_for_lazy_proxy_modules,
+        id,
+        plugin_idx,
+        self.lazy_compilation_plugin_idx,
+      ) {
+        continue;
+      }
 
       trace_action!(action::HookTransformCallStart {
         action: "HookTransformCallStart",
@@ -380,9 +416,17 @@ impl PluginDriver {
     skip_all
   )]
   pub async fn transform_ast(&self, mut args: HookTransformAstArgs<'_>) -> HookTransformAstReturn {
-    for (_, plugin, ctx) in
+    for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_transform_ast_meta)
     {
+      if should_skip_plugin_for_lazy_proxy(
+        self.should_skip_user_plugins_for_lazy_proxy_modules,
+        args.id,
+        plugin_idx,
+        self.lazy_compilation_plugin_idx,
+      ) {
+        continue;
+      }
       // Reconstructing the struct is necessary because `args.ast` is moved and reassigned each iteration
       #[expect(clippy::unnecessary_struct_initialization)]
       let transform_args = HookTransformAstArgs {
@@ -412,9 +456,18 @@ impl PluginDriver {
     module_info: Arc<ModuleInfo>,
     normal_module: &NormalModule,
   ) -> HookNoopReturn {
+    let module_id = normal_module.id.as_str();
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_module_parsed_meta)
     {
+      if should_skip_plugin_for_lazy_proxy(
+        self.should_skip_user_plugins_for_lazy_proxy_modules,
+        module_id,
+        plugin_idx,
+        self.lazy_compilation_plugin_idx,
+      ) {
+        continue;
+      }
       let start = self.start_timing();
       let result = plugin.call_module_parsed(ctx, Arc::clone(&module_info), normal_module).await;
       self.record_timing(plugin_idx, start);

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -36,6 +36,8 @@ pub struct PluginDriver {
   plugins: IndexPluginable,
   contexts: IndexPluginContext,
   hook_orders: PluginHookOrders,
+  pub(crate) should_skip_user_plugins_for_lazy_proxy_modules: bool,
+  pub(crate) lazy_compilation_plugin_idx: Option<PluginIdx>,
   pub file_emitter: SharedFileEmitter,
   pub watch_files: Arc<FxDashSet<ArcStr>>,
   pub module_infos: SharedModuleInfoDashMap,

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use dashmap::DashMap;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  ModuleIdx, SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions,
+  ModuleIdx, PluginIdx, SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions,
 };
 use rolldown_resolver::Resolver;
 use rolldown_utils::dashmap::FxDashSet;
@@ -58,10 +58,13 @@ impl PluginDriverFactory {
     } else {
       None
     };
+    let should_skip_user_plugins_for_lazy_proxy_modules =
+      options.experimental.dev_mode.as_ref().and_then(|dev_mode| dev_mode.lazy) == Some(true);
 
     Arc::new_cyclic(|plugin_driver| {
       let mut index_plugins = IndexPluginable::with_capacity(self.plugins.len());
       let mut index_contexts = IndexPluginContext::with_capacity(self.plugins.len());
+      let mut lazy_compilation_plugin_idx: Option<PluginIdx> = None;
 
       self.plugins.iter().for_each(|plugin| {
         let plugin_idx = index_plugins.push(Arc::clone(plugin));
@@ -73,6 +76,9 @@ impl PluginDriverFactory {
           if !plugin_name.starts_with("builtin:") {
             collector.register_plugin(plugin_idx, ArcStr::from(plugin_name.as_ref()));
           }
+        }
+        if lazy_compilation_plugin_idx.is_none() && plugin_name == "lazy-compilation" {
+          lazy_compilation_plugin_idx = Some(plugin_idx);
         }
 
         index_contexts.push(PluginContext::Native(Arc::new(NativePluginContextImpl {
@@ -97,6 +103,8 @@ impl PluginDriverFactory {
         hook_orders: PluginHookOrders::new(&index_plugins, &plugin_usage_vec),
         plugins: index_plugins,
         contexts: index_contexts,
+        should_skip_user_plugins_for_lazy_proxy_modules,
+        lazy_compilation_plugin_idx,
         file_emitter: Arc::clone(file_emitter),
         watch_files,
         module_infos,

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -149,6 +149,7 @@ When `load` is called for a proxy module:
 
 1. Only ids present in `lazy_entries` are served at all — any other `?rolldown-lazy=1` id falls through to `Ok(None)`
 2. If in `fetched_entries` → return fetched template; otherwise → return stub template
+3. User-land build hooks are skipped for proxy ids (`?rolldown-lazy=1`) so plugins only see real modules; the lazy plugin itself still runs to serve the stub/fetched template.
 
 **Security gate — unknown module rejection (#9969)**: the id passed to `compileEntry` / `compile_lazy_entry` is treated purely as a lookup key into the build cache, never resolved as a filesystem path. An id not present from a prior build is rejected in `HmrStage::compile_lazy_entry` with `Lazy entry module not found in cache` — so a malicious `/@vite/lazy` request cannot bundle an arbitrary file (analogous to Vite's `server.fs.strict`; pinned by `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`). Note the ordering: `DevEngine::compile_lazy_entry` calls `mark_as_fetched` unconditionally **before** this validation, so an unknown id still lands in `fetched_entries` (harmless, but worth knowing when debugging).
 

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -221,6 +221,73 @@ test(
   },
 );
 
+test(
+  'lazy proxy modules skip user plugin hooks',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-skip-hooks-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const main = path.join(dir, 'main.js');
+    const lazy = path.join(dir, 'lazy.js');
+    fs.writeFileSync(main, `globalThis.load = () => import('./lazy.js');\n`);
+    fs.writeFileSync(lazy, `export const value = 1;\n`);
+
+    const seenTransformIds: string[] = [];
+    const seenModuleParsedIds: string[] = [];
+    const plugin = {
+      name: 'assert-no-lazy-proxy-hooks',
+      load: {
+        order: 'pre',
+        handler(id: string) {
+          if (id.includes('?rolldown-lazy=1')) {
+            throw new Error(`load hook saw lazy proxy id: ${id}`);
+          }
+        },
+      },
+      transform(code: string, id: string) {
+        seenTransformIds.push(id);
+        if (id.includes('?rolldown-lazy=1')) {
+          throw new Error(`transform hook saw lazy proxy id: ${id}`);
+        }
+        return code;
+      },
+      moduleParsed(moduleInfo: { id: string }) {
+        seenModuleParsedIds.push(moduleInfo.id);
+        if (moduleInfo.id.includes('?rolldown-lazy=1')) {
+          throw new Error(`moduleParsed hook saw lazy proxy id: ${moduleInfo.id}`);
+        }
+      },
+    };
+
+    const engine = await dev(
+      {
+        input: main,
+        plugins: [plugin],
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await engine.registerClient('c1');
+    await engine.compileEntry(`${lazy}?rolldown-lazy=1`, 'c1');
+
+    expect(seenTransformIds.some((id) => id.includes('?rolldown-lazy=1'))).toBe(false);
+    expect(seenTransformIds.some((id) => id.endsWith('lazy.js'))).toBe(true);
+    expect(seenModuleParsedIds.some((id) => id.includes('?rolldown-lazy=1'))).toBe(false);
+    expect(seenModuleParsedIds.some((id) => id.endsWith('lazy.js'))).toBe(true);
+  },
+);
+
 // With `sourcemap: true` the chunk gets a `sourceMappingURL`, so the map it names
 // has to be reachable: a lazy chunk is not written to disk, which leaves the
 // return value as the only way for the consumer to serve it.


### PR DESCRIPTION
## Summary
Fixes #10030 by keeping `?rolldown-lazy=1` proxy modules internal during dev lazy compilation.

## Why
Lazy proxy modules contain internal JavaScript wrapper code, but user plugins may treat their IDs like real source modules (for example CSS plugins seeing `*.css?rolldown-lazy=1`). That can trigger incorrect transforms and hard dev-time failures.

## What changed
- Skip user-land build hooks for lazy proxy IDs in dev lazy mode:
  - `load`
  - `transform`
  - `transform_ast`
  - `module_parsed`
- Keep the internal `lazy-compilation` plugin active for those proxy IDs so lazy runtime behavior is unchanged.
- Gate this behavior to `experimental.devMode.lazy === true` only.
- Match only exact proxy IDs via `ends_with("?rolldown-lazy=1")`.
- Add regression coverage in `packages/rolldown/tests/dev/dev-lazy-compile.test.ts` to assert user hooks do not see lazy proxy IDs while real modules are still processed.
- Update `internal-docs/lazy-compilation/implementation.md` with the new contract.

## Validation
- `pnpm --filter rolldown run build-native:debug`
- `pnpm --filter @rolldown/test-dev-server build`
- `pnpm --filter rolldown-tests exec vitest run dev/dev-lazy-compile.test.ts --reporter verbose --hideSkippedTests`
- Two independent real-project adversarial reproductions:
  - Baseline (`origin/main`) reproduces failure (user hooks receive `?rolldown-lazy=1` IDs)
  - Patched branch passes with identical dummy lazy-mode project

## AI disclosure
This PR was developed with AI assistance. All generated changes were reviewed, tested, and adjusted by the author before submission.
