### PR TITLE
refactor(plugin): dedupe hook binding boilerplate

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import type {
   BindingHookFilter,
   BindingHookResolveIdOutput,
-  BindingPluginContext,
   BindingPluginOptions,
 } from '../binding.cjs';
 import { RolldownMagicString } from '../binding-magic-string';
@@ -28,23 +27,8 @@ import {
 } from './bindingify-plugin-hook-meta';
 import type { PluginHooks, SourceDescription } from './index';
 import { LoadPluginContextImpl } from './load-plugin-context';
-import { PluginContextImpl } from './plugin-context';
+import { createPluginContext } from './plugin-context';
 import { TransformPluginContextImpl } from './transform-plugin-context';
-
-function createPluginContext(
-  args: BindingifyPluginArgs,
-  ctx: BindingPluginContext,
-): PluginContextImpl {
-  return new PluginContextImpl(
-    args.outputOptions,
-    ctx,
-    args.plugin,
-    args.pluginContextData,
-    args.onLog,
-    args.logLevel,
-    args.watchMode,
-  );
-}
 
 export function bindingifyBuildStart(
   args: BindingifyPluginArgs,

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -9,7 +9,6 @@ import { RolldownMagicString } from '../binding-magic-string';
 import { parseAst } from '../parse-ast-index';
 import { bindingifySourcemap, type ExistingRawSourceMap } from '../types/sourcemap';
 import { aggregateBindingErrorsIntoJsError } from '../utils/error';
-import { normalizeHook } from '../utils/normalize-hook';
 import { transformModuleInfo } from '../utils/transform-module-info';
 import {
   isEmptySourcemapFiled,
@@ -21,10 +20,7 @@ import {
   bindingifyTransformFilter,
 } from './bindingify-hook-filter';
 import type { BindingifyPluginArgs } from './bindingify-plugin';
-import {
-  bindingifyPluginHookMeta,
-  type PluginHookWithBindingExt,
-} from './bindingify-plugin-hook-meta';
+import { bindingifyHook, type PluginHookWithBindingExt } from './bindingify-plugin-hook-meta';
 import type { PluginHooks, SourceDescription } from './index';
 import { LoadPluginContextImpl } from './load-plugin-context';
 import { createPluginContext } from './plugin-context';
@@ -33,52 +29,33 @@ import { TransformPluginContextImpl } from './transform-plugin-context';
 export function bindingifyBuildStart(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['buildStart']> {
-  const hook = args.plugin.buildStart;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.buildStart, ({ handler }) => ({
     plugin: async (ctx, opts) => {
       await handler.call(
         createPluginContext(args, ctx),
         args.pluginContextData.getInputOptions(opts),
       );
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 export function bindingifyBuildEnd(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['buildEnd']> {
-  const hook = args.plugin.buildEnd;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.buildEnd, ({ handler }) => ({
     plugin: async (ctx, err) => {
       await handler.call(
         createPluginContext(args, ctx),
         err ? aggregateBindingErrorsIntoJsError(err) : undefined,
       );
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyResolveId(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['resolveId'], BindingHookFilter | undefined> {
   const hook = args.plugin.resolveId as unknown as PluginHooks['resolveId'];
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta, options } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(hook, ({ handler, options }) => ({
     plugin: async (ctx, specifier, importer, extraOptions) => {
       const contextResolveOptions =
         extraOptions.custom != null
@@ -123,21 +100,14 @@ export function bindingifyResolveId(
         packageJsonPath: ret.packageJsonPath,
       };
     },
-    meta: bindingifyPluginHookMeta(meta),
     filter: bindingifyResolveIdFilter(options.filter),
-  };
+  }));
 }
 
 export function bindingifyResolveDynamicImport(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['resolveDynamicImport']> {
-  const hook = args.plugin.resolveDynamicImport;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.resolveDynamicImport, ({ handler }) => ({
     plugin: async (ctx, specifier, importer) => {
       const ret = await handler.call(
         createPluginContext(args, ctx),
@@ -177,20 +147,13 @@ export function bindingifyResolveDynamicImport(
 
       return result;
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyTransform(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['transform'], BindingHookFilter | undefined> {
-  const hook = args.plugin.transform;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta, options } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.transform, ({ handler, options }) => ({
     plugin: async (ctx, code, id, meta) => {
       let magicStringInstance: RolldownMagicString, astInstance: Program;
       Object.defineProperties(meta, {
@@ -288,21 +251,14 @@ export function bindingifyTransform(
         moduleType: ret.moduleType,
       };
     },
-    meta: bindingifyPluginHookMeta(meta),
     filter: bindingifyTransformFilter(options.filter),
-  };
+  }));
 }
 
 export function bindingifyLoad(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['load'], BindingHookFilter | undefined> {
-  const hook = args.plugin.load;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta, options } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.load, ({ handler, options }) => ({
     plugin: async (ctx, id) => {
       const ret = await handler.call(
         new LoadPluginContextImpl(
@@ -342,9 +298,8 @@ export function bindingifyLoad(
         moduleSideEffects: moduleOption.moduleSideEffects ?? undefined,
       };
     },
-    meta: bindingifyPluginHookMeta(meta),
     filter: bindingifyLoadFilter(options.filter),
-  };
+  }));
 }
 
 function preProcessSourceMap(
@@ -368,19 +323,12 @@ function preProcessSourceMap(
 export function bindingifyModuleParsed(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['moduleParsed']> {
-  const hook = args.plugin.moduleParsed;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.moduleParsed, ({ handler }) => ({
     plugin: async (ctx, moduleInfo) => {
       await handler.call(
         createPluginContext(args, ctx),
         transformModuleInfo(moduleInfo, args.pluginContextData.getModuleOption(moduleInfo.id)),
       );
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -339,15 +339,17 @@ export function bindingifyCloseBundle(
   };
 }
 
-export function bindingifyBanner(
+function bindingifyAddonHook(
   args: BindingifyPluginArgs,
+  name: 'banner' | 'footer' | 'intro' | 'outro',
 ): PluginHookWithBindingExt<BindingPluginOptions['banner']> {
-  const hook = args.plugin.banner;
+  const hook = args.plugin[name];
   if (!hook) {
     return {};
   }
 
   const { handler, meta } = normalizeHook(hook);
+
   return {
     plugin: async (ctx, chunk) => {
       if (typeof handler === 'string') {
@@ -369,103 +371,28 @@ export function bindingifyBanner(
     },
     meta: bindingifyPluginHookMeta(meta),
   };
+}
+
+export function bindingifyBanner(
+  args: BindingifyPluginArgs,
+): PluginHookWithBindingExt<BindingPluginOptions['banner']> {
+  return bindingifyAddonHook(args, 'banner');
 }
 
 export function bindingifyFooter(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['footer']> {
-  const hook = args.plugin.footer;
-  if (!hook) {
-    return {};
-  }
-
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
-    plugin: async (ctx, chunk) => {
-      if (typeof handler === 'string') {
-        return handler;
-      }
-
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        transformRenderedChunk(chunk),
-      );
-    },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  return bindingifyAddonHook(args, 'footer');
 }
 
 export function bindingifyIntro(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['intro']> {
-  const hook = args.plugin.intro;
-  if (!hook) {
-    return {};
-  }
-
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
-    plugin: async (ctx, chunk) => {
-      if (typeof handler === 'string') {
-        return handler;
-      }
-
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        transformRenderedChunk(chunk),
-      );
-    },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  return bindingifyAddonHook(args, 'intro');
 }
 
 export function bindingifyOutro(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['outro']> {
-  const hook = args.plugin.outro;
-  if (!hook) {
-    return {};
-  }
-
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
-    plugin: async (ctx, chunk) => {
-      if (typeof handler === 'string') {
-        return handler;
-      }
-
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        transformRenderedChunk(chunk),
-      );
-    },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  return bindingifyAddonHook(args, 'outro');
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -1,8 +1,13 @@
-import type { BindingHookFilter, BindingPluginOptions } from '../binding.cjs';
+import type {
+  BindingHookFilter,
+  BindingOutputs,
+  BindingPluginContext,
+  BindingPluginOptions,
+  BindingResult,
+} from '../binding.cjs';
 import { RolldownMagicString } from '../binding-magic-string';
 import { bindingifySourcemap } from '../types/sourcemap';
 import { aggregateBindingErrorsIntoJsError, unwrapBindingResult } from '../utils/error';
-import { normalizeHook } from '../utils/normalize-hook';
 import { transformRenderedChunk } from '../utils/transform-rendered-chunk';
 import {
   type ChangedOutputs,
@@ -11,22 +16,13 @@ import {
 } from '../utils/transform-to-rollup-output';
 import { bindingifyRenderChunkFilter } from './bindingify-hook-filter';
 import type { BindingifyPluginArgs } from './bindingify-plugin';
-import {
-  bindingifyPluginHookMeta,
-  type PluginHookWithBindingExt,
-} from './bindingify-plugin-hook-meta';
+import { bindingifyHook, type PluginHookWithBindingExt } from './bindingify-plugin-hook-meta';
 import { createPluginContext } from './plugin-context';
 
 export function bindingifyRenderStart(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['renderStart']> {
-  const hook = args.plugin.renderStart;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.renderStart, ({ handler }) => ({
     plugin: async (ctx, opts) => {
       await handler.call(
         createPluginContext(args, ctx),
@@ -34,19 +30,12 @@ export function bindingifyRenderStart(
         args.pluginContextData.getInputOptions(opts),
       );
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 export function bindingifyRenderChunk(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['renderChunk'], BindingHookFilter | undefined> {
-  const hook = args.plugin.renderChunk;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta, options } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.renderChunk, ({ handler, options }) => ({
     plugin: async (ctx, code, chunk, opts, meta) => {
       // cache the chunks binding to deduplicated avoid clone chunks
       if (args.pluginContextData.getRenderChunkMeta() == null) {
@@ -142,142 +131,96 @@ export function bindingifyRenderChunk(
         map: bindingifySourcemap(ret.map),
       };
     },
-    meta: bindingifyPluginHookMeta(meta),
     filter: bindingifyRenderChunkFilter(options.filter),
-  };
+  }));
 }
 
 export function bindingifyAugmentChunkHash(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['augmentChunkHash']> {
-  const hook = args.plugin.augmentChunkHash;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.augmentChunkHash, ({ handler }) => ({
     plugin: async (ctx, chunk) => {
       return handler.call(createPluginContext(args, ctx), transformRenderedChunk(chunk));
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyResolveFileUrl(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['resolveFileUrl']> {
-  const hook = args.plugin.resolveFileUrl;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.resolveFileUrl, ({ handler }) => ({
     plugin: async (ctx, resolveFileUrlArgs) => {
       return handler.call(createPluginContext(args, ctx), resolveFileUrlArgs);
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyRenderError(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['renderError']> {
-  const hook = args.plugin.renderError;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.renderError, ({ handler }) => ({
     plugin: async (ctx, err) => {
       await handler.call(createPluginContext(args, ctx), aggregateBindingErrorsIntoJsError(err));
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
+}
+
+function createOutputBundle(
+  args: BindingifyPluginArgs,
+  ctx: BindingPluginContext,
+  bundle: BindingResult<BindingOutputs>,
+) {
+  const changed = {
+    updated: new Set(),
+    deleted: new Set(),
+  } as ChangedOutputs;
+  const context = createPluginContext(args, ctx);
+  const output = transformToOutputBundle(context, unwrapBindingResult(bundle), changed);
+  return { changed, context, output };
 }
 
 export function bindingifyGenerateBundle(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['generateBundle']> {
-  const hook = args.plugin.generateBundle;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.generateBundle, ({ handler }) => ({
     plugin: async (ctx, bundle, isWrite, opts) => {
-      const changed = {
-        updated: new Set(),
-        deleted: new Set(),
-      } as ChangedOutputs;
-      const context = createPluginContext(args, ctx);
-      const output = transformToOutputBundle(context, unwrapBindingResult(bundle), changed);
+      const { changed, context, output } = createOutputBundle(args, ctx, bundle);
       await handler.call(context, args.pluginContextData.getOutputOptions(opts), output, isWrite);
       return collectChangedBundle(changed, output);
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyWriteBundle(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['writeBundle']> {
-  const hook = args.plugin.writeBundle;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.writeBundle, ({ handler }) => ({
     plugin: async (ctx, bundle, opts) => {
-      const changed = {
-        updated: new Set(),
-        deleted: new Set(),
-      } as ChangedOutputs;
-      const context = createPluginContext(args, ctx);
-      const output = transformToOutputBundle(context, unwrapBindingResult(bundle), changed);
+      const { changed, context, output } = createOutputBundle(args, ctx, bundle);
       await handler.call(context, args.pluginContextData.getOutputOptions(opts), output);
       return collectChangedBundle(changed, output);
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyCloseBundle(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['closeBundle']> {
-  const hook = args.plugin.closeBundle;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.closeBundle, ({ handler }) => ({
     plugin: async (ctx, err) => {
       await handler.call(
         createPluginContext(args, ctx),
         err ? aggregateBindingErrorsIntoJsError(err) : undefined,
       );
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 function bindingifyAddonHook(
   args: BindingifyPluginArgs,
   name: 'banner' | 'footer' | 'intro' | 'outro',
 ): PluginHookWithBindingExt<BindingPluginOptions['banner']> {
-  const hook = args.plugin[name];
-  if (!hook) {
-    return {};
-  }
-
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin[name], ({ handler }) => ({
     plugin: async (ctx, chunk) => {
       if (typeof handler === 'string') {
         return handler;
@@ -285,8 +228,7 @@ function bindingifyAddonHook(
 
       return handler.call(createPluginContext(args, ctx), transformRenderedChunk(chunk));
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyBanner(

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -216,10 +216,10 @@ export function bindingifyCloseBundle(
   }));
 }
 
-function bindingifyAddonHook(
+export function bindingifyAddonHook<K extends 'banner' | 'footer' | 'intro' | 'outro'>(
   args: BindingifyPluginArgs,
-  name: 'banner' | 'footer' | 'intro' | 'outro',
-): PluginHookWithBindingExt<BindingPluginOptions['banner']> {
+  name: K,
+): PluginHookWithBindingExt<BindingPluginOptions[K]> {
   return bindingifyHook(args.plugin[name], ({ handler }) => ({
     plugin: async (ctx, chunk) => {
       if (typeof handler === 'string') {
@@ -229,28 +229,4 @@ function bindingifyAddonHook(
       return handler.call(createPluginContext(args, ctx), transformRenderedChunk(chunk));
     },
   }));
-}
-
-export function bindingifyBanner(
-  args: BindingifyPluginArgs,
-): PluginHookWithBindingExt<BindingPluginOptions['banner']> {
-  return bindingifyAddonHook(args, 'banner');
-}
-
-export function bindingifyFooter(
-  args: BindingifyPluginArgs,
-): PluginHookWithBindingExt<BindingPluginOptions['footer']> {
-  return bindingifyAddonHook(args, 'footer');
-}
-
-export function bindingifyIntro(
-  args: BindingifyPluginArgs,
-): PluginHookWithBindingExt<BindingPluginOptions['intro']> {
-  return bindingifyAddonHook(args, 'intro');
-}
-
-export function bindingifyOutro(
-  args: BindingifyPluginArgs,
-): PluginHookWithBindingExt<BindingPluginOptions['outro']> {
-  return bindingifyAddonHook(args, 'outro');
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -15,7 +15,7 @@ import {
   bindingifyPluginHookMeta,
   type PluginHookWithBindingExt,
 } from './bindingify-plugin-hook-meta';
-import { PluginContextImpl } from './plugin-context';
+import { createPluginContext } from './plugin-context';
 
 export function bindingifyRenderStart(
   args: BindingifyPluginArgs,
@@ -29,15 +29,7 @@ export function bindingifyRenderStart(
   return {
     plugin: async (ctx, opts) => {
       await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
+        createPluginContext(args, ctx),
         args.pluginContextData.getOutputOptions(opts),
         args.pluginContextData.getInputOptions(opts),
       );
@@ -82,15 +74,7 @@ export function bindingifyRenderChunk(
       }
 
       const ret = await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
+        createPluginContext(args, ctx),
         code,
         transformRenderedChunk(chunk),
         args.pluginContextData.getOutputOptions(opts),
@@ -174,18 +158,7 @@ export function bindingifyAugmentChunkHash(
 
   return {
     plugin: async (ctx, chunk) => {
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        transformRenderedChunk(chunk),
-      );
+      return handler.call(createPluginContext(args, ctx), transformRenderedChunk(chunk));
     },
     meta: bindingifyPluginHookMeta(meta),
   };
@@ -202,18 +175,7 @@ export function bindingifyResolveFileUrl(
 
   return {
     plugin: async (ctx, resolveFileUrlArgs) => {
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        resolveFileUrlArgs,
-      );
+      return handler.call(createPluginContext(args, ctx), resolveFileUrlArgs);
     },
     meta: bindingifyPluginHookMeta(meta),
   };
@@ -230,18 +192,7 @@ export function bindingifyRenderError(
 
   return {
     plugin: async (ctx, err) => {
-      await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        aggregateBindingErrorsIntoJsError(err),
-      );
+      await handler.call(createPluginContext(args, ctx), aggregateBindingErrorsIntoJsError(err));
     },
     meta: bindingifyPluginHookMeta(meta),
   };
@@ -262,15 +213,7 @@ export function bindingifyGenerateBundle(
         updated: new Set(),
         deleted: new Set(),
       } as ChangedOutputs;
-      const context = new PluginContextImpl(
-        args.outputOptions,
-        ctx,
-        args.plugin,
-        args.pluginContextData,
-        args.onLog,
-        args.logLevel,
-        args.watchMode,
-      );
+      const context = createPluginContext(args, ctx);
       const output = transformToOutputBundle(context, unwrapBindingResult(bundle), changed);
       await handler.call(context, args.pluginContextData.getOutputOptions(opts), output, isWrite);
       return collectChangedBundle(changed, output);
@@ -294,15 +237,7 @@ export function bindingifyWriteBundle(
         updated: new Set(),
         deleted: new Set(),
       } as ChangedOutputs;
-      const context = new PluginContextImpl(
-        args.outputOptions,
-        ctx,
-        args.plugin,
-        args.pluginContextData,
-        args.onLog,
-        args.logLevel,
-        args.watchMode,
-      );
+      const context = createPluginContext(args, ctx);
       const output = transformToOutputBundle(context, unwrapBindingResult(bundle), changed);
       await handler.call(context, args.pluginContextData.getOutputOptions(opts), output);
       return collectChangedBundle(changed, output);
@@ -323,15 +258,7 @@ export function bindingifyCloseBundle(
   return {
     plugin: async (ctx, err) => {
       await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
+        createPluginContext(args, ctx),
         err ? aggregateBindingErrorsIntoJsError(err) : undefined,
       );
     },
@@ -356,18 +283,7 @@ function bindingifyAddonHook(
         return handler;
       }
 
-      return handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        transformRenderedChunk(chunk),
-      );
+      return handler.call(createPluginContext(args, ctx), transformRenderedChunk(chunk));
     },
     meta: bindingifyPluginHookMeta(meta),
   };

--- a/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
@@ -1,5 +1,7 @@
 import { type BindingPluginHookMeta, BindingPluginOrder } from '../binding.cjs';
-import type { ObjectHookMeta, PluginOrder } from '.';
+import type { ObjectHook, ObjectHookMeta, PluginOrder } from '.';
+import type { AnyFn } from '../types/utils';
+import { normalizeHook } from '../utils/normalize-hook';
 
 export function bindingifyPluginHookMeta(options: ObjectHookMeta): BindingPluginHookMeta {
   return {
@@ -26,3 +28,17 @@ export type PluginHookWithBindingExt<T, F = undefined> = {
   meta?: BindingPluginHookMeta;
   filter?: F;
 };
+
+export function bindingifyHook<Hook extends ObjectHook<AnyFn | string>, T, F = undefined>(
+  hook: Hook | undefined,
+  build: (normalized: ReturnType<typeof normalizeHook<Hook>>) => { plugin: T; filter?: F },
+): PluginHookWithBindingExt<T, F> {
+  if (!hook) {
+    return {};
+  }
+  const normalized = normalizeHook(hook);
+  return {
+    ...build(normalized),
+    meta: bindingifyPluginHookMeta(normalized.meta),
+  };
+}

--- a/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
@@ -3,7 +3,7 @@ import type { ObjectHook, ObjectHookMeta, PluginOrder } from '.';
 import type { AnyFn } from '../types/utils';
 import { normalizeHook } from '../utils/normalize-hook';
 
-export function bindingifyPluginHookMeta(options: ObjectHookMeta): BindingPluginHookMeta {
+function bindingifyPluginHookMeta(options: ObjectHookMeta): BindingPluginHookMeta {
   return {
     order: bindingPluginOrder(options.order),
   };

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -10,14 +10,11 @@ import {
 } from './bindingify-build-hooks';
 
 import {
+  bindingifyAddonHook,
   bindingifyAugmentChunkHash,
   bindingifyResolveFileUrl,
-  bindingifyBanner,
   bindingifyCloseBundle,
-  bindingifyFooter,
   bindingifyGenerateBundle,
-  bindingifyIntro,
-  bindingifyOutro,
   bindingifyRenderChunk,
   bindingifyRenderError,
   bindingifyRenderStart,
@@ -110,13 +107,13 @@ export function bindingifyPlugin(
 
   const { plugin: closeBundle, meta: closeBundleMeta } = bindingifyCloseBundle(args);
 
-  const { plugin: banner, meta: bannerMeta } = bindingifyBanner(args);
+  const { plugin: banner, meta: bannerMeta } = bindingifyAddonHook(args, 'banner');
 
-  const { plugin: footer, meta: footerMeta } = bindingifyFooter(args);
+  const { plugin: footer, meta: footerMeta } = bindingifyAddonHook(args, 'footer');
 
-  const { plugin: intro, meta: introMeta } = bindingifyIntro(args);
+  const { plugin: intro, meta: introMeta } = bindingifyAddonHook(args, 'intro');
 
-  const { plugin: outro, meta: outroMeta } = bindingifyOutro(args);
+  const { plugin: outro, meta: outroMeta } = bindingifyAddonHook(args, 'outro');
 
   const { plugin: watchChange, meta: watchChangeMeta } = bindingifyWatchChange(args);
 

--- a/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
@@ -6,7 +6,7 @@ import {
   type PluginHookWithBindingExt,
 } from './bindingify-plugin-hook-meta';
 import type { ChangeEvent } from './index';
-import { PluginContextImpl } from './plugin-context';
+import { createPluginContext } from './plugin-context';
 
 export function bindingifyWatchChange(
   args: BindingifyPluginArgs,
@@ -19,19 +19,7 @@ export function bindingifyWatchChange(
 
   return {
     plugin: async (ctx, id, event) => {
-      await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-        id,
-        { event: event as ChangeEvent },
-      );
+      await handler.call(createPluginContext(args, ctx), id, { event: event as ChangeEvent });
     },
     meta: bindingifyPluginHookMeta(meta),
   };
@@ -48,17 +36,7 @@ export function bindingifyCloseWatcher(
 
   return {
     plugin: async (ctx) => {
-      await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
-      );
+      await handler.call(createPluginContext(args, ctx));
     },
     meta: bindingifyPluginHookMeta(meta),
   };

--- a/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
@@ -1,43 +1,25 @@
 import type { BindingPluginOptions } from '../binding.cjs';
-import { normalizeHook } from '../utils/normalize-hook';
 import type { BindingifyPluginArgs } from './bindingify-plugin';
-import {
-  bindingifyPluginHookMeta,
-  type PluginHookWithBindingExt,
-} from './bindingify-plugin-hook-meta';
+import { bindingifyHook, type PluginHookWithBindingExt } from './bindingify-plugin-hook-meta';
 import type { ChangeEvent } from './index';
 import { createPluginContext } from './plugin-context';
 
 export function bindingifyWatchChange(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['watchChange']> {
-  const hook = args.plugin.watchChange;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.watchChange, ({ handler }) => ({
     plugin: async (ctx, id, event) => {
       await handler.call(createPluginContext(args, ctx), id, { event: event as ChangeEvent });
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }
 
 export function bindingifyCloseWatcher(
   args: BindingifyPluginArgs,
 ): PluginHookWithBindingExt<BindingPluginOptions['closeWatcher']> {
-  const hook = args.plugin.closeWatcher;
-  if (!hook) {
-    return {};
-  }
-  const { handler, meta } = normalizeHook(hook);
-
-  return {
+  return bindingifyHook(args.plugin.closeWatcher, ({ handler }) => ({
     plugin: async (ctx) => {
       await handler.call(createPluginContext(args, ctx));
     },
-    meta: bindingifyPluginHookMeta(meta),
-  };
+  }));
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -22,6 +22,7 @@ import type { PartialNull } from '../types/utils';
 import { type AssetSource, bindingAssetSource } from '../utils/asset-source';
 import { bindingifyPreserveEntrySignatures } from '../utils/bindingify-input-options';
 import { isPathFragment, unreachable } from '../utils/misc';
+import type { BindingifyPluginArgs } from './bindingify-plugin';
 import { fsModule, type RolldownFsModule } from './fs';
 import type { CustomPluginOptions, ModuleOptions, Plugin, ResolvedId } from './index';
 import type { PluginContextData } from './plugin-context-data';
@@ -440,6 +441,21 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
   public parse(input: string, options?: ParserOptions | null): Program {
     return parseAst(input, options);
   }
+}
+
+export function createPluginContext(
+  args: BindingifyPluginArgs,
+  ctx: BindingPluginContext,
+): PluginContextImpl {
+  return new PluginContextImpl(
+    args.outputOptions,
+    ctx,
+    args.plugin,
+    args.pluginContextData,
+    args.onLog,
+    args.logLevel,
+    args.watchMode,
+  );
 }
 
 function _assert() {


### PR DESCRIPTION
The four addon hook copies accumulated one at a time (#1419, #1713, #1763), and the same guard/normalize/meta shell repeated around all 20 hook bindings. The commits are independent in case the later ones go further than wanted.