### PR TITLE
fix(import-glob): escape generated string literals

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -9,7 +9,10 @@ use oxc::ast::ast::{
 use oxc::ast_visit::{VisitJs, walk_js};
 use rolldown_ecmascript_utils::ExpressionExt;
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
-use rolldown_plugin_utils::constants::{ViteImportGlob, ViteImportGlobValue};
+use rolldown_plugin_utils::{
+  constants::{ViteImportGlob, ViteImportGlobValue},
+  to_string_literal,
+};
 use rolldown_std_utils::relative_path_to_slash;
 use string_wizard::MagicString;
 use sugar_path::SugarPath;
@@ -185,6 +188,7 @@ impl<'ast> GlobImportVisit<'_> {
         Cow::Borrowed(import_path)
       };
 
+      let formatted_file = to_string_literal(&formatted_file);
       let value: Cow<'_, str> = if matches!(omit_type, ImportGlobOmitType::Values) {
         Cow::Borrowed("0")
       } else if options.eager {
@@ -205,16 +209,16 @@ impl<'ast> GlobImportVisit<'_> {
           Some(import) => format!("{{ {import} as {name} }}"),
         };
 
-        self.import_decls.push(format!("import {module_specifier} from \"{formatted_file}\";"));
+        self.import_decls.push(format!("import {module_specifier} from {formatted_file};"));
 
         Cow::Owned(name)
       } else {
         // () => import('./dir/bar.js') or () => import('./dir/foo.js').then((m) => m.setup)
         Cow::Owned(match options.import.as_deref() {
           Some(import) if import != "*" => {
-            format!("() => import(\"{formatted_file}\").then((m) => m[\"{import}\"])")
+            format!("() => import({formatted_file}).then((m) => m[{}])", to_string_literal(import))
           }
-          _ => format!("() => import(\"{formatted_file}\")"),
+          _ => format!("() => import({formatted_file})"),
         })
       };
 
@@ -237,14 +241,14 @@ impl<'ast> GlobImportVisit<'_> {
       ImportGlobOmitType::Values => format!(
         "{{{}{line_breaks}}}",
         properties
-          .map(|(file, value)| format!("\"{file}\": {value}"))
+          .map(|(file, value)| format!("{}: {value}", to_string_literal(file)))
           .collect::<Vec<_>>()
           .join(",")
       ),
       ImportGlobOmitType::None => format!(
         "/* #__PURE__ */ Object.assign({{{}{line_breaks}}})",
         properties
-          .map(|(file, value)| format!("\"{file}\": {value}"))
+          .map(|(file, value)| format!("{}: {value}", to_string_literal(file)))
           .collect::<Vec<_>>()
           .join(",")
       ),

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/_config.ts
@@ -1,0 +1,45 @@
+import { rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { viteImportGlobPlugin } from 'rolldown/experimental';
+
+const quotedModulePaths = ['eager', 'lazy', 'keys'].map((type) =>
+  join(import.meta.dirname, 'dir', `a"b.${type}.js`),
+);
+const quotedModulePrefix = '\0quoted-module:';
+
+function removeQuotedModules() {
+  for (const path of quotedModulePaths) rmSync(path, { force: true });
+}
+
+export default defineTest({
+  skip: process.platform === 'win32',
+  config: {
+    plugins: [
+      viteImportGlobPlugin(),
+      {
+        name: 'quoted-module',
+        resolveId(id) {
+          if (id.startsWith('./dir/a"b.')) return quotedModulePrefix + id;
+        },
+        load(id) {
+          if (id.startsWith(quotedModulePrefix)) return 'export default 42;\n';
+        },
+      },
+    ],
+  },
+  beforeTest() {
+    for (const path of quotedModulePaths) writeFileSync(path, 'export default 42;\n');
+  },
+  async afterTest() {
+    try {
+      await import('./assert.mjs');
+    } finally {
+      removeQuotedModules();
+    }
+  },
+  catchError(error) {
+    removeQuotedModules();
+    throw error;
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/assert.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { eager, keys, lazy } from './dist/main.js';
+
+const eagerId = './dir/a"b.eager.js';
+const lazyId = './dir/a"b.lazy.js';
+const keysId = './dir/a"b.keys.js';
+
+assert.strictEqual(eager[eagerId].default, 42);
+assert.strictEqual((await lazy[lazyId]()).default, 42);
+assert.deepStrictEqual(keys, [keysId]);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/escaped-paths/main.js
@@ -1,0 +1,5 @@
+const eager = import.meta.glob('./dir/*.eager.js', { eager: true });
+const lazy = import.meta.glob('./dir/*.lazy.js');
+const keys = Object.keys(import.meta.glob('./dir/*.keys.js'));
+
+export { eager, lazy, keys };


### PR DESCRIPTION
- Escape module specifiers and object keys emitted by the native Vite import-glob plugin.
- Unescaped quotes in matched file names produced invalid JavaScript during builds.

Closes #10437


