### PR TITLE
fix(dev): resolve re-exports from externals through a real import

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -117,21 +117,10 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             }
           });
         });
-        match importee {
-          Module::Normal(_) => {
-            if let Some(stmt) =
-              self.create_load_exports_call_stmt(importee, &binding_name, import_decl.span)
-            {
-              program_body.push(stmt);
-            }
-          }
-          Module::External(importee_ext) => {
-            self.create_static_import_stmt_from_external_module(
-              importee_ext,
-              &binding_name,
-              import_decl.span,
-            );
-          }
+        if let Some(stmt) =
+          self.create_importee_binding_stmt(importee, &binding_name, import_decl.span)
+        {
+          program_body.push(stmt);
         }
       }
       ast::Statement::ExportNamedDeclaration(mut decl) => {
@@ -175,7 +164,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               &self.ast_builder,
             )
           }));
-          if let Some(stmt) = self.create_load_exports_call_stmt(importee, &binding_name, decl.span)
+          if let Some(stmt) = self.create_importee_binding_stmt(importee, &binding_name, decl.span)
           {
             program_body.push(stmt);
           }
@@ -293,7 +282,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         self.dependencies.insert(importee_idx);
         let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
         if let Some(stmt) =
-          self.create_load_exports_call_stmt(importee, &binding_name, export_all_decl.span)
+          self.create_importee_binding_stmt(importee, &binding_name, export_all_decl.span)
         {
           program_body.push(stmt);
         }
@@ -407,23 +396,46 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     }
   }
 
-  fn create_load_exports_call_stmt(
+  /// Bind the importee's namespace object to `binding_name`, whatever brought the importee in -
+  /// a plain import or any of the three re-export forms. All of them read the binding the same
+  /// way afterwards, so they must all obtain it the same way.
+  ///
+  /// Only normal modules can come from the dev runtime registry: it holds the modules this build
+  /// wrapped, and an external is by definition not one of them. `loadExports` on an external id
+  /// finds nothing, warns, and returns `{}` - so an external has to keep a real import statement
+  /// and let the host resolve it. That statement is emitted outside the wrapper, hence no
+  /// statement to return here.
+  fn create_importee_binding_stmt(
     &mut self,
     importee: &Module,
     binding_name: &str,
     span: Span,
   ) -> Option<Statement<'ast>> {
-    if self.imports.contains(&importee.idx()) {
+    match importee {
+      Module::Normal(importee) => self.create_load_exports_call_stmt(importee, binding_name, span),
+      Module::External(importee) => {
+        self.create_static_import_stmt_from_external_module(importee, binding_name, span);
+        None
+      }
+    }
+  }
+
+  /// Takes a `&NormalModule` rather than a `&Module` on purpose: asking the registry for an
+  /// external is the defect this pairing exists to prevent, so it should not be expressible.
+  fn create_load_exports_call_stmt(
+    &mut self,
+    importee: &NormalModule,
+    binding_name: &str,
+    span: Span,
+  ) -> Option<Statement<'ast>> {
+    if self.imports.contains(&importee.idx) {
       return None;
     }
-    self.imports.insert(importee.idx());
+    self.imports.insert(importee.idx);
 
     // Use stable module ID for consistent runtime lookup
-    let id = importee.stable_id();
-    let interop = match importee {
-      Module::Normal(importee) => self.module.interop(importee),
-      Module::External(_) => None,
-    };
+    let id = importee.stable_id.as_ref();
+    let interop = self.module.interop(importee);
     let call_expr = Expression::new_call_with_arg(
       Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", self),
       ast::Expression::new_string_literal(SPAN, Str::from_str_in(id, self), None, self),
@@ -513,8 +525,6 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     binding_name_for_namespace_object_ref: &str,
     scoping: &Scoping,
   ) -> Vec<ast::Statement<'ast>> {
-    // TODO reexport external module
-
     // construct `{ prop_name: () => returned, ... }`
     let mut arg_obj_expr = ast::ObjectExpression::boxed(
       SPAN,

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["node:assert", "node:util"],
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
@@ -1,0 +1,167 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import * as assertNS from "node:assert";
+import assert, { deepStrictEqual, ok as assertOk } from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+__rolldown_runtime__.registerGraph({
+	ids: [
+		"dep.js",
+		"reexport.js",
+		"shadow.js",
+		"hmr.js",
+		"main.js"
+	],
+	localCount: 5,
+	edges: [
+		[],
+		[0],
+		[0],
+		[1, 2],
+		[3]
+	],
+	dynamicEdges: [
+		[],
+		[],
+		[],
+		[],
+		[]
+	]
+});
+//#region dep.js
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+__rolldown_runtime__.createModuleHotContext("dep.js");
+__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+const value = "from-dep";
+//#endregion
+//#region reexport.js
+var reexport_exports = /* @__PURE__ */ __exportAll({
+	assertNS: () => assertNS,
+	assertOk: () => assertOk,
+	value: () => value
+});
+import * as import_node_util from "node:util";
+__reExport(reexport_exports, import_node_util);
+__rolldown_runtime__.createModuleHotContext("reexport.js");
+__rolldown_runtime__.registerModule("reexport.js", { exports: reexport_exports });
+//#endregion
+//#region shadow.js
+var shadow_exports = /* @__PURE__ */ __exportAll({
+	shadowWorks: () => shadowWorks,
+	value: () => value
+});
+import * as import_node_assert from "node:assert";
+__reExport(shadow_exports, import_node_assert);
+__rolldown_runtime__.createModuleHotContext("shadow.js");
+__rolldown_runtime__.registerModule("shadow.js", { exports: shadow_exports });
+const shadowWorks = typeof deepStrictEqual === "function";
+//#endregion
+//#region hmr.js
+var hmr_exports = /* @__PURE__ */ __exportAll({});
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+assert.strictEqual(value, "from-dep");
+assert.strictEqual(typeof assertOk, "function", "export { x } from external");
+assert.strictEqual(typeof assertNS?.ok, "function", "export * as ns from external");
+assert.strictEqual(typeof reexport_exports.format, "function", "export * from external");
+assert.strictEqual(shadowWorks, true, "import + export * from the same external");
+assert.strictEqual(typeof shadow_exports.strictEqual, "function");
+hmr_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+//#endregion
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["dep.js","hmr.js","reexport.js","shadow.js"],localCount:4,edges:[[],[2,3],[0],[0]],dynamicEdges:[[],[],[],[]]});
+//#region dep.js
+__rolldown_runtime__.registerFactory("dep.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const value = "from-dep";
+		console.log("dep updated");
+	} finally {}
+}));
+
+//#endregion
+//#region hmr.js
+import * as import_node_assert_10 from "node:assert";
+__rolldown_runtime__.registerFactory("hmr.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("reexport.js");
+		__rolldown_runtime__.initModule("shadow.js");
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_reexport_11 = __rolldown_runtime__.loadExports("reexport.js");
+		var import_shadow_12 = __rolldown_runtime__.loadExports("shadow.js");
+		import_node_assert_10.default.strictEqual(import_reexport_11.value, "from-dep");
+		import_node_assert_10.default.strictEqual(typeof import_reexport_11.assertOk, "function", "export { x } from external");
+		import_node_assert_10.default.strictEqual(typeof import_reexport_11.assertNS?.ok, "function", "export * as ns from external");
+		import_node_assert_10.default.strictEqual(typeof import_reexport_11.format, "function", "export * from external");
+		import_node_assert_10.default.strictEqual(import_shadow_12.shadowWorks, true, "import + export * from the same external");
+		import_node_assert_10.default.strictEqual(typeof import_shadow_12.strictEqual, "function");
+		hot_hmr.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region reexport.js
+import * as import_node_assert_21 from "node:assert";
+import * as import_node_util_23 from "node:util";
+__rolldown_runtime__.registerFactory("reexport.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			assertOk: () => import_node_assert_21.ok,
+			assertNS: () => import_node_assert_21
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("dep.js");
+		const hot_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_dep_20 = __rolldown_runtime__.loadExports("dep.js");
+		__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep_20);
+		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_util_23);
+	} finally {}
+}));
+
+//#endregion
+//#region shadow.js
+import * as import_node_assert_30 from "node:assert";
+__rolldown_runtime__.registerFactory("shadow.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ shadowWorks: () => shadowWorks });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("dep.js");
+		const hot_shadow = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var import_dep_31 = __rolldown_runtime__.loadExports("dep.js");
+		__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep_31);
+		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_assert_30);
+		const shadowWorks = typeof import_node_assert_30.deepStrictEqual === "function";
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- dep.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import * as assertNS from "node:assert";
-import assert, { deepStrictEqual, ok as assertOk } from "node:assert";
+import assert, { deepStrictEqual, ok as assertOk, default as assertDefault } from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 __rolldown_runtime__.registerGraph({
 	ids: [
@@ -41,6 +41,7 @@ const value = "from-dep";
 //#endregion
 //#region reexport.js
 var reexport_exports = /* @__PURE__ */ __exportAll({
+	assertDefault: () => assertDefault,
 	assertNS: () => assertNS,
 	assertOk: () => assertOk,
 	value: () => value
@@ -67,6 +68,7 @@ const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 assert.strictEqual(value, "from-dep");
 assert.strictEqual(typeof assertOk, "function", "export { x } from external");
+assert.strictEqual(assertDefault, assert, "export { default as y } from external");
 assert.strictEqual(typeof assertNS?.ok, "function", "export * as ns from external");
 assert.strictEqual(typeof reexport_exports.format, "function", "export * from external");
 assert.strictEqual(shadowWorks, true, "import + export * from the same external");
@@ -112,6 +114,7 @@ __rolldown_runtime__.registerFactory("hmr.js", "esm", (function(__rolldown_modul
 		var import_shadow_12 = __rolldown_runtime__.loadExports("shadow.js");
 		import_node_assert_10.default.strictEqual(import_reexport_11.value, "from-dep");
 		import_node_assert_10.default.strictEqual(typeof import_reexport_11.assertOk, "function", "export { x } from external");
+		import_node_assert_10.default.strictEqual(import_reexport_11.assertDefault, import_node_assert_10.default, "export { default as y } from external");
 		import_node_assert_10.default.strictEqual(typeof import_reexport_11.assertNS?.ok, "function", "export * as ns from external");
 		import_node_assert_10.default.strictEqual(typeof import_reexport_11.format, "function", "export * from external");
 		import_node_assert_10.default.strictEqual(import_shadow_12.shadowWorks, true, "import + export * from the same external");
@@ -123,11 +126,12 @@ __rolldown_runtime__.registerFactory("hmr.js", "esm", (function(__rolldown_modul
 //#endregion
 //#region reexport.js
 import * as import_node_assert_21 from "node:assert";
-import * as import_node_util_23 from "node:util";
+import * as import_node_util_24 from "node:util";
 __rolldown_runtime__.registerFactory("reexport.js", "esm", (function(__rolldown_module_id__) {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			assertOk: () => import_node_assert_21.ok,
+			assertDefault: () => import_node_assert_21.default,
 			assertNS: () => import_node_assert_21
 		});
 		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
@@ -135,7 +139,7 @@ __rolldown_runtime__.registerFactory("reexport.js", "esm", (function(__rolldown_
 		const hot_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		var import_dep_20 = __rolldown_runtime__.loadExports("dep.js");
 		__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep_20);
-		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_util_23);
+		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_util_24);
 	} finally {}
 }));
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/dep.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/dep.hmr-0.js
@@ -1,0 +1,3 @@
+export const value = 'from-dep';
+
+console.log('dep updated');

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/dep.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/dep.js
@@ -1,0 +1,1 @@
+export const value = 'from-dep';

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/hmr.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import { assertOk, assertNS, format, value } from './reexport.js';
+import { shadowWorks, strictEqual } from './shadow.js';
+
+assert.strictEqual(value, 'from-dep');
+assert.strictEqual(typeof assertOk, 'function', 'export { x } from external');
+assert.strictEqual(typeof assertNS?.ok, 'function', 'export * as ns from external');
+assert.strictEqual(typeof format, 'function', 'export * from external');
+assert.strictEqual(shadowWorks, true, 'import + export * from the same external');
+assert.strictEqual(typeof strictEqual, 'function');
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/hmr.js
@@ -1,9 +1,12 @@
 import assert from 'node:assert';
-import { assertOk, assertNS, format, value } from './reexport.js';
+import { assertOk, assertDefault, assertNS, format, value } from './reexport.js';
 import { shadowWorks, strictEqual } from './shadow.js';
 
 assert.strictEqual(value, 'from-dep');
 assert.strictEqual(typeof assertOk, 'function', 'export { x } from external');
+// `default` is a name like any other on the namespace object, but the only named
+// re-export shape whose meaning depends on the importee's interop.
+assert.strictEqual(assertDefault, assert, 'export { default as y } from external');
 assert.strictEqual(typeof assertNS?.ok, 'function', 'export * as ns from external');
 assert.strictEqual(typeof format, 'function', 'export * from external');
 assert.strictEqual(shadowWorks, true, 'import + export * from the same external');

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/main.js
@@ -1,0 +1,1 @@
+import './hmr.js';

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/reexport.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/reexport.js
@@ -1,5 +1,6 @@
 export * from './dep.js';
 
 export { ok as assertOk } from 'node:assert';
+export { default as assertDefault } from 'node:assert';
 export * as assertNS from 'node:assert';
 export * from 'node:util';

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/reexport.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/reexport.js
@@ -1,0 +1,5 @@
+export * from './dep.js';
+
+export { ok as assertOk } from 'node:assert';
+export * as assertNS from 'node:assert';
+export * from 'node:util';

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/shadow.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/shadow.js
@@ -1,0 +1,6 @@
+import { deepStrictEqual } from 'node:assert';
+
+export * from './dep.js';
+export * from 'node:assert';
+
+export const shadowWorks = typeof deepStrictEqual === 'function';

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -458,6 +458,12 @@ The flow is:
 
 **Solution**: When `exported` is present, bind the importee's `loadExports` result under that single name in the namespace object (`{ ns: () => import_dep }`, computed when the name is not a valid identifier) and emit no `__reExport`. Pinned by `crates/rolldown/tests/rolldown/topics/hmr/export_star_as/`.
 
+### Issue 12: Re-exports From Externals Must Keep a Real Import (#10478)
+
+**Problem**: The dev runtime registry only holds modules this build wrapped, so an external is never in it — `loadExports('<external id>')` warns `Module <id> not found` and returns `{}`. The plain-import arm of the HMR finalizer knew this and emitted a real `import * as X from 'ext'` hoisted outside the wrapper; the three re-export arms (`export * from`, `export * as ns from`, `export { x } from`) did not, and asked the registry instead. Every re-exported name read as `undefined`, silently. When the same module also imported that external, both arms named the binding through `ensure_static_import_info` but deduplicated against different sets, so both declarations were emitted under one name — and since the real import sits at chunk top level while the `var` sits inside the factory, the `var` legally shadowed it and the module's own uses of the external broke too.
+
+**Solution**: Route all four arms through one `create_importee_binding_stmt`, which picks `loadExports` for normal modules and a real import statement for externals. The per-kind deduplication sets then stay disjoint by construction, so the shadowing `var` cannot be emitted. Pinned by `crates/rolldown/tests/rolldown/topics/hmr/reexport_external/` (HMR patch, executed) and a `dev-lazy-compile.test.ts` case (lazy chunk).
+
 ## Implementation Notes
 
 ### Naming Convention for Injected Helpers

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -383,3 +383,67 @@ test(
     expect(chunk.code).not.toMatch(/__reExport\(/);
   },
 );
+
+// The dev runtime registry only holds modules this build wrapped, so an external can
+// only be reached through a real import statement. The three re-export forms used to
+// ask the registry for it instead, which yields `{}`; and when the same module also
+// imported that external, the two paths emitted one binding name twice, the inner
+// `var` shadowing the real import.
+test(
+  'a lazy chunk imports externals it re-exports instead of asking the registry',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-reexport-external-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'main.js'), `import('./lazy.js');\n`);
+    // reachable only through the lazy chunk, and re-exports the external three ways
+    // while also importing it — the case that produced the shadowing `var`
+    fs.writeFileSync(
+      path.join(dir, 'reexport.js'),
+      `import { helper } from 'external-dep';\n` +
+        `export { helper as reHelper } from 'external-dep';\n` +
+        `export * as EXT from 'external-dep';\n` +
+        `export * from 'external-dep';\n` +
+        `export const helperType = typeof helper;\n`,
+    );
+    fs.writeFileSync(
+      path.join(dir, 'lazy.js'),
+      `import { EXT, reHelper, helperType } from './reexport.js';\n` +
+        `export const lazy = [EXT, reHelper, helperType];\n`,
+    );
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        external: ['external-dep'],
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+
+    const chunk = await engine.compileEntry(
+      `${path.join(dir, 'lazy.js')}?rolldown-lazy=1`,
+      'reexport-external-client',
+    );
+
+    const bindings = [...chunk.code.matchAll(/import \* as (\w+) from "external-dep"/g)].map(
+      (match) => match[1],
+    );
+    expect(bindings).toHaveLength(1);
+    // the registry never holds an external, so nothing may look it up there
+    expect(chunk.code).not.toMatch(/loadExports\("external-dep"\)/);
+    // and the one binding is declared once, so the import is not shadowed
+    expect(chunk.code).not.toMatch(new RegExp(`var\\s+${bindings[0]}\\b`));
+  },
+);


### PR DESCRIPTION
Fixes #10478.

## What's broken

The dev runtime registry holds the modules this build wrapped. An external is by definition not one of them, so `loadExports('<external id>')` finds nothing, warns `Module <id> not found`, and returns `{}` — it does not throw. The import arm of `HmrAstFinalizer` knew that and emitted a real import statement, hoisted outside the wrapper. The three re-export arms asked the registry instead:

```js
// input: export { ok as assertOk } from 'node:assert'
__rolldown_runtime__.registerFactory("lazy.js", "esm", (function(__rolldown_module_id__) {
	var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ assertOk: () => import_node_assert_00.ok });
	// …
	var import_node_assert_00 = __rolldown_runtime__.loadExports("node:assert");  // {}
}));
```

Every re-exported name reads as `undefined`, with nothing failing at build time.

The second symptom is worse. When a module both imports and re-exports the same external, both arms name the binding through `ensure_static_import_info` — so they agree on the name — but they deduplicate against different sets (`self.imports` vs `generated_static_import_stmts_from_external`), so both emit a declaration. The real import sits at chunk top level and the `var` inside the factory, which is legal shadowing rather than a redeclaration error. Every reference in the module body then reads the empty object, including the ones that were working before.

## Root cause

Four statement kinds need the same thing — a local binding for the importee's namespace — and each decided how to obtain it on its own. Only one of the four knew about externals.

## The fix

All four now route through one `create_importee_binding_stmt`: `loadExports` for a normal module, a real import statement for an external. The two deduplication sets become disjoint by construction, so the shadowing `var` has no path to being emitted.

`create_load_exports_call_stmt` now takes a `&NormalModule` rather than a `&Module`, which makes "ask the registry for an external" a compile error rather than a rule to remember. It also removes a `Module::External => None` interop arm that is now unreachable.

## Scope

Only the module-wrapper path (HMR patches, lazy chunks) changes. Scope hoisting already resolved all four forms correctly, so the initial dev bundle and production builds were never affected — in the new fixture's snapshot the eager output and the patch sit side by side, and the patch now matches what the eager output always had.

No existing snapshot moved, which is also the answer to why this survived: no fixture reached this path.

## Tests

- `crates/rolldown/tests/rolldown/topics/hmr/reexport_external/` — all three re-export forms plus the import-and-re-export shadowing case, against `node:assert` and `node:util`. The fixture executes, and it runs its assertions twice against the same expectations: first on the eagerly bundled output, then again once every module has been re-emitted as a wrapper. So the wrapper is held to what scope hoisting already satisfies, instead of to a second set of numbers written by hand.
- `packages/rolldown/tests/dev/dev-lazy-compile.test.ts` — the lazy-chunk path, which reaches the same finalizer by a different route. Asserts exactly one `import * as … from "external-dep"`, no `loadExports("external-dep")`, and no `var` redeclaring that binding.

Both fail against the finalizer as it stands on `main` and pass with this change; reverting only the finalizer hunk turns both red again.

## Alternatives considered

- **Give each re-export arm its own `Module::External` branch**, mirroring the import arm. Fixes the empty re-exports, but leaves the same decision written in four places — which is what produced the bug — and does not fix the shadowing, since the two deduplication sets stay independent.
- **Merge the two deduplication sets into one.** Fixes the shadowing but not the empty re-exports. Once the two module kinds route separately the sets are disjoint anyway, so merging them would hide the invariant rather than enforce it.
- **Register externals in the dev runtime registry** so `loadExports` works for them. An external is resolved by the host, so the runtime would have to import it anyway, and this would change the registry contract for every consumer to fix one caller.

## Worth a closer look

- The `&NormalModule` signature change is the part I would most like a second opinion on. It is what turns this from a fix into an invariant, but it does narrow a public-ish helper inside the crate.
- `export * from 'ext'` is lowered as a real `import * as` plus `__reExport`, matching what scope hoisting emits for the same input. It cannot be a top-level `export * from` because a wrapper's exports object is a runtime value.

## Docs

`internal-docs/lazy-compilation/implementation.md` gains Issue 12, in the format the file already uses for Issues 1–11.

## AI disclosure

Written with AI assistance. I reproduced the bug, reviewed the fix and both tests, and verified them against a real project before submitting.
