### PR TITLE
fix(watch): preserve plugin attribution in warnings

### DIFF
--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -14,7 +14,7 @@ use napi::{
   bindgen_prelude::{PromiseRaw, ToNapiValue},
 };
 use napi_derive::napi;
-use rolldown::{LogLevel, NormalizedBundlerOptions};
+use rolldown::{Log, LogLevel, NormalizedBundlerOptions};
 use rolldown_error::{
   BuildDiagnostic, Diagnostic, DiagnosticOptions, filter_out_disabled_diagnostics,
 };
@@ -99,39 +99,7 @@ pub async fn handle_warnings(
   // #9748 was the per-warning re-render above, not the JS round-trip, so awaiting
   // one call at a time does not reintroduce the hang.
   for (warning, rendered) in warnings.into_iter().zip(rendered) {
-    // Only include loc/pos for warning types that report specific source locations.
-    // Use warning.id() for the file path since the diagnostic may only store the filename.
-    #[expect(
-      clippy::cast_possible_truncation,
-      reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
-    )]
-    let (loc, pos) = match rendered.primary_location {
-      Some(location) => (
-        Some(rolldown::LogLocation {
-          line: location.line as u32,
-          column: location.column as u32,
-          file: warning.id(),
-        }),
-        Some(location.utf16_position as u32),
-      ),
-      None => (None, None),
-    };
-
-    on_log
-      .call(
-        LogLevel::Warn,
-        rolldown::Log {
-          id: warning.id(),
-          exporter: warning.exporter(),
-          code: Some(warning.kind().to_string()),
-          message: rendered.message,
-          plugin: warning.plugin(),
-          loc,
-          pos,
-          ids: warning.ids(),
-        },
-      )
-      .await?;
+    on_log.call(LogLevel::Warn, Log::from_rendered(&warning, rendered)).await?;
   }
 
   Ok(())

--- a/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
 use derive_more::Debug;
+use rolldown_error::{BuildDiagnostic, RenderedDiagnostic};
 
 use super::log_level::LogLevel;
 
@@ -42,6 +43,38 @@ pub struct Log {
   pub loc: Option<LogLocation>,
   pub pos: Option<u32>,
   pub ids: Option<Vec<String>>,
+}
+
+impl Log {
+  pub fn from_rendered(warning: &BuildDiagnostic, rendered: RenderedDiagnostic) -> Self {
+    #[expect(
+      clippy::cast_possible_truncation,
+      reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
+    )]
+    let (loc, pos) = match rendered.primary_location {
+      Some(location) => (
+        Some(LogLocation {
+          line: location.line as u32,
+          column: location.column as u32,
+          // Use warning.id() since the diagnostic may only store the filename.
+          file: warning.id(),
+        }),
+        Some(location.utf16_position as u32),
+      ),
+      None => (None, None),
+    };
+
+    Self {
+      id: warning.id(),
+      exporter: warning.exporter(),
+      code: Some(warning.kind().to_string()),
+      message: rendered.message,
+      plugin: warning.plugin(),
+      loc,
+      pos,
+      ids: warning.ids(),
+    }
+  }
 }
 
 #[derive(Debug, Default)]

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -1,7 +1,7 @@
 use arcstr::ArcStr;
 use rolldown::{Bundler, BundlerBuilder, BundlerConfig};
 use rolldown_common::{
-  BundleMode, LogLevel, NormalizedBundlerOptions, ScanMode, WatcherChangeKind,
+  BundleMode, Log, LogLevel, NormalizedBundlerOptions, ScanMode, WatcherChangeKind,
 };
 use rolldown_error::{
   BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, Diagnostic, DiagnosticOptions, ResultExt,
@@ -213,36 +213,7 @@ impl WatchTask {
     // that throws to abort the build stops at the first failure without invoking
     // later handlers. Mirrors `handle_warnings` in the binding. See #9748.
     for (warning, rendered) in warnings.into_iter().zip(rendered) {
-      #[expect(
-        clippy::cast_possible_truncation,
-        reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
-      )]
-      let (loc, pos) = match rendered.primary_location {
-        Some(location) => (
-          Some(rolldown_common::LogLocation {
-            line: location.line as u32,
-            column: location.column as u32,
-            file: warning.id(),
-          }),
-          Some(location.utf16_position as u32),
-        ),
-        None => (None, None),
-      };
-      on_log
-        .call(
-          LogLevel::Warn,
-          rolldown_common::Log {
-            id: warning.id(),
-            exporter: warning.exporter(),
-            code: Some(warning.kind().to_string()),
-            message: rendered.message,
-            plugin: None,
-            loc,
-            pos,
-            ids: warning.ids(),
-          },
-        )
-        .await?;
+      on_log.call(LogLevel::Warn, Log::from_rendered(&warning, rendered)).await?;
     }
     Ok(())
   }

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1294,6 +1294,46 @@ test.concurrent(
 );
 
 test.concurrent(
+  'watch should preserve plugin attribution in sourcemap warnings',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-sourcemap-warning-plugin', retryCount, {
+      'main.js': `console.log('main')`,
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const pluginName = 'test-sourcemap-plugin';
+    const onLogFn = vi.fn();
+    const watcher = watch({
+      input: path.join(dir, 'main.js'),
+      output: { dir: path.join(dir, 'dist'), sourcemap: true },
+      plugins: [
+        {
+          name: pluginName,
+          transform(code) {
+            return { code: code + '\n// touched\n' };
+          },
+        },
+      ],
+      onLog(_level, log) {
+        if (log.code === 'SOURCEMAP_BROKEN') {
+          onLogFn(log.plugin);
+        }
+      },
+    });
+    onTestFinished(async () => await watcher.close());
+
+    await waitBuildFinished(watcher);
+    expect(onLogFn).toHaveBeenCalledWith(pluginName);
+  },
+);
+
+test.concurrent(
   'watch should fail when onLog rejects a warning',
   { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
   async ({ task, expect, onTestFinished }) => {


### PR DESCRIPTION
The watcher's warning loop was forked from the binding's before #9600 picked up plugin attribution, so watch-mode logs report `plugin: null`. Both copies now build the `Log` through one constructor.

Fixes #10472