### PR TITLE
ci(metric): mint a short-lived GitHub App token instead of a PAT

### DIFF
--- a/.github/workflows/metric.yml
+++ b/.github/workflows/metric.yml
@@ -48,12 +48,22 @@ jobs:
     needs: [compile-time-and-binary-size]
     runs-on: namespace-profile-linux-x64-default
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # the token defaults to the current repository, so `rolldown/metric` has to be requested explicitly
+          owner: rolldown
+          repositories: metric
+          permission-contents: write # all this job needs: clone `rolldown/metric` and push `metric.json`
+
       - name: Checkout rolldown metric repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'rolldown/metric'
           ref: 'main'
-          token: ${{ secrets.METRIC_SECRET_KEY }}
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true # required by `git push` below
 
       - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
@@ -64,14 +74,13 @@ jobs:
       - name: Install dependencies and push metric
         run: |
           node ./scripts/compile-time-and-binary-size.mjs
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'rolldown-guard[bot]'
+          git config --global user.email '278280044+rolldown-guard[bot]@users.noreply.github.com'
           git add metric.json
           git commit -m "Update benchmark results"
           git push
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPILE_TIME: ${{ needs.compile-time-and-binary-size.outputs.time }}
           COMMIT_HASH: ${{ github.sha }}
           GIT_REPOSITORY_URL: ${{ github.repository }}


### PR DESCRIPTION
## Problem

The `Metric` job has failed on **every** push to `main` since 2026-07-15 10:51 UTC — 85 red runs in July alone. It always dies the same way, in the checkout of `rolldown/metric`:

```
Syncing repository: rolldown/metric
git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin +refs/heads/main*
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled
##[error]The process '/usr/bin/git' failed with exit code 128
```

([latest example](https://github.com/rolldown/rolldown/actions/runs/30165294180/job/89697441974))

`secrets.METRIC_SECRET_KEY` has expired:

| | |
|---|---|
| Last green run | `2026-07-15T09:39Z` — pushed the last commit to `rolldown/metric` at 09:44Z |
| First red run | `2026-07-15T10:51Z` — same error, byte for byte |
| `METRIC_SECRET_KEY` last rotated | `2025-07-14T10:17Z` |

A one-year PAT rotated at 2025-07-14 10:17Z dies right inside the 09:44 → 10:51 window. No commit touched `metric.yml` in that window either — the last edit was #10241 at 08:05Z that day, which then ran green twice.

This credential has expired once before: there is a failure cluster on **2025-07-11..13** that stops exactly when the secret was rotated on 2025-07-14.

Note that `rolldown/metric` is public, so a *missing* token would still fetch anonymously. Only a *rejected* one makes git fall back to the credential prompt and exit 128 — which is what pins this on the token rather than on repo access.

### Impact

Compile-time and binary-size datapoints have not been recorded since 2026-07-15 09:44Z. The repo looks alive only because `rolldown/metric` has its own 00:00-UTC cron writing `metric.json` with the built-in `GITHUB_TOKEN` — that is where the daily "Update benchmark results" commits come from, not from this workflow.

## Fix

Use a GitHub App installation token instead of a PAT. It is minted per run, lives ~1h, is scoped to `rolldown/metric` + `contents: write`, and is owned by the org rather than a person — so there is nothing left to expire on a yearly cadence.

The cross-repo shape (`owner` + `repositories` + a narrow `permission-*`) follows the existing usage in `vite-ecosystem-ci-trigger.yml:146` and `:247`, the latter of which already reaches into another org.

`persist-credentials: true` keeps working unchanged: checkout writes the App token into `http.https://github.com/.extraheader`, which is what the later `git push` picks up.

Two incidental cleanups in the same step:

- Drop `GITHUB_TOKEN` — the workflow sets `permissions: {}` and `scripts/compile-time-and-binary-size.mjs` only reads `COMPILE_TIME`, `COMMIT_HASH`, `GIT_REPOSITORY_URL` and `BINARY_SIZE`.
- Attribute the commit to the bot that actually pushes it, which also tells these commits apart from the ones the daily cron in `rolldown/metric` makes as `github-actions[bot]`.

## Draft, because it needs an admin first

**An org admin must install the App on `rolldown/metric` with `Contents: Read and write` before this can go green.** Every existing `secrets.APP_ID` usage in this repo targets `rolldown/rolldown` itself, so nothing here proves `rolldown-guard` can already reach `rolldown/metric`. The `permission-contents: write` line makes that fail loudly at the token step rather than as a confusing git 128 — and if the App turns out to be installed there already, this works as-is with no admin action.

Open question for whoever has admin: use `APP_ID` (`rolldown-guard`, the org's automation bot — what this PR assumes) or `ECOSYSTEM_CI_GITHUB_APP_ID` (already proven cross-org, but semantically the ecosystem-CI trigger identity)? Happy to switch.

`METRIC_SECRET_KEY` is deliberately left in place so a rollback stays possible; it can be deleted once this is green.

## Alternatives considered

- **Rotate the PAT.** Fixes it today, breaks again in a year — this is the second occurrence.
- **Fine-grained PAT** scoped to `rolldown/metric`. Narrower blast radius, but still capped at 366 days, so it only moves the cliff.
- **Deploy key.** Never expires and is repo-scoped, but it is a long-lived unrotatable secret again.
- **Invert to a pull model** (metric fetches the numbers). Reading another repo's Actions artifacts needs a cross-repo credential too, so it does not remove the problem.

## Follow-up worth doing separately

This was red for 11 days without anyone noticing. An `if: failure()` notify step to `secrets.DISCORD_ROLLDOWN_CHANNEL` (already used in `publish-to-npm.yml:56`) would surface the next breakage on day one.
