### PR TITLE
fix(error): align filename-pattern diagnostics with Rollup's wording

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -195,12 +195,12 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
         let pattern_name = match chunk {
           rolldown_common::Output::Chunk(c) => {
             if c.is_entry {
-              "entryFileNames"
+              "output.entryFileNames"
             } else {
-              "chunkFileNames"
+              "output.chunkFileNames"
             }
           }
-          rolldown_common::Output::Asset(_) => "assetFileNames",
+          rolldown_common::Output::Asset(_) => "output.assetFileNames",
         };
         return Err(
           BuildDiagnostic::invalid_option(rolldown_error::InvalidOptionType::NulByteInFilename {

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/invalid_filename_pattern/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/invalid_filename_pattern/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Invalid pattern "/absolute/[name].js" for "entryFileNames", patterns can be neither absolute nor relative paths. If you want your files to be stored in a subdirectory, write its name without a leading slash like this: subdirectory/pattern.
+[INVALID_OPTION] Invalid pattern "/absolute/[name].js" for "output.entryFileNames", patterns can be neither absolute nor relative paths. If you want your files to be stored in a subdirectory, write its name without a leading slash like this: subdirectory/pattern.
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/preserve_modules_dot_dot_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/preserve_modules_dot_dot_name/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Invalid substitution "..y" for placeholder "[name]" in "entryFileNames" pattern, can be neither absolute nor relative paths.
+[INVALID_OPTION] Invalid substitution "..y" for placeholder "[name]" in "output.entryFileNames" pattern, can be neither absolute nor relative path.
 
 ```

--- a/crates/rolldown/tests/rolldown/function/hashing/maximum-hash-size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/hashing/maximum-hash-size/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Hashes cannot be longer than 21 characters, received 22. Check the `entryFileNames` option.
+[INVALID_OPTION] Hashes cannot be longer than 21 characters, received 22. Check the "output.entryFileNames" option.
 
 ```

--- a/crates/rolldown/tests/rolldown/function/hashing/minimum-hash-size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/hashing/minimum-hash-size/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] To generate hashes for this number of chunks (currently 1), you need a minimum hash size of 6, received 2. Check the `entryFileNames` option.
+[INVALID_OPTION] To generate hashes for this number of chunks (currently 1), you need a minimum hash size of 6, received 2. Check the "output.entryFileNames" option.
 
 ```

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -180,7 +180,7 @@ impl Chunk {
       options.chunk_filenames.call(rollup_pre_rendered_chunk).await?
     };
 
-    let pattern_name = if is_entry { "entryFileNames" } else { "chunkFileNames" };
+    let pattern_name = if is_entry { "output.entryFileNames" } else { "output.chunkFileNames" };
 
     Ok(FilenameTemplate::new(ret, pattern_name))
   }
@@ -242,7 +242,7 @@ impl Chunk {
     };
     let sourcemap_filename = sourcemap_filename.call(rollup_pre_rendered_chunk).await?;
 
-    let filename_template = FilenameTemplate::new(sourcemap_filename, "sourcemapFileNames");
+    let filename_template = FilenameTemplate::new(sourcemap_filename, "output.sourcemapFileNames");
     let has_hash_pattern = filename_template.has_hash_pattern();
 
     let mut hash_placeholder = has_hash_pattern.then_some(vec![]);

--- a/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
@@ -120,13 +120,13 @@ mod tests {
 
   #[test]
   fn basic() {
-    FilenameTemplate::new("[name]-[hash:8].js".to_string(), "entryFileNames");
+    FilenameTemplate::new("[name]-[hash:8].js".to_string(), "output.entryFileNames");
   }
 
   #[test]
   fn hash_with_len() {
     let filename_template =
-      FilenameTemplate::new("[name]-[hash:3]-[hash:3].js".to_string(), "entryFileNames");
+      FilenameTemplate::new("[name]-[hash:3]-[hash:3].js".to_string(), "output.entryFileNames");
 
     let mut hash_iter = ["abc", "def"].iter();
     let hash_replacer =
@@ -175,7 +175,8 @@ mod tests {
 
   #[test]
   fn test_invalid_pattern() {
-    let template = FilenameTemplate::new("/absolute/path/[name].js".to_string(), "entryFileNames");
+    let template =
+      FilenameTemplate::new("/absolute/path/[name].js".to_string(), "output.entryFileNames");
     let result = template.render(Some("test"), None, None, None, None::<&str>);
     assert!(result.is_err());
     assert!(
@@ -185,7 +186,7 @@ mod tests {
 
   #[test]
   fn test_invalid_name_substitution() {
-    let template = FilenameTemplate::new("[name].js".to_string(), "entryFileNames");
+    let template = FilenameTemplate::new("[name].js".to_string(), "output.entryFileNames");
     let result = template.render(Some("/absolute/name"), None, None, None, None::<&str>);
     assert!(result.is_err());
     assert!(
@@ -198,7 +199,7 @@ mod tests {
 
   #[test]
   fn test_valid_subdirectory() {
-    let template = FilenameTemplate::new("dist/[name].js".to_string(), "entryFileNames");
+    let template = FilenameTemplate::new("dist/[name].js".to_string(), "output.entryFileNames");
     let result = template.render(Some("test"), None, None, None, None::<&str>);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "dist/test.js");

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -249,7 +249,7 @@ impl NormalizedBundlerOptions {
   ) -> anyhow::Result<FilenameTemplate> {
     Ok(FilenameTemplate::new(
       self.asset_filenames.call(rollup_pre_rendered_asset).await?,
-      "assetFileNames",
+      "output.assetFileNames",
     ))
   }
 
@@ -270,7 +270,7 @@ impl NormalizedBundlerOptions {
         .map_or(vec![], |original_file_name| vec![original_file_name.into()]),
     };
     let asset_filename = self.asset_filenames.call(&rollup_pre_rendered_asset).await?;
-    Ok(Some(FilenameTemplate::new(asset_filename, "assetFileNames")))
+    Ok(Some(FilenameTemplate::new(asset_filename, "output.assetFileNames")))
   }
 
   pub async fn sanitize_file_name_with_file(

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -87,7 +87,7 @@ impl BuildEvent for InvalidOption {
         InvalidOptionType::InvalidFilenameSubstitution { name, pattern_name } => {
           format!(
             "Invalid substitution \"{name}\" for placeholder \"[name]\" in \"{pattern_name}\" pattern, \
-             can be neither absolute nor relative paths."
+             can be neither absolute nor relative path."
           )
         }
         InvalidOptionType::CodeSplittingDisabledWithMultipleInputs => {
@@ -97,10 +97,10 @@ impl BuildEvent for InvalidOption {
           "Invalid value \"false\" for option \"output.codeSplitting\" - this option is not supported for \"output.preserveModules\".".to_string()
         }
         InvalidOptionType::HashLengthTooLong { pattern_name, received, max } => {
-          format!("Hashes cannot be longer than {max} characters, received {received}. Check the `{pattern_name}` option.")
+          format!("Hashes cannot be longer than {max} characters, received {received}. Check the \"{pattern_name}\" option.")
         }
         InvalidOptionType::HashLengthTooShort { pattern_name, received, min, chunk_count } => {
-          format!("To generate hashes for this number of chunks (currently {chunk_count}), you need a minimum hash size of {min}, received {received}. Check the `{pattern_name}` option.")
+          format!("To generate hashes for this number of chunks (currently {chunk_count}), you need a minimum hash size of {min}, received {received}. Check the \"{pattern_name}\" option.")
         }
         InvalidOptionType::InvalidEmittedFileName(name) => {
           format!("The \"fileName\" or \"name\" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received \"{name}\".")

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -149,7 +149,10 @@ impl NativePluginContextImpl {
   ) -> anyhow::Result<ArcStr> {
     let file_name_is_none = file.file_name.is_none();
     let asset_filename_template = file_name_is_none.then(|| {
-      FilenameTemplate::new(self.options.asset_filenames.value(fn_asset_filename), "assetFileNames")
+      FilenameTemplate::new(
+        self.options.asset_filenames.value(fn_asset_filename),
+        "output.assetFileNames",
+      )
     });
     let sanitized_file_name = file_name_is_none.then(|| {
       self.options.sanitize_filename.value(file.name_for_sanitize(), fn_sanitized_file_name)

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/invalid-pattern-diagnostic/_config.ts
@@ -2,8 +2,9 @@ import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
 
 // An absolute `sourcemapFileNames` pattern is invalid and must be rejected. The diagnostic
-// has to name the public camelCase option (`sourcemapFileNames`); before the fix it leaked the
-// internal snake_case identifier `sourcemap_filename`, which is not a real option name.
+// has to name the public option the way Rollup does (`output.sourcemapFileNames`); before the
+// fix it leaked the internal snake_case identifier `sourcemap_filename`, which is not a real
+// option name.
 export default defineTest({
   config: {
     output: {
@@ -15,7 +16,7 @@ export default defineTest({
     expect.unreachable('an absolute sourcemapFileNames pattern should fail validation');
   },
   catchError: (error: unknown) => {
-    expect(String(error)).toContain('for "sourcemapFileNames"');
+    expect(String(error)).toContain('for "output.sourcemapFileNames"');
     expect(String(error)).not.toContain('sourcemap_filename');
   },
 });

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/issue-10186/_config.ts
@@ -7,7 +7,7 @@ import { expect } from 'vitest';
 // With `preserveModules`, a module whose id is a rooted-but-drive-less path
 // (`/favicon.ico`, or `\favicon.ico`) used to crash **only on Windows** with:
 //   [INVALID_OPTION] Invalid substitution "/favicon" for placeholder "[name]"
-//   in "entryFileNames" pattern, can be neither absolute nor relative paths.
+//   in "output.entryFileNames" pattern, can be neither absolute nor relative path.
 //
 // Root cause: Rust's `Path::is_absolute()` reports `/favicon` as non-absolute on
 // Windows (no drive prefix), so `get_preserve_modules_chunk_name` skips the


### PR DESCRIPTION
Stacked on #10400. Diagnostic wording only — no behavior change.

#10398 made rolldown's `is_path_fragment` agree with Rollup on *which* names are rejected. Running the resulting `preserve_modules_dot_dot_name` fixture against `rollup@4.62.3` shows the two bundlers now reject the same input at the same point but still *say* different things:

```
rollup    Invalid substitution "..y" for placeholder "[name]" in
          "output.entryFileNames" pattern, can be neither absolute nor relative path.

rolldown  Invalid substitution "..y" for placeholder "[name]" in
          "entryFileNames" pattern, can be neither absolute nor relative paths.
```

Two differences: the option is named without Rollup's `output.` prefix, and the trailing "path" is pluralised.

## Change

**1. Prefix every pattern name with `output.` at its origin.** Rollup passes `output.entryFileNames` / `output.chunkFileNames` / `output.assetFileNames` / `output.sourcemapFileNames` as `patternName` (`Chunk.ts:595-596,630`, `FileEmitter.ts:81`); rolldown passed the bare camelCase name. Updated at all six origins — chunk entry/non-entry, sourcemap, the two asset-template constructors, and the null-byte diagnostic in `bundle.rs`.

This is a message-only value: `pattern_name` is never compared or matched on, only interpolated, so nothing downstream depends on it. It reaches four diagnostics — `InvalidFilenamePattern`, `InvalidFilenameSubstitution`, `HashLengthTooLong`/`TooShort`, and `NulByteInFilename` — all of which now name the option the way the docs and Rollup do.

**2. Drop the plural** in `InvalidFilenameSubstitution`: `…nor relative paths.` → `…nor relative path.`, matching `renderNamePattern.ts:31`. (`InvalidFilenamePattern` is plural in Rollup too — `patterns can be neither…` — and already matched, so it is left alone.)

**3. Quote the option name in the hash-size messages.** Rollup writes `Check the "output.entryFileNames" option.` (`hashPlaceholders.ts:22,33`); rolldown used backticks. These strings changed anyway from (1), so this aligns the quoting at the same time.

Worth noting the other `InvalidOption` variants already named `output.`-prefixed options (`output.format`, `output.file`, `output.dir`, `output.codeSplitting`, `output.preserveModules`) — the four `*FileNames` ones were the exception, not the rule.

## Tests

Four Rust snapshots and two JS fixtures updated. The `sourcemap-filenames/invalid-pattern-diagnostic` fixture guards that the diagnostic names the public option rather than leaking the internal `sourcemap_filename`; its assertion is tightened to the Rollup-shaped `for "output.sourcemapFileNames"`, which keeps that guarantee.

`cargo test -p rolldown --test integration` and the Node fixture suite pass.

## What this does not change

The error *code* still differs — rolldown reports `INVALID_OPTION`, Rollup reports `VALIDATION_ERROR` — as does when the check is reachable under `preserveModules`, since rolldown inlines const modules that Rollup preserves. Both are noted in #10398 and are out of scope here.
