### PR TITLE
fix(treeshake): preserve eagerly evaluated child effects of manual pure chains

### DIFF
--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -193,7 +193,7 @@ impl<'a> StmtEvalAnalyzer<'a> {
 
   fn analyze_member_expr(&self, member_expr: &ast::MemberExpression) -> StmtEvalFacts {
     if self.is_expr_manual_pure_functions(member_expr.object()) {
-      let mut facts = self.analyze_member_expr_like_eager_children(member_expr.object());
+      let mut facts = self.analyze_eager_chain_children(member_expr.object());
       if let ast::MemberExpression::ComputedMemberExpression(expr) = member_expr {
         facts |= self.analyze_expr(&expr.expression);
       }
@@ -218,9 +218,9 @@ impl<'a> StmtEvalAnalyzer<'a> {
     facts
   }
 
-  fn analyze_member_expr_like_eager_children(&self, expr: &Expression) -> StmtEvalFacts {
+  fn analyze_eager_chain_children(&self, expr: &Expression) -> StmtEvalFacts {
     let mut facts = StmtEvalFacts::default();
-    walk_member_expr_like(expr, |child| {
+    for_each_eager_chain_child(expr, |child| {
       facts |= child
         .map_or_else(StmtEvalFacts::from_unknown_side_effect, |child| self.analyze_expr(child));
     });
@@ -303,8 +303,7 @@ impl<'a> StmtEvalAnalyzer<'a> {
       return false;
     }
     let manual_pure_functions = self.options.treeshake.manual_pure_functions().unwrap();
-    extract_first_part_of_member_expr_like(expr)
-      .is_some_and(|first| manual_pure_functions.contains(first))
+    chain_root_ident(expr).is_some_and(|first| manual_pure_functions.contains(first))
   }
 
   fn analyze_expr(&self, expr: &Expression) -> StmtEvalFacts {
@@ -943,19 +942,24 @@ fn check_pure_cjs_export(scope: &AstScopes, target: &AssignmentTarget) -> Option
   }
 }
 
-/// Walk a member-expression-like chain down to its leftmost identifier, feeding every eagerly
-/// evaluated child (computed keys and call arguments; `None` stands for a spread argument) to the
-/// visitor.
-fn walk_member_expr_like<'a>(
+/// Descend a member-expression-like chain to its leftmost identifier, invoking `on_eager_child`
+/// for every eagerly-evaluated subexpression on the way down — computed keys and call arguments,
+/// with `None` marking a spread argument. Returns the root identifier's name, or `None` when the
+/// chain doesn't bottom out in a plain identifier.
+///
+/// This is the shared engine behind [`chain_root_ident`] and [`for_each_eager_chain_child`]; call
+/// whichever of those fits instead of reading the return value and driving the visitor from the
+/// same call site.
+fn chain_root_visiting_eager_children<'a>(
   expr: &'a Expression,
-  mut visit_eager_child: impl FnMut(Option<&'a Expression>),
+  mut on_eager_child: impl FnMut(Option<&'a Expression>),
 ) -> Option<&'a str> {
   fn visit_call_args<'a>(
     args: &'a [Argument<'a>],
-    visit_eager_child: &mut impl FnMut(Option<&'a Expression<'a>>),
+    on_eager_child: &mut impl FnMut(Option<&'a Expression<'a>>),
   ) {
     for arg in args {
-      visit_eager_child(match arg {
+      on_eager_child(match arg {
         Argument::SpreadElement(_) => None,
         _ => Some(arg.to_expression()),
       });
@@ -967,23 +971,23 @@ fn walk_member_expr_like<'a>(
     match cur {
       Expression::Identifier(ident) => break Some(ident.name.as_str()),
       Expression::ComputedMemberExpression(expr) => {
-        visit_eager_child(Some(&expr.expression));
+        on_eager_child(Some(&expr.expression));
         cur = &expr.object;
       }
       Expression::StaticMemberExpression(expr) => {
         cur = &expr.object;
       }
       Expression::CallExpression(expr) => {
-        visit_call_args(&expr.arguments, &mut visit_eager_child);
+        visit_call_args(&expr.arguments, &mut on_eager_child);
         cur = &expr.callee;
       }
       Expression::ChainExpression(expr) => match expr.expression {
         ChainElement::CallExpression(ref call_expression) => {
-          visit_call_args(&call_expression.arguments, &mut visit_eager_child);
+          visit_call_args(&call_expression.arguments, &mut on_eager_child);
           cur = &call_expression.callee;
         }
         ChainElement::ComputedMemberExpression(ref computed_member_expression) => {
-          visit_eager_child(Some(&computed_member_expression.expression));
+          on_eager_child(Some(&computed_member_expression.expression));
           cur = &computed_member_expression.object;
         }
         ChainElement::StaticMemberExpression(ref static_member_expression) => {
@@ -998,11 +1002,17 @@ fn walk_member_expr_like<'a>(
   }
 }
 
-/// Extract the first (leftmost) identifier name from a member expression chain.
-/// Used by both `StmtEvalAnalyzer::is_expr_manual_pure_functions` and
-/// `StmtEvalAnalyzer::manual_pure_functions`.
-fn extract_first_part_of_member_expr_like<'a>(expr: &'a Expression) -> Option<&'a str> {
-  walk_member_expr_like(expr, |_| {})
+/// The leftmost identifier a member-expression-like chain reads from (`a` in `a.b().c[d]`), or
+/// `None` when the chain doesn't bottom out in a plain identifier. Used by
+/// `StmtEvalAnalyzer::is_expr_manual_pure_functions` and `StmtEvalAnalyzer::manual_pure_functions`.
+fn chain_root_ident<'a>(expr: &'a Expression) -> Option<&'a str> {
+  chain_root_visiting_eager_children(expr, |_| {})
+}
+
+/// Invoke `visit` on every eagerly-evaluated subexpression of a member-expression-like chain —
+/// computed keys and call arguments, with `None` marking a spread argument.
+fn for_each_eager_chain_child<'a>(expr: &'a Expression, visit: impl FnMut(Option<&'a Expression>)) {
+  let _ = chain_root_visiting_eager_children(expr, visit);
 }
 
 impl GlobalContext<'_> for StmtEvalAnalyzer<'_> {
@@ -1022,7 +1032,7 @@ impl MayHaveSideEffectsContext<'_> for StmtEvalAnalyzer<'_> {
 
   fn manual_pure_functions(&self, callee: &Expression) -> bool {
     self.is_expr_manual_pure_functions(callee)
-      && !self.analyze_member_expr_like_eager_children(callee).has_side_effect_for_tree_shaking()
+      && !self.analyze_eager_chain_children(callee).has_side_effect_for_tree_shaking()
   }
 
   fn property_read_side_effects(&self) -> PropertyReadSideEffects {
@@ -2431,18 +2441,18 @@ let remove15 = class {
   }
 
   #[test]
-  fn test_extract_first_part_of_member_expr_like() {
-    assert_eq!(extract_first_part_of_member_expr_like_helper("a.b"), "a");
-    assert_eq!(extract_first_part_of_member_expr_like_helper("styled?.div()"), "styled");
-    assert_eq!(extract_first_part_of_member_expr_like_helper("styled()"), "styled");
-    assert_eq!(extract_first_part_of_member_expr_like_helper("styled().div"), "styled");
-    assert_eq!(extract_first_part_of_member_expr_like_helper("styled()()"), "styled");
+  fn test_chain_root_ident() {
+    assert_eq!(chain_root_ident_helper("a.b"), "a");
+    assert_eq!(chain_root_ident_helper("styled?.div()"), "styled");
+    assert_eq!(chain_root_ident_helper("styled()"), "styled");
+    assert_eq!(chain_root_ident_helper("styled().div"), "styled");
+    assert_eq!(chain_root_ident_helper("styled()()"), "styled");
   }
 
-  fn extract_first_part_of_member_expr_like_helper(code: &str) -> String {
+  fn chain_root_ident_helper(code: &str) -> String {
     let allocator = oxc::allocator::Allocator::default();
     let parser = Parser::new(&allocator, code, SourceType::ts());
     let expr = parser.parse_expression().unwrap();
-    super::extract_first_part_of_member_expr_like(&expr).unwrap().to_string()
+    super::chain_root_ident(&expr).unwrap().to_string()
   }
 }

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -193,7 +193,11 @@ impl<'a> StmtEvalAnalyzer<'a> {
 
   fn analyze_member_expr(&self, member_expr: &ast::MemberExpression) -> StmtEvalFacts {
     if self.is_expr_manual_pure_functions(member_expr.object()) {
-      return StmtEvalFacts::default();
+      let mut facts = self.analyze_member_expr_like_eager_children(member_expr.object());
+      if let ast::MemberExpression::ComputedMemberExpression(expr) = member_expr {
+        facts |= self.analyze_expr(&expr.expression);
+      }
+      return facts;
     }
     // ES module namespace objects are frozen/sealed by spec — property reads
     // on them are guaranteed side-effect-free. A computed key is still evaluated,
@@ -211,6 +215,15 @@ impl<'a> StmtEvalAnalyzer<'a> {
     let has_side_effect = member_expr.may_have_side_effects(self);
     let mut facts = StmtEvalFacts::from_tree_shaking_side_effect(has_side_effect);
     facts.set_order_sensitive_reason(StmtOrderSensitiveReasons::GlobalVarAccess, is_global);
+    facts
+  }
+
+  fn analyze_member_expr_like_eager_children(&self, expr: &Expression) -> StmtEvalFacts {
+    let mut facts = StmtEvalFacts::default();
+    walk_member_expr_like(expr, |child| {
+      facts |= child
+        .map_or_else(StmtEvalFacts::from_unknown_side_effect, |child| self.analyze_expr(child));
+    });
     facts
   }
 
@@ -930,40 +943,65 @@ fn check_pure_cjs_export(scope: &AstScopes, target: &AssignmentTarget) -> Option
   }
 }
 
-/// Extract the first (leftmost) identifier name from a member expression chain.
-/// Used by both `StmtEvalAnalyzer::is_expr_manual_pure_functions` and
-/// `StmtEvalAnalyzer::manual_pure_functions`.
-fn extract_first_part_of_member_expr_like<'a>(expr: &'a Expression) -> Option<&'a str> {
+fn walk_member_expr_like<'a>(
+  expr: &'a Expression,
+  mut visit_eager_child: impl FnMut(Option<&'a Expression>),
+) -> Option<&'a str> {
   let mut cur = expr;
   loop {
+    cur = cur.get_inner_expression();
     match cur {
       Expression::Identifier(ident) => break Some(ident.name.as_str()),
       Expression::ComputedMemberExpression(expr) => {
+        visit_eager_child(Some(&expr.expression));
         cur = &expr.object;
       }
       Expression::StaticMemberExpression(expr) => {
         cur = &expr.object;
       }
       Expression::CallExpression(expr) => {
+        for arg in &expr.arguments {
+          visit_eager_child(match arg {
+            Argument::SpreadElement(_) => None,
+            _ => Some(arg.to_expression()),
+          });
+        }
         cur = &expr.callee;
       }
       Expression::ChainExpression(expr) => match expr.expression {
         ChainElement::CallExpression(ref call_expression) => {
+          for arg in &call_expression.arguments {
+            visit_eager_child(match arg {
+              Argument::SpreadElement(_) => None,
+              _ => Some(arg.to_expression()),
+            });
+          }
           cur = &call_expression.callee;
         }
         ChainElement::ComputedMemberExpression(ref computed_member_expression) => {
+          visit_eager_child(Some(&computed_member_expression.expression));
           cur = &computed_member_expression.object;
         }
         ChainElement::StaticMemberExpression(ref static_member_expression) => {
           cur = &static_member_expression.object;
         }
-        ChainElement::TSNonNullExpression(_) | ChainElement::PrivateFieldExpression(_) => {
+        ChainElement::TSNonNullExpression(ref ts_non_null_expression) => {
+          cur = &ts_non_null_expression.expression;
+        }
+        ChainElement::PrivateFieldExpression(_) => {
           break None;
         }
       },
       _ => break None,
     }
   }
+}
+
+/// Extract the first (leftmost) identifier name from a member expression chain.
+/// Used by both `StmtEvalAnalyzer::is_expr_manual_pure_functions` and
+/// `StmtEvalAnalyzer::manual_pure_functions`.
+fn extract_first_part_of_member_expr_like<'a>(expr: &'a Expression) -> Option<&'a str> {
+  walk_member_expr_like(expr, |_| {})
 }
 
 impl GlobalContext<'_> for StmtEvalAnalyzer<'_> {
@@ -983,6 +1021,7 @@ impl MayHaveSideEffectsContext<'_> for StmtEvalAnalyzer<'_> {
 
   fn manual_pure_functions(&self, callee: &Expression) -> bool {
     self.is_expr_manual_pure_functions(callee)
+      && !self.analyze_member_expr_like_eager_children(callee).has_side_effect_for_tree_shaking()
   }
 
   fn property_read_side_effects(&self) -> PropertyReadSideEffects {
@@ -2025,6 +2064,30 @@ mod test {
   }
 
   #[test]
+  fn test_manual_pure_chains_keep_eager_child_side_effects() {
+    let options = Arc::new(NormalizedBundlerOptions {
+      treeshake: InnerOptions {
+        manual_pure_functions: Some(std::iter::once("make".to_string()).collect()),
+        ..InnerOptions::default()
+      }
+      .into(),
+      ..NormalizedBundlerOptions::default()
+    });
+    for code in [
+      "make()[effect()];",
+      "make(effect()).value;",
+      "new (make()[effect()].Box)();",
+      "make(effect());",
+    ] {
+      assert_eq!(
+        get_stmt_eval_with_options(code, &options),
+        vec![(StmtEvalFlags::UnknownSideEffect, true)],
+        "{code}"
+      );
+    }
+  }
+
+  #[test]
   fn test_conditional_and_logical_iife_callees_behind_manual_pure_member() {
     // A bare conditional/logical-callee IIFE needs no collector arm: oxc's IIFE certification
     // recognizes only direct function/arrow callees, so the statement keeps `UnknownSideEffect`
@@ -2041,9 +2104,7 @@ mod test {
       vec![(StmtEvalFlags::UnknownSideEffect, true)]
     );
 
-    // Behind a manual-pure member root the regular analyzer certifies the whole member read
-    // without visiting the computed key, so the collector's conditional/logical callee arms are
-    // the only detector of the branch bodies the call may run.
+    // Computed-key indirect IIFEs stay conservative under both analysis paths.
     let make_options = strict_on_demand_options(InnerOptions {
       manual_pure_functions: Some(std::iter::once("make".to_string()).collect()),
       ..InnerOptions::default()
@@ -2052,13 +2113,17 @@ mod test {
       "function make() {} const value = make[(true ? (() => (/* @__PURE__ */ globalThis.__orderRead?.() ?? 5)) : (() => 9))()];",
       "function make() {} const value = make[(true && (() => (/* @__PURE__ */ globalThis.__orderRead?.() ?? 5)))()];",
     ] {
-      assert_last_statement_gets_eager_reason_only(code, &make_options, StmtEvalFlags::empty());
+      let regular = get_stmt_eval_with_options(code, &make_options);
+      assert_eq!(regular.last(), Some(&(StmtEvalFlags::UnknownSideEffect, true)), "{code}");
+      assert_eq!(
+        get_stmt_eval_with_top_level_eager_order_reasons(code, &make_options),
+        regular,
+        "{code}"
+      );
     }
   }
 
-  // The same manual-pure member-root route, for the remaining eager-execution forms: `new` of a
-  // class literal runs construction-time positions, evaluating a template calls a literal tag,
-  // and an assignment-expression callee may invoke its RHS.
+  // The same manual-pure member-root route, for the remaining eager-execution forms.
   #[test]
   fn test_eager_walk_covers_constructed_classes_literal_tags_and_assignment_callees() {
     let make_options = strict_on_demand_options(InnerOptions {
@@ -2081,7 +2146,13 @@ mod test {
       // Logical assignments are `AssignmentExpression`s, not `LogicalExpression`s.
       "function make() {} let assigned; const value = make[(assigned ??= () => (/* @__PURE__ */ globalThis.__orderRead?.() ?? 5))()];",
     ] {
-      assert_last_statement_gets_eager_reason_only(code, &make_options, StmtEvalFlags::empty());
+      let regular = get_stmt_eval_with_options(code, &make_options);
+      assert_eq!(regular.last(), Some(&(StmtEvalFlags::UnknownSideEffect, true)), "{code}");
+      assert_eq!(
+        get_stmt_eval_with_top_level_eager_order_reasons(code, &make_options),
+        regular,
+        "{code}"
+      );
     }
   }
 

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -943,10 +943,25 @@ fn check_pure_cjs_export(scope: &AstScopes, target: &AssignmentTarget) -> Option
   }
 }
 
+/// Walk a member-expression-like chain down to its leftmost identifier, feeding every eagerly
+/// evaluated child (computed keys and call arguments; `None` stands for a spread argument) to the
+/// visitor.
 fn walk_member_expr_like<'a>(
   expr: &'a Expression,
   mut visit_eager_child: impl FnMut(Option<&'a Expression>),
 ) -> Option<&'a str> {
+  fn visit_call_args<'a>(
+    args: &'a [Argument<'a>],
+    visit_eager_child: &mut impl FnMut(Option<&'a Expression<'a>>),
+  ) {
+    for arg in args {
+      visit_eager_child(match arg {
+        Argument::SpreadElement(_) => None,
+        _ => Some(arg.to_expression()),
+      });
+    }
+  }
+
   let mut cur = expr;
   loop {
     cur = cur.get_inner_expression();
@@ -960,22 +975,12 @@ fn walk_member_expr_like<'a>(
         cur = &expr.object;
       }
       Expression::CallExpression(expr) => {
-        for arg in &expr.arguments {
-          visit_eager_child(match arg {
-            Argument::SpreadElement(_) => None,
-            _ => Some(arg.to_expression()),
-          });
-        }
+        visit_call_args(&expr.arguments, &mut visit_eager_child);
         cur = &expr.callee;
       }
       Expression::ChainExpression(expr) => match expr.expression {
         ChainElement::CallExpression(ref call_expression) => {
-          for arg in &call_expression.arguments {
-            visit_eager_child(match arg {
-              Argument::SpreadElement(_) => None,
-              _ => Some(arg.to_expression()),
-            });
-          }
+          visit_call_args(&call_expression.arguments, &mut visit_eager_child);
           cur = &call_expression.callee;
         }
         ChainElement::ComputedMemberExpression(ref computed_member_expression) => {

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -964,7 +964,6 @@ fn walk_member_expr_like<'a>(
 
   let mut cur = expr;
   loop {
-    cur = cur.get_inner_expression();
     match cur {
       Expression::Identifier(ident) => break Some(ident.name.as_str()),
       Expression::ComputedMemberExpression(expr) => {
@@ -990,10 +989,7 @@ fn walk_member_expr_like<'a>(
         ChainElement::StaticMemberExpression(ref static_member_expression) => {
           cur = &static_member_expression.object;
         }
-        ChainElement::TSNonNullExpression(ref ts_non_null_expression) => {
-          cur = &ts_non_null_expression.expression;
-        }
-        ChainElement::PrivateFieldExpression(_) => {
+        ChainElement::TSNonNullExpression(_) | ChainElement::PrivateFieldExpression(_) => {
           break None;
         }
       },

--- a/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/_config.ts
@@ -13,8 +13,15 @@ export default defineTest({
     let code = output.output[0].code;
 
     expect(code).toMatchInlineSnapshot(`
-      "import "styled-components";
+      "import styled from "styled-components";
       //#region main.js
+      function effect(value) {
+      \tconsole.log(value);
+      \treturn value;
+      }
+      styled()[effect("computed key")];
+      styled(effect("call argument")).value;
+      new (styled())[effect("new callee")].Box();
       let another = console.log;
       another();
       //#endregion

--- a/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
@@ -9,5 +9,13 @@ styled?.div(); // removed
 styled()(); // removed
 styled().div(); // removed
 
+function effect(value) {
+  console.log(value);
+  return value;
+}
+styled()[effect('computed key')];
+styled(effect('call argument')).value;
+new (styled()[effect('new callee')].Box)();
+
 let another = console.log;
 another(); // retained

--- a/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
@@ -13,9 +13,9 @@ function effect(value) {
   console.log(value);
   return value;
 }
-styled()[effect('computed key')];
-styled(effect('call argument')).value;
-new (styled()[effect('new callee')].Box)();
+styled()[effect('computed key')]; // retained
+styled(effect('call argument')).value; // retained
+new (styled()[effect('new callee')].Box)(); // retained
 
 let another = console.log;
 another(); // retained


### PR DESCRIPTION
Fixes #10397, at both drop paths named in the issue's Cause section.

One note for review. Two unit tests from #10387 encoded the old behavior as their premise, their comments said so explicitly, and they now expect conservative retention in both analysis dimensions.