### PR TITLE
fix(code-splitting): collect top-level eager order reasons in every strict build

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -83,7 +83,10 @@ impl<'me, 'ast: 'me> VisitJs<'ast> for AstScanner<'me, 'ast> {
         Some(&self.namespace_object_symbol_ids),
       );
       let mut stmt_eval_facts = analyzer.analyze_stmt(stmt);
-      if self.immutable_ctx.options.is_strict_on_demand_wrapping_enabled()
+      // `ExecutionOrderSensitive` is read outside the wrap planner too — it gates which leaf
+      // modules `sort_chunk_modules` may sort by id — so it has to mean the same thing in every
+      // strict plan. Collecting the reasons only for the selective plan left the default weaker.
+      if self.immutable_ctx.options.is_strict_execution_order_enabled()
         && !self.result.ecma_view_meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
         && !stmt_eval_facts.is_order_sensitive()
       {

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -26,7 +26,7 @@ bitflags! {
         /// Reads from an unresolved global or a member chain rooted at one.
         const GlobalVarAccess = 1;
         /// A call/new/tagged-template expression was treated as pure by an annotation or
-        /// cross-module analysis. Only the strict on-demand statement walk additionally sets it
+        /// cross-module analysis. Only the strict top-level statement walk additionally sets it
         /// for `manualPureFunctions` forms; the regular analyzer and the class-mode collector
         /// deliberately do not.
         const PureAnnotation = 1 << 1;
@@ -515,11 +515,11 @@ impl<'a> StmtEvalAnalyzer<'a> {
 
   /// Add order-only facts from every expression that may run while evaluating this top-level
   /// statement. This deliberately does not reuse the tree-shaking walk: that walk may stop as soon
-  /// as Oxc proves a surrounding call/member/binding operation pure, while strict on-demand order
-  /// analysis still needs reads hidden behind that operation.
+  /// as Oxc proves a surrounding call/member/binding operation pure, while strict order analysis
+  /// still needs reads hidden behind that operation.
   ///
-  /// The scanner only calls this for strict on-demand builds whose regular facts are not already
-  /// order-sensitive. Keeping the entry point separate leaves the default and wrap-all hot paths,
+  /// The scanner only calls this for strict builds whose regular facts are not already
+  /// order-sensitive. Keeping the entry point separate leaves the non-strict hot path,
   /// cross-module tree-shaking re-analysis, and `tree_shaking_flags` unchanged.
   pub(crate) fn add_top_level_eager_order_reasons(
     &self,
@@ -726,9 +726,9 @@ impl<'analyzer, 'ctx> EagerEvaluationOrderReasonCollector<'analyzer, 'ctx> {
     analyzer: &'analyzer StmtEvalAnalyzer<'ctx>,
     class: &ast::Class,
   ) -> StmtOrderSensitiveReasons {
-    // Preserve the original class-definition collector outside strict on-demand builds. The
-    // extended statement-level cases below are scheduling metadata for that mode only and must not
-    // perturb ordinary chunk sorting.
+    // Preserve the original class-definition collector outside the strict top-level statement
+    // walk. The extended statement-level cases below are order metadata for strict builds only and
+    // must not perturb non-strict analysis.
     let mut collector = Self::new(analyzer, false);
     collector.visit_class(class);
     collector.reasons
@@ -1211,7 +1211,7 @@ mod test {
       .map(|stmt| {
         let analyzer = StmtEvalAnalyzer::new(&ast_scopes, flags, options, None, None);
         let mut facts = analyzer.analyze_stmt(stmt);
-        if options.is_strict_on_demand_wrapping_enabled() && !facts.is_order_sensitive() {
+        if options.is_strict_execution_order_enabled() && !facts.is_order_sensitive() {
           analyzer.add_top_level_eager_order_reasons(stmt, &mut facts);
         }
         (facts.tree_shaking_flags(), facts.is_order_sensitive())
@@ -2277,7 +2277,7 @@ mod test {
   }
 
   #[test]
-  fn test_extended_top_level_reasons_do_not_leak_to_default_or_wrap_all() {
+  fn test_extended_top_level_reasons_do_not_leak_to_the_non_strict_default() {
     let manual_pure_tag = "function tag() { return (/* @__PURE__ */ globalThis.__orderRead?.() ?? 5); } class C { static value = tag``; }";
     let manual_pure_treeshake = || InnerOptions {
       manual_pure_functions: Some(std::iter::once("tag".to_string()).collect()),
@@ -2293,19 +2293,20 @@ mod test {
       strict_execution_order: true,
       ..NormalizedBundlerOptions::default()
     });
-    for options in [&default_options, &wrap_all_options] {
-      assert_eq!(
-        get_stmt_eval_with_top_level_eager_order_reasons(manual_pure_tag, options),
-        vec![(StmtEvalFlags::empty(), false), (StmtEvalFlags::empty(), false)]
+    assert_eq!(
+      get_stmt_eval_with_top_level_eager_order_reasons(manual_pure_tag, &default_options),
+      vec![(StmtEvalFlags::empty(), false), (StmtEvalFlags::empty(), false)]
+    );
+
+    // Both strict plans read the same signal, so both collect the same reasons.
+    let strict_on_demand = strict_on_demand_options(manual_pure_treeshake());
+    for options in [&wrap_all_options, &strict_on_demand] {
+      assert_last_statement_gets_eager_reason_only(
+        manual_pure_tag,
+        options,
+        StmtEvalFlags::empty(),
       );
     }
-
-    let strict_on_demand = strict_on_demand_options(manual_pure_treeshake());
-    assert_last_statement_gets_eager_reason_only(
-      manual_pure_tag,
-      &strict_on_demand,
-      StmtEvalFlags::empty(),
-    );
   }
 
   #[test]

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -220,8 +220,8 @@ impl NormalizedBundlerOptions {
     self.strict_execution_order
   }
 
-  /// Strict execution order with on-demand wrapping — the mode that runs the extended
-  /// eager-evaluation order-reason walk during scanning.
+  /// Strict execution order with on-demand wrapping — the selective mode that derives its wrapping
+  /// plan from the execution-order analysis instead of deferring every eligible module.
   pub fn is_strict_on_demand_wrapping_enabled(&self) -> bool {
     self.strict_execution_order && self.experimental.is_on_demand_wrapping_enabled()
   }


### PR DESCRIPTION
`add_top_level_eager_order_reasons` ran only when `experimental.onDemandWrapping` was set, which left `EcmaViewMeta::ExecutionOrderSensitive` less complete in the default strict plan than in the selective one. That walk exists because a pure annotation answers a different question than execution order asks: it says a statement is safe to *drop* when nothing uses it, not that the statement is safe to *run at a different time* when it is kept. A top-level statement tree-shaking treats as pure — a `manualPureFunctions`-tagged call in a class static initializer that reads mutable global state, say — still observes its own position once the module is included. So the plan that defers every eligible module was working from a weaker signal than the plan that derives its wrapping from the analysis, for a fact that is a property of the module rather than of the plan.

## What reads the signal

`ExecutionOrderSensitive` is not read only by the wrap planner. `sort_chunk_modules` splits a chunk's modules into the leaf ones — no import records and no `ExecutionOrderSensitive` — and the rest, then hoists that leaf group and sorts it by module id rather than by execution order under `experimental.chunkModulesOrder: 'module-id'`. That consumer has no idea which plan produced the wrap set, so as things stand the same module lands in the leaf group under the default plan and outside it under `onDemandWrapping`, on a question about the module's own content.

Under the default plan the difference is textual for now, and deliberately so: `wrap_all_order_analysis` defers every eligible module, so nothing evaluates at chunk top level and hoisting a leaf cannot move an evaluation. It stops being textual as soon as something reads sensitivity to make a decision under that plan, which is what #10454's exemption for a merged-away entry with an unobservable load does. Landing the completeness first keeps that PR's rule reading the same signal the selective plan already reads.

## The change

Gate the walk on `strictExecutionOrder` rather than on strict plus on-demand wrapping. Non-strict builds keep the old behaviour on purpose: `add_top_level_eager_order_reasons` only ever adds order reasons and never touches the tree-shaking flags, so running it without the flag could only make a build that never asked for an order guarantee pay for one. The three comments that scoped the walk to on-demand builds are updated to match.

Measured on its own, with #10454's entry rule disabled: ComfyUI_frontend and plane are byte-identical, and lobehub is byte-identical raw, with gzip and brotli moving by 30 and 59 bytes out of 19 MB.

Extracted from #10454, which has since been closed in favor of #10456's call-site-trigger line; the completeness argument above stands on its own, and any future default-plan decision that reads sensitivity needs it. Until then the accessor has no in-repo caller, so its doc comment now describes the mode it names rather than the walk it used to gate.

## Tests

`test_extended_top_level_reasons_do_not_leak_to_default_or_wrap_all` becomes `test_extended_top_level_reasons_do_not_leak_to_the_non_strict_default` and now covers both halves at the analyzer level: the non-strict default still collects no reasons, and the two strict plans — wrap-all and on-demand — collect the same one. The full `-p rolldown` suite passes with no snapshot changes.

