### PR TITLE
fix(code-splitting): align dynamicImports metadata with the rewritten import() specifier

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -385,8 +385,18 @@ impl GenerateStage<'_> {
                     return;
                   }
                   if matches!(rec.kind, ImportKind::DynamicImport) {
-                    let importee_chunk =
-                      chunk_graph.module_to_chunk[module_idx].expect("importee chunk should exist");
+                    // The finalizer rewrites `import()` specifiers through
+                    // `entry_module_to_entry_chunk`, which diverges from the hosting chunk
+                    // whenever the dynamic entry's facade chunk survives while another chunk
+                    // hosts its body (order-wrap facade splits, or kept facades when
+                    // common-chunk merging is off); record the chunk the emitted specifier
+                    // actually names.
+                    let importee_chunk = chunk_graph
+                      .entry_module_to_entry_chunk
+                      .get(&module_idx)
+                      .copied()
+                      .or(chunk_graph.module_to_chunk[module_idx])
+                      .expect("importee chunk should exist");
                     cross_chunk_dynamic_imports.insert(importee_chunk);
                   }
                 }

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/_config.ts
@@ -1,0 +1,26 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// Top-level await disables common-chunk merging, so the dynamic entry keeps its
+// facade chunk while the manual group hosts the entry module's body — the same
+// metadata/specifier split as the order-wrap facade, without `strictExecutionOrder`.
+export default defineTest({
+  config: {
+    input: ['main.js'],
+    output: {
+      entryFileNames: '[name].js',
+      chunkFileNames: 'chunks/[name].js',
+      codeSplitting: {
+        groups: [{ name: 'grp', test: /[\\/](?:page|lib)\.js$/ }],
+      },
+    },
+  },
+  afterTest: (output) => {
+    const main = output.output.find((item) => item.type === 'chunk' && item.fileName === 'main.js');
+    if (main?.type !== 'chunk') {
+      throw new Error('main.js should be emitted as a chunk');
+    }
+    expect(main.code).toContain('import("./chunks/page.js")');
+    expect(main.dynamicImports).toStrictEqual(['chunks/page.js']);
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/lib.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/lib.js
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/main.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/main.js
@@ -1,0 +1,3 @@
+import { ready } from './tla.js';
+export const p = import('./page.js');
+console.log('main', ready);

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/page.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/page.js
@@ -1,0 +1,3 @@
+import { x } from './lib.js';
+console.log('page', x);
+export const v = x;

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/tla.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/kept-facade-tla/tla.js
@@ -1,0 +1,1 @@
+export const ready = await Promise.resolve('ready');

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/_config.ts
@@ -1,0 +1,30 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// An order-wrap entry facade keeps `entry_module_to_entry_chunk` pointing at the
+// facade chunk while the manual group hosts the entry module's body. The emitted
+// `import()` names the facade, and `dynamicImports` must name the same file.
+export default defineTest({
+  config: {
+    input: ['a.js', 'b.js'],
+    experimental: {
+      onDemandWrapping: true,
+    },
+    output: {
+      strictExecutionOrder: true,
+      entryFileNames: '[name].js',
+      chunkFileNames: 'chunks/[name].js',
+      codeSplitting: {
+        groups: [{ name: 'dyn', test: /[\\/](?:target|observer)\.js$/ }],
+      },
+    },
+  },
+  afterTest: (output) => {
+    const a = output.output.find((item) => item.type === 'chunk' && item.fileName === 'a.js');
+    if (a?.type !== 'chunk') {
+      throw new Error('a.js should be emitted as a chunk');
+    }
+    expect(a.code).toContain('import("./chunks/target.js")');
+    expect(a.dynamicImports).toStrictEqual(['chunks/target.js']);
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/a.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/a.js
@@ -1,0 +1,3 @@
+globalThis.events = [];
+export const targetPromise = import('./target.js');
+console.log('a done');

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/b.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/b.js
@@ -1,0 +1,2 @@
+import './observer.js';
+console.log('b done');

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/observer.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/observer.js
@@ -1,0 +1,3 @@
+globalThis.events ??= [];
+globalThis.events.push('observer:' + Boolean(globalThis.ready));
+console.log('observer eval', Boolean(globalThis.ready));

--- a/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/target.js
+++ b/packages/rolldown/tests/fixtures/output/dynamic-imports-metadata/strict-facade/target.js
@@ -1,0 +1,5 @@
+globalThis.events ??= [];
+globalThis.events.push('target');
+globalThis.ready = true;
+console.log('target eval');
+export const value = 1;


### PR DESCRIPTION
The emitted code and the chunk metadata could disagree about which file a dynamic import loads. The code was always right; `chunk.dynamicImports` was wrong. This PR makes the metadata name the same file the emitted `import()` names.

```js
// a.js — emitted code (correct)
import("./chunks/target.js")

// a.js — metadata before this PR (wrong)
dynamicImports: ["chunks/dyn.js"]
```

### Problem

A dynamically imported module becomes a dynamic entry. Normally its body lives in its own entry chunk, so the file you import is the file that holds the code — no ambiguity. The two diverge when only a facade file remains at the entry (importing the body chunk and triggering init) while the body is hosted elsewhere:

- order-wrap entry facades under `strictExecutionOrder`;
- with strict order off: facade elimination skipped (top-level await anywhere in the graph, or `chunkOptimization.mergeCommonChunks: false`) while a manual group — or a chunk shared by static+dynamic importers — hosts the body.

The root cause is two different lookup tables: the finalizer rewrites the `import()` specifier through `entry_module_to_entry_chunk` (→ the facade), while `collect_depended_symbols` recorded the metadata edge from `module_to_chunk[importee]` (→ the body chunk).

Runtime behavior is unaffected; only metadata consumers get the wrong edge: `build.manifest` (backend preload tags point at the body chunk and miss the facade — an extra request waterfall), the devtools chunk graph, and the bundle analyzer. Vite's `__vitePreload` and SSR manifest re-parse the emitted code, so runtime preloading was never affected.

### Fix

Record the edge through the same mapping the finalizer uses: `entry_module_to_entry_chunk` first, `module_to_chunk` as fallback. When the mapping is present, every rewrite path derives the emitted path from it; when it is absent the finalizer emits `void 0`, and the fallback keeps today's metadata byte-for-byte. `cross_chunk_dynamic_imports` feeds only metadata surfaces (RollupRenderedChunk, `OutputChunk.dynamicImports`, devtools trace), so emitted code cannot change.

Two pre-existing wrinkles are deliberately left alone (a mapping-absent `void 0` import and a same-chunk merged entry can still record an edge with no emitted request): both record identically before and after this change; tracked in #10294.

### Validation

- Two vitest fixtures (`output/dynamic-imports-metadata/{strict-facade,kept-facade-tla}`) pin both shapes from the public JS API surface: red on an unfixed build (`['chunks/dyn.js']` / `['chunks/grp.js']` recorded while the code names the facade), green with the fix. The dual static+dynamic combo was verified with a one-off probe on both builds.
- Full Rust fixture sweep (`--include-ignored`): failure list identical to unmodified main on the same machine (the pre-existing local environment set), zero snapshot changes. clippy and fmt clean.

Part of #10294.
