### PR TITLE
docs(code-splitting): record the thenable-namespace rule

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -1349,9 +1349,10 @@ impl GenerateStage<'_> {
           loop {
             named_index += 1;
             export_name = generate_minified_names(named_index).into();
-            // Unreachable in practice — base54 needs about 14M names before it produces a
-            // four-character `then` — but the generator is the only other source of internal
-            // export names, so make it impossible rather than improbable.
+            // Unreachable in practice — the generator first produces the four-character `then`
+            // at value 443,179, i.e. after ~443k internal exports in one chunk — but it is the
+            // only other source of internal export names, so make it impossible rather than
+            // improbable.
             if !used_names.contains(&export_name) && export_name != THENABLE_HAZARD_EXPORT_NAME {
               break;
             }
@@ -1393,7 +1394,8 @@ impl GenerateStage<'_> {
       let mut resolver =
         ConflictResolver::with_capacity(index_chunk_exported_symbols[chunk_id].len());
       // Names taken from source symbols can collide with `then`; reserving it up front deconflicts
-      // those to `then$1` like any other collision. Predefined names take the `lst` branch below,
+      // those to `then$1` like any other collision. See
+      // internal-docs/code-splitting/design.md ("Thenable chunk namespaces"). Predefined names take the `lst` branch below,
       // which re-reserves (a no-op) and emits them verbatim, so a public `then` still stays `then`.
       resolver.reserve(CompactStr::new_const(THENABLE_HAZARD_EXPORT_NAME));
       for (chunk_export, predefined_names) in index_chunk_exported_symbols[chunk_id]

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_aliased_then/_test.mjs
@@ -4,3 +4,8 @@ const { targetPromise } = await import('./dist/a.js');
 const target = await targetPromise;
 
 assert.strictEqual(target.value, 1);
+
+// Link the consumer chunk too: `b.js` imports the renamed binding from the host chunk, so a
+// producer/consumer disagreement on the new name would surface here as a SyntaxError.
+await import('./dist/b.js');
+assert.strictEqual(typeof globalThis.hostThen, 'function');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_host_exporting_then/_test.mjs
@@ -4,3 +4,8 @@ const { targetPromise } = await import('./dist/a.js');
 const target = await targetPromise;
 
 assert.strictEqual(target.value, 1);
+
+// Link the consumer chunk too: `b.js` imports the renamed binding from the host chunk, so a
+// producer/consumer disagreement on the new name would surface here as a SyntaxError.
+await import('./dist/b.js');
+assert.strictEqual(typeof globalThis.hostThen, 'function');

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -93,6 +93,32 @@ after the host chunk settles. The importing promise still resolves only after `i
 a microtask queued during host evaluation can observe the target before initialization. Both strict
 modes use this policy; `m4_dynamic_facade_race` pins it.
 
+## Thenable chunk namespaces
+
+`import()` resolves through the promise resolution procedure, so a chunk namespace that carries a
+callable `then` export is assimilated: the promise settles with whatever that `then` produces, and
+the call-site rewrite's extraction callback never receives the namespace. For a merged dynamic
+entry this would let a chunk-mate's export change what importing the target observes — impossible
+in source, where importing a module never exposes a sibling's exports.
+
+The defense splits by who owns the export name:
+
+- **Bundler-owned names are never `then`.** `deconflict_exported_names` reserves it before naming
+  internal exports — a source symbol named `then` deconflicts to `then$1` like any collision — and
+  the minified-name generator skips the literal `then` (it would otherwise appear at value
+  443,179). An `emitFile`-promised export keeps `then` only when `then` is the promised name
+  itself; #10500 tracks routing those through the predefined-names path, which removes that
+  carve-out.
+- **User-observable names cannot be renamed, so the collapse is refused instead**: an entry's own
+  public exports, `emitFile`-promised names, and whatever an `export * from` chain reaching an
+  external module supplies at runtime. `order_wrap_host_can_expose_then_export` guards the restore
+  path and the entry-facade decision guards the create path — see the entry-trigger facade bullet
+  above.
+
+Deliberately kept: a dynamic-import target's own `then` export. Native `import()` of the source
+module assimilates the same way, so renaming it would diverge from source semantics rather than
+preserve them.
+
 ## Tree-shaking parity across strict modes
 
 Late order lowering cannot make an excluded import binding or re-export live. The difficult case


### PR DESCRIPTION
Follow-ups from #10480's review (https://github.com/rolldown/rolldown/pull/10480#issuecomment-5100864763) that missed the merge.

- The two `then`-hazard fixtures only loaded the dynamic importer, so the chunk that imports the renamed binding was never linked at runtime — a producer/consumer disagreement on the new name would have stayed green. Both `_test.mjs` now load `b.js` and assert the re-exported binding arrived.
- `internal-docs/code-splitting/design.md` gains a "Thenable chunk namespaces" section: the assimilation mechanism, why the defense splits by name ownership (bundler-owned names are never `then`; user-observable ones keep the facade instead), and which case deliberately keeps `then` (the target's own export — native `import()` behaves the same). The reservation site in `deconflict_exported_names` points at it.
- The generator comment claimed `then` needs ~14M names; that is where five-character names begin. It first appears at value 443,179.
