### PR TITLE
refactor(plugin): reuse rolldown_utils::stabilize_id in bundle analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,6 @@ dependencies = [
  "arcstr",
  "rolldown_common",
  "rolldown_plugin",
- "rolldown_std_utils",
  "rolldown_utils",
  "rustc-hash",
  "serde",

--- a/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
+++ b/crates/rolldown_plugin_bundle_analyzer/Cargo.toml
@@ -15,7 +15,6 @@ test = false
 arcstr = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_std_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rolldown_plugin_bundle_analyzer/src/lib.rs
+++ b/crates/rolldown_plugin_bundle_analyzer/src/lib.rs
@@ -1,10 +1,10 @@
-use std::{borrow::Cow, path::Path, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use arcstr::ArcStr;
 use rolldown_common::{EmittedAsset, Output, OutputChunk};
 use rolldown_plugin::{HookNoopReturn, HookUsage, Plugin, PluginContext};
-use rolldown_std_utils::relative_path_to_slash;
 use rolldown_utils::rustc_hash::FxHashMapExt;
+use rolldown_utils::stabilize_id::stabilize_id;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 
@@ -162,7 +162,7 @@ impl BundleAnalyzerPlugin {
 
           modules_data.push(ModuleData {
             id: format!("mod-{idx}"),
-            path: stabilize_module_id(module_id, cwd),
+            path: stabilize_id(module_id, cwd),
             size,
             importers: None, // Will be filled in later
           });
@@ -348,21 +348,6 @@ impl BundleAnalyzerPlugin {
     }
 
     visited.into_iter().collect()
-  }
-}
-
-/// Stabilize a module ID by converting absolute paths to relative paths from cwd.
-/// This ensures stable, portable output across different machines.
-fn stabilize_module_id(id: &str, cwd: &Path) -> String {
-  let path = Path::new(id);
-  if path.is_absolute() {
-    // Convert absolute path to relative path from cwd using forward slashes
-    relative_path_to_slash(path, cwd)
-  } else if id.starts_with('\0') {
-    // Escape virtual module prefix
-    id.replace('\0', "\\0")
-  } else {
-    id.to_string()
   }
 }
 


### PR DESCRIPTION
The analyzer's private copy is behavior-identical: under its `is_absolute` guard the shared helper reduces to the same `relative_path_to_slash` call, and the virtual-module and passthrough branches match exactly.