### PR TITLE
fix(code-splitting): only split an entry facade when something else can load its chunk

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -13,8 +13,8 @@ use oxc_str::CompactStr;
 use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, CrossChunkImportItem, EntryPointKind, ExportsKind, ImportKind,
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PostChunkOptimizationOperation,
-  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, RuntimeHelper, SymbolRef, UsedSymbolRefs,
-  UsedSymbolRefsBuilder, WrapKind,
+  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, RuntimeHelper, SymbolRef, TaggedSymbolRef,
+  UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
 };
 use rolldown_utils::index_vec_ext::IndexVecRefExt as _;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -58,6 +58,26 @@ impl<'a> FinalEsmInitMetadataAvailability<'a> {
   }
 }
 
+/// What a cross-chunk link computation does with the symbol->chunk ownership it derives.
+///
+/// [`GenerateStage::collect_depended_symbols`] does not only *read* the chunk graph: it writes each
+/// declared symbol's owning chunk back into the shared symbol database, and
+/// [`GenerateStage::compute_chunk_imports`] then reads that ownership to resolve which chunk a
+/// depended symbol is imported from. So the write is load-bearing *within* one pass, and the pass
+/// cannot be turned into a plain read-only query by dropping it.
+///
+/// It can be scoped instead. `Scoped` records each symbol's previous owner while committing, so the
+/// caller can roll the database back afterwards and leave no trace. That is what lets the entry
+/// facade decision run the real link computation as a question ("which chunks import this chunk?")
+/// before the final pass answers it for real.
+enum SymbolChunkOwnership<'a> {
+  /// Keep the derived ownership. Used by the final [`GenerateStage::compute_cross_chunk_links`].
+  Commit,
+  /// Keep it only for the duration of this pass; record the previous owners into the journal so the
+  /// caller can restore them.
+  Scoped(&'a mut Vec<(SymbolRef, Option<ChunkIdx>)>),
+}
+
 trait UsedSymbolRefsView: Sync {
   fn contains(&self, symbol_ref: &SymbolRef) -> bool;
 }
@@ -96,6 +116,7 @@ impl GenerateStage<'_> {
       used_symbol_refs,
       order_state,
       FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
+      SymbolChunkOwnership::Commit,
     );
 
     #[cfg(debug_assertions)]
@@ -248,13 +269,64 @@ impl GenerateStage<'_> {
     used_symbol_refs: &UsedSymbolRefsBuilder,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     let empty_order_state = super::order_wrap_state::OrderWrapState::default();
-    self
-      .compute_cross_chunk_link_state(
-        chunk_graph,
-        used_symbol_refs,
-        &empty_order_state,
-        FinalEsmInitMetadataAvailability::Unavailable,
-      )
+    let state = self.compute_cross_chunk_link_state(
+      chunk_graph,
+      used_symbol_refs,
+      &empty_order_state,
+      FinalEsmInitMetadataAvailability::Unavailable,
+      SymbolChunkOwnership::Commit,
+    );
+    Self::static_import_edges_of(chunk_graph, state)
+  }
+
+  /// The static chunk->chunk import edges the *final* cross-chunk link pass will compute, asked
+  /// before that pass runs.
+  ///
+  /// Unlike [`Self::predicted_static_import_edges`] this is not a prediction: it drives the same
+  /// machinery with the fully lowered [`OrderWrapState`](super::order_wrap_state::OrderWrapState)
+  /// and the real final init metadata, so every edge source the final pass registers — value
+  /// references, `init_*` forwarding, retained re-export overlays, transitive init obligations —
+  /// is present, with no re-derived approximation that could silently miss one.
+  ///
+  /// The entry-facade decision in `create_order_wrap_entry_facades` needs exactly this: an entry's
+  /// inline `init_E()` trigger is only safe while nothing *else* loads the chunk hosting `E`.
+  ///
+  /// Answering it here is sound because the facade split cannot invalidate the answer. A facade is
+  /// an empty chunk that takes over the entry role from the implementation chunk: it adds one
+  /// importer of that implementation chunk (itself), and it inherits — never widens — the outgoing
+  /// edges the implementation chunk had as an entry chunk. So for every *other* chunk the relation
+  /// "some chunk other than me imports me" is unchanged, and all facade decisions can be taken
+  /// together from this one pre-facade snapshot.
+  ///
+  /// The symbol->chunk ownership the pass commits is rolled back before returning, so this leaves
+  /// the symbol database exactly as it found it and the final pass is still the only writer.
+  pub(super) fn lowered_static_import_edges(
+    &mut self,
+    chunk_graph: &ChunkGraph,
+    used_symbol_refs: &UsedSymbolRefsBuilder,
+    order_state: &super::order_wrap_state::OrderWrapState,
+    final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
+  ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
+    let mut journal = Vec::new();
+    let state = self.compute_cross_chunk_link_state(
+      chunk_graph,
+      used_symbol_refs,
+      order_state,
+      FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
+      SymbolChunkOwnership::Scoped(&mut journal),
+    );
+    let symbols = &mut self.link_output.symbol_db;
+    for (symbol_ref, previous_chunk_idx) in journal.into_iter().rev() {
+      symbols.get_mut(symbol_ref).chunk_idx = previous_chunk_idx;
+    }
+    Self::static_import_edges_of(chunk_graph, state)
+  }
+
+  fn static_import_edges_of(
+    chunk_graph: &ChunkGraph,
+    state: CrossChunkLinkState,
+  ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
+    state
       .index_imports_from_other_chunks
       .into_iter_enumerated()
       .map(|(chunk_idx, importee_map)| {
@@ -272,6 +344,7 @@ impl GenerateStage<'_> {
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
+    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
   ) -> CrossChunkLinkState {
     let mut index_chunk_depended_symbols: IndexChunkDependedSymbols =
       index_vec![FxIndexSet::<SymbolRef>::default(); chunk_graph.chunk_table.len()];
@@ -312,6 +385,7 @@ impl GenerateStage<'_> {
       used_symbol_refs,
       order_state,
       final_esm_init_metadata,
+      symbol_chunk_ownership,
     );
 
     self.compute_chunk_imports(
@@ -350,6 +424,7 @@ impl GenerateStage<'_> {
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
+    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
   ) {
     let symbols = &self.link_output.symbol_db;
     let chunk_id_to_symbols_vec = append_only_vec::AppendOnlyVec::new();
@@ -556,8 +631,22 @@ impl GenerateStage<'_> {
         chunk_id_to_symbols_vec.push((chunk_id, symbol_needs_to_assign));
       },
     );
+    self.assign_symbol_chunk_ownership(chunk_id_to_symbols_vec, symbol_chunk_ownership);
+  }
+
+  /// Record which chunk owns each declared symbol, so [`Self::compute_chunk_imports`] can resolve a
+  /// depended symbol to the chunk it must be imported from.
+  fn assign_symbol_chunk_ownership(
+    &mut self,
+    chunk_id_to_symbols_vec: append_only_vec::AppendOnlyVec<(ChunkIdx, Vec<TaggedSymbolRef>)>,
+    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
+  ) {
     // shadowing previous immutable borrow
     let symbols = &mut self.link_output.symbol_db;
+    let mut journal = match symbol_chunk_ownership {
+      SymbolChunkOwnership::Commit => None,
+      SymbolChunkOwnership::Scoped(journal) => Some(journal),
+    };
     for (chunk_idx, symbol_list) in chunk_id_to_symbols_vec {
       for declared in symbol_list {
         let declared = declared.inner();
@@ -574,6 +663,9 @@ impl GenerateStage<'_> {
         }
 
         let symbol_data = symbols.get_mut(declared);
+        if let Some(journal) = journal.as_deref_mut() {
+          journal.push((declared, symbol_data.chunk_idx));
+        }
         symbol_data.chunk_idx = Some(chunk_idx);
       }
     }

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -43,12 +43,6 @@ fn order_debug_trace(message: impl FnOnce() -> String) {
 #[derive(Debug)]
 pub(super) struct OrderAnalysis {
   pub(super) plan: OrderWrapPlan,
-  pub(super) import_edges: IndexVec<ChunkIdx, FxHashSet<ChunkIdx>>,
-  /// Whether this analysis was produced by the selective on-demand mode (as opposed to wrap-all).
-  /// Lowering reads it to decide whether entry-facade splitting is conditional (on-demand) or
-  /// unconditional (wrap-all) instead of re-reading the `experimental.onDemandWrapping` option, so
-  /// the wrapping policy lives in exactly one place — the analysis that already branched on it.
-  pub(super) on_demand: bool,
 }
 
 #[derive(Debug, Default)]
@@ -112,7 +106,7 @@ impl GenerateStage<'_> {
     // inert and no evaluation-order prediction is needed. The on-demand analysis below is the
     // opt-in selective mode behind `experimental.onDemandWrapping`.
     if !self.options.experimental.is_on_demand_wrapping_enabled() {
-      return Some(self.wrap_all_order_analysis(chunk_graph));
+      return Some(self.wrap_all_order_analysis());
     }
 
     let import_edges = self.predicted_static_import_edges(chunk_graph, used_symbol_refs);
@@ -239,7 +233,7 @@ impl GenerateStage<'_> {
       planned_modules = plan.len(),
       "emergent-cycle fixpoint converged"
     );
-    Some(OrderAnalysis { plan, import_edges, on_demand: true })
+    Some(OrderAnalysis { plan })
   }
 
   /// Project the chunk-level static import edges the lowering of `plan` will produce, as the
@@ -605,7 +599,7 @@ impl GenerateStage<'_> {
     probe_state
   }
 
-  fn wrap_all_order_analysis(&self, chunk_graph: &ChunkGraph) -> OrderAnalysis {
+  fn wrap_all_order_analysis(&self) -> OrderAnalysis {
     let mut plan = OrderWrapPlan::default();
     // Only membership matters here, so one shared visit-state vector lets every module be
     // walked once across all roots instead of once per root.
@@ -620,11 +614,7 @@ impl GenerateStage<'_> {
         }
       }
     }
-    OrderAnalysis {
-      plan,
-      import_edges: index_vec![FxHashSet::default(); chunk_graph.chunk_table.len()],
-      on_demand: false,
-    }
+    OrderAnalysis { plan }
   }
 
   fn expected_order_for_root(&self, root: ModuleIdx) -> Vec<ModuleIdx> {

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use itertools::Itertools;
 use oxc::ast::ast::{Declaration, ExportDefaultDeclarationKind, Statement};
+use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, ImportKind, ImportRecordIdx, ImportRecordMeta,
   IndexModules, ModuleIdx, OutputFormat, PostChunkOptimizationOperation, RuntimeHelper,
@@ -111,8 +112,19 @@ impl GenerateStage<'_> {
     let plan = &analysis.plan;
     if plan.is_empty() {
       // Entry-trigger facades are needed even with an empty plan: a pure interop graph can
-      // still share one entry's chunk with another entry.
-      if !self.create_order_wrap_entry_facades(chunk_graph, analysis) {
+      // still share one entry's chunk with another entry. With nothing order-wrapped, the only
+      // candidates are interop-wrapped entries, so a pure-ESM graph has none and asks nothing.
+      //
+      // The three passes hoisted ahead of the query below are skipped here, which is safe only
+      // because an empty plan makes each one a no-op: nothing demands an order-wrap runtime
+      // helper, restoring is filtered by the plan, and `finalize_chunk_plan` already ran the
+      // namespace pass against this same default `order_state`.
+      let candidates = self.entry_facade_candidates(plan);
+      if candidates.is_empty() {
+        return false;
+      }
+      let import_edges = self.entry_facade_import_edges(chunk_graph, used_symbol_refs, order_state);
+      if !self.create_order_wrap_entry_facades(chunk_graph, candidates, &import_edges) {
         return false;
       }
       chunk_graph.sort_chunk_modules(self.link_output, self.options);
@@ -145,12 +157,67 @@ impl GenerateStage<'_> {
       &self.link_output.symbol_db,
     );
     self.place_order_wrap_modules(chunk_graph, plan, order_state);
-    self.create_order_wrap_entry_facades(chunk_graph, analysis);
+    // Restoring runs before everything below it. A restored facade is an optimizer-removed chunk
+    // brought back to life, so it changes both the live-chunk count the runtime placement reads
+    // and the edge set the facade decision reads — and `compute_chunk_imports` skips removed
+    // chunks, so asking first would hide the edge from a revived facade to the chunk hosting its
+    // implementation, leaving an entry that shares that chunk with an inline trigger the restored
+    // facade's load then fires. Restoring is not itself a candidate for the necessity gate: it
+    // exists because a chunk can host only one entry's top-level trigger, so an entry merged into
+    // another entry's chunk has no trigger at all without its own file.
     self.restore_order_wrap_entry_facades(chunk_graph, plan);
-    self.ensure_runtime_module_for_order_wraps(chunk_graph, order_state);
+    // Placement runs before the facade decision so that decision can ask the real link computation
+    // which chunks import which: the order wrappers demand runtime helpers, and resolving a
+    // depended symbol to its chunk requires the runtime module to already sit in one. The merge
+    // re-proof this normalizes for is deferred to `fold_runtime_chunk_after_order_lowering` below,
+    // because it counts the runtime chunk's consumers and must see the final facade topology.
+    let fold_runtime_chunk = self.ensure_runtime_module_for_order_wraps(chunk_graph);
+    // Refresh the namespace facts against the lowered order state before querying the edges.
+    // `finalize_chunk_plan` re-runs this once more after lowering anyway; doing it here too means
+    // the query sees the namespaces the final link pass will see, instead of the provisional
+    // pre-lowering set, so a namespace an import overlay demands cannot become an edge the query
+    // missed. Facades do not move modules between chunks, so the result is the same before and
+    // after they are created.
+    self.finalized_module_namespace_ref_usage(chunk_graph, order_state);
+    // Collecting the candidates reads only the module graph, so it can run before the edges and
+    // spare the query entirely when no entry could need a facade in the first place.
+    let candidates = self.entry_facade_candidates(plan);
+    if !candidates.is_empty() {
+      let import_edges = self.entry_facade_import_edges(chunk_graph, used_symbol_refs, order_state);
+      self.create_order_wrap_entry_facades(chunk_graph, candidates, &import_edges);
+    }
+    if fold_runtime_chunk {
+      self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
+    }
     chunk_graph.sort_chunk_modules(self.link_output, self.options);
     self.renumber_live_chunks(chunk_graph);
     true
+  }
+
+  /// The chunk->chunk static import edges the entry-facade decision is taken against.
+  ///
+  /// Computed from the fully lowered order state through the same cross-chunk link pass that
+  /// produces the final edges, so the decision reads facts rather than a re-derived approximation
+  /// of them. See [`GenerateStage::lowered_static_import_edges`].
+  fn entry_facade_import_edges(
+    &mut self,
+    chunk_graph: &ChunkGraph,
+    used_symbol_refs: &UsedSymbolRefsBuilder,
+    order_state: &OrderWrapState,
+  ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
+    if self.options.code_splitting.is_disabled() {
+      // A single-chunk build has no other chunk to load the entry's implementation, and
+      // `create_order_wrap_entry_facades` bails out on it anyway.
+      return index_vec![FxHashSet::default(); chunk_graph.chunk_table.len()];
+    }
+    let final_esm_init_metadata =
+      self.compute_wrapped_esm_init_metadata(&self.ast_table, chunk_graph, order_state);
+    self.lowered_static_import_edges(
+      chunk_graph,
+      used_symbol_refs,
+      order_state,
+      &final_esm_init_metadata,
+    )
   }
 
   fn place_order_wrap_modules(
@@ -174,17 +241,16 @@ impl GenerateStage<'_> {
     }
   }
 
-  fn create_order_wrap_entry_facades(
-    &self,
-    chunk_graph: &mut ChunkGraph,
-    analysis: &OrderAnalysis,
-  ) -> bool {
+  /// Entries whose inline `init_E()` trigger might have to move into a facade — an order-wrapped
+  /// entry, or an interop-wrapped one, whether or not anything imports it.
+  ///
+  /// Reads only the module graph, never the chunk topology, so the caller can collect these before
+  /// computing the import edges and skip that query entirely when there is nothing to decide.
+  fn entry_facade_candidates(&self, plan: &OrderWrapPlan) -> Vec<ModuleIdx> {
     if self.options.code_splitting.is_disabled() {
-      return false;
+      return vec![];
     }
-    let plan = &analysis.plan;
-
-    let mut entries_to_split = plan
+    let mut candidates = plan
       .modules()
       .filter(|module_idx| self.link_output.entries.contains_key(module_idx))
       .collect_vec();
@@ -195,7 +261,7 @@ impl GenerateStage<'_> {
       if !meta.is_included {
         continue;
       }
-      entries_to_split.extend(module.import_records.iter().filter_map(|rec| {
+      candidates.extend(module.import_records.iter().filter_map(|rec| {
         if !matches!(rec.kind, ImportKind::Import | ImportKind::Require) {
           return None;
         }
@@ -206,19 +272,30 @@ impl GenerateStage<'_> {
         .then_some(importee_idx)
       }));
     }
+    candidates.extend(self.link_output.entries.keys().copied().filter(|entry_module_idx| {
+      !matches!(self.link_output.metas[*entry_module_idx].wrap_kind(), WrapKind::None)
+    }));
+    candidates
+  }
 
-    // Move an interop entry trigger to a facade when another chunk imports its implementation.
-    // Wrap-all mode computes no prediction and splits unconditionally. The wrapping policy is
-    // carried on the analysis (decided once in `analyze_execution_order`) rather than re-read here.
-    let on_demand = analysis.on_demand;
+  fn create_order_wrap_entry_facades(
+    &self,
+    chunk_graph: &mut ChunkGraph,
+    facade_candidates: Vec<ModuleIdx>,
+    import_edges: &IndexVec<ChunkIdx, FxHashSet<ChunkIdx>>,
+  ) -> bool {
+    if self.options.code_splitting.is_disabled() {
+      return false;
+    }
+
     let mut imported_chunks = FxHashSet::default();
-    for (chunk_idx, importee_chunks) in analysis.import_edges.iter_enumerated() {
+    for (chunk_idx, importee_chunks) in import_edges.iter_enumerated() {
       imported_chunks
         .extend(importee_chunks.iter().copied().filter(|importee| *importee != chunk_idx));
     }
     // A dynamic import evaluates its target's chunk, so an inline entry trigger hosted there
     // would run the entry's whole program during that load (e.g. a manual group placing a
-    // dynamic target next to an entry). Predicted static edges cannot see these loads; collect
+    // dynamic target next to an entry). The static edge set cannot see these loads; collect
     // the cross-chunk dynamic-import targets directly.
     let mut dynamic_target_modules_by_chunk: FxHashMap<ChunkIdx, FxHashSet<ModuleIdx>> =
       FxHashMap::default();
@@ -230,7 +307,15 @@ impl GenerateStage<'_> {
       }
       let importer_chunk = chunk_graph.module_to_chunk[module.idx];
       for rec in &module.import_records {
-        if rec.kind != ImportKind::DynamicImport {
+        // Only records the emitted code still executes count as loads. Tree shaking flags a
+        // dynamic record whose entry it dropped as `DeadDynamicImport`, and the finalizer rewrites
+        // exactly those to an inert `Promise.resolve().then(...)` stub that loads nothing — so a
+        // dead record must not force the split. The importee can still be included through a
+        // static route, which is precisely when it may share an entry's chunk. Same exclusion as
+        // `dynamic_already_loaded`.
+        if rec.kind != ImportKind::DynamicImport
+          || rec.meta.contains(ImportRecordMeta::DeadDynamicImport)
+        {
           continue;
         }
         let Some(importee_idx) = rec.resolved_module else { continue };
@@ -246,20 +331,30 @@ impl GenerateStage<'_> {
         dynamic_target_modules_by_chunk.entry(importee_chunk).or_default().insert(importee_idx);
       }
     }
-    entries_to_split.extend(self.link_output.entries.keys().copied().filter(|entry_module_idx| {
-      !matches!(self.link_output.metas[*entry_module_idx].wrap_kind(), WrapKind::None)
-        && (!on_demand
-          || chunk_graph.entry_module_to_entry_chunk.get(entry_module_idx).is_some_and(
-            |entry_chunk_idx| {
-              imported_chunks.contains(entry_chunk_idx)
-                // A dynamic import of the entry module itself must run its program, so only
-                // other hosted targets force the split.
-                || dynamic_target_modules_by_chunk.get(entry_chunk_idx).is_some_and(|targets| {
-                  targets.iter().any(|target| target != entry_module_idx)
-                })
-            },
-          ))
-    }));
+    // An entry's `init_E()` trigger may stay inline at the top of the chunk hosting `E` exactly
+    // while that chunk is loaded only to enter `E`. Once anything else can load it — another chunk
+    // imports it, or it also hosts some other chunk's dynamic-import target — the trigger has to
+    // move into a facade or `E`'s program runs during that unrelated load.
+    //
+    // This is the same question for an order-wrapped entry and for an interop-wrapped one, so all
+    // candidate sources are gated by it. It used to be asked only of interop entries, and only in
+    // on-demand mode; an order-wrapped entry always split, which cost one extra chunk per entry
+    // (including every dynamic entry) even when nothing but the entry itself could load the chunk.
+    let mut entries_to_split = facade_candidates
+      .into_iter()
+      .filter(|entry_module_idx| {
+        chunk_graph.entry_module_to_entry_chunk.get(entry_module_idx).is_some_and(
+          |entry_chunk_idx| {
+            imported_chunks.contains(entry_chunk_idx)
+              // A dynamic import of the entry module itself must run its program, so only
+              // other hosted targets force the split.
+              || dynamic_target_modules_by_chunk.get(entry_chunk_idx).is_some_and(|targets| {
+                targets.iter().any(|target| target != entry_module_idx)
+              })
+          },
+        )
+      })
+      .collect_vec();
     entries_to_split.sort_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order());
     entries_to_split.dedup();
 
@@ -393,31 +488,32 @@ impl GenerateStage<'_> {
     }
   }
 
-  /// Normalize the runtime module onto a standalone chunk, then re-run the runtime-chunk merge
-  /// proof with the post-lowering consumer set.
+  /// Normalize the runtime module onto a standalone chunk. Returns whether the caller still owes
+  /// the runtime-chunk merge re-proof (`fold_runtime_chunk_after_order_lowering`).
   ///
   /// The baseline `try_merge_runtime_chunk` calls run before order analysis, so a pre-lowering
   /// merge never proved anything about the helper demand the wrappers and overlays above added.
   /// Evicting a co-hosted runtime first restores the standalone shape that proof requires; by this
   /// point lowering has materialized every order-introduced demand in [`OrderWrapState`], so the
   /// re-proof sees the complete consumer set.
-  fn ensure_runtime_module_for_order_wraps(
-    &mut self,
-    chunk_graph: &mut ChunkGraph,
-    order_state: &OrderWrapState,
-  ) {
+  ///
+  /// Normalizing has to happen before the entry-facade edge query — resolving a depended symbol to
+  /// its chunk needs the runtime module to sit in one — while the re-proof has to happen after it,
+  /// because it counts the runtime chunk's consumers and facade creation is what settles them. So
+  /// the two are split: this returns the obligation and `apply_order_wraps` discharges it once the
+  /// facade topology is final.
+  fn ensure_runtime_module_for_order_wraps(&mut self, chunk_graph: &mut ChunkGraph) -> bool {
     let runtime_idx = self.link_output.runtime.id();
     if let Some(runtime_chunk_idx) = chunk_graph.module_to_chunk[runtime_idx] {
       if self.options.code_splitting.is_disabled() {
-        return;
+        return false;
       }
       let runtime_chunk = &chunk_graph.chunk_table[runtime_chunk_idx];
       if runtime_chunk.modules.len() == 1 {
         self.clear_module_symbol_chunk_indices(runtime_idx);
-        // Facade restoration above can tombstone chunks the pre-lowering merge counted as
-        // consumers, so a standalone runtime may only now have a sole consumer left.
-        self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
-        return;
+        // Facade restoration can tombstone chunks the pre-lowering merge counted as consumers, so
+        // a standalone runtime may only now have a sole consumer left.
+        return true;
       }
       let mut bits = runtime_chunk.bits.clone();
       for chunk_idx in self.live_chunks(chunk_graph) {
@@ -456,13 +552,12 @@ impl GenerateStage<'_> {
         self.link_output.metas[runtime_idx].depended_runtime_helper,
       );
       self.clear_module_symbol_chunk_indices(runtime_idx);
-      self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
-      return;
+      return true;
     }
 
     let live_chunk_indices = self.live_chunks(chunk_graph);
     let Some(first_chunk_idx) = live_chunk_indices.first().copied() else {
-      return;
+      return false;
     };
 
     if self.options.code_splitting.is_disabled() || live_chunk_indices.len() == 1 {
@@ -470,7 +565,7 @@ impl GenerateStage<'_> {
       chunk.modules.insert(0, runtime_idx);
       chunk_graph.module_to_chunk[runtime_idx] = Some(first_chunk_idx);
       self.clear_module_symbol_chunk_indices(runtime_idx);
-      return;
+      return false;
     }
 
     let mut bits = chunk_graph.chunk_table[first_chunk_idx].bits.clone();
@@ -500,7 +595,7 @@ impl GenerateStage<'_> {
       self.link_output.metas[runtime_idx].depended_runtime_helper,
     );
     self.clear_module_symbol_chunk_indices(runtime_idx);
-    self.fold_runtime_chunk_after_order_lowering(chunk_graph, order_state);
+    true
   }
 
   /// Re-run the runtime-chunk merge proof against the post-lowering consumer set: the

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -31,14 +31,6 @@ export { foo as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as init_foo, t as foo } from "./vendor.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 import nodeAssert from "node:assert";
@@ -50,7 +42,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/array_destructuring_rest_binding/artifacts.snap
@@ -34,15 +34,6 @@ export { all };
 ### main.js
 
 ```js
-import { n as init_main, t as all } from "./main2.js";
-init_main();
-export { all };
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
@@ -73,6 +64,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as n, all as t };
+init_main();
+export { all };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_gap/artifacts.snap
@@ -6,15 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import "./p.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as init_p } from "./p.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region e.js
@@ -28,7 +19,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -74,15 +65,6 @@ export { __esmMin as n, __commonJSMin as t };
 ## second.js
 
 ```js
-import "./p.js";
-import { t as init_second } from "./second2.js";
-init_second();
-
-```
-
-## second2.js
-
-```js
 import { t as init_p } from "./p.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region second.js
@@ -92,7 +74,7 @@ function init_second() {
 	})))();
 }
 //#endregion
-export { init_second as t };
+init_second();
 
 ```
 
@@ -101,15 +83,6 @@ export { init_second as t };
 ## Assets
 
 ### main.js
-
-```js
-import "./p.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
 
 ```js
 import { t as init_p } from "./p.js";
@@ -130,7 +103,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e as n, init_main as t };
+init_main();
 
 ```
 
@@ -176,15 +149,6 @@ export { __esmMin as n, __commonJSMin as t };
 ### second.js
 
 ```js
-import "./p.js";
-import { t as init_second } from "./second2.js";
-init_second();
-
-```
-
-### second2.js
-
-```js
 import { t as init_p } from "./p.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region second.js
@@ -194,6 +158,6 @@ function init_second() {
 	})))();
 }
 //#endregion
-export { init_second as t };
+init_second();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
@@ -24,14 +24,6 @@ export default require_pure_cjs();
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as read, t as init_reader } from "./reader.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region e.js
@@ -46,7 +38,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -120,14 +112,6 @@ export { __esmMin as n, __commonJSMin as t };
 ## second.js
 
 ```js
-import { t as init_second } from "./second2.js";
-init_second();
-
-```
-
-## second2.js
-
-```js
 import { n as read, t as init_reader } from "./reader.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region second.js
@@ -138,19 +122,11 @@ function init_second() {
 	})))();
 }
 //#endregion
-export { init_second as t };
+init_second();
 
 ```
 
 ## unused.js
-
-```js
-import { t as init_unused } from "./unused2.js";
-init_unused();
-
-```
-
-## unused2.js
 
 ```js
 import { n as __esmMin } from "./rolldown-runtime.js";
@@ -161,7 +137,7 @@ function init_unused() {
 	})))();
 }
 //#endregion
-export { init_unused as t };
+init_unused();
 
 ```
 
@@ -190,14 +166,6 @@ export default require_pure_cjs();
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as read, t as init_reader } from "./reader.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region e.js
@@ -217,7 +185,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e as n, init_main as t };
+init_main();
 
 ```
 
@@ -291,14 +259,6 @@ export { __esmMin as n, __commonJSMin as t };
 ### second.js
 
 ```js
-import { t as init_second } from "./second2.js";
-init_second();
-
-```
-
-### second2.js
-
-```js
 import { n as read, t as init_reader } from "./reader.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region second.js
@@ -309,19 +269,11 @@ function init_second() {
 	})))();
 }
 //#endregion
-export { init_second as t };
+init_second();
 
 ```
 
 ### unused.js
-
-```js
-import { t as init_unused } from "./unused2.js";
-init_unused();
-
-```
-
-### unused2.js
 
 ```js
 import { n as __esmMin } from "./rolldown-runtime.js";
@@ -332,6 +284,6 @@ function init_unused() {
 	})))();
 }
 //#endregion
-export { init_unused as t };
+init_unused();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_entry_shared_carrier/artifacts.snap
@@ -52,14 +52,6 @@ export { __commonJSMin as i, init_s1 as n, s1_exports as r, require_b as t };
 ### a.js
 
 ```js
-import { t as require_a } from "./a2.js";
-export default require_a();
-
-```
-
-### a2.js
-
-```js
 import { i as __commonJSMin, n as init_s1 } from "./b2.js";
 //#region a.cjs
 var require_a = /* @__PURE__ */ __commonJSMin((() => {
@@ -67,7 +59,7 @@ var require_a = /* @__PURE__ */ __commonJSMin((() => {
 	console.log("A");
 }));
 //#endregion
-export { require_a as t };
+export default require_a();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_ns_merge_skipped/artifacts.snap
@@ -29,14 +29,6 @@ console.log("main", fromLib, import_cjs.default.value);
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region cjs.cjs
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -63,7 +55,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
@@ -54,14 +54,6 @@ console.log("main");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 function init_setup() {
@@ -78,7 +70,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```
 
@@ -87,14 +79,6 @@ export { init_setup as n, init_main as t };
 ## Assets
 
 ### main.js
-
-```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -113,7 +97,7 @@ function init_main() {
 	}))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```
 
@@ -122,14 +106,6 @@ export { init_setup as n, init_main as t };
 ## Assets
 
 ### main.js
-
-```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
@@ -148,6 +124,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -29,14 +29,6 @@ assert.equal(foo_inner_default.foo, "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
@@ -72,6 +64,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_foo as n, init_setup as r, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_inlined_member/artifacts.snap
@@ -81,8 +81,8 @@ export { y as n, init_constants as t };
 
 ```js
 //#region main.js
-await import("./page-b2.js").then(console.log);
-await import("./page-a2.js").then(console.log);
+await import("./page-b.js").then(console.log);
+await import("./page-a.js").then(console.log);
 //#endregion
 
 ```
@@ -104,14 +104,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -132,14 +124,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 
@@ -179,24 +163,16 @@ export { y as n, init_constants as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-b2.js").then(console.log);
-		await import("./page-a2.js").then(console.log);
+		await import("./page-b.js").then(console.log);
+		await import("./page-a.js").then(console.log);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -217,14 +193,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -245,14 +213,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_namespace_member/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.js
-await import("./page-b2.js").then(console.log);
-await import("./page-a2.js").then(console.log);
+await import("./page-b.js").then(console.log);
+await import("./page-a.js").then(console.log);
 //#endregion
 
 ```
@@ -41,14 +41,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -69,14 +61,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-## page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 
@@ -97,24 +81,16 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-b2.js").then(console.log);
-		await import("./page-a2.js").then(console.log);
+		await import("./page-b.js").then(console.log);
+		await import("./page-a.js").then(console.log);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -146,14 +122,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -174,14 +142,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_barrel_reexport/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.js
-await import("./page-b2.js").then(console.log);
-await import("./page-a2.js").then(console.log);
+await import("./page-b.js").then(console.log);
+await import("./page-a.js").then(console.log);
 //#endregion
 
 ```
@@ -41,14 +41,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -69,14 +61,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-## page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 
@@ -97,24 +81,16 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-b2.js").then(console.log);
-		await import("./page-a2.js").then(console.log);
+		await import("./page-b.js").then(console.log);
+		await import("./page-a.js").then(console.log);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -146,14 +122,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -174,14 +142,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "b.js's only dynamic import of t.js is a top-level pure dynamic import with an unused result, so tree shaking drops the dynamic entry and the finalizer emits an inert `Promise.resolve().then(...)` stub - the emitted code can never load t.js's chunk through it. t.js stays included because entry e uses it statically, so it shares e's chunk. A dead record must not count as a dynamic-import load of e's chunk, so e keeps its inline trigger and no facade is emitted.",
+  "configName": "wrap-all",
+  "config": {
+    "input": [
+      { "name": "b", "import": "./b.js" },
+      { "name": "e", "import": "./e.js" }
+    ],
+    "strictExecutionOrder": true,
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  },
+  "configVariants": [{ "_configName": "on-demand", "onDemandWrapping": true }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/artifacts.snap
@@ -1,0 +1,78 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## b.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+function init_b() {
+	return (init_b = __esmMin((() => {
+		Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+		console.log("B");
+	})))();
+}
+//#endregion
+init_b();
+
+```
+
+## e.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region t.js
+var t;
+function init_t() {
+	return (init_t = __esmMin((() => {
+		t = String(globalThis.__t ?? "t");
+	})))();
+}
+//#endregion
+//#region e.js
+function init_e() {
+	return (init_e = __esmMin((() => {
+		init_t();
+		console.log("E", t);
+	})))();
+}
+//#endregion
+init_e();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### b.js
+
+```js
+//#region b.js
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+console.log("B");
+//#endregion
+
+```
+
+### e.js
+
+```js
+//#region t.js
+const t = String(globalThis.__t ?? "t");
+//#endregion
+//#region e.js
+console.log("E", t);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/b.js
@@ -1,0 +1,3 @@
+import('./t.js');
+
+console.log('B');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/e.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/e.js
@@ -1,0 +1,3 @@
+import { t } from './t.js';
+
+console.log('E', t);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/t.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_dynamic_target_in_entry_chunk/t.js
@@ -1,0 +1,1 @@
+export const t = String(globalThis.__t ?? 't');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region main.js
 await import("./page-b2.js");
-const pageA = await import("./page-a2.js");
+const pageA = await import("./page-a.js");
 console.log(pageA.common, pageA._);
 //#endregion
 
@@ -17,6 +17,7 @@ console.log(pageA.common, pageA._);
 ## page-a.js
 
 ```js
+import "./page-b.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region common.js
@@ -39,15 +40,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common as i, _ as n, common as r, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { n as _, r as common, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { _, common };
 
@@ -97,26 +89,18 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var pageA;
 function init_main() {
 	return (init_main = __esmMin((async () => {
 		await import("./page-b2.js");
-		pageA = await import("./page-a2.js");
+		pageA = await import("./page-a.js");
 		console.log(pageA.common, pageA._);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -146,15 +130,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common as i, _ as n, common as r, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as _, r as common, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { _, common };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_fanout/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region main.js
 await import("./page-b2.js");
-const pageA = await import("./page-a2.js");
+const pageA = await import("./page-a.js");
 console.log(pageA.commonA, pageA.commonB);
 //#endregion
 
@@ -17,6 +17,7 @@ console.log(pageA.commonA, pageA.commonB);
 ## page-a.js
 
 ```js
+import "./page-b.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region common-a.js
@@ -51,15 +52,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common_a as a, commonA as i, commonB as n, init_common_b as r, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { i as commonA, n as commonB, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { commonA, commonB };
 
@@ -110,26 +102,18 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var pageA;
 function init_main() {
 	return (init_main = __esmMin((async () => {
 		await import("./page-b2.js");
-		pageA = await import("./page-a2.js");
+		pageA = await import("./page-a.js");
 		console.log(pageA.commonA, pageA.commonB);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -171,15 +155,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common_a as a, commonA as i, commonB as n, init_common_b as r, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { i as commonA, n as commonB, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { commonA, commonB };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_entry_retained_star_named/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region main.js
 await import("./page-b2.js");
-const pageA = await import("./page-a2.js");
+const pageA = await import("./page-a.js");
 console.log(pageA.common, pageA._);
 //#endregion
 
@@ -17,6 +17,7 @@ console.log(pageA.common, pageA._);
 ## page-a.js
 
 ```js
+import "./page-b.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
 //#region common.js
@@ -39,15 +40,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common as i, _ as n, common as r, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { n as _, r as common, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { _, common };
 
@@ -97,26 +89,18 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var pageA;
 function init_main() {
 	return (init_main = __esmMin((async () => {
 		await import("./page-b2.js");
-		pageA = await import("./page-a2.js");
+		pageA = await import("./page-a.js");
 		console.log(pageA.common, pageA._);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -146,15 +130,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_common as i, _ as n, common as r, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as _, r as common, t as init_page_a } from "./page-a.js";
-import "./page-b.js";
 init_page_a();
 export { _, common };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_nested_barrel_definer/artifacts.snap
@@ -76,14 +76,6 @@ function init_dynamic_page() {
 	})))();
 }
 //#endregion
-export { init_reader_host as n, init_dynamic_page as t };
-
-```
-
-## dynamic-page2.js
-
-```js
-import { t as init_dynamic_page } from "./dynamic-page.js";
 init_dynamic_page();
 
 ```
@@ -91,19 +83,10 @@ init_dynamic_page();
 ## main.js
 
 ```js
-import { n as loadPage, t as init_main } from "./main2.js";
-init_main();
-export { loadPage };
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function loadPage() {
-	return import("./dynamic-page2.js");
+	return import("./dynamic-page.js");
 }
 function init_main() {
 	return (init_main = __esmMin((() => {
@@ -111,7 +94,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { loadPage as n, init_main as t };
+init_main();
+export { loadPage };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dynamic_target_in_entry_chunk/artifacts.snap
@@ -34,21 +34,13 @@ export { require_a as n, require_b as t };
 ## c.js
 
 ```js
-import { t as require_c } from "./c2.js";
-export default require_c();
-
-```
-
-## c2.js
-
-```js
 import { n as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
 //#region c.js
 var require_c = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.load = () => import("./b.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
 }));
 //#endregion
-export { require_c as t };
+export default require_c();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/eager_read_nested_in_pure_expression/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/eager_read_nested_in_pure_expression/artifacts.snap
@@ -21,14 +21,6 @@ To fix:
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as value, t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region patch.js
@@ -42,7 +34,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -92,14 +84,6 @@ To fix:
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as value, t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region patch.js
@@ -118,7 +102,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_patch as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_eager_reexport_overlay/artifacts.snap
@@ -68,16 +68,6 @@ export { pv as n, init_eagerhaz as r, init_definer as t };
 ## main.js
 
 ```js
-import "./a.js";
-import "./b.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as marker } from "./a.js";
 import { n as pv, r as init_eagerhaz, t as init_definer } from "./b.js";
@@ -103,7 +93,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 
@@ -184,16 +174,6 @@ export { pv as n, init_eagerhaz as r, init_definer as t };
 ### main.js
 
 ```js
-import "./a.js";
-import "./b.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as marker } from "./a.js";
 import { n as pv, r as init_eagerhaz, t as init_definer } from "./b.js";
@@ -219,7 +199,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_excluded_forwarder_import/artifacts.snap
@@ -68,16 +68,6 @@ export { tv as n, init_eagerhaz as r, init_t as t };
 ## main.js
 
 ```js
-import "./a.js";
-import "./c.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as wv, t as init_wrapper } from "./a.js";
 import { n as tv, r as init_eagerhaz, t as init_t } from "./c.js";
@@ -104,7 +94,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 
@@ -185,16 +175,6 @@ export { tv as n, init_eagerhaz as r, init_t as t };
 ### main.js
 
 ```js
-import "./a.js";
-import "./c.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as wv, t as init_wrapper } from "./a.js";
 import { n as tv, r as init_eagerhaz, t as init_t } from "./c.js";
@@ -221,7 +201,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_cycle_partial_forwarder/artifacts.snap
@@ -79,16 +79,6 @@ export { init_eagerhaz as a, pv as i, init_definer_b as n, init_definer as r, bv
 ## main.js
 
 ```js
-import "./a.js";
-import "./b.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as marker } from "./a.js";
 import { a as init_eagerhaz, i as pv, n as init_definer_b, r as init_definer, t as bv } from "./b.js";
@@ -116,7 +106,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 
@@ -208,16 +198,6 @@ export { init_eagerhaz as a, pv as i, init_definer_b as n, init_definer as r, bv
 ### main.js
 
 ```js
-import "./a.js";
-import "./b.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_a_first, n as marker } from "./a.js";
 import { a as init_eagerhaz, i as pv, n as init_definer_b, r as init_definer, t as bv } from "./b.js";
@@ -245,7 +225,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/emergent_init_cycle_eager_interop/artifacts.snap
@@ -35,16 +35,6 @@ export { pv as n, init_eagerhaz as r, init_pure as t };
 ## main.js
 
 ```js
-import "./s.js";
-import "./h.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_s_first, n as init_barrel, t as bmark } from "./s.js";
 import { n as pv, r as init_eagerhaz } from "./h.js";
@@ -70,7 +60,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 
@@ -153,16 +143,6 @@ export { pv as n, init_eagerhaz as r, init_pure as t };
 ### main.js
 
 ```js
-import "./s.js";
-import "./h.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { i as init_s_first, n as init_barrel, t as bmark } from "./s.js";
 import { n as pv, r as init_eagerhaz } from "./h.js";
@@ -188,7 +168,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_e_first as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade/artifacts.snap
@@ -6,18 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import "./reader.js";
-import { t as init_main } from "./main2.js";
-export * from "external";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
+export * from "external";
 //#region setup.js
 globalThis.setupValue = "ready";
 //#endregion
@@ -28,7 +19,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -62,18 +53,9 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import "./reader.js";
-import { t as init_main } from "./main2.js";
-export * from "external";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
+export * from "external";
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -89,7 +71,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_external_reexport_facade_attributes/artifacts.snap
@@ -6,18 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import "./reader.js";
-import { t as init_main } from "./main2.js";
-export * from "external" with { type: "json" };
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
+export * from "external" with { type: "json" };
 //#region setup.js
 globalThis.setupValue = "ready";
 //#endregion
@@ -28,7 +19,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -62,18 +53,9 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import "./reader.js";
-import { t as init_main } from "./main2.js";
-export * from "external" with { type: "json" };
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
+export * from "external" with { type: "json" };
 //#region setup.js
 function init_setup() {
 	return (init_setup = __esmMin((() => {
@@ -89,7 +71,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_fn_captures_wrapped_value/artifacts.snap
@@ -6,14 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as init_facade, t as getPref } from "./pref.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region first.js
@@ -45,7 +37,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_first as n, init_main as t };
+init_main();
 
 ```
 
@@ -91,14 +83,6 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as init_facade, t as getPref } from "./pref.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region first.js
@@ -125,7 +109,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/_config.json
@@ -1,0 +1,19 @@
+{
+  "configName": "wrap-all",
+  "config": {
+    "input": [
+      { "name": "b", "import": "./b.js" },
+      { "name": "e", "import": "./e.js" }
+    ],
+    "strictExecutionOrder": true,
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "e-group",
+          "test": "[\\\\/]entry_shared_chunk_facade[\\\\/](?:e|shared)\\.js$"
+        }
+      ]
+    }
+  },
+  "configVariants": [{ "_configName": "on-demand", "onDemandWrapping": true }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+
+globalThis.events = [];
+await import('./dist/b.js');
+
+assert.deepStrictEqual(
+  globalThis.events,
+  ['S body', 'B body S'],
+  'entry `e` shares a chunk with `shared.js`, so loading it for `b` must not run `e`',
+);
+
+await import('./dist/e.js');
+assert.deepStrictEqual(
+  globalThis.events,
+  ['S body', 'B body S', 'E body'],
+  'entry `e` runs its program when it is entered',
+);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/artifacts.snap
@@ -1,0 +1,122 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## b.js
+
+```js
+import { n as init_shared, r as s } from "./e2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_shared();
+		globalThis.events.push("B body " + s);
+	})))();
+}
+//#endregion
+init_b();
+
+```
+
+## e.js
+
+```js
+import { t as init_e } from "./e2.js";
+init_e();
+
+```
+
+## e2.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
+var s;
+function init_shared() {
+	return (init_shared = __esmMin((() => {
+		globalThis.events.push("S body");
+		s = String(globalThis.__s ?? "S");
+	})))();
+}
+//#endregion
+//#region e.js
+function init_e() {
+	return (init_e = __esmMin((() => {
+		globalThis.events.push("E body");
+	})))();
+}
+//#endregion
+export { init_shared as n, s as r, init_e as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### b.js
+
+```js
+import { n as init_shared, r as s } from "./e2.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region b.js
+function init_b() {
+	return (init_b = __esmMin((() => {
+		init_shared();
+		globalThis.events.push("B body " + s);
+	})))();
+}
+//#endregion
+init_b();
+
+```
+
+### e.js
+
+```js
+import { t as init_e } from "./e2.js";
+init_e();
+
+```
+
+### e2.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region shared.js
+var s;
+function init_shared() {
+	return (init_shared = __esmMin((() => {
+		globalThis.events.push("S body");
+		s = String(globalThis.__s ?? "S");
+	})))();
+}
+//#endregion
+//#region e.js
+function init_e() {
+	return (init_e = __esmMin((() => {
+		globalThis.events.push("E body");
+	})))();
+}
+//#endregion
+export { init_shared as n, s as r, init_e as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/b.js
@@ -1,0 +1,3 @@
+import { s } from './shared.js';
+
+globalThis.events.push('B body ' + s);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/e.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/e.js
@@ -1,0 +1,1 @@
+globalThis.events.push('E body');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/shared.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/entry_shared_chunk_facade/shared.js
@@ -1,0 +1,3 @@
+globalThis.events.push('S body');
+
+export const s = String(globalThis.__s ?? 'S');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/artifacts.snap
@@ -49,14 +49,6 @@ function init_lazy_chunk() {
 	})))();
 }
 //#endregion
-export { init_lazy_chunk as t };
-
-```
-
-### lazy-chunk2.js
-
-```js
-import { t as init_lazy_chunk } from "./lazy-chunk.js";
 init_lazy_chunk();
 
 ```
@@ -82,7 +74,7 @@ function init_polyfill() {
 //#endregion
 //#region user-lib.js
 async function foo() {
-	return import("./lazy-chunk2.js");
+	return import("./lazy-chunk.js");
 }
 function init_user_lib() {
 	return (init_user_lib = __esmMin((() => {
@@ -128,14 +120,6 @@ function init_lazy_chunk() {
 	})))();
 }
 //#endregion
-export { init_lazy_chunk as t };
-
-```
-
-### lazy-chunk2.js
-
-```js
-import { t as init_lazy_chunk } from "./lazy-chunk.js";
 init_lazy_chunk();
 
 ```
@@ -161,7 +145,7 @@ function init_polyfill() {
 //#endregion
 //#region user-lib.js
 async function foo() {
-	return import("./lazy-chunk2.js");
+	return import("./lazy-chunk.js");
 }
 function init_user_lib() {
 	return (init_user_lib = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/artifacts.snap
@@ -39,15 +39,6 @@ global.foo.log();
 ### entry1.js
 
 ```js
-import "./run-dep.js";
-import { t as init_entry1 } from "./entry12.js";
-init_entry1();
-
-```
-
-### entry12.js
-
-```js
 import { t as init_run_dep } from "./run-dep.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region init-dep-1.js
@@ -65,20 +56,11 @@ function init_entry1() {
 	})))();
 }
 //#endregion
-export { init_init_dep_1 as n, init_entry1 as t };
+init_entry1();
 
 ```
 
 ### entry2.js
-
-```js
-import "./run-dep.js";
-import { t as init_entry2 } from "./entry22.js";
-init_entry2();
-
-```
-
-### entry22.js
 
 ```js
 import { t as init_run_dep } from "./run-dep.js";
@@ -98,7 +80,7 @@ function init_entry2() {
 	})))();
 }
 //#endregion
-export { init_init_dep_2 as n, init_entry2 as t };
+init_entry2();
 
 ```
 
@@ -132,15 +114,6 @@ export { init_run_dep as t };
 ### entry1.js
 
 ```js
-import "./run-dep.js";
-import { t as init_entry1 } from "./entry12.js";
-init_entry1();
-
-```
-
-### entry12.js
-
-```js
 import { t as init_run_dep } from "./run-dep.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region init-dep-1.js
@@ -153,20 +126,11 @@ function init_entry1() {
 	})))();
 }
 //#endregion
-export { init_entry1 as t };
+init_entry1();
 
 ```
 
 ### entry2.js
-
-```js
-import "./run-dep.js";
-import { t as init_entry2 } from "./entry22.js";
-init_entry2();
-
-```
-
-### entry22.js
 
 ```js
 import { t as init_run_dep } from "./run-dep.js";
@@ -181,7 +145,7 @@ function init_entry2() {
 	})))();
 }
 //#endregion
-export { init_entry2 as t };
+init_entry2();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_interop_entry_facade/artifacts.snap
@@ -69,14 +69,6 @@ export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 ### a.js
 
 ```js
-import { t as init_a } from "./a2.js";
-init_a();
-
-```
-
-### a2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { n as init_e } from "./e2.js";
 //#region a.js
@@ -87,19 +79,11 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { init_a as t };
+init_a();
 
 ```
 
 ### b.js
-
-```js
-import { t as require_b } from "./b2.js";
-export default require_b();
-
-```
-
-### b2.js
 
 ```js
 import { t as __commonJSMin } from "./rolldown-runtime.js";
@@ -110,7 +94,7 @@ var require_b = /* @__PURE__ */ __commonJSMin((() => {
 	console.log("B");
 }));
 //#endregion
-export { require_b as t };
+export default require_b();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -38,14 +38,6 @@ nodeAssert.equal("foo", "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
@@ -64,6 +56,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -22,14 +22,6 @@ nodeAssert.equal("foo", "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
@@ -48,6 +40,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -38,14 +38,6 @@ nodeAssert.equal("foo", "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib-foo.js
@@ -64,6 +56,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -26,15 +26,6 @@ export { inner_exports as star };
 ### main.js
 
 ```js
-import { n as init_inner, r as inner_exports, t as init_main } from "./main2.js";
-
-init_main();
-export { inner_exports as star };
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region leaf.js
 var foo;
@@ -63,5 +54,6 @@ function init_main() {
 }
 
 //#endregion
-export { init_inner as n, inner_exports as r, init_main as t };
+init_main();
+export { inner_exports as star };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/external_builtin_in_wrapped_module/artifacts.snap
@@ -24,15 +24,6 @@ export { out };
 ### main.js
 
 ```js
-import { n as out, t as init_main } from "./main2.js";
-init_main();
-export { out };
-
-```
-
-### main2.js
-
-```js
 import { sep } from "node:path";
 // HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
@@ -53,7 +44,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { out as n, init_main as t };
+init_main();
+export { out };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/internal_wrapped_entry_order/artifacts.snap
@@ -108,14 +108,6 @@ export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 ### e1.js
 
 ```js
-import { t as require_e1 } from "./e12.js";
-export default require_e1();
-
-```
-
-### e12.js
-
-```js
 import { t as __commonJSMin } from "./rolldown-runtime.js";
 import { t as require_m5 } from "./m5.js";
 import { t as init_m2 } from "./m22.js";
@@ -126,19 +118,11 @@ var require_e1 = /* @__PURE__ */ __commonJSMin((() => {
 	globalThis.__entryInteropOrder.push("e1");
 }));
 //#endregion
-export { require_e1 as t };
+export default require_e1();
 
 ```
 
 ### e2.js
-
-```js
-import { t as require_e2 } from "./e22.js";
-export default require_e2();
-
-```
-
-### e22.js
 
 ```js
 import { t as __commonJSMin } from "./rolldown-runtime.js";
@@ -149,7 +133,7 @@ var require_e2 = /* @__PURE__ */ __commonJSMin((() => {
 	globalThis.__entryInteropOrder.push("e2");
 }));
 //#endregion
-export { require_e2 as t };
+export default require_e2();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/interop_trigger_host_transfer/artifacts.snap
@@ -56,14 +56,6 @@ export { init_m3 as t };
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { t as init_s } from "./s.js";
 import { t as init_m3 } from "./m32.js";
@@ -84,7 +76,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_m1 as n, init_main as t };
+init_main();
 
 ```
 
@@ -117,14 +109,6 @@ export { s_exports as n, init_s as t };
 ### b.js
 
 ```js
-import { t as require_b } from "./b2.js";
-export default require_b();
-
-```
-
-### b2.js
-
-```js
 import { t as __commonJSMin } from "./rolldown-runtime.js";
 import { t as init_s } from "./s.js";
 //#region b.cjs
@@ -133,7 +117,7 @@ var require_b = /* @__PURE__ */ __commonJSMin((() => {
 	console.log("B");
 }));
 //#endregion
-export { require_b as t };
+export default require_b();
 
 ```
 
@@ -175,14 +159,6 @@ export { init_m3 as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { t as init_s } from "./s.js";
 import { t as init_m3 } from "./m32.js";
@@ -203,7 +179,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_m1 as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -38,14 +38,6 @@ nodeAssert.strictEqual(import_foo.value, "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 __rolldown_runtime__.registerGraph({
@@ -72,6 +64,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -16,14 +16,6 @@ function init_dynamic() {
 	})))();
 }
 //#endregion
-export { init_dynamic as t };
-
-```
-
-## dynamic2.js
-
-```js
-import { t as init_dynamic } from "./dynamic.js";
 init_dynamic();
 
 ```
@@ -70,7 +62,7 @@ function init_main() {
 		init_read();
 		setup();
 		read();
-		import("./dynamic2.js");
+		import("./dynamic.js");
 		nodeAssert.strictEqual(globalThis.foo, "foo");
 	})))();
 }
@@ -104,14 +96,6 @@ function init_dynamic() {
 	})))();
 }
 //#endregion
-export { init_dynamic as t };
-
-```
-
-### dynamic2.js
-
-```js
-import { t as init_dynamic } from "./dynamic.js";
 init_dynamic();
 
 ```
@@ -158,7 +142,7 @@ function init_main() {
 		init_read();
 		setup();
 		read();
-		import("./dynamic2.js");
+		import("./dynamic.js");
 		nodeAssert.strictEqual(globalThis.foo, "foo");
 	})))();
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -6,14 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -37,7 +29,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_dep_b as n, init_main as t };
+init_main();
 
 ```
 
@@ -48,14 +40,6 @@ export { init_dep_b as n, init_main as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region dep-a.js
 var require_dep_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -79,6 +63,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_dep_b as n, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -27,15 +27,6 @@ export { dep_default as dep };
 ### main.js
 
 ```js
-import { n as dep_default, t as init_main } from "./main2.js";
-init_main();
-export { dep_default as dep };
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
@@ -57,6 +48,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { dep_default as n, init_dep as r, init_main as t };
+init_main();
+export { dep_default as dep };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
@@ -6,15 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import "./test.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as init_foo } from "./test.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region setup.js
@@ -27,7 +18,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -71,15 +62,6 @@ export { init_foo as t };
 ### main.js
 
 ```js
-import "./test.js";
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as init_foo } from "./test.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region setup.js
@@ -97,7 +79,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -29,15 +29,6 @@ export { Foo, fooClasses, getFooUtilityClass };
 ### main.js
 
 ```js
-import { a as getFooUtilityClass, i as fooClasses, n as Foo, t as init_main } from "./main2.js";
-init_main();
-export { Foo, fooClasses, getFooUtilityClass };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region components/Foo/fooClasses.js
 function getFooUtilityClass(slot) {
@@ -70,6 +61,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { getFooUtilityClass as a, fooClasses as i, Foo as n, init_fooClasses as o, init_Foo as r, init_main as t };
+init_main();
+export { Foo, fooClasses, getFooUtilityClass };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8910/artifacts.snap
@@ -70,22 +70,13 @@ export { __esmMin as n, __exportAll as r, __commonJSMin as t };
 import { n as __esmMin } from "./rolldown-runtime.js";
 //#region node0.js
 var node_0;
-var init_node0 = __esmMin((() => {
+//#endregion
+__esmMin((() => {
 	globalThis.__acyclic_output_fuzz_0 = 0;
 	import("./node12.js").then((n) => (n.n(), n.r));
 	node_0 = {};
 	node_0.value = 0;
-}));
-//#endregion
-export { node_0 as n, init_node0 as t };
-
-```
-
-### node02.js
-
-```js
-import { t as init_node0 } from "./node0.js";
-init_node0();
+}))();
 
 ```
 
@@ -106,7 +97,7 @@ var node2_exports = /* @__PURE__ */ __exportAll({ node_2: () => node_2 });
 var node_2;
 var init_node2 = __esmMin((() => {
 	globalThis.__acyclic_output_fuzz_2 = 2;
-	import("./node02.js");
+	import("./node0.js");
 	node_2 = {};
 	node_2.value = 2;
 }));

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_ambiguous_star_reexports/artifacts.snap
@@ -6,24 +6,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-b2.js");
-		await import("./page-a2.js");
+		await import("./page-b.js");
+		await import("./page-a.js");
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -68,14 +60,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { t as init_page_a } from "./page-a.js";
 init_page_a();
 
 ```
@@ -104,14 +88,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { init_page_b as t };
-
-```
-
-## page-b2.js
-
-```js
-import { t as init_page_b } from "./page-b.js";
 init_page_b();
 
 ```
@@ -132,8 +108,8 @@ export { __exportAll as n, __esmMin as t };
 
 ```js
 //#region main.js
-await import("./page-b2.js");
-await import("./page-a2.js");
+await import("./page-b.js");
+await import("./page-a.js");
 //#endregion
 
 ```
@@ -179,14 +155,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { t as init_page_a } from "./page-a.js";
 init_page_a();
 
 ```
@@ -211,14 +179,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { t as init_page_b } from "./page-b.js";
 init_page_b();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
@@ -6,24 +6,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-b2.js");
-		await import("./page-a2.js");
+		await import("./page-b.js");
+		await import("./page-a.js");
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -68,14 +60,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { t as init_page_a } from "./page-a.js";
 init_page_a();
 
 ```
@@ -104,14 +88,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { init_page_b as t };
-
-```
-
-## page-b2.js
-
-```js
-import { t as init_page_b } from "./page-b.js";
 init_page_b();
 
 ```
@@ -132,8 +108,8 @@ export { __exportAll as n, __esmMin as t };
 
 ```js
 //#region main.js
-await import("./page-b2.js");
-await import("./page-a2.js");
+await import("./page-b.js");
+await import("./page-a.js");
 //#endregion
 
 ```
@@ -179,14 +155,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { t as init_page_a } from "./page-a.js";
 init_page_a();
 
 ```
@@ -211,14 +179,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { t as init_page_b } from "./page-b.js";
 init_page_b();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_pure_reexport_barrel/artifacts.snap
@@ -104,14 +104,6 @@ function init_dynamic_page() {
 	})))();
 }
 //#endregion
-export { getScale as n, init_reader as r, init_dynamic_page as t };
-
-```
-
-## dynamic-page2.js
-
-```js
-import { n as getScale, t as init_dynamic_page } from "./dynamic-page.js";
 init_dynamic_page();
 export { getScale };
 
@@ -120,19 +112,10 @@ export { getScale };
 ## main.js
 
 ```js
-import { n as loadPage, t as init_main } from "./main2.js";
-init_main();
-export { loadPage };
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function loadPage() {
-	return import("./dynamic-page2.js");
+	return import("./dynamic-page.js");
 }
 function init_main() {
 	return (init_main = __esmMin((() => {
@@ -140,7 +123,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { loadPage as n, init_main as t };
+init_main();
+export { loadPage };
 
 ```
 
@@ -257,14 +241,6 @@ function init_dynamic_page() {
 	})))();
 }
 //#endregion
-export { getScale as n, init_reader as r, init_dynamic_page as t };
-
-```
-
-### dynamic-page2.js
-
-```js
-import { n as getScale, t as init_dynamic_page } from "./dynamic-page.js";
 init_dynamic_page();
 export { getScale };
 
@@ -276,7 +252,7 @@ export { getScale };
 //#region main.js
 (globalThis.__events ??= []).push("main");
 function loadPage() {
-	return import("./dynamic-page2.js");
+	return import("./dynamic-page.js");
 }
 //#endregion
 export { loadPage };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
@@ -28,14 +28,6 @@ export { require_dynamic as t };
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as require_dynamic } from "./dynamic2.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { strictEqual } from "node:assert";
@@ -75,7 +67,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -116,14 +108,6 @@ export { require_dynamic as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as require_dynamic } from "./dynamic2.js";
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { strictEqual } from "node:assert";
@@ -163,7 +147,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/package_barrel_plain_reexport/artifacts.snap
@@ -112,14 +112,6 @@ function init_dynamic_page() {
 	})))();
 }
 //#endregion
-export { init_reader as n, render as r, init_dynamic_page as t };
-
-```
-
-## dynamic-page2.js
-
-```js
-import { r as render, t as init_dynamic_page } from "./dynamic-page.js";
 init_dynamic_page();
 export { render };
 
@@ -128,19 +120,10 @@ export { render };
 ## main.js
 
 ```js
-import { n as loadPage, t as init_main } from "./main2.js";
-init_main();
-export { loadPage };
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function loadPage() {
-	return import("./dynamic-page2.js");
+	return import("./dynamic-page.js");
 }
 function init_main() {
 	return (init_main = __esmMin((() => {
@@ -148,7 +131,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { loadPage as n, init_main as t };
+init_main();
+export { loadPage };
 
 ```
 
@@ -273,14 +257,6 @@ function init_dynamic_page() {
 	})))();
 }
 //#endregion
-export { init_reader as n, render as r, init_dynamic_page as t };
-
-```
-
-### dynamic-page2.js
-
-```js
-import { r as render, t as init_dynamic_page } from "./dynamic-page.js";
 init_dynamic_page();
 export { render };
 
@@ -292,7 +268,7 @@ export { render };
 //#region main.js
 (globalThis.__events ??= []).push("main");
 function loadPage() {
-	return import("./dynamic-page2.js");
+	return import("./dynamic-page.js");
 }
 //#endregion
 export { loadPage };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
@@ -29,14 +29,6 @@ assert.strictEqual(dep_default, "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
@@ -66,6 +58,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_setup as n, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_delegated_breadth_nested_barrels/artifacts.snap
@@ -64,15 +64,6 @@ export { vDef as n, outer_exports as t };
 ### a.js
 
 ```js
-import { n as init_a, r as nsObject, t as defValue } from "./a2.js";
-init_a();
-export { defValue, nsObject };
-
-```
-
-### a2.js
-
-```js
 import { i as vDef, n as outer_exports, t as init_outer } from "./outer.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
@@ -86,20 +77,12 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { init_a as n, nsObject as r, defValue as t };
+init_a();
+export { defValue, nsObject };
 
 ```
 
 ### b.js
-
-```js
-import { n as sharedDef, t as init_b } from "./b2.js";
-init_b();
-export { sharedDef };
-
-```
-
-### b2.js
 
 ```js
 import { i as vDef, t as init_outer } from "./outer.js";
@@ -114,7 +97,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { sharedDef as n, init_b as t };
+init_b();
+export { sharedDef };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_nested_star_barrel_split_readers/artifacts.snap
@@ -58,15 +58,6 @@ export { vDef as n, outer_barrel_exports as t };
 ### a.js
 
 ```js
-import { n as init_a, t as defValue } from "./a2.js";
-init_a();
-export { defValue };
-
-```
-
-### a2.js
-
-```js
 import { i as vDef, t as init_outer_barrel } from "./outer-barrel.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
@@ -79,20 +70,12 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { init_a as n, defValue as t };
+init_a();
+export { defValue };
 
 ```
 
 ### b.js
-
-```js
-import { n as loaded, t as init_b } from "./b2.js";
-init_b();
-export { loaded };
-
-```
-
-### b2.js
 
 ```js
 import { n as outer_barrel_exports, t as init_outer_barrel } from "./outer-barrel.js";
@@ -107,7 +90,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { loaded as n, init_b as t };
+init_b();
+export { loaded };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_opaque_and_resolved_reads/artifacts.snap
@@ -62,15 +62,6 @@ export { vDef as n, barrel_exports as t };
 ### a.js
 
 ```js
-import { n as init_a, r as nsObject, t as defValue } from "./a2.js";
-init_a();
-export { defValue, nsObject };
-
-```
-
-### a2.js
-
-```js
 import { i as vDef, n as init_barrel, t as barrel_exports } from "./barrel.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
@@ -84,20 +75,12 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { init_a as n, nsObject as r, defValue as t };
+init_a();
+export { defValue, nsObject };
 
 ```
 
 ### b.js
-
-```js
-import { n as sharedDef, t as init_b } from "./b2.js";
-init_b();
-export { sharedDef };
-
-```
-
-### b2.js
 
 ```js
 import { i as vDef, n as init_barrel } from "./barrel.js";
@@ -112,7 +95,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { sharedDef as n, init_b as t };
+init_b();
+export { sharedDef };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_definer_star_barrel_split_readers/artifacts.snap
@@ -45,15 +45,6 @@ export { init_a as n, init_definer as r, defValue as t };
 ## b.js
 
 ```js
-import { n as sibValue, t as init_b } from "./b2.js";
-init_b();
-export { sibValue };
-
-```
-
-## b2.js
-
-```js
 import { r as vSib, t as init_barrel } from "./barrel.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region b.js
@@ -66,7 +57,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { sibValue as n, init_b as t };
+init_b();
+export { sibValue };
 
 ```
 
@@ -150,15 +142,6 @@ export { init_a as n, init_definer as r, defValue as t };
 ### b.js
 
 ```js
-import { n as sibValue, t as init_b } from "./b2.js";
-init_b();
-export { sibValue };
-
-```
-
-### b2.js
-
-```js
 import { r as vSib, t as init_barrel } from "./barrel.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region b.js
@@ -171,7 +154,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { sibValue as n, init_b as t };
+init_b();
+export { sibValue };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/react-like/artifacts.snap
@@ -43,14 +43,6 @@ assert.equal(test().toString(), "1");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region react.js
@@ -88,6 +80,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -34,14 +34,6 @@ nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should 
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region main.js
@@ -51,6 +43,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/retained_star_renamed_cycle/artifacts.snap
@@ -96,14 +96,6 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var pageA;
@@ -115,7 +107,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.js
-await import("./page-a2.js").then(console.log);
-await import("./page-b2.js").then(console.log);
+await import("./page-a.js").then(console.log);
+await import("./page-b.js").then(console.log);
 //#endregion
 
 ```
@@ -41,14 +41,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-## page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -67,14 +59,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-## page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 
@@ -95,24 +79,16 @@ export { __esmMin as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 function init_main() {
 	return (init_main = __esmMin((async () => {
-		await import("./page-a2.js").then(console.log);
-		await import("./page-b2.js").then(console.log);
+		await import("./page-a.js").then(console.log);
+		await import("./page-b.js").then(console.log);
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```
 
@@ -144,14 +120,6 @@ function init_page_a() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_a as t };
-
-```
-
-### page-a2.js
-
-```js
-import { n as render, t as init_page_a } from "./page-a.js";
 init_page_a();
 export { render };
 
@@ -170,14 +138,6 @@ function init_page_b() {
 	})))();
 }
 //#endregion
-export { render as n, init_page_b as t };
-
-```
-
-### page-b2.js
-
-```js
-import { n as render, t as init_page_b } from "./page-b.js";
 init_page_b();
 export { render };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/suffix_closure_gap/artifacts.snap
@@ -65,15 +65,6 @@ function init_dyn() {
 	})))();
 }
 //#endregion
-export { init_dyn as t };
-
-```
-
-### dyn2.js
-
-```js
-import "./main2.js";
-import { t as init_dyn } from "./dyn.js";
 init_dyn();
 
 ```
@@ -123,7 +114,7 @@ function init_main() {
 		init_setup();
 		init_intermediate();
 		setup();
-		import("./dyn2.js");
+		import("./dyn.js");
 	})))();
 }
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -22,14 +22,6 @@ console.log(123);
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-await init_main();
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region foo.js
 function init_foo() {
@@ -46,6 +38,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+await init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -16,11 +16,5 @@ async function e(){console.log(`foo`)}await e();
 ### main.js
 
 ```js
-import{t as e}from"./main2.js";await e();
-```
-
-### main2.js
-
-```js
-var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}function n(){return(n=e((async()=>{await t()})))()}export{n as t};
+var e=(e,t,n)=>()=>{if(n)throw n[0];try{return e&&(t=e(e=0)),t}catch(e){throw n=[e],e}};async function t(){console.log(`foo`)}function n(){return(n=e((async()=>{await t()})))()}await n();
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrap_all_wraps_hazard_free/artifacts.snap
@@ -6,14 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region dep.js
 function init_dep() {
@@ -30,7 +22,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/wrapped_entry_chunk_cycle/artifacts.snap
@@ -61,15 +61,6 @@ export { extend as n, init_shared as r, init_hub as t };
 ## main.js
 
 ```js
-import { n as init_main, t as go } from "./main2.js";
-init_main();
-export { go };
-
-```
-
-## main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { r as useDep } from "./dep.js";
 import { n as extend, t as init_hub } from "./hub2.js";
@@ -82,7 +73,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as n, go as t };
+init_main();
+export { go };
 
 ```
 
@@ -213,15 +205,6 @@ Object.defineProperty(exports, "init_shared", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_main = require("./main2.js");
-require_main.init_main();
-exports.go = require_main.go;
-
-```
-
-### main2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_dep = require("./dep.js");
 const require_hub = require("./hub2.js");
@@ -234,18 +217,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "go", {
-	enumerable: true,
-	get: function() {
-		return go;
-	}
-});
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.go = go;
 
 ```
 
@@ -393,15 +366,6 @@ Object.defineProperty(exports, "init_shared", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_main = require("./main2.js");
-require_main.init_main();
-exports.go = require_main.go;
-
-```
-
-### main2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_dep = require("./dep.js");
 const require_hub = require("./hub2.js");
@@ -414,18 +378,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "go", {
-	enumerable: true,
-	get: function() {
-		return go;
-	}
-});
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.go = go;
 
 ```
 
@@ -536,15 +490,6 @@ export { extend as n, init_shared as r, init_hub as t };
 ### main.js
 
 ```js
-import { n as init_main, t as go } from "./main2.js";
-init_main();
-export { go };
-
-```
-
-### main2.js
-
-```js
 import { n as __esmMin } from "./rolldown-runtime.js";
 import { r as useDep } from "./dep.js";
 import { n as extend, t as init_hub } from "./hub2.js";
@@ -557,7 +502,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as n, go as t };
+init_main();
+export { go };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/entry.js
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/entry.js
@@ -1,0 +1,7 @@
+import { a } from './lib.js';
+
+(globalThis.__events ??= []).push('entry ' + a);
+
+import('./lib.js').then((mod) => {
+  (globalThis.__events ??= []).push('lazy ' + mod.a);
+});

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/lib.js
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/lib.js
@@ -1,0 +1,3 @@
+import './probe.js';
+
+export const a = 123;

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/probe.js
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/late_split_revalidates_output_file/probe.js
@@ -1,0 +1,1 @@
+(globalThis.__events ??= []).push('probe');

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_dependency/artifacts.snap
@@ -6,15 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## e0.js
 
 ```js
-import "./gb.js";
-import { t as init_e0 } from "./e02.js";
-init_e0();
-
-```
-
-## e02.js
-
-```js
 import { r as init_m13 } from "./gb.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region e0.js
@@ -27,7 +18,7 @@ function init_e0() {
 	})))();
 }
 //#endregion
-export { init_e0 as t };
+init_e0();
 
 ```
 
@@ -97,15 +88,6 @@ export { __esmMin as t };
 ### e0.js
 
 ```js
-import "./gb.js";
-import { t as init_e0 } from "./e02.js";
-init_e0();
-
-```
-
-### e02.js
-
-```js
 import { r as init_m13 } from "./gb.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region e0.js
@@ -118,7 +100,7 @@ function init_e0() {
 	})))();
 }
 //#endregion
-export { init_e0 as t };
+init_e0();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/m4_dynamic_facade_race/artifacts.snap
@@ -20,16 +20,6 @@ export { targetPromise };
 
 ```js
 if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
-import "./dyn.js";
-import { t as init_b } from "./b2.js";
-init_b();
-
-```
-
-## b2.js
-
-```js
-if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
 import { r as init_observer } from "./dyn.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region b.js
@@ -40,7 +30,7 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { init_b as t };
+init_b();
 
 ```
 
@@ -101,16 +91,6 @@ export { value };
 
 ```js
 if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
-import { n as targetPromise, t as init_a } from "./a2.js";
-init_a();
-export { targetPromise };
-
-```
-
-### a2.js
-
-```js
-if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
 var targetPromise;
@@ -122,21 +102,12 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { targetPromise as n, init_a as t };
+init_a();
+export { targetPromise };
 
 ```
 
 ### b.js
-
-```js
-if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
-import "./dyn.js";
-import { t as init_b } from "./b2.js";
-init_b();
-
-```
-
-### b2.js
 
 ```js
 if (import.meta.url.endsWith("/dyn.js")) queueMicrotask(() => (globalThis.events ??= []).push("checkpoint:" + Boolean(globalThis.ready)));
@@ -150,7 +121,7 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { init_b as t };
+init_b();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/strict_execution_order_invariants/mod.rs
@@ -497,20 +497,25 @@ async fn duplicate_emitted_entries_keep_order_wrapper_facades() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn late_order_wrapping_revalidates_output_file() {
-  let fixture_dir = format!("{FIXTURE_ROOT}/../experimental/strict_execution_order/issue_4782");
+  // `output.file` is first validated against the provisional chunk graph, so the shape that
+  // exercises the *re*-validation has to be single-chunk then and multi-chunk only after order
+  // lowering. Here the chunk optimizer merges the dynamically imported `lib.js` into the user
+  // entry's chunk, leaving one chunk; `restore_order_wrap_entry_facades` then revives `lib.js`'s
+  // facade because a chunk can host only one entry's top-level trigger.
+  //
+  // `lib.js` pulls in a side-effectful `probe.js`, which keeps its load closure order-sensitive.
+  // Without that the wrapper is skippable — the entry would never be wrapped, nothing would be
+  // restored, and the graph would stay single-chunk, testing nothing.
+  let fixture_dir = format!("{FIXTURE_ROOT}/late_split_revalidates_output_file");
   let mut bundler = Bundler::new(BundlerOptions {
     input: Some(vec![InputItem {
-      name: Some("main".to_string()),
-      import: "./main.js".to_string(),
+      name: Some("entry".to_string()),
+      import: "./entry.js".to_string(),
     }]),
     cwd: Some(fixture_dir.into()),
     file: Some("bundle.js".to_string()),
     format: Some(OutputFormat::Esm),
     strict_execution_order: Some(true),
-    experimental: Some(rolldown_common::ExperimentalOptions {
-      on_demand_wrapping: Some(true),
-      ..Default::default()
-    }),
     ..Default::default()
   })
   .expect("failed to create bundler");

--- a/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10013/artifacts.snap
@@ -40,22 +40,6 @@ export { other as t };
 ### a.js
 
 ```js
-import { t as init_entry_a } from "./entry-a.js";
-init_entry_a();
-
-```
-
-### b.js
-
-```js
-import { t as init_entry_b } from "./entry-b.js";
-init_entry_b();
-
-```
-
-### entry-a.js
-
-```js
 import { n as other, t as init_helper } from "./helper.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region entry-a.js
@@ -66,11 +50,11 @@ function init_entry_a() {
 	})))();
 }
 //#endregion
-export { init_entry_a as t };
+init_entry_a();
 
 ```
 
-### entry-b.js
+### b.js
 
 ```js
 import { n as other, t as init_helper } from "./helper.js";
@@ -83,7 +67,7 @@ function init_entry_b() {
 	})))();
 }
 //#endregion
-export { init_entry_b as t };
+init_entry_b();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10048/artifacts.snap
@@ -34,15 +34,6 @@ export { getProjectAnnotations };
 ### entry.js
 
 ```js
-import { n as init_entry, t as getProjectAnnotations } from "./entry2.js";
-init_entry();
-export { getProjectAnnotations };
-
-```
-
-### entry2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region data.js
 var themes;
@@ -72,6 +63,7 @@ function init_entry() {
 	})))();
 }
 //#endregion
-export { init_entry as n, getProjectAnnotations as t };
+init_entry();
+export { getProjectAnnotations };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10259/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10259/artifacts.snap
@@ -6,15 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## admin.js
 
 ```js
-import "./apps~personal~admin~theming.js";
-import { t as init_admin } from "./admin2.js";
-init_admin();
-
-```
-
-## admin2.js
-
-```js
 import { n as init_app_admin } from "./apps~personal~admin~theming.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region admin.js
@@ -25,7 +16,7 @@ function init_admin() {
 	})))();
 }
 //#endregion
-export { init_admin as t };
+init_admin();
 
 ```
 
@@ -106,15 +97,6 @@ export { __esmMin as t };
 ## theming.js
 
 ```js
-import "./apps~personal~admin~theming.js";
-import { t as init_theming } from "./theming2.js";
-init_theming();
-
-```
-
-## theming2.js
-
-```js
 import { t as init_app_theming } from "./apps~personal~admin~theming.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region theming.js
@@ -125,7 +107,7 @@ function init_theming() {
 	})))();
 }
 //#endregion
-export { init_theming as t };
+init_theming();
 
 ```
 
@@ -134,15 +116,6 @@ export { init_theming as t };
 ## Assets
 
 ### admin.js
-
-```js
-import "./apps~personal~admin~theming.js";
-import { t as init_admin } from "./admin2.js";
-init_admin();
-
-```
-
-### admin2.js
 
 ```js
 import { n as init_app_admin } from "./apps~personal~admin~theming.js";
@@ -155,7 +128,7 @@ function init_admin() {
 	})))();
 }
 //#endregion
-export { init_admin as t };
+init_admin();
 
 ```
 
@@ -236,15 +209,6 @@ export { __esmMin as t };
 ### theming.js
 
 ```js
-import "./apps~personal~admin~theming.js";
-import { t as init_theming } from "./theming2.js";
-init_theming();
-
-```
-
-### theming2.js
-
-```js
 import { t as init_app_theming } from "./apps~personal~admin~theming.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region theming.js
@@ -255,6 +219,6 @@ function init_theming() {
 	})))();
 }
 //#endregion
-export { init_theming as t };
+init_theming();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10265/artifacts.snap
@@ -6,15 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { n as result, t as init_main } from "./main2.js";
-init_main();
-export { result };
-
-```
-
-## main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region b.js
 function getB() {
@@ -49,7 +40,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { result as n, init_main as t };
+init_main();
+export { result };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -40,14 +40,6 @@ export { init_first as n, value as r, first_exports as t };
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import { n as second_exports, t as init_second } from "./second.js";
 import { n as init_first, t as first_exports } from "./first.js";
@@ -60,7 +52,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 
@@ -132,14 +124,6 @@ export { init_first as n, value as r, first_exports as t };
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import { n as second_exports, t as init_second } from "./second.js";
 import { n as init_first, t as first_exports } from "./first.js";
@@ -152,7 +136,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -35,14 +35,6 @@ assert.strictEqual(1, 1);
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
@@ -77,6 +69,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_log as n, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7286/artifacts.snap
@@ -22,14 +22,6 @@ assert.strictEqual(foo, "foo");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region main.js
@@ -42,6 +34,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
@@ -19,14 +19,6 @@ console.log(42);
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region main.js
 function init_main() {
@@ -35,6 +27,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9083/artifacts.snap
@@ -64,15 +64,6 @@ export { manager };
 ### main.js
 
 ```js
-import { r as manager, t as init_main } from "./main2.js";
-await init_main();
-export { manager };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region deep.js
 function sleep(ms) {
@@ -116,6 +107,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_middle as n, manager as r, init_main as t };
+await init_main();
+export { manager };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9374/artifacts.snap
@@ -66,20 +66,10 @@ export { b };
 ### entry_a.js
 
 ```js
-import { n as init_entry_b, t as b } from "./entry_b2.js";
-import { n as init_entry_a, t as a } from "./entry_a2.js";
-
-export * from "external"
-
-init_entry_a();
-export { a, b };
-```
-
-### entry_a2.js
-
-```js
 import { n as __exportAll, r as __reExport, t as __esmMin } from "./rolldown-runtime.js";
 import { n as init_entry_b, t as b } from "./entry_b2.js";
+
+export * from "external"
 
 //#region entry_a.js
 var a;
@@ -91,7 +81,8 @@ function init_entry_a() {
 }
 
 //#endregion
-export { init_entry_a as n, a as t };
+init_entry_a();
+export { a, b };
 ```
 
 ### entry_b.js

--- a/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9806/artifacts.snap
@@ -50,14 +50,6 @@ nodeAssert.equal(import_other.default, "other-value");
 ### main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-### main2.js
-
-```js
 import nodeAssert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region pkg-barrel/other.cjs
@@ -81,6 +73,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9961/artifacts.snap
@@ -6,14 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { t as init_main } from "./main2.js";
-init_main();
-
-```
-
-## main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region core/setupWorker.js
 function setupWorker(handler) {
@@ -34,7 +26,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_main as t };
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/artifacts.snap
@@ -3,43 +3,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## _virtual/lazy.js
-
-```js
-import { __esmMin } from "../rolldown-runtime.js";
-//#region lazy.js
-var lazy;
-function init_lazy() {
-	return (init_lazy = __esmMin((() => {
-		globalThis.__events.push("lazy");
-		lazy = "L";
-	})))();
-}
-//#endregion
-export { init_lazy, lazy };
-
-```
-
-## _virtual/main.js
-
-```js
-import dep, { init_dep } from "../dep.js";
-import { __esmMin } from "../rolldown-runtime.js";
-//#region main.js
-var mod;
-function init_main() {
-	return (init_main = __esmMin((async () => {
-		init_dep();
-		globalThis.__events.push("main " + dep() + "N");
-		mod = await import("../lazy.js");
-		globalThis.__events.push("after " + mod.lazy);
-	})))();
-}
-//#endregion
-export { init_main };
-
-```
-
 ## dep.js
 
 ```js
@@ -62,7 +25,16 @@ export { dep as default, init_dep };
 ## lazy.js
 
 ```js
-import { init_lazy, lazy } from "./_virtual/lazy.js";
+import { __esmMin } from "./rolldown-runtime.js";
+//#region lazy.js
+var lazy;
+function init_lazy() {
+	return (init_lazy = __esmMin((() => {
+		globalThis.__events.push("lazy");
+		lazy = "L";
+	})))();
+}
+//#endregion
 init_lazy();
 export { lazy };
 
@@ -71,8 +43,19 @@ export { lazy };
 ## main.js
 
 ```js
-import "./dep.js";
-import { init_main } from "./_virtual/main.js";
+import dep, { init_dep } from "./dep.js";
+import { __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+var mod;
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		init_dep();
+		globalThis.__events.push("main " + dep() + "N");
+		mod = await import("./lazy.js");
+		globalThis.__events.push("after " + mod.lazy);
+	})))();
+}
+//#endregion
 await init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -15,14 +15,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { t as init_entry } from "./entry2.js";
-init_entry();
-
-```
-
-## entry2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
@@ -38,7 +30,7 @@ function init_entry() {
 	})))();
 }
 //#endregion
-export { init_entry as t };
+init_entry();
 
 ```
 
@@ -58,13 +50,6 @@ export { init_entry as t };
 ### entry.js
 
 ```js
-require("./entry2.js").init_entry();
-
-```
-
-### entry2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
@@ -81,12 +66,7 @@ function init_entry() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_entry", {
-	enumerable: true,
-	get: function() {
-		return init_entry;
-	}
-});
+init_entry();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_6227/artifacts.snap
@@ -36,14 +36,6 @@ console.log(globalThis.array);
 ### entry.js
 
 ```js
-import { t as init_main } from "./main.js";
-init_main();
-
-```
-
-### main.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region init.js
 function init_init() {
@@ -84,6 +76,6 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_init as i, init_bar as n, init_foo as r, init_main as t };
+init_main();
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/artifacts.snap
@@ -22,13 +22,6 @@ node_assert.default.strictEqual(42, 42);
 ### main.js
 
 ```js
-require("./main2.js").init_main();
-
-```
-
-### main2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
@@ -39,12 +32,7 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
@@ -91,15 +91,6 @@ Object.defineProperty(exports, "named", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_lib = require("./lib2.js");
-require("./main2.js").init_main();
-exports.lib = require_lib.lib_default;
-
-```
-
-### main2.js
-
-```js
-const require_lib = require("./lib2.js");
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
@@ -111,12 +102,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.lib = require_lib.lib_default;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
@@ -87,16 +87,6 @@ Object.defineProperty(exports, "init_lib", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_lib = require("./lib2.js");
-require("./main2.js").init_main();
-exports.bar = require_lib.bar;
-exports.foo = require_lib.foo;
-
-```
-
-### main2.js
-
-```js
-const require_lib = require("./lib2.js");
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
@@ -109,12 +99,9 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/runtime_merge_respects_preserve_entry_signatures/artifacts.snap
@@ -145,16 +145,6 @@ Object.defineProperty(exports, "init_lib", {
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_lib = require("./lib2.js");
-require("./main2.js").init_main();
-exports.bar = require_lib.bar;
-exports.foo = require_lib.foo;
-
-```
-
-### main2.js
-
-```js
-const require_lib = require("./lib2.js");
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
@@ -167,12 +157,9 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
 
 ```
 
@@ -251,16 +238,6 @@ Object.defineProperty(exports, "init_lib", {
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_lib = require("./lib2.js");
-require("./main2.js").init_main();
-exports.bar = require_lib.bar;
-exports.foo = require_lib.foo;
-
-```
-
-### main2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 const require_lib = require("./lib2.js");
 let node_assert = require("node:assert");
@@ -274,12 +251,9 @@ function init_main() {
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "init_main", {
-	enumerable: true,
-	get: function() {
-		return init_main;
-	}
-});
+init_main();
+exports.bar = require_lib.bar;
+exports.foo = require_lib.foo;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
@@ -20,15 +20,6 @@ export { foo };
 ### main.js
 
 ```js
-import { n as foo, t as init_main } from "./main2.js";
-await init_main();
-export { foo };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var foo;
@@ -45,7 +36,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { foo as n, init_lib as r, init_main as t };
+await init_main();
+export { foo };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
@@ -23,15 +23,6 @@ export { foo };
 ### main.js
 
 ```js
-import { n as foo, t as init_main } from "./main2.js";
-await init_main();
-export { foo };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var foo;
@@ -50,7 +41,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { foo as n, init_lib as r, init_main as t };
+await init_main();
+export { foo };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/on_demand_await_call/artifacts.snap
@@ -27,15 +27,6 @@ export { value as normalLibValue, value$1 as tlaLibValue };
 ### main.js
 
 ```js
-import { a as value, r as value$1, t as init_main } from "./main2.js";
-await init_main();
-export { value as normalLibValue, value$1 as tlaLibValue };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region normal-dep.js
 var value$3;
@@ -46,28 +37,28 @@ function init_normal_dep() {
 }
 //#endregion
 //#region normal-lib.js
-var value$2;
+var value;
 function init_normal_lib() {
 	return (init_normal_lib = __esmMin((() => {
 		init_normal_dep();
-		value$2 = value$3 + "+normal-lib";
+		value = value$3 + "+normal-lib";
 	})))();
 }
 //#endregion
 //#region tla-dep.js
-var value$1;
+var value$2;
 function init_tla_dep() {
 	return (init_tla_dep = __esmMin((async () => {
-		value$1 = await Promise.resolve("tla-dep");
+		value$2 = await Promise.resolve("tla-dep");
 	})))();
 }
 //#endregion
 //#region tla-lib.js
-var value;
+var value$1;
 function init_tla_lib() {
 	return (init_tla_lib = __esmMin((async () => {
 		await init_tla_dep();
-		value = value$1 + "+tla-lib";
+		value$1 = value$2 + "+tla-lib";
 	})))();
 }
 //#endregion
@@ -79,7 +70,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { value$2 as a, init_normal_lib as i, init_tla_lib as n, value as r, init_main as t };
+await init_main();
+export { value as normalLibValue, value$1 as tlaLibValue };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_cycle_ring/artifacts.snap
@@ -25,15 +25,6 @@ export { value };
 ### main.js
 
 ```js
-import { n as value, t as init_main } from "./main2.js";
-await init_main();
-export { value };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region ring-b.js
 function init_ring_b() {
@@ -61,7 +52,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { value as n, init_main as t };
+await init_main();
+export { value };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_dynamic_root/artifacts.snap
@@ -30,25 +30,17 @@ export { value };
 ### main.js
 
 ```js
-import { n as loaded, t as init_main } from "./main2.js";
-init_main();
-export { loaded };
-
-```
-
-### main2.js
-
-```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var loaded;
 function init_main() {
 	return (init_main = __esmMin((() => {
-		loaded = import("./tla-target2.js").then((mod) => mod.value);
+		loaded = import("./tla-target.js").then((mod) => mod.value);
 	})))();
 }
 //#endregion
-export { loaded as n, init_main as t };
+init_main();
+export { loaded };
 
 ```
 
@@ -72,14 +64,6 @@ function init_tla_target() {
 	})))();
 }
 //#endregion
-export { value as n, init_tla_target as t };
-
-```
-
-### tla-target2.js
-
-```js
-import { n as value, t as init_tla_target } from "./tla-target.js";
 await init_tla_target();
 export { value };
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_entry_also_imported/artifacts.snap
@@ -48,7 +48,17 @@ export { value };
 ### b.js
 
 ```js
-import { n as init_entry_b, t as combined } from "./entry-b.js";
+import { n as value, t as init_entry_a } from "./entry-a.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region entry-b.js
+var combined;
+function init_entry_b() {
+	return (init_entry_b = __esmMin((async () => {
+		await init_entry_a();
+		combined = `b:${value}`;
+	})))();
+}
+//#endregion
 await init_entry_b();
 export { combined };
 
@@ -67,24 +77,6 @@ function init_entry_a() {
 }
 //#endregion
 export { value as n, init_entry_a as t };
-
-```
-
-### entry-b.js
-
-```js
-import { n as value, t as init_entry_a } from "./entry-a.js";
-import { t as __esmMin } from "./rolldown-runtime.js";
-//#region entry-b.js
-var combined;
-function init_entry_b() {
-	return (init_entry_b = __esmMin((async () => {
-		await init_entry_a();
-		combined = `b:${value}`;
-	})))();
-}
-//#endregion
-export { init_entry_b as n, combined as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/strict_shared_chunk/artifacts.snap
@@ -42,15 +42,6 @@ export { shared as t };
 ### a.js
 
 ```js
-import { n as init_a, t as a } from "./a2.js";
-await init_a();
-export { a };
-
-```
-
-### a2.js
-
-```js
 import { n as shared, t as init_shared } from "./shared.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region a.js
@@ -62,20 +53,12 @@ function init_a() {
 	})))();
 }
 //#endregion
-export { init_a as n, a as t };
+await init_a();
+export { a };
 
 ```
 
 ### b.js
-
-```js
-import { n as init_b, t as b } from "./b2.js";
-await init_b();
-export { b };
-
-```
-
-### b2.js
 
 ```js
 import { n as shared, t as init_shared } from "./shared.js";
@@ -89,7 +72,8 @@ function init_b() {
 	})))();
 }
 //#endregion
-export { init_b as n, b as t };
+await init_b();
+export { b };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -22,15 +22,6 @@ export { value };
 ### main.js
 
 ```js
-import { r as value, t as init_main } from "./main2.js";
-await init_main();
-export { value };
-
-```
-
-### main2.js
-
-```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region tla.js
 var value$1;
@@ -56,7 +47,8 @@ function init_main() {
 	})))();
 }
 //#endregion
-export { init_lib as n, value as r, init_main as t };
+await init_main();
+export { value };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dead_dynamic_entry_side_effect_free/artifacts.snap
@@ -41,22 +41,6 @@ export { other as t };
 ### a.js
 
 ```js
-import { t as init_entry_a } from "./entry-a.js";
-init_entry_a();
-
-```
-
-### b.js
-
-```js
-import { t as init_entry_b } from "./entry-b.js";
-init_entry_b();
-
-```
-
-### entry-a.js
-
-```js
 import { n as other, t as init_helper } from "./helper.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region entry-a.js
@@ -68,11 +52,11 @@ function init_entry_a() {
 	})))();
 }
 //#endregion
-export { init_entry_a as t };
+init_entry_a();
 
 ```
 
-### entry-b.js
+### b.js
 
 ```js
 import { n as other, t as init_helper } from "./helper.js";
@@ -85,7 +69,7 @@ function init_entry_b() {
 	})))();
 }
 //#endregion
-export { init_entry_b as t };
+init_entry_b();
 
 ```
 

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -45,12 +45,16 @@ These are the main places where strict output deliberately accepts extra wrapper
   moves that entry point; the prediction also cannot see `var`-form interop wrapper
   definitions that another cycle chunk calls eagerly.
 - **Entry-trigger facades**: an inline entry trigger fires whenever its chunk is evaluated,
-  so an interop-wrapped entry whose chunk another chunk loads moves its trigger to a facade
-  (unconditionally in wrap-all mode, which has no predicted edges). "Loads" covers both
-  predicted static imports and cross-chunk dynamic imports of any other module hosted in the
-  entry chunk — e.g. a manual group placing a dynamic target next to an entry, where the
-  `import()` evaluates the entry chunk (a dynamic import of the entry module itself must run
-  its program, so it does not force the split).
+  so an entry whose chunk anything else _can_ load — order-wrapped or interop-wrapped, in both
+  strict modes — moves its trigger to a facade. The question is answered by running the real
+  cross-chunk link computation against the fully lowered order state
+  (`lowered_static_import_edges`), not a prediction, so an entry whose chunk only it can load
+  keeps its trigger inline and costs no extra file. "Loads" covers both static imports from
+  other chunks and cross-chunk dynamic imports of any other module hosted in the entry chunk —
+  e.g. a manual group placing a dynamic target next to an entry, where the `import()` evaluates
+  the entry chunk. A dynamic import of the entry module itself must run its program, and a
+  dead dynamic import lowers to an inert stub, so neither forces the split; any other surviving
+  record counts as a possible load even if never executed.
 - **CJS namespace merge is skipped under strict** (`determine_safely_merge_cjs_ns`): merging
   moves the surviving require call to whichever statement stays included — an intra-body
   move no wrapping can repair. Per-importer call sites cost bytes; the wrapper memoizes.
@@ -61,12 +65,12 @@ These are the main places where strict output deliberately accepts extra wrapper
 
 Every site that can run a wrapped module, in one place:
 
-| Trigger                                                      | Lives in                                    | Owner                                                                  |
-| ------------------------------------------------------------ | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `init_*()` for an order-wrapped importee of a live statement | importer body, statement position           | finalizer via the shared init-target view                              |
-| `init_*()` / `require_*()` obligations of removed statements | importer body, removed statement's position | `OrderImportOverlay` / transitive init targets                         |
-| user or dynamic entry activation                             | entry facade prologue                       | `create_order_wrap_entry_facades` / `restore_order_wrap_entry_facades` |
-| interop `require_*()` of an eager importer                   | importer body (its carrier)                 | flag-off interop machinery, order-analysis carrier rule                |
+| Trigger                                                      | Lives in                                                                                 | Owner                                                                  |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `init_*()` for an order-wrapped importee of a live statement | importer body, statement position                                                        | finalizer via the shared init-target view                              |
+| `init_*()` / `require_*()` obligations of removed statements | importer body, removed statement's position                                              | `OrderImportOverlay` / transitive init targets                         |
+| user or dynamic entry activation                             | entry chunk prologue (a facade only when other chunks can load the implementation chunk) | `create_order_wrap_entry_facades` / `restore_order_wrap_entry_facades` |
+| interop `require_*()` of an eager importer                   | importer body (its carrier)                                                              | flag-off interop machinery, order-analysis carrier rule                |
 
 A trigger must never sit inline in a chunk body that other chunks can evaluate as a
 dependency; that is the facade rule's content.

--- a/packages/rolldown/tests/behaviors/strict-execution-order-entry-facade.test.ts
+++ b/packages/rolldown/tests/behaviors/strict-execution-order-entry-facade.test.ts
@@ -1,0 +1,158 @@
+import type { OutputChunk, Plugin } from 'rolldown';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+// `strictExecutionOrder` moves an entry's body into `init_E()` and puts a top-level `init_E()` call
+// in the entry chunk. That inline trigger is only safe while the chunk hosting `E` is loaded solely
+// to enter `E`; when something else can load it, the trigger has to move into a facade — an extra
+// chunk that holds no modules at all.
+//
+// Emitting that facade unconditionally is invisible to output-correctness tests: the bundle still
+// runs correctly, it just costs one extra file per entry, which on a real app with lazy routes is a
+// ~50% chunk-count increase. These tests pin the *shape* of the output, in both directions: no
+// facade when nothing else can load the chunk, and a facade when something can.
+
+function virtualPlugin(modules: Record<string, string>): Plugin {
+  return {
+    name: 'virtual',
+    resolveId(id) {
+      return id in modules ? id : undefined;
+    },
+    load(id) {
+      return modules[id];
+    },
+  };
+}
+
+type Mode = 'off' | 'wrap-all' | 'on-demand';
+
+async function build(
+  modules: Record<string, string>,
+  input: Record<string, string>,
+  mode: Mode,
+  groups?: { name: string; test: RegExp }[],
+  moduleSideEffects?: boolean,
+): Promise<OutputChunk[]> {
+  const bundle = await rolldown({
+    input,
+    plugins: [virtualPlugin(modules)],
+    ...(mode === 'on-demand' ? { experimental: { onDemandWrapping: true } } : {}),
+    ...(moduleSideEffects === undefined ? {} : { treeshake: { moduleSideEffects } }),
+  });
+  const { output } = await bundle.generate({
+    format: 'esm',
+    ...(mode === 'off' ? {} : { strictExecutionOrder: true }),
+    ...(groups ? { codeSplitting: { groups } } : {}),
+  });
+  await bundle.close();
+  return output.filter((chunk): chunk is OutputChunk => chunk.type === 'chunk');
+}
+
+/** A facade holds no modules: it exists only to host an entry's `init_*()` trigger. */
+function facadeNames(chunks: OutputChunk[]): string[] {
+  return chunks
+    .filter((chunk) => chunk.moduleIds.length === 0)
+    .map((chunk) => chunk.name)
+    .sort();
+}
+
+const ROUTES = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+// An app whose lazy routes share a library. Nothing outside a route can load that route's chunk, so
+// no entry here needs its trigger moved into a facade.
+const lazyRouteApp: Record<string, string> = {
+  './lib.js': `console.log('lib');\nexport const version = String(globalThis.__v ?? '1');`,
+  './early.js': `console.log('early');\nexport const early = 1;`,
+  './main.js': `import './early.js';\nimport { version } from './lib.js';\nconsole.log('main', version);\n${ROUTES.map(
+    (r) => `await import('./route-${r}.js');`,
+  ).join('\n')}`,
+  ...Object.fromEntries(
+    ROUTES.map((r) => [
+      `./route-${r}.js`,
+      `import { version } from './lib.js';\nconsole.log('route-${r}', version);\nexport const name = '${r}';`,
+    ]),
+  ),
+};
+
+// Grouping `early.js` with `lib.js` makes the chunk-driven evaluation order differ from source
+// order, which is what puts modules on `onDemandWrapping`'s plan. Without it on-demand finds no
+// hazard, wraps nothing, and the shape would not exercise entry splitting at all.
+const lazyRouteGroups = [{ name: 'grp', test: /(?:lib|early)\.js$/ }];
+
+test.each<Mode>(['wrap-all', 'on-demand'])(
+  'strictExecutionOrder (%s) does not emit an entry facade per lazy route',
+  async (mode) => {
+    const off = await build(lazyRouteApp, { main: './main.js' }, 'off', lazyRouteGroups);
+    const strict = await build(lazyRouteApp, { main: './main.js' }, mode, lazyRouteGroups);
+
+    // Nothing here can load a route chunk except entering that route, so no entry needs its
+    // trigger moved out. Every extra chunk would be one empty file per lazy route.
+    expect(facadeNames(strict)).toEqual([]);
+
+    // Same statement from the other side, so a facade that grew a module still fails: the only
+    // chunk strict mode may add is the shared runtime holding `__esmMin`. A per-entry split shows
+    // up here as a second chunk carrying the entry's name (`route-a` plus `route-a2`, ...).
+    const addedByStrict = strict
+      .map((chunk) => chunk.name)
+      .filter((name) => name !== 'rolldown-runtime')
+      .sort();
+    expect(addedByStrict).toEqual(off.map((chunk) => chunk.name).sort());
+  },
+);
+
+// The counterpart, so the check above can never be satisfied by simply never splitting: entry `e`
+// shares a chunk with `shared.js`, and entry `b` imports `shared.js`. Loading that chunk for `b`
+// must not run `e`'s program, so `e`'s trigger has to move into a facade.
+const sharedEntryChunkApp: Record<string, string> = {
+  './shared.js': `console.log('shared');\nexport const s = String(globalThis.__s ?? 's');`,
+  './b.js': `import { s } from './shared.js';\nconsole.log('b', s);`,
+  './e.js': `console.log('e');`,
+};
+
+test.each<Mode>(['wrap-all', 'on-demand'])(
+  'strictExecutionOrder (%s) still splits the entry facade when another chunk imports the entry chunk',
+  async (mode) => {
+    const chunks = await build(sharedEntryChunkApp, { b: './b.js', e: './e.js' }, mode, [
+      { name: 'e-group', test: /(?:e|shared)\.js$/ },
+    ]);
+
+    expect(facadeNames(chunks)).toEqual(['e']);
+
+    // The facade took over the entry role; the chunk that actually holds `e.js` is no longer an
+    // entry, so nothing calls `init_e()` when `b` pulls that chunk in for `shared.js`.
+    const implementation = chunks.find((chunk) =>
+      chunk.moduleIds.some((id) => id.endsWith('e.js')),
+    );
+    expect(implementation?.isEntry).toBe(false);
+    expect(implementation?.moduleIds.map((id) => id.replace(/^.*[\\/]/, '')).sort()).toEqual([
+      'e.js',
+      'shared.js',
+    ]);
+  },
+);
+
+// A dynamic import whose entry tree shaking dropped is rewritten to an inert
+// `Promise.resolve().then(...)` stub, so it loads nothing and must not count as a load. Here `b`'s
+// only reference to `t.js` is such a record, while `e` uses `t.js` statically and so shares a chunk
+// with it — the shape where a dead record would otherwise keep a facade alive.
+const deadDynamicApp: Record<string, string> = {
+  // `String(...)` keeps the export from being constant-inlined, which would drop `t.js` entirely.
+  './t.js': `export const t = String(globalThis.__t ?? 't');`,
+  './e.js': `import { t } from './t.js';\nconsole.log('E', t);`,
+  './b.js': `import('./t.js');\nconsole.log('B');`,
+};
+
+test.each<Mode>(['wrap-all', 'on-demand'])(
+  'strictExecutionOrder (%s) does not let a dead dynamic import force an entry facade',
+  async (mode) => {
+    const chunks = await build(
+      deadDynamicApp,
+      { b: './b.js', e: './e.js' },
+      mode,
+      undefined,
+      false,
+    );
+
+    expect(facadeNames(chunks)).toEqual([]);
+  },
+);


### PR DESCRIPTION
## Summary

Under `strictExecutionOrder` (SEO), an entry's body moves into `init_E()` and the entry chunk carries a top-level `init_E()` call. That inline trigger is only safe while the chunk hosting `E` is loaded *solely to enter* `E`. Once another chunk imports that chunk, the entry's program runs during an unrelated load — which is exactly what SEO exists to prevent. The facade split moves the trigger into its own file when that happens.

`create_order_wrap_entry_facades` asked that question only of interop-wrapped entries, and only under `onDemandWrapping`. **Every order-wrapped entry split unconditionally**, so each one cost an extra chunk even when nothing but the entry itself could ever load it — including every dynamic entry, i.e. one extra file per lazy route.

This PR gates all three facade sources on one predicate — *can anything else load this chunk?* — answered from the real cross-chunk link computation instead of a prediction.

Measured on a generated 120-lazy-route app:

| | `main` | this PR |
| --- | --- | --- |
| SEO off | 146 chunks | 146 |
| `strictExecutionOrder` (wrap-all) | **268** (+122) | **147** (+1) |
| `strictExecutionOrder` + `onDemandWrapping` | **267** (+121) | **147** (+1) |

Raw JS bytes in wrap-all: 96,326 → 82,870 (−14%). The `+1` in both fixed columns is the runtime chunk. The executed output of all three modes is byte-identical before and after.

Relates to #10294. Independent of #10433, which addresses a different facade case.

## Why the decision could not read facts before

The facade decision sits in `finalize_chunk_plan`, which runs *before* `compute_cross_chunk_links`. The only edge set available was `predicted_static_import_edges` — computed with an **empty** `OrderWrapState`, i.e. "what would the edges be if nothing were wrapped" — and in wrap-all mode not computed at all (`wrap_all_order_analysis` filled `import_edges` with empty sets, which the `!on_demand ||` short-circuit papered over).

## Alternatives explored

Two ways of re-deriving the missing edges were tried and rejected, both unsound in the same way:

1. **Scan the module graph** for chunks that some included module in another chunk statically imports into. Misses `init_*` obligations that reach their target *through a non-included forwarder* — `collect_order_wrap_esm_init_targets` descends into the import records of a tree-shaken forwarder, so both hops have a non-included endpoint and the scan skips them. Produces an entry whose program runs during another entry's load.
2. **Reuse `post_lowering_import_edges`** (the emergent-cycle fixpoint's projection). That projection deliberately omits interop `WrapKind::Esm` overlay edges and consumption-gated hops, because for *cycle detection* projecting them would fabricate a cycle and over-wrap. Omissions that are safe there are unsafe here: it drops a needed facade and breaks `retained_star_renamed_cycle` at runtime.

The lesson is that any hand-rolled reachability scan silently misses an edge source, and a missed edge is an execution-order bug with no signal. So this PR asks the real computation rather than re-deriving it.

## How the query is made possible

`collect_depended_symbols` does not only read the chunk graph — it writes each declared symbol's owning chunk back into the shared symbol database, and `compute_chunk_imports` reads that ownership back to resolve which chunk a depended symbol is imported from. The write is load-bearing *within* one pass, so the pass cannot be made read-only by dropping it.

It can be scoped instead. `SymbolChunkOwnership::Scoped` records the previous owner of every symbol the pass assigns; the caller restores them afterwards, leaving the symbol database exactly as it found it. `lowered_static_import_edges` drives the pass with the fully lowered `OrderWrapState` and the real final init metadata, so every edge source the final pass registers — value references, `init_*` forwarding, retained re-export overlays, transitive init obligations — is present, with no approximation.

**Why deciding before the facades exist is sound.** A facade is an empty chunk that takes over the entry role from the implementation chunk: it adds exactly one importer of that chunk (itself), and it inherits — never widens — the outgoing edges the implementation chunk had as an entry chunk. So for every *other* chunk the relation "some chunk other than me imports me" is unchanged, and all facade decisions can be taken together from one pre-facade snapshot.

## Ordering changes

Three passes move ahead of the query, none of which depends on facades existing:

- `ensure_runtime_module_for_order_wraps` — resolving a depended symbol to its chunk requires the runtime module to already sit in one, and order wrappers demand runtime helpers. A facade chunk copies its implementation chunk's bits, so the runtime chunk's bit union is unchanged.
- `restore_order_wrap_entry_facades` — `compute_chunk_imports` **skips chunks marked `Removed`**, so restoring afterwards would hide the edge from a resurrected facade to the chunk hosting its implementation, and an entry sharing that chunk would keep an inline trigger that the restored facade's load then fires. This one is not hypothetical: an earlier revision of this PR hit it, and the fixture suite did not catch it.
- `finalized_module_namespace_ref_usage` — so the query sees the namespaces the final link pass will see rather than the provisional pre-lowering set. No output changes from this today; it closes the gap rather than fixing an observed failure.

Restoring stays **ungated**. Unlike splitting, it exists because a chunk can host only one entry's top-level trigger, so an entry merged into another entry's chunk has no trigger at all without its own file.

## Tests

### The regression test that was missing

The over-split was invisible to every existing test, and that is the more important thing to fix: an
output-correctness test cannot see it, because the over-split bundle still *runs* correctly — it just
ships one extra file per entry. `packages/rolldown/tests/behaviors/strict-execution-order-entry-facade.test.ts`
pins the **shape** of the output instead, keying on the property that defines a facade: a chunk
holding zero modules, existing only to host an entry's `init_*()` trigger.

Both directions are pinned, so the budget check cannot be satisfied by simply never splitting:

| | assertion |
| --- | --- |
| six lazy routes over a shared library | no facade, and no chunk beyond the shared runtime |
| two entries, one sharing a chunk with a module the other imports | the facade is still emitted, and the chunk holding the entry's own module is no longer an entry chunk |

Each runs under wrap-all and `onDemandWrapping`. **Against the parent commit all four fail** — seven
facades for the lazy-route app, and `['b', 'e']` instead of `['e']` for the shared-chunk app.

The manual group in the lazy-route app is load-bearing: it makes the chunk-driven evaluation order
differ from source order, which is what puts modules on the on-demand plan. Without it on-demand
finds no hazard, wraps nothing, and the shape does not exercise entry splitting at all.

### Execution-order coverage

New fixture `function/experimental/strict_execution_order/entry_shared_chunk_facade`: entry `e` shares a chunk with `shared.js`, which entry `b` imports. The facade must be kept, and `_test.mjs` asserts `e`'s program does not run while `b` is loading. Forcing the predicate to return an empty edge set makes it fail with `['E body', 'S body', 'B body S']` — the violation this PR must not introduce.

Existing coverage that pins the discrimination in both directions: `m4_dynamic_facade_race` keeps `target.js`'s facade (its chunk also hosts `observer.js`) while dropping `a2.js`/`b2.js`; `dynamic_target_in_entry_chunk` keeps `a.js`'s and drops `c.js`'s.

89 snapshots update, removing 207 emitted assets. No fixture loses a facade it needs — every strict fixture executes its output under Node.

- Rust integration suite: 1896 passed / 0 failed, identical to `main` on the same machine.
- Node suite: 913 passed / 0 failed.

## Reviewer attention

- **The soundness argument for a pre-facade snapshot** (the "How the query is made possible" section) is the load-bearing claim. If a facade can widen the set of chunks that import some *other* chunk, the decision would need a fixpoint.
- **The restore/query ordering** — the removed-chunk skip in `compute_chunk_imports` is easy to miss and produces a silent wrong answer.
- **Build time.** Strict mode now runs one extra `compute_wrapped_esm_init_metadata` and one extra `compute_cross_chunk_link_state`. On the 120-route app, wrap-all median 63.9ms → 67.6ms (~+6%); SEO-off is unchanged. Partly offset downstream by 45% fewer chunks to name, render and hash; the balance on a large app is worth a look.

## Unrelated pre-existing bug found while testing

`preserveModules` + `strictExecutionOrder` panics on `main` at `chunk.entry_module(...).unwrap()` in `render_chunk_exports`, because strict lowering demotes an entry chunk to `Common` while `preserve_modules` assumes every chunk has an entry module. Behaviour is identical before and after this PR; filing separately.
