### PR TITLE
fix(link): resolve circular star reexports as null

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -73,6 +73,7 @@ impl Hash for MatchImportKindNormal {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[expect(clippy::box_collection)]
 pub enum MatchImportKind {
   // "sourceIndex" and "ref" are in use
   Normal(MatchImportKindNormal),

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -38,6 +38,7 @@ struct ImportTracker {
 #[derive(Debug)]
 pub struct MatchingContext {
   tracker_stack: Vec<ImportTracker>,
+  circular_reexport: Option<(String, String)>,
 }
 
 impl MatchingContext {
@@ -987,7 +988,7 @@ impl BindImportsAndExportsContext<'_> {
     // from an empty stack (and the ambiguous-reexport recursion gets its own cloned stack), so
     // clearing before each call preserves behavior while reusing this allocation instead of
     // allocating a fresh `Vec` per import.
-    let mut matching_ctx = MatchingContext { tracker_stack: Vec::new() };
+    let mut matching_ctx = MatchingContext { tracker_stack: Vec::new(), circular_reexport: None };
     for (imported_as_ref, named_import) in &module.named_imports {
       let match_import_span = tracing::trace_span!(
         "MATCH_IMPORT",
@@ -1040,6 +1041,7 @@ impl BindImportsAndExportsContext<'_> {
         }
       }
       matching_ctx.tracker_stack.clear();
+      matching_ctx.circular_reexport = None;
       let ret = self.match_import_with_export(
         self.index_modules,
         &mut matching_ctx,
@@ -1052,7 +1054,15 @@ impl BindImportsAndExportsContext<'_> {
       );
       tracing::trace!("Got match result {:?}", ret);
       match ret {
-        MatchImportKind::Cycle => {}
+        MatchImportKind::Cycle => {
+          let (importer_id, imported_specifier) = matching_ctx
+            .circular_reexport
+            .take()
+            .expect("cycle should always have a circular reexport diagnostic");
+          self
+            .diagnostics
+            .push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
+        }
         MatchImportKind::Ambiguous { symbol_ref, potentially_ambiguous_symbol_refs } => {
           let importee = self.index_modules[resolved_module_idx].stable_id().to_string();
 
@@ -1235,18 +1245,17 @@ impl BindImportsAndExportsContext<'_> {
 
     let mut ambiguous_results = vec![];
     let mut reexports = vec![];
-    let ret = loop {
+    let ret = 'tracking: loop {
       for prev_tracker in ctx.tracker_stack.iter().rev() {
         if prev_tracker.importer == tracker.importer
           && prev_tracker.imported_as == tracker.imported_as
         {
+          // ResolveExport treats an in-progress (module, binding) request as null.
           let importer_module = &index_modules[tracker.importer];
           let importer_id = importer_module.id().to_string();
           let imported_specifier = tracker.imported.to_string();
-          self
-            .diagnostics
-            .push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
-          return MatchImportKind::Cycle;
+          ctx.circular_reexport = Some((importer_id, imported_specifier));
+          break 'tracking MatchImportKind::Cycle;
         }
       }
       ctx.tracker_stack.push(tracker.clone());
@@ -1294,7 +1303,10 @@ impl BindImportsAndExportsContext<'_> {
                 if let Some(resolved_module_idx) = rec.resolved_module {
                   let ambiguous_result = self.match_import_with_export(
                     index_modules,
-                    &mut MatchingContext { tracker_stack: ctx.tracker_stack.clone() },
+                    &mut MatchingContext {
+                      tracker_stack: ctx.tracker_stack.clone(),
+                      circular_reexport: None,
+                    },
                     ImportTracker {
                       importer: ambiguous_ref_owner.idx(),
                       importee: resolved_module_idx,
@@ -1366,6 +1378,12 @@ impl BindImportsAndExportsContext<'_> {
 
     tracing::trace!("ambiguous_results {:#?}", ambiguous_results);
     tracing::trace!("ret {:#?}", ret);
+    ambiguous_results.retain(|result| !matches!(result, MatchImportKind::Cycle));
+    let ret = if matches!(ret, MatchImportKind::Cycle) && !ambiguous_results.is_empty() {
+      ambiguous_results.pop().unwrap()
+    } else {
+      ret
+    };
 
     for ambiguous_result in &ambiguous_results {
       if *ambiguous_result != ret {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -72,6 +72,21 @@ impl Hash for MatchImportKindNormal {
   }
 }
 
+/// Bookkeeping for a collected star branch so it can be promoted if the primary path turns out to
+/// be a cycle: the outer re-export hops accumulated up to the collection point, the branch's own
+/// export symbol, and where the branch was collected — the star-exporting module (and the name
+/// requested there) whose cached `resolved_exports` winner points into the cycle.
+#[derive(Debug)]
+struct StarBranchPromotion {
+  reexports_prefix: Vec<SymbolRef>,
+  export: SymbolRef,
+  star_module: ModuleIdx,
+  imported: Specifier,
+}
+
+/// Non-cycle star branches keyed by resolution, in collection order.
+type DedupedStarBranches = FxIndexMap<MatchImportKind, StarBranchPromotion>;
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[expect(clippy::box_collection)]
 pub enum MatchImportKind {
@@ -1274,6 +1289,48 @@ impl BindImportsAndExportsContext<'_> {
     }
   }
 
+  /// Apply `ResolveExport`'s null-cycle rule to the collected star branches. Cycle branches are
+  /// dropped from the agreement set: `ResolveExport` skips a star branch that resolves to null
+  /// instead of failing the whole lookup. Walking a cycle also re-visits the same module once per
+  /// lap, which collects the surviving branches repeatedly — those duplicates would otherwise
+  /// show up as repeated exporters, and repeated files, in the ambiguity diagnostic. An
+  /// insertion-ordered map keeps source order for the "first branch wins" rule and the first
+  /// collection's promotion state while deduplicating in linear time, since a name supplied by N
+  /// distinct `export *` sources would otherwise make the scan quadratic.
+  ///
+  /// When the primary path was itself a cycle it resolves to null, so the binding is whatever the
+  /// remaining branches say: per `ResolveExport` the first non-null branch wins and the rest only
+  /// have to agree with it. The promoted branch's state is returned (its prefix already spliced
+  /// into the result) so the caller can realign the collection module's cached winner.
+  fn promote_first_surviving_star_branch(
+    ret: MatchImportKind,
+    ambiguous_results: Vec<(MatchImportKind, StarBranchPromotion)>,
+  ) -> (MatchImportKind, DedupedStarBranches, Option<StarBranchPromotion>) {
+    let mut deduped_ambiguous_results = DedupedStarBranches::default();
+    for (result, promotion_state) in ambiguous_results {
+      if !matches!(result, MatchImportKind::Cycle { .. }) {
+        deduped_ambiguous_results.entry(result).or_insert(promotion_state);
+      }
+    }
+
+    let (ret, promoted) = if matches!(ret, MatchImportKind::Cycle { .. }) {
+      if let Some((mut promoted, mut promotion)) = deduped_ambiguous_results.shift_remove_index(0) {
+        if let MatchImportKind::Normal(normal) = &mut promoted {
+          let mut reexports = std::mem::take(&mut promotion.reexports_prefix);
+          reexports.append(&mut normal.reexports);
+          normal.reexports = reexports;
+        }
+        (promoted, Some(promotion))
+      } else {
+        (ret, None)
+      }
+    } else {
+      (ret, None)
+    };
+
+    (ret, deduped_ambiguous_results, promoted)
+  }
+
   fn match_import_with_export(
     &mut self,
     index_modules: &IndexModules,
@@ -1290,14 +1347,20 @@ impl BindImportsAndExportsContext<'_> {
 
     let mut ambiguous_results = vec![];
     let mut reexports = vec![];
+    // The ambiguous-branch recursion below inherits a clone of the caller's stack, so a cycle can
+    // match a frame belonging to the *outer* request. Resolving that as null is still right for
+    // THIS request, but such a resolution is context-dependent and must not be persisted into the
+    // context-free `resolved_exports` cache: standalone, the collection module may resolve the
+    // name to a different branch, or find it ambiguous. Frames at `stack_base` and beyond were
+    // pushed by this invocation, so only a cycle hitting them justifies the cache write below.
+    let stack_base = ctx.tracker_stack.len();
+    let mut cycle_in_own_frames = false;
     let ret = loop {
-      if ctx
-        .tracker_stack
-        .iter()
-        .rev()
-        .any(|prev| prev.importer == tracker.importer && prev.imported_as == tracker.imported_as)
-      {
+      if let Some(matched) = ctx.tracker_stack.iter().rposition(|prev| {
+        prev.importer == tracker.importer && prev.imported_as == tracker.imported_as
+      }) {
         // ResolveExport treats an in-progress (module, binding) request as null.
+        cycle_in_own_frames = matched >= stack_base;
         break MatchImportKind::Cycle {
           importer: tracker.importer,
           imported: tracker.imported.clone(),
@@ -1358,7 +1421,15 @@ impl BindImportsAndExportsContext<'_> {
                   );
                   let mut reexports_prefix = reexports.clone();
                   reexports_prefix.push(another_named_import.imported_as);
-                  ambiguous_results.push((ambiguous_result, (reexports_prefix, *ambiguous_ref)));
+                  ambiguous_results.push((
+                    ambiguous_result,
+                    StarBranchPromotion {
+                      reexports_prefix,
+                      export: *ambiguous_ref,
+                      star_module: tracker.importee,
+                      imported: tracker.imported.clone(),
+                    },
+                  ));
                 }
               }
               _ => {
@@ -1367,7 +1438,12 @@ impl BindImportsAndExportsContext<'_> {
                     symbol: *ambiguous_ref,
                     reexports: vec![],
                   }),
-                  (reexports.clone(), *ambiguous_ref),
+                  StarBranchPromotion {
+                    reexports_prefix: reexports.clone(),
+                    export: *ambiguous_ref,
+                    star_module: tracker.importee,
+                    imported: tracker.imported.clone(),
+                  },
                 ));
               }
             }
@@ -1425,37 +1501,8 @@ impl BindImportsAndExportsContext<'_> {
 
     tracing::trace!("ambiguous_results {:#?}", ambiguous_results);
     tracing::trace!("ret {:#?}", ret);
-    // `ResolveExport` skips a star branch that resolves to null instead of failing the whole
-    // lookup, so cycles must not take part in the agreement check below. Walking a cycle also
-    // re-visits the same module once per lap, which collects the surviving branches repeatedly —
-    // those duplicates would otherwise show up as repeated exporters, and repeated files, in the
-    // ambiguity diagnostic. An insertion-ordered map keeps source order for the "first branch
-    // wins" rule and the first result's outer prefix while deduplicating in linear time, since a
-    // name supplied by N distinct `export *` sources would otherwise make this scan quadratic.
-    let mut deduped_ambiguous_results = FxIndexMap::default();
-    for (result, promotion_state) in ambiguous_results {
-      if !matches!(result, MatchImportKind::Cycle { .. }) {
-        deduped_ambiguous_results.entry(result).or_insert(promotion_state);
-      }
-    }
-
-    // A cycle resolves to null, so the binding is whatever the remaining star branches say. Per
-    // `ResolveExport` the first non-null branch wins and the rest only have to agree with it.
-    let (ret, promoted_export) = if matches!(ret, MatchImportKind::Cycle { .. }) {
-      if let Some((mut promoted, (mut reexports_prefix, promoted_export))) =
-        deduped_ambiguous_results.shift_remove_index(0)
-      {
-        if let MatchImportKind::Normal(normal) = &mut promoted {
-          reexports_prefix.append(&mut normal.reexports);
-          normal.reexports = reexports_prefix;
-        }
-        (promoted, Some(promoted_export))
-      } else {
-        (ret, None)
-      }
-    } else {
-      (ret, None)
-    };
+    let (ret, deduped_ambiguous_results, promoted) =
+      Self::promote_first_surviving_star_branch(ret, ambiguous_results);
 
     if let Some(symbol_ref) = ret.bound_symbol()
       && deduped_ambiguous_results.keys().any(|result| *result != ret)
@@ -1468,13 +1515,25 @@ impl BindImportsAndExportsContext<'_> {
       };
     }
 
-    // Keep the cached star-export winner aligned with the promoted branch.
-    if matches!(&ret, MatchImportKind::Normal(_))
-      && let Some(promoted_export) = promoted_export
-      && let Specifier::Literal(imported) = &tracker.imported
-      && let Some(resolved_export) = self.metas[tracker.importee].resolved_exports.get_mut(imported)
+    // A star-exporting module on the walked chain cached the cycle branch as its
+    // `resolved_exports` winner (`add_exports_for_export_star` records the first branch in source
+    // order — the one this walk just found circular), and module interfaces are generated from
+    // that raw winner (e.g. the per-module exports under `preserveModules`), so re-point it at
+    // the promoted branch. The write targets the module the branch was collected from: that is
+    // the module whose cached winner is stale. The loop-final `tracker.importee` is merely where
+    // the lap closed — for cycles longer than one named hop it is a different module whose own
+    // direct export must not be clobbered. `cycle_in_own_frames` keeps context-dependent
+    // resolutions (cycles against an outer request's frames) out of the cache. Per slot the write
+    // is idempotent — the promoted branch for a given (module, name) is deterministic — but a
+    // cycle threading several star modules only gets the collection module realigned; the other
+    // stale winners on the lap are a known limitation of this cache design.
+    if cycle_in_own_frames
+      && matches!(&ret, MatchImportKind::Normal(_))
+      && let Some(StarBranchPromotion { export, star_module, imported, .. }) = promoted
+      && let Specifier::Literal(imported) = &imported
+      && let Some(resolved_export) = self.metas[star_module].resolved_exports.get_mut(imported)
     {
-      resolved_export.symbol_ref = promoted_export;
+      resolved_export.symbol_ref = export;
     }
 
     if let Module::Normal(importee) = &self.index_modules[tracker.importee] {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::hash::{Hash, Hasher};
 
 use arcstr::ArcStr;
 use indexmap::IndexSet;
@@ -38,7 +39,6 @@ struct ImportTracker {
 #[derive(Debug)]
 pub struct MatchingContext {
   tracker_stack: Vec<ImportTracker>,
-  circular_reexport: Option<(String, String)>,
 }
 
 impl MatchingContext {
@@ -64,7 +64,15 @@ impl PartialEq for MatchImportKindNormal {
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+// Must agree with the `PartialEq` above: `reexports` is deliberately excluded from both, so that
+// two resolutions of the same symbol hash and compare as one.
+impl Hash for MatchImportKindNormal {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.symbol.hash(state);
+  }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
 #[expect(clippy::box_collection)]
 pub enum MatchImportKind {
   // "sourceIndex" and "ref" are in use
@@ -73,11 +81,35 @@ pub enum MatchImportKind {
   Namespace { namespace_ref: SymbolRef },
   // Both "matchImportNormal" and "matchImportNamespace"
   NormalAndNamespace { namespace_ref: SymbolRef, alias: CompactStr },
-  // The import could not be evaluated due to a cycle
-  Cycle,
+  // The import could not be evaluated due to a cycle. Boxed to keep the enum small, since this
+  // carries everything needed to report the cycle if no other branch resolves the binding.
+  Cycle(Box<CircularReexportInfo>),
   // The import resolved to multiple symbols via "export * from"
   Ambiguous { symbol_ref: SymbolRef, potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>> },
   NoMatch,
+}
+
+/// Where a circular re-export was detected, so `CIRCULAR_REEXPORT` can be reported by whoever ends
+/// up keeping the `Cycle` as the final resolution.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct CircularReexportInfo {
+  importer_id: String,
+  imported_specifier: String,
+}
+
+impl MatchImportKind {
+  /// The symbol a resolution binds to, if it has one. Used to describe a resolution when reporting
+  /// an ambiguous export.
+  fn bound_symbol(&self) -> Option<SymbolRef> {
+    match *self {
+      MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) => Some(symbol),
+      MatchImportKind::Namespace { namespace_ref }
+      | MatchImportKind::NormalAndNamespace { namespace_ref, .. } => Some(namespace_ref),
+      MatchImportKind::Cycle(_) | MatchImportKind::Ambiguous { .. } | MatchImportKind::NoMatch => {
+        None
+      }
+    }
+  }
 }
 
 #[derive(Debug)]
@@ -988,7 +1020,7 @@ impl BindImportsAndExportsContext<'_> {
     // from an empty stack (and the ambiguous-reexport recursion gets its own cloned stack), so
     // clearing before each call preserves behavior while reusing this allocation instead of
     // allocating a fresh `Vec` per import.
-    let mut matching_ctx = MatchingContext { tracker_stack: Vec::new(), circular_reexport: None };
+    let mut matching_ctx = MatchingContext { tracker_stack: Vec::new() };
     for (imported_as_ref, named_import) in &module.named_imports {
       let match_import_span = tracing::trace_span!(
         "MATCH_IMPORT",
@@ -1041,7 +1073,6 @@ impl BindImportsAndExportsContext<'_> {
         }
       }
       matching_ctx.tracker_stack.clear();
-      matching_ctx.circular_reexport = None;
       let ret = self.match_import_with_export(
         self.index_modules,
         &mut matching_ctx,
@@ -1054,14 +1085,10 @@ impl BindImportsAndExportsContext<'_> {
       );
       tracing::trace!("Got match result {:?}", ret);
       match ret {
-        MatchImportKind::Cycle => {
-          let (importer_id, imported_specifier) = matching_ctx
-            .circular_reexport
-            .take()
-            .expect("cycle should always have a circular reexport diagnostic");
+        MatchImportKind::Cycle(info) => {
           self
             .diagnostics
-            .push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
+            .push(BuildDiagnostic::circular_reexport(info.importer_id, info.imported_specifier));
         }
         MatchImportKind::Ambiguous { symbol_ref, potentially_ambiguous_symbol_refs } => {
           let importee = self.index_modules[resolved_module_idx].stable_id().to_string();
@@ -1252,10 +1279,10 @@ impl BindImportsAndExportsContext<'_> {
         {
           // ResolveExport treats an in-progress (module, binding) request as null.
           let importer_module = &index_modules[tracker.importer];
-          let importer_id = importer_module.id().to_string();
-          let imported_specifier = tracker.imported.to_string();
-          ctx.circular_reexport = Some((importer_id, imported_specifier));
-          break 'tracking MatchImportKind::Cycle;
+          break 'tracking MatchImportKind::Cycle(Box::new(CircularReexportInfo {
+            importer_id: importer_module.id().to_string(),
+            imported_specifier: tracker.imported.to_string(),
+          }));
         }
       }
       ctx.tracker_stack.push(tracker.clone());
@@ -1303,10 +1330,7 @@ impl BindImportsAndExportsContext<'_> {
                 if let Some(resolved_module_idx) = rec.resolved_module {
                   let ambiguous_result = self.match_import_with_export(
                     index_modules,
-                    &mut MatchingContext {
-                      tracker_stack: ctx.tracker_stack.clone(),
-                      circular_reexport: None,
-                    },
+                    &mut MatchingContext { tracker_stack: ctx.tracker_stack.clone() },
                     ImportTracker {
                       importer: ambiguous_ref_owner.idx(),
                       importee: resolved_module_idx,
@@ -1378,36 +1402,35 @@ impl BindImportsAndExportsContext<'_> {
 
     tracing::trace!("ambiguous_results {:#?}", ambiguous_results);
     tracing::trace!("ret {:#?}", ret);
-    ambiguous_results.retain(|result| !matches!(result, MatchImportKind::Cycle));
-    let ret = if matches!(ret, MatchImportKind::Cycle) && !ambiguous_results.is_empty() {
-      ambiguous_results.pop().unwrap()
+    // `ResolveExport` skips a star branch that resolves to null instead of failing the whole
+    // lookup, so cycles must not take part in the agreement check below. Walking a cycle also
+    // re-visits the same module once per lap, which collects the surviving branches repeatedly —
+    // those duplicates would otherwise show up as repeated exporters, and repeated files, in the
+    // ambiguity diagnostic. An insertion-ordered set keeps source order for the "first branch
+    // wins" rule below while deduplicating in linear time, since a name supplied by N distinct
+    // `export *` sources would make a scan of the collected results quadratic.
+    let mut ambiguous_results = ambiguous_results
+      .into_iter()
+      .filter(|result| !matches!(result, MatchImportKind::Cycle(_)))
+      .collect::<FxIndexSet<_>>();
+
+    // A cycle resolves to null, so the binding is whatever the remaining star branches say. Per
+    // `ResolveExport` the first non-null branch wins and the rest only have to agree with it.
+    let ret = if matches!(ret, MatchImportKind::Cycle(_)) {
+      ambiguous_results.shift_remove_index(0).unwrap_or(ret)
     } else {
       ret
     };
 
-    for ambiguous_result in &ambiguous_results {
-      if *ambiguous_result != ret {
-        if let MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) = ret {
-          return MatchImportKind::Ambiguous {
-            symbol_ref: symbol,
-            potentially_ambiguous_symbol_refs: Box::new(
-              ambiguous_results
-                .iter()
-                .filter_map(|kind| match *kind {
-                  MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) => Some(symbol),
-                  MatchImportKind::Namespace { namespace_ref }
-                  | MatchImportKind::NormalAndNamespace { namespace_ref, .. } => {
-                    Some(namespace_ref)
-                  }
-                  _ => None,
-                })
-                .collect(),
-            ),
-          };
-        }
-
-        unreachable!("symbol should always exist");
-      }
+    if let Some(symbol_ref) = ret.bound_symbol()
+      && ambiguous_results.iter().any(|result| *result != ret)
+    {
+      return MatchImportKind::Ambiguous {
+        symbol_ref,
+        potentially_ambiguous_symbol_refs: Box::new(
+          ambiguous_results.iter().filter_map(MatchImportKind::bound_symbol).collect(),
+        ),
+      };
     }
 
     if let Module::Normal(importee) = &self.index_modules[tracker.importee] {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -73,28 +73,30 @@ impl Hash for MatchImportKindNormal {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[expect(clippy::box_collection)]
 pub enum MatchImportKind {
   // "sourceIndex" and "ref" are in use
   Normal(MatchImportKindNormal),
   // "namespaceRef" and "alias" are in use
-  Namespace { namespace_ref: SymbolRef },
+  Namespace {
+    namespace_ref: SymbolRef,
+  },
   // Both "matchImportNormal" and "matchImportNamespace"
-  NormalAndNamespace { namespace_ref: SymbolRef, alias: CompactStr },
-  // The import could not be evaluated due to a cycle. Boxed to keep the enum small, since this
-  // carries everything needed to report the cycle if no other branch resolves the binding.
-  Cycle(Box<CircularReexportInfo>),
+  NormalAndNamespace {
+    namespace_ref: SymbolRef,
+    alias: CompactStr,
+  },
+  /// The import could not be evaluated due to a cycle; carries where it was detected so
+  /// CIRCULAR_REEXPORT can be reported if no other branch resolves the binding.
+  Cycle {
+    importer: ModuleIdx,
+    imported: Specifier,
+  },
   // The import resolved to multiple symbols via "export * from"
-  Ambiguous { symbol_ref: SymbolRef, potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>> },
+  Ambiguous {
+    symbol_ref: SymbolRef,
+    potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>>,
+  },
   NoMatch,
-}
-
-/// Where a circular re-export was detected, so `CIRCULAR_REEXPORT` can be reported by whoever ends
-/// up keeping the `Cycle` as the final resolution.
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct CircularReexportInfo {
-  importer_id: String,
-  imported_specifier: String,
 }
 
 impl MatchImportKind {
@@ -105,9 +107,9 @@ impl MatchImportKind {
       MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) => Some(symbol),
       MatchImportKind::Namespace { namespace_ref }
       | MatchImportKind::NormalAndNamespace { namespace_ref, .. } => Some(namespace_ref),
-      MatchImportKind::Cycle(_) | MatchImportKind::Ambiguous { .. } | MatchImportKind::NoMatch => {
-        None
-      }
+      MatchImportKind::Cycle { .. }
+      | MatchImportKind::Ambiguous { .. }
+      | MatchImportKind::NoMatch => None,
     }
   }
 }
@@ -1085,10 +1087,11 @@ impl BindImportsAndExportsContext<'_> {
       );
       tracing::trace!("Got match result {:?}", ret);
       match ret {
-        MatchImportKind::Cycle(info) => {
-          self
-            .diagnostics
-            .push(BuildDiagnostic::circular_reexport(info.importer_id, info.imported_specifier));
+        MatchImportKind::Cycle { importer, imported } => {
+          self.diagnostics.push(BuildDiagnostic::circular_reexport(
+            self.index_modules[importer].id().to_string(),
+            imported.to_string(),
+          ));
         }
         MatchImportKind::Ambiguous { symbol_ref, potentially_ambiguous_symbol_refs } => {
           let importee = self.index_modules[resolved_module_idx].stable_id().to_string();
@@ -1286,18 +1289,18 @@ impl BindImportsAndExportsContext<'_> {
 
     let mut ambiguous_results = vec![];
     let mut reexports = vec![];
-    let ret = 'tracking: loop {
-      for prev_tracker in ctx.tracker_stack.iter().rev() {
-        if prev_tracker.importer == tracker.importer
-          && prev_tracker.imported_as == tracker.imported_as
-        {
-          // ResolveExport treats an in-progress (module, binding) request as null.
-          let importer_module = &index_modules[tracker.importer];
-          break 'tracking MatchImportKind::Cycle(Box::new(CircularReexportInfo {
-            importer_id: importer_module.id().to_string(),
-            imported_specifier: tracker.imported.to_string(),
-          }));
-        }
+    let ret = loop {
+      if ctx
+        .tracker_stack
+        .iter()
+        .rev()
+        .any(|prev| prev.importer == tracker.importer && prev.imported_as == tracker.imported_as)
+      {
+        // ResolveExport treats an in-progress (module, binding) request as null.
+        break MatchImportKind::Cycle {
+          importer: tracker.importer,
+          imported: tracker.imported.clone(),
+        };
       }
       ctx.tracker_stack.push(tracker.clone());
       let import_status = self.advance_import_tracker(ctx);
@@ -1430,14 +1433,14 @@ impl BindImportsAndExportsContext<'_> {
     // name supplied by N distinct `export *` sources would otherwise make this scan quadratic.
     let mut deduped_ambiguous_results = FxIndexMap::default();
     for (result, promotion_state) in ambiguous_results {
-      if !matches!(result, MatchImportKind::Cycle(_)) {
+      if !matches!(result, MatchImportKind::Cycle { .. }) {
         deduped_ambiguous_results.entry(result).or_insert(promotion_state);
       }
     }
 
     // A cycle resolves to null, so the binding is whatever the remaining star branches say. Per
     // `ResolveExport` the first non-null branch wins and the rest only have to agree with it.
-    let (ret, promoted_export) = if matches!(ret, MatchImportKind::Cycle(_)) {
+    let (ret, promoted_export) = if matches!(ret, MatchImportKind::Cycle { .. }) {
       if let Some((mut promoted, (mut reexports_prefix, promoted_export))) =
         deduped_ambiguous_results.shift_remove_index(0)
       {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -1096,20 +1096,21 @@ impl BindImportsAndExportsContext<'_> {
           let mut exporter = Vec::with_capacity(potentially_ambiguous_symbol_refs.len() + 1);
           if let Some(owner) = self.index_modules[symbol_ref.owner].as_normal() {
             if let Specifier::Literal(name) = &named_import.imported {
-              let named_export = &owner.named_exports[name];
-              exporter.push(AmbiguousExternalNamespaceModule {
-                source: owner.source.clone(),
-                module_id: owner.id.to_string(),
-                stable_id: owner.stable_id.to_string(),
-                span_of_identifier: named_export.span,
-              });
+              if let Some(named_export) = owner.named_exports.get(name) {
+                exporter.push(AmbiguousExternalNamespaceModule {
+                  source: owner.source.clone(),
+                  module_id: owner.id.to_string(),
+                  stable_id: owner.stable_id.to_string(),
+                  span_of_identifier: named_export.span,
+                });
+              }
             }
           }
 
           exporter.extend(potentially_ambiguous_symbol_refs.iter().filter_map(|&symbol_ref| {
             let normal_module = self.index_modules[symbol_ref.owner].as_normal()?;
             if let Specifier::Literal(name) = &named_import.imported {
-              let named_export = &normal_module.named_exports[name];
+              let named_export = normal_module.named_exports.get(name)?;
               return Some(AmbiguousExternalNamespaceModule {
                 source: normal_module.source.clone(),
                 module_id: normal_module.id.to_string(),
@@ -1121,17 +1122,30 @@ impl BindImportsAndExportsContext<'_> {
             None
           }));
 
-          self.diagnostics.push(BuildDiagnostic::ambiguous_external_namespace(
-            named_import.imported.to_string(),
-            importee,
-            AmbiguousExternalNamespaceModule {
-              source: module.source.clone(),
-              module_id: module.id.to_string(),
-              stable_id: module.stable_id.to_string(),
-              span_of_identifier: named_import.span_imported,
-            },
-            exporter,
-          ));
+          if exporter.is_empty() {
+            self.diagnostics.push(BuildDiagnostic::missing_export(
+              module.id.to_string(),
+              module.stable_id.to_string(),
+              self.index_modules[resolved_module_idx].id().to_string(),
+              self.index_modules[resolved_module_idx].stable_id().to_string(),
+              module.source.clone(),
+              named_import.imported.to_string(),
+              named_import.span_imported,
+              None,
+            ));
+          } else {
+            self.diagnostics.push(BuildDiagnostic::ambiguous_external_namespace(
+              named_import.imported.to_string(),
+              importee,
+              AmbiguousExternalNamespaceModule {
+                source: module.source.clone(),
+                module_id: module.id.to_string(),
+                stable_id: module.stable_id.to_string(),
+                span_of_identifier: named_import.span_imported,
+              },
+              exporter,
+            ));
+          }
         }
         MatchImportKind::Normal(MatchImportKindNormal { symbol, reexports }) => {
           for r in &reexports {
@@ -1338,14 +1352,19 @@ impl BindImportsAndExportsContext<'_> {
                       imported_as: another_named_import.imported_as,
                     },
                   );
-                  ambiguous_results.push(ambiguous_result);
+                  let mut reexports_prefix = reexports.clone();
+                  reexports_prefix.push(another_named_import.imported_as);
+                  ambiguous_results.push((ambiguous_result, (reexports_prefix, *ambiguous_ref)));
                 }
               }
               _ => {
-                ambiguous_results.push(MatchImportKind::Normal(MatchImportKindNormal {
-                  symbol: *ambiguous_ref,
-                  reexports: vec![],
-                }));
+                ambiguous_results.push((
+                  MatchImportKind::Normal(MatchImportKindNormal {
+                    symbol: *ambiguous_ref,
+                    reexports: vec![],
+                  }),
+                  (reexports.clone(), *ambiguous_ref),
+                ));
               }
             }
           }
@@ -1406,31 +1425,52 @@ impl BindImportsAndExportsContext<'_> {
     // lookup, so cycles must not take part in the agreement check below. Walking a cycle also
     // re-visits the same module once per lap, which collects the surviving branches repeatedly —
     // those duplicates would otherwise show up as repeated exporters, and repeated files, in the
-    // ambiguity diagnostic. An insertion-ordered set keeps source order for the "first branch
-    // wins" rule below while deduplicating in linear time, since a name supplied by N distinct
-    // `export *` sources would make a scan of the collected results quadratic.
-    let mut ambiguous_results = ambiguous_results
-      .into_iter()
-      .filter(|result| !matches!(result, MatchImportKind::Cycle(_)))
-      .collect::<FxIndexSet<_>>();
+    // ambiguity diagnostic. An insertion-ordered map keeps source order for the "first branch
+    // wins" rule and the first result's outer prefix while deduplicating in linear time, since a
+    // name supplied by N distinct `export *` sources would otherwise make this scan quadratic.
+    let mut deduped_ambiguous_results = FxIndexMap::default();
+    for (result, promotion_state) in ambiguous_results {
+      if !matches!(result, MatchImportKind::Cycle(_)) {
+        deduped_ambiguous_results.entry(result).or_insert(promotion_state);
+      }
+    }
 
     // A cycle resolves to null, so the binding is whatever the remaining star branches say. Per
     // `ResolveExport` the first non-null branch wins and the rest only have to agree with it.
-    let ret = if matches!(ret, MatchImportKind::Cycle(_)) {
-      ambiguous_results.shift_remove_index(0).unwrap_or(ret)
+    let (ret, promoted_export) = if matches!(ret, MatchImportKind::Cycle(_)) {
+      if let Some((mut promoted, (mut reexports_prefix, promoted_export))) =
+        deduped_ambiguous_results.shift_remove_index(0)
+      {
+        if let MatchImportKind::Normal(normal) = &mut promoted {
+          reexports_prefix.append(&mut normal.reexports);
+          normal.reexports = reexports_prefix;
+        }
+        (promoted, Some(promoted_export))
+      } else {
+        (ret, None)
+      }
     } else {
-      ret
+      (ret, None)
     };
 
     if let Some(symbol_ref) = ret.bound_symbol()
-      && ambiguous_results.iter().any(|result| *result != ret)
+      && deduped_ambiguous_results.keys().any(|result| *result != ret)
     {
       return MatchImportKind::Ambiguous {
         symbol_ref,
         potentially_ambiguous_symbol_refs: Box::new(
-          ambiguous_results.iter().filter_map(MatchImportKind::bound_symbol).collect(),
+          deduped_ambiguous_results.keys().filter_map(MatchImportKind::bound_symbol).collect(),
         ),
       };
+    }
+
+    // Keep the cached star-export winner aligned with the promoted branch.
+    if matches!(&ret, MatchImportKind::Normal(_))
+      && let Some(promoted_export) = promoted_export
+      && let Specifier::Literal(imported) = &tracker.imported
+      && let Some(resolved_export) = self.metas[tracker.importee].resolved_exports.get_mut(imported)
+    {
+      resolved_export.symbol_ref = promoted_export;
     }
 
     if let Module::Normal(importee) = &self.index_modules[tracker.importee] {

--- a/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
+++ b/crates/rolldown/tests/integration/snapshots/integration__test262__test262_module_code.snap
@@ -2,7 +2,7 @@
 source: crates/rolldown/tests/integration/test262.rs
 expression: snapshot
 ---
-Summary: 543 passed, 56 failed, 599 total
+Summary: 545 passed, 54 failed, 599 total
 
 ---
 
@@ -1258,31 +1258,15 @@ Actual: Runtime execution succeeded
 ---
 
 # language/module-code/instn-star-iee-multi-cycle-same-name.js
-Result: FAIL
-Reason: Incorrect ambiguous export detection in Rolldown
+Result: PASS
 Expected: success
-Actual:
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-multi-cycle-same-name-d_FIXTURE.js' as it is a reexport that references itself.
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/instn-star-iee-single-cycle-same-name.js
-Result: FAIL
-Reason: Incorrect ambiguous export detection in Rolldown
+Result: PASS
 Expected: success
-Actual:
-'foo' cannot be exported from 'instn-star-iee-single-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
-'foo' cannot be exported from 'instn-star-iee-single-cycle-same-name-b_FIXTURE.js' as it is a reexport that references itself.
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/instn-star-props-circular.js

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ]
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/a.js
@@ -1,0 +1,3 @@
+export * from './b.js';
+export * from './d1.js';
+export * from './d2.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## MISSING_EXPORT
+
+```text
+[MISSING_EXPORT] "foo" is not exported by "a.js".
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── Missing export
+───╯
+
+```
+
+## MISSING_EXPORT
+
+```text
+[MISSING_EXPORT] "foo" is not exported by "a.js".
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── Missing export
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/cjs1.cjs
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/cjs1.cjs
@@ -1,0 +1,1 @@
+module.exports = { bar: 1 };

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/cjs2.cjs
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/cjs2.cjs
@@ -1,0 +1,1 @@
+module.exports = { baz: 2 };

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/d1.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/d1.js
@@ -1,0 +1,1 @@
+export { foo } from './e1.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/d2.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/d2.js
@@ -1,0 +1,1 @@
+export { foo } from './e2.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/e1.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/e1.js
@@ -1,0 +1,1 @@
+export * from './cjs1.cjs';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/e2.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/e2.js
@@ -1,0 +1,1 @@
+export * from './cjs2.cjs';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_all_namespace_alternatives/index.js
@@ -1,0 +1,2 @@
+import { foo } from './a.js';
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ]
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/a.js
@@ -1,0 +1,1 @@
+export let x = 1;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/artifacts.snap
@@ -1,0 +1,129 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { x } from './t2.js';
+   │          ┬  
+   │          ╰── "t2.js" re-exports "x"
+   │
+   ├─[ a.js:1:12 ]
+   │
+ 1 │ export let x = 1;
+   │            ┬  
+   │            ╰── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let x = 2;
+   │            ┬  
+   │            ╰── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ c.js:1:10 ]
+   │
+ 1 │ export { x } from './m.js';
+   │          ┬  
+   │          ╰── "m.js" re-exports "x"
+   │
+   ├─[ a.js:1:12 ]
+   │
+ 1 │ export let x = 1;
+   │            ┬  
+   │            ╰── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let x = 2;
+   │            ┬  
+   │            ╰── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { x } from './m.js';
+   │          ┬  
+   │          ╰── "m.js" re-exports "x"
+   │
+   ├─[ a.js:1:12 ]
+   │
+ 1 │ export let x = 1;
+   │            ┬  
+   │            ╰── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let x = 2;
+   │            ┬  
+   │            ╰── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:2:10 ]
+   │
+ 2 │ import { x as xt2 } from './t2.js';
+   │          ┬  
+   │          ╰── "t2.js" re-exports "x"
+   │
+   ├─[ a.js:1:12 ]
+   │
+ 1 │ export let x = 1;
+   │            ┬  
+   │            ╰── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let x = 2;
+   │            ┬  
+   │            ╰── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ m.js:1:10 ]
+   │
+ 1 │ export { x } from './t.js';
+   │          ┬  
+   │          ╰── "t.js" re-exports "x"
+   │
+   ├─[ a.js:1:12 ]
+   │
+ 1 │ export let x = 1;
+   │            ┬  
+   │            ╰── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let x = 2;
+   │            ┬  
+   │            ╰── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/b.js
@@ -1,0 +1,1 @@
+export { x } from './t2.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/c.js
@@ -1,0 +1,1 @@
+export { x } from './m.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/d.js
@@ -1,0 +1,1 @@
+export let x = 2;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/index.js
@@ -1,0 +1,3 @@
+import { x } from './m.js';
+import { x as xt2 } from './t2.js';
+console.log(x, xt2);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/m.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/m.js
@@ -1,0 +1,1 @@
+export { x } from './t.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/t.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/t.js
@@ -1,0 +1,2 @@
+export * from './a.js';
+export * from './b.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/t2.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_inherited_cycle_no_cache_write/t2.js
@@ -1,0 +1,2 @@
+export * from './c.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/a.js
@@ -1,0 +1,2 @@
+export * from './b.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/artifacts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { foo } from "./d.js";
+export { foo };
+
+```
+
+## c.js
+
+```js
+import { foo } from "./d.js";
+import "./a.js";
+export { foo };
+
+```
+
+## d.js
+
+```js
+//#region d.js
+let foo = globalThis.SEED;
+//#endregion
+export { foo };
+
+```
+
+## index.js
+
+```js
+import { zfoo } from "./z.js";
+//#region index.js
+console.log(zfoo);
+//#endregion
+
+```
+
+## z.js
+
+```js
+import { foo } from "./d.js";
+import "./c.js";
+//#region z.js
+const zfoo = foo;
+//#endregion
+export { zfoo };
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/b.js
@@ -1,0 +1,1 @@
+export { foo } from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/c.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/d.js
@@ -1,0 +1,1 @@
+export let foo = globalThis.SEED;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/index.js
@@ -1,0 +1,2 @@
+import { zfoo } from './z.js';
+console.log(zfoo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/z.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_direct_consumer/z.js
@@ -1,0 +1,2 @@
+import { foo } from './c.js';
+export const zfoo = foo;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/a.js
@@ -1,0 +1,2 @@
+export * from './b.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { foo } from "./d.js";
+export { foo };
+
+```
+
+## d.js
+
+```js
+//#region d.js
+let foo = globalThis.SEED;
+//#endregion
+export { foo };
+
+```
+
+## index.js
+
+```js
+import { foo } from "./d.js";
+import "./a.js";
+import { zfoo } from "./z.js";
+//#region index.js
+console.log(foo, zfoo);
+//#endregion
+
+```
+
+## z.js
+
+```js
+import { foo } from "./d.js";
+//#region z.js
+const zfoo = foo;
+//#endregion
+export { zfoo };
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/b.js
@@ -1,0 +1,1 @@
+export { foo } from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/c.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/d.js
@@ -1,0 +1,1 @@
+export let foo = globalThis.SEED;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+import { zfoo } from './z.js';
+console.log(foo, zfoo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/z.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_long_cycle_shared_consumer/z.js
@@ -1,0 +1,2 @@
+import { foo } from './c.js';
+export const zfoo = foo;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/a.js
@@ -1,0 +1,2 @@
+export * from './b.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { foo } from "./e.js";
+import "./d.js";
+export { foo };
+
+```
+
+## d.js
+
+```js
+import { foo } from "./e.js";
+export { foo };
+
+```
+
+## e.js
+
+```js
+//#region e.js
+let foo = globalThis.SEED;
+//#endregion
+export { foo };
+
+```
+
+## index.js
+
+```js
+import { foo } from "./e.js";
+import "./a.js";
+//#region index.js
+console.log(foo);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/d.js
@@ -1,0 +1,1 @@
+export { foo } from './e.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/e.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/e.js
@@ -1,0 +1,1 @@
+export let foo = globalThis.SEED;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_cycle_first/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/a.js
@@ -1,0 +1,2 @@
+export * from './d.js';
+export * from './b.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/artifacts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { foo } from "./e.js";
+import "./d.js";
+import "./b.js";
+export { foo };
+
+```
+
+## b.js
+
+```js
+import "./e.js";
+import "./a.js";
+
+```
+
+## d.js
+
+```js
+import { foo } from "./e.js";
+export { foo };
+
+```
+
+## e.js
+
+```js
+//#region e.js
+let foo = globalThis.SEED;
+//#endregion
+export { foo };
+
+```
+
+## index.js
+
+```js
+import { foo } from "./e.js";
+import "./a.js";
+//#region index.js
+console.log(foo);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/d.js
@@ -1,0 +1,1 @@
+export { foo } from './e.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/e.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/e.js
@@ -1,0 +1,1 @@
+export let foo = globalThis.SEED;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_preserve_modules_resolution_first/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ]
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/a.js
@@ -1,0 +1,3 @@
+export * from './b.js';
+export * from './c.js';
+export * from './d.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let foo = 2;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+   │
+   ├─[ d.js:1:12 ]
+   │
+ 1 │ export let foo = 2;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/c.js
@@ -1,0 +1,1 @@
+export let foo = 1;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/d.js
@@ -1,0 +1,1 @@
+export let foo = 2;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_ambiguous_alternatives/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ]
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/a.js
@@ -1,0 +1,3 @@
+export * from './b.js';
+export * from './d.js';
+export * from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/c.js
@@ -1,0 +1,1 @@
+export let foo = 1;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/cjs.cjs
@@ -1,0 +1,1 @@
+module.exports = { bar: 1 };

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/d.js
@@ -1,0 +1,1 @@
+export { foo } from './e.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/e.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/e.js
@@ -1,0 +1,1 @@
+export * from './cjs.cjs';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_commonjs_alternative/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "external": ["ext-pkg"],
+    "format": "cjs"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/a.js
@@ -1,0 +1,3 @@
+export * from './b.js';
+export * from './d.js';
+export * from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/c.js
@@ -1,0 +1,1 @@
+export let foo = 1;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/d.js
@@ -1,0 +1,1 @@
+export { foo } from 'ext-pkg';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_external_alternative/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/a.js
@@ -1,0 +1,2 @@
+export * from './b.js';
+export * from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/artifacts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+//#region index.js
+console.log(42, 42);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/c.js
@@ -1,0 +1,1 @@
+export let foo = 42;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_non_circular_resolution/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo, 42);

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      }
+    ],
+    "external": ["ext-pkg"],
+    "format": "cjs"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/a.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/a.js
@@ -1,0 +1,3 @@
+export * from './b.js';
+export * from './d.js';
+export * from './c.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ b.js:1:10 ]
+   │
+ 1 │ export { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ index.js:1:10 ]
+   │
+ 1 │ import { foo } from './a.js';
+   │          ─┬─  
+   │           ╰─── "a.js" re-exports "foo"
+   │
+   ├─[ c.js:1:12 ]
+   │
+ 1 │ export let foo = 1;
+   │            ─┬─  
+   │             ╰─── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/b.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/b.js
@@ -1,0 +1,1 @@
+export { foo } from './a.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/c.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/c.js
@@ -1,0 +1,1 @@
+export let foo = 1;

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/d.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/d.js
@@ -1,0 +1,1 @@
+export { foo } from './e.js';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/e.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/e.js
@@ -1,0 +1,1 @@
+export * from 'ext-pkg';

--- a/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/index.js
+++ b/crates/rolldown/tests/rolldown/misc/circular_star_reexport_with_one_hop_external_alternative/index.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+console.log(foo);

--- a/crates/rolldown/tests/test262_failures.json
+++ b/crates/rolldown/tests/test262_failures.json
@@ -152,12 +152,6 @@
   "language/module-code/instn-named-bndng-dflt-gen-anon.js": {
     "reason": "keepNames feature in Rolldown does not work for accesses requiring the function to be hoisted"
   },
-  "language/module-code/instn-star-iee-multi-cycle-same-name.js": {
-    "reason": "Incorrect ambiguous export detection in Rolldown"
-  },
-  "language/module-code/instn-star-iee-single-cycle-same-name.js": {
-    "reason": "Incorrect ambiguous export detection in Rolldown"
-  },
   "language/module-code/namespace/internals/super-access-to-tdz-binding.js": {
     "reason": "Rolldown does not preserve TDZ semantics"
   },


### PR DESCRIPTION
Fixes #9175. A circular star-reexport path now resolves as null per ResolveExport instead of failing the build; CIRCULAR_REEXPORT still fires when a binding has no non-circular resolution.