### PR TITLE
test(dev): run vite playgrounds under bundled dev (test-serve-bundled)

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -107,6 +107,12 @@ const failedTestServe = await runCmdAndPipe(
 );
 if (failedTestServe) failed.push('test-serve');
 
+const failedTestServeBundled = await runCmdAndPipe(
+  '# Running `pnpm test-serve-bundled`...',
+  ['pnpm', ['run', 'test-serve-bundled'], { nodeOptions: { cwd: REPO_PATH } }],
+);
+if (failedTestServeBundled) failed.push('test-serve-bundled');
+
 const failedTestBuild = await runCmdAndPipe(
   '# Running `pnpm test-build`...',
   ['pnpm', ['run', 'test-build'], { nodeOptions: { cwd: REPO_PATH } }],


### PR DESCRIPTION
Vite merged vitejs/vite#23027, which added a `test-serve-bundled` script: it runs the whole playground e2e suite under bundled dev mode (`VITE_TEST_BUNDLED_DEV=1`), with unsupported cases skipped.

This PR makes `packages/vite-tests/run.ts` run that suite as well, between `test-serve` and `test-build`. The prepared vite checkout is always the latest `rolldown-canary` rebased onto `main`, and that always contains the script since the rebase on 2026-07-24.

Verified locally at the current `rolldown-canary` tip (50fd47de7) with a locally built rolldown linked in: 330 passed, 116 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)