### PR TITLE
test: refuse to hide runtime regions that swallowed user code in snapshots

### DIFF
--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -8,7 +8,44 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import "x";
 import "x";
-// HIDDEN [\0rolldown/runtime.js]
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+var __copyProps = (to, from, except, desc) => {
+	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+		key = keys[i];
+		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+			get: ((k) => from[k]).bind(null, key),
+			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+		});
+	}
+	return to;
+};
+var __reExport = (target, mod, secondTarget) => (__copyProps(target, mod, "default"), secondTarget && __copyProps(secondTarget, mod, "default"));
+var init_a = __esmMin((() => {}));
+var init_b = __esmMin((() => {}));
+var init_c = __esmMin((() => {}));
+var init_d = __esmMin((() => {}));
+//#endregion
 //#region e.js
 var e_exports = /* @__PURE__ */ __exportAll({});
 import * as import_x from "x";

--- a/crates/rolldown/tests/rolldown/function/module_types/asset/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/asset/artifacts.snap
@@ -8,7 +8,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+//#region \0rolldown/runtime.js
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __copyProps = (to, from, except, desc) => {
+	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+		key = keys[i];
+		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+			get: ((k) => from[k]).bind(null, key),
+			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+		});
+	}
+	return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: true
+}) : target, mod));
+var main_default = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "./assets/foo-Cctl21F7.txt";
+})))())).default;
+//#endregion
 export { main_default as default };
 
 //# sourceMappingURL=main.js.map

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
@@ -7,7 +7,36 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
+//#region \0rolldown/runtime.js
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __copyProps = (to, from, except, desc) => {
+	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+		key = keys[i];
+		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+			get: ((k) => from[k]).bind(null, key),
+			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+		});
+	}
+	return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: true
+}) : target, mod));
+const value = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { value: "yes" };
+	Object.defineProperty(module.exports, "__esModule", {
+		value: true,
+		enumerable: false
+	});
+})))(), 1)).default.value;
+//#endregion
 //#region main.js
 assert.strictEqual(value, "yes");
 //#endregion

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
@@ -6,7 +6,36 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+//#region \0rolldown/runtime.js
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+var __copyProps = (to, from, except, desc) => {
+	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+		key = keys[i];
+		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+			get: ((k) => from[k]).bind(null, key),
+			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+		});
+	}
+	return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: true
+}) : target, mod));
+const foo = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.version = "1.0.0";
+	Object.defineProperty(exports, "version", { get() {
+		throw new Error("see stacktrace");
+	} });
+})))())).version.startsWith("1");
+console.log(foo);
+//#endregion
 
 //# sourceMappingURL=main.js.map
 ```

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
@@ -6,7 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+//#region \0rolldown/runtime.js
+var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+const value = (/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.value = "cjs-value";
+})))().value;
+//#endregion
 export { value };
 
 ```

--- a/crates/rolldown_testing/src/utils/mod.rs
+++ b/crates/rolldown_testing/src/utils/mod.rs
@@ -35,6 +35,55 @@ pub(crate) static OXC_RUNTIME_MODULE_OUTPUT_RE: LazyLock<Regex> = LazyLock::new(
     .expect("invalid oxc runtime module output regex")
 });
 
+/// A column-zero declaration and the name it binds, for probing what a runtime region span
+/// actually declares.
+static TOP_LEVEL_DECL_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(
+    r"(?m)^(?:var|let|const|class)\s+([A-Za-z_$][\w$]*)|^(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)",
+  )
+  .expect("invalid top-level declaration probe regex")
+});
+
+/// Top-level names the dev runtime glue adds to the `\0rolldown/runtime.js` region, from
+/// `rolldown_plugin_hmr/src/runtime/runtime-extra-dev-*.js` and the test harness's
+/// `hmr-runtime.js`. If a name is added there, dev-mode snapshots will show the runtime region
+/// raw until it is added here too.
+const DEV_RUNTIME_TOP_LEVEL_NAMES: &[&str] = &[
+  "Module",
+  "MissingFactoryError",
+  "DevRuntime",
+  "BaseDevRuntime",
+  "ModuleHotContext",
+  "DefaultDevRuntime",
+  "loadScript",
+  "clientId",
+  "addr",
+  "socket",
+  "TestHotContext",
+  "TestDevRuntime",
+];
+
+/// Whether a matched runtime region span really contains only runtime code.
+///
+/// Region markers are ordinary comments, and the default `minify: 'dce-only'` pass drops the
+/// comments attached to a statement it removes. A removed statement at a module boundary takes
+/// the adjacent `//#endregion` + `//#region` pair with it, after which the surviving markers
+/// still pair up textually — the lazy match then extends across the next module and hiding it
+/// would silently swallow user code. Marker structure cannot reveal this; content can: the
+/// runtime region only ever declares `__`-prefixed helpers plus the known dev-runtime names, so
+/// any other column-zero declaration proves foreign code, and the span is left visible instead —
+/// a noisy-but-truthful snapshot beats one that hides user code. (Indented regions inside
+/// iife/umd wrappers have no column-zero declarations and are hidden as before; the corruption
+/// this guards against arises from esm strict-order layouts.)
+fn runtime_region_is_hidable(span: &str) -> bool {
+  span.lines().skip(1).all(|line| !line.trim_start().starts_with("//#region "))
+    && TOP_LEVEL_DECL_NAME_RE.captures_iter(span).all(|caps| {
+      caps.get(1).or_else(|| caps.get(2)).is_none_or(|name| {
+        name.as_str().starts_with("__") || DEV_RUNTIME_TOP_LEVEL_NAMES.contains(&name.as_str())
+      })
+    })
+}
+
 // Some content of snapshot are meaningless, we'd like to remove them to reduce the noise when reviewing snapshots.
 pub fn tweak_snapshot(
   content: &str,
@@ -49,7 +98,13 @@ pub fn tweak_snapshot(
 
   if hide_runtime_module {
     result = RUNTIME_MODULE_OUTPUT_RE
-      .replace_all(&result, "// HIDDEN [\\0rolldown/runtime.js]")
+      .replace_all(&result, |caps: &regex::Captures| {
+        if runtime_region_is_hidable(&caps[0]) {
+          "// HIDDEN [\\0rolldown/runtime.js]".to_string()
+        } else {
+          caps[0].to_string()
+        }
+      })
       .into_owned();
   }
 
@@ -63,4 +118,48 @@ pub fn tweak_snapshot(
     .into_owned();
 
   Cow::Owned(result)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::tweak_snapshot;
+
+  #[test]
+  fn hides_a_pure_runtime_region() {
+    let content = "//#region \\0rolldown/runtime.js\nvar __esmMin = (fn) => fn;\nfunction __reExport(a) {\n\treturn a;\n}\n//#endregion\n//#region main.js\nconsole.log(1);\n//#endregion\n";
+    let tweaked = tweak_snapshot(content, true, false);
+    assert!(tweaked.contains("// HIDDEN [\\0rolldown/runtime.js]"));
+    assert!(!tweaked.contains("__esmMin"));
+    assert!(tweaked.contains("console.log(1);"));
+  }
+
+  #[test]
+  fn hides_a_runtime_region_with_dev_runtime_declarations() {
+    let content = "//#region \\0rolldown/runtime.js\nvar __esmMin = (fn) => fn;\nvar Module = class {};\nvar DevRuntime = class {};\n//#endregion\n";
+    let tweaked = tweak_snapshot(content, true, false);
+    assert!(tweaked.contains("// HIDDEN [\\0rolldown/runtime.js]"));
+    assert!(!tweaked.contains("DevRuntime"));
+  }
+
+  #[test]
+  fn keeps_a_region_that_swallowed_user_code() {
+    // The dce-only pass removed a statement at the runtime/user boundary together with its
+    // attached `//#endregion` + `//#region foo.js` pair, so the runtime region now textually
+    // extends over `init_foo`. The remaining markers still pair up; only the non-runtime
+    // declaration reveals the foreign code.
+    let content = "//#region \\0rolldown/runtime.js\nvar __esmMin = (fn) => fn;\nfunction init_foo() {\n\treturn (init_foo = __esmMin(0))();\n}\n//#endregion\n//#region main.js\nconsole.log(1);\n//#endregion\n";
+    let tweaked = tweak_snapshot(content, true, false);
+    assert!(!tweaked.contains("// HIDDEN"));
+    assert!(tweaked.contains("function init_foo()"));
+  }
+
+  #[test]
+  fn keeps_a_region_that_crossed_into_another_region() {
+    // No closer of its own before the next module's region: the lazy span would end at that
+    // module's closer, so the contained foreign opener must refuse the hide.
+    let content = "//#region \\0rolldown/runtime.js\nvar __esmMin = (fn) => fn;\n//#region foo.js\nvar __state = 1;\n//#endregion\n";
+    let tweaked = tweak_snapshot(content, true, false);
+    assert!(!tweaked.contains("// HIDDEN"));
+    assert!(tweaked.contains("//#region foo.js"));
+  }
 }


### PR DESCRIPTION
### Problem

`tweak_snapshot` hides the rolldown-runtime region of every artifact snapshot by lazily matching `//#region \0rolldown/runtime.js … //#endregion`. That match trusts the region markers to be balanced — and chunk output does not guarantee that.

Region markers are ordinary comments, and the default `minify: 'dce-only'` pass re-parses the joined chunk and removes unused statements *together with their attached comments*. When the removed statement sits at a module boundary (e.g. the hoisted `var foo;` of a wrapped TLA module whose only write is dead), the adjacent `//#endregion` + `//#region next.js` pair vanishes with it. The surviving markers still pair up textually, so the lazy hide silently extends across the following module and the snapshot swallows real user code while claiming it hid only the runtime.

Observed on `strict_execution_order/top_level_await_syntax` while validating #10414: after the runtime folds into the same chunk, the snapshot's `// HIDDEN [\0rolldown/runtime.js]` also ate the `init_foo` wrapper. The emitted chunk is correct — only the snapshot view lied. Verified end-to-end: the pre-DCE output (`minify: false`) carries fully balanced markers; the imbalance is introduced exclusively by the dce-only pass dropping comments attached to removed statements.

### Fix (test harness only)

The three hide regexes are untouched. Before the rolldown-runtime match is replaced with `// HIDDEN`, a guard now checks that the span really is runtime-only, and otherwise leaves it visible verbatim — a noisy-but-truthful snapshot instead of one that silently hides user code. The span is refused when:

- it contains another `//#region` line (the runtime region lost its own closer and the lazy match ran into the next module), or
- a column-zero declaration binds a name that is neither `__`-prefixed (all runtime helpers) nor one of the known dev-runtime glue names (`Module`, `DevRuntime`, … — a literal list with a pointer to the composing sources). This is the only signal that survives the eaten-adjacent-pair case, where the remaining markers still pair up and marker structure looks perfectly well-formed.

Indented (iife/umd) regions have no column-zero declarations and keep their existing hiding behavior; the marker corruption this guards against arises from esm layouts.

### The guard immediately caught five pre-existing swallows

Re-running the full fixture suite updates five snapshots where the old hide was already swallowing user code on main — each one the eaten-boundary shape described above, where the "runtime" span also contained user statements (`var init_a = __esmMin(...)` wrappers, `var main_default = __toESM(...)`, `const value = …`):

- `esbuild/default/external_es6_converted_to_common_js`
- `function/module_types/asset`
- `resolve/attach_correct_package_json`
- `sourcemap/issue_6099`
- `topics/runtime/transform`

Those snapshots now show what the chunks actually contain. The full-suite failure list is byte-identical to unmodified main on the same machine (the pre-existing local css/legal-comments environment set); four unit tests cover the hide, the dev-runtime hide, the swallowed-span refusal, and the crossed-region refusal.

The underlying output-level issue — dce-only corrupting `attachDebugInfo` region markers by dropping comments attached to removed statements — is a separate product bug (fix belongs in oxc's comment preservation); this PR only stops the test harness from being misled by it.
