### PR TITLE
feat(plugin): time the user callbacks configured on the options

### DIFF
--- a/crates/rolldown_binding/src/types/binding_plugin_timings.rs
+++ b/crates/rolldown_binding/src/types/binding_plugin_timings.rs
@@ -1,12 +1,14 @@
-use rolldown_error::{PluginTiming, PluginTimingsMeasurement};
+use rolldown_error::{PluginTiming, PluginTimingKind, PluginTimingsMeasurement};
 
 /// What one callback cost, measured inside it on the JavaScript side — the one place the
 /// measurement exists, since this side can only bracket dispatch and completion.
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
 pub struct BindingPluginTiming {
-  /// The plugin the callback belongs to.
+  /// The plugin the callback belongs to, or the options it was configured on.
   pub owner: String,
+  #[napi(ts_type = "'plugin' | 'outputOption' | 'inputOption'")]
+  pub kind: String,
   pub hook: String,
   pub calls: u32,
   pub ms: f64,
@@ -30,6 +32,13 @@ impl From<BindingPluginTiming> for PluginTiming {
   fn from(row: BindingPluginTiming) -> Self {
     Self {
       owner: row.owner,
+      // An unknown discriminant is not worth failing a build over, and every consumer of
+      // `kind` today only groups by it.
+      kind: match row.kind.as_str() {
+        "outputOption" => PluginTimingKind::OutputOption,
+        "inputOption" => PluginTimingKind::InputOption,
+        _ => PluginTimingKind::Plugin,
+      },
       hook: row.hook,
       calls: row.calls,
       ms: row.ms,

--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
@@ -8,6 +8,16 @@ const MIN_ROW_MS: f64 = 1_000.0;
 const MAX_MEASURED_ROWS: usize = 12;
 const MAX_UNMEASURABLE_ROWS: usize = 3;
 
+/// Where a measured callback was configured, so a report can tell a plugin's hook from a
+/// user callback the core invokes directly. The warning below does not use it; it is
+/// carried for the other consumers of the same measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginTimingKind {
+  Plugin,
+  OutputOption,
+  InputOption,
+}
+
 /// What one callback cost, measured inside it on the JavaScript side.
 ///
 /// The bundler can only bracket dispatch and completion, and for a concurrently dispatched
@@ -15,8 +25,9 @@ const MAX_UNMEASURABLE_ROWS: usize = 3;
 /// side of the binding. See `packages/rolldown/src/utils/plugin-timings.ts`.
 #[derive(Debug, Clone)]
 pub struct PluginTiming {
-  /// The plugin the callback belongs to.
+  /// The plugin the callback belongs to, or the options it was configured on.
   pub owner: String,
+  pub kind: PluginTimingKind,
   /// `transform`, `codeSplitting groups[].name`, … — what the user writes in their config.
   pub hook: String,
   pub calls: u32,
@@ -185,6 +196,7 @@ mod tests {
   fn row(owner: &str, hook: &str, ms: f64, calls: u32, max_in_flight: u32) -> PluginTiming {
     PluginTiming {
       owner: owner.to_string(),
+      kind: PluginTimingKind::Plugin,
       hook: hook.to_string(),
       calls,
       ms,

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -17,7 +17,7 @@ pub use crate::{
   build_diagnostic::events::invalid_option::InvalidOptionType,
   build_diagnostic::events::plugin_error::CausedPlugin,
   build_diagnostic::events::plugin_timings::{
-    PluginTiming, PluginTimings, PluginTimingsMeasurement,
+    PluginTiming, PluginTimingKind, PluginTimings, PluginTimingsMeasurement,
   },
   build_diagnostic::events::require_tla::{ImportChainNote, RequireTla},
   build_diagnostic::events::resolve_error::DiagnosableResolveError,

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2719,8 +2719,9 @@ export declare enum BindingPluginOrder {
  * measurement exists, since this side can only bracket dispatch and completion.
  */
 export interface BindingPluginTiming {
-  /** The plugin the callback belongs to. */
+  /** The plugin the callback belongs to, or the options it was configured on. */
   owner: string
+  kind: 'plugin' | 'outputOption' | 'inputOption'
   hook: string
   calls: number
   ms: number

--- a/packages/rolldown/src/options/docs/checks-plugin-timings.md
+++ b/packages/rolldown/src/options/docs/checks-plugin-timings.md
@@ -8,9 +8,9 @@ The clock starts and stops **inside the JavaScript callback**, not around the ca
 
 2. **Detection threshold**: a warning is triggered when plugin time (total build time minus link stage time) exceeds 100x the link stage time. This threshold was determined by studying plugin impact on real-world projects. The link stage is the one part of a build that runs no plugins at all, which is what makes it a usable baseline.
 
-3. **Rows**: up to 12 hooks are listed, sorted by measured time, each shown as a share of total build time with its call count. Only hooks costing at least 1 second get a line.
+3. **Rows**: up to 12 hooks are listed, sorted by measured time, each shown as a share of total build time with its call count. Only hooks costing at least 1 second get a line. User callbacks configured on the options rather than on a plugin — `external`, `treeshake.moduleSideEffects`, the file-name and addon callbacks, and the [`output.advancedChunks`](/reference/OutputOptions.advancedChunks) `groups[].name` classifier and `groups[].test` predicate — appear under `input options` / `output options`.
 
-   The headline figure is the wall time in which _any_ plugin callback was running, counted once however much they overlap, so it can never exceed the build.
+   The headline figure is the wall time in which _any_ plugin callback was running, counted once however much they overlap, so it can never exceed the build. Individual rows can add up to more than it, because one callback may run inside another — `this.emitFile()` in `buildStart` invokes your `assetFileNames`, and that time belongs to both.
 
 > [!IMPORTANT]
 > **Some hooks are listed without a number**, under a heading saying they are not measurable.

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -190,7 +190,7 @@ export function bindingifyPlugin(
   };
   // Keyed on the user's plugin object rather than its name: the same plugin configured
   // twice is two culprits, and `normalizePlugins` allows the duplicate name.
-  return wrapHandlers(result, { key: plugin, name: result.name }, timings);
+  return wrapHandlers(result, { key: plugin, name: result.name, kind: 'plugin' }, timings);
 }
 
 function wrapHandlers(

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2719,8 +2719,9 @@ export declare enum BindingPluginOrder {
  * measurement exists, since this side can only bracket dispatch and completion.
  */
 export interface BindingPluginTiming {
-  /** The plugin the callback belongs to. */
+  /** The plugin the callback belongs to, or the options it was configured on. */
   owner: string
+  kind: 'plugin' | 'outputOption' | 'inputOption'
   hook: string
   calls: number
   ms: number

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -29,7 +29,13 @@ import {
 } from './normalize-transform-options';
 import { getParallelPluginInfo } from './parallel-plugin';
 import { getDefaultDevRuntime } from './default-dev-runtime';
-import { type PluginTimingsRecorder, summarizePluginTimings } from './plugin-timings';
+import {
+  INPUT_OPTIONS_OWNER,
+  measureHookCost,
+  measureIfFunction,
+  type PluginTimingsRecorder,
+  summarizePluginTimings,
+} from './plugin-timings';
 
 export function bindingifyInputOptions(
   rawPlugins: RolldownPlugin[],
@@ -74,7 +80,7 @@ export function bindingifyInputOptions(
     input: bindingifyInput(inputOptions.input),
     plugins,
     cwd: inputOptions.cwd ?? process.cwd(),
-    external: bindingifyExternal(inputOptions.external),
+    external: bindingifyExternal(inputOptions.external, timings),
     resolve: bindingifyResolve(inputOptions.resolve),
     platform: inputOptions.platform,
     shimMissingExports: inputOptions.shimMissingExports,
@@ -83,7 +89,7 @@ export function bindingifyInputOptions(
     // After normalized, `false` will be converted to `undefined`, otherwise, default value will be assigned
     // Because it is hard to represent Enum in napi, ref: https://github.com/napi-rs/napi-rs/issues/507
     // So we use `undefined | NormalizedTreeshakingOptions` (or Option<NormalizedTreeshakingOptions> in Rust side), to represent `false | NormalizedTreeshakingOptions`
-    treeshake: bindingifyTreeshakeOptions(inputOptions.treeshake),
+    treeshake: bindingifyTreeshakeOptions(inputOptions.treeshake, timings),
     moduleTypes: inputOptions.moduleTypes,
     define: normalizedTransform.define,
     inject: bindingifyInject(normalizedTransform.inject),
@@ -154,12 +160,17 @@ function bindingifyAttachDebugInfo(
   }
 }
 
-function bindingifyExternal(external: InputOptions['external']): BindingInputOptions['external'] {
+function bindingifyExternal(
+  external: InputOptions['external'],
+  timings: PluginTimingsRecorder | undefined,
+): BindingInputOptions['external'] {
   if (external) {
     if (typeof external === 'function') {
+      // Runs once per import specifier, so a slow one is felt across the whole graph.
+      const measured = measureHookCost(timings, INPUT_OPTIONS_OWNER, 'external', external);
       return (id, importer, isResolved) => {
         if (id.startsWith('\0')) return false;
-        return external(id, importer, isResolved) ?? false;
+        return measured(id, importer, isResolved) ?? false;
       };
     }
     return arraify(external);
@@ -328,6 +339,7 @@ function bindingifyWatch(watch: InputOptions['watch']): BindingInputOptions['wat
 
 function bindingifyTreeshakeOptions(
   config: InputOptions['treeshake'],
+  timings: PluginTimingsRecorder | undefined,
 ): BindingInputOptions['treeshake'] {
   if (config === false) {
     return undefined;
@@ -373,7 +385,13 @@ function bindingifyTreeshakeOptions(
       { external: false, sideEffects: true },
     ];
   } else {
-    normalizedConfig.moduleSideEffects = config.moduleSideEffects;
+    // The function form runs once per module.
+    normalizedConfig.moduleSideEffects = measureIfFunction(
+      timings,
+      INPUT_OPTIONS_OWNER,
+      'treeshake.moduleSideEffects',
+      config.moduleSideEffects,
+    );
   }
 
   return normalizedConfig;

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -8,6 +8,7 @@ import { transformRenderedChunk } from './transform-rendered-chunk';
 import { logger } from '../cli/logger';
 import {
   measureHookCost,
+  measureIfFunction,
   OUTPUT_OPTIONS_OWNER,
   type PluginTimingsRecorder,
 } from './plugin-timings';
@@ -44,6 +45,7 @@ export function bindingifyOutputOptions(
     paths,
     generatedCode,
     file,
+    // Already measured at the source; see `createBundlerOptions`.
     sanitizeFileName,
     preserveModules,
     virtualDirname,
@@ -80,25 +82,51 @@ export function bindingifyOutputOptions(
     sourcemap: bindingifySourcemap(sourcemap),
     sourcemapBaseUrl,
     sourcemapDebugIds,
-    sourcemapFileNames,
+    sourcemapFileNames: measureIfFunction(
+      timings,
+      OUTPUT_OPTIONS_OWNER,
+      'sourcemapFileNames',
+      sourcemapFileNames,
+    ),
     sourcemapExcludeSources,
-    sourcemapIgnoreList: sourcemapIgnoreList ?? /node_modules/,
-    sourcemapPathTransform,
-    banner: bindingifyAddon(banner),
-    footer: bindingifyAddon(footer),
-    postBanner: bindingifyAddon(postBanner),
-    postFooter: bindingifyAddon(postFooter),
-    intro: bindingifyAddon(intro),
-    outro: bindingifyAddon(outro),
+    sourcemapIgnoreList: measureIfFunction(
+      timings,
+      OUTPUT_OPTIONS_OWNER,
+      'sourcemapIgnoreList',
+      sourcemapIgnoreList ?? /node_modules/,
+    ),
+    sourcemapPathTransform: measureIfFunction(
+      timings,
+      OUTPUT_OPTIONS_OWNER,
+      'sourcemapPathTransform',
+      sourcemapPathTransform,
+    ),
+    banner: bindingifyAddon(banner, 'banner', timings),
+    footer: bindingifyAddon(footer, 'footer', timings),
+    postBanner: bindingifyAddon(postBanner, 'postBanner', timings),
+    postFooter: bindingifyAddon(postFooter, 'postFooter', timings),
+    intro: bindingifyAddon(intro, 'intro', timings),
+    outro: bindingifyAddon(outro, 'outro', timings),
     extend: outputOptions.extend,
-    globals,
-    paths,
+    globals: measureIfFunction(timings, OUTPUT_OPTIONS_OWNER, 'globals', globals),
+    paths: measureIfFunction(timings, OUTPUT_OPTIONS_OWNER, 'paths', paths),
     generatedCode,
     esModule,
     name,
+    // Already measured at the source; see `createBundlerOptions`.
     assetFileNames: bindingifyAssetFilenames(assetFileNames),
-    entryFileNames,
-    chunkFileNames,
+    entryFileNames: measureIfFunction(
+      timings,
+      OUTPUT_OPTIONS_OWNER,
+      'entryFileNames',
+      entryFileNames,
+    ),
+    chunkFileNames: measureIfFunction(
+      timings,
+      OUTPUT_OPTIONS_OWNER,
+      'chunkFileNames',
+      chunkFileNames,
+    ),
     // TODO(sapphi-red): support parallel plugins
     plugins: [],
     minify: outputOptions.minify,
@@ -123,12 +151,19 @@ export function bindingifyOutputOptions(
 
 type AddonKeys = 'banner' | 'footer' | 'intro' | 'outro';
 
-function bindingifyAddon(configAddon: OutputOptions[AddonKeys]): BindingOutputOptions[AddonKeys] {
+function bindingifyAddon(
+  configAddon: OutputOptions[AddonKeys],
+  name: AddonKeys | 'postBanner' | 'postFooter',
+  timings: PluginTimingsRecorder | undefined,
+): BindingOutputOptions[AddonKeys] {
   if (configAddon == null || configAddon === '') {
     return undefined;
   }
   if (typeof configAddon === 'function') {
-    return async (chunk) => configAddon(transformRenderedChunk(chunk));
+    // Measure the user's callback, not `transformRenderedChunk` around it, so the row is
+    // their work rather than the conversion their choice of a function forced.
+    const measured = measureHookCost(timings, OUTPUT_OPTIONS_OWNER, name, configAddon);
+    return async (chunk) => measured(transformRenderedChunk(chunk));
   }
   return configAddon;
 }
@@ -321,9 +356,13 @@ function bindingifyCodeSplitting(
     advancedChunksResult = {
       ...restOptions,
       groups: groups?.map((group) => {
-        const { name, ...restGroup } = group;
+        const { name, test, ...restGroup } = group;
         return {
           ...restGroup,
+          test:
+            typeof test === 'function'
+              ? measureHookCost(timings, OUTPUT_OPTIONS_OWNER, 'codeSplitting groups[].test', test)
+              : test,
           // The core calls this classifier directly rather than through a plugin, so it
           // belongs to no plugin's rows — and it runs once per module, which is how it ends
           // up dominating a build.

--- a/packages/rolldown/src/utils/create-bundler-option.ts
+++ b/packages/rolldown/src/utils/create-bundler-option.ts
@@ -10,7 +10,11 @@ import { getObjectPlugins } from '../plugin/plugin-driver';
 import { bindingifyInputOptions } from './bindingify-input-options';
 import { bindingifyOutputOptions } from './bindingify-output-options';
 import { initializeParallelPlugins } from './initialize-parallel-plugins';
-import { pluginTimingsRecorderFor } from './plugin-timings';
+import {
+  measureIfFunction,
+  OUTPUT_OPTIONS_OWNER,
+  pluginTimingsRecorderFor,
+} from './plugin-timings';
 import {
   ANONYMOUS_OUTPUT_PLUGIN_PREFIX,
   ANONYMOUS_PLUGIN_PREFIX,
@@ -69,6 +73,28 @@ export async function createBundlerOptions(
     measureTimings && inputOptions.checks?.pluginTimings !== false
       ? pluginTimingsRecorderFor(inputOptions)
       : undefined;
+
+  // `assetFileNames` and `sanitizeFileName` are read twice: once here on the way to Rust,
+  // and again by `this.emitFile` in a plugin context, which calls the user's option
+  // directly. Measuring at each consumer would count one call in two places, so these two
+  // are measured once at the source and passed on already wrapped.
+  if (timings) {
+    outputOptions = {
+      ...outputOptions,
+      assetFileNames: measureIfFunction(
+        timings,
+        OUTPUT_OPTIONS_OWNER,
+        'assetFileNames',
+        outputOptions.assetFileNames,
+      ),
+      sanitizeFileName: measureIfFunction(
+        timings,
+        OUTPUT_OPTIONS_OWNER,
+        'sanitizeFileName',
+        outputOptions.sanitizeFileName,
+      ),
+    };
+  }
 
   const parallelPluginInitResult = import.meta.browserBuild
     ? undefined

--- a/packages/rolldown/src/utils/plugin-timings.ts
+++ b/packages/rolldown/src/utils/plugin-timings.ts
@@ -65,10 +65,19 @@ export interface TimingOwner {
   key: unknown;
   /** What the report shows. */
   name: string;
+  kind: PluginTimingKind;
 }
+
+/**
+ * Where a callback was configured. Supplied by the wrapping call site, which knows: it
+ * cannot be recovered from the owner's name, since a plugin may legally be called
+ * `output options`.
+ */
+export type PluginTimingKind = 'plugin' | 'outputOption' | 'inputOption';
 
 interface HookCost {
   owner: string;
+  kind: PluginTimingKind;
   hookName: string;
   calls: number;
   ms: number;
@@ -135,6 +144,7 @@ function costFor(recorder: PluginTimingsRecorder, owner: TimingOwner, hookName: 
   if (cost === undefined) {
     cost = {
       owner: owner.name,
+      kind: owner.kind,
       hookName,
       calls: 0,
       ms: 0,
@@ -242,12 +252,44 @@ export function measureHookCost<T extends (...args: never[]) => unknown>(
 export const OUTPUT_OPTIONS_OWNER: TimingOwner = {
   key: Symbol('output options'),
   name: 'output options',
+  kind: 'outputOption',
 };
+
+/** As {@link OUTPUT_OPTIONS_OWNER}, for callbacks configured on the input options. */
+export const INPUT_OPTIONS_OWNER: TimingOwner = {
+  key: Symbol('input options'),
+  name: 'input options',
+  kind: 'inputOption',
+};
+
+/**
+ * Wrap `value` when the user supplied a function, and leave every other form alone.
+ *
+ * Most option callbacks are declared as `string | RegExp | Function | ...`, so this keeps
+ * the one cast the wrapping needs in a single place.
+ */
+export function measureIfFunction<T>(
+  recorder: PluginTimingsRecorder | undefined,
+  owner: TimingOwner,
+  hookName: string,
+  value: T,
+): T {
+  if (typeof value !== 'function') {
+    return value;
+  }
+  return measureHookCost(
+    recorder,
+    owner,
+    hookName,
+    value as unknown as (...args: never[]) => unknown,
+  ) as unknown as T;
+}
 
 /** What one owner's hook cost the build. */
 export interface PluginTimingRow {
-  /** The plugin the callback belongs to. */
+  /** The plugin the callback belongs to, or the options it was configured on. */
   owner: string;
+  kind: PluginTimingKind;
   /** `transform`, `codeSplitting groups[].name`, … — what the user wrote in their config. */
   hook: string;
   calls: number;
@@ -310,6 +352,7 @@ export function summarizePluginTimings(key: object): PluginTimingsMeasurement {
       }
       rows.push({
         owner: cost.owner,
+        kind: cost.kind,
         hook: cost.hookName,
         calls: cost.calls,
         ms: cost.ms,

--- a/packages/rolldown/tests/plugin-timings.test.ts
+++ b/packages/rolldown/tests/plugin-timings.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   measureHookCost,
+  type PluginTimingKind,
   type PluginTimingRow,
   type PluginTimingsRecorder,
+  OUTPUT_OPTIONS_OWNER,
   pluginTimingsRecorderFor,
   summarizePluginTimings,
 } from '../src/utils/plugin-timings';
@@ -46,7 +48,7 @@ describe('measureHookCost', () => {
     const recorder = newRecorder();
     const hook = measureHookCost(
       recorder,
-      { key: 'my-plugin', name: 'my-plugin' },
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
       'transform',
       () => {
         clock.advance(40);
@@ -66,7 +68,12 @@ describe('measureHookCost', () => {
   it('returns the handler untouched when nothing is recording', () => {
     const handler = () => 'x';
     expect(
-      measureHookCost(undefined, { key: 'my-plugin', name: 'my-plugin' }, 'transform', handler),
+      measureHookCost(
+        undefined,
+        { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
+        'transform',
+        handler,
+      ),
     ).toBe(handler);
   });
 
@@ -74,10 +81,15 @@ describe('measureHookCost', () => {
     const clock = fakeClock();
     const recorder = newRecorder();
     const boom = new Error('boom');
-    const hook = measureHookCost(recorder, { key: 'my-plugin', name: 'my-plugin' }, 'load', () => {
-      clock.advance(10);
-      throw boom;
-    });
+    const hook = measureHookCost(
+      recorder,
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
+      'load',
+      () => {
+        clock.advance(10);
+        throw boom;
+      },
+    );
 
     expect(hook).toThrow(boom);
 
@@ -91,8 +103,11 @@ describe('measureHookCost', () => {
   it('settles when the returned promise rejects, and rejects', async () => {
     const recorder = newRecorder();
     const boom = new Error('boom');
-    const hook = measureHookCost(recorder, { key: 'my-plugin', name: 'my-plugin' }, 'load', () =>
-      Promise.reject(boom),
+    const hook = measureHookCost(
+      recorder,
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
+      'load',
+      () => Promise.reject(boom),
     );
 
     await expect(hook()).rejects.toBe(boom);
@@ -104,7 +119,7 @@ describe('measureHookCost', () => {
     const recorder = newRecorder();
     const hook = measureHookCost(
       recorder,
-      { key: 'my-plugin', name: 'my-plugin' },
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
       'resolveId',
       () => ({ id: 'x' }),
     );
@@ -122,7 +137,7 @@ describe('measureHookCost', () => {
     const recorder = newRecorder();
     const hook = measureHookCost(
       recorder,
-      { key: 'my-plugin', name: 'my-plugin' },
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
       'transform',
       async () => {
         clock.advance(30);
@@ -145,7 +160,7 @@ describe('measureHookCost', () => {
     });
     const hook = measureHookCost(
       recorder,
-      { key: 'my-plugin', name: 'my-plugin' },
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
       'transform',
       () => gate,
     );
@@ -168,12 +183,22 @@ describe('owner identity', () => {
     // unrankable.
     const first = { name: 'dup' };
     const second = { name: 'dup' };
-    const a = measureHookCost(recorder, { key: first, name: 'dup' }, 'transform', () => {
-      clock.advance(10);
-    });
-    const b = measureHookCost(recorder, { key: second, name: 'dup' }, 'transform', () => {
-      clock.advance(30);
-    });
+    const a = measureHookCost(
+      recorder,
+      { key: first, name: 'dup', kind: 'plugin' },
+      'transform',
+      () => {
+        clock.advance(10);
+      },
+    );
+    const b = measureHookCost(
+      recorder,
+      { key: second, name: 'dup', kind: 'plugin' },
+      'transform',
+      () => {
+        clock.advance(30);
+      },
+    );
 
     a();
     b();
@@ -183,6 +208,25 @@ describe('owner identity', () => {
     expect(recorder.costs.size).toBe(2);
     expect(costOf(recorder, first, 'transform').ms).toBe(10);
     expect(costOf(recorder, second, 'transform').ms).toBe(30);
+  });
+});
+
+describe('owner kind', () => {
+  it('says where a callback was configured, so no consumer has to match on the name', () => {
+    const clock = fakeClock();
+    const recorder = newRecorder();
+    measureHookCost(recorder, OUTPUT_OPTIONS_OWNER, 'codeSplitting groups[].name', () => {
+      clock.advance(1);
+    })();
+    measureHookCost(recorder, { key: 'p', name: 'p', kind: 'plugin' }, 'transform', () => {
+      clock.advance(1);
+    })();
+
+    const kinds = [...recorder.costs.values()].flatMap((byHook) =>
+      [...byHook.values()].map((cost) => cost.kind),
+    );
+    const expected: PluginTimingKind[] = ['outputOption', 'plugin'];
+    expect(kinds).toEqual(expected);
   });
 });
 
@@ -202,7 +246,7 @@ describe('overlap accounting', () => {
     let next = 0;
     const hook = measureHookCost(
       recorder,
-      { key: 'my-plugin', name: 'my-plugin' },
+      { key: 'my-plugin', name: 'my-plugin', kind: 'plugin' },
       'transform',
       () => gates[next++]!,
     );
@@ -242,14 +286,14 @@ describe('busy time', () => {
     clock.set(0);
     const first = measureHookCost(
       recorder,
-      { key: 'a-plugin', name: 'a-plugin' },
+      { key: 'a-plugin', name: 'a-plugin', kind: 'plugin' },
       'transform',
       () => a,
     )();
     clock.set(10);
     const second = measureHookCost(
       recorder,
-      { key: 'b-plugin', name: 'b-plugin' },
+      { key: 'b-plugin', name: 'b-plugin', kind: 'plugin' },
       'transform',
       () => b,
     )();
@@ -288,6 +332,7 @@ function summaryWith(
     byHook.set(hookName, {
       owner,
       hookName,
+      kind: 'plugin',
       inFlight: 0,
       lastChange: 0,
       overlapMs: 0,
@@ -317,6 +362,7 @@ describe('summarizePluginTimings', () => {
         hook: 'transform',
         calls: 2,
         ms: 4,
+        kind: 'plugin',
         maxInFlight: 1,
         overlapMs: 0,
         rankable: true,


### PR DESCRIPTION
Stacked on #10508, which moves the measurement into the JavaScript callback. This adds the callbacks that are not plugin hooks.

## Problem

Plugin hooks are not the only JavaScript the bundler calls. Every option-level callback crosses the same boundary, and any of them can dominate a build while belonging to no plugin's rows — a heavy `codeSplitting.name` in a real project was what prompted this.

Sixteen of them reach napi unwrapped, so none could appear in `[PLUGIN_TIMINGS]` at all. (`groups[].name` is the seventeenth and lands in #10508, because `main` already times it there and that PR removes the Rust-side timing it relies on.)

## What is now measured

Audited from the Rust side — every field on `BindingInputOptions` / `BindingOutputOptions` typed as a JS callback — rather than by reading the TypeScript, so the list is complete rather than the ones I happened to think of:

| | |
|---|---|
| **output** | `codeSplitting` `groups[].test`, `entryFileNames`, `chunkFileNames`, `assetFileNames`, `sourcemapFileNames`, `sanitizeFileName`, `banner`/`footer`/`intro`/`outro` and their `post` variants, `globals`, `paths`, `sourcemapPathTransform`, `sourcemapIgnoreList` |
| **input** | `external`, `treeshake.moduleSideEffects` |

`external` runs once per import specifier and `treeshake.moduleSideEffects` once per module — the same fan-out as the classifier, so both are just as capable of dominating a build.

They report under `output options` / `input options`, and rows carry a `kind` discriminator supplied by the wrapping call site — not derived from the owner's name, since a plugin may legally be called `output options`.

## Two things worth review attention

**`assetFileNames` and `sanitizeFileName` have two call paths.** Besides the binding, `PluginContextImpl` calls the user's option *directly* for `this.emitFile`. Wrapping at each consumer would count one call in two places, so those two are measured once in `createBundlerOptions` and passed on already wrapped.

**Rows can now sum past 100%.** `this.emitFile` inside `buildStart` invokes `assetFileNames`, so the nested time belongs to both rows. The headline figure is the union of every span, so it cannot exceed the build. Documented in the check's docs.

## Verification

Each callback made individually expensive enough to clear the one-second row floor, so the wiring is checked by execution rather than by inspection:

```
  - virtual-fs buildStart                        - output options intro
  - output options paths                         - output options chunkFileNames
  - output options sanitizeFileName              - output options entryFileNames
  - input options treeshake.moduleSideEffects    - output options outro
  - input options external                       - output options footer
  - output options codeSplitting groups[].name   - output options banner
  - output options codeSplitting groups[].test   - output options assetFileNames
  - output options globals                       - output options sourcemapFileNames
```

The motivating case in isolation: 61 calls, 3.1s, `output options codeSplitting groups[].name` at 60% of a 5.1s build.

**Two exceptions, stated rather than implied:** `sourcemapPathTransform` and `sourcemapIgnoreList` are wrapped but I could not get the core to invoke them under `generate` with `sourcemap: true` — zero calls. They are used in `process_code_and_sourcemap.rs`, so they are presumably reached on another path; wrapped either way, but unverified by execution.
