### PR TITLE
refactor(code-splitting): derive symbol chunk ownership as pass-local link data

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -13,8 +13,8 @@ use oxc_str::CompactStr;
 use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, CrossChunkImportItem, EntryPointKind, ExportsKind, ImportKind,
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PostChunkOptimizationOperation,
-  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, RuntimeHelper, SymbolRef, TaggedSymbolRef,
-  UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
+  PreserveEntrySignatures, RUNTIME_HELPER_NAMES, RuntimeHelper, SymbolRef, SymbolRefDb,
+  TaggedSymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
 };
 use rolldown_utils::index_vec_ext::IndexVecRefExt as _;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -39,6 +39,7 @@ struct CrossChunkLinkState {
   index_cross_chunk_imports: IndexCrossChunkImports,
   index_cross_chunk_dynamic_imports: IndexCrossChunkDynamicImports,
   order_live_symbols: FxHashSet<SymbolRef>,
+  symbol_chunk_table: SymbolChunkTable,
 }
 
 #[derive(Clone, Copy)]
@@ -58,24 +59,29 @@ impl<'a> FinalEsmInitMetadataAvailability<'a> {
   }
 }
 
-/// What a cross-chunk link computation does with the symbol->chunk ownership it derives.
+/// Symbol -> owning chunk, derived by [`GenerateStage::collect_depended_symbols`] for one
+/// cross-chunk link pass.
 ///
-/// [`GenerateStage::collect_depended_symbols`] does not only *read* the chunk graph: it writes each
-/// declared symbol's owning chunk back into the shared symbol database, and
-/// [`GenerateStage::compute_chunk_imports`] then reads that ownership to resolve which chunk a
-/// depended symbol is imported from. So the write is load-bearing *within* one pass, and the pass
-/// cannot be turned into a plain read-only query by dropping it.
-///
-/// It can be scoped instead. `Scoped` records each symbol's previous owner while committing, so the
-/// caller can roll the database back afterwards and leave no trace. That is what lets the entry
-/// facade decision run the real link computation as a question ("which chunks import this chunk?")
-/// before the final pass answers it for real.
-enum SymbolChunkOwnership<'a> {
-  /// Keep the derived ownership. Used by the final [`GenerateStage::compute_cross_chunk_links`].
-  Commit,
-  /// Keep it only for the duration of this pass; record the previous owners into the journal so the
-  /// caller can restore them.
-  Scoped(&'a mut Vec<(SymbolRef, Option<ChunkIdx>)>),
+/// The derivation used to be written into the shared symbol database mid-pass so that
+/// [`GenerateStage::compute_chunk_imports`] could read it back — a load-bearing write that forced
+/// every link pass, including the what-if ones, to mutate shared state and undo it afterwards.
+/// Carried as pass-local data instead, the whole pass is read-only by construction: a pass whose
+/// result is never committed (the prediction pass, the entry-facade edge query) simply drops its
+/// table, and the final [`GenerateStage::compute_cross_chunk_links`] remains the single writer,
+/// flushing its table into the database in one place for the downstream consumers of
+/// `chunk_idx` (the CJS cross-chunk reference rendering in the module finalizer and the
+/// chunk-export generator).
+struct SymbolChunkTable {
+  map: FxHashMap<SymbolRef, ChunkIdx>,
+}
+
+impl SymbolChunkTable {
+  /// The chunk owning `symbol_ref`, as this pass derived it; falls back to the value already in
+  /// the symbol database, mirroring the write-then-read behavior this table replaced (a symbol
+  /// the pass did not assign resolves exactly as it did then).
+  fn chunk_of(&self, symbol_ref: SymbolRef, symbols: &SymbolRefDb) -> Option<ChunkIdx> {
+    self.map.get(&symbol_ref).copied().or_else(|| symbols.get(symbol_ref).chunk_idx)
+  }
 }
 
 trait UsedSymbolRefsView: Sync {
@@ -111,13 +117,18 @@ impl GenerateStage<'_> {
       index_cross_chunk_imports,
       index_cross_chunk_dynamic_imports,
       order_live_symbols,
+      symbol_chunk_table,
     } = self.compute_cross_chunk_link_state(
       chunk_graph,
       used_symbol_refs,
       order_state,
       FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
-      SymbolChunkOwnership::Commit,
     );
+    // The single flush of symbol->chunk ownership into the shared symbol database. Everything
+    // downstream that reads `chunk_idx` — the module finalizer and the chunk-export generator
+    // rendering CJS cross-chunk references — sees exactly this pass's derivation; the what-if
+    // passes (prediction, the entry-facade edge query) never write at all.
+    self.commit_symbol_chunk_table(&symbol_chunk_table);
 
     #[cfg(debug_assertions)]
     let predicted_static_import_edges: IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> =
@@ -258,13 +269,14 @@ impl GenerateStage<'_> {
     }
   }
 
-  /// Compute provisional links for order analysis. Runtime symbol placement is cleared if moved.
-  /// Uses an empty order state and explicitly marks final-init metadata unavailable, so the edges
-  /// are the *pre-lowering* baseline topology (value and side-effect imports, before wrapping adds
-  /// `init_*` imports). The emergent-cycle fixpoint layers the plan's `init_*` forwarding edges on
-  /// top of this baseline (`post_lowering_import_edges`).
+  /// Compute provisional links for order analysis. Uses an empty order state and explicitly marks
+  /// final-init metadata unavailable, so the edges are the *pre-lowering* baseline topology (value
+  /// and side-effect imports, before wrapping adds `init_*` imports). The emergent-cycle fixpoint
+  /// layers the plan's `init_*` forwarding edges on top of this baseline
+  /// (`post_lowering_import_edges`). Read-only: the symbol ownership this pass derives is dropped
+  /// with its table, so no provisional values ever reach the symbol database.
   pub(super) fn predicted_static_import_edges(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &UsedSymbolRefsBuilder,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
@@ -274,7 +286,6 @@ impl GenerateStage<'_> {
       used_symbol_refs,
       &empty_order_state,
       FinalEsmInitMetadataAvailability::Unavailable,
-      SymbolChunkOwnership::Commit,
     );
     Self::static_import_edges_of(chunk_graph, state)
   }
@@ -298,27 +309,22 @@ impl GenerateStage<'_> {
   /// "some chunk other than me imports me" is unchanged, and all facade decisions can be taken
   /// together from this one pre-facade snapshot.
   ///
-  /// The symbol->chunk ownership the pass commits is rolled back before returning, so this leaves
-  /// the symbol database exactly as it found it and the final pass is still the only writer.
+  /// The symbol->chunk ownership the pass derives stays in its pass-local [`SymbolChunkTable`] and
+  /// is dropped with the state, so this query is read-only by construction and the final pass is
+  /// still the only writer of the symbol database.
   pub(super) fn lowered_static_import_edges(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &UsedSymbolRefsBuilder,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
-    let mut journal = Vec::new();
     let state = self.compute_cross_chunk_link_state(
       chunk_graph,
       used_symbol_refs,
       order_state,
       FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
-      SymbolChunkOwnership::Scoped(&mut journal),
     );
-    let symbols = &mut self.link_output.symbol_db;
-    for (symbol_ref, previous_chunk_idx) in journal.into_iter().rev() {
-      symbols.get_mut(symbol_ref).chunk_idx = previous_chunk_idx;
-    }
     Self::static_import_edges_of(chunk_graph, state)
   }
 
@@ -339,12 +345,11 @@ impl GenerateStage<'_> {
   }
 
   fn compute_cross_chunk_link_state(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
-    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
   ) -> CrossChunkLinkState {
     let mut index_chunk_depended_symbols: IndexChunkDependedSymbols =
       index_vec![FxIndexSet::<SymbolRef>::default(); chunk_graph.chunk_table.len()];
@@ -377,7 +382,7 @@ impl GenerateStage<'_> {
       },
     );
 
-    self.collect_depended_symbols(
+    let symbol_chunk_table = self.collect_depended_symbols(
       chunk_graph,
       &mut index_chunk_depended_symbols,
       &mut index_chunk_direct_imports_from_external_modules,
@@ -385,7 +390,6 @@ impl GenerateStage<'_> {
       used_symbol_refs,
       order_state,
       final_esm_init_metadata,
-      symbol_chunk_ownership,
     );
 
     self.compute_chunk_imports(
@@ -399,6 +403,7 @@ impl GenerateStage<'_> {
       used_symbol_refs,
       order_state,
       &order_live_symbols,
+      &symbol_chunk_table,
     );
 
     CrossChunkLinkState {
@@ -409,14 +414,16 @@ impl GenerateStage<'_> {
       index_cross_chunk_imports,
       index_cross_chunk_dynamic_imports,
       order_live_symbols,
+      symbol_chunk_table,
     }
   }
 
-  /// - Assign each symbol to the chunk it belongs to
+  /// - Derive each declared symbol's owning chunk, returned as the pass-local
+  ///   [`SymbolChunkTable`]
   /// - Collect all referenced symbols and consider them potential imports
   #[expect(clippy::too_many_arguments)]
   fn collect_depended_symbols(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     index_chunk_depended_symbols: &mut IndexChunkDependedSymbols,
     index_chunk_imports_from_external_modules: &mut IndexChunkImportsFromExternalModules,
@@ -424,8 +431,7 @@ impl GenerateStage<'_> {
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
-    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
-  ) {
+  ) -> SymbolChunkTable {
     let symbols = &self.link_output.symbol_db;
     let chunk_id_to_symbols_vec = append_only_vec::AppendOnlyVec::new();
 
@@ -631,43 +637,37 @@ impl GenerateStage<'_> {
         chunk_id_to_symbols_vec.push((chunk_id, symbol_needs_to_assign));
       },
     );
-    self.assign_symbol_chunk_ownership(chunk_id_to_symbols_vec, symbol_chunk_ownership);
+    self.build_symbol_chunk_table(chunk_id_to_symbols_vec)
   }
 
   /// Record which chunk owns each declared symbol, so [`Self::compute_chunk_imports`] can resolve a
   /// depended symbol to the chunk it must be imported from.
-  fn assign_symbol_chunk_ownership(
-    &mut self,
+  fn build_symbol_chunk_table(
+    &self,
     chunk_id_to_symbols_vec: append_only_vec::AppendOnlyVec<(ChunkIdx, Vec<TaggedSymbolRef>)>,
-    symbol_chunk_ownership: SymbolChunkOwnership<'_>,
-  ) {
-    // shadowing previous immutable borrow
-    let symbols = &mut self.link_output.symbol_db;
-    let mut journal = match symbol_chunk_ownership {
-      SymbolChunkOwnership::Commit => None,
-      SymbolChunkOwnership::Scoped(journal) => Some(journal),
-    };
+  ) -> SymbolChunkTable {
+    let mut map = FxHashMap::default();
     for (chunk_idx, symbol_list) in chunk_id_to_symbols_vec {
       for declared in symbol_list {
         let declared = declared.inner();
-        if cfg!(debug_assertions) {
-          let symbol_data = symbols.get(declared);
-          debug_assert!(
-            symbol_data.chunk_idx.unwrap_or(chunk_idx) == chunk_idx,
-            "Symbol: {:?}, {:?} in {:?} should only belong to one chunk. Existed {:?}, new {chunk_idx:?}",
-            declared.name(symbols),
-            declared,
-            self.link_output.module_table[declared.owner].id().as_str(),
-            symbol_data.chunk_idx,
-          );
-        }
-
-        let symbol_data = symbols.get_mut(declared);
-        if let Some(journal) = journal.as_deref_mut() {
-          journal.push((declared, symbol_data.chunk_idx));
-        }
-        symbol_data.chunk_idx = Some(chunk_idx);
+        let previous = map.insert(declared, chunk_idx);
+        debug_assert!(
+          previous.is_none_or(|previous| previous == chunk_idx),
+          "Symbol: {:?}, {:?} in {:?} should only belong to one chunk. Existed {previous:?}, new {chunk_idx:?}",
+          declared.name(&self.link_output.symbol_db),
+          declared,
+          self.link_output.module_table[declared.owner].id().as_str(),
+        );
       }
+    }
+    SymbolChunkTable { map }
+  }
+
+  /// The single point where derived symbol->chunk ownership enters the shared symbol database.
+  fn commit_symbol_chunk_table(&mut self, table: &SymbolChunkTable) {
+    let symbols = &mut self.link_output.symbol_db;
+    for (symbol_ref, chunk_idx) in &table.map {
+      symbols.get_mut(*symbol_ref).chunk_idx = Some(*chunk_idx);
     }
   }
 
@@ -913,6 +913,7 @@ impl GenerateStage<'_> {
     used_symbol_refs: &impl UsedSymbolRefsView,
     order_state: &super::order_wrap_state::OrderWrapState,
     order_live_symbols: &FxHashSet<SymbolRef>,
+    symbol_chunk_table: &SymbolChunkTable,
   ) {
     // For each module that has been absorbed as a facade namespace, we need to know
     // which other modules dynamically import it so we can tell whether the absorbed
@@ -1119,7 +1120,7 @@ impl GenerateStage<'_> {
             // namespace or default imports from external modules. Named-only imports render as
             // direct `require()` bindings and must not inherit another chunk's `__toESM`.
             let to_esm_ref = self.link_output.runtime.resolve_symbol("__toESM");
-            if self.link_output.symbol_db.get(to_esm_ref).chunk_idx.is_some() {
+            if symbol_chunk_table.chunk_of(to_esm_ref, &self.link_output.symbol_db).is_some() {
               // __toESM is in a chunk, so it's being used
               to_esm_ref
             } else {
@@ -1130,16 +1131,17 @@ impl GenerateStage<'_> {
           } else {
             import_ref
           };
-          let import_symbol = self.link_output.symbol_db.get(import_ref);
-          let importee_chunk_idx = import_symbol.chunk_idx.unwrap_or_else(|| {
-            let symbol_owner = &self.link_output.module_table[import_ref.owner];
-            let symbol_name = import_ref.name(&self.link_output.symbol_db);
-            panic!(
-              "Symbol {:?} in {:?} should belong to a chunk",
-              symbol_name,
-              symbol_owner.id().as_str()
-            )
-          });
+          let importee_chunk_idx = symbol_chunk_table
+            .chunk_of(import_ref, &self.link_output.symbol_db)
+            .unwrap_or_else(|| {
+              let symbol_owner = &self.link_output.module_table[import_ref.owner];
+              let symbol_name = import_ref.name(&self.link_output.symbol_db);
+              panic!(
+                "Symbol {:?} in {:?} should belong to a chunk",
+                symbol_name,
+                symbol_owner.id().as_str()
+              )
+            });
           // Check if the import is from another chunk
           if chunk_id != importee_chunk_idx {
             index_cross_chunk_imports[chunk_id].insert(importee_chunk_idx);

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -94,7 +94,7 @@ struct ActualOrderTraversal {
 
 impl GenerateStage<'_> {
   pub(super) fn analyze_execution_order(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &UsedSymbolRefsBuilder,
   ) -> Option<OrderAnalysis> {

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -200,7 +200,7 @@ impl GenerateStage<'_> {
   /// produces the final edges, so the decision reads facts rather than a re-derived approximation
   /// of them. See [`GenerateStage::lowered_static_import_edges`].
   fn entry_facade_import_edges(
-    &mut self,
+    &self,
     chunk_graph: &ChunkGraph,
     used_symbol_refs: &UsedSymbolRefsBuilder,
     order_state: &OrderWrapState,


### PR DESCRIPTION
Asking the cross-chunk link computation a question used to change the state it answers from: the what-if passes — the wrapping prediction and the entry-facade edge query of #10441 — had to write into the shared ownership records they read, then undo their own writes by hand. This PR makes asking side-effect-free by construction: a pass derives ownership as data local to itself, only the final pass commits it, and the compiler now enforces what a doc comment used to promise.

```rust
// before — the edge query undoes its own writes, in reverse, by hand
let mut journal = Vec::new();
let state = self.compute_cross_chunk_link_state(…, Scoped(&mut journal));
for (symbol_ref, previous_chunk_idx) in journal.into_iter().rev() {
  symbols.get_mut(symbol_ref).chunk_idx = previous_chunk_idx;
}

// after — asking cannot write, so there is nothing to undo
let state = self.compute_cross_chunk_link_state(…); // &self
```

## Motivation

The cost of the old shape was a silent-failure class, not a bug today. The undo was complete only while the pass contained exactly one write; nothing stopped a future edit from adding a second one the journal does not cover. An incomplete undo leaves values behind that later reads can pick up, and what ships is misresolved cross-chunk imports or a wrong facade decision — with no test signal unless a fixture happens to traverse the exact path. Reviewing #10441 meant manually enumerating every mutation site in the pass to prove the undo complete, and that proof expires with every future edit to the pass.

The old shape also leaked between passes even when nothing went wrong. The prediction pass committed provisional ownership it had no way to retract, so stale values sat in the shared records until the final pass overwrote them — the runtime-module spot-clean exists solely to patch the cases where overwriting was not enough (its three call sites now overwrite `None` with `None`; see non-goals).

The coupling itself: the collect step (`collect_depended_symbols`, which derives each declared symbol's owning chunk) wrote its derivation into the shared symbol database because the import-resolution step (`compute_chunk_imports`) reads ownership back later in the same pass. The write was load-bearing within one pass, so no caller could simply skip it — every caller had to either keep it (and pollute) or undo it (and be provably complete).

Emitted output is unaffected. The downstream consumers of committed ownership — the CJS cross-chunk reference rendering in the module finalizer and the chunk-export generator — read identical values at identical times.

## Change

Ownership becomes a value the pass returns instead of state it writes, and committing becomes the final caller's single explicit act. The collect step builds that value — a pass-local `SymbolChunkTable` — from the per-chunk symbol lists it already materialized.

- The import-resolution step resolves a depended symbol through the table, falling back to the database value on a miss — exactly the write-then-read union it replaces, so behavior is unchanged by construction.
- A pass whose answer is never committed (the prediction, the facade edge query) drops its table on return. The `SymbolChunkOwnership` enum, the journal, and its reverse replay are deleted.
- The final `compute_cross_chunk_links` flushes its table in one place, ahead of every downstream reader, and the whole pass chain down from `compute_cross_chunk_link_state` (including `analyze_execution_order`) becomes `&self`.
- The one-chunk-per-symbol debug assert now checks within the pass's own derivation instead of against whatever an earlier pass left behind, removing its only false-positive source.

Alternative weighed: a two-impl ownership view — the committing pass reading the flushed database directly, monomorphized separately from the table-reading query — would keep the final pass's resolve a direct field read instead of an `FxHashMap` probe. Not taken: it doubles the read-path surface for a cost that should be noise (one probe per depended-symbol resolve plus one map build per pass). CodSpeed on this PR is the check, and the view design stays the escalation path if the strict-mode benchmarks disagree.

Non-goal: removing the now-inert runtime-module spot-clean (`clear_module_symbol_chunk_indices`). With no provisional writes left to clean up, its three call sites overwrite `None` with `None`; deleting them wants its own verification, so they stay untouched here.

## Validation

A behavior-preserving refactor pins itself on the existing suite, and the suite is built to catch exactly the drift this change could introduce: any output difference surfaces as a snapshot diff. 1896 integration tests pass with zero snapshot modifications; `cargo clippy --all-targets` and `cargo fmt --check` are clean. (`test262_module_code` fails locally only because this worktree has no test262 submodule checkout — the panic fires before any bundling runs; CI executes it with submodules.) Unverified locally and delegated to CI: the CodSpeed benchmarks for the probe-vs-field-read cost above.

Stacked on #10441.
