### PR TITLE
refactor(plugin): share the oxc parse preamble between import-glob and dynamic-import-vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,7 +2970,10 @@ dependencies = [
 name = "rolldown_plugin_utils"
 version = "1.2.0"
 dependencies = [
+ "anyhow",
  "memchr",
+ "oxc",
+ "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
  "serde_json",
@@ -3007,8 +3010,8 @@ dependencies = [
  "derive_more",
  "memchr",
  "oxc",
- "rolldown_common",
  "rolldown_plugin",
+ "rolldown_plugin_utils",
  "rolldown_std_utils",
  "rolldown_utils",
  "string_wizard",
@@ -3024,7 +3027,6 @@ dependencies = [
  "itoa",
  "oxc",
  "path-posix",
- "rolldown_common",
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -18,7 +18,10 @@ doctest = false
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 memchr = { workspace = true }
+oxc = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -1,5 +1,6 @@
 mod data_to_esm;
 mod is_special_query;
+mod parse_program;
 mod strip_bom;
 mod to_string_literal;
 
@@ -7,5 +8,6 @@ pub mod constants;
 
 pub use data_to_esm::data_to_esm;
 pub use is_special_query::is_special_query;
+pub use parse_program::parse_program;
 pub use strip_bom::strip_bom;
 pub use to_string_literal::to_string_literal;

--- a/crates/rolldown_plugin_utils/src/parse_program.rs
+++ b/crates/rolldown_plugin_utils/src/parse_program.rs
@@ -1,0 +1,37 @@
+use oxc::{
+  allocator::Allocator,
+  parser::{ParseOptions, Parser, ParserReturn},
+  span::SourceType,
+};
+use rolldown_common::ModuleType;
+
+pub fn parse_program<'a>(
+  allocator: &'a Allocator,
+  code: &'a str,
+  module_type: &ModuleType,
+  id: &str,
+) -> anyhow::Result<Option<ParserReturn<'a>>> {
+  if !matches!(module_type, ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx) {
+    return Ok(None);
+  }
+
+  let source_type = match module_type {
+    ModuleType::Js => SourceType::mjs(),
+    ModuleType::Jsx => SourceType::jsx(),
+    ModuleType::Ts => SourceType::ts(),
+    ModuleType::Tsx => SourceType::tsx(),
+    _ => unreachable!(),
+  };
+  let parser_ret = Parser::new(allocator, code, source_type)
+    .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+    .parse();
+
+  if parser_ret.panicked
+    && let Some(err) =
+      parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+  {
+    return Err(anyhow::anyhow!(format!("Failed to parse code in '{}': {:?}", id, err.message)));
+  }
+
+  Ok(Some(parser_ret))
+}

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -23,8 +23,8 @@ cow-utils = { workspace = true }
 derive_more = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
-rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 string_wizard = { workspace = true }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -5,12 +5,12 @@ mod utils;
 use std::{borrow::Cow, pin::Pin, sync::Arc};
 
 use oxc::ast_visit::VisitJs;
-use rolldown_common::ModuleType;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
   HookResolveIdReturn, HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin,
   PluginContext, SharedLoadPluginContext,
 };
+use rolldown_plugin_utils::parse_program;
 use rolldown_std_utils::relative_path_as_js_specifier;
 use rolldown_utils::{
   futures::{block_on, block_on_spawn_all},
@@ -68,34 +68,12 @@ impl Plugin for ViteDynamicImportVarsPlugin {
     if !self.filter(args.id, ctx.cwd()) {
       return Ok(None);
     }
-    if matches!(
-      args.module_type,
-      ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
-    ) && utils::has_dynamic_import(args.code)
-    {
+    if utils::has_dynamic_import(args.code) {
       let allocator = oxc::allocator::Allocator::default();
-      let source_type = match args.module_type {
-        ModuleType::Js => oxc::span::SourceType::mjs(),
-        ModuleType::Jsx => oxc::span::SourceType::jsx(),
-        ModuleType::Ts => oxc::span::SourceType::ts(),
-        ModuleType::Tsx => oxc::span::SourceType::tsx(),
-        _ => unreachable!(),
+      let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
+      else {
+        return Ok(None);
       };
-      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type)
-        .with_options(oxc::parser::ParseOptions {
-          preserve_parens: false,
-          ..oxc::parser::ParseOptions::default()
-        })
-        .parse();
-      if parser_ret.panicked
-        && let Some(err) =
-          parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
-      {
-        return Err(anyhow::anyhow!(format!(
-          "Failed to parse code in '{}': {:?}",
-          args.id, err.message
-        )));
-      }
       let mut visitor = ast_visit::DynamicImportVarsVisit {
         ctx: &ctx,
         source_text: args.code,

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -23,7 +23,6 @@ fast-glob = { workspace = true }
 itoa = { workspace = true }
 oxc = { workspace = true }
 path-posix = { workspace = true }
-rolldown_common = { workspace = true }
 rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -3,8 +3,8 @@ mod utils;
 use std::{borrow::Cow, path::PathBuf};
 
 use oxc::ast_visit::VisitJs;
-use rolldown_common::ModuleType;
 use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
+use rolldown_plugin_utils::parse_program;
 use sugar_path::SugarPath as _;
 
 #[derive(Debug, Default)]
@@ -28,34 +28,12 @@ impl Plugin for ViteImportGlobPlugin {
     ctx: rolldown_plugin::SharedTransformPluginContext,
     args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
-    if matches!(
-      args.module_type,
-      ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
-    ) && args.code.contains("import.meta.glob")
-    {
+    if args.code.contains("import.meta.glob") {
       let allocator = oxc::allocator::Allocator::default();
-      let source_type = match args.module_type {
-        ModuleType::Js => oxc::span::SourceType::mjs(),
-        ModuleType::Jsx => oxc::span::SourceType::jsx(),
-        ModuleType::Ts => oxc::span::SourceType::ts(),
-        ModuleType::Tsx => oxc::span::SourceType::tsx(),
-        _ => unreachable!(),
+      let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
+      else {
+        return Ok(None);
       };
-      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type)
-        .with_options(oxc::parser::ParseOptions {
-          preserve_parens: false,
-          ..oxc::parser::ParseOptions::default()
-        })
-        .parse();
-      if parser_ret.panicked
-        && let Some(err) =
-          parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
-      {
-        return Err(anyhow::anyhow!(format!(
-          "Failed to parse code in '{}': {:?}",
-          args.id, err.message
-        )));
-      }
       let id = args.id.to_slash_lossy();
       let root = self.root.as_ref().map(PathBuf::from);
       let root = root.as_ref().unwrap_or(ctx.cwd());


### PR DESCRIPTION
#10057 and #10396 each had to patch this identical parse preamble in both plugins. Split from #10450.