### PR TITLE
feat(dev): expose `enabled` through the dev engine bindings

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -48,6 +48,7 @@ impl BindingDevEngine {
       dev_options.as_ref().and_then(|opts| opts.rebuild_strategy).map(Into::into);
     // Take ownership of watch so we can consume Vec fields (include/exclude).
     let watch_options = dev_options.and_then(|opts| opts.watch);
+    let watcher_enabled = watch_options.as_ref().and_then(|watch| watch.enabled);
     let skip_write = watch_options.as_ref().and_then(|watch| watch.skip_write);
     let use_polling = watch_options.as_ref().and_then(|watch| watch.use_polling);
     let poll_interval = watch_options.as_ref().and_then(|watch| watch.poll_interval);
@@ -127,7 +128,8 @@ impl BindingDevEngine {
       }) as OnAdditionalAssetsCallback
     });
 
-    let dev_watch_options = if skip_write.is_some()
+    let dev_watch_options = if watcher_enabled.is_some()
+      || skip_write.is_some()
       || use_polling.is_some()
       || poll_interval.is_some()
       || use_debounce.is_some()
@@ -138,7 +140,7 @@ impl BindingDevEngine {
       || watch_exclude.is_some()
     {
       Some(rolldown_dev::DevWatchOptions {
-        disable_watcher: None,
+        disable_watcher: watcher_enabled.map(|enabled| !enabled),
         skip_write,
         use_polling,
         poll_interval: poll_interval.map(u64::from),

--- a/crates/rolldown_binding/src/binding_dev_options.rs
+++ b/crates/rolldown_binding/src/binding_dev_options.rs
@@ -8,6 +8,7 @@ use napi::bindgen_prelude::FnArgs;
 
 #[napi_derive::napi(object, object_to_js = false)]
 pub struct BindingDevWatchOptions {
+  pub enabled: Option<bool>,
   pub skip_write: Option<bool>,
   pub use_polling: Option<bool>,
   pub poll_interval: Option<u32>,

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -77,6 +77,7 @@ export class DevEngine {
           : BindingRebuildStrategy.Never
         : undefined,
       watch: devOptions.watch && {
+        enabled: devOptions.watch.enabled,
         skipWrite: devOptions.watch.skipWrite,
         usePolling: devOptions.watch.usePolling,
         pollInterval: devOptions.watch.pollInterval,

--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -17,6 +17,12 @@ type DevOnAdditionalAssets = (output: RolldownOutput) => void | Promise<void>;
 
 export interface DevWatchOptions {
   /**
+   * If `false`, no file system watcher is started, so file changes are never
+   * picked up and no rebuild or HMR update is triggered on their own.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
    * If `true`, files are not written to disk.
    * @default false
    */

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2041,6 +2041,7 @@ export interface BindingDevtoolsOptions {
 }
 
 export interface BindingDevWatchOptions {
+  enabled?: boolean
   skipWrite?: boolean
   usePolling?: boolean
   pollInterval?: number


### PR DESCRIPTION
## Problem

`DevWatchOptions` has a `disableWatcher` option that swaps the file system watcher for a no-op one (`dev_engine.rs:101-105`). It works, and rolldown's own Rust integration tests use it, but a JS caller cannot reach it: `BindingDevWatchOptions` has no such field and the binding hard-codes `disable_watcher: None` when it builds the options.

So `dev()` has no way to turn the watcher off. Vite's bundled dev needs exactly that to honor `server.watch: null`, which today silently keeps watching in full bundle mode.

## Related Issues

Unblocks the "expose watcher options on the Vite side" item in #10019. The Vite side maps `server.watch` onto these options and needs this released before it can honor `server.watch: null`.
