### PR TITLE
test(treeshake): reduce manual-pure fixture to a minimal smoke test, move matrix to unit tests

### DIFF
--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -2172,6 +2172,42 @@ mod test {
   }
 
   #[test]
+  fn test_manual_pure_chains_without_eager_children_are_side_effect_free() {
+    let options = Arc::new(NormalizedBundlerOptions {
+      treeshake: InnerOptions {
+        manual_pure_functions: Some(std::iter::once("make".to_string()).collect()),
+        ..InnerOptions::default()
+      }
+      .into(),
+      ..NormalizedBundlerOptions::default()
+    });
+    // A manual-pure root with no eagerly-evaluated child is side-effect-free (removable), across
+    // bare calls, member reads, repeated/optional/chained calls, and tagged templates. `make` is
+    // declared so it resolves locally and its read contributes no global-access order reason.
+    for code in [
+      "function make() {} make();",
+      "function make() {} make.div;",
+      "function make() {} make.div`x`;",
+      "function make() {} make?.div();",
+      "function make() {} make()();",
+      "function make() {} make().div();",
+    ] {
+      assert_eq!(
+        get_stmt_eval_with_options(code, &options).last(),
+        Some(&(StmtEvalFlags::empty(), false)),
+        "{code}"
+      );
+    }
+    // Scoping: `manualPureFunctions` only touches listed names, so a call to an unlisted function
+    // keeps its side effects.
+    assert_eq!(
+      get_stmt_eval_with_options("other();", &options).first().map(|(flags, _)| *flags),
+      Some(StmtEvalFlags::UnknownSideEffect),
+      "unlisted call must not be treated as pure"
+    );
+  }
+
+  #[test]
   fn test_conditional_and_logical_iife_callees_behind_manual_pure_member() {
     // A bare conditional/logical-callee IIFE needs no collector arm: oxc's IIFE certification
     // recognizes only direct function/arrow callees, so the statement keeps `UnknownSideEffect`

--- a/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/_config.ts
@@ -5,7 +5,7 @@ export default defineTest({
   sequential: true,
   config: {
     treeshake: {
-      manualPureFunctions: ['styled', 'local'],
+      manualPureFunctions: ['styled'],
     },
     external: ['styled-components'],
   },
@@ -13,18 +13,7 @@ export default defineTest({
     let code = output.output[0].code;
 
     expect(code).toMatchInlineSnapshot(`
-      "import styled from "styled-components";
-      //#region main.js
-      function effect(value) {
-      \tconsole.log(value);
-      \treturn value;
-      }
-      styled()[effect("computed key")];
-      styled(effect("call argument")).value;
-      new (styled())[effect("new callee")].Box();
-      let another = console.log;
-      another();
-      //#endregion
+      "import "styled-components";
       "
     `);
   },

--- a/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/manual-pure-functions/main.js
@@ -1,21 +1,8 @@
 import styled from 'styled-components';
-let local = console.log;
-local(); // removed
+
+// Smoke test that the `manualPureFunctions` option reaches the pipeline and drops a listed
+// function's call. The retain/remove behavior lives in the Rust `stmt_eval_analyzer` unit tests
+// (`test_manual_pure_chains_*`).
 styled.div`
   color: blue;
-`; // removed
-styled.div; // removed
-styled?.div(); // removed
-styled()(); // removed
-styled().div(); // removed
-
-function effect(value) {
-  console.log(value);
-  return value;
-}
-styled()[effect('computed key')]; // retained
-styled(effect('call argument')).value; // retained
-new (styled()[effect('new callee')].Box)(); // retained
-
-let another = console.log;
-another(); // retained
+`;


### PR DESCRIPTION
Follow-up to #10427 / #10432 (both merged).

There's exactly one JS-side `manualPureFunctions` test — the `manual-pure-functions` fixture (added in #10427). It re-tested the retain/remove behavior matrix that the Rust `stmt_eval_analyzer` unit tests already own. A JS fixture only needs to smoke-test that the option is wired through the pipeline; the exhaustive behavior belongs in fast, precise Rust unit tests.

## Changes

- **Fixture → minimal smoke test.** `main.js` is now a single case: a listed function's call (`` styled.div`...` ``) is dropped, leaving just `import "styled-components";`. That alone proves the `manualPureFunctions` option reaches the pipeline — without it, the call would be retained. Snapshot regenerated against a fresh debug build.
- **Rust unit test.** `test_manual_pure_chains_without_eager_children_are_side_effect_free` covers the removed shapes (`make.div`, `` make.div`x` ``, `make?.div()`, `make()()`, `make().div()`) that previously had end-to-end-only coverage. The retained-child and spread matrices were already unit-tested (`test_manual_pure_chains_keep_eager_child_side_effects`, `test_manual_pure_chains_drop_side_effect_free_spreads`).

Test-only; no behavior change.
