### PR TITLE
fix(code-splitting): avoid the dynamic-entry facade when the same-chunk collapse carries the trigger

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -214,6 +214,9 @@ impl<'me, 'ast: 'me> VisitJs<'ast> for AstScanner<'me, 'ast> {
           meta.set(ImportRecordMeta::IsTopLevel, self.is_root_scope());
           meta.set(ImportRecordMeta::IsUnspannedImport, expr.source.span().is_empty());
           meta.set(ImportRecordMeta::InTryCatchBlock, self.in_side_try_catch_block());
+          // Mirrors the bail condition in `try_rewrite_import_expression` exactly: any options
+          // argument at all makes it leave the specifier untouched.
+          meta.set(ImportRecordMeta::DynamicImportWithOptions, expr.options.is_some());
           meta
         },
         Some(expr.node_id()),

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -2242,70 +2242,52 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if is_importer_importee_in_same_chunk {
       let importee_meta = &self.ctx.linking_infos[importee.idx];
 
-      let finalized_expr = match importee_meta.wrap_kind() {
-        WrapKind::Cjs => {
-          let importee_wrapper_ref = self.ctx.linking_infos[importee.idx].wrapper_ref.unwrap();
+      let finalized_expr = if matches!(importee_meta.wrap_kind(), WrapKind::Cjs) {
+        let importee_wrapper_ref = self.ctx.linking_infos[importee.idx].wrapper_ref.unwrap();
 
-          let (finalized_importee_wrapper_ref, _) =
-            self.finalized_expr_for_symbol_ref(importee_wrapper_ref, false, false);
+        let (finalized_importee_wrapper_ref, _) =
+          self.finalized_expr_for_symbol_ref(importee_wrapper_ref, false, false);
 
-          let finalized_to_esm = self.finalized_expr_for_runtime_symbol("__toESM");
+        let finalized_to_esm = self.finalized_expr_for_runtime_symbol("__toESM");
 
-          // require_xxx()
-          let wrapper_ref_call_expr = ast::Expression::new_call_expression(
-            SPAN,
-            finalized_importee_wrapper_ref,
-            NONE,
-            [],
-            false,
-            self,
-          );
+        // require_xxx()
+        let wrapper_ref_call_expr = ast::Expression::new_call_expression(
+          SPAN,
+          finalized_importee_wrapper_ref,
+          NONE,
+          [],
+          false,
+          self,
+        );
 
-          // __toESM(require_xxx(), isNodeMode)
-          Expression::new_to_esm_wrapper(
-            finalized_to_esm,
-            wrapper_ref_call_expr,
-            self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-            self,
-          )
-        }
-        WrapKind::Esm => {
-          // (init_xxx(), namespace_exports)
-          let importee_wrapper_ref = self.ctx.linking_infos[importee.idx].wrapper_ref.unwrap();
+        // __toESM(require_xxx(), isNodeMode)
+        Expression::new_to_esm_wrapper(
+          finalized_to_esm,
+          wrapper_ref_call_expr,
+          self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+          self,
+        )
+      } else if let Some(target) =
+        self.ctx.order_wrap_state.esm_init_target(importee_idx, importee_meta)
+      {
+        // (init_xxx(), namespace_exports) — the `esm_init_target` view covers both interop
+        // `WrapKind::Esm` wrappers and execution-order wrappers, so a merged dynamic entry
+        // carries its trigger inline instead of resurrecting the facade chunk.
+        //
+        // This shape never awaits the init. A TLA-tainted entry cannot reach it today
+        // because facade elimination is globally disabled when any module is TLA-tainted
+        // (`allow_merge_common_chunks` in code_splitting.rs); pin that coupling here.
+        debug_assert!(!target.tla_tainted);
+        let wrapper_call_expr = self.wrapped_esm_init_call_expr(importee_idx, SPAN, true, false);
 
-          let (finalized_importee_wrapper_ref, _) =
-            self.finalized_expr_for_symbol_ref(importee_wrapper_ref, false, false);
+        let (finalized_namespace, _) =
+          self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
 
-          let (finalized_namespace, _) =
-            self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
-
-          // init_xxx()
-          let wrapper_call_expr = ast::Expression::new_call_expression(
-            SPAN,
-            finalized_importee_wrapper_ref,
-            NONE,
-            [],
-            false,
-            self,
-          );
-
-          // (init_xxx(), namespace_exports)
-          Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, self)
-        }
-        WrapKind::None => {
-          // Order-wrapped dynamic entries never reach this rewrite: their eliminated facades
-          // are restored in `restore_order_wrap_entry_facades`.
-          debug_assert!(
-            self
-              .ctx
-              .order_wrap_state
-              .esm_init_target(importee_idx, &self.ctx.linking_infos[importee_idx])
-              .is_none()
-          );
-          let (finalized_expr, _) =
-            self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
-          finalized_expr
-        }
+        Expression::new_seq_in_parens(wrapper_call_expr, finalized_namespace, self)
+      } else {
+        let (finalized_expr, _) =
+          self.finalized_expr_for_symbol_ref(importee.namespace_object_ref, false, false);
+        finalized_expr
       };
 
       Some(Expression::new_promise_resolve_then(finalized_expr, self))
@@ -2318,19 +2300,29 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // For ESM modules with wrap_kind Esm, convert to `import('./chunk.js').then(n => (n.init_xxx(), n.namespace))`
       let importee_meta = &self.ctx.linking_infos[importee_idx];
       let wrap_kind = importee_meta.wrap_kind();
+      // Interop `WrapKind::Esm` wrappers and execution-order wrappers share the same
+      // `.then(n => (n.init_xxx(), n.namespace))` shape via the `esm_init_target` view.
+      let init_target = if matches!(wrap_kind, WrapKind::Cjs) {
+        None
+      } else {
+        self.ctx.order_wrap_state.esm_init_target(importee_idx, importee_meta)
+      };
 
-      // For wrapped modules (CJS/ESM), look up the wrapper_ref; for others, look up the namespace symbol
-      let primary_export_symbol = match wrap_kind {
-        WrapKind::Cjs | WrapKind::Esm => importee_meta.wrapper_ref,
-        WrapKind::None => self.ctx.modules[importee_idx].namespace_object_ref(),
+      // For wrapped modules, look up the wrapper_ref; for others, look up the namespace symbol
+      let primary_export_symbol = if matches!(wrap_kind, WrapKind::Cjs) {
+        importee_meta.wrapper_ref
+      } else if let Some(target) = &init_target {
+        Some(target.wrapper_ref)
+      } else {
+        self.ctx.modules[importee_idx].namespace_object_ref()
       };
 
       let primary_export_name = primary_export_symbol.and_then(|sym| {
         importee_chunk.exports_to_other_chunks.get(&sym).and_then(|names| names.first())
       });
 
-      // For ESM wrapped modules, we also need the namespace symbol
-      let namespace_export_name = if matches!(wrap_kind, WrapKind::Esm) {
+      // For ESM-init wrapped modules, we also need the namespace symbol
+      let namespace_export_name = if init_target.is_some() {
         self.ctx.modules[importee_idx].namespace_object_ref().and_then(|ns_ref| {
           importee_chunk.exports_to_other_chunks.get(&ns_ref).and_then(|names| names.first())
         })
@@ -2363,46 +2355,35 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             Expression::ImportExpression(import_expr)
           };
 
-          match wrap_kind {
-            WrapKind::Cjs => {
-              // For CJS modules: import('./chunk.js').then(n => __toESM(n.require_xxx()))
-              let finalized_to_esm = self.finalized_expr_for_runtime_symbol("__toESM");
-              let call_expr = CallExpression::new_then_call_cjs_wrapper_with_to_esm(
-                base_expr,
-                name,
-                finalized_to_esm,
-                self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
-                self,
+          if matches!(wrap_kind, WrapKind::Cjs) {
+            // For CJS modules: import('./chunk.js').then(n => __toESM(n.require_xxx()))
+            let finalized_to_esm = self.finalized_expr_for_runtime_symbol("__toESM");
+            let call_expr = CallExpression::new_then_call_cjs_wrapper_with_to_esm(
+              base_expr,
+              name,
+              finalized_to_esm,
+              self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
+              self,
+            );
+            Some(Expression::CallExpression(call_expr))
+          } else if init_target.is_some() {
+            // For ESM-init wrapped modules: import('./chunk.js').then(n => (n.init_xxx(), n.namespace))
+            if let Some(ns_name) = namespace_export_name {
+              let call_expr = CallExpression::new_then_call_esm_wrapper_with_namespace(
+                base_expr, name, ns_name, self,
               );
               Some(Expression::CallExpression(call_expr))
-            }
-            WrapKind::Esm => {
-              // For ESM modules: import('./chunk.js').then(n => (n.init_xxx(), n.namespace))
-              if let Some(ns_name) = namespace_export_name {
-                let call_expr = CallExpression::new_then_call_esm_wrapper_with_namespace(
-                  base_expr, name, ns_name, self,
-                );
-                Some(Expression::CallExpression(call_expr))
-              } else {
-                tracing::warn!(
-                  "ESM wrapped module {:?} in chunk {:?} has wrapper but no namespace export.",
-                  importee_idx,
-                  importee_chunk_idx
-                );
-                None
-              }
-            }
-            WrapKind::None => {
-              debug_assert!(
-                self
-                  .ctx
-                  .order_wrap_state
-                  .esm_init_target(importee_idx, &self.ctx.linking_infos[importee_idx])
-                  .is_none()
+            } else {
+              tracing::warn!(
+                "ESM wrapped module {:?} in chunk {:?} has wrapper but no namespace export.",
+                importee_idx,
+                importee_chunk_idx
               );
-              let call_expr = CallExpression::new_then_extract_property(base_expr, name, self);
-              Some(Expression::CallExpression(call_expr))
+              None
             }
+          } else {
+            let call_expr = CallExpression::new_then_extract_property(base_expr, name, self);
+            Some(Expression::CallExpression(call_expr))
           }
         }
         None => {

--- a/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
@@ -100,7 +100,12 @@ impl GenerateStage<'_> {
         let entry_chunk_idx = chunk_graph.entry_module_to_entry_chunk[&module_idx];
         debug_assert!(is_rendered_chunk(chunk_graph, entry_chunk_idx));
         match chunk_graph.chunk_table[entry_chunk_idx].kind {
-          ChunkKind::EntryPoint { module, .. } => debug_assert_eq!(module, module_idx),
+          // A dynamic entry merged into a user-defined entry chunk keeps that host chunk as
+          // its entry chunk (the facade stays eliminated); the host must contain the module.
+          ChunkKind::EntryPoint { module, .. } => debug_assert!(
+            module == module_idx
+              || chunk_graph.chunk_table[entry_chunk_idx].modules.contains(&module_idx)
+          ),
           ChunkKind::Common => {
             debug_assert!(chunk_graph.chunk_table[entry_chunk_idx].modules.contains(&module_idx));
           }

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -439,8 +439,74 @@ impl GenerateStage<'_> {
       .filter(|module_idx| self.link_output.entries.contains_key(module_idx))
       .sorted_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order())
       .collect_vec();
+    if entries_to_restore.is_empty() {
+      return;
+    }
+
+    // Chunk of every live dynamic importer, per restore candidate; one pass over the
+    // module table serves all candidates.
+    let mut dynamic_importer_chunks: FxHashMap<ModuleIdx, Vec<Option<ChunkIdx>>> =
+      entries_to_restore.iter().map(|module_idx| (*module_idx, Vec::new())).collect();
+    for module in
+      self.link_output.module_table.modules.iter().filter_map(|module| module.as_normal())
+    {
+      let meta = &self.link_output.metas[module.idx];
+      if !meta.is_included {
+        continue;
+      }
+      // Walk statements rather than records: a record whose statement tree-shaking excluded is not
+      // a call site, and `DeadDynamicImport` only marks a pure import of a side-effect-free module,
+      // not statement exclusion. Same discipline as `is_included_dynamic_import_record` in
+      // `dynamic_already_loaded`.
+      for (stmt_info_idx, stmt_info) in
+        self.link_output.stmt_infos[module.idx].iter_enumerated_without_namespace_stmt()
+      {
+        if !meta.stmt_info_included.has_bit(stmt_info_idx) {
+          continue;
+        }
+        for rec_idx in &stmt_info.import_records {
+          let rec = &module.import_records[*rec_idx];
+          if rec.kind == ImportKind::DynamicImport
+            && !rec.meta.contains(ImportRecordMeta::DeadDynamicImport)
+            && let Some(importee_idx) = rec.resolved_module
+            && let Some(importer_chunks) = dynamic_importer_chunks.get_mut(&importee_idx)
+          {
+            // `None` means "this call site cannot carry the trigger". A two-argument `import()`
+            // is never rewritten by the finalizer, so it keeps its original specifier and needs
+            // the facade file to exist at that stable path; recording it as chunkless makes the
+            // same-chunk check below reject the collapse, since the host chunk is always `Some`.
+            importer_chunks.push(
+              if rec.meta.contains(ImportRecordMeta::DynamicImportWithOptions) {
+                None
+              } else {
+                chunk_graph.module_to_chunk[module.idx]
+              },
+            );
+          }
+        }
+      }
+    }
 
     for entry_module_idx in entries_to_restore {
+      // When every live dynamic importer sits in the chunk that hosts the entry's
+      // implementation, the same-chunk collapse in `rewrite_dynamic_import_for_merged_entry`
+      // carries the trigger inline (`Promise.resolve().then(() => (init_x(), ns))`) without
+      // loading any file, so the eliminated facade stays eliminated. A cross-chunk dynamic
+      // importer still needs the facade: its trigger must run synchronously within the
+      // facade's module evaluation, not in a `.then` microtask after the host chunk settles
+      // (see `m4_dynamic_facade_race`). Emitted-chunk facades are always restored because an
+      // `emitFile` reference id must resolve to a real file.
+      //
+      // A two-argument `import()` breaks the collapse the same way: the finalizer's
+      // `try_rewrite_import_expression` bails on `expr.options.is_some()`, so the call site keeps
+      // its original specifier and still needs a real file there. The importer scan above records
+      // those call sites as `None`, which fails the same-chunk check and keeps the facade.
+      let entry_host_chunk = chunk_graph.module_to_chunk[entry_module_idx];
+      let collapse_carries_trigger = entry_host_chunk.is_some()
+        && dynamic_importer_chunks[&entry_module_idx]
+          .iter()
+          .all(|importer_chunk| *importer_chunk == entry_host_chunk);
+
       let facade_chunk_indices = chunk_graph
         .chunk_table
         .iter_enumerated()
@@ -449,6 +515,7 @@ impl GenerateStage<'_> {
             if module == entry_module_idx
               && chunk.modules.is_empty()
               && meta.intersects(ChunkMeta::DynamicImported | ChunkMeta::EmittedChunk)
+              && (meta.contains(ChunkMeta::EmittedChunk) || !collapse_carries_trigger)
               && matches!(
                 chunk_graph.post_chunk_optimization_operations.get(&chunk_idx),
                 Some(

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/_config.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "A dynamic entry with one same-chunk and one cross-chunk dynamic importer must keep its restored facade: the cross-chunk importer needs the trigger to run synchronously within the facade's module evaluation (see m4_dynamic_facade_race). Only when every dynamic importer is same-chunk may the facade stay eliminated.",
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "ga",
+          "test": "[\\\\/](?:a|target)\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/_test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+// A dynamic entry with a cross-chunk dynamic importer keeps its facade chunk (asserted
+// by the snapshot), so its trigger runs synchronously within the facade's module
+// evaluation. Executing entry `b` must initialize `target` without triggering entry
+// `a`'s side effect, and `target` must initialize exactly once across both entries.
+
+globalThis.log = [];
+
+const { bTargetPromise } = await import(new URL('./dist/b.js', import.meta.url));
+const nsFromB = await bTargetPromise;
+assert.strictEqual(nsFromB.value, 1);
+assert.deepStrictEqual(globalThis.log, ['b', 'target']);
+
+const { aTargetPromise } = await import(new URL('./dist/a.js', import.meta.url));
+const nsFromA = await aTargetPromise;
+assert.strictEqual(nsFromA.value, 1);
+assert.deepStrictEqual(globalThis.log, ['b', 'target', 'a']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/a.js
@@ -1,0 +1,5 @@
+// Same-chunk dynamic importer: the group places `target.js` in this entry's chunk, so
+// this `import()` alone could collapse — but b.js's cross-chunk import must keep the
+// facade for everyone.
+(globalThis.log ??= []).push('a');
+export const aTargetPromise = import('./target.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/artifacts.snap
@@ -1,0 +1,133 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { i as init_a, r as aTargetPromise } from "./ga.js";
+init_a();
+export { aTargetPromise };
+
+```
+
+## b.js
+
+```js
+//#region b.js
+(globalThis.log ??= []).push("b");
+const bTargetPromise = import("./target.js");
+//#endregion
+export { bTargetPromise };
+
+```
+
+## ga.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var aTargetPromise;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		(globalThis.log ??= []).push("a");
+		aTargetPromise = import("./target.js");
+	})))();
+}
+//#endregion
+//#region target.js
+var value;
+function init_target() {
+	return (init_target = __esmMin((() => {
+		(globalThis.log ??= []).push("target");
+		value = 1;
+	})))();
+}
+//#endregion
+export { init_a as i, value as n, aTargetPromise as r, init_target as t };
+
+```
+
+## target.js
+
+```js
+import { n as value, t as init_target } from "./ga.js";
+init_target();
+export { value };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { i as init_a, r as aTargetPromise } from "./ga.js";
+init_a();
+export { aTargetPromise };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+var bTargetPromise;
+function init_b() {
+	return (init_b = __esmMin((() => {
+		(globalThis.log ??= []).push("b");
+		bTargetPromise = import("./target.js");
+	})))();
+}
+//#endregion
+init_b();
+export { bTargetPromise };
+
+```
+
+### ga.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var aTargetPromise;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		(globalThis.log ??= []).push("a");
+		aTargetPromise = import("./target.js");
+	})))();
+}
+//#endregion
+//#region target.js
+var value;
+function init_target() {
+	return (init_target = __esmMin((() => {
+		(globalThis.log ??= []).push("target");
+		value = 1;
+	})))();
+}
+//#endregion
+export { init_a as i, value as n, aTargetPromise as r, init_target as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```
+
+### target.js
+
+```js
+import { n as value, t as init_target } from "./ga.js";
+init_target();
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/b.js
@@ -1,0 +1,4 @@
+// Cross-chunk dynamic importer: loading `b` must initialize `target` without running
+// entry `a`'s side effects.
+(globalThis.log ??= []).push('b');
+export const bTargetPromise = import('./target.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/target.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cross_chunk_dynamic_importer_keeps_facade/target.js
@@ -1,0 +1,2 @@
+(globalThis.log ??= []).push('target');
+export const value = 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/manual_group_phantom_dynamic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## group-0.js
 
 ```js
-import { n as init_leafhost } from "./group-l.js";
+import { t as init_leafhost } from "./group-l.js";
 import { t as init_x } from "./x.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region y.js
@@ -32,31 +32,24 @@ export { init_y as n, init_main as t };
 ## group-l.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 //#region leafhost.js
 function init_leafhost() {
 	return (init_leafhost = __esmMin((() => {
-		globalThis.__loadM6 = () => import("./m6.js");
+		globalThis.__loadM6 = () => Promise.resolve().then(() => (init_m6(), m6_exports));
 		console.log("L");
 	})))();
 }
 //#endregion
 //#region m6.js
+var m6_exports = /* @__PURE__ */ __exportAll({});
 function init_m6() {
 	return (init_m6 = __esmMin((() => {
 		console.log("M6");
 	})))();
 }
 //#endregion
-export { init_leafhost as n, init_m6 as t };
-
-```
-
-## m6.js
-
-```js
-import { t as init_m6 } from "./group-l.js";
-init_m6();
+export { init_leafhost as t };
 
 ```
 
@@ -102,7 +95,7 @@ export { init_x as t };
 ### group-0.js
 
 ```js
-import { n as init_leafhost } from "./group-l.js";
+import { t as init_leafhost } from "./group-l.js";
 import { t as init_x } from "./x.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region y.js
@@ -128,31 +121,24 @@ export { init_y as n, init_main as t };
 ### group-l.js
 
 ```js
-import { t as __esmMin } from "./rolldown-runtime.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 //#region leafhost.js
 function init_leafhost() {
 	return (init_leafhost = __esmMin((() => {
-		globalThis.__loadM6 = () => import("./m6.js");
+		globalThis.__loadM6 = () => Promise.resolve().then(() => (init_m6(), m6_exports));
 		console.log("L");
 	})))();
 }
 //#endregion
 //#region m6.js
+var m6_exports = /* @__PURE__ */ __exportAll({});
 function init_m6() {
 	return (init_m6 = __esmMin((() => {
 		console.log("M6");
 	})))();
 }
 //#endregion
-export { init_leafhost as n, init_m6 as t };
-
-```
-
-### m6.js
-
-```js
-import { t as init_m6 } from "./group-l.js";
-init_m6();
+export { init_leafhost as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/mixed_static_dynamic_same_target/artifacts.snap
@@ -12,23 +12,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 # Assets
 
-## dep-b.js
-
-```js
-import { n as init_dep_b } from "./main2.js";
-init_dep_b();
-
-```
-
 ## main.js
-
-```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -40,6 +24,7 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 }));
 //#endregion
 //#region dep-b.js
+var dep_b_exports = /* @__PURE__ */ __exportAll({});
 function init_dep_b() {
 	return (init_dep_b = __esmMin((() => {
 		sideEffect.touched = true;
@@ -51,11 +36,11 @@ function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();
 		init_dep_b();
-		import("./dep-b.js");
+		Promise.resolve().then(() => (init_dep_b(), dep_b_exports));
 	})))();
 }
 //#endregion
-export { init_dep_b as n, init_main as t };
+init_main();
 
 ```
 
@@ -72,23 +57,7 @@ export { init_dep_b as n, init_main as t };
 
 ## Assets
 
-### dep-b.js
-
-```js
-import { n as init_dep_b } from "./main2.js";
-init_dep_b();
-
-```
-
 ### main.js
-
-```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -100,6 +69,7 @@ var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 }));
 //#endregion
 //#region dep-b.js
+var dep_b_exports = /* @__PURE__ */ __exportAll({});
 function init_dep_b() {
 	return (init_dep_b = __esmMin((() => {
 		sideEffect.touched = true;
@@ -111,10 +81,10 @@ function init_main() {
 	return (init_main = __esmMin((() => {
 		require_dep_a();
 		init_dep_b();
-		import("./dep-b.js");
+		Promise.resolve().then(() => (init_dep_b(), dep_b_exports));
 	})))();
 }
 //#endregion
-export { init_dep_b as n, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/_config.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "A dynamic import record whose statement tree-shaking excluded is not a call site: only live importers decide whether the eliminated facade stays eliminated. Here the only live importer of `target.js` sits in the chunk hosting it, while an excluded helper in `b`'s chunk still holds a record to it — that phantom record must not resurrect the facade.",
+  "configName": "on-demand",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    },
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "dyn",
+          "test": "[\\\\/](?:loader|target)\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/_test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+
+// The tree-shaken helper's record must not resurrect a facade file for the target.
+assert.strictEqual(fs.existsSync(new URL('./dist/target.js', import.meta.url)), false);
+
+const { targetPromise } = await import('./dist/a.js');
+const target = await targetPromise;
+assert.strictEqual(target.value, 1);
+
+await import('./dist/b.js');
+assert.deepStrictEqual(globalThis.log, ['a', 'target', 'used']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/a.js
@@ -1,0 +1,3 @@
+import { load } from './loader.js';
+(globalThis.log ??= []).push('a');
+export const targetPromise = load();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/artifacts.snap
@@ -1,0 +1,125 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { r as load } from "./dyn.js";
+//#region a.js
+(globalThis.log ??= []).push("a");
+const targetPromise = load();
+//#endregion
+export { targetPromise };
+
+```
+
+## b.js
+
+```js
+//#region helpers.js
+function used() {
+	(globalThis.log ??= []).push("used");
+}
+//#endregion
+//#region b.js
+used();
+//#endregion
+
+```
+
+## dyn.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region loader.js
+const load = () => Promise.resolve().then(() => (init_target(), target_exports));
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+function init_target() {
+	return (init_target = __esmMin((() => {
+		(globalThis.log ??= []).push("target");
+	})))();
+}
+//#endregion
+export { target_exports as n, load as r, init_target as t };
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### a.js
+
+```js
+import { i as load, r as init_loader } from "./dyn.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region a.js
+var targetPromise;
+function init_a() {
+	return (init_a = __esmMin((() => {
+		init_loader();
+		(globalThis.log ??= []).push("a");
+		targetPromise = load();
+	})))();
+}
+//#endregion
+init_a();
+export { targetPromise };
+
+```
+
+### b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region helpers.js
+function used() {
+	(globalThis.log ??= []).push("used");
+}
+//#endregion
+//#region b.js
+function init_b() {
+	return (init_b = __esmMin((() => {
+		used();
+	})))();
+}
+//#endregion
+init_b();
+
+```
+
+### dyn.js
+
+```js
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
+//#region loader.js
+var load;
+function init_loader() {
+	return (init_loader = __esmMin((() => {
+		load = () => Promise.resolve().then(() => (init_target(), target_exports));
+	})))();
+}
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+function init_target() {
+	return (init_target = __esmMin((() => {
+		(globalThis.log ??= []).push("target");
+	})))();
+}
+//#endregion
+export { load as i, target_exports as n, init_loader as r, init_target as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/b.js
@@ -1,0 +1,2 @@
+import { used } from './helpers.js';
+used();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/helpers.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/helpers.js
@@ -1,0 +1,7 @@
+export function used() {
+  (globalThis.log ??= []).push('used');
+}
+
+export function unused() {
+  return import('./target.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/loader.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/loader.js
@@ -1,0 +1,1 @@
+export const load = () => import('./target.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/target.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/tree_shaken_dynamic_importer_keeps_collapse/target.js
@@ -1,0 +1,2 @@
+(globalThis.log ??= []).push('target');
+export const value = 1;

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/entry.js
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/entry.js
@@ -2,6 +2,8 @@ import { a } from './lib.js';
 
 (globalThis.__events ??= []).push('entry ' + a);
 
-import('./lib.js').then((mod) => {
+// Two-argument form on purpose: an options import is never rewritten, so the call site cannot
+// carry the trigger and lowering has to revive `lib.js`'s facade.
+import('./lib.js', {}).then((mod) => {
   (globalThis.__events ??= []).push('lazy ' + mod.a);
 });

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/mod.rs
@@ -503,6 +503,12 @@ async fn late_order_wrapping_revalidates_output_file() {
   // entry's chunk, leaving one chunk; `restore_order_wrap_entry_facades` then revives `lib.js`'s
   // facade because a chunk can host only one entry's top-level trigger.
   //
+  // The fixture's `import()` takes a second argument on purpose. An options import is never
+  // rewritten, so its call site cannot carry the trigger and lowering must revive the facade —
+  // which is what makes the graph multi-chunk late, exactly the `output.file` re-validation this
+  // test pins. A one-argument `import()` here would collapse into the entry's chunk instead,
+  // leaving a single chunk and testing nothing.
+  //
   // `lib.js` pulls in a side-effectful `probe.js`, which keeps its load closure order-sensitive.
   // Without that the wrapper is skippable — the entry would never be wrapped, nothing would be
   // restored, and the graph would stay single-chunk, testing nothing.

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -94,11 +94,9 @@ init_b();
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
-}
-function init_shared() {
-	return (init_shared = __esmMin((() => {})))();
 }
 //#endregion
 //#region a.js
@@ -113,21 +111,12 @@ function init_a() {
 function init_b() {
 	return (init_b = __esmMin((() => {
 		(globalThis.sideEffectLog ??= []).push("b");
-		import("./shared.js").then(({ foo }) => {
+		Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 			foo();
 		});
 	})))();
 }
 //#endregion
-export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### shared.js
-
-```js
-import { i as init_shared, r as foo } from "./common~a~b~shared.js";
-init_shared();
-export { foo };
+export { init_a as n, init_b as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -94,11 +94,9 @@ init_b();
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
-}
-function init_shared() {
-	return (init_shared = __esmMin((() => {})))();
 }
 //#endregion
 //#region a.js
@@ -113,21 +111,12 @@ function init_a() {
 function init_b() {
 	return (init_b = __esmMin((() => {
 		(globalThis.sideEffectLog ??= []).push("b");
-		import("./shared.js").then(({ foo }) => {
+		Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 			foo();
 		});
 	})))();
 }
 //#endregion
-export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### shared.js
-
-```js
-import { i as init_shared, r as foo } from "./common.js";
-init_shared();
-export { foo };
+export { init_a as n, init_b as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -111,69 +111,27 @@ Object.defineProperty(exports, "__toESM", {
 ### entry.js
 
 ```js
-require("./entry2.js").init_entry();
-
-```
-
-### entry2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#region lib.js
 var lib_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ a: () => 123 });
-var a;
 function init_lib() {
-	return (init_lib = require_rolldown_runtime.__esmMin((() => {
-		a = 123;
-	})))();
+	return (init_lib = require_rolldown_runtime.__esmMin((() => {})))();
 }
 //#endregion
 //#region entry.js
 function init_entry() {
 	return (init_entry = require_rolldown_runtime.__esmMin((() => {
 		init_lib();
-		Promise.resolve().then(() => require("./lib.js")).then((mod) => {
+		Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
 			node_assert.default.strictEqual(mod.a, 123);
 			node_assert.default.strictEqual(123, 123);
 		});
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "a", {
-	enumerable: true,
-	get: function() {
-		return a;
-	}
-});
-Object.defineProperty(exports, "init_entry", {
-	enumerable: true,
-	get: function() {
-		return init_entry;
-	}
-});
-Object.defineProperty(exports, "init_lib", {
-	enumerable: true,
-	get: function() {
-		return init_lib;
-	}
-});
-Object.defineProperty(exports, "lib_exports", {
-	enumerable: true,
-	get: function() {
-		return lib_exports;
-	}
-});
-
-```
-
-### lib.js
-
-```js
-const require_entry = require("./entry2.js");
-require_entry.init_lib();
-exports.a = require_entry.a;
+init_entry();
 
 ```
 
@@ -218,44 +176,25 @@ Object.defineProperty(exports, "__toESM", {
 ### entry.js
 
 ```js
-import { t as init_entry } from "./entry2.js";
-init_entry();
-
-```
-
-### entry2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
-var a;
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
 function init_lib() {
-	return (init_lib = __esmMin((() => {
-		a = 123;
-	})))();
+	return (init_lib = __esmMin((() => {})))();
 }
 //#endregion
 //#region entry.js
 function init_entry() {
 	return (init_entry = __esmMin((() => {
 		init_lib();
-		import("./lib.js").then((mod) => {
+		Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
 			assert.strictEqual(mod.a, 123);
 			assert.strictEqual(123, 123);
 		});
 	})))();
 }
 //#endregion
-export { a as n, init_lib as r, init_entry as t };
-
-```
-
-### lib.js
-
-```js
-import { n as a, r as init_lib } from "./entry2.js";
-init_lib();
-export { a };
+init_entry();
 
 ```

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -78,6 +78,15 @@ bitflags::bitflags! {
     /// The import record is solely for re-export purposes, created by
     /// `export { .. } from '..'` or `export * as ns from '..'`
     const IsReExportOnly = 1 << 10;
+    /// The `import()` call has a second argument, e.g. `import('mod', { with: { type: 'json' } })`.
+    /// `try_rewrite_import_expression` returns early on `expr.options.is_some()`, so the specifier
+    /// rewrite that redirects a call site at a merged host chunk — and the `.then(...)` rewrite
+    /// that makes it carry an execution-order trigger — never run: the emitted code keeps the
+    /// specifier exactly as written. Passes that assume a dynamic import call site can be pointed
+    /// somewhere else must treat these records as unrewritable. Note this is specific to that
+    /// function; `try_rewrite_inline_dynamic_import_expr` runs first and does not check options,
+    /// so a dead or code-splitting-disabled import is still replaced wholesale.
+    const DynamicImportWithOptions = 1 << 11;
 
     const TopLevelPureDynamicImport = Self::IsTopLevel.bits() | Self::PureDynamicImport.bits();
   }


### PR DESCRIPTION
Under `strictExecutionOrder`, dynamically importing a module that chunking already placed in the importer's own chunk still shipped a dedicated facade chunk, and the `import()` stayed a real network fetch of that file. After this PR the import collapses inline and carries the module's deferred initialization with it, so the facade chunk disappears — matching what the same layout already produced without strict mode. A facade is still emitted whenever any other chunk dynamically imports the module.

```js
// before — the importer fetches a file whose whole job is the trigger:
import("./lib.js").then((mod) => ...)
// dist/lib.js:
//   import { n as a, r as init_lib } from "./entry2.js";
//   init_lib();
//   export { a };

// after — dist/lib.js is gone; the collapse carries the trigger:
Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => ...)
```

### Problem

Second P1 item of #10294. Strict-order builds defer each module's execution behind an initializer, and a dynamically imported module needs that initializer called when the import resolves. When code splitting co-locates the import target with its importer — a `codeSplitting` group matching both, or `experimental.chunkOptimization` merging the dynamic entry into its host — the build resurrected the eliminated facade chunk to carry that call, even though nothing else would ever load it. `issues/9463` wrap-all ships a `shared.js` chunk containing only a noop initializer call plus a re-export; the same shape recurs with real, non-noop initializers in `manual_group_phantom_dynamic`, `mixed_static_dynamic_same_target`, and `chunk_merging/dynamic_entry_merged_in_user_defined_entry`. Wrap-all hits every such entry; on-demand hits whichever targets the analysis wraps.

Root cause: the restore pass (`restore_order_wrap_entry_facades`, which un-tombstones facade chunks the chunk optimizer eliminated) ran unconditionally for every wrapped entry, because the finalizer's merged-entry rewrite (`rewrite_dynamic_import_for_merged_entry`, which turns `import()` of a merged dynamic entry into an inline namespace access) could not express an execution-order trigger — its non-interop arms asserted such entries never reach them. The interop arm already carries its wrapper's trigger through the collapse, and the cross-chunk links stage already publishes execution-order wrapper exports; the machinery was half-built, so the restore undid every merge the optimizer had proved.

Blast radius: output shape only — one extra chunk and one extra request per affected dynamic entry; runtime behavior was already correct. Not affected: non-strict builds, single-chunk builds, `emitFile`'d chunks, and any dynamic entry with a cross-chunk dynamic importer.

### Fix

Keep the facade eliminated exactly when every live dynamic importer sits in the chunk that hosts the entry's implementation, and let the collapse carry the trigger.

- The merged-entry rewrite now routes both arms through the shared `esm_init_target` view, which presents interop and execution-order wrappers uniformly, and emits `Promise.resolve().then(() => (init_x(), ns))` for the same-chunk case. A noop initializer call gets the `/* @__PURE__ */` annotation, so the default dce-only minify drops it — `issues/9463` wrap-all becomes byte-identical to its on-demand cell. A new `debug_assert!(!target.tla_tainted)` pins why the non-awaiting collapse is sound: facade elimination is globally disabled when any module is TLA-tainted.
- The restore still runs when any cross-chunk dynamic importer exists: a facade runs the trigger synchronously within its own module evaluation, while a `.then` trigger would run a microtask after the host chunk settles — an observable reordering that `m4_dynamic_facade_race` and `wrapped_dynamic_entry_keeps_facade_after_manual_chunk_merge` pin (both stay green). Emitted-chunk facades are always restored so `emitFile` reference ids keep resolving to a real file. The importer scan is one pass over the module table shared by all restore candidates.
- The plan-applied debug assertion now accepts an entry whose entry chunk is another module's entry chunk containing it (dynamic entry merged into a user-defined entry), a state the unconditional restore previously made unreachable.

Why not the ledger's narrower alternative — skip the facade only when the initializer is a noop: three of the four anchor fixtures have real initializers (`init_m6`, `init_dep_b`, `init_lib`), so only trigger-carrying collapse removes their facades.

Non-goals: the cross-chunk `esm_init_target` arm is dead-by-construction today (any cross-chunk importer forces the restore) and is kept for symmetry, not as a functional path; routing the interop arm through the shared init-call helper widens the PURE-when-noop annotation to merged interop entries in non-strict builds (no existing snapshot changes); the wrap-all-side unconditional entry split stays as tracked in #10294.

### Validation

- New fixture `strict_execution_order/cross_chunk_dynamic_importer_keeps_facade` pins the boundary in minimal form (two entries, one target, one group): one same-chunk plus one cross-chunk dynamic importer keeps the restored facade with its synchronous trigger, in both wrap modes. Verified it bites: neutralizing the cross-chunk guard flips this fixture's snapshot, while its runtime assertions alone would not catch it — the microtask-race semantics stay pinned by `m4_dynamic_facade_race`.
- Acceptance and anchors, green with runtime `_test.mjs` assertions: `issues/9463` wrap-all loses the `shared.js` facade (byte-identical to on-demand), `issues/9463_plain_group` likewise; `manual_group_phantom_dynamic` drops `m6.js` in both wrap modes; `mixed_static_dynamic_same_target` drops `dep-b.js`; `chunk_merging/dynamic_entry_merged_in_user_defined_entry` drops `lib.js` in the esm and cjs wrap-all cells and stops publishing the now-dead exports.
- Full `cargo test -p rolldown --test integration`: 1889 passed; the only failures are the pre-existing environment set (`cjs_module_lexer_compat` ×3, `npm_packages/util_deprecate`, `test262`), verified byte-identical by rerun on unmodified main on the same machine.
- Execution-order fuzzer differential, 80 mixed cases per cell (seeds 400001–400080) in on-demand and wrap-all against this build and an unmodified-main build: identical results in all four cells (78/80); the two failing seeds are the known packaged pure-definer-behind-barrel residue tracked in #10294, with byte-identical verdict signatures on both builds — zero failure signatures introduced or altered.
- Not exercised by a fixture: a TLA-tainted entry reaching the collapse. It is unreachable today (facade elimination is globally disabled when any module is TLA-tainted) and the new debug assertion pins that coupling.

Part of #10294.
