### PR TITLE
test(code-splitting): cover a single-chunk dynamic import of a wrapped module

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/_config.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Single-chunk strict coverage for iife/umd: with `codeSplitting: false` there is no other chunk to load, so `determine_module_exports_kind` wraps the dynamic target and `wrap_modules` follows into its whole subgraph, and the finalizer inlines both `import()` call sites to `Promise.resolve().then(() => (init_lazy(), lazy_exports))`. Strict order must not disturb that: the target stays lazy (nothing it pulls in runs before the promise settles), initializes exactly once, and hands both call sites the same namespace object, while the dependency it shares with the entry keeps its eager static position. Wrap-all additionally wraps the entry itself, so the two formats also render `exports.ready` from a wrapped entry instead of from an inline body.",
+  "configName": "iife-wrap-all",
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "format": "iife",
+    "name": "singleChunkDynamicImportWrappedModule",
+    "strictExecutionOrder": true,
+    "codeSplitting": false
+  },
+  "configVariants": [
+    {
+      "_configName": "iife-on-demand",
+      "onDemandWrapping": true
+    },
+    {
+      "_configName": "umd-wrap-all",
+      "format": "umd"
+    },
+    {
+      "_configName": "umd-on-demand",
+      "format": "umd",
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/_test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+
+globalThis.log = [];
+
+await import('./dist/main.js');
+await globalThis.ready;
+
+assert.deepStrictEqual(globalThis.log, [
+  // Eager phase: the shared dependency keeps its static position, and nothing the dynamic
+  // target pulls in has run by the time the entry body finishes.
+  'shared',
+  'main-body',
+  'lazy-pending:true',
+  // Deferred phase: one evaluation of the wrapped target and its own dependency, in source
+  // order, with both `import()` call sites settling to the same namespace object.
+  'lazy-dep',
+  'lazy-body',
+  'lazy-resolved:dep:shared',
+  'same-namespace:true',
+]);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/artifacts.snap
@@ -1,0 +1,234 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+var singleChunkDynamicImportWrappedModule = (function(exports) {
+	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	// HIDDEN [\0rolldown/runtime.js]
+	//#region shared.js
+	function mark(entry) {
+		globalThis.log.push(entry);
+	}
+	var label;
+	var init_shared = __esmMin((() => {
+		globalThis.log.push("shared");
+		label = "shared";
+	}));
+	//#endregion
+	//#region lazy-dep.js
+	var init_lazy_dep = __esmMin((() => {
+		globalThis.log.push("lazy-dep");
+	}));
+	//#endregion
+	//#region lazy.js
+	var lazy_exports = /* @__PURE__ */ __exportAll({
+		sharedLabel: () => sharedLabel,
+		value: () => value
+	});
+	var value, sharedLabel;
+	var init_lazy = __esmMin((() => {
+		init_shared();
+		init_lazy_dep();
+		mark("lazy-body");
+		value = "dep";
+		sharedLabel = label;
+	}));
+	//#endregion
+	//#region main.js
+	var ready;
+	function init_main() {
+		return (init_main = __esmMin((() => {
+			init_shared();
+			mark("main-body");
+			ready = Promise.all([Promise.resolve().then(() => (init_lazy(), lazy_exports)), Promise.resolve().then(() => (init_lazy(), lazy_exports))]).then(([first, second]) => {
+				mark(`lazy-resolved:${first.value}:${first.sharedLabel}`);
+				mark(`same-namespace:${first === second}`);
+			});
+			globalThis.ready = ready;
+			mark(`lazy-pending:${!globalThis.log.includes("lazy-body")}`);
+		})))();
+	}
+	//#endregion
+	init_main();
+	exports.ready = ready;
+	return exports;
+})({});
+
+```
+
+# Variant: iife-on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+var singleChunkDynamicImportWrappedModule = (function(exports) {
+	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	// HIDDEN [\0rolldown/runtime.js]
+	//#region shared.js
+	function mark(entry) {
+		globalThis.log.push(entry);
+	}
+	var label;
+	var init_shared = __esmMin((() => {
+		globalThis.log.push("shared");
+		label = "shared";
+	}));
+	//#endregion
+	//#region lazy-dep.js
+	var init_lazy_dep = __esmMin((() => {
+		globalThis.log.push("lazy-dep");
+	}));
+	//#endregion
+	//#region lazy.js
+	var lazy_exports = /* @__PURE__ */ __exportAll({
+		sharedLabel: () => sharedLabel,
+		value: () => value
+	});
+	var value, sharedLabel;
+	var init_lazy = __esmMin((() => {
+		init_shared();
+		init_lazy_dep();
+		mark("lazy-body");
+		value = "dep";
+		sharedLabel = label;
+	}));
+	//#endregion
+	//#region main.js
+	init_shared();
+	mark("main-body");
+	const ready = Promise.all([Promise.resolve().then(() => (init_lazy(), lazy_exports)), Promise.resolve().then(() => (init_lazy(), lazy_exports))]).then(([first, second]) => {
+		mark(`lazy-resolved:${first.value}:${first.sharedLabel}`);
+		mark(`same-namespace:${first === second}`);
+	});
+	globalThis.ready = ready;
+	mark(`lazy-pending:${!globalThis.log.includes("lazy-body")}`);
+	//#endregion
+	exports.ready = ready;
+	return exports;
+})({});
+
+```
+
+# Variant: umd-wrap-all: [format: Umd]
+
+## Assets
+
+### main.js
+
+```js
+(function(global, factory) {
+	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.singleChunkDynamicImportWrappedModule = {}));
+})(this, function(exports) {
+	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	// HIDDEN [\0rolldown/runtime.js]
+	//#region shared.js
+	function mark(entry) {
+		globalThis.log.push(entry);
+	}
+	var label;
+	var init_shared = __esmMin((() => {
+		globalThis.log.push("shared");
+		label = "shared";
+	}));
+	//#endregion
+	//#region lazy-dep.js
+	var init_lazy_dep = __esmMin((() => {
+		globalThis.log.push("lazy-dep");
+	}));
+	//#endregion
+	//#region lazy.js
+	var lazy_exports = /* @__PURE__ */ __exportAll({
+		sharedLabel: () => sharedLabel,
+		value: () => value
+	});
+	var value, sharedLabel;
+	var init_lazy = __esmMin((() => {
+		init_shared();
+		init_lazy_dep();
+		mark("lazy-body");
+		value = "dep";
+		sharedLabel = label;
+	}));
+	//#endregion
+	//#region main.js
+	var ready;
+	function init_main() {
+		return (init_main = __esmMin((() => {
+			init_shared();
+			mark("main-body");
+			ready = Promise.all([Promise.resolve().then(() => (init_lazy(), lazy_exports)), Promise.resolve().then(() => (init_lazy(), lazy_exports))]).then(([first, second]) => {
+				mark(`lazy-resolved:${first.value}:${first.sharedLabel}`);
+				mark(`same-namespace:${first === second}`);
+			});
+			globalThis.ready = ready;
+			mark(`lazy-pending:${!globalThis.log.includes("lazy-body")}`);
+		})))();
+	}
+	//#endregion
+	init_main();
+	exports.ready = ready;
+});
+
+```
+
+# Variant: umd-on-demand: [format: Umd] [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+(function(global, factory) {
+	typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.singleChunkDynamicImportWrappedModule = {}));
+})(this, function(exports) {
+	Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+	// HIDDEN [\0rolldown/runtime.js]
+	//#region shared.js
+	function mark(entry) {
+		globalThis.log.push(entry);
+	}
+	var label;
+	var init_shared = __esmMin((() => {
+		globalThis.log.push("shared");
+		label = "shared";
+	}));
+	//#endregion
+	//#region lazy-dep.js
+	var init_lazy_dep = __esmMin((() => {
+		globalThis.log.push("lazy-dep");
+	}));
+	//#endregion
+	//#region lazy.js
+	var lazy_exports = /* @__PURE__ */ __exportAll({
+		sharedLabel: () => sharedLabel,
+		value: () => value
+	});
+	var value, sharedLabel;
+	var init_lazy = __esmMin((() => {
+		init_shared();
+		init_lazy_dep();
+		mark("lazy-body");
+		value = "dep";
+		sharedLabel = label;
+	}));
+	//#endregion
+	//#region main.js
+	init_shared();
+	mark("main-body");
+	const ready = Promise.all([Promise.resolve().then(() => (init_lazy(), lazy_exports)), Promise.resolve().then(() => (init_lazy(), lazy_exports))]).then(([first, second]) => {
+		mark(`lazy-resolved:${first.value}:${first.sharedLabel}`);
+		mark(`same-namespace:${first === second}`);
+	});
+	globalThis.ready = ready;
+	mark(`lazy-pending:${!globalThis.log.includes("lazy-body")}`);
+	//#endregion
+	exports.ready = ready;
+});
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/lazy-dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/lazy-dep.js
@@ -1,0 +1,3 @@
+globalThis.log.push('lazy-dep');
+
+export const helperValue = 'dep';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/lazy.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/lazy.js
@@ -1,0 +1,7 @@
+import { label, mark } from './shared.js';
+import { helperValue } from './lazy-dep.js';
+
+mark('lazy-body');
+
+export const value = helperValue;
+export const sharedLabel = label;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/main.js
@@ -1,0 +1,15 @@
+import { mark } from './shared.js';
+
+mark('main-body');
+
+export const ready = Promise.all([import('./lazy.js'), import('./lazy.js')]).then(
+  ([first, second]) => {
+    mark(`lazy-resolved:${first.value}:${first.sharedLabel}`);
+    mark(`same-namespace:${first === second}`);
+  },
+);
+
+globalThis.ready = ready;
+
+// Reached synchronously, so the wrapped dynamic target must still be uninitialized here.
+mark(`lazy-pending:${!globalThis.log.includes('lazy-body')}`);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/shared.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/single_chunk_dynamic_import_wrapped_module/shared.js
@@ -1,0 +1,7 @@
+globalThis.log.push('shared');
+
+export const label = 'shared';
+
+export function mark(entry) {
+  globalThis.log.push(entry);
+}


### PR DESCRIPTION
Last P1 item of #10294.

### Why

With `codeSplitting: false` there is no second chunk to load, so `determine_module_exports_kind` marks the dynamic target `WrapKind::Esm`, `wrap_modules` follows into its whole subgraph, and the finalizer inlines every `import()` call site to `Promise.resolve().then(() => (init_target(), target_exports))`. Generate-stage order lowering is almost entirely short-circuited on this path — six `code_splitting.is_disabled()` early returns in `order_wrapping.rs` — so `strictExecutionOrder` was relying on it without pinning it.

`strict_execution_order/` had no coverage of that shape, and no `iife` or `umd` coverage of any shape: of its 80+ fixtures, three use `codeSplitting: false` (none with a dynamic import) and none use `iife`/`umd`.

### What

One fixture, four cells: `iife`/`umd` × wrap-all/on-demand.

The snapshot difference between the wrap modes is real rather than cosmetic — wrap-all also wraps the entry, so both formats render `exports.ready` from a wrapped entry (`init_main(); exports.ready = ready;`, the `render_wrapped_entry_chunk` path) while on-demand renders it from an inline body. Both keep `init_lazy` behind the deferred `Promise.resolve().then(...)`.

`_test.mjs` runs in all four cells and asserts the full execution sequence, so the pin is behavioural and not just textual:

- the dependency shared with the entry keeps its eager static position,
- nothing the dynamic target pulls in has run while the entry body is still executing,
- the target initializes exactly once,
- both `import()` call sites settle to the same namespace object.

### Verification

- New fixture green; full `strict_execution_order` group green (101 tests).
- Negative check: flipping the `lazy-pending:true` expectation makes the fixture fail, confirming `_test.mjs` really executes in every cell rather than being skipped.