### PR TITLE
refactor(code-splitting): remove redundant synthetic statement owner

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
@@ -197,8 +197,8 @@ impl OrderWrapState {
     wrapper_ref: SymbolRef,
     runtime_helper: RuntimeHelper,
   ) {
+    debug_assert_eq!(wrapper_ref.owner, module_idx);
     let wrapper_statement = self.add_synthetic_statement(OrderSyntheticStmt {
-      owner: module_idx,
       declared_symbols: vec![TaggedSymbolRef::normal(wrapper_ref)],
       referenced_symbols: vec![],
       runtime_helpers: runtime_helper,
@@ -226,8 +226,9 @@ impl OrderWrapState {
     referenced_symbols: Vec<SymbolRef>,
     runtime_helpers: RuntimeHelper,
   ) {
+    debug_assert_eq!(spec.wrapper_ref.owner, key.importer);
+    debug_assert_eq!(spec.namespace_ref.owner, key.importer);
     let wrapper_statement = self.add_synthetic_statement(OrderSyntheticStmt {
-      owner: key.importer,
       declared_symbols: vec![
         TaggedSymbolRef::normal(spec.wrapper_ref),
         TaggedSymbolRef::normal(spec.namespace_ref),
@@ -321,7 +322,6 @@ impl OrderWrapState {
   /// See `internal-docs/code-splitting/design.md` ("Trigger placement").
   pub(super) fn insert_simulated_facade_namespace(
     &mut self,
-    owner: ModuleIdx,
     namespace_ref: SymbolRef,
     chunk_idx: ChunkIdx,
     runtime_helpers: RuntimeHelper,
@@ -339,7 +339,6 @@ impl OrderWrapState {
     }
     requirement.live_importers.extend(live_importers);
     let stmt_idx = self.add_synthetic_statement(OrderSyntheticStmt {
-      owner,
       declared_symbols: vec![TaggedSymbolRef::normal(namespace_ref)],
       referenced_symbols,
       runtime_helpers,
@@ -721,7 +720,6 @@ pub struct EsmInitTarget {
 
 #[derive(Debug)]
 pub struct OrderSyntheticStmt {
-  pub(crate) owner: ModuleIdx,
   pub(crate) declared_symbols: Vec<TaggedSymbolRef>,
   pub(crate) referenced_symbols: Vec<SymbolRef>,
   pub(crate) runtime_helpers: RuntimeHelper,

--- a/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrap_state.rs
@@ -186,8 +186,8 @@ impl OrderWrapState {
     wrapper_ref: SymbolRef,
     runtime_helper: RuntimeHelper,
   ) {
+    debug_assert_eq!(wrapper_ref.owner, module_idx);
     let wrapper_statement = self.add_synthetic_statement(OrderSyntheticStmt {
-      owner: module_idx,
       declared_symbols: vec![TaggedSymbolRef::normal(wrapper_ref)],
       referenced_symbols: vec![],
       runtime_helpers: runtime_helper,
@@ -249,7 +249,6 @@ impl OrderWrapState {
   /// See `internal-docs/code-splitting/design.md` ("Trigger placement").
   pub(super) fn insert_simulated_facade_namespace(
     &mut self,
-    owner: ModuleIdx,
     namespace_ref: SymbolRef,
     chunk_idx: ChunkIdx,
     runtime_helpers: RuntimeHelper,
@@ -267,7 +266,6 @@ impl OrderWrapState {
     }
     requirement.live_importers.extend(live_importers);
     let stmt_idx = self.add_synthetic_statement(OrderSyntheticStmt {
-      owner,
       declared_symbols: vec![TaggedSymbolRef::normal(namespace_ref)],
       referenced_symbols,
       runtime_helpers,
@@ -539,7 +537,6 @@ pub struct EsmInitTarget {
 
 #[derive(Debug)]
 pub struct OrderSyntheticStmt {
-  pub(crate) owner: ModuleIdx,
   pub(crate) declared_symbols: Vec<TaggedSymbolRef>,
   pub(crate) referenced_symbols: Vec<SymbolRef>,
   pub(crate) runtime_helpers: RuntimeHelper,

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -869,7 +869,6 @@ impl GenerateStage<'_> {
           .or_default()
           .insert(entry_module_idx);
         order_state.insert_simulated_facade_namespace(
-          entry_module_idx,
           entry_module.namespace_object_ref,
           entry_chunk_idx,
           RuntimeHelper::ExportAll,
@@ -1106,7 +1105,6 @@ impl GenerateStage<'_> {
           .as_normal()
           .expect("dynamic entry should be a normal module");
         order_state.insert_simulated_facade_namespace(
-          entry_module_idx,
           entry_module.namespace_object_ref,
           entry_host_chunk,
           RuntimeHelper::ExportAll,

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -454,7 +454,6 @@ impl GenerateStage<'_> {
           .or_default()
           .insert(entry_module_idx);
         order_state.insert_simulated_facade_namespace(
-          entry_module_idx,
           entry_module.namespace_object_ref,
           entry_chunk_idx,
           RuntimeHelper::ExportAll,

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -191,7 +191,6 @@ pub fn deconflict_chunk_symbols(
 
   for synthetic in order_wrap_state.synthetic_statements_for_chunk(chunk_idx) {
     for declared_symbol in synthetic.declared_symbols.iter().filter(|item| item.is_normal()) {
-      debug_assert_eq!(declared_symbol.inner().owner, synthetic.owner);
       renamer.add_symbol_in_root_scope(declared_symbol.inner(), true);
     }
   }

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -181,7 +181,6 @@ pub fn deconflict_chunk_symbols(
 
   for synthetic in order_wrap_state.synthetic_statements_for_chunk(chunk_idx) {
     for declared_symbol in synthetic.declared_symbols.iter().filter(|item| item.is_normal()) {
-      debug_assert_eq!(declared_symbol.inner().owner, synthetic.owner);
       renamer.add_symbol_in_root_scope(declared_symbol.inner(), true);
     }
   }

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -527,7 +527,7 @@ link + tree shaking
 
 - No generate-stage call can change `LinkingMetadata::wrap_kind()`.
 - No order-lowering call can set a user statement inclusion bit.
-- Every order wrapper has exactly one symbol owner and one rendered chunk.
+- Every order wrapper's declared `SymbolRef` has exactly one module owner, and its synthetic declaration has exactly one rendered chunk.
 - Every CJS re-export carrier is keyed by one importer record and rendered in its CJS importee's chunk.
 - Every synthetic declaration participates in symbol-to-chunk assignment and deconfliction.
 - Every import overlay is backed by an immutable link-stage execution dependency or retained re-export contract.

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -273,7 +273,6 @@ pub struct OrderWrappedModule {
 }
 
 pub struct OrderSyntheticStmt {
-  pub owner: ModuleIdx,
   pub declared_symbols: Vec<TaggedSymbolRef>,
   pub referenced_symbols: Vec<SymbolRef>,
   pub runtime_helpers: RuntimeHelper,
@@ -438,7 +437,7 @@ link + tree shaking
 
 - No generate-stage call can change `LinkingMetadata::wrap_kind()`.
 - No order-lowering call can set a user statement inclusion bit.
-- Every order wrapper has exactly one symbol owner and one rendered chunk.
+- Every order wrapper's declared `SymbolRef` has exactly one module owner, and its synthetic declaration has exactly one rendered chunk.
 - Every synthetic declaration participates in symbol-to-chunk assignment and deconfliction.
 - Every import overlay is backed by an immutable link-stage execution dependency or retained re-export contract.
 - Every synthesized init call references a reachable interop or order wrapper.


### PR DESCRIPTION
## Summary

- remove the duplicate `OrderSyntheticStmt.owner` field because each declared symbol already carries its module owner
- keep the order-wrapper ownership assertion at the registration boundary while leaving `chunk` as the physical placement fact
- update the code-splitting design to document symbol ownership and synthetic declaration placement separately

## Validation

- `cargo check -p rolldown --lib`
- `cargo clippy -p rolldown --lib --features experimental -- --deny warnings`
- `cargo test -p rolldown --test integration strict_execution_order_invariants` (12 passed)
- `cargo test -p rolldown --test integration strict_execution_order_invariants -- --ignored` (5 passed)
- `cargo test -p rolldown --test integration cjs_dynamic_entry_transitive_external_star -- --ignored`
- `cargo fmt --all -- --check`
- `just lint-repo`