### PR TITLE
ci(metric): alert Discord when the metric workflow fails

### DIFF
--- a/.github/workflows/metric.yml
+++ b/.github/workflows/metric.yml
@@ -85,3 +85,22 @@ jobs:
           COMMIT_HASH: ${{ github.sha }}
           GIT_REPOSITORY_URL: ${{ github.repository }}
           BINARY_SIZE: ${{ needs.compile-time-and-binary-size.outputs.binary_size }}
+
+  # Nothing consumes this workflow's output, so a break here is invisible until
+  # someone notices the charts have gone flat — last time that took 11 days.
+  notify-failure:
+    name: Notify Failure
+    needs: [compile-time-and-binary-size, metric]
+    # `failure()` covers either job failing, and unlike `always()` it stays quiet
+    # on cancellation.
+    if: ${{ failure() && github.repository == 'rolldown/rolldown' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_ROLLDOWN_CHANNEL }}
+          embed-title: Metric workflow failed
+          embed-description: |
+            Compile time and binary size are no longer being recorded to [rolldown/metric](https://github.com/rolldown/metric).
+          embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Stacked on #10446 — that PR fixes the expired credential, this one makes the next breakage visible.

## Problem

Nothing consumes this workflow's output, so a break in it is invisible until someone notices the charts at [rolldown/metric](https://rolldown.github.io/metric/) have gone flat. The PAT expiry fixed in #10446 ran red on **every** push to `main` for 11 days and 85 runs before anyone looked.

## Change

A `notify-failure` job posting to `secrets.DISCORD_ROLLDOWN_CHANNEL`, reusing the webhook and the pinned action already used at `publish-to-npm.yml:54` and `:169`.

## Notes for reviewers

- **A separate job, not an `if: failure()` step inside `metric`.** A step would only cover the `metric` job; `needs: [compile-time-and-binary-size, metric]` means a `cargo build --release` failure in the first job gets reported too.
- **`failure()` rather than `always()`** — stays quiet on cancellation.
- **`github.repository == 'rolldown/rolldown'` guard**, matching `publish-to-npm.yml:48`. Forks don't have `DISCORD_ROLLDOWN_CHANNEL`, so without it a fork pushing to its own `main` would fail this job on an empty webhook URL.
- **Noise tradeoff, worth a second opinion:** this pings once per failed run, so a repeat of the 11-day outage would post ~80 messages. That is deliberate — the whole failure mode being fixed here is a break nobody noticed. One ping per *incident* instead would need de-duplication state (only notify when the previous run succeeded, via the runs API), which is noticeably more code. Happy to switch if reviewers prefer that.

## Alternatives considered

- **Rely on the red ✗ on `main`.** That is exactly what failed for 11 days.
- **Email via GitHub's own "Actions workflow failure" notifications.** They go to the commit author of each push, not to a channel anyone owns, so responsibility for a shared piece of infrastructure lands on whoever happened to merge last.
- **Open an issue on failure.** Louder and more persistent, but needs `issues: write` on a workflow that currently declares `permissions: {}`, and risks a pile of duplicate issues without the same de-duplication logic a per-incident ping would need.
