### PR TITLE
fix(dev): keep the export name of `export * as ns from`

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -297,7 +297,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         {
           program_body.push(stmt);
         }
-        if let Some(stmt) =
+        if let Some(exported) = &export_all_decl.exported {
+          // `export * as ns from './dep.js'` binds the importee's namespace object to a
+          // single export name. It must not go through `__reExport`, which copies the
+          // importee's own exports onto this module - that is `export * from './dep.js'`,
+          // a different statement that happens to share this AST node.
+          let exported_name = exported.name();
+          self.exports.push(ObjectPropertyKind::new_lazy_export_property(
+            &exported_name,
+            Expression::new_id_ref_expr(SPAN, &binding_name, &self.ast_builder),
+            !is_validate_identifier_name(&exported_name),
+            &self.ast_builder,
+          ));
+        } else if let Some(stmt) =
           self.create_re_export_call_stmt(importee, &binding_name, export_all_decl.span)
         {
           program_body.push(stmt);

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/artifacts.snap
@@ -1,0 +1,113 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+__rolldown_runtime__.registerGraph({
+	ids: [
+		"dep.js",
+		"reexport.js",
+		"hmr.js",
+		"main.js"
+	],
+	localCount: 4,
+	edges: [
+		[],
+		[0],
+		[1],
+		[2]
+	],
+	dynamicEdges: [
+		[],
+		[],
+		[],
+		[]
+	]
+});
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+const value = "from-dep";
+//#endregion
+//#region reexport.js
+var reexport_exports = /* @__PURE__ */ __exportAll({ NS: () => dep_exports });
+__rolldown_runtime__.createModuleHotContext("reexport.js");
+__rolldown_runtime__.registerModule("reexport.js", { exports: reexport_exports });
+//#endregion
+//#region hmr.js
+var hmr_exports = /* @__PURE__ */ __exportAll({});
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+assert.ok(dep_exports, "NS should be a namespace object");
+assert.strictEqual(value, "from-dep");
+hmr_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["dep.js","hmr.js","reexport.js"],localCount:3,edges:[[],[2],[0]],dynamicEdges:[[],[],[]]});
+//#region dep.js
+__rolldown_runtime__.registerFactory("dep.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "from-dep";
+		console.log("dep updated");
+	} finally {}
+}));
+
+//#endregion
+//#region hmr.js
+import * as import_node_assert_10 from "node:assert";
+__rolldown_runtime__.registerFactory("hmr.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("reexport.js");
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_reexport_11 = __rolldown_runtime__.loadExports("reexport.js");
+		import_node_assert_10.default.ok(import_reexport_11.NS, "NS should be a namespace object");
+		import_node_assert_10.default.strictEqual(import_reexport_11.NS.value, "from-dep");
+		hot_hmr.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region reexport.js
+__rolldown_runtime__.registerFactory("reexport.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ NS: () => import_dep_20 });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("dep.js");
+		const hot_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_dep_20 = __rolldown_runtime__.loadExports("dep.js");
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- dep.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/dep.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/dep.hmr-0.js
@@ -1,0 +1,3 @@
+export const value = 'from-dep';
+
+console.log('dep updated');

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/dep.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/dep.js
@@ -1,0 +1,1 @@
+export const value = 'from-dep';

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/hmr.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import { NS } from './reexport.js';
+
+// `export * as NS from './dep.js'` must export the namespace object under `NS` -
+// not spread `./dep.js`'s exports onto this module like `export *` does.
+assert.ok(NS, 'NS should be a namespace object');
+assert.strictEqual(NS.value, 'from-dep');
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/main.js
@@ -1,0 +1,1 @@
+import './hmr.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/reexport.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star_as/reexport.js
@@ -1,0 +1,1 @@
+export * as NS from './dep.js';

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -454,7 +454,7 @@ The flow is:
 
 ### Issue 11: `export * as ns from` Is Not `export * from`
 
-**Problem**: `export * as ns from './dep'` and `export * from './dep'` are the same oxc AST node (`ExportAllDeclaration`), distinguished only by whether `exported` is set. The HMR finalizer ignored that field and rendered both as a star re-export — `__reExport(__rolldown_exports__, import_dep)` — so the re-exporting module's namespace object never carried `ns`, and every consumer read `undefined`. Only the module wrappers were affected (lazy chunks and HMR patches); the scope-hoisted build resolves the same source correctly, which is why the bug appeared only under `experimental.devMode.lazy`.
+**Problem**: `export * as ns from './dep'` and `export * from './dep'` are the same oxc AST node (`ExportAllDeclaration`), distinguished only by whether `exported` is set. The HMR finalizer ignored that field and rendered both as a star re-export — `__reExport(__rolldown_exports__, import_dep)` — so the re-exporting module's namespace object never carried `ns`, and every consumer read `undefined`. Only the module wrappers were affected (lazy chunks and HMR patches); the scope-hoisted build resolves the same source correctly.
 
 **Solution**: When `exported` is present, bind the importee's `loadExports` result under that single name in the namespace object (`{ ns: () => import_dep }`, computed when the name is not a valid identifier) and emit no `__reExport`. Pinned by `crates/rolldown/tests/rolldown/topics/hmr/export_star_as/`.
 

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -452,6 +452,12 @@ The flow is:
 
 **Solution**: The stub template awaits the **re-registered proxy's own `'rolldown:exports'` promise** (`return await loadExports($STABLE_PROXY_MODULE_ID)['rolldown:exports']`) rather than handing back a namespace — so a rejection anywhere in the chain rejects `lazyExports` and the consumer's import promise. Pinned by the two lazy-init-error specs (cold and warm paths).
 
+### Issue 11: `export * as ns from` Is Not `export * from`
+
+**Problem**: `export * as ns from './dep'` and `export * from './dep'` are the same oxc AST node (`ExportAllDeclaration`), distinguished only by whether `exported` is set. The HMR finalizer ignored that field and rendered both as a star re-export — `__reExport(__rolldown_exports__, import_dep)` — so the re-exporting module's namespace object never carried `ns`, and every consumer read `undefined`. Only the module wrappers were affected (lazy chunks and HMR patches); the scope-hoisted build resolves the same source correctly, which is why the bug appeared only under `experimental.devMode.lazy`.
+
+**Solution**: When `exported` is present, bind the importee's `loadExports` result under that single name in the namespace object (`{ ns: () => import_dep }`, computed when the name is not a valid identifier) and emit no `__reExport`. Pinned by `crates/rolldown/tests/rolldown/topics/hmr/export_star_as/`.
+
 ## Implementation Notes
 
 ### Naming Convention for Injected Helpers

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -332,3 +332,54 @@ test(
     expect(position.line).toBe(2);
   },
 );
+
+// `export * as ns from './dep'` and `export * from './dep'` are the same oxc node,
+// separated only by `exported`. Reading it wrong drops the name from the namespace
+// object, and the consumer sees `undefined`. The snapshot fixture
+// (crates/rolldown/tests/rolldown/topics/hmr/export_star_as) pins the HMR patch; this
+// pins the lazy chunk, which reaches the same finalizer by a different route.
+test(
+  'a lazy chunk keeps the export name of `export * as ns from`',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-export-star-as-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'main.js'), `import('./lazy.js');\n`);
+    // reachable only through the namespace re-export
+    fs.writeFileSync(path.join(dir, 'dep.js'), `export const value = 'from-dep';\n`);
+    fs.writeFileSync(path.join(dir, 'reexport.js'), `export * as NS from './dep.js';\n`);
+    fs.writeFileSync(
+      path.join(dir, 'lazy.js'),
+      `import { NS } from './reexport.js';\nexport const lazy = NS.value;\n`,
+    );
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+
+    const chunk = await engine.compileEntry(
+      `${path.join(dir, 'lazy.js')}?rolldown-lazy=1`,
+      'export-star-as-client',
+    );
+
+    // the namespace object carries `NS`, rather than `dep.js`'s own exports being
+    // spread onto the re-exporting module the way `export *` would
+    expect(chunk.code).toMatch(/NS:\s*\(\)\s*=>/);
+    expect(chunk.code).not.toMatch(/__reExport\(/);
+  },
+);


### PR DESCRIPTION
In dev mode, `export * as ns from './dep.js'` silently loses its export name. The eagerly bundled output of the same build is correct, which is what makes this look like a bug rather than a missing feature.

```js
// dep.js
export const value = 'from-dep'
// reexport.js
export * as NS from './dep.js'
// main.js
import { NS } from './reexport.js'
NS.value // TypeError: Cannot read properties of undefined
```

## The two statements share one AST node

`export * from './dep.js'` and `export * as ns from './dep.js'` both parse to `ExportAllDeclaration`; they differ only by whether `exported` is set. `HmrAstFinalizer` never read that field, so the named form fell through to the anonymous star re-export path and was finalized as:

```js
var __rolldown_exports__ = __rolldown_runtime__.__exportAll({})
__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep)
```

That is the semantics of the *unnamed* form — `dep`'s own exports are spread onto this module, and the name `ns` never comes into existence. A consumer importing `ns` gets `undefined`, with no error at build time.

The fix binds the importee's namespace object to that single export name instead, and only when `exported` is present. The unnamed form keeps taking `create_re_export_call_stmt`, byte for byte.

Export names that are not valid identifiers are handled: `export * as "not-an-ident" from './dep.js'` is legal ES2022, so the property is emitted in computed form via the existing `is_validate_identifier_name` check rather than as a bare key.

## Tests

Two separate paths reach this finalizer, and both were broken. Each is pinned by its own test:

- `crates/rolldown/tests/rolldown/topics/hmr/export_star_as` — the HMR patch path. The snapshot shows the export name surviving into the patch.
- `packages/rolldown/tests/dev/dev-lazy-compile.test.ts` — the lazy-chunk path, where the re-exported module is reachable *only* through the namespace re-export, so nothing else can pull it in.

Both fail on `main` and pass with this change; reverting only the finalizer hunk turns both red again.

The lazy-chunk case is a dev-engine test rather than a Rust fixture because lazy compilation is not reachable from the fixture config (`lazyBarrel` is a different feature). `cargo test --workspace` and the Node.js suite pass, with no other snapshot changes.

## Documentation

`internal-docs/lazy-compilation/implementation.md` gains Issue 11, following the format already used there for Issues 1-10, per `AGENTS.md` ("Keep in sync: if your changes affect a doc, update it in the same change").

## Alternatives considered

- **Emitting `__reExport` and then aliasing the name on top.** Works for the common case, but it leaks `dep`'s own exports onto the re-exporting module as a side effect — the exact bug, just harder to see.
- **Handling this in the shared finalizer instead.** `ScopeHoistingFinalizer` already gets this right; the defect is specific to the HMR/dev path, so widening the change would touch a correct code path for no reason.

## Worth a closer look

- **Only the dev/HMR finalizer changes.** Production scope hoisting was already correct, so there is no user-facing change to `build`.
- **How it surfaced.** Found through Vite's `experimental.bundledDev` with lazy compilation, where a UI library re-exported as a namespace arrived as `undefined` at runtime. The HMR patch path is affected identically, so this is not Vite-specific.

## AI disclosure

This PR was developed with AI assistance. The diagnosis, the fix, and both tests were reviewed and validated by me against a real project before submission.
