### PR TITLE
perf: use VisitJsMut in JavaScript-only AST passes

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -12,7 +12,7 @@ pub type FinalizerMutableFields = (
 );
 
 use oxc::ast::builder::AstBuilder;
-use oxc::ast_visit::VisitMut as _;
+use oxc::ast_visit::VisitJsMut as _;
 use oxc::semantic::NodeId;
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{BuildDiagnostic, CausedPlugin};

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -8,7 +8,7 @@ use oxc::{
     builder::NONE,
     match_member_expression,
   },
-  ast_visit::{VisitMut, walk_mut},
+  ast_visit::{VisitJsMut, walk_js_mut},
   span::{SPAN, Span},
 };
 use oxc_str::CompactStr;
@@ -24,7 +24,7 @@ use crate::module_finalizers::{KeepNameId, ModuleWrapperMode, TraverseState};
 
 use super::ScopeHoistingFinalizer;
 
-impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
+impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn enter_scope(
     &mut self,
     flags: oxc::semantic::ScopeFlags,
@@ -82,7 +82,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn visit_logical_expression(&mut self, it: &mut ast::LogicalExpression<'ast>) {
     let pre = self.state;
     self.state.insert(TraverseState::SmartInlineConst);
-    walk_mut::walk_logical_expression(self, it);
+    walk_js_mut::walk_logical_expression(self, it);
     self.state = pre;
   }
 
@@ -142,7 +142,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       }
     });
 
-    walk_mut::walk_program(self, program);
+    walk_js_mut::walk_program(self, program);
 
     // Insert keep_name statements for top-level declarations
     self.insert_keep_name_statements(&mut program.body);
@@ -341,7 +341,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn visit_statement(&mut self, it: &mut ast::Statement<'ast>) {
     _ = self.try_inline_json_module_prop(it);
 
-    walk_mut::walk_statement(self, it);
+    walk_js_mut::walk_statement(self, it);
 
     // transform top level `var a = 1, b = 1;` to `a = 1, b = 1`
     // for `__esm(() => {})` wrapping VariableDeclaration hoist
@@ -509,7 +509,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         {
           *expr = new_expr;
           self.rewrite_import_meta_hot(expr);
-          walk_mut::walk_expression(self, expr);
+          walk_js_mut::walk_expression(self, expr);
           return;
         }
 
@@ -557,7 +557,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(new_expr) = self.try_inline_enum_access(expr) {
             *expr = new_expr;
             self.rewrite_import_meta_hot(expr);
-            walk_mut::walk_expression(self, expr);
+            walk_js_mut::walk_expression(self, expr);
             return;
           }
         }
@@ -577,13 +577,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     }
     self.rewrite_import_meta_hot(expr);
 
-    walk_mut::walk_expression(self, expr);
+    walk_js_mut::walk_expression(self, expr);
   }
 
   fn visit_jsx_element_name(&mut self, it: &mut ast::JSXElementName<'ast>) {
     match it {
       ast::JSXElementName::Identifier(ident) => {
-        walk_mut::walk_jsx_identifier(self, ident);
+        walk_js_mut::walk_jsx_identifier(self, ident);
       }
       ast::JSXElementName::IdentifierReference(identifier_reference) => {
         if let Some(new_expr) =
@@ -611,7 +611,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
       ast::JSXElementName::NamespacedName(jsx_namespace_name) => {
-        walk_mut::walk_jsx_namespaced_name(self, jsx_namespace_name);
+        walk_js_mut::walk_jsx_namespaced_name(self, jsx_namespace_name);
       }
       ast::JSXElementName::MemberExpression(jsx_member_expression) => {
         if let Some(ident) = jsx_member_expression.get_identifier() {
@@ -646,7 +646,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
       ast::JSXElementName::ThisExpression(this_expression) => {
-        walk_mut::walk_this_expression(self, this_expression);
+        walk_js_mut::walk_this_expression(self, this_expression);
       }
     }
   }
@@ -665,7 +665,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
     } else {
-      walk_mut::walk_member_expression(self, expr);
+      walk_js_mut::walk_member_expression(self, expr);
     }
   }
 
@@ -685,13 +685,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       }
     }
 
-    walk_mut::walk_object_property(self, prop);
+    walk_js_mut::walk_object_property(self, prop);
   }
 
   fn visit_object_pattern(&mut self, pat: &mut ast::ObjectPattern<'ast>) {
     self.rewrite_object_pat_shorthand(pat);
 
-    walk_mut::walk_object_pattern(self, pat);
+    walk_js_mut::walk_object_pattern(self, pat);
   }
 
   fn visit_assignment_target_property(
@@ -724,13 +724,13 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       }
     }
 
-    walk_mut::walk_assignment_target_property(self, property);
+    walk_js_mut::walk_assignment_target_property(self, property);
   }
 
   fn visit_simple_assignment_target(&mut self, target: &mut SimpleAssignmentTarget<'ast>) {
     self.rewrite_simple_assignment_target(target);
 
-    walk_mut::walk_simple_assignment_target(self, target);
+    walk_js_mut::walk_simple_assignment_target(self, target);
   }
 
   fn visit_assignment_expression(&mut self, it: &mut ast::AssignmentExpression<'ast>) {
@@ -740,11 +740,11 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         &mut it.right,
       );
     }
-    walk_mut::walk_assignment_expression(self, it);
+    walk_js_mut::walk_assignment_expression(self, it);
   }
 
   fn visit_for_statement_init(&mut self, it: &mut ast::ForStatementInit<'ast>) {
-    walk_mut::walk_for_statement_init(self, it);
+    walk_js_mut::walk_for_statement_init(self, it);
     if self.state.contains(TraverseState::TopLevel)
       && self.needs_hosted_top_level_binding
       && let ast::ForStatementInit::VariableDeclaration(decl) = it
@@ -816,7 +816,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       | ast::Declaration::TSGlobalDeclaration(_) => unreachable!(),
     }
 
-    walk_mut::walk_declaration(self, it);
+    walk_js_mut::walk_declaration(self, it);
   }
 }
 

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1084,7 +1084,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         match parse_injected_expression(self.allocator(), &resolved.code) {
           Ok(mut expr) => {
             let mut rewriter = ResolveFileUrlHookResultSpanRewriter(original_expr_span);
-            oxc::ast_visit::VisitMut::visit_expression(&mut rewriter, &mut expr);
+            oxc::ast_visit::VisitJsMut::visit_expression(&mut rewriter, &mut expr);
             return Some(expr);
           }
           Err(diagnostics) => {
@@ -2772,7 +2772,7 @@ impl<'ast> GetAllocator<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
 
 struct ResolveFileUrlHookResultSpanRewriter(Span);
 
-impl oxc::ast_visit::VisitMut<'_> for ResolveFileUrlHookResultSpanRewriter {
+impl oxc::ast_visit::VisitJsMut<'_> for ResolveFileUrlHookResultSpanRewriter {
   fn visit_span(&mut self, span: &mut Span) {
     *span = self.0;
   }

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arcstr::ArcStr;
-use oxc::ast_visit::VisitMut;
+use oxc::ast_visit::VisitJsMut;
 use oxc::span::SourceType;
 use oxc_index::IndexVec;
 use rolldown_common::{

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use oxc::ast::ast::CommentContent;
 use oxc::ast::ast::Program;
 use oxc::ast::ast::{Declaration, ExportDefaultDeclarationKind, Statement};
-use oxc::ast_visit::{VisitJs, VisitMut, walk_js};
+use oxc::ast_visit::{VisitJs, VisitJsMut, walk_js};
 use oxc::diagnostics::{LabeledSpan, Severity as OxcSeverity};
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
 use oxc::semantic::{Scoping, Stats};

--- a/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
+++ b/crates/rolldown/src/utils/tweak_ast_for_scanning.rs
@@ -3,7 +3,7 @@ use oxc::allocator::GetAllocator;
 use oxc::allocator::{Allocator, ReplaceWith, TakeIn};
 use oxc::ast::ast::{self, BindingPattern, Declaration, ImportOrExportKind, Statement};
 use oxc::ast::builder::{AstBuilder, GetAstBuilder, NONE};
-use oxc::ast_visit::{VisitMut, walk_mut};
+use oxc::ast_visit::{VisitJsMut, walk_js_mut};
 use oxc::span::{SPAN, Span};
 use rolldown_ecmascript_utils::StatementExt;
 use rustc_hash::FxHashSet;
@@ -153,13 +153,13 @@ impl<'ast, 'a> PreProcessor<'ast, 'a> {
   }
 }
 
-impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
+impl<'ast> VisitJsMut<'ast> for PreProcessor<'ast, '_> {
   fn visit_import_declaration(&mut self, it: &mut ast::ImportDeclaration<'ast>) {
     if matches!(it.phase, Some(ast::ImportPhase::Defer)) {
       self.defer_spans.push(it.span);
       it.phase = None;
     }
-    walk_mut::walk_import_declaration(self, it);
+    walk_js_mut::walk_import_declaration(self, it);
   }
 
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
@@ -174,7 +174,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
         self.top_level_stmt_temp_storage.push(stmt);
         continue;
       }
-      walk_mut::walk_statement(self, &mut stmt);
+      walk_js_mut::walk_statement(self, &mut stmt);
       if let Some(split) = self.split_multi_declarator(&mut stmt, true) {
         self.top_level_stmt_temp_storage.extend(split);
       } else if stmt.is_module_declaration_with_source() {
@@ -194,7 +194,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
     if self.try_drop_labeled(it) {
       return;
     }
-    walk_mut::walk_statement(self, it);
+    walk_js_mut::walk_statement(self, it);
     if let Some(split) = self.split_multi_declarator(it, false) {
       *it =
         Statement::new_block_statement(SPAN, oxc::allocator::Vec::from_iter_in(split, self), self);
@@ -206,7 +206,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
   /// `var`s here so each binding becomes independently tree-shakeable.
   fn visit_statements(&mut self, it: &mut oxc::allocator::Vec<'ast, Statement<'ast>>) {
     if !self.keep_names {
-      walk_mut::walk_statements(self, it);
+      walk_js_mut::walk_statements(self, it);
       return;
     }
     let stmts = it.take_in(self);
@@ -215,7 +215,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
         it.push(stmt);
         continue;
       }
-      walk_mut::walk_statement(self, &mut stmt);
+      walk_js_mut::walk_statement(self, &mut stmt);
       if let Some(split) = self.split_multi_declarator(&mut stmt, false) {
         it.extend(split);
       } else {
@@ -229,7 +229,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
       self.defer_spans.push(it.span);
       it.phase = None;
     }
-    walk_mut::walk_import_expression(self, it);
+    walk_js_mut::walk_import_expression(self, it);
   }
 
   fn visit_expression(&mut self, it: &mut ast::Expression<'ast>) {
@@ -293,7 +293,7 @@ impl<'ast> VisitMut<'ast> for PreProcessor<'ast, '_> {
         )
       });
     }
-    walk_mut::walk_expression(self, it);
+    walk_js_mut::walk_expression(self, it);
   }
 }
 

--- a/crates/rolldown_ecmascript_utils/src/injected_expression.rs
+++ b/crates/rolldown_ecmascript_utils/src/injected_expression.rs
@@ -1,6 +1,6 @@
 use oxc::allocator::{Allocator, TakeIn};
 use oxc::ast::ast::{Expression, Statement};
-use oxc::ast_visit::VisitMut;
+use oxc::ast_visit::VisitJsMut;
 use oxc::parser::{ParseOptions, Parser};
 use oxc::span::{SPAN, SourceType, Span};
 
@@ -8,7 +8,7 @@ use oxc::span::{SPAN, SourceType, Span};
 /// so implementing this one method covers the whole subtree.
 struct SpanZeroer;
 
-impl VisitMut<'_> for SpanZeroer {
+impl VisitJsMut<'_> for SpanZeroer {
   fn visit_span(&mut self, it: &mut Span) {
     *it = SPAN;
   }

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use arcstr::ArcStr;
 use oxc::{
   allocator::IntoIn,
-  ast_visit::VisitMut,
+  ast_visit::VisitJsMut,
   codegen::Codegen,
   isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
 };

--- a/crates/rolldown_plugin_isolated_declaration/src/type_import_visitor.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/type_import_visitor.rs
@@ -2,14 +2,14 @@ use oxc::{
   ast::ast::{
     ExportNamedDeclaration, ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, Str,
   },
-  ast_visit::VisitMut,
+  ast_visit::VisitJsMut,
 };
 
 pub struct TypeImportVisitor<'ast> {
   pub imported: Vec<Str<'ast>>,
 }
 
-impl<'ast> VisitMut<'ast> for TypeImportVisitor<'ast> {
+impl<'ast> VisitJsMut<'ast> for TypeImportVisitor<'ast> {
   fn visit_import_declaration(&mut self, decl: &mut ImportDeclaration<'ast>) {
     match decl.import_kind {
       ImportOrExportKind::Type => {

--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
 use arcstr::ArcStr;
-use oxc::ast_visit::VisitMut;
+use oxc::ast_visit::VisitJsMut;
 use rolldown_common::{ImportKind, ModuleId};
 use rolldown_plugin::{HookResolveIdOutput, HookUsage, Plugin, PluginContextResolveOptions};
 use rolldown_utils::dashmap::FxDashSet;

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -8,7 +8,7 @@ use oxc::{
     },
     builder::{AstBuilder, GetAstBuilder, NONE},
   },
-  ast_visit::{VisitMut, walk_mut},
+  ast_visit::{VisitJsMut, walk_js_mut},
   span::SPAN,
 };
 
@@ -25,10 +25,10 @@ impl<'ast> LazyCompilationRuntimeInjector<'ast> {
   }
 }
 
-impl<'ast> VisitMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
+impl<'ast> VisitJsMut<'ast> for LazyCompilationRuntimeInjector<'ast> {
   fn visit_expression(&mut self, expr: &mut Expression<'ast>) {
     // First visit children
-    walk_mut::walk_expression(self, expr);
+    walk_js_mut::walk_expression(self, expr);
 
     // Then transform import expressions
     if matches!(expr, Expression::ImportExpression(_)) {

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -10,7 +10,7 @@ use oxc::{
     },
     builder::NONE,
   },
-  ast_visit::walk_mut::walk_arguments,
+  ast_visit::walk_js_mut::walk_arguments,
   semantic::ScopeFlags,
   span::SPAN,
 };

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -9,7 +9,7 @@ use oxc::{
     },
     builder::NONE,
   },
-  ast_visit::{VisitMut, walk_mut},
+  ast_visit::{VisitJsMut, walk_js_mut},
   semantic::ScopeFlags,
   span::SPAN,
 };
@@ -31,9 +31,9 @@ pub struct BuildImportAnalysisVisitor<'a> {
   pub is_modern: bool,
 }
 
-impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
+impl<'a> VisitJsMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_program(&mut self, it: &mut oxc::ast::ast::Program<'a>) {
-    walk_mut::walk_program(self, it);
+    walk_js_mut::walk_program(self, it);
     if self.need_prepend_helper && self.insert_preload && !self.has_inserted_helper {
       it.body.push(Statement::new_import_declaration(
         SPAN,
@@ -68,7 +68,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
         return;
       }
     }
-    walk_mut::walk_expression(self, expr);
+    walk_js_mut::walk_expression(self, expr);
   }
 
   fn visit_import_declaration(&mut self, it: &mut oxc::ast::ast::ImportDeclaration<'a>) {
@@ -96,12 +96,12 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
           ));
           self.need_prepend_helper = true;
         } else {
-          walk_mut::walk_variable_declarator(self, decl);
+          walk_js_mut::walk_variable_declarator(self, decl);
         }
       }
       return;
     }
-    walk_mut::walk_variable_declaration(self, decl);
+    walk_js_mut::walk_variable_declaration(self, decl);
   }
 
   fn visit_variable_declarator(&mut self, it: &mut oxc::ast::ast::VariableDeclarator<'a>) {
@@ -111,7 +111,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
         self.has_inserted_helper = id.name == PRELOAD_METHOD;
       }
     }
-    walk_mut::walk_variable_declarator(self, it);
+    walk_js_mut::walk_variable_declarator(self, it);
   }
 
   fn enter_scope(

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 use arcstr::ArcStr;
 use oxc::ast::builder::AstBuilder;
-use oxc::ast_visit::VisitMut;
+use oxc::ast_visit::VisitJsMut;
 use rolldown_common::side_effects::HookSideEffects;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,

--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -2,7 +2,7 @@ use oxc::allocator::{Allocator, GetAllocator};
 use oxc::ast::builder::{AstBuilder, GetAstBuilder};
 use oxc::{
   ast::ast::{Expression, IdentifierName, ObjectPropertyKind, Statement},
-  ast_visit::VisitMut,
+  ast_visit::VisitJsMut,
   span::SPAN,
 };
 use rolldown_ecmascript_utils::{ExpressionExt as _, StatementFactoryExt as _};
@@ -57,9 +57,9 @@ impl<'ast> WebWorkerPostVisitor<'ast> {
   }
 }
 
-impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
+impl<'ast> VisitJsMut<'ast> for WebWorkerPostVisitor<'ast> {
   fn visit_program(&mut self, it: &mut oxc::ast::ast::Program<'ast>) {
-    oxc::ast_visit::walk_mut::walk_program(self, it);
+    oxc::ast_visit::walk_js_mut::walk_program(self, it);
     if self.should_inject_import_meta_object {
       it.body.insert(0, self.create_import_meta_object_decl());
     }
@@ -76,7 +76,7 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
         self.should_inject_import_meta_object = true;
         *it = Expression::new_identifier(SPAN, "_vite_importMeta", self);
       }
-      _ => oxc::ast_visit::walk_mut::walk_expression(self, it),
+      _ => oxc::ast_visit::walk_js_mut::walk_expression(self, it),
     }
   }
 }

--- a/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/lib.rs
@@ -3,7 +3,7 @@ mod ast_visitor;
 use std::borrow::Cow;
 
 use oxc::ast::builder::AstBuilder;
-use oxc::ast_visit::VisitMut;
+use oxc::ast_visit::VisitJsMut;
 use rolldown_plugin::{HookUsage, Plugin, PluginHookMeta, PluginOrder};
 
 use crate::ast_visitor::WebWorkerPostVisitor;


### PR DESCRIPTION
Use Oxc's `VisitJsMut` for mutable JavaScript-only AST passes to avoid monomorphizing pure TypeScript traversal.

The macOS arm64 release binding shrinks from 16,391,760 to 16,342,112 bytes (−49,648 bytes, −0.303%).

Validated with `just lint-rust` and `just test-rust`.