### PR TITLE
fix(code-splitting): never name an internal chunk export `then`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -31,6 +31,17 @@ type IndexCrossChunkDynamicImports = IndexVec<ChunkIdx, FxIndexSet<ChunkIdx>>;
 type IndexImportsFromOtherChunks =
   IndexVec<ChunkIdx, FxHashMap<ChunkIdx, Vec<CrossChunkImportItem>>>;
 
+/// A chunk is loaded through `import('./chunk.js')`, whose promise resolves with the chunk's
+/// namespace object. Promise resolution assimilates any value with a callable `then` as a
+/// thenable, so a chunk exporting `then` hijacks every dynamic import of that chunk — including
+/// the `.then((n) => n.ns)` the finalizer generates to reach a merged dynamic entry, whose
+/// callback then receives whatever the exported `then` resolved with instead of the namespace.
+///
+/// Internal cross-chunk export names are bundler-owned, so simply never hand out `then` for one.
+/// Names the user can observe — an entry chunk's public exports and the export names an
+/// `emitFile` consumer relies on — are a contract and keep whatever they declare.
+const THENABLE_HAZARD_EXPORT_NAME: &str = "then";
+
 struct CrossChunkLinkState {
   index_chunk_exported_symbols: IndexChunkExportedSymbols,
   index_chunk_direct_imports_from_external_modules: IndexChunkImportsFromExternalModules,
@@ -1338,7 +1349,10 @@ impl GenerateStage<'_> {
           loop {
             named_index += 1;
             export_name = generate_minified_names(named_index).into();
-            if !used_names.contains(&export_name) {
+            // Unreachable in practice — base54 needs about 14M names before it produces a
+            // four-character `then` — but the generator is the only other source of internal
+            // export names, so make it impossible rather than improbable.
+            if !used_names.contains(&export_name) && export_name != THENABLE_HAZARD_EXPORT_NAME {
               break;
             }
           }
@@ -1349,8 +1363,39 @@ impl GenerateStage<'_> {
         continue;
       }
 
+      // The symbols an `emitFile` consumer reaches under the name `then`. Unlike an entry
+      // signature they arrive with no predefined name, so they would otherwise be
+      // indistinguishable from a bundler-owned internal name below. Only the export name is the
+      // contract: a preserve-name module whose local `then` leaves under an alias goes through
+      // the resolver like everything else, so it can never hand `then` to the chunk.
+      //
+      // The carve-out below additionally requires the declaring symbol to be named `then`: with
+      // internal minification off this pass outputs declaring-symbol names, so export aliases are
+      // already not honored — a pre-existing defect tracked in #10500, whose fix (routing
+      // preserved names through the predefined-names path) also removes this set and the
+      // first-wins flag below.
+      let preserved_then_refs: FxHashSet<SymbolRef> = preserve_export_names_modules
+        .get(&chunk_id)
+        .map(|modules| {
+          modules
+            .iter()
+            .flat_map(|&module_idx| {
+              self.link_output.metas[module_idx]
+                .canonical_exports(false)
+                .filter(|(name, _)| name.as_str() == THENABLE_HAZARD_EXPORT_NAME)
+                .map(|(_, export)| self.link_output.symbol_db.canonical_ref_for(export.symbol_ref))
+            })
+            .collect()
+        })
+        .unwrap_or_default();
+      let mut preserved_then_taken = false;
+
       let mut resolver =
         ConflictResolver::with_capacity(index_chunk_exported_symbols[chunk_id].len());
+      // Names taken from source symbols can collide with `then`; reserving it up front deconflicts
+      // those to `then$1` like any other collision. Predefined names take the `lst` branch below,
+      // which re-reserves (a no-op) and emits them verbatim, so a public `then` still stays `then`.
+      resolver.reserve(CompactStr::new_const(THENABLE_HAZARD_EXPORT_NAME));
       for (chunk_export, predefined_names) in index_chunk_exported_symbols[chunk_id]
         .iter()
         .sorted_by_cached_key(|(symbol_ref, _predefined_names)| {
@@ -1403,7 +1448,20 @@ impl GenerateStage<'_> {
         } else {
           original_name
         };
-        let chosen = resolver.resolve(base, |_, _| true);
+        let chosen = if base == THENABLE_HAZARD_EXPORT_NAME
+          && !preserved_then_taken
+          && preserved_then_refs
+            .contains(&self.link_output.symbol_db.canonical_ref_for(*chunk_export))
+        {
+          // A name an `emitFile` consumer relies on is a contract, so it keeps `then`. The
+          // reservation above only fences off bundler-owned internal names. Two preserved
+          // modules both exporting the name `then` cannot both be honored — the second falls
+          // back to the resolver so the chunk at least stays parseable.
+          preserved_then_taken = true;
+          base
+        } else {
+          resolver.resolve(base, |_, _| true)
+        };
         chunk.exports_to_other_chunks.entry(*chunk_export).or_default().push(chosen);
       }
     }

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/artifacts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+import { then$1, then$2 as then } from "./libs.js";
+import assert from "node:assert";
+//#region index.js
+assert.strictEqual(typeof then, "function");
+assert.strictEqual(typeof then$1, "function");
+//#endregion
+
+```
+
+## libs.js
+
+```js
+//#region lib1.js
+function then$1(resolve) {
+	resolve("lib1");
+}
+//#endregion
+//#region lib2.js
+function then(resolve) {
+	resolve("lib2");
+}
+//#endregion
+export { then as then$1, then$1 as then$2 };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/index.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/index.js
@@ -1,0 +1,7 @@
+import { first } from './lib1.js';
+import { second } from './lib2.js';
+
+import assert from 'node:assert';
+
+assert.strictEqual(typeof first, 'function');
+assert.strictEqual(typeof second, 'function');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/lib1.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/lib1.js
@@ -1,0 +1,4 @@
+function then(resolve) {
+  resolve('lib1');
+}
+export { then as first };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/lib2.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/lib2.js
@@ -1,0 +1,4 @@
+function then(resolve) {
+  resolve('lib2');
+}
+export { then as second };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/mod.rs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_merge_aliased_then_locals/mod.rs
@@ -1,0 +1,71 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, InputItem, PreserveEntrySignatures};
+use rolldown_common::{
+  CodeSplittingMode, EmittedChunk, ManualCodeSplittingOptions, MatchGroup, MatchGroupName,
+  MatchGroupTest,
+};
+use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+use rolldown_testing::{manual_integration_test, test_config::TestMeta};
+use rolldown_utils::js_regex::HybridRegex;
+
+/// Test that emitted chunks with AllowExtension preserve entry signatures
+/// can be properly merged with other chunks during chunk merging optimization.
+#[derive(Debug)]
+struct EmitChunkPlugin;
+
+impl Plugin for EmitChunkPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "emit-chunk-plugin".into()
+  }
+
+  async fn build_start(
+    &self,
+    ctx: &PluginContext,
+    _args: &rolldown_plugin::HookBuildStartArgs<'_>,
+  ) -> Result<(), anyhow::Error> {
+    // Emit all library files as entry chunks with AllowExtension
+    ctx.emit_chunk(EmittedChunk {
+      id: "./lib1.js".to_string(),
+      preserve_entry_signatures: Some(PreserveEntrySignatures::AllowExtension),
+      ..Default::default()
+    })?;
+    ctx.emit_chunk(EmittedChunk {
+      id: "./lib2.js".to_string(),
+      preserve_entry_signatures: Some(PreserveEntrySignatures::AllowExtension),
+      ..Default::default()
+    })?;
+    Ok(())
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildStart
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allow_extension_merge_aliased_then_locals() {
+  // Two emitted AllowExtension entries each declare a local `then` but export it under a
+  // different alias, so neither exports the *name* `then`. With internal export names kept,
+  // both symbols must go through the resolver — handing `then` to either would put a
+  // callable `then` on the merged chunk's namespace (or, to both, emit a duplicate export).
+  manual_integration_test!()
+    .build(TestMeta { expect_executed: true, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem { name: Some("index".into()), import: "./index.js".into() }]),
+        minify_internal_exports: Some(false),
+        code_splitting: Some(CodeSplittingMode::Advanced(ManualCodeSplittingOptions {
+          groups: Some(vec![MatchGroup {
+            name: MatchGroupName::Static("libs".to_string()),
+            test: Some(MatchGroupTest::Regex(HybridRegex::new("lib").unwrap())),
+            ..Default::default()
+          }]),
+          ..Default::default()
+        })),
+        ..Default::default()
+      },
+      vec![Arc::new(EmitChunkPlugin)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_config.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Same thenable-assimilation hazard as `dynamic_import_host_exporting_then`, reached through an alias: a cross-chunk export is emitted under the declaring symbol's name, so `export { then as hostThen }` still puts `then` on the host chunk.",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "entryFilenames": "[name].js",
+    "chunkFilenames": "[name].js",
+    "minifyInternalExports": false,
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "dyn",
+          "test": "[\\\\/](?:target|observer|then-export)\\.js$"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+
+const { targetPromise } = await import('./dist/a.js');
+const target = await targetPromise;
+
+assert.strictEqual(target.value, 1);

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/a.js
@@ -1,0 +1,1 @@
+export const targetPromise = import('./target.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+//#region a.js
+const targetPromise = import("./dyn.js").then((n) => n.target_exports);
+//#endregion
+export { targetPromise };
+
+```
+
+## b.js
+
+```js
+import { then$1 as then } from "./dyn.js";
+//#region b.js
+globalThis.hostThen = then;
+//#endregion
+
+```
+
+## dyn.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region observer.js
+globalThis.observed = true;
+//#endregion
+//#region then-export.js
+function then(resolve) {
+	resolve("not the host namespace");
+}
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+//#endregion
+export { target_exports, then as then$1 };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/b.js
@@ -1,0 +1,4 @@
+import './observer.js';
+import { hostThen } from './then-export.js';
+
+globalThis.hostThen = hostThen;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/observer.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/observer.js
@@ -1,0 +1,1 @@
+globalThis.observed = true;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/target.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/target.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/then-export.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/then-export.js
@@ -1,0 +1,5 @@
+function then(resolve) {
+  resolve('not the host namespace');
+}
+
+export { then as hostThen };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_config.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "A merged dynamic entry is reached through `import('./dyn.js').then((n) => n.ns)`. If the host chunk also carries an internal cross-chunk export literally named `then`, promise resolution assimilates the chunk namespace as a thenable and the callback never sees the namespace.",
+  "config": {
+    "input": [
+      {
+        "name": "a",
+        "import": "./a.js"
+      },
+      {
+        "name": "b",
+        "import": "./b.js"
+      }
+    ],
+    "entryFilenames": "[name].js",
+    "chunkFilenames": "[name].js",
+    "minifyInternalExports": false,
+    "codeSplitting": {
+      "groups": [
+        {
+          "name": "dyn",
+          "test": "[\\\\/](?:target|observer|then-export)\\.js$"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+
+const { targetPromise } = await import('./dist/a.js');
+const target = await targetPromise;
+
+assert.strictEqual(target.value, 1);

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/a.js
@@ -1,0 +1,1 @@
+export const targetPromise = import('./target.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+//#region a.js
+const targetPromise = import("./dyn.js").then((n) => n.target_exports);
+//#endregion
+export { targetPromise };
+
+```
+
+## b.js
+
+```js
+import { then$1 as then } from "./dyn.js";
+//#region b.js
+globalThis.hostThen = then;
+//#endregion
+
+```
+
+## dyn.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region observer.js
+globalThis.observed = true;
+//#endregion
+//#region then-export.js
+function then(resolve) {
+	resolve("not the host namespace");
+}
+//#endregion
+//#region target.js
+var target_exports = /* @__PURE__ */ __exportAll({ value: () => 1 });
+//#endregion
+export { target_exports, then as then$1 };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/b.js
@@ -1,0 +1,4 @@
+import './observer.js';
+import { then } from './then-export.js';
+
+globalThis.hostThen = then;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/observer.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/observer.js
@@ -1,0 +1,1 @@
+globalThis.observed = true;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/target.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/target.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/then-export.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/then-export.js
@@ -1,0 +1,3 @@
+export function then(resolve) {
+  resolve('not the host namespace');
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/mod.rs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/mod.rs
@@ -1,2 +1,3 @@
 mod allow_extension_exports;
+mod allow_extension_merge_aliased_then_locals;
 mod allow_extension_merge_same_exports;


### PR DESCRIPTION
A chunk is loaded through `import('./chunk.js')`, whose promise resolves with the chunk namespace. Promise resolution assimilates any value with a callable `then` as a thenable, so a chunk that exports `then` hijacks every dynamic import of itself — including the `.then((n) => n.ns)` the finalizer generates to reach a merged dynamic entry, whose callback then receives whatever the exported `then` resolved with instead of the namespace. With `minifyInternalExports: false` an internal cross-chunk export named `then` reaches the host namespace directly or through an alias, since a cross-chunk export is emitted under the declaring symbol's name (`export { then as hostThen }` still emits `then`).

`deconflict_exported_names` now reserves `then` before naming bundler-owned internal exports, so they deconflict to `then$1` like any other collision, and the minified-name generator skips the literal `then` (unreachable in practice at four characters, but the generator is the only other source of internal names). Names the user can observe keep whatever they declare: an entry chunk's public exports arrive with predefined names and are emitted verbatim, and an `emitFile`-preserved export keeps `then` only when `then` is the exported name itself — a preserve-name module whose local `then` leaves under an alias deconflicts like any other symbol, so it cannot hand `then` to the chunk (and two preserved modules cannot emit a duplicate one; the second falls back to the resolver).

No snapshot churn: the full fixture sweep produces exactly the same set of snapshots as `main`, so no existing fixture had an internal export named `then`.

#10456's strict-side guard stays for what renaming can't reach: an entry's own public `then` and `export * from` an external module.
