### PR TITLE
fix(preserve-modules): don't assume every chunk mirrors a module

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -1295,9 +1295,15 @@ impl GenerateStage<'_> {
         // single default export per chunk must be named `default`. Otherwise use the
         // `default_export_ref` representative name. The `&&` keeps the `entry_module`
         // lookup guarded behind the `preserve_modules` check.
+        //
+        // `preserve_modules` emits one chunk per module, so a chunk normally carries the module it
+        // mirrors. Synthetic chunks are the exception: the shared `rolldown-runtime` chunk that
+        // strict execution order splits out mirrors no user module and is `ChunkKind::Common`, so
+        // it has no entry module and none of its exports can be a module's default export.
         let base = if self.options.preserve_modules
-          && chunk.entry_module(&self.link_output.module_table).unwrap().default_export_ref
-            == *chunk_export
+          && chunk
+            .entry_module(&self.link_output.module_table)
+            .is_some_and(|entry_module| entry_module.default_export_ref == *chunk_export)
         {
           CompactStr::new_const("default")
         } else {

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/_config.json
@@ -1,0 +1,19 @@
+{
+  "configName": "wrap-all",
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "preserveModules": true,
+    "strictExecutionOrder": true
+  },
+  "configVariants": [
+    {
+      "_configName": "on-demand",
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/_test.mjs
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/_test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+
+globalThis.__events = [];
+await import('./dist/main.js');
+
+// `preserveModules` emits one file per module plus the shared `rolldown-runtime` chunk that strict
+// execution order splits out. That runtime chunk mirrors no user module, which used to make the
+// `preserveModules` export naming assume every chunk has an entry module and panic.
+assert.deepStrictEqual(globalThis.__events, ['dep', 'main DN', 'lazy', 'after L']);

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/artifacts.snap
@@ -1,0 +1,126 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/lazy.js
+
+```js
+import { __esmMin } from "../rolldown-runtime.js";
+//#region lazy.js
+var lazy;
+function init_lazy() {
+	return (init_lazy = __esmMin((() => {
+		globalThis.__events.push("lazy");
+		lazy = "L";
+	})))();
+}
+//#endregion
+export { init_lazy, lazy };
+
+```
+
+## _virtual/main.js
+
+```js
+import dep, { init_dep } from "../dep.js";
+import { __esmMin } from "../rolldown-runtime.js";
+//#region main.js
+var mod;
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		init_dep();
+		globalThis.__events.push("main " + dep() + "N");
+		mod = await import("../lazy.js");
+		globalThis.__events.push("after " + mod.lazy);
+	})))();
+}
+//#endregion
+export { init_main };
+
+```
+
+## dep.js
+
+```js
+import { __esmMin } from "./rolldown-runtime.js";
+//#region dep.js
+function dep() {
+	return "D";
+}
+function init_dep() {
+	return (init_dep = __esmMin((() => {
+		globalThis.__events.push("dep");
+	})))();
+}
+//#endregion
+init_dep();
+export { dep as default, init_dep };
+
+```
+
+## lazy.js
+
+```js
+import { init_lazy, lazy } from "./_virtual/lazy.js";
+init_lazy();
+export { lazy };
+
+```
+
+## main.js
+
+```js
+import "./dep.js";
+import { init_main } from "./_virtual/main.js";
+await init_main();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### dep.js
+
+```js
+//#region dep.js
+globalThis.__events.push("dep");
+function dep() {
+	return "D";
+}
+//#endregion
+export { dep as default };
+
+```
+
+### lazy.js
+
+```js
+//#region lazy.js
+globalThis.__events.push("lazy");
+const lazy = "L";
+//#endregion
+export { lazy };
+
+```
+
+### main.js
+
+```js
+import dep from "./dep.js";
+//#region main.js
+globalThis.__events.push("main " + dep() + "N");
+const mod = await import("./lazy.js");
+globalThis.__events.push("after " + mod.lazy);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/dep.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/dep.js
@@ -1,0 +1,7 @@
+globalThis.__events.push('dep');
+
+export default function dep() {
+  return 'D';
+}
+
+export const named = 'N';

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/lazy.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/lazy.js
@@ -1,0 +1,3 @@
+globalThis.__events.push('lazy');
+
+export const lazy = 'L';

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/main.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/strict_execution_order_runtime_chunk/main.js
@@ -1,0 +1,7 @@
+import dep, { named } from './dep.js';
+
+globalThis.__events.push('main ' + dep() + named);
+
+const mod = await import('./lazy.js');
+
+globalThis.__events.push('after ' + mod.lazy);


### PR DESCRIPTION
## Summary

`preserveModules` emits one chunk per module, and the export-naming pass in `compute_cross_chunk_links` relies on that: to decide whether a chunk export should be named `default`, it reaches for `chunk.entry_module(&self.link_output.module_table).unwrap()`.

Synthetic chunks break the assumption. `strictExecutionOrder` splits the shared `rolldown-runtime` chunk that holds `__esmMin`; that chunk mirrors no user module and is `ChunkKind::Common`, so the lookup returns `None`:

```
thread 'rolldown-worker' panicked at crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs:1299:65:
called `Option::unwrap()` on a `None` value
```

Any `preserveModules` build with `strictExecutionOrder` and more than one emitted chunk hits it — a two-module entry is enough:

```js
// dep.js
export default function dep() { return 'D'; }
// main.js
import dep from './dep.js';
console.log(dep());
```

```js
await (await rolldown({ input: './main.js' }))
  .generate({ format: 'esm', preserveModules: true, strictExecutionOrder: true }); // panics
```

## Fix

A chunk with no entry module has no module default export to rename, so ask the question instead of asserting the answer — `is_some_and` in place of `unwrap`.

Behaviour for chunks that *do* mirror a module is unchanged: the condition is identical whenever `entry_module()` is `Some`, and no existing snapshot moves. The only chunks reaching the new branch are ones that previously panicked.

The sibling `entry_module(...).expect(...)` a little earlier in the same function is already guarded by an `if let ChunkKind::EntryPoint { .. }`, so it is sound and left alone.

## Tests

New fixture `misc/preserve_modules/strict_execution_order_runtime_chunk`, run under both wrap-all and `onDemandWrapping`. It builds a static import with a default export plus a dynamic import, so the output has a per-module file, a `default` export to name, and the split runtime chunk. `_test.mjs` asserts the modules evaluate in source order.

Without the source change the fixture panics at the line above; with it, it passes. `dep.js` still exports `default`, so the naming path this code exists for is covered rather than merely bypassed.

Full Rust integration suite: 1892 passed, with the only 4 failures (`cjs_module_lexer_compat` ×3, `npm_packages/util_deprecate`) failing identically on unpatched `main` in the same tree — they need npm packages this worktree does not have installed.

## Relationship to #10441

Independent, and this PR is based on `main` rather than stacked. The panicking chunk is the synthetic runtime chunk, which #10441 does not touch; the panic reproduces identically with and without that PR, and the fix is in a different function.

One thing reviewers should know: this fixture's snapshot shows `preserveModules` currently emitting *two* files for an order-wrapped entry — `main.js` plus `_virtual/main.js` — because the entry facade splits unconditionally. That contradicts the one-file-per-module contract, and it is exactly what #10441 fixes. Whichever lands second will regenerate this snapshot with the facades gone. That is a snapshot update, not a conflict.
