### PR TITLE
refactor(plugin): share asset emission helpers between copy_module and asset_module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,14 +2827,11 @@ name = "rolldown_plugin_asset_module"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "memchr",
  "rolldown_common",
  "rolldown_plugin",
- "rolldown_std_utils",
+ "rolldown_plugin_utils",
  "rolldown_utils",
  "rustc-hash",
- "string_wizard",
- "tokio",
 ]
 
 [[package]]
@@ -2870,14 +2867,11 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "arcstr",
- "memchr",
  "rolldown_common",
  "rolldown_plugin",
- "rolldown_std_utils",
+ "rolldown_plugin_utils",
  "rolldown_utils",
  "rustc-hash",
- "string_wizard",
- "tokio",
 ]
 
 [[package]]
@@ -2971,12 +2965,16 @@ name = "rolldown_plugin_utils"
 version = "1.2.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "memchr",
  "oxc",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_std_utils",
  "rolldown_utils",
  "serde_json",
+ "string_wizard",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/rolldown_plugin_asset_module/Cargo.toml
+++ b/crates/rolldown_plugin_asset_module/Cargo.toml
@@ -13,11 +13,8 @@ test = false
 
 [dependencies]
 anyhow = { workspace = true }
-memchr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_std_utils = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
-string_wizard = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }

--- a/crates/rolldown_plugin_asset_module/src/lib.rs
+++ b/crates/rolldown_plugin_asset_module/src/lib.rs
@@ -1,16 +1,13 @@
-use std::{borrow::Cow, path::Path, sync::Arc};
+use std::{borrow::Cow, path::Path};
 
-use memchr::memmem;
-use rolldown_common::{EmittedAsset, ModuleType, StrOrBytes, side_effects::HookSideEffects};
+use rolldown_common::{ModuleType, side_effects::HookSideEffects};
 use rolldown_plugin::{
-  HookLoadArgs, HookLoadOutput, HookLoadReturn, HookRenderChunkArgs, HookRenderChunkOutput,
-  HookRenderChunkReturn, HookTransformOutputMap, HookUsage, Plugin, PluginHookMeta, PluginOrder,
-  SharedLoadPluginContext,
+  HookLoadArgs, HookLoadOutput, HookLoadReturn, HookRenderChunkArgs, HookRenderChunkReturn,
+  HookUsage, Plugin, PluginHookMeta, PluginOrder, SharedLoadPluginContext,
 };
-use rolldown_std_utils::relative_path_as_js_specifier;
+use rolldown_plugin_utils::{emit_asset, rewrite_emitted_asset_references};
 use rolldown_utils::url::clean_url;
 use rustc_hash::FxHashSet;
-use string_wizard::{MagicString, SourceMapOptions};
 
 const PREFIX: &str = "__ROLLDOWN_ASSET__#";
 
@@ -64,61 +61,7 @@ impl Plugin for AssetModulePlugin {
     ctx: &rolldown_plugin::PluginContext,
     args: &HookRenderChunkArgs<'_>,
   ) -> HookRenderChunkReturn {
-    // Quick bail: if the code doesn't contain our prefix, nothing to do
-    if !args.code.contains(PREFIX) {
-      return Ok(None);
-    }
-
-    let chunk_filename = &args.chunk.filename;
-    let code = args.code.as_str();
-    let mut magic_string = MagicString::new(code);
-    let mut changed = false;
-
-    // Use memchr for SIMD-accelerated substring search
-    let finder = memmem::find_iter(code.as_bytes(), PREFIX.as_bytes());
-
-    for abs_pos in finder {
-      let after_prefix = abs_pos + PREFIX.len();
-
-      // Extract ref_id: scan until we hit a quote (", ') or end of string
-      let rest = &code[after_prefix..];
-      let ref_end = rest.find(['"', '\'']).unwrap_or(rest.len());
-      let ref_id = &rest[..ref_end];
-
-      if ref_id.is_empty() {
-        continue;
-      }
-
-      // Resolve the asset filename
-      let asset_filename = match ctx.get_file_name(ref_id) {
-        Ok(name) => name,
-        Err(_) => continue,
-      };
-
-      // Compute relative path from chunk to asset
-      let relative = compute_relative_path(chunk_filename, &asset_filename);
-
-      let end = after_prefix + ref_end;
-      #[expect(clippy::cast_possible_truncation)]
-      if magic_string.update(abs_pos as u32, end as u32, relative).is_ok() {
-        changed = true;
-      }
-    }
-
-    if changed {
-      Ok(Some(HookRenderChunkOutput {
-        code: magic_string.to_string(),
-        map: HookTransformOutputMap::from_if_enabled(args.options.sourcemap.is_some(), || {
-          magic_string.source_map(SourceMapOptions {
-            hires: string_wizard::Hires::Boundary,
-            include_content: false,
-            source: Arc::from(args.chunk.filename.as_str()),
-          })
-        }),
-      }))
-    } else {
-      Ok(None)
-    }
+    Ok(rewrite_emitted_asset_references(ctx, args, PREFIX))
   }
 }
 
@@ -142,36 +85,14 @@ impl AssetModulePlugin {
       return Ok(None);
     }
 
-    let path = Path::new(clean_id);
-
-    // Read file as binary (use cleaned path for filesystem access)
-    let bytes = tokio::fs::read(clean_id)
-      .await
-      .map_err(|e| anyhow::anyhow!("Failed to read asset module {clean_id}: {e}"))?;
-
-    // Derive name from the cleaned file path
-    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("asset").to_string();
-
-    // Use relative path for original_file_name to avoid leaking absolute paths
-    let original_file_name =
-      path.strip_prefix(ctx.cwd()).unwrap_or(path).to_string_lossy().into_owned();
-
-    // Emit the file as an asset
-    let reference_id = ctx
-      .emit_file_async(EmittedAsset {
-        name: Some(file_name),
-        original_file_name: Some(original_file_name),
-        source: StrOrBytes::Bytes(bytes),
-        ..Default::default()
-      })
-      .await?;
-
-    // Associate this module with the emitted file so the `new URL()` finalizer
-    // can look up the asset filename by module ID (use original args.id for mapping)
-    ctx.associate_module_with_file_ref(args.id, &reference_id);
-
-    // Add watch file for watch mode (use cleaned path)
-    ctx.add_watch_file(clean_id);
+    let reference_id = emit_asset(
+      &ctx,
+      clean_id,
+      |e| anyhow::anyhow!("Failed to read asset module {clean_id}: {e}"),
+      |reference_id| ctx.associate_module_with_file_ref(args.id, reference_id),
+      |clean_id| ctx.add_watch_file(clean_id),
+    )
+    .await?;
 
     // Return JS code that exports the asset placeholder via CJS.
     // Using `module.exports` ensures `require()` returns the string directly.
@@ -197,12 +118,4 @@ impl AssetModulePlugin {
       .and_then(|e| e.to_str())
       .is_some_and(|ext| self.asset_extensions.contains(ext))
   }
-}
-
-/// Compute the relative path from a chunk file to an asset file,
-/// ensuring it starts with "./" for relative paths.
-fn compute_relative_path(chunk_filename: &str, asset_filename: &str) -> String {
-  let chunk_dir = Path::new(chunk_filename).parent().unwrap_or(Path::new(""));
-
-  relative_path_as_js_specifier(asset_filename, chunk_dir)
 }

--- a/crates/rolldown_plugin_asset_module/src/lib.rs
+++ b/crates/rolldown_plugin_asset_module/src/lib.rs
@@ -85,14 +85,11 @@ impl AssetModulePlugin {
       return Ok(None);
     }
 
-    let reference_id = emit_asset(
-      &ctx,
-      clean_id,
-      |e| anyhow::anyhow!("Failed to read asset module {clean_id}: {e}"),
-      |reference_id| ctx.associate_module_with_file_ref(args.id, reference_id),
-      |clean_id| ctx.add_watch_file(clean_id),
-    )
+    let reference_id = emit_asset(&ctx, clean_id, |e| {
+      anyhow::anyhow!("Failed to read asset module {clean_id}: {e}")
+    })
     .await?;
+    ctx.associate_module_with_file_ref(args.id, &reference_id);
 
     // Return JS code that exports the asset placeholder via CJS.
     // Using `module.exports` ensures `require()` returns the string directly.

--- a/crates/rolldown_plugin_asset_module/src/lib.rs
+++ b/crates/rolldown_plugin_asset_module/src/lib.rs
@@ -90,6 +90,8 @@ impl AssetModulePlugin {
     })
     .await?;
     ctx.associate_module_with_file_ref(args.id, &reference_id);
+    // Through LoadPluginContext, which also records the module's HMR transform dependency.
+    ctx.add_watch_file(clean_id);
 
     // Return JS code that exports the asset placeholder via CJS.
     // Using `module.exports` ensures `require()` returns the string directly.

--- a/crates/rolldown_plugin_copy_module/Cargo.toml
+++ b/crates/rolldown_plugin_copy_module/Cargo.toml
@@ -14,11 +14,8 @@ test = false
 [dependencies]
 anyhow = { workspace = true }
 arcstr = { workspace = true }
-memchr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_std_utils = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
-string_wizard = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }

--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -95,6 +95,7 @@ impl Plugin for CopyModulePlugin {
       anyhow::anyhow!("Failed to read copy module {}: {e}", resolved_id.id)
     })
     .await?;
+    ctx.add_watch_file(clean_id);
 
     // Return a prefixed external ID — the prefix will be rewritten in render_chunk
     let placeholder_id: ArcStr = format!("{PREFIX}{reference_id}").into();

--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -1,17 +1,14 @@
-use std::{borrow::Cow, path::Path, sync::Arc};
+use std::{borrow::Cow, path::Path};
 
 use arcstr::ArcStr;
-use memchr::memmem;
-use rolldown_common::{EmittedAsset, ModuleType, ResolvedExternal, StrOrBytes};
+use rolldown_common::{ModuleType, ResolvedExternal};
 use rolldown_plugin::{
-  HookRenderChunkArgs, HookRenderChunkOutput, HookRenderChunkReturn, HookResolveIdArgs,
-  HookResolveIdOutput, HookResolveIdReturn, HookTransformOutputMap, HookUsage, Plugin,
-  PluginContext, PluginHookMeta, PluginOrder,
+  HookRenderChunkArgs, HookRenderChunkReturn, HookResolveIdArgs, HookResolveIdOutput,
+  HookResolveIdReturn, HookUsage, Plugin, PluginContext, PluginHookMeta, PluginOrder,
 };
-use rolldown_std_utils::relative_path_as_js_specifier;
+use rolldown_plugin_utils::{emit_asset, rewrite_emitted_asset_references};
 use rolldown_utils::url::clean_url;
 use rustc_hash::FxHashSet;
-use string_wizard::{MagicString, SourceMapOptions};
 
 const PREFIX: &str = "__ROLLDOWN_COPY_MODULE__#";
 
@@ -94,31 +91,14 @@ impl Plugin for CopyModulePlugin {
       return Ok(None);
     }
 
-    // Read the file bytes asynchronously to avoid blocking the tokio worker thread
-    let bytes = tokio::fs::read(clean_id)
-      .await
-      .map_err(|e| anyhow::anyhow!("Failed to read copy module {}: {e}", resolved_id.id))?;
-
-    // Derive a name from the file path
-    let file_name =
-      resolved_path.file_name().and_then(|n| n.to_str()).unwrap_or("asset").to_string();
-
-    // Use relative path for original_file_name to avoid leaking absolute paths into output
-    let original_file_name =
-      resolved_path.strip_prefix(ctx.cwd()).unwrap_or(resolved_path).to_string_lossy().into_owned();
-
-    // Emit the file as an asset
-    let reference_id = ctx
-      .emit_file_async(EmittedAsset {
-        name: Some(file_name),
-        original_file_name: Some(original_file_name),
-        source: StrOrBytes::Bytes(bytes),
-        ..Default::default()
-      })
-      .await?;
-
-    // Add watch file for watch mode (use the clean absolute path)
-    ctx.add_watch_file(clean_id);
+    let reference_id = emit_asset(
+      ctx,
+      clean_id,
+      |e| anyhow::anyhow!("Failed to read copy module {}: {e}", resolved_id.id),
+      |_| {},
+      |clean_id| ctx.add_watch_file(clean_id),
+    )
+    .await?;
 
     // Return a prefixed external ID — the prefix will be rewritten in render_chunk
     let placeholder_id: ArcStr = format!("{PREFIX}{reference_id}").into();
@@ -141,68 +121,6 @@ impl Plugin for CopyModulePlugin {
     ctx: &PluginContext,
     args: &HookRenderChunkArgs<'_>,
   ) -> HookRenderChunkReturn {
-    // Quick bail: if the code doesn't contain our prefix, nothing to do
-    if !args.code.contains(PREFIX) {
-      return Ok(None);
-    }
-
-    let chunk_filename = &args.chunk.filename;
-    let code = args.code.as_str();
-    let mut magic_string = MagicString::new(code);
-    let mut changed = false;
-
-    // Use memchr for SIMD-accelerated substring search
-    let finder = memmem::find_iter(code.as_bytes(), PREFIX.as_bytes());
-
-    for abs_pos in finder {
-      let after_prefix = abs_pos + PREFIX.len();
-
-      // Extract ref_id: scan until we hit a quote (", ') or end of string
-      let rest = &code[after_prefix..];
-      let ref_end = rest.find(['"', '\'']).unwrap_or(rest.len());
-      let ref_id = &rest[..ref_end];
-
-      if ref_id.is_empty() {
-        continue;
-      }
-
-      // Resolve the asset filename
-      let asset_filename = match ctx.get_file_name(ref_id) {
-        Ok(name) => name,
-        Err(_) => continue,
-      };
-
-      // Compute relative path from chunk to asset
-      let relative = compute_relative_path(chunk_filename, &asset_filename);
-
-      let end = after_prefix + ref_end;
-      #[expect(clippy::cast_possible_truncation)]
-      if magic_string.update(abs_pos as u32, end as u32, relative).is_ok() {
-        changed = true;
-      }
-    }
-
-    if changed {
-      Ok(Some(HookRenderChunkOutput {
-        code: magic_string.to_string(),
-        map: HookTransformOutputMap::from_if_enabled(args.options.sourcemap.is_some(), || {
-          magic_string.source_map(SourceMapOptions {
-            hires: string_wizard::Hires::Boundary,
-            include_content: false,
-            source: Arc::from(args.chunk.filename.as_str()),
-          })
-        }),
-      }))
-    } else {
-      Ok(None)
-    }
+    Ok(rewrite_emitted_asset_references(ctx, args, PREFIX))
   }
-}
-
-/// Compute the relative path from a chunk file to an asset file,
-/// ensuring it starts with "./" for relative paths.
-fn compute_relative_path(chunk_filename: &str, asset_filename: &str) -> String {
-  let chunk_dir = Path::new(chunk_filename).parent().unwrap_or(Path::new(""));
-
-  relative_path_as_js_specifier(asset_filename, chunk_dir)
 }

--- a/crates/rolldown_plugin_copy_module/src/lib.rs
+++ b/crates/rolldown_plugin_copy_module/src/lib.rs
@@ -91,13 +91,9 @@ impl Plugin for CopyModulePlugin {
       return Ok(None);
     }
 
-    let reference_id = emit_asset(
-      ctx,
-      clean_id,
-      |e| anyhow::anyhow!("Failed to read copy module {}: {e}", resolved_id.id),
-      |_| {},
-      |clean_id| ctx.add_watch_file(clean_id),
-    )
+    let reference_id = emit_asset(ctx, clean_id, |e| {
+      anyhow::anyhow!("Failed to read copy module {}: {e}", resolved_id.id)
+    })
     .await?;
 
     // Return a prefixed external ID — the prefix will be rewritten in render_chunk

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -19,9 +19,13 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+arcstr = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 serde_json = { workspace = true }
+string_wizard = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }

--- a/crates/rolldown_plugin_utils/src/asset_emission.rs
+++ b/crates/rolldown_plugin_utils/src/asset_emission.rs
@@ -13,8 +13,6 @@ pub async fn emit_asset(
   ctx: &PluginContext,
   clean_id: &str,
   read_error: impl FnOnce(std::io::Error) -> anyhow::Error,
-  after_emit: impl FnOnce(&str),
-  add_watch_file: impl FnOnce(&str),
 ) -> anyhow::Result<ArcStr> {
   let path = Path::new(clean_id);
   let bytes = tokio::fs::read(clean_id).await.map_err(read_error)?;
@@ -31,8 +29,7 @@ pub async fn emit_asset(
     })
     .await?;
 
-  after_emit(&reference_id);
-  add_watch_file(clean_id);
+  ctx.add_watch_file(clean_id);
 
   Ok(reference_id)
 }

--- a/crates/rolldown_plugin_utils/src/asset_emission.rs
+++ b/crates/rolldown_plugin_utils/src/asset_emission.rs
@@ -29,8 +29,6 @@ pub async fn emit_asset(
     })
     .await?;
 
-  ctx.add_watch_file(clean_id);
-
   Ok(reference_id)
 }
 

--- a/crates/rolldown_plugin_utils/src/asset_emission.rs
+++ b/crates/rolldown_plugin_utils/src/asset_emission.rs
@@ -1,0 +1,97 @@
+use std::{path::Path, sync::Arc};
+
+use arcstr::ArcStr;
+use memchr::memmem;
+use rolldown_common::{EmittedAsset, StrOrBytes};
+use rolldown_plugin::{
+  HookRenderChunkArgs, HookRenderChunkOutput, HookTransformOutputMap, PluginContext,
+};
+use rolldown_std_utils::relative_path_as_js_specifier;
+use string_wizard::{MagicString, SourceMapOptions};
+
+pub async fn emit_asset(
+  ctx: &PluginContext,
+  clean_id: &str,
+  read_error: impl FnOnce(std::io::Error) -> anyhow::Error,
+  after_emit: impl FnOnce(&str),
+  add_watch_file: impl FnOnce(&str),
+) -> anyhow::Result<ArcStr> {
+  let path = Path::new(clean_id);
+  let bytes = tokio::fs::read(clean_id).await.map_err(read_error)?;
+  let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("asset").to_string();
+  let original_file_name =
+    path.strip_prefix(ctx.cwd()).unwrap_or(path).to_string_lossy().into_owned();
+
+  let reference_id = ctx
+    .emit_file_async(EmittedAsset {
+      name: Some(file_name),
+      original_file_name: Some(original_file_name),
+      source: StrOrBytes::Bytes(bytes),
+      ..Default::default()
+    })
+    .await?;
+
+  after_emit(&reference_id);
+  add_watch_file(clean_id);
+
+  Ok(reference_id)
+}
+
+pub fn rewrite_emitted_asset_references(
+  ctx: &PluginContext,
+  args: &HookRenderChunkArgs<'_>,
+  prefix: &str,
+) -> Option<HookRenderChunkOutput> {
+  if !args.code.contains(prefix) {
+    return None;
+  }
+
+  let chunk_filename = &args.chunk.filename;
+  let code = args.code.as_str();
+  let mut magic_string = MagicString::new(code);
+  let mut changed = false;
+  let finder = memmem::find_iter(code.as_bytes(), prefix.as_bytes());
+
+  for abs_pos in finder {
+    let after_prefix = abs_pos + prefix.len();
+    let rest = &code[after_prefix..];
+    let ref_end = rest.find(['"', '\'']).unwrap_or(rest.len());
+    let ref_id = &rest[..ref_end];
+
+    if ref_id.is_empty() {
+      continue;
+    }
+
+    let Ok(asset_filename) = ctx.get_file_name(ref_id) else {
+      continue;
+    };
+    let relative = compute_relative_path(chunk_filename, &asset_filename);
+    let end = after_prefix + ref_end;
+
+    #[expect(clippy::cast_possible_truncation)]
+    if magic_string.update(abs_pos as u32, end as u32, relative).is_ok() {
+      changed = true;
+    }
+  }
+
+  if changed {
+    Some(HookRenderChunkOutput {
+      code: magic_string.to_string(),
+      map: HookTransformOutputMap::from_if_enabled(args.options.sourcemap.is_some(), || {
+        magic_string.source_map(SourceMapOptions {
+          hires: string_wizard::Hires::Boundary,
+          include_content: false,
+          source: Arc::from(args.chunk.filename.as_str()),
+        })
+      }),
+    })
+  } else {
+    None
+  }
+}
+
+fn compute_relative_path(chunk_filename: &str, asset_filename: &str) -> String {
+  let chunk_dir = Path::new(chunk_filename).parent().unwrap_or(Path::new(""));
+
+  relative_path_as_js_specifier(asset_filename, chunk_dir)
+}

--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -1,3 +1,4 @@
+mod asset_emission;
 mod data_to_esm;
 mod is_special_query;
 mod parse_program;
@@ -6,6 +7,7 @@ mod to_string_literal;
 
 pub mod constants;
 
+pub use asset_emission::{emit_asset, rewrite_emitted_asset_references};
 pub use data_to_esm::data_to_esm;
 pub use is_special_query::is_special_query;
 pub use parse_program::parse_program;


### PR DESCRIPTION
#9601 patched the same placeholder machinery in both plugins at once. This moves it into rolldown_plugin_utils, behavior unchanged. The parse half is split out per review.