### PR TITLE
fix(code-splitting): don't order-wrap a merged-away entry with an unobservable load

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -83,7 +83,10 @@ impl<'me, 'ast: 'me> VisitJs<'ast> for AstScanner<'me, 'ast> {
         Some(&self.namespace_object_symbol_ids),
       );
       let mut stmt_eval_facts = analyzer.analyze_stmt(stmt);
-      if self.immutable_ctx.options.is_strict_on_demand_wrapping_enabled()
+      // Every strict build reads `ExecutionOrderSensitive` to decide what a wrapper would buy, so
+      // the reasons have to be collected whenever strict execution order is on. Collecting them
+      // only for the selective plan left the default plan with a weaker signal than it needs.
+      if self.immutable_ctx.options.is_strict_execution_order_enabled()
         && !self.result.ecma_view_meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
         && !stmt_eval_facts.is_order_sensitive()
       {

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -1211,7 +1211,7 @@ mod test {
       .map(|stmt| {
         let analyzer = StmtEvalAnalyzer::new(&ast_scopes, flags, options, None, None);
         let mut facts = analyzer.analyze_stmt(stmt);
-        if options.is_strict_on_demand_wrapping_enabled() && !facts.is_order_sensitive() {
+        if options.is_strict_execution_order_enabled() && !facts.is_order_sensitive() {
           analyzer.add_top_level_eager_order_reasons(stmt, &mut facts);
         }
         (facts.tree_shaking_flags(), facts.is_order_sensitive())
@@ -2277,7 +2277,7 @@ mod test {
   }
 
   #[test]
-  fn test_extended_top_level_reasons_do_not_leak_to_default_or_wrap_all() {
+  fn test_extended_top_level_reasons_do_not_leak_to_the_non_strict_default() {
     let manual_pure_tag = "function tag() { return (/* @__PURE__ */ globalThis.__orderRead?.() ?? 5); } class C { static value = tag``; }";
     let manual_pure_treeshake = || InnerOptions {
       manual_pure_functions: Some(std::iter::once("tag".to_string()).collect()),
@@ -2293,19 +2293,20 @@ mod test {
       strict_execution_order: true,
       ..NormalizedBundlerOptions::default()
     });
-    for options in [&default_options, &wrap_all_options] {
-      assert_eq!(
-        get_stmt_eval_with_top_level_eager_order_reasons(manual_pure_tag, options),
-        vec![(StmtEvalFlags::empty(), false), (StmtEvalFlags::empty(), false)]
+    assert_eq!(
+      get_stmt_eval_with_top_level_eager_order_reasons(manual_pure_tag, &default_options),
+      vec![(StmtEvalFlags::empty(), false), (StmtEvalFlags::empty(), false)]
+    );
+
+    // Both strict plans read the same signal, so both collect the same reasons.
+    let strict_on_demand = strict_on_demand_options(manual_pure_treeshake());
+    for options in [&wrap_all_options, &strict_on_demand] {
+      assert_last_statement_gets_eager_reason_only(
+        manual_pure_tag,
+        options,
+        StmtEvalFlags::empty(),
       );
     }
-
-    let strict_on_demand = strict_on_demand_options(manual_pure_treeshake());
-    assert_last_statement_gets_eager_reason_only(
-      manual_pure_tag,
-      &strict_on_demand,
-      StmtEvalFlags::empty(),
-    );
   }
 
   #[test]

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -4,9 +4,10 @@ use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use petgraph::prelude::DiGraphMap;
 use rolldown_common::{
-  ChunkIdx, ConcatenateWrappedModuleKind, EcmaViewMeta, ExportsKind, ImportKind, ImportRecordIdx,
-  ImportRecordMeta, Module, ModuleIdx, NormalModule, SymbolOrMemberExprRef, SymbolRef,
-  UsedSymbolRefsBuilder, WrapKind,
+  ChunkIdx, ChunkKind, ChunkMeta, ConcatenateWrappedModuleKind, EcmaViewMeta, ExportsKind,
+  ImportKind, ImportRecordIdx, ImportRecordMeta, Module, ModuleIdx, NormalModule,
+  PostChunkOptimizationOperation, SymbolOrMemberExprRef, SymbolRef, UsedSymbolRefsBuilder,
+  WrapKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -103,10 +104,11 @@ impl GenerateStage<'_> {
     }
 
     // Wrap-all is the default strict mode: every eligible module defers, so the eager phase is
-    // inert and no evaluation-order prediction is needed. The on-demand analysis below is the
-    // opt-in selective mode behind `experimental.onDemandWrapping`.
-    if !self.options.experimental.is_on_demand_wrapping_enabled() {
-      return Some(self.wrap_all_order_analysis());
+    // inert and no evaluation-order prediction is needed. The one exception is an entry whose
+    // wrapper would only buy a resurrected facade file — see `unobservable_merged_away_entries`.
+    // The selective plan below stays behind `experimental.onDemandWrapping`.
+    if !self.options.is_strict_on_demand_wrapping_enabled() {
+      return Some(self.wrap_all_order_analysis(chunk_graph));
     }
 
     let import_edges = self.predicted_static_import_edges(chunk_graph, used_symbol_refs);
@@ -599,8 +601,9 @@ impl GenerateStage<'_> {
     probe_state
   }
 
-  fn wrap_all_order_analysis(&self) -> OrderAnalysis {
+  fn wrap_all_order_analysis(&self, chunk_graph: &ChunkGraph) -> OrderAnalysis {
     let mut plan = OrderWrapPlan::default();
+    let exempt = self.unobservable_merged_away_entries(chunk_graph);
     // Only membership matters here, so one shared visit-state vector lets every module be
     // walked once across all roots instead of once per root.
     let mut states = index_vec![VisitState::Unvisited; self.link_output.module_table.modules.len()];
@@ -609,12 +612,60 @@ impl GenerateStage<'_> {
         continue;
       }
       for module_idx in self.expected_order_for_root_with_states(root, &mut states) {
-        if self.is_order_wrap_eligible(module_idx) {
+        if self.is_order_wrap_eligible(module_idx) && !exempt.contains(&module_idx) {
           plan.insert(module_idx);
         }
       }
     }
     OrderAnalysis { plan }
+  }
+
+  /// Entry modules `restore_order_wrap_entry_facades` would resurrect a file for: an emptied
+  /// dynamic-imported or emitted entry chunk the post-chunk optimizer removed. Collected in one pass
+  /// over the chunk table rather than re-scanning it per entry, and mirroring that function's
+  /// condition exactly.
+  fn merged_away_entries(&self, chunk_graph: &ChunkGraph) -> FxHashSet<ModuleIdx> {
+    chunk_graph
+      .chunk_table
+      .iter_enumerated()
+      .filter_map(|(chunk_idx, chunk)| match chunk.kind {
+        ChunkKind::EntryPoint { meta, module, .. } => (chunk.modules.is_empty()
+          && meta.intersects(ChunkMeta::DynamicImported | ChunkMeta::EmittedChunk)
+          && matches!(
+            chunk_graph.post_chunk_optimization_operations.get(&chunk_idx),
+            Some(
+              PostChunkOptimizationOperation::Removed
+                | PostChunkOptimizationOperation::RemovedWithPreservedExports
+            )
+          ))
+        .then_some(module),
+        ChunkKind::Common => None,
+      })
+      .collect()
+  }
+
+  /// Entries wrap-all should not wrap even though it wraps everything else.
+  ///
+  /// An entry the post-chunk optimizer merged away has no file of its own, so wrapping it makes
+  /// `restore_order_wrap_entry_facades` resurrect one — a file per lazy route on apps that declare
+  /// many (lobehub: 1008 of them). That file is unavoidable *given the wrapper*: the resurrected
+  /// chunk is the only place the entry's trigger can live, since one file can host only one entry's
+  /// top-level trigger and a cross-chunk `import()` call-site trigger fires a microtask too late
+  /// (`m4_dynamic_facade_race`). So the wrapper itself is what to drop, and it is safe to drop
+  /// exactly when nothing about the entry's execution position is observable: no module in its own
+  /// static load closure is order-sensitive, so running the whole closure early — which is what an
+  /// unwrapped body inline in the host chunk does — changes nothing an importer can see.
+  ///
+  /// Reads module content through [`Self::is_order_sensitive`], never chunk reachability, so it
+  /// needs no prediction of a graph that does not exist yet — the failure mode every earlier attempt
+  /// at narrowing this cost ran into.
+  fn unobservable_merged_away_entries(&self, chunk_graph: &ChunkGraph) -> FxHashSet<ModuleIdx> {
+    self
+      .merged_away_entries(chunk_graph)
+      .into_iter()
+      .filter(|&root| self.link_output.metas[root].is_included)
+      .filter(|&root| self.sensitive_order(&self.expected_order_for_root(root)).is_empty())
+      .collect()
   }
 
   fn expected_order_for_root(&self, root: ModuleIdx) -> Vec<ModuleIdx> {

--- a/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463/artifacts.snap
@@ -94,11 +94,9 @@ init_b();
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
-}
-function init_shared() {
-	return (init_shared = __esmMin((() => {})))();
 }
 //#endregion
 //#region a.js
@@ -113,21 +111,12 @@ function init_a() {
 function init_b() {
 	return (init_b = __esmMin((() => {
 		(globalThis.sideEffectLog ??= []).push("b");
-		import("./shared.js").then(({ foo }) => {
+		Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 			foo();
 		});
 	})))();
 }
 //#endregion
-export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### shared.js
-
-```js
-import { i as init_shared, r as foo } from "./common~a~b~shared.js";
-init_shared();
-export { foo };
+export { init_a as n, init_b as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9463_plain_group/artifacts.snap
@@ -94,11 +94,9 @@ init_b();
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	(globalThis.sideEffectLog ??= []).push("shared-foo");
-}
-function init_shared() {
-	return (init_shared = __esmMin((() => {})))();
 }
 //#endregion
 //#region a.js
@@ -113,21 +111,12 @@ function init_a() {
 function init_b() {
 	return (init_b = __esmMin((() => {
 		(globalThis.sideEffectLog ??= []).push("b");
-		import("./shared.js").then(({ foo }) => {
+		Promise.resolve().then(() => shared_exports).then(({ foo }) => {
 			foo();
 		});
 	})))();
 }
 //#endregion
-export { init_shared as i, init_a as n, foo as r, init_b as t };
-
-```
-
-### shared.js
-
-```js
-import { i as init_shared, r as foo } from "./common.js";
-init_shared();
-export { foo };
+export { init_a as n, init_b as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -111,69 +111,23 @@ Object.defineProperty(exports, "__toESM", {
 ### entry.js
 
 ```js
-require("./entry2.js").init_entry();
-
-```
-
-### entry2.js
-
-```js
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 let node_assert = require("node:assert");
 node_assert = require_rolldown_runtime.__toESM(node_assert);
 //#region lib.js
 var lib_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ a: () => 123 });
-var a;
-function init_lib() {
-	return (init_lib = require_rolldown_runtime.__esmMin((() => {
-		a = 123;
-	})))();
-}
 //#endregion
 //#region entry.js
 function init_entry() {
 	return (init_entry = require_rolldown_runtime.__esmMin((() => {
-		init_lib();
-		Promise.resolve().then(() => require("./lib.js")).then((mod) => {
+		Promise.resolve().then(() => lib_exports).then((mod) => {
 			node_assert.default.strictEqual(mod.a, 123);
 			node_assert.default.strictEqual(123, 123);
 		});
 	})))();
 }
 //#endregion
-Object.defineProperty(exports, "a", {
-	enumerable: true,
-	get: function() {
-		return a;
-	}
-});
-Object.defineProperty(exports, "init_entry", {
-	enumerable: true,
-	get: function() {
-		return init_entry;
-	}
-});
-Object.defineProperty(exports, "init_lib", {
-	enumerable: true,
-	get: function() {
-		return init_lib;
-	}
-});
-Object.defineProperty(exports, "lib_exports", {
-	enumerable: true,
-	get: function() {
-		return lib_exports;
-	}
-});
-
-```
-
-### lib.js
-
-```js
-const require_entry = require("./entry2.js");
-require_entry.init_lib();
-exports.a = require_entry.a;
+init_entry();
 
 ```
 
@@ -218,44 +172,21 @@ Object.defineProperty(exports, "__toESM", {
 ### entry.js
 
 ```js
-import { t as init_entry } from "./entry2.js";
-init_entry();
-
-```
-
-### entry2.js
-
-```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
-var a;
-function init_lib() {
-	return (init_lib = __esmMin((() => {
-		a = 123;
-	})))();
-}
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => 123 });
 //#endregion
 //#region entry.js
 function init_entry() {
 	return (init_entry = __esmMin((() => {
-		init_lib();
-		import("./lib.js").then((mod) => {
+		Promise.resolve().then(() => lib_exports).then((mod) => {
 			assert.strictEqual(mod.a, 123);
 			assert.strictEqual(123, 123);
 		});
 	})))();
 }
 //#endregion
-export { a as n, init_lib as r, init_entry as t };
-
-```
-
-### lib.js
-
-```js
-import { n as a, r as init_lib } from "./entry2.js";
-init_lib();
-export { a };
+init_entry();
 
 ```

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -220,8 +220,8 @@ impl NormalizedBundlerOptions {
     self.strict_execution_order
   }
 
-  /// Strict execution order with on-demand wrapping — the mode that runs the extended
-  /// eager-evaluation order-reason walk during scanning.
+  /// Strict execution order with on-demand wrapping — the selective mode that derives its wrapping
+  /// plan from the execution-order analysis instead of deferring every eligible module.
   pub fn is_strict_on_demand_wrapping_enabled(&self) -> bool {
     self.strict_execution_order && self.experimental.is_on_demand_wrapping_enabled()
   }


### PR DESCRIPTION
Under `output.strictExecutionOrder`, order-wrapping an entry whose chunk the post-chunk optimizer merged away does not defer anything. It makes `restore_order_wrap_entry_facades` resurrect a file for that entry, because a merged entry has nowhere else to put its trigger. On an app that declares a lazy entry per route, that is one extra chunk per route. This skips the wrapper in the one case where it cannot buy anything: no module in the entry's own static load closure is order-sensitive, so running that whole closure early is not observable.

lobehub, same Vite, only the rolldown package swapped:

| | JS files | raw | gzip | brotli |
| --- | ---: | ---: | ---: | ---: |
| `strictExecutionOrder` off | 1518 | — | — | — |
| before | 2585 (+1067) | +0.80% | +2.12% | +2.04% |
| after | 1600 (+82) | +0.42% | +0.94% | +0.91% |

ComfyUI_frontend and plane are byte-identical before and after — neither has an entry the optimizer merged away, so nothing is skipped.

## Motivation

The chunk growth is a regression against released behaviour, not an inherent cost of the guarantee. `order_wrapping.rs` does not exist at `v1.2.0`; it arrived with #10104. Released 1.2.0 emits 1471 JS files on lobehub with `strictExecutionOrder` on, 47 *fewer* than with it off. Current `main` emits 2585.

Nor is the growth the price of the correctness fixes in that series. #10441 gates `create_order_wrap_entry_facades` on the real cross-chunk edges, and on lobehub that gate creates 59 facades. The other 1008 files come from `restore_order_wrap_entry_facades`, whose candidate set is every order-wrapped entry with no necessity test — and the default plan wraps every entry.

Restoring is not the thing to gate. A resurrected chunk is the only place a merged entry's trigger can live:

- Dropping the restore leaves the entry with no trigger at all, so it never initializes. That is a missing evaluation, not a mis-ordering, which is why gating it broke `optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry`.
- One file can host only one entry's top-level trigger, so two merged entries sharing a host chunk cannot share one.
- Moving the trigger to the `import()` call site fires a microtask too late even when the host chunk's top level is inert. `function/strict_execution_order_invariants/m4_dynamic_facade_race` pins that with a fully wrapped host chunk.

So the wrapper is what to skip, and it is safe to skip exactly when the entry's execution position is unobservable. `is_order_sensitive` already answers that per module from module content — `EcmaViewMeta::ExecutionOrderSensitive`, plus eagerly triggering an interop module. When no module in the entry's static load closure is order-sensitive, an unwrapped body inline in the host chunk runs that closure whenever the chunk loads and nothing an importer can observe differs.

That question reads module content, never chunk reachability, so it does not approximate a graph that does not exist yet when the plan is built — the failure mode that sank three earlier attempts at narrowing this cost, recorded in #10294.

## What comes off, concretely

`issues/9463` is the fixture this facade mechanism exists for: entry `b` must not run entry `a`'s top-level side effect. Its `shared.js` is a dynamic-import target the optimizer merged into the shared chunk, so it was order-wrapped and restored as its own file:

```js
// shared.js — resurrected so this call has somewhere to live
import { i as init_shared, r as foo } from "./common~a~b~shared.js";
init_shared();
export { foo };
```

`init_shared` was `__esmMin((() => {}))`. `shared.js` only declares a function, so the wrapper deferred nothing and the file existed to call an empty init. Afterwards the module is a namespace object in the host chunk and the dynamic import collapses to a same-chunk `Promise.resolve()`. `init_a` and `init_b` are untouched, and the fixture's `_test.mjs` — which asserts that loading `b` never runs `a`'s side effect — still passes.

`optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry` goes from three emitted files to one for the same reason.

## The sensitivity signal has to be complete

`add_top_level_eager_order_reasons` ran only when `experimental.onDemandWrapping` was set, which left `ExecutionOrderSensitive` less complete in the default plan than in the selective one. Any decision about what a wrapper buys reads that flag, so the reasons are now collected whenever `strictExecutionOrder` is on.

Measured on its own, with the entry rule disabled: ComfyUI_frontend and plane byte-identical, lobehub raw byte-identical with gzip and brotli moving by 30 and 59 bytes out of 19 MB.

## Non-goals

- The selective wrapping plan stays behind `experimental.onDemandWrapping`. The predicted chunk edges, the expected-versus-actual order comparison and the emergent-cycle fixpoint are untouched, and which non-entry modules the default plan defers is unchanged.
- The default plan is not brought to parity with the selective one on bytes. Both emit 1600 files on lobehub, but the selective plan is 28 KB smaller raw there, and on ComfyUI_frontend it is +4.13% raw against this PR's +7.12%. That remainder is wrapper code rather than chunk proliferation.
- 1471 is not a target. Counting execution-order violations directly in the emitted output — a chunk whose inline `__esm` init another chunk statically imports, so loading that other chunk runs it — gives 58 for `strictExecutionOrder` off (pre-existing, from interop wrapping), 56 for released 1.2.0, and 0 both before and after this PR. Part of why the released file count is lower is that the build was not emitting those triggers.

## Tests

`test_extended_top_level_reasons_do_not_leak_to_the_non_strict_default` replaces `..._do_not_leak_to_default_or_wrap_all`: the reasons still must not reach a non-strict build, and both strict plans now collect the same ones. The snapshot updates are the fixtures whose entries the rule now leaves unwrapped.
