### PR TITLE
test: stop snapshots from silently hiding user code inside the runtime region

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/const_value_inlining_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/const_value_inlining_bundle/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region circular-import-cycle.js
 console.log(bar());
+//#endregion
+//#region circular-import-constants.js
 function bar() {
 	return 123;
 }
@@ -20,6 +22,8 @@ function bar() {
 ```js
 //#region circular-re-export-cycle.js
 console.log(bar());
+//#endregion
+//#region circular-re-export-constants.js
 function bar() {
 	return 123;
 }
@@ -35,6 +39,8 @@ console.log(0);
 ```js
 //#region circular-re-export-star-cycle.js
 console.log(bar());
+//#endregion
+//#region circular-re-export-star-constants.js
 function bar() {
 	return 123;
 }
@@ -45,6 +51,7 @@ function bar() {
 ## cross-module-entry.js
 
 ```js
+//#region cross-module-constants.js
 //#endregion
 //#region cross-module-entry.js
 console.log(1, 1);
@@ -67,6 +74,7 @@ export { y_keep };
 ## non-circular-export-entry.js
 
 ```js
+//#region non-circular-export-constants.js
 function bar() {
 	return 123;
 }
@@ -80,6 +88,7 @@ console.log(123, bar());
 ## print-shorthand-entry.js
 
 ```js
+//#region print-shorthand-constants.js
 //#endregion
 //#region print-shorthand-entry.js
 console.log({

--- a/crates/rolldown/tests/esbuild/dce/dce_class_static_blocks/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_class_static_blocks/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 (class {
 	static {
 		foo;

--- a/crates/rolldown/tests/esbuild/dce/dce_class_static_blocks_minify_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_class_static_blocks_minify_syntax/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 (class {
 	static {
 		foo;

--- a/crates/rolldown/tests/esbuild/dce/dce_of_decorators/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_of_decorators/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 const fn = () => {
 	console.log("side effect");
 };
+//#endregion
+//#region keep-these.js
 (@fn class {});
 (class {
 	@fn field;

--- a/crates/rolldown/tests/esbuild/dce/disable_tree_shaking/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/disable_tree_shaking/artifacts.snap
@@ -6,9 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region remove-me.js
 //#endregion
 //#region keep-me/index.js
 console.log("side effects");
+//#endregion
+//#region entry.jsx
 pure();
 some.fn();
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/import_re_export_of_namespace_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/import_re_export_of_namespace_import/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pkg/foo.js
+//#endregion
 //#region node_modules/pkg/index.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 123;

--- a/crates/rolldown/tests/esbuild/dce/nested_function_inlining_with_spread/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/nested_function_inlining_with_spread/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-outer.js
 
 ```js
+//#region inner.js
 function identity1(x) {
 	return x;
 }

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
@@ -258,6 +258,7 @@ export { c0, c1, c2, c3, l0, l1, l2, l3, v0, v1, v2, v3 };
 ## stmt-fn.js
 
 ```js
+//#region stmt-fn.js
 //! These should all have "no side effects"
 //#endregion
 
@@ -266,6 +267,7 @@ export { c0, c1, c2, c3, l0, l1, l2, l3, v0, v1, v2, v3 };
 ## stmt-local.js
 
 ```js
+//#region stmt-local.js
 //! Only "c0" and "c2" should have "no side effects" (Rollup only respects "const" and only for the first one)
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -6,14 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## src_entry.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
+// HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
 //#endregion
 //#region src/entry.js
 __esmMin((() => {

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
@@ -7,5 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
+//#region src/entry.js
+(/* @__PURE__ */ __commonJSMin(((exports) => {
+	console.log("hello");
+})))();
+console.log("unused import");
+//#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/top_level_function_inlining_with_spread/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/top_level_function_inlining_with_spread/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-outer.js
 
 ```js
+//#region inner.js
 //#endregion
 //#region entry-outer.js
 args;

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 (class {
 	static x = "x";
 	static y = sideEffects();

--- a/crates/rolldown/tests/esbuild/default/avoid_tdz_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/avoid_tdz_no_bundle/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 let foo = class Foo {
 	static foo = new Foo();
 }.foo;

--- a/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
@@ -6,14 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_js.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-}, x;
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
 //#endregion
 //#region entry.js
 __esmMin((() => {

--- a/crates/rolldown/tests/esbuild/default/const_with_let_no_mangle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/const_with_let_no_mangle/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 console.log(1);
 console.log(2);
 for (const c = x;;) console.log(c);

--- a/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region index.js
+//#endregion
 //#region entry.js
 var import_dot_import = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.x = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -6,31 +6,42 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
-var init_a = __esmMin((() => {})), init_b = __esmMin((() => {}));
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var init_a = __esmMin((() => {})), init_b = __esmMin((() => {
+	//#endregion
+	//#region b.js
+}));
+//#endregion
+//#region commonjs.js
 var init_commonjs = __esmMin((() => {
 	init_a();
 	init_b();
 }));
+//#endregion
+//#region c.js
 var init_c = __esmMin((() => {}));
+//#endregion
+//#region d.js
 var Foo;
 var init_d = __esmMin((() => {
 	Foo = class {};
 	Foo.prop = 123;
 }));
+//#endregion
+//#region e.js
 var init_e = __esmMin((() => {}));
+//#endregion
+//#region f.js
 function foo$1() {}
 var init_f = __esmMin((() => {
 	foo$1.prop = 123;
 }));
+//#endregion
+//#region g.js
 var init_g = __esmMin((() => {}));
+//#endregion
+//#region h.js
 async function foo() {}
 var init_h = __esmMin((() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_special_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_special_name/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region entry.mjs
 //#endregion
 Object.defineProperty(exports, "__proto__", {
 	enumerable: true,

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -9,6 +9,18 @@ source: crates/rolldown_testing/src/integration_test.rs
 import "x";
 import "x";
 // HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var init_a = __esmMin((() => {}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {}));
+//#endregion
+//#region c.js
+var init_c = __esmMin((() => {}));
+//#endregion
+//#region d.js
+var init_d = __esmMin((() => {}));
+//#endregion
 //#region e.js
 var e_exports = /* @__PURE__ */ __exportAll({});
 import * as import_x from "x";

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
@@ -66,6 +66,18 @@ init_e();
 import "x";
 import "x";
 // HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var init_a = __esmMin((() => {}));
+//#endregion
+//#region b.js
+var init_b = __esmMin((() => {}));
+//#endregion
+//#region c.js
+var init_c = __esmMin((() => {}));
+//#endregion
+//#region d.js
+var init_d = __esmMin((() => {}));
+//#endregion
 //#region e.js
 var e_exports = /* @__PURE__ */ __exportAll({});
 import * as import_x from "x";
@@ -86,7 +98,7 @@ init_e();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,43 +1,10 @@
+@@ -1,43 +1,14 @@
 -var a_exports = {};
 -__export(a_exports, {
 -    ns: () => ns
@@ -128,6 +140,10 @@ init_e();
 -});
 +import "x";
 +import "x";
++var init_a = __esmMin(() => {});
++var init_b = __esmMin(() => {});
++var init_c = __esmMin(() => {});
++var init_d = __esmMin(() => {});
 +var e_exports = __exportAll({});
 +import * as import_x from "x";
 +__reExport(e_exports, import_x);

--- a/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.x = 123;

--- a/crates/rolldown/tests/esbuild/default/import_with_hash_in_path/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_with_hash_in_path/artifacts.snap
@@ -6,6 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region file#foo.txt
+//#endregion
+//#region file#bar.txt
 //#endregion
 //#region entry.js
 console.log("foo", "bar");

--- a/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import "./rolldown-runtime.js";
+//#region array.js
 //#endregion
 
 ```
@@ -35,6 +36,7 @@ __require.cache;
 
 ```js
 import "./rolldown-runtime.js";
+//#region ident.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/inject_with_define/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/inject_with_define/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region inject.js
 //#endregion
 //#region entry.js
 console.log(true, true, true, true);

--- a/crates/rolldown/tests/esbuild/default/jsx_automatic_imports_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_automatic_imports_common_js/artifacts.snap
@@ -17,6 +17,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import { Fragment, jsx } from "react/jsx-runtime";
 // HIDDEN [\0rolldown/runtime.js]
+//#region custom-react.js
+//#endregion
 //#region entry.jsx
 var import_custom_react = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};

--- a/crates/rolldown/tests/esbuild/default/jsx_imports_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_imports_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region custom-react.js
+//#endregion
 //#region entry.jsx
 var import_custom_react = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};

--- a/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/minify_identifiers_import_path_frequency_analysis/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minify_identifiers_import_path_frequency_analysis/artifacts.snap
@@ -16,6 +16,8 @@ console.log(123, "no identifier in this file should be named W, X, Y, or Z");
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDDDDDDD.js
+//#endregion
 //#region require.js
 const foo = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 123;

--- a/crates/rolldown/tests/esbuild/default/minify_private_identifiers_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minify_private_identifiers_no_bundle/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/named_function_expression_argument_collision/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/named_function_expression_argument_collision/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.fn = function() {

--- a/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 new ((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	var Foo = class {};

--- a/crates/rolldown/tests/esbuild/default/node_modules/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/node_modules/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/default/object_literal_proto_setter_edge_cases/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/object_literal_proto_setter_edge_cases/artifacts.snap
@@ -35,6 +35,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import "foo";
+//#region import-normal.js
 //#endregion
 
 ```
@@ -43,6 +44,7 @@ import "foo";
 
 ```js
 import "foo";
+//#region import-shorthand.js
 //#endregion
 
 ```
@@ -50,6 +52,7 @@ import "foo";
 ## local-normal.js
 
 ```js
+//#region local-normal.js
 //#endregion
 
 ```
@@ -57,6 +60,7 @@ import "foo";
 ## local-shorthand.js
 
 ```js
+//#region local-shorthand.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/object_literal_proto_setter_edge_cases_minify_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/object_literal_proto_setter_edge_cases_minify_syntax/artifacts.snap
@@ -35,6 +35,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import "foo";
+//#region import-computed.js
 //#endregion
 
 ```
@@ -43,6 +44,7 @@ import "foo";
 
 ```js
 import "foo";
+//#region import-normal.js
 //#endregion
 
 ```
@@ -50,6 +52,7 @@ import "foo";
 ## local-computed.js
 
 ```js
+//#region local-computed.js
 //#endregion
 
 ```
@@ -57,6 +60,7 @@ import "foo";
 ## local-normal.js
 
 ```js
+//#region local-normal.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
@@ -7,6 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
+//#region entry.js
+//#endregion
 var bar = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.bar = 123;
 })))().bar;

--- a/crates/rolldown/tests/esbuild/default/rename_private_identifiers_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/rename_private_identifiers_no_bundle/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/require_child_dir_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_child_dir_common_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region dir/index.js
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 123;

--- a/crates/rolldown/tests/esbuild/default/require_fs_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_fs_browser/artifacts.snap
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 console.log((/* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, { get: (a, b) => (typeof require !== "undefined" ? require : a)[b] }) : x)(function(x) {
 	if (typeof require !== "undefined") return require.apply(this, arguments);

--- a/crates/rolldown/tests/esbuild/default/require_json/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_json/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.json
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {

--- a/crates/rolldown/tests/esbuild/default/require_txt/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_txt/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.txt
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "This is a test.";

--- a/crates/rolldown/tests/esbuild/default/simple_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/simple_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import * as assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 const fn = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/default/this_undefined_warning_esm/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/this_undefined_warning_esm/artifacts.snap
@@ -6,6 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region file1.js
+//#endregion
+//#region node_modules/pkg/file2.js
 //#endregion
 //#region entry.js
 console.log([void 0, void 0], [void 0, void 0]);

--- a/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
@@ -85,6 +85,10 @@ console.log(void 0);
 //#endregion
 //#region es6-export-star-as.js
 console.log(void 0);
+//#endregion
+//#region es6-export-assign.ts
+//#endregion
+//#region es6-export-import-assign.ts
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 123;
 	console.log(exports);

--- a/crates/rolldown/tests/esbuild/default/top_level_await_esm_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_esm_dead_branch/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
@@ -16,19 +16,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 (function() {
-	var __esmMin = (fn, res, err) => () => {
-		if (err) throw err[0];
-		try {
-			return fn && (res = fn(fn = 0)), res;
-		} catch (e) {
-			throw err = [e], e;
-		}
-	};
-	var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
-	//#endregion
+	// HIDDEN [\0rolldown/runtime.js]
 	//#region c.js
 	var require_c = /* @__PURE__ */ __commonJSMin((() => {}));
+	//#endregion
+	//#region b.js
 	var init_b = __esmMin((() => {}));
+	//#endregion
+	//#region a.js
 	var init_a = __esmMin((() => {}));
 	//#endregion
 	//#region entry.js

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_dead_branch/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_esm_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_esm_dead_branch/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
@@ -18,6 +18,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 "use strict";
 (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region entry.js
 	//#endregion
 	exports.a = 1;
 	return exports;

--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = (/* @__PURE__ */ __commonJSMin(((exports) => {})))();
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region bar.js
 var import_foo = (/* @__PURE__ */ __commonJSMin(((exports) => {})))();
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
@@ -17,6 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region entry.js
 	//#endregion
 	exports.foo = 123;
 	return exports;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var someName = (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region entry.js
 	//#endregion
 	exports.foo = 123;
 	return exports;

--- a/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
@@ -9,6 +9,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
+//#region foo.js
+//#endregion
+//#region entry.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;
 })))();

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region folders/child/foo.js
 const foo = () => "hi there";
 //#endregion
+//#region folders/index.js
+//#endregion
 //#region entry.js
 console.log(JSON.stringify(/* @__PURE__ */ __exportAll({ foo: () => foo })));
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.x = 123;

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.x = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.ts
+//#endregion
 //#region entry.ts
 console.log(/* @__PURE__ */ __exportAll({ foo: () => 123 }), 123, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_capture/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.ts
+//#endregion
 //#region entry.ts
 var import_foo = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_no_capture/artifacts.snap
@@ -6,7 +6,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.ts
+//#endregion
+//#region entry.ts
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = 123;
 })))();

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.ts
+//#endregion
 //#region entry.ts
 console.log(/* @__PURE__ */ __exportAll({ foo: () => 123 }), 123, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.ts
+//#endregion
 //#region entry.ts
 console.log(/* @__PURE__ */ __exportAll({ foo: () => 123 }), 123, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region bar.ts
+//#endregion
 //#region entry.ts
 console.log(/* @__PURE__ */ __exportAll({ foo: () => 123 }), 123, 234);
 //#endregion

--- a/crates/rolldown/tests/esbuild/loader/assert_type_json_wrong_loader/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/assert_type_json_wrong_loader/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region foo.json
 //#endregion
 //#region entry.js
 console.log({});

--- a/crates/rolldown/tests/esbuild/loader/auto_detect_mime_type_from_extension/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/auto_detect_mime_type_from_extension/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.svg
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "data:image/svg+xml;base64,YQBigGP/ZA==";

--- a/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_base64_common_js_and_es6/artifacts.snap
@@ -11,6 +11,8 @@ import assert from "node:assert/strict";
 //#region y.b64
 var y_default = "eQ==";
 //#endregion
+//#region x.b64
+//#endregion
 //#region entry.js
 const x_b64 = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "eA==";

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
@@ -6,6 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region \0rolldown/data-url:2sIfhqSWlzaAHOZh4OtugA
+//#endregion
+//#region \0rolldown/data-url:Zc9opCw73EFYe8tLmXMbQA
+//#endregion
+//#region \0rolldown/data-url:2aX92f-tk6SUzQNEPgBe-w
+//#endregion
+//#region \0rolldown/data-url:VArahB_JWxTNyEv16je5Vg
 //#endregion
 //#region entry.js
 console.log([

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_invalid_utf8/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_invalid_utf8/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region binary.txt
 //#endregion
 //#region entry.js
 console.log("data:application/octet-stream;base64,/w==");

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_invalid_utf8/diff.md
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_invalid_utf8/diff.md
@@ -9,6 +9,7 @@ console.log(binary_default);
 ```
 ### rolldown
 ```js
+//#region binary.txt
 //#endregion
 //#region entry.js
 console.log("data:application/octet-stream;base64,/w==");

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_vs_percent_encoding/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_base64_vs_percent_encoding/artifacts.snap
@@ -6,6 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region shouldUsePercent_1.txt
+//#endregion
+//#region shouldUsePercent_2.txt
+//#endregion
+//#region shouldUseBase64_1.txt
+//#endregion
+//#region shouldUseBase64_2.txt
 //#endregion
 //#region entry.js
 console.log("data:text/plain;charset=utf-8,%0A%0A%0A", "data:text/plain;charset=utf-8,%0A%0A%0A%0A", "data:text/plain;charset=utf-8;base64,CgoKCgo=", "data:text/plain;charset=utf-8;base64,CgoKCgoK");

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_common_js_and_es6/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region y.txt
 var y_default = "data:text/plain;charset=utf-8,y";
 //#endregion
+//#region x.txt
+//#endregion
 //#region entry.js
 const x_url = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "data:text/plain;charset=utf-8,x";

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_escape_percents/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_escape_percents/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region percents.txt
 //#endregion
 //#region entry.js
 console.log("data:text/plain;charset=utf-8,%0A%, %3, %2533, %25333%0A%, %e, %25ee, %25eee%0A%, %E, %25EE, %25EEE%0A");

--- a/crates/rolldown/tests/esbuild/loader/loader_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.svg
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "./assets/test-CmpSc5Ku.svg";

--- a/crates/rolldown/tests/esbuild/loader/loader_file_one_source_two_different_output_paths_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_one_source_two_different_output_paths_js/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region shared/common.png
+//#endregion
 //#region shared/common.js
 var import_common = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "./assets/common-RzbKAZGz.png";

--- a/crates/rolldown/tests/esbuild/loader/loader_file_public_path_asset_names_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_public_path_asset_names_js/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region images/image.png
+//#endregion
 //#region entries/entry.js
 var import_image = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "../assets/image-RzbKAZGz.png";

--- a/crates/rolldown/tests/esbuild/loader/loader_file_public_path_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_public_path_js/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region images/image.png
+//#endregion
 //#region entries/entry.js
 var import_image = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "../assets/image-RzbKAZGz.png";

--- a/crates/rolldown/tests/esbuild/loader/loader_file_relative_path_asset_names_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_relative_path_asset_names_js/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region images/image.png
+//#endregion
 //#region entries/entry.js
 var import_image = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "../assets/image-RzbKAZGz.png";

--- a/crates/rolldown/tests/esbuild/loader/loader_file_relative_path_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_relative_path_js/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region images/image.png
+//#endregion
 //#region entries/entry.js
 var import_image = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "../image-RzbKAZGz.png";

--- a/crates/rolldown/tests/esbuild/loader/loader_json_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_common_js_and_es6/artifacts.snap
@@ -17,6 +17,8 @@ var y_default = {
 var small = "some small text";
 var _if = "test keyword imports";
 //#endregion
+//#region x.json
+//#endregion
 //#region entry.js
 const x_json = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { "x": true };

--- a/crates/rolldown/tests/esbuild/loader/loader_json_prototype/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_prototype/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region data.json
 //#endregion
 //#region entry.js
 console.log({

--- a/crates/rolldown/tests/esbuild/loader/loader_json_prototype_es5/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_prototype_es5/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region data.json
 //#endregion
 //#region entry.js
 console.log({

--- a/crates/rolldown/tests/esbuild/loader/loader_text_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_text_common_js_and_es6/artifacts.snap
@@ -11,6 +11,8 @@ import assert from "node:assert";
 //#region y.txt
 var y_default = "y";
 //#endregion
+//#region x.txt
+//#endregion
 //#region entry.js
 const x_txt = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "x";

--- a/crates/rolldown/tests/esbuild/loader/loader_text_utf8_bom/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_text_utf8_bom/artifacts.snap
@@ -6,6 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region data1.txt
+//#endregion
+//#region data2.txt
 //#endregion
 //#region entry.js
 console.log("\\xEF\\xBB\\xBFtext", "text\\xEF\\xBB\\xBF");

--- a/crates/rolldown/tests/esbuild/loader/require_custom_extension_base64/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/require_custom_extension_base64/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.custom
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "YQBigGP/ZA==";

--- a/crates/rolldown/tests/esbuild/loader/require_custom_extension_data_url/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/require_custom_extension_data_url/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.custom
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "data:application/octet-stream;base64,YQBigGP/ZA==";

--- a/crates/rolldown/tests/esbuild/loader/require_custom_extension_string/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/require_custom_extension_string/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.custom
+//#endregion
 //#region entry.js
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "#include <stdio.h>";

--- a/crates/rolldown/tests/esbuild/lower/java_script_decorators_bundle_issue3768/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_decorators_bundle_issue3768/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-instance-accessor.js
 
 ```js
+//#region base-instance-accessor.js
 (class Foo {
 	@dec accessor foo = Foo;
 });
@@ -16,6 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-instance-field.js
 
 ```js
+//#region base-instance-field.js
 (class Foo {
 	@dec foo = Foo;
 });
@@ -26,6 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-instance-method.js
 
 ```js
+//#region base-instance-method.js
 (class Foo {
 	@dec foo() {
 		return Foo;
@@ -38,6 +41,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-static-accessor.js
 
 ```js
+//#region base-static-accessor.js
 (class Foo {
 	@dec static accessor foo = Foo;
 });
@@ -48,6 +52,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-static-field.js
 
 ```js
+//#region base-static-field.js
 (class Foo {
 	@dec static foo = Foo;
 });
@@ -58,6 +63,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## base-static-method.js
 
 ```js
+//#region base-static-method.js
 (class Foo {
 	@dec static foo() {
 		return Foo;
@@ -70,6 +76,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-instance-accessor.js
 
 ```js
+//#region derived-instance-accessor.js
 (class Foo extends Bar {
 	@dec accessor foo = Foo;
 });
@@ -80,6 +87,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-instance-field.js
 
 ```js
+//#region derived-instance-field.js
 (class Foo extends Bar {
 	@dec foo = Foo;
 });
@@ -90,6 +98,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-instance-method.js
 
 ```js
+//#region derived-instance-method.js
 (class Foo extends Bar {
 	@dec foo() {
 		return Foo;
@@ -102,6 +111,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-static-accessor.js
 
 ```js
+//#region derived-static-accessor.js
 (class Foo extends Bar {
 	@dec static accessor foo = Foo;
 });
@@ -112,6 +122,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-static-field.js
 
 ```js
+//#region derived-static-field.js
 (class Foo extends Bar {
 	@dec static foo = Foo;
 });
@@ -122,6 +133,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## derived-static-method.js
 
 ```js
+//#region derived-static-method.js
 (class Foo extends Bar {
 	@dec static foo() {
 		return Foo;

--- a/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_es2016/artifacts.snap
@@ -67,6 +67,8 @@ var baz2_default = class extends x {
 		return () => () => super.foo("baz2");
 	}
 };
+//#endregion
+//#region outer.js
 (async function() {
 	class y extends z {
 		foo = async () => super.foo();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_setter_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_arrow_super_setter_es2016/artifacts.snap
@@ -67,6 +67,8 @@ var baz2_default = class extends x {
 		return () => () => super.foo = "baz2";
 	}
 };
+//#endregion
+//#region outer.js
 (async function() {
 	class y extends z {
 		foo = async () => super.foo = "foo";

--- a/crates/rolldown/tests/esbuild/lower/lower_const_issue4448/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_const_issue4448/artifacts.snap
@@ -21,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_ts.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region entry.ts
 const x = (/* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, { get: (a, b) => (typeof require !== "undefined" ? require : a)[b] }) : x)(function(x) {
 	if (typeof require !== "undefined") return require.apply(this, arguments);

--- a/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision/artifacts.snap
@@ -36,6 +36,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import * as _foo from "path2";
 import * as _ns from "path1";
+//#region nested.js
 //#endregion
 //#region entry.js
 console.log(_foo, 123);

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_es2016/artifacts.snap
@@ -67,6 +67,8 @@ var baz2_default = class extends x {
 		return () => () => super.foo("baz2");
 	}
 };
+//#endregion
+//#region outer.js
 (async function() {
 	class y extends z {
 		static foo = async () => super.foo();

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_setter_es2016/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_setter_es2016/artifacts.snap
@@ -67,6 +67,8 @@ var baz2_default = class extends x {
 		return () => () => super.foo = "baz2";
 	}
 };
+//#endregion
+//#region outer.js
 (async function() {
 	class y extends z {
 		static foo = async () => super.foo = "foo";

--- a/crates/rolldown/tests/esbuild/lower/static_class_block_es2021/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/static_class_block_es2021/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 (class A {
 	static {}
 	static {

--- a/crates/rolldown/tests/esbuild/lower/static_class_block_es_next/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/static_class_block_es_next/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
 (class A {
 	static {}
 	static {

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 (class {
 	constructor() {
 		this.#foo = 123;

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_bad_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_bad_main/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_a/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_a/artifacts.snap
@@ -12,6 +12,8 @@ var require_bar = /* @__PURE__ */ __commonJSMin((() => {
 	works();
 }));
 //#endregion
+//#region src/node_modules/pkg/sub/foo.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin((() => {
 	require_bar();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_b/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_b/artifacts.snap
@@ -22,6 +22,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region src/node_modules/pkg/sub/foo.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin((() => {
 	__require("sub");

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_c/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_issue2002_c/artifacts.snap
@@ -12,6 +12,8 @@ var require_sub = /* @__PURE__ */ __commonJSMin((() => {
 	works();
 }));
 //#endregion
+//#region src/node_modules/pkg/sub/foo.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin((() => {
 	require_sub();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_disabled/artifacts.snap
@@ -11,6 +11,8 @@ import assert from "node:assert";
 //#region (ignored) node_modules/demo-pkg
 var require_demo_pkg$1 = /* @__PURE__ */ __commonJSMin((() => {}));
 //#endregion
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const fn = require_demo_pkg$1();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_module/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_module/artifacts.snap
@@ -15,6 +15,8 @@ var require_node_pkg_browser = /* @__PURE__ */ __commonJSMin(((exports, module) 
 	};
 }));
 //#endregion
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const fn = require_node_pkg_browser();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_relative/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_relative/artifacts.snap
@@ -15,6 +15,8 @@ var require_node_pkg_browser = /* @__PURE__ */ __commonJSMin(((exports, module) 
 	};
 }));
 //#endregion
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const fn = require_node_pkg_browser();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_native_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_native_module_disabled/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region (ignored) node_modules/demo-pkg
 var require_demo_pkg$1 = /* @__PURE__ */ __commonJSMin((() => {}));
 //#endregion
+//#region node_modules/demo-pkg/index.js
+//#endregion
 //#region src/entry.js
 var import_demo_pkg = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const fs = require_demo_pkg$1();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
@@ -11,6 +11,8 @@ import assert from "node:assert/strict";
 //#region (ignored) node_modules/demo-pkg/util-node.js
 var require_util_node = /* @__PURE__ */ __commonJSMin((() => {}));
 //#endregion
+//#region node_modules/demo-pkg/main.js
+//#endregion
 //#region src/entry.js
 var import_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const util = require_util_node();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
@@ -13,6 +13,8 @@ var require_util_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "util-browser";
 }));
 //#endregion
+//#region node_modules/demo-pkg/main.js
+//#endregion
 //#region src/entry.js
 var import_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const util = require_util_browser();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
@@ -13,6 +13,8 @@ var require_util_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "util-browser";
 }));
 //#endregion
+//#region node_modules/demo-pkg/main-browser.js
+//#endregion
 //#region src/entry.js
 var import_main_browser = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const util = require_util_browser();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_main_node/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_main_node/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/main.js
+//#endregion
 //#region src/entry.js
 var import_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_module_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_module_browser/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/main.browser.js
+//#endregion
 //#region src/entry.js
 var import_main_browser = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_string/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_string/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/browser.js
+//#endregion
 //#region src/entry.js
 var import_browser = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_with_main_node/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_with_main_node/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/main.js
+//#endregion
 //#region src/entry.js
 var import_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_disabled_type_module_issue3367/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_disabled_type_module_issue3367/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region (ignored) 
 //#endregion
 //#region entry.js
 (void 0)();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_disabled_type_module_issue3367/diff.md
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_disabled_type_module_issue3367/diff.md
@@ -13,6 +13,7 @@ var import_foo = __toESM(require_foo());
 ```
 ### rolldown
 ```js
+//#region (ignored) 
 //#endregion
 //#region entry.js
 (void 0)();

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_only/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region node_modules/demo-pkg/module.js
 //#endregion
 //#region src/entry.js
 assert.equal("module", "module");

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_exports_alternatives/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_exports_alternatives/artifacts.snap
@@ -36,6 +36,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import redApple from "pkg/apples/red.js";
 import redBook from "pkg/books/red";
+//#region node_modules/pkg/good-apples/green.js
+//#endregion
+//#region node_modules/pkg/good-books/green-book.js
 //#endregion
 //#region src/entry.js
 console.log({

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_exports_import_over_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_exports_import_over_require/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pkg/require.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin((() => {
 	console.log("FAILURE");

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_exports_require_over_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_exports_require_over_import/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pkg/require.js
+//#endregion
 //#region src/entry.js
 (/* @__PURE__ */ __commonJSMin((() => {
 	console.log("SUCCESS");

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_main/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/custom-main.js
+//#endregion
 //#region src/entry.js
 var import_custom_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_main_fields_a/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_main_fields_a/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/a.js
+//#endregion
 //#region src/entry.js
 var import_a = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "a";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_explicit_main_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_explicit_main_fields/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-pkg/main.js
+//#endregion
 //#region src/entry.js
 var import_main = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = function() {

--- a/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
@@ -18,6 +18,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
+//#region x.js
+//#endregion
+//#region y.js
+//#endregion
+//#region z.js
+//#endregion
+//#region c.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -16,6 +16,10 @@ var b_exports = /* @__PURE__ */ __exportAll({ foo: () => 123 });
 //#region test.ts
 var Test = void 0;
 //#endregion
+//#region c.ts
+//#endregion
+//#region d.ts
+//#endregion
 //#region entry.ts
 console.log(a_exports, b_exports, /* @__PURE__ */ __exportAll({
 	Test: () => Test,

--- a/crates/rolldown/tests/esbuild/ts/parameter_props_use_define_for_class_fields_false/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/parameter_props_use_define_for_class_fields_false/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_ts.js
 
 ```js
+//#region entry.ts
 (class {
 	static {
 		console.log("a");

--- a/crates/rolldown/tests/esbuild/ts/parameter_props_use_define_for_class_fields_true/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/parameter_props_use_define_for_class_fields_true/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_ts.js
 
 ```js
+//#region entry.ts
 (class {
 	b1;
 	b2;

--- a/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_assign/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_assign/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 var Foo = class {};
 (() => new Foo())();
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_definitions/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_definitions/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region enums.ts
 //#endregion
 //#region entry.ts
 console.log([

--- a/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_edge_cases/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_edge_cases/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region enums.ts
 //#endregion
 //#region entry.ts
 console.log("a_val");

--- a/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_re_export/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_enum_cross_module_inlining_re_export/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region enums.ts
 //#endregion
 //#region entry.js
 console.log([

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_keep_names/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_keep_names/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region entry.ts
 let Foo = class Foo {};

--- a/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_assign_semantics/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_experimental_decorators_mangle_props_static_assign_semantics/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 (class {
 	static {
 		this.prop1 = null;

--- a/crates/rolldown/tests/esbuild/ts/ts_export_equals/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_equals/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region b.ts
+//#endregion
 //#region a.ts
 var import_b = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = [123, foo];

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region bar.js
 var nope = void 0;
 //#endregion
+//#region foo.ts
+//#endregion
 //#region entry.js
 console.log(/* @__PURE__ */ __exportAll({ nope: () => nope }));
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_import_cts/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_cts/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region required.cjs
+//#endregion
 //#region entry.ts
 (/* @__PURE__ */ __commonJSMin((() => {
 	console.log("works");

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 let bar = foo.a.b.c;
 //#endregion
 export { bar };

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 console.log(123);
 //#endregion
 

--- a/crates/rolldown/tests/esbuild/ts/ts_minify_derived_class/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_minify_derived_class/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.ts
 Bar;
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -21,6 +21,8 @@ var init_esm = __esmMin((() => {
 	esm_named_class = class {};
 }));
 //#endregion
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_esm(), __toCommonJS(esm_exports));

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_cjs/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
 //#region main.js
 const cjs = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "cjs";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -6,14 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
+// HIDDEN [\0rolldown/runtime.js]
+//#region esm.js
 //#endregion
 //#region main.js
 __esmMin((() => {}))();

--- a/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
@@ -19,6 +19,8 @@ __reExport(b_exports, /* @__PURE__ */ __toESM(require_c()));
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({});
 __reExport(a_exports, b_exports);
+//#endregion
+//#region main.js
 __reExport(/* @__PURE__ */ __exportAll({}), a_exports);
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert/strict";
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = 1;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = 1;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default/artifacts.snap
@@ -7,6 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
+//#region main.js
+//#endregion
 var commonjs_default = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "foo";
 })))())).default;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
@@ -7,6 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
+//#region main.js
+//#endregion
 var a = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = 1;
 })))().a;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_the_same_cjs_twice/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_the_same_cjs_twice/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.a = {};

--- a/crates/rolldown/tests/rolldown/cjs_compat/issue_3364/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/issue_3364/artifacts.snap
@@ -21,6 +21,8 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	};
 }));
 //#endregion
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = Math.random() < .5 ? require_a() : require_b();

--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -44,6 +44,8 @@ var require_esm_import_cjs_export = /* @__PURE__ */ __commonJSMin(((exports, mod
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 1;
 }));
+//#endregion
+//#region esm-import-cjs-require.js
 require_esm_import_cjs_export();
 var import_cjs = require_cjs();
 require_foo();
@@ -69,11 +71,11 @@ assert.equal(import_cjs.a, void 0);
 (0:7) "exports = " --> (20:8) "exports = "
 (0:17) "1;\n" --> (20:18) "1;\n"
 - ../esm-import-cjs-require.js
-(3:0) "assert." --> (25:0) "assert."
-(3:7) "equal(" --> (25:7) "equal("
-(3:13) "a, " --> (25:13) "import_cjs."
-(3:13) "a, " --> (25:24) "a, "
-(3:16) "undefined" --> (25:27) "void "
-(3:16) "undefined" --> (25:32) "0"
-(3:25) ");\n" --> (25:33) ");\n"
+(3:0) "assert." --> (27:0) "assert."
+(3:7) "equal(" --> (27:7) "equal("
+(3:13) "a, " --> (27:13) "import_cjs."
+(3:13) "a, " --> (27:24) "a, "
+(3:16) "undefined" --> (27:27) "void "
+(3:16) "undefined" --> (27:32) "0"
+(3:25) ");\n" --> (27:33) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
@@ -21,6 +21,8 @@ var init_esm = __esmMin((() => {
 	moduleExports = { foo: "foo" };
 }));
 //#endregion
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_esm(), __toCommonJS(esm_exports));

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
@@ -18,6 +18,8 @@ var init_esm = __esmMin((() => {
 	esm_default = { defaultValue: "default" };
 }));
 //#endregion
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_esm(), __toCommonJS(esm_exports));

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
@@ -21,6 +21,8 @@ var init_esm = __esmMin((() => {
 	moduleExports = { priorityValue: "module.exports wins" };
 }));
 //#endregion
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_esm(), __toCommonJS(esm_exports));

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/this-is-only-used-for-testing/index.js
+//#endregion
 //#region entry.js
 var import_this_is_only_used_for_testing = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	function React() {}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/this-is-only-used-for-testing/index.js
+//#endregion
 //#region helper.js
 var import_this_is_only_used_for_testing = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	function CJS() {}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_default_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_default_import/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/this-is-only-used-for-testing/index.js
+//#endregion
 //#region entry.js
 var import_this_is_only_used_for_testing = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	function React() {}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_separate_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_separate_imports/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/this-is-only-used-for-testing/index.js
+//#endregion
 //#region entry.js
 var import_this_is_only_used_for_testing = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	function React() {}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
@@ -21,6 +21,8 @@ var init_esm = __esmMin((() => {
 	moduleExports = { customExport: "custom" };
 }));
 //#endregion
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_esm(), __toCommonJS(esm_exports));

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -15,6 +15,8 @@ var init_json = __esmMin((() => {
 	json_default = JSON.parse("[1, 2, 3]");
 }));
 //#endregion
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	var __importDefault = exports && exports.__importDefault || function(mod) {

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region commonjs.js
+//#endregion
 //#region refactor.mjs
 var import_commonjs = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	let elements = {

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
 //#region a.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 1e4;

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
@@ -16,6 +16,8 @@ var require_react = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.version = 1;
 }));
 //#endregion
+//#region commonjs.js
+//#endregion
 //#region lib.js
 var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = require_react();
@@ -23,6 +25,8 @@ var import_commonjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((e
 function test() {
 	return 1;
 }
+//#endregion
+//#region commonjs2.js
 //#endregion
 //#region main.js
 var import_commonjs2 = (/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
@@ -6,6 +6,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region esm.js
+//#endregion
+//#region main.js
 //#endregion
 
 //# sourceMappingURL=main.js.map

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -13,7 +13,10 @@ require("./rolldown-runtime.js");
 ## main2.js
 
 ```js
+//#region esm.js
 require("./rolldown-runtime.js").__esmMin((() => {}));
+//#endregion
+//#region main2.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_8184/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_8184/artifacts.snap
@@ -37,6 +37,9 @@ import "./a.js";
 
 ```js
 import { t as __commonJSMin } from "./a.js";
+//#region x.js
+//#endregion
+//#region b.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 42;
 })))();

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_8809/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_8809/artifacts.snap
@@ -41,6 +41,7 @@ export { __commonJSMin as i, start as n, stop as r, daemon_exports as t };
 
 ```js
 import { i as __commonJSMin, n as start, r as stop } from "./daemon.js";
+//#region cjs-dep.cjs
 //#endregion
 //#region gateway.js
 var import_cjs_dep = (/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region icons.js
 //#endregion
 //#region main.js
 console.log(window.bar(function() {
@@ -22,6 +23,7 @@ console.log(window.bar(function() {
 ### main.js
 
 ```js
+//#region icons.js
 //#endregion
 //#region main.js
 console.log(/* @__PURE__ */ window.bar(function() {

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## entries/C-bmCRtQ-C-bmCRtQIpy-C-bmCR-C-bmCRtQIpyGHipoT-XWG.js
+## entries/CVnZcglA-CVnZcglA2a8-CVnZcg-CVnZcglA2a8BkrMWP5bfd.js
 
 ```js
 //#region shared.js

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region lib.js
 //#endregion
 //#region main.js
 const [first, ...rest] = Object.values({

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
@@ -41,6 +41,8 @@ var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("C");
 	module.exports = {};
 }));
+//#endregion
+//#region p.js
 function init_p() {
 	return (init_p = __esmMin((() => {
 		require_c();
@@ -141,6 +143,8 @@ var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("C");
 	module.exports = {};
 }));
+//#endregion
+//#region p.js
 function init_p() {
 	return (init_p = __esmMin((() => {
 		require_c();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+//#endregion
 //#region lib.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("cjs");
@@ -86,6 +88,8 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("cjs");
 	module.exports = { value: 1 };
 }));
+//#endregion
+//#region lib.js
 const fromLib = (/* @__PURE__ */ __toESM(require_cjs())).default.value;
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## constants.js
 
 ```js
+//#region constants.js
 function mark() {
 	globalThis.inlineNamespaceValue = 0;
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
@@ -59,6 +59,7 @@ export { render };
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+//#region bridge.js
 //#endregion
 //#region page-b.js
 function render() {}
@@ -163,6 +164,7 @@ export { render };
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+//#region bridge.js
 //#endregion
 //#region page-b.js
 function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
@@ -59,6 +59,7 @@ export { render };
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+//#region bridge.js
 //#endregion
 //#region page-b.js
 function render() {}
@@ -163,6 +164,7 @@ export { render };
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+//#region bridge.js
 //#endregion
 //#region page-b.js
 function render() {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/ensure_lazy_module_eval/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/ensure_lazy_module_eval/artifacts.snap
@@ -23,6 +23,7 @@ export { require_dynamic as t };
 ```js
 import { t as require_dynamic } from "./dynamic.js";
 import { strictEqual } from "node:assert";
+//#region sideeffects.js
 require_dynamic();
 globalThis.a = 2;
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import nodeAssert from "node:assert";
+//#region lib-foo.js
 //#endregion
 //#region main.js
 nodeAssert.equal("foo", "foo");
@@ -22,6 +23,7 @@ nodeAssert.equal("foo", "foo");
 
 ```js
 import nodeAssert from "node:assert";
+//#region lib-foo.js
 //#endregion
 //#region main.js
 nodeAssert.equal("foo", "foo");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import nodeAssert from "node:assert";
+//#region lib-foo.js
 //#endregion
 //#region main.js
 nodeAssert.equal("foo", "foo");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import nodeAssert from "node:assert";
+//#region lib-foo.js
 //#endregion
 //#region main.js
 nodeAssert.equal("foo", "foo");
@@ -22,6 +23,7 @@ nodeAssert.equal("foo", "foo");
 
 ```js
 import nodeAssert from "node:assert";
+//#region lib-foo.js
 //#endregion
 //#region main.js
 nodeAssert.equal("foo", "foo");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
@@ -40,6 +40,8 @@ var require_c1 = /* @__PURE__ */ __commonJSMin((() => {
 	require_c2();
 	console.log("C1");
 }));
+//#endregion
+//#region m3.js
 function init_m3() {
 	return (init_m3 = __esmMin((() => {
 		require_c1();
@@ -157,6 +159,8 @@ var require_c1 = /* @__PURE__ */ __commonJSMin((() => {
 	require_c2();
 	console.log("C1");
 }));
+//#endregion
+//#region m3.js
 function init_m3() {
 	return (init_m3 = __esmMin((() => {
 		require_c1();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -28,6 +28,8 @@ function init_dep_b() {
 		sideEffect.touched = true;
 	})))();
 }
+//#endregion
+//#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();
@@ -76,6 +78,8 @@ function init_dep_b() {
 		sideEffect.touched = true;
 	})))();
 }
+//#endregion
+//#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_interop_cycle/artifacts.snap
@@ -38,6 +38,7 @@ export { init_m2 as n, require_m3 as r, init_main as t };
 ```js
 import { r as require_m3 } from "./group-0.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
+//#region m1.js
 function init_m1() {
 	return (init_m1 = __esmMin((() => {
 		require_m3();
@@ -105,6 +106,7 @@ export { init_m2 as n, require_m3 as r, init_main as t };
 ```js
 import { r as require_m3 } from "./group-0.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
+//#region m1.js
 function init_m1() {
 	return (init_m1 = __esmMin((() => {
 		require_m3();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
@@ -40,6 +40,8 @@ function init_leafhost() {
 		console.log("L");
 	})))();
 }
+//#endregion
+//#region m6.js
 function init_m6() {
 	return (init_m6 = __esmMin((() => {
 		console.log("M6");
@@ -134,6 +136,8 @@ function init_leafhost() {
 		console.log("L");
 	})))();
 }
+//#endregion
+//#region m6.js
 function init_m6() {
 	return (init_m6 = __esmMin((() => {
 		console.log("M6");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
@@ -38,11 +38,15 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.sideEffect = sideEffect;
 	module.exports = sideEffect;
 }));
+//#endregion
+//#region dep-b.js
 function init_dep_b() {
 	return (init_dep_b = __esmMin((() => {
 		sideEffect.touched = true;
 	})))();
 }
+//#endregion
+//#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();
@@ -102,11 +106,15 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.sideEffect = sideEffect;
 	module.exports = sideEffect;
 }));
+//#endregion
+//#region dep-b.js
 function init_dep_b() {
 	return (init_dep_b = __esmMin((() => {
 		sideEffect.touched = true;
 	})))();
 }
+//#endregion
+//#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/order_wrapped_bare_cjs_import/artifacts.snap
@@ -12,6 +12,8 @@ import { n as require_c3 } from "./main2.js";
 var require_c4 = /* @__PURE__ */ __commonJSMin((() => {
 	console.log("c4");
 }));
+//#endregion
+//#region m2.js
 function init_m2() {
 	return (init_m2 = __esmMin((() => {
 		require_c4();
@@ -19,6 +21,8 @@ function init_m2() {
 		console.log("m2");
 	})))();
 }
+//#endregion
+//#region m1.js
 function init_m1() {
 	return (init_m1 = __esmMin((() => {
 		require_c3();
@@ -84,6 +88,8 @@ import { n as require_c3 } from "./main2.js";
 var require_c4 = /* @__PURE__ */ __commonJSMin((() => {
 	console.log("c4");
 }));
+//#endregion
+//#region m2.js
 function init_m2() {
 	return (init_m2 = __esmMin((() => {
 		require_c4();
@@ -91,6 +97,8 @@ function init_m2() {
 		console.log("m2");
 	})))();
 }
+//#endregion
+//#region m1.js
 function init_m1() {
 	return (init_m1 = __esmMin((() => {
 		require_c3();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
@@ -20,6 +20,8 @@ var require_react = /* @__PURE__ */ __commonJSMin(((exports) => {
 var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = require_react();
 }));
+//#endregion
+//#region lib.js
 require_commonjs();
 function test() {
 	return 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -31,6 +31,7 @@ await init_main();
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
+//#region foo.js
 function init_foo() {
 	return (init_foo = __esmMin((async () => {
 		await 1e3;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
@@ -35,6 +35,7 @@ export { extend, useDep };
 ```js
 import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
 import { n as init_dep } from "./dep.js";
+//#region shared.js
 var extend;
 var init_shared = __esmMin((() => {
 	extend = Object.assign;
@@ -45,6 +46,8 @@ var require_interop = /* @__PURE__ */ __commonJSMin((() => {
 	init_shared();
 	init_dep();
 }));
+//#endregion
+//#region hub.js
 var init_hub = __esmMin((() => {
 	require_interop();
 	init_shared();
@@ -166,6 +169,7 @@ exports.useDep = require_dep.useDep;
 ```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_dep = require("./dep.js");
+//#region shared.js
 var extend;
 var init_shared = require_rolldown_runtime.__esmMin((() => {
 	extend = Object.assign;
@@ -176,6 +180,8 @@ var require_interop = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin((()
 	init_shared();
 	require_dep.init_dep();
 }));
+//#endregion
+//#region hub.js
 var init_hub = require_rolldown_runtime.__esmMin((() => {
 	require_interop();
 	init_shared();
@@ -343,6 +349,7 @@ exports.useDep = require_dep.useDep;
 ```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_dep = require("./dep.js");
+//#region shared.js
 var extend;
 var init_shared = require_rolldown_runtime.__esmMin((() => {
 	extend = Object.assign;
@@ -353,6 +360,8 @@ var require_interop = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin((()
 	init_shared();
 	require_dep.init_dep();
 }));
+//#endregion
+//#region hub.js
 var init_hub = require_rolldown_runtime.__esmMin((() => {
 	require_interop();
 	init_shared();
@@ -501,6 +510,7 @@ export { extend, useDep };
 ```js
 import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
 import { n as init_dep } from "./dep.js";
+//#region shared.js
 var extend;
 var init_shared = __esmMin((() => {
 	extend = Object.assign;
@@ -511,6 +521,8 @@ var require_interop = /* @__PURE__ */ __commonJSMin((() => {
 	init_shared();
 	init_dep();
 }));
+//#endregion
+//#region hub.js
 var init_hub = __esmMin((() => {
 	require_interop();
 	init_shared();

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_default/artifacts.snap
@@ -9,6 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 (function(global, factory) {
 	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define([], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.test = global.test || {}, global.test.module = factory());
 })(this, function() {
+	//#region main.js
 	//#endregion
 	return "default";
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_named/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory((global.test = global.test || {}, global.test.module = {})));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.a = 1;
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/default/artifacts.snap
@@ -9,6 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 (function(global, factory) {
 	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define([], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.module = factory());
 })(this, function() {
+	//#region main.js
 	//#endregion
 	return "default";
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/named/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.module = {}));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.a = 1;
 });

--- a/crates/rolldown/tests/rolldown/function/extend/iife/no_name_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/no_name_default/artifacts.snap
@@ -16,6 +16,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 (function() {
+	//#region main.js
 	//#endregion
 	return "default";
 })();

--- a/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_default/artifacts.snap
@@ -9,6 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 (function(global, factory) {
 	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define([], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.test = global.test || {}, global.test.module = factory());
 })(this, function() {
+	//#region main.js
 	//#endregion
 	return "default";
 });

--- a/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_named/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory((global.test = global.test || {}, global.test.module = global.test.module || {})));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.a = 1;
 });

--- a/crates/rolldown/tests/rolldown/function/extend/umd/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/default/artifacts.snap
@@ -9,6 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 (function(global, factory) {
 	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define([], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.module = factory());
 })(this, function() {
+	//#region main.js
 	//#endregion
 	return "default";
 });

--- a/crates/rolldown/tests/rolldown/function/extend/umd/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/named/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.module = global.module || {}));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.a = 1;
 });

--- a/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import * as ext1 from "external";
 import { a, a as a$1, a as a1, b, b as b$1, b as b1 } from "external";
+//#region foo.js
 console.log(1);
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/format/export_proto/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/export_proto/artifacts.snap
@@ -21,6 +21,7 @@ export { __proto__ };
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region main.js
 //#endregion
 Object.defineProperty(exports, "__proto__", {
 	enumerable: true,
@@ -38,6 +39,7 @@ Object.defineProperty(exports, "__proto__", {
 ```js
 var bundle = (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	Object.defineProperty(exports, "__proto__", {
 		enumerable: true,
@@ -60,6 +62,7 @@ globalThis.bundle = bundle;
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.bundle = {}));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	Object.defineProperty(exports, "__proto__", {
 		enumerable: true,

--- a/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.exports = "exports";
 	return exports;

--- a/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region foo.js
 	//#endregion
 	exports.value = 1;
 	return exports;

--- a/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.module = {}));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.exports = "exports";
 });

--- a/crates/rolldown/tests/rolldown/function/format/umd/namespaced_name_reserved/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/namespaced_name_reserved/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory((global["1"] = global["1"] || {}, global["1"]["2"] = {})));
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region foo.js
 	//#endregion
 	exports.value = 1;
 });

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
@@ -7,10 +7,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 1;
 }));
+//#endregion
+//#region esm.js
 //#endregion
 //#region main.js
 Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
@@ -28,10 +32,14 @@ Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 1;
 }));
+//#endregion
+//#region esm.js
 //#endregion
 //#region main.js
 Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
@@ -50,10 +58,14 @@ Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))
 ```js
 (function() {
 	// HIDDEN [\0rolldown/runtime.js]
+	//#region foo.js
+	//#endregion
 	//#region cjs.js
 	var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		module.exports = 1;
 	}));
+	//#endregion
+	//#region esm.js
 	//#endregion
 	//#region main.js
 	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));

--- a/crates/rolldown/tests/rolldown/function/intro/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/intro/iife/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 var module = (function() {
+	//#region main.js
 	//#endregion
 	return "banner";
 })();

--- a/crates/rolldown/tests/rolldown/function/module_types/asset/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/asset/artifacts.snap
@@ -9,6 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.txt
+//#endregion
+//#region main.js
+var main_default = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "./assets/foo-Cctl21F7.txt";
+})))())).default;
+//#endregion
 export { main_default as default };
 
 //# sourceMappingURL=main.js.map
@@ -22,15 +29,15 @@ export { main_default as default };
 
 ```
 - ../main.js
-(2:0) "export default " --> (22:0) "var "
-(2:0) "export default " --> (22:4) "main_default = ("
-(2:15) "filePath;\n" --> (22:20) "/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {\n"
+(2:0) "export default " --> (26:0) "var "
+(2:0) "export default " --> (26:4) "main_default = ("
+(2:15) "filePath;\n" --> (26:20) "/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {\n"
 - ../foo.txt
-(0:0) "module." --> (23:1) "module."
-(0:7) "exports = " --> (23:8) "exports = "
-(0:17) "\"__ROLLDOWN_ASSET__#VRAku6fjghkApIISiBWPzg\"" --> (23:18) "\"./assets/foo-Cctl21F7.txt\";\n"
+(0:0) "module." --> (27:1) "module."
+(0:7) "exports = " --> (27:8) "exports = "
+(0:17) "\"__ROLLDOWN_ASSET__#VRAku6fjghkApIISiBWPzg\"" --> (27:18) "\"./assets/foo-Cctl21F7.txt\";\n"
 - ../main.js
-(2:15) "filePath;\n" --> (24:6) "))"
-(2:15) "filePath;\n" --> (24:8) "."
-(2:15) "filePath;\n" --> (24:9) "default;\n"
+(2:15) "filePath;\n" --> (28:6) "))"
+(2:15) "filePath;\n" --> (28:8) "."
+(2:15) "filePath;\n" --> (28:9) "default;\n"
 ```

--- a/crates/rolldown/tests/rolldown/function/module_types/base64/binary/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/base64/binary/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region rolldown.webp
 //#endregion
 //#region main.js
 assert(true);

--- a/crates/rolldown/tests/rolldown/function/module_types/base64/empty/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/base64/empty/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region example.base64
 //#endregion
 //#region main.js
 assert(true);

--- a/crates/rolldown/tests/rolldown/function/module_types/base64/text/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/base64/text/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region text.data
 //#endregion
 //#region main.js
 assert(true);

--- a/crates/rolldown/tests/rolldown/function/module_types/binary/binary/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/binary/binary/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region rolldown.webp
 var rolldown_default = (/* @__PURE__ */ (() => {
 	var table = /* @__PURE__ */ new Uint8Array(128);

--- a/crates/rolldown/tests/rolldown/function/module_types/binary/empty/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/binary/empty/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region example.data
 var example_default = (/* @__PURE__ */ (() => {
 	var table = /* @__PURE__ */ new Uint8Array(128);

--- a/crates/rolldown/tests/rolldown/function/module_types/binary/text/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/binary/text/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region text.data
 var text_default = (/* @__PURE__ */ (() => {
 	var table = /* @__PURE__ */ new Uint8Array(128);

--- a/crates/rolldown/tests/rolldown/function/module_types/copy/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/copy/basic/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import data from "./assets/hello-CUbDYdKJ.txt";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 const data2 = (/* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, { get: (a, b) => (typeof require !== "undefined" ? require : a)[b] }) : x)(function(x) {
 	if (typeof require !== "undefined") return require.apply(this, arguments);
@@ -29,16 +29,16 @@ console.log(data, data2);
 
 ```
 - ../main.js
-(1:0) "const " --> (3:0) "const "
-(1:6) "data2 = require(" --> (3:6) "data2 = ("
-(1:6) "data2 = require(" --> (3:15) "/* @__PURE__ */ ((x) => typeof require !== \"undefined\" ? require : typeof Proxy !== \"undefined\" ? new Proxy(x, { get: (a, b) => (typeof require !== \"undefined\" ? require : a)[b] }) : x)(function(x) {\n"
-(1:6) "data2 = require(" --> (6:1) "))"
-(1:6) "data2 = require(" --> (6:3) "("
-(1:22) "'./hello.txt'" --> (6:4) "\"./assets/hello-CUbDYdKJ.txt\""
-(1:35) ");\n" --> (6:33) ");\n"
-(2:0) "console." --> (7:0) "console."
-(2:8) "log(" --> (7:8) "log("
-(2:12) "data, " --> (7:12) "data, "
-(2:18) "data2" --> (7:18) "data2"
-(2:23) ");\n" --> (7:23) ");\n"
+(1:0) "const " --> (4:0) "const "
+(1:6) "data2 = require(" --> (4:6) "data2 = ("
+(1:6) "data2 = require(" --> (4:15) "/* @__PURE__ */ ((x) => typeof require !== \"undefined\" ? require : typeof Proxy !== \"undefined\" ? new Proxy(x, { get: (a, b) => (typeof require !== \"undefined\" ? require : a)[b] }) : x)(function(x) {\n"
+(1:6) "data2 = require(" --> (7:1) "))"
+(1:6) "data2 = require(" --> (7:3) "("
+(1:22) "'./hello.txt'" --> (7:4) "\"./assets/hello-CUbDYdKJ.txt\""
+(1:35) ");\n" --> (7:33) ");\n"
+(2:0) "console." --> (8:0) "console."
+(2:8) "log(" --> (8:8) "log("
+(2:12) "data, " --> (8:12) "data, "
+(2:18) "data2" --> (8:18) "data2"
+(2:23) ");\n" --> (8:23) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/function/module_types/dataurl/empty/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/dataurl/empty/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region empty.empty
 //#endregion
 //#region main.js
 assert(true);

--- a/crates/rolldown/tests/rolldown/function/module_types/issue-6345/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/issue-6345/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.txt
+//#endregion
 //#region main.cjs
 console.log((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "./assets/foo-Cctl21F7.txt";

--- a/crates/rolldown/tests/rolldown/function/module_types/json/array/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/array/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region foo.json
 //#endregion
 //#region main.js
 assert.deepStrictEqual(["foo"], ["foo"]);

--- a/crates/rolldown/tests/rolldown/function/module_types/json/customize/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/customize/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region foo.json2
 //#endregion
 //#region main.js
 assert.deepStrictEqual(["foo"], ["foo"]);

--- a/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region foo.json
 //#endregion
 //#region main.js
 assert.deepStrictEqual({ "null": null }, { null: null });

--- a/crates/rolldown/tests/rolldown/function/module_types/txt/empty/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/txt/empty/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region x.txt
 //#endregion
 //#region main.js
 assert.equal("", "");

--- a/crates/rolldown/tests/rolldown/function/outro/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/outro/iife/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 var module = (function() {
+	//#region main.js
 	//#endregion
 	return "banner";
 	// outro

--- a/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { createRequire } from "node:module";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 (/* @__PURE__ */ (() => createRequire(import.meta.url))())("fs");
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/resolve/browser_filed_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/browser_filed_false/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## package.js
 
 ```js
+//#region (ignored) node_modules/package/util.js
 //#endregion
 //#region node_modules/package/index.js
 console.log(void 0);

--- a/crates/rolldown/tests/rolldown/function/resolve/should_resolve_to_different_target_for_import_and_require/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/should_resolve_to_different_target_for_import_and_require/artifacts.snap
@@ -10,6 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region node_modules/package/esm-output.js
 const output = "esm";
 //#endregion
+//#region node_modules/package/cjs-output.js
+//#endregion
 //#region main.js
 const { output: requireOutput } = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.output = "cjs";

--- a/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
@@ -6,14 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
 var missing;
 var init_foo = __esmMin((() => {
 	missing = void 0;

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
@@ -57,6 +57,8 @@ function init_observer() {
 		console.log("observer eval", Boolean(globalThis.ready));
 	})))();
 }
+//#endregion
+//#region target.js
 var value;
 function init_target() {
 	return (init_target = __esmMin((() => {
@@ -165,6 +167,8 @@ function init_observer() {
 		console.log("observer eval", Boolean(globalThis.ready));
 	})))();
 }
+//#endregion
+//#region target.js
 var value;
 function init_target() {
 	return (init_target = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
@@ -38,6 +38,7 @@ export { mod_a_exports as a, init_mod_a as i, init_mod_b as n, __exportAll as o,
 
 ```js
 import { i as init_mod_a, n as init_mod_b, o as __exportAll, s as __reExport, t as barrel_exports } from "./barrel.js";
+//#region main.js
 __reExport(/* @__PURE__ */ __exportAll({}), barrel_exports);
 globalThis.__log.push("BEFORE_REQUIRE");
 init_mod_a();

--- a/crates/rolldown/tests/rolldown/hash/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/hash/basic/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## main-i_WGlLtW.js
+## main-BmqLIKka.js
 
 ```js
 //#region main.js

--- a/crates/rolldown/tests/rolldown/hash/code_splitting/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/hash/code_splitting/artifacts.snap
@@ -3,27 +3,27 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## a-DXjxO52b.js
+## a-C-4L9xJi.js
 
 ```js
-import { t as shared } from "./shared-Cam0AukT.js";
+import { t as shared } from "./shared-CnOBP72w.js";
 //#region a.js
 console.log("a", shared);
 //#endregion
 
 ```
 
-## b-BsawQ1y5.js
+## b-IfP5aka_.js
 
 ```js
-import { t as shared } from "./shared-Cam0AukT.js";
+import { t as shared } from "./shared-CnOBP72w.js";
 //#region b.js
 console.log("b", shared);
 //#endregion
 
 ```
 
-## shared-Cam0AukT.js
+## shared-CnOBP72w.js
 
 ```js
 //#region shared.js

--- a/crates/rolldown/tests/rolldown/hash/content_include_placeholder/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/hash/content_include_placeholder/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## main-CrorcHoQ.js
+## main-DS_ejcz-.js
 
 ```js
 //#region main.js

--- a/crates/rolldown/tests/rolldown/hash/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/hash/dynamic_import/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## lazy-AClzwoon.js
+## lazy-BXESIgqT.js
 
 ```js
 //#region lazy.js
@@ -13,11 +13,11 @@ export { value };
 
 ```
 
-## main-CUtrtAQI.js
+## main-BWT7TV1e.js
 
 ```js
 //#region main.js
-import("./lazy-AClzwoon.js").then((m) => console.log(m));
+import("./lazy-BXESIgqT.js").then((m) => console.log(m));
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region data.js
 //#endregion
 //#region entry.js
 globalThis.__themes = {

--- a/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
@@ -29,6 +29,8 @@ function leaf() {
 	return "leaf";
 }
 var init_leaf = __esmMin((() => {}));
+//#endregion
+//#region a.js
 function getA() {
 	return getB && leaf ? "a" : "unreachable";
 }
@@ -66,15 +68,7 @@ export { __exportAll as n, __esmMin as t };
 ### main.js
 
 ```js
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region b.js
 function getB() {
 	return getA ? "b" : "unreachable";
@@ -88,6 +82,8 @@ function leaf() {
 	return "leaf";
 }
 var init_leaf = __esmMin((() => {}));
+//#endregion
+//#region a.js
 function getA() {
 	return getB && leaf ? "a" : "unreachable";
 }

--- a/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
@@ -16,6 +16,8 @@ export { main, sub };
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region sub.cjs
+//#endregion
 //#region main.js
 var import_sub = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.sub = "sub";

--- a/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
 //#region main.js
 var import_foo = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.foo = "foo";

--- a/crates/rolldown/tests/rolldown/issues/1769/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1769/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region lib.js
 //#endregion
 //#region main.js
 console.log(1e3);

--- a/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
@@ -18,6 +18,8 @@ export { a };
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region c.js
+//#endregion
 //#region b.js
 var import_c = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.test = 1e3;

--- a/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+//#endregion
 //#region a.js
 var import_b = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports._default = function test() {

--- a/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { createRequire } from "node:module";
+//#region \0rolldown/runtime.js
 //#endregion
 //#region main.js
 var main_default = (/* @__PURE__ */ (() => createRequire(import.meta.url))())("path").join;

--- a/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
@@ -6,6 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region cjs-dep.js
+//#endregion
+//#region main.js
 (/* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports, module) => {
 	module.exports = console.log("cjs-dep");
 })))();
@@ -16,6 +19,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main2.js
 
 ```js
+//#region cjs-dep2.js
+//#endregion
+//#region main2.js
 (/* @__PURE__ */ require("./rolldown-runtime.js").__commonJSMin(((exports, module) => {
 	module.exports = console.log("cjs-dep2");
 })))();

--- a/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
@@ -7,5 +7,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
+//#region main.mjs
+(/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = {};
+})))();
+//#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/4274/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4274/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "assert";
+//#region package.json
 //#endregion
 //#region main.js
 assert.strictEqual("lib", "lib");

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -42,6 +42,10 @@ async function main() {
 	nodeAssert$1.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const nodeAssert$2 = __require("node:assert");
 	async function main() {
@@ -106,6 +110,10 @@ async function main() {
 	node_assert.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const nodeAssert = require("node:assert");
 	async function main() {
@@ -156,6 +164,10 @@ async function main() {
 	nodeAssert$1.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const nodeAssert$2 = __require("node:assert");
 	async function main() {

--- a/crates/rolldown/tests/rolldown/issues/4443/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4443/artifacts.snap
@@ -8,5 +8,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+//#endregion
+//#region main.js
+(/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.value = "foo";
+	globalThis.value = exports.value;
+})))();
+assert.strictEqual(globalThis.value, "foo", "globalThis.value should be \"foo\"");
+//#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/4780/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4780/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region colors.js
 //#endregion
 //#region main.js
 const foo = {

--- a/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
@@ -7,6 +7,23 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region leaflet.js
+//#endregion
+//#region leaflet-toolbar.js
+(/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	(function(global, factory) {
+		typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.leaflet = {}));
+	})(exports, function(exports$1) {
+		"use strict";
+		exports$1.foo = "foo";
+		global.L = exports$1;
+	});
+})))();
+(function(t) {
+	"use strict";
+	t.L.Toolbar = L.foo;
+})(global);
+//#endregion
 //#region lib.js
 console.log("hello", !!L);
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/5209/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5209/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.default = function() {

--- a/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
@@ -24,6 +24,8 @@ var require_leaflet_toolbar = /* @__PURE__ */ __commonJSMin(((exports, module) =
 	global.bar = global.L.foo;
 	module.exports = bar;
 }));
+//#endregion
+//#region lib.js
 require_leaflet();
 require_leaflet_toolbar();
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -17,6 +17,10 @@ init_lib();
 //#endregion
 //#region log.js
 assert.strictEqual(1, 1);
+//#endregion
+//#region commonjs.cjs
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_lib(), __toCommonJS(lib_exports));
 })))();
@@ -64,6 +68,8 @@ function init_log() {
 var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = (init_lib(), __toCommonJS(lib_exports));
 }));
+//#endregion
+//#region main.js
 function init_main() {
 	return (init_main = __esmMin((() => {
 		init_log();

--- a/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
@@ -13,6 +13,10 @@ node_assert = __toESM(node_assert);
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};
 }));
+//#endregion
+//#region rule.js
+//#endregion
+//#region main.js
 const plugin = { mod: (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	const mod = require_lib();
 	module.exports = {
@@ -65,6 +69,7 @@ const require_runtime = require("./_virtual/_rolldown/runtime.js");
 const require_rule$1 = require("./rule.js");
 let node_assert = require("node:assert");
 node_assert = require_runtime.__toESM(node_assert);
+//#region main.js
 const plugin = { mod: (/* @__PURE__ */ require_runtime.__toESM(require_rule$1.default)).default };
 node_assert.default.strictEqual(plugin.mod.meta, 19);
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/5930_1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5930_1/artifacts.snap
@@ -19,6 +19,7 @@ const require_runtime = require("./_virtual/_rolldown/runtime.js");
 const require_rule$1 = require("./rule.js");
 let node_assert = require("node:assert");
 node_assert = require_runtime.__toESM(node_assert);
+//#region main.js
 const plugin = { mod: (/* @__PURE__ */ require_runtime.__toESM(require_rule$1)).default };
 node_assert.default.strictEqual(plugin.mod.meta, 19);
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region react.ts
+//#endregion
 //#region component/hello.tsx
 var Import_react = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -24,6 +24,7 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
+//#region lib.js
 //#endregion
 //#region entry.js
 var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -32,6 +32,7 @@ export default require_c();
 
 ```js
 import { n as __esmMin } from "./index.js";
+//#region e.js
 //#endregion
 __esmMin((() => {
 	console.log("event");
@@ -43,6 +44,8 @@ __esmMin((() => {
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region b.js
+//#endregion
 //#region a.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.defaultProvider = async function test() {

--- a/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { n as utilityClass, t as helper } from "./main.js";
+//#region dynamic.js
 new utilityClass(helper());
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/issues/7235/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7235/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 console.log("flag is false correctly");
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/issues/7773/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7773/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+//#endregion
 //#region main.js
 var import_lib = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};
@@ -35,6 +37,8 @@ Object.defineProperty(exports, "dayjs2", {
 })(this, function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 	// HIDDEN [\0rolldown/runtime.js]
+	//#region lib.js
+	//#endregion
 	//#region main.js
 	var import_lib = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 		module.exports = {};

--- a/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
@@ -20,6 +20,8 @@ assert(typeof import_lodash.noop === "function");
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region lodash.cjs
+//#endregion
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
@@ -59,6 +61,7 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
+//#region lodash.cjs
 //#endregion
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {

--- a/crates/rolldown/tests/rolldown/issues/8345/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8345/artifacts.snap
@@ -21,6 +21,8 @@ var require_dev = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.b = b;
 }));
 //#endregion
+//#region lib/index.js
+//#endregion
 //#region main.js
 const lib = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	if (process.env.NODE_ENV === "production") module.exports = require_prod();

--- a/crates/rolldown/tests/rolldown/issues/8361/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361/artifacts.snap
@@ -27,6 +27,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = 42;
 }));
+//#endregion
+//#region b.js
 require_cjs();
 var b_exports = /* @__PURE__ */ __exportAll({});
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));

--- a/crates/rolldown/tests/rolldown/issues/8863/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8863/artifacts.snap
@@ -50,6 +50,8 @@ var require_designer = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		GC.Spread.Sheets.Designer = GC.Spread.Sheets.Designer || {};
 	});
 }));
+//#endregion
+//#region noop.js
 require_resource();
 require_designer();
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/9049/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9049/artifacts.snap
@@ -6,9 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region src/utils/util0.js
 function fn0(x) {
 	return x + "u0";
 }
+//#endregion
+//#region src/utils/util1.js
 function fn1(x) {
 	return x + "u1";
 }

--- a/crates/rolldown/tests/rolldown/issues/9055/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9055/artifacts.snap
@@ -16,6 +16,8 @@ var require_greet$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.greet = greet;
 }));
 //#endregion
+//#region cjs-dependency.cjs
+//#endregion
 //#region index.js
 var import_cjs_dependency = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });

--- a/crates/rolldown/tests/rolldown/issues/9375/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9375/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var __expose__ = (function(pinia) {
 	// HIDDEN [\0rolldown/runtime.js]
+	//#region index.ts
+	//#endregion
 	return (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 		var freeModule = freeExports && typeof module == "object" && module && !module.nodeType && module;
 		var pinia$1 = (0, pinia.createPinia)();
@@ -28,6 +30,8 @@ var __expose__ = (function(pinia) {
 	typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory(require("pinia")) : typeof define === "function" && define.amd ? define(["pinia"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, global.__expose__ = factory(global.Pinia));
 })(this, function(pinia) {
 	// HIDDEN [\0rolldown/runtime.js]
+	//#region index.ts
+	//#endregion
 	return (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 		var freeModule = freeExports && typeof module == "object" && module && !module.nodeType && module;
 		var pinia$1 = (0, pinia.createPinia)();

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -101,6 +101,7 @@ init_b();
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -101,6 +101,7 @@ init_b();
 
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
 }

--- a/crates/rolldown/tests/rolldown/issues/9566/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9566/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region data.json
 //#endregion
 //#region main.js
 assert.strictEqual({ "default": { "value": 1 } }.default.value, 1);

--- a/crates/rolldown/tests/rolldown/issues/9630/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9630/artifacts.snap
@@ -45,6 +45,7 @@ export default require_last();
 
 ```js
 import { r as __toESM, t as require_isArrayLike } from "./isArrayLike.js";
+//#region main.js
 const eager = (0, require_isArrayLike().isArrayLike)([1]);
 async function lazy() {
 	return (await import("./last.js").then((m) => /* @__PURE__ */ __toESM(m.default))).default.last([
@@ -127,6 +128,7 @@ Object.defineProperty(exports, "default", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_isArrayLike$1 = require("./isArrayLike.js");
+//#region main.js
 const eager = (0, require_isArrayLike$1.require_isArrayLike().isArrayLike)([1]);
 async function lazy() {
 	return (await Promise.resolve().then(() => /* @__PURE__ */ require_isArrayLike$1.__toESM(require("./last.js").default))).default.last([

--- a/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9651/artifacts.snap
@@ -6,11 +6,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region src/zod/locales.js
 function en() {
 	return "en";
 }
+//#endregion
+//#region src/dyn/a.js
+//#endregion
+//#region main.js
 Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 if (en() !== "en") throw new Error("expected z.locales.en() to be 'en'");
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/9691/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9691/artifacts.snap
@@ -22,15 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import dep_a from "node:https";
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region lib/dep-a.js
 var init_dep_a = __esmMin((() => {}));
 //#endregion
@@ -45,6 +37,10 @@ var init_handler_a = __esmMin((() => {
 //#endregion
 //#region lib/handler-b.js
 var init_handler_b = __esmMin((() => {}));
+//#endregion
+//#region lib/index.js
+//#endregion
+//#region trigger.js
 //#endregion
 //#region main.js
 __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region pkg-barrel/other.cjs
+//#endregion
 //#region pkg-barrel/index.mjs
 var import_other = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "other-value";
@@ -28,6 +30,8 @@ nodeAssert.equal(import_other.default, "other-value");
 ```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region pkg-barrel/other.cjs
+//#endregion
 //#region pkg-barrel/index.mjs
 var import_other = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = "other-value";

--- a/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/dead_meta_url_issue/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import "node:module";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 export {};
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 const authURL = "foo";
 //#endregion
 export { authURL };

--- a/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/banner/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/banner/iife/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // Banner
 var module = (function() {
+	//#region main.js
 	//#endregion
 	return "banner";
 })();

--- a/crates/rolldown/tests/rolldown/misc/footer/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/footer/iife/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 var module = (function() {
+	//#region main.js
 	//#endregion
 	return "banner";
 })();

--- a/crates/rolldown/tests/rolldown/misc/object_shorthand_property/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/object_shorthand_property/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "assert";
+//#region main.js
 assert.strictEqual({ foo: "foo" }.foo, "foo");
 //#endregion
 
@@ -17,13 +18,13 @@ assert.strictEqual({ foo: "foo" }.foo, "foo");
 
 ```
 - ../main.js
-(5:0) "assert." --> (1:0) "assert."
-(5:7) "strictEqual(" --> (1:7) "strictEqual("
-(5:19) "value.foo, 'foo');\n" --> (1:19) "{ "
-(3:16) "foo };\n" --> (1:21) "foo: "
-(3:16) "foo };\n" --> (1:26) "\"foo\" "
-(5:19) "value." --> (1:32) "}."
-(5:25) "foo, " --> (1:34) "foo, "
-(5:30) "'foo'" --> (1:39) "\"foo\""
-(5:35) ");\n" --> (1:44) ");\n"
+(5:0) "assert." --> (2:0) "assert."
+(5:7) "strictEqual(" --> (2:7) "strictEqual("
+(5:19) "value.foo, 'foo');\n" --> (2:19) "{ "
+(3:16) "foo };\n" --> (2:21) "foo: "
+(3:16) "foo };\n" --> (2:26) "\"foo\" "
+(5:19) "value." --> (2:32) "}."
+(5:25) "foo, " --> (2:34) "foo, "
+(5:30) "'foo'" --> (2:39) "\"foo\""
+(5:35) ");\n" --> (2:44) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region main.js
 (class Example {
 	static {
 		this.prop = new Example("bar");
@@ -28,6 +29,7 @@ import assert from "node:assert";
 
 ```js
 import assert from "node:assert";
+//#region main.js
 (class Example {
 	static {
 		this.prop = new Example("bar");

--- a/crates/rolldown/tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	console.log("This chunk should have \"use strict\" at the top.");

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
@@ -9,6 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert_strict = require("node:assert/strict");
 node_assert_strict = __toESM(node_assert_strict);
+//#region cjs.js
 //#endregion
 //#region main.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -256,6 +256,7 @@ init_entry();
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
+//#region lib.js
 var a;
 function init_lib() {
 	return (init_lib = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk/artifacts.snap
@@ -21,6 +21,8 @@ import assert from "node:assert";
 var require_cjs_module = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.value = 42;
 }));
+//#endregion
+//#region main.js
 require_cjs_module();
 assert.strictEqual(42, 42);
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs_module())).then((mod) => {
@@ -58,6 +60,8 @@ node_assert = __toESM(node_assert);
 var require_cjs_module = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.value = 42;
 }));
+//#endregion
+//#region main.js
 require_cjs_module();
 node_assert.default.strictEqual(42, 42);
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs_module())).then((mod) => {

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/6101/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/6101/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region react.js
+//#endregion
 //#region main.js
 var import_react = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.version = "1.0.0";

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/cross_module_boolean/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/cross_module_boolean/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 console.log("flag is false correctly");
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
@@ -46,6 +46,7 @@ demo();
 ### pagea.js
 
 ```js
+//#region pagea.js
 //#endregion
 
 ```
@@ -53,6 +54,7 @@ demo();
 ### pageb.js
 
 ```js
+//#region pageb.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/artifacts.snap
@@ -6,9 +6,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region const_b.js
+//#endregion
+//#region const_c.js
+//#endregion
+//#region unrelated.js
 function unrelatedFn() {
 	return "hello";
 }
+//#endregion
+//#region main.js
 console.log(unrelatedFn());
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region constants.js
 //#endregion
 //#region main.js
 console.log("production", 1, true, null, void 0, "1234", "123");

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 //#endregion
 
 ```
@@ -13,6 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main2.js
 
 ```js
+//#region main2.js
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/basic/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region a.js
 //#endregion
 //#region main.js
 function _page($$payload, $$props) {

--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/multiple_dynamic_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/multiple_dynamic_imports/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region a.js
 //#endregion
 //#region main.js
 function _page($$payload, $$props) {}

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region entry.js
 console.log((/* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, { get: (a, b) => (typeof require !== "undefined" ? require : a)[b] }) : x)(function(x) {
 	if (typeof require !== "undefined") return require.apply(this, arguments);

--- a/crates/rolldown/tests/rolldown/resolve/add_module_condition_by_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/add_module_condition_by_default/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region node_modules/demo-lib/module.js
 //#endregion
 //#region main.js
 assert.strictEqual("module", "module");

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
@@ -8,6 +8,17 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/demo-lib/index.js
+//#endregion
+//#region node_modules/demo-lib/nested-lib/index.js
+const value = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = { value: "yes" };
+	Object.defineProperty(module.exports, "__esModule", {
+		value: true,
+		enumerable: false
+	});
+})))(), 1)).default.value;
+//#endregion
 //#region main.js
 assert.strictEqual(value, "yes");
 //#endregion

--- a/crates/rolldown/tests/rolldown/resolve/wildcard_alias/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/wildcard_alias/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region app/index.js
 //#endregion
 //#region main.js
 assert.strictEqual(1e3, 1e3);

--- a/crates/rolldown/tests/rolldown/sourcemap/debug_ids/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/debug_ids/artifacts.snap
@@ -10,6 +10,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 console.log(1);
 //#endregion
 
-//# debugId=3cad8a52-95c7-4b1f-8e1d-207c2c380239
+//# debugId=cceb17c1-9997-454c-a466-bbe4a06b58eb
 //# sourceMappingURL=main.js.map
 ```

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_10070/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_10070/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region dep.cjs
+//#endregion
 //#region app.js
 var import_dep = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.hello = function() {
@@ -30,30 +32,30 @@ globalThis.a = app;
 
 ```
 - ../dep.cjs
-(0:0) "module." --> (5:1) "module."
-(0:7) "exports." --> (5:8) "exports."
-(0:15) "hello = " --> (5:16) "hello = "
-(0:23) "function () " --> (5:24) "function() "
-(0:35) "{\n" --> (5:35) "{\n"
-(1:2) "return " --> (6:2) "return "
-(1:9) "'hi';\n" --> (6:9) "\"hi\";\n"
-(2:0) "};\n" --> (7:1) "};\n"
+(0:0) "module." --> (7:1) "module."
+(0:7) "exports." --> (7:8) "exports."
+(0:15) "hello = " --> (7:16) "hello = "
+(0:23) "function () " --> (7:24) "function() "
+(0:35) "{\n" --> (7:35) "{\n"
+(1:2) "return " --> (8:2) "return "
+(1:9) "'hi';\n" --> (8:9) "\"hi\";\n"
+(2:0) "};\n" --> (9:1) "};\n"
 - ../app.js
-(0:0) "export function " --> (9:0) "function "
-(0:16) "app() " --> (9:9) "app() "
-(0:22) "{\n" --> (9:15) "{\n"
-(1:2) "globalThis." --> (10:1) "globalThis."
-(1:13) "side = " --> (10:12) "side = "
-(1:20) "1;\n" --> (10:19) "1;\n"
-(2:2) "return " --> (11:1) "return "
-(2:9) "42;\n" --> (11:8) "42;\n"
-(3:0) "}\n" --> (12:0) "}\n"
+(0:0) "export function " --> (11:0) "function "
+(0:16) "app() " --> (11:9) "app() "
+(0:22) "{\n" --> (11:15) "{\n"
+(1:2) "globalThis." --> (12:1) "globalThis."
+(1:13) "side = " --> (12:12) "side = "
+(1:20) "1;\n" --> (12:19) "1;\n"
+(2:2) "return " --> (13:1) "return "
+(2:9) "42;\n" --> (13:8) "42;\n"
+(3:0) "}\n" --> (14:0) "}\n"
 - ../main.js
-(2:0) "globalThis." --> (15:0) "globalThis."
-(2:11) "h = " --> (15:11) "h = "
-(2:15) "hello;\n" --> (15:15) "import_dep."
-(2:15) "hello;\n" --> (15:26) "hello;\n"
-(3:0) "globalThis." --> (16:0) "globalThis."
-(3:11) "a = " --> (16:11) "a = "
-(3:15) "app;\n" --> (16:15) "app;\n"
+(2:0) "globalThis." --> (17:0) "globalThis."
+(2:11) "h = " --> (17:11) "h = "
+(2:15) "hello;\n" --> (17:15) "import_dep."
+(2:15) "hello;\n" --> (17:26) "hello;\n"
+(3:0) "globalThis." --> (18:0) "globalThis."
+(3:11) "a = " --> (18:11) "a = "
+(3:15) "app;\n" --> (18:15) "app;\n"
 ```

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
@@ -7,6 +7,17 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region cjs.js
+//#endregion
+//#region main.js
+const foo = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.version = "1.0.0";
+	Object.defineProperty(exports, "version", { get() {
+		throw new Error("see stacktrace");
+	} });
+})))())).version.startsWith("1");
+console.log(foo);
+//#endregion
 
 //# sourceMappingURL=main.js.map
 ```
@@ -15,37 +26,37 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```
 - ../main.js
-(2:0) "const " --> (22:0) "const "
-(2:6) "foo = mod.version.startsWith('1');\n" --> (22:6) "foo = ("
-(2:6) "foo = mod.version.startsWith('1');\n" --> (22:13) "/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {\n"
+(2:0) "const " --> (26:0) "const "
+(2:6) "foo = mod.version.startsWith('1');\n" --> (26:6) "foo = ("
+(2:6) "foo = mod.version.startsWith('1');\n" --> (26:13) "/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {\n"
 - ../cjs.js
-(0:0) "exports." --> (23:1) "exports."
-(0:8) "version = " --> (23:9) "version = "
-(0:18) "'1.0.0';\n" --> (23:19) "\"1.0.0\";\n"
-(1:0) "Object." --> (24:1) "Object."
-(1:7) "defineProperty(" --> (24:8) "defineProperty("
-(1:22) "exports, " --> (24:23) "exports, "
-(1:31) "'version', " --> (24:32) "\"version\", "
-(1:42) "{\n" --> (24:43) "{ "
-(2:2) "get() " --> (24:45) "get() "
-(2:8) "{\n" --> (24:51) "{\n"
-(3:4) "throw " --> (25:2) "throw "
-(3:10) "new " --> (25:8) "new "
-(3:14) "Error(" --> (25:12) "Error("
-(3:20) "'see stacktrace'" --> (25:18) "\"see stacktrace\""
-(3:36) ");\n" --> (25:34) ");\n"
-(4:2) "},\n" --> (26:1) "} "
-(5:0) "}" --> (26:3) "}"
-(5:1) ");\n" --> (26:4) ");\n"
+(0:0) "exports." --> (27:1) "exports."
+(0:8) "version = " --> (27:9) "version = "
+(0:18) "'1.0.0';\n" --> (27:19) "\"1.0.0\";\n"
+(1:0) "Object." --> (28:1) "Object."
+(1:7) "defineProperty(" --> (28:8) "defineProperty("
+(1:22) "exports, " --> (28:23) "exports, "
+(1:31) "'version', " --> (28:32) "\"version\", "
+(1:42) "{\n" --> (28:43) "{ "
+(2:2) "get() " --> (28:45) "get() "
+(2:8) "{\n" --> (28:51) "{\n"
+(3:4) "throw " --> (29:2) "throw "
+(3:10) "new " --> (29:8) "new "
+(3:14) "Error(" --> (29:12) "Error("
+(3:20) "'see stacktrace'" --> (29:18) "\"see stacktrace\""
+(3:36) ");\n" --> (29:34) ");\n"
+(4:2) "},\n" --> (30:1) "} "
+(5:0) "}" --> (30:3) "}"
+(5:1) ");\n" --> (30:4) ");\n"
 - ../main.js
-(2:6) "foo = mod." --> (27:6) "))"
-(2:6) "foo = mod." --> (27:8) "."
-(2:16) "version." --> (27:9) "version."
-(2:24) "startsWith(" --> (27:17) "startsWith("
-(2:35) "'1'" --> (27:28) "\"1\""
-(2:38) ");\n" --> (27:31) ");\n"
-(3:0) "console." --> (28:0) "console."
-(3:8) "log(" --> (28:8) "log("
-(3:12) "foo" --> (28:12) "foo"
-(3:15) ");\n" --> (28:15) ");\n"
+(2:6) "foo = mod." --> (31:6) "))"
+(2:6) "foo = mod." --> (31:8) "."
+(2:16) "version." --> (31:9) "version."
+(2:24) "startsWith(" --> (31:17) "startsWith("
+(2:35) "'1'" --> (31:28) "\"1\""
+(2:38) ");\n" --> (31:31) ");\n"
+(3:0) "console." --> (32:0) "console."
+(3:8) "log(" --> (32:8) "log("
+(3:12) "foo" --> (32:12) "foo"
+(3:15) ");\n" --> (32:15) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/default_function/artifacts.snap
@@ -12,6 +12,10 @@ const a$2 = 1;
 function foo$1(a$1) {
 	console.log(a$1, a$2);
 }
+//#endregion
+//#region bar.js
+//#endregion
+//#region main.js
 const { foo } = { foo: foo$1 };
 assert.strictEqual(typeof foo, "function");
 //#endregion
@@ -37,19 +41,19 @@ assert.strictEqual(typeof foo, "function");
 (3:20) ");\n" --> (4:21) ");\n"
 (4:0) "}\n" --> (5:0) "}\n"
 - ../main.js
-(5:0) "const " --> (6:0) "const "
-(5:6) "{ " --> (6:6) "{ "
-(5:8) "foo } = " --> (6:8) "foo } = "
-(5:16) "bar;\n" --> (6:16) "{ "
+(5:0) "const " --> (10:0) "const "
+(5:6) "{ " --> (10:6) "{ "
+(5:8) "foo } = " --> (10:8) "foo } = "
+(5:16) "bar;\n" --> (10:16) "{ "
 - ../bar.js
-(2:17) "foo };\n" --> (6:18) "foo: "
-(2:17) "foo };\n" --> (6:23) "foo$1 "
+(2:17) "foo };\n" --> (10:18) "foo: "
+(2:17) "foo };\n" --> (10:23) "foo$1 "
 - ../main.js
-(5:16) "bar;\n" --> (6:29) "};\n"
-(7:0) "assert." --> (7:0) "assert."
-(7:7) "strictEqual(" --> (7:7) "strictEqual("
-(7:19) "typeof " --> (7:19) "typeof "
-(7:26) "foo, " --> (7:26) "foo, "
-(7:31) "'function'" --> (7:31) "\"function\""
-(7:41) ");\n" --> (7:41) ");\n"
+(5:16) "bar;\n" --> (10:29) "};\n"
+(7:0) "assert." --> (11:0) "assert."
+(7:7) "strictEqual(" --> (11:7) "strictEqual("
+(7:19) "typeof " --> (11:19) "typeof "
+(7:26) "foo, " --> (11:26) "foo, "
+(7:31) "'function'" --> (11:31) "\"function\""
+(7:41) ");\n" --> (11:41) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_same_module_shadowing/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_same_module_shadowing/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "assert";
+//#region a.js
 function getA(x) {
 	let conflict$1 = x + 1;
 	function inner() {
@@ -14,6 +15,8 @@ function getA(x) {
 	}
 	return 1 + inner() - x;
 }
+//#endregion
+//#region b.js
 function getB() {
 	return 3;
 }

--- a/crates/rolldown/tests/rolldown/topics/deconflict/module_id_with_dots/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/module_id_with_dots/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region foo.bar/index.js
+//#endregion
 //#region main.js
 var import_foo_bar = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/deconflict/nested_scope_same_module_conflict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/nested_scope_same_module_conflict/artifacts.snap
@@ -13,6 +13,8 @@ function test(a) {
 }
 console.log(a$1);
 //#endregion
+//#region other.js
+//#endregion
 //#region main.js
 console.log("from-other", test("x"));
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/deconflict/unreferenced_renamed_conflict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/unreferenced_renamed_conflict/artifacts.snap
@@ -6,9 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region module_a.js
 function test(unused$1) {
 	return unused$1 + "-test";
 }
+//#endregion
+//#region module_b.js
 //#endregion
 //#region main.js
 console.log(test("x"), "from-module-b");

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -7,14 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
 function foo$1(a$1) {
 	assert.equal(a$1, a$1);
 	assert.equal(a$2, 1);
@@ -26,6 +20,8 @@ var init_foo = __esmMin((() => {
 //#endregion
 //#region bar.js
 init_foo();
+//#endregion
+//#region main.js
 const { foo } = { foo: foo$1 };
 assert.strictEqual(typeof foo, "function");
 init_foo();
@@ -38,40 +34,40 @@ init_foo();
 
 ```
 - ../foo.js
-(4:0) "export default function " --> (9:0) "function "
-(4:24) "foo(" --> (9:9) "foo$1("
-(4:28) "a$1) " --> (9:15) "a$1) "
-(4:33) "{\n" --> (9:20) "{\n"
-(5:2) "assert." --> (10:1) "assert."
-(5:9) "equal(" --> (10:8) "equal("
-(5:15) "a$1, " --> (10:14) "a$1, "
-(5:20) "a$1" --> (10:19) "a$1"
-(5:23) ");\n" --> (10:22) ");\n"
-(6:2) "assert." --> (11:1) "assert."
-(6:9) "equal(" --> (11:8) "equal("
-(6:15) "a, " --> (11:14) "a$2, "
-(6:18) "1" --> (11:19) "1"
-(6:19) ");\n" --> (11:20) ");\n"
-(7:0) "}\n" --> (12:0) "}\n"
-(2:6) "a = " --> (15:1) "a$2 = "
-(2:10) "1;\n" --> (15:7) "1;\n"
+(4:0) "export default function " --> (12:0) "function "
+(4:24) "foo(" --> (12:9) "foo$1("
+(4:28) "a$1) " --> (12:15) "a$1) "
+(4:33) "{\n" --> (12:20) "{\n"
+(5:2) "assert." --> (13:1) "assert."
+(5:9) "equal(" --> (13:8) "equal("
+(5:15) "a$1, " --> (13:14) "a$1, "
+(5:20) "a$1" --> (13:19) "a$1"
+(5:23) ");\n" --> (13:22) ");\n"
+(6:2) "assert." --> (14:1) "assert."
+(6:9) "equal(" --> (14:8) "equal("
+(6:15) "a, " --> (14:14) "a$2, "
+(6:18) "1" --> (14:19) "1"
+(6:19) ");\n" --> (14:20) ");\n"
+(7:0) "}\n" --> (15:0) "}\n"
+(2:6) "a = " --> (18:1) "a$2 = "
+(2:10) "1;\n" --> (18:7) "1;\n"
 - ../bar.js
-(0:23) ";\n" --> (19:0) "init_foo("
-(0:23) ";\n" --> (19:9) ");\n"
+(0:23) ";\n" --> (22:0) "init_foo("
+(0:23) ";\n" --> (22:9) ");\n"
 - ../main.js
-(5:0) "const " --> (20:0) "const "
-(5:6) "{ " --> (20:6) "{ "
-(5:8) "foo } = " --> (20:8) "foo } = "
-(5:16) "bar;\n" --> (20:16) "{ "
+(5:0) "const " --> (25:0) "const "
+(5:6) "{ " --> (25:6) "{ "
+(5:8) "foo } = " --> (25:8) "foo } = "
+(5:16) "bar;\n" --> (25:16) "{ "
 - ../bar.js
-(2:17) "foo };\n" --> (20:18) "foo: "
-(2:17) "foo };\n" --> (20:23) "foo$1 "
+(2:17) "foo };\n" --> (25:18) "foo: "
+(2:17) "foo };\n" --> (25:23) "foo$1 "
 - ../main.js
-(5:16) "bar;\n" --> (20:29) "};\n"
-(7:0) "assert." --> (21:0) "assert."
-(7:7) "strictEqual(" --> (21:7) "strictEqual("
-(7:19) "typeof " --> (21:19) "typeof "
-(7:26) "foo, " --> (21:26) "foo, "
-(7:31) "'function'" --> (21:31) "\"function\""
-(7:41) ");\n" --> (21:41) ");\n"
+(5:16) "bar;\n" --> (25:29) "};\n"
+(7:0) "assert." --> (26:0) "assert."
+(7:7) "strictEqual(" --> (26:7) "strictEqual("
+(7:19) "typeof " --> (26:19) "typeof "
+(7:26) "foo, " --> (26:26) "foo, "
+(7:31) "'function'" --> (26:31) "\"function\""
+(7:41) ");\n" --> (26:41) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -7,14 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "assert";
-var __esmMin = (fn, res, err) => () => {
-	if (err) throw err[0];
-	try {
-		return fn && (res = fn(fn = 0)), res;
-	} catch (e) {
-		throw err = [e], e;
-	}
-};
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
 function foo$1(a$1) {
 	console.log(a$1, a$2);
 }
@@ -25,6 +19,8 @@ var init_foo = __esmMin((() => {
 //#endregion
 //#region bar.js
 init_foo();
+//#endregion
+//#region main.js
 const { foo } = { foo: foo$1 };
 assert.strictEqual(typeof foo, "function");
 init_foo();
@@ -37,35 +33,35 @@ init_foo();
 
 ```
 - ../foo.js
-(2:0) "export function " --> (9:0) "function "
-(2:16) "foo(" --> (9:9) "foo$1("
-(2:20) "a$1) " --> (9:15) "a$1) "
-(2:25) "{\n" --> (9:20) "{\n"
-(3:2) "console." --> (10:1) "console."
-(3:10) "log(" --> (10:9) "log("
-(3:14) "a$1, " --> (10:13) "a$1, "
-(3:19) "a" --> (10:18) "a$2"
-(3:20) ");\n" --> (10:21) ");\n"
-(4:0) "}\n" --> (11:0) "}\n"
-(0:6) "a = " --> (14:1) "a$2 = "
-(0:10) "1;\n" --> (14:7) "1;\n"
+(2:0) "export function " --> (12:0) "function "
+(2:16) "foo(" --> (12:9) "foo$1("
+(2:20) "a$1) " --> (12:15) "a$1) "
+(2:25) "{\n" --> (12:20) "{\n"
+(3:2) "console." --> (13:1) "console."
+(3:10) "log(" --> (13:9) "log("
+(3:14) "a$1, " --> (13:13) "a$1, "
+(3:19) "a" --> (13:18) "a$2"
+(3:20) ");\n" --> (13:21) ");\n"
+(4:0) "}\n" --> (14:0) "}\n"
+(0:6) "a = " --> (17:1) "a$2 = "
+(0:10) "1;\n" --> (17:7) "1;\n"
 - ../bar.js
-(0:27) ";\n" --> (18:0) "init_foo("
-(0:27) ";\n" --> (18:9) ");\n"
+(0:27) ";\n" --> (21:0) "init_foo("
+(0:27) ";\n" --> (21:9) ");\n"
 - ../main.js
-(5:0) "const " --> (19:0) "const "
-(5:6) "{ " --> (19:6) "{ "
-(5:8) "foo } = " --> (19:8) "foo } = "
-(5:16) "bar;\n" --> (19:16) "{ "
+(5:0) "const " --> (24:0) "const "
+(5:6) "{ " --> (24:6) "{ "
+(5:8) "foo } = " --> (24:8) "foo } = "
+(5:16) "bar;\n" --> (24:16) "{ "
 - ../bar.js
-(2:17) "foo };\n" --> (19:18) "foo: "
-(2:17) "foo };\n" --> (19:23) "foo$1 "
+(2:17) "foo };\n" --> (24:18) "foo: "
+(2:17) "foo };\n" --> (24:23) "foo$1 "
 - ../main.js
-(5:16) "bar;\n" --> (19:29) "};\n"
-(7:0) "assert." --> (20:0) "assert."
-(7:7) "strictEqual(" --> (20:7) "strictEqual("
-(7:19) "typeof " --> (20:19) "typeof "
-(7:26) "foo, " --> (20:26) "foo, "
-(7:31) "'function'" --> (20:31) "\"function\""
-(7:41) ");\n" --> (20:41) ");\n"
+(5:16) "bar;\n" --> (24:29) "};\n"
+(7:0) "assert." --> (25:0) "assert."
+(7:7) "strictEqual(" --> (25:7) "strictEqual("
+(7:19) "typeof " --> (25:19) "typeof "
+(7:26) "foo, " --> (25:26) "foo, "
+(7:31) "'function'" --> (25:31) "\"function\""
+(7:41) ");\n" --> (25:41) ");\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols/artifacts.snap
@@ -46,6 +46,7 @@ export { a };
 ```js
 (function(exports) {
 	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	//#region main.js
 	//#endregion
 	exports.a = 1;
 	return exports;

--- a/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
@@ -13,6 +13,7 @@ __rolldown_runtime__.registerGraph({
 	edges: [[]],
 	dynamicEdges: [[]]
 });
+//#region entry.js
 __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", {});
 console.log("input\n");

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
@@ -38,6 +38,8 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.registerModule("b.js", module);
 	console.log("b");
 }));
+//#endregion
+//#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", {});
 require_a();

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
@@ -34,6 +34,7 @@ __rolldown_runtime__.registerGraph({
 	edges: [[]],
 	dynamicEdges: [[]]
 });
+//#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", {});
 console.log("main.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/artifacts.snap
@@ -29,6 +29,7 @@ __rolldown_runtime__.registerGraph({
 		[]
 	]
 });
+//#region jsx-dev-runtime.production.js
 //#endregion
 //#region jsx-dev-runtime.development.js
 var require_jsx_dev_runtime_development = /* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -75,6 +75,7 @@ __rolldown_runtime__.registerGraph({
 	edges: [[]],
 	dynamicEdges: [[1, 2]]
 });
+//#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", {});
 import("./foo.js"), import("./bar.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -13,6 +13,7 @@ __rolldown_runtime__.registerGraph({
 	edges: [[]],
 	dynamicEdges: [[]]
 });
+//#region entry.js
 __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", {});
 console.log("entry");
@@ -30,6 +31,7 @@ __rolldown_runtime__.registerGraph({
 	edges: [[]],
 	dynamicEdges: [[]]
 });
+//#region index.js
 __rolldown_runtime__.createModuleHotContext("index.js");
 __rolldown_runtime__.registerModule("index.js", {});
 console.log("index");

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -25,6 +25,7 @@ __rolldown_runtime__.registerGraph({
 		[]
 	]
 });
+//#region cjs.js
 //#endregion
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -56,6 +56,9 @@ __rolldown_runtime__.registerGraph({
 		[]
 	]
 });
+//#region modules/dep-cjs.js
+//#endregion
+//#region modules/dep-esm.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.createModuleHotContext("modules/dep-cjs.js");
 	__rolldown_runtime__.registerModule("modules/dep-cjs.js", module);
@@ -64,6 +67,8 @@ __rolldown_runtime__.registerGraph({
 var dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => "esm" });
 __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
+//#endregion
+//#region modules/dep-cjs-default.js
 //#endregion
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -76,6 +81,8 @@ __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
 //#endregion
+//#region modules/dep-cjs-named.js
+//#endregion
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.createModuleHotContext("modules/dep-cjs-named.js");
@@ -86,6 +93,8 @@ var dep_esm_named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
 __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
+//#endregion
+//#region modules/dep-cjs-namespace.js
 //#endregion
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/if_stmt/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/if_stmt/artifacts.snap
@@ -7,8 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 //#region c.js
 var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	function Router() {}
@@ -16,6 +15,8 @@ var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return { Router };
 	};
 }));
+//#endregion
+//#region cjs.js
 //#endregion
 //#region main.js
 var import_cjs = (/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-//#endregion
+// HIDDEN [\0rolldown/runtime.js]
 // HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
 //#region main.ts
 var _MyClass;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_var_redeclaration/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_var_redeclaration/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 var main_default = 41;
 //#endregion
 export { main_default as default };

--- a/crates/rolldown/tests/rolldown/topics/new_url/nested_dirs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/new_url/nested_dirs/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 foo
 ```
 
-## chunks/dep-BUzgE9pt.js
+## chunks/dep-DvJlI0iL.js
 
 ```js
 //#region dep.js
@@ -24,7 +24,7 @@ export { url };
 ```js
 //#region main.js
 const url = new URL("assets/foo-CKfX4HZF.txt", import.meta.url);
-const dep = import("./chunks/dep-BUzgE9pt.js");
+const dep = import("./chunks/dep-DvJlI0iL.js");
 //#endregion
 export { dep, url };
 

--- a/crates/rolldown/tests/rolldown/topics/new_url/template_literal_with_expression/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/new_url/template_literal_with_expression/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 const url = new URL(`./foo.txt`, import.meta.url);
 //#endregion
 export { url };

--- a/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
@@ -10,6 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 let node_util = require("node:util");
+//#region ../../../../../../../node_modules/.pnpm/util-deprecate@1.0.2/node_modules/util-deprecate/node.js
 //#endregion
 //#region main.js
 const exports$1 = (/* @__PURE__ */ __commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
@@ -7,6 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region dep.cjs
+//#endregion
+//#region entry.js
+const value = (/* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.value = "cjs-value";
+})))().value;
+//#endregion
 export { value };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
@@ -6,9 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region normal-dep.js
 //#endregion
 //#region normal-lib.js
 const value = "normal-dep+normal-lib";
+//#endregion
+//#region tla-dep.js
 //#endregion
 //#region tla-lib.js
 const value$1 = await Promise.resolve("tla-dep") + "+tla-lib";
@@ -95,9 +98,12 @@ export { __esmMin as t };
 ### main.js
 
 ```js
+//#region normal-dep.js
 //#endregion
 //#region normal-lib.js
 const value = "normal-dep+normal-lib";
+//#endregion
+//#region tla-dep.js
 //#endregion
 //#region tla-lib.js
 const value$1 = await Promise.resolve("tla-dep") + "+tla-lib";

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region ring-b.js
 globalThis.__ringB = "b";
 //#endregion
+//#region ring-a.js
+//#endregion
 //#region main.js
 const value = await Promise.resolve("a");
 //#endregion
@@ -80,6 +82,8 @@ export { __esmMin as t };
 ```js
 //#region ring-b.js
 globalThis.__ringB = "b";
+//#endregion
+//#region ring-a.js
 //#endregion
 //#region main.js
 const value = await Promise.resolve("a");

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region tla.js
 //#endregion
 //#region lib.js
 const value = await Promise.resolve("tla") + "+lib";
@@ -74,6 +75,7 @@ export { __esmMin as t };
 ### main.js
 
 ```js
+//#region tla.js
 //#endregion
 //#region lib.js
 const value = await Promise.resolve("tla") + "+lib";

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
@@ -22,9 +22,15 @@ var require_basic_ref_with_named_default = /* @__PURE__ */ __commonJSMin(((expor
 var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "export-star-from-cjs-a";
 }));
+//#endregion
+//#region src/export_star_from_cjs/index.js
 require_basic_ns();
 require_basic_ref_with_named_default();
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM(require_cjs$2()));
+//#endregion
+//#region src/nested_export_star_from_cjs/cjs.js
+//#endregion
+//#region src/nested_export_star_from_cjs/reexport.js
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "nested-export-star-from-cjs-a";
 })))()));
@@ -42,6 +48,10 @@ __reExport(named_import_export_star_from_cjs_exports, /* @__PURE__ */ __toESM(re
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "react-like-a";
 }));
+//#endregion
+//#region src/indirect_common_js/index.js
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = require_lib();
 })))();

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_5546/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_5546/artifacts.snap
@@ -13,6 +13,10 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.default = "default";
 	exports.foo = "foo";
 }));
+//#endregion
+//#region lib/index.js
+//#endregion
+//#region main.js
 let indirect = (/* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = require_cjs();
 })))())).default;

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
@@ -22,12 +22,22 @@ var require_basic_ref_with_named_default = /* @__PURE__ */ __commonJSMin(((expor
 var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "export-star-from-cjs-a";
 }));
+//#endregion
+//#region src/export_star_from_cjs/index.js
 require_basic_ns();
 require_basic_ref_with_named_default();
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM(require_cjs$2()));
+//#endregion
+//#region src/named_import_export_star_from_cjs/cjs.js
+//#endregion
+//#region src/named_import_export_star_from_cjs/index.js
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "named-import-export-star-from-cjs-a";
 })))()));
+//#endregion
+//#region src/nested_export_star_from_cjs/cjs.js
+//#endregion
+//#region src/nested_export_star_from_cjs/reexport.js
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "nested-export-star-from-cjs-a";
 })))()));
@@ -36,6 +46,10 @@ __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE_
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "react-like-a";
 }));
+//#endregion
+//#region src/indirect_common_js/index.js
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = require_lib();
 })))();

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const_computed_key_write_object/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const_computed_key_write_object/artifacts.snap
@@ -7,7 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
-var __commonJSMin = (cb, mod) => () => (mod || (cb((mod = { exports: {} }).exports, mod), cb = null), mod.exports);
+// HIDDEN [\0rolldown/runtime.js]
+//#region src/cjs.js
+//#endregion
+//#region main.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "cjs-a";
 })))();

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_mixed/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_mixed/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib/fromTokenFile.js
 //#endregion
 //#region lib/fromWebToken.js
 const fromWebToken = (init) => async () => {

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_redefine_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_redefine_export/artifacts.snap
@@ -8,6 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
+//#region scope.js
+//#endregion
 //#region main.js
 var import_scope = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/artifacts.snap
@@ -20,6 +20,8 @@ var require_cjs_impl = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.foo = "from-cjs";
 }));
 //#endregion
+//#region reexporter.js
+//#endregion
 //#region main.js
 var import_reexporter = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	if (process.env.USE_ESM) module.exports = (init_esm_impl(), __toCommonJS(esm_impl_exports));

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_default/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region export.js
 //#endregion
 //#region main.js
 ({ foo: 1 }).foo;

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region export-star.js
+//#endregion
 //#region main.js
 console.log(/* @__PURE__ */ __exportAll({ foo: () => 1 }));
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_module_def_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_module_def_format/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+//#region test.json
+//#endregion
 //#region main.js
 const a = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { "a": 1 };

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_object/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_object/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region foo.json
 //#endregion
 //#region main.js
 assert.equal("shouldBeReserved", "shouldBeReserved");

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_undefined_property/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert/strict";
+//#region foo.json
 //#endregion
 //#region main.js
 assert.deepEqual([[1, 2]].flat(), [1, 2]);

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects_namespace_cross_chunk_cases/artifacts.snap
@@ -11,6 +11,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 function fn() {
 	console.log("fn side effect");
 }
+//#endregion
+//#region entry-a.js
 console.log(/* @__PURE__ */ fn());
 fn.call(null);
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/optional_chainning_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/optional_chainning_namespace/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region bar.js
 //#endregion
 //#region main.js
 console.log("used");

--- a/crates/rolldown/tests/rolldown/tree_shaking/optional_chainning_namespace_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/optional_chainning_namespace_2/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "node:assert";
+//#region foo.js
 //#endregion
 //#region main.js
 assert.strictEqual({ value: "used" }.something?.foo, void 0);

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/invalid_context_entity/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/invalid_context_entity/artifacts.snap
@@ -15,5 +15,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region main.js
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/missing_name_option_for_iife_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/missing_name_option_for_iife_export/artifacts.snap
@@ -16,6 +16,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 (function() {
+	//#region main.js
 	//#endregion
 	return 1;
 })();

--- a/crates/rolldown/tests/rollup/assignment-patterns/artifacts.snap
+++ b/crates/rolldown/tests/rollup/assignment-patterns/artifacts.snap
@@ -7,6 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import assert from "assert";
+//#region other.js
 //#endregion
 //#region main.js
 function foo(bar = 1, { baz } = { baz: 2 }, [[[, x = 3] = []] = []] = [], ...items) {

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-expression/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-expression/artifacts.snap
@@ -6,8 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log("element 1");
+//#endregion
+//#region dep2.js
 console.log("element 2");
+//#endregion
+//#region dep3.js
 console.log("element 3");
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-attribute/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-attribute/artifacts.snap
@@ -6,11 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log({ value1: true });
 //#endregion
 //#region dep2.js
 const obj$1 = { value2: true };
 console.log(obj$1);
+//#endregion
+//#region dep3.js
 console.log({ value3: true });
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-child/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-child/artifacts.snap
@@ -6,11 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log(["spread 1"]);
 //#endregion
 //#region dep2.js
 const spread$1 = ["spread 2"];
 console.log(spread$1);
+//#endregion
+//#region dep3.js
 console.log(["spread 3"]);
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-expression/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-expression/artifacts.snap
@@ -6,8 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log("element 1");
+//#endregion
+//#region dep2.js
 console.log("element 2");
+//#endregion
+//#region dep3.js
 console.log("element 3");
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-attribute/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-attribute/artifacts.snap
@@ -6,11 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log({ value1: true });
 //#endregion
 //#region dep2.js
 const obj$1 = { value2: true };
 console.log(obj$1);
+//#endregion
+//#region dep3.js
 console.log({ value3: true });
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-child/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-child/artifacts.snap
@@ -6,11 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+//#region dep1.js
 console.log(["spread 1"]);
 //#endregion
 //#region dep2.js
 const spread$1 = ["spread 2"];
 console.log(spread$1);
+//#endregion
+//#region dep3.js
 console.log(["spread 3"]);
 //#endregion
 //#region main.js

--- a/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## input.js
 
 ```js
+//#region input.js
 console.log("production");
 //#endregion
 
@@ -16,8 +17,8 @@ console.log("production");
 
 ```
 - ../input.js
-(5:2) "console." --> (0:0) "console."
-(5:10) "log(" --> (0:8) "log("
-(5:14) "'production'" --> (0:12) "\"production\""
-(5:26) ");\n" --> (0:24) ");\n"
+(5:2) "console." --> (1:0) "console."
+(5:10) "log(" --> (1:8) "log("
+(5:14) "'production'" --> (1:12) "\"production\""
+(5:26) ");\n" --> (1:24) ");\n"
 ```

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -26,6 +26,7 @@ use crate::hmr_files::{
   apply_hmr_edit_files_to_hmr_temp_dir, collect_hmr_edit_files,
   copy_non_hmr_edit_files_to_hmr_temp_dir, get_changed_files_from_hmr_edit_files,
 };
+use crate::preserve_region_markers::PreserveRegionMarkersPlugin;
 use crate::types::{
   BuildArtifactsSnapshot, BuildRoundOutput, DevArtifactsSnapshot, DevRoundOutput, HmrStepOutput,
 };
@@ -560,8 +561,12 @@ impl IntegrationTest {
   pub async fn run_multiple(
     &self,
     mut multiple_options: Vec<NamedBundlerOptions>,
-    plugins: Vec<SharedPluginable>,
+    mut plugins: Vec<SharedPluginable>,
   ) {
+    // Registered last so it runs right before the internal dce pass; see the module docs of
+    // `preserve_region_markers` for why snapshots need markers kept intact.
+    plugins.push(Arc::new(PreserveRegionMarkersPlugin));
+
     let test_folder_path = &self.test_folder_path;
 
     // Detect HMR mode by checking for HMR edit files

--- a/crates/rolldown_testing/src/lib.rs
+++ b/crates/rolldown_testing/src/lib.rs
@@ -2,6 +2,7 @@ pub mod fixture;
 mod hmr_files;
 pub mod integration_test;
 pub mod manual_integration_test_helper;
+mod preserve_region_markers;
 pub mod test_config;
 pub mod types;
 pub mod utils;

--- a/crates/rolldown_testing/src/preserve_region_markers.rs
+++ b/crates/rolldown_testing/src/preserve_region_markers.rs
@@ -1,0 +1,120 @@
+//! Test-harness plugin that keeps `attachDebugInfo` region markers intact through rolldown's
+//! default `dce-only` minify pass.
+//!
+//! Region markers are ordinary line comments, and oxc attaches a comment to the statement that
+//! follows it (blank lines don't detach it). When the dce pass removes that statement, its
+//! comments go with it — a removed statement at a module boundary silently takes the adjacent
+//! `//#endregion` + `//#region` pair out of the output. That corrupts the region structure the
+//! snapshot tooling relies on: the runtime-hide replacement matches `//#region … //#endregion`,
+//! so an eaten pair at the runtime boundary makes snapshots silently hide user code.
+//!
+//! Legal comments survive the removal of their host statement, so this plugin disguises the
+//! markers as legal comments right before the internal minify pass (`renderChunk` runs before it)
+//! and restores them after everything else (`generateBundle`). Both rewrites are line-anchored
+//! and reversible; codegen prints comments verbatim, so only the disguise prefix ever changes.
+//! The plugin is registered after every fixture-defined plugin, so a fixture's own
+//! `generateBundle` hook runs before the restore and observes the disguised `//!#region` form.
+//!
+//! This lives in the test harness on purpose: production builds and the public API are
+//! untouched. The proper long-term fix is for oxc to re-attach orphaned comments of removed
+//! statements, at which point this plugin can be deleted.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use rolldown::plugin::{
+  HookGenerateBundleArgs, HookNoopReturn, HookRenderChunkArgs, HookRenderChunkOutput,
+  HookRenderChunkReturn, HookTransformOutputMap, HookUsage, Plugin, PluginContext,
+};
+use rolldown_common::{MinifyOptions, Output};
+
+#[derive(Debug)]
+pub struct PreserveRegionMarkersPlugin;
+
+impl Plugin for PreserveRegionMarkersPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "rolldown-testing:preserve-region-markers".into()
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::RenderChunk | HookUsage::GenerateBundle
+  }
+
+  async fn render_chunk(
+    &self,
+    _ctx: &PluginContext,
+    args: &HookRenderChunkArgs<'_>,
+  ) -> HookRenderChunkReturn {
+    // Only the dce-only pass eats markers selectively; full minification strips all normal
+    // comments on purpose, and a legal-comment disguise would wrongly keep markers alive there.
+    if !matches!(args.options.minify, MinifyOptions::DeadCodeEliminationOnly(_)) {
+      return Ok(None);
+    }
+    if !args.code.contains("//#region") {
+      return Ok(None);
+    }
+    Ok(Some(HookRenderChunkOutput {
+      code: map_region_marker_lines(&args.code, "//#", "//!#"),
+      // The rewrite only touches whole-line comments, so the existing sourcemap stays valid —
+      // `Null` states that on purpose (an omitted map would raise SOURCEMAP_BROKEN).
+      map: HookTransformOutputMap::Null,
+    }))
+  }
+
+  async fn generate_bundle(
+    &self,
+    _ctx: &PluginContext,
+    args: &mut HookGenerateBundleArgs<'_>,
+  ) -> HookNoopReturn {
+    // Same gate as `render_chunk`: only a dce-only build can carry disguised markers, and a
+    // fixture's own `//!#region`-shaped content must not be rewritten on other builds.
+    if !matches!(args.options.minify, MinifyOptions::DeadCodeEliminationOnly(_)) {
+      return Ok(());
+    }
+    for output in args.bundle.iter_mut() {
+      if let Output::Chunk(chunk) = output {
+        if chunk.code.contains("//!#") {
+          Arc::make_mut(chunk).code = map_region_marker_lines(&chunk.code, "//!#", "//#");
+        }
+      }
+    }
+    Ok(())
+  }
+}
+
+/// Rewrite the marker token of every line that starts (after indentation) with
+/// `{from}region` or `{from}endregion`. Line-anchored, so `//# sourceMappingURL` and marker-like
+/// text inside string content never match; only the first token on the line is touched.
+fn map_region_marker_lines(source: &str, from: &str, to: &str) -> String {
+  let mut out = String::with_capacity(source.len() + 64);
+  for line in source.split_inclusive('\n') {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with(from)
+      && (trimmed[from.len()..].starts_with("region")
+        || trimmed[from.len()..].starts_with("endregion"))
+    {
+      out.push_str(&line[..line.len() - trimmed.len()]);
+      out.push_str(to);
+      out.push_str(&trimmed[from.len()..]);
+    } else {
+      out.push_str(line);
+    }
+  }
+  out
+}
+
+#[cfg(test)]
+mod tests {
+  use super::map_region_marker_lines;
+
+  #[test]
+  fn rewrite_is_line_anchored_and_reversible() {
+    let source = "//#region a.js\n\tvar a = 1;\n\t//#endregion\nconst s = \"//#region not a marker\";\n//# sourceMappingURL=x.map\n";
+    let protected = map_region_marker_lines(source, "//#", "//!#");
+    assert_eq!(
+      protected,
+      "//!#region a.js\n\tvar a = 1;\n\t//!#endregion\nconst s = \"//#region not a marker\";\n//# sourceMappingURL=x.map\n"
+    );
+    assert_eq!(map_region_marker_lines(&protected, "//!#", "//#"), source);
+  }
+}


### PR DESCRIPTION
Artifact snapshots can silently present user code as part of the hidden runtime region — six fixtures on main do this today. This PR keeps fixture output's region structure intact through the default dce pass, so the hide applies exactly to the runtime and everything else stays visible. `topics/runtime/transform` before and after:

```js
// before: the fixture's own code is invisible
// HIDDEN [\0rolldown/runtime.js]
export { value };
```

```js
// after: the chunk contained this all along
// HIDDEN [\0rolldown/runtime.js]
//#region dep.cjs
//#endregion
//#region entry.js
const value = (/* @__PURE__ */ __commonJSMin(((exports) => {
	exports.value = "cjs-value";
})))().value;
//#endregion
export { value };
```

### Problem

The snapshot harness hides the runtime by matching `//#region \0rolldown/runtime.js … //#endregion`, trusting the markers to delimit it. But markers are ordinary comments, and under the default `minify: 'dce-only'` a statement removed at a module boundary takes the adjacent `//#endregion` + `//#region` pair with it — the surviving markers still pair up textually, so the hide silently extends across the next module's code.

The comment loss is oxc behavior: a comment rides the statement that follows it, and the minifier drops a removed statement's comments (the pre-dce output is fully balanced, verified with `minify: false`). Filed upstream as oxc-project/oxc#24885.

Blast radius: the snapshot review surface. Production builds and the public API are untouched by this PR — the change lives entirely in the test harness. Real builds keep the corrupted markers until the upstream fix.

### Fix

Keep the markers alive across the dce pass, from inside the harness only: a plugin registered for every fixture build rewrites marker lines to legal-comment form (`//!#region`) in `renderChunk`, which runs before the internal minify pass — legal comments survive the removal of their host statement, that is their license-text contract — and rewrites them back in `generateBundle`. The rewrite is line-anchored (only a line starting with a marker token matches) and gated to dce-only builds; full minification strips all normal comments on purpose and is left alone.

Two alternatives were rejected: preserving the markers inside the minify pipeline itself would put workaround logic in production code paths, and hardening the snapshot hide heuristically (#10429, superseded) cannot recover a boundary the text no longer contains.

Non-goal: fixing emitted output for real builds — that is oxc-project/oxc#24885; this plugin gets deleted when it lands.

### Sourcemap impact

No mapping is invalidated, by construction: the rewrite is line-preserving (one `!` per marker line, line count unchanged), marker lines are comments carrying no mapping segments, and every other position is untouched. `renderChunk` returns `map: Null` — the explicit "no remapping needed" form, covered by an existing test asserting it raises no `SOURCEMAP_BROKEN`. Known precision edge: the emitted `.map` is finalized against the disguised text and the restore runs after, so marker lines' columns differ from the map by one character — those lines have no segments, so no lookup can observe it.

### Validation

- Unit test pins the rewrite as line-anchored and reversible (`//# sourceMappingURL` and string contents never match).
- Full fixture suite: the failure list is byte-identical to unmodified main on the same machine (the pre-existing local environment set). Every snapshot change was classified: restored marker pairs (the bulk), the runtime hide turning precise again (previously-leaked helper definitions hidden), the six swallow fixtures revealing their user code (`esbuild/default/external_es6_converted_to_common_js`, `function/module_types/asset`, `resolve/attach_correct_package_json`, `sourcemap/issue_6099`, `topics/runtime/transform`, `issues/4782`), and line/hash shifts that follow mechanically (visualizer sections shift by the restored lines; content hashes in eight hash-bearing fixtures change deterministically, since hashing runs while the disguise is in place).

Supersedes #10429. Long-term fix tracked in oxc-project/oxc#24885.
