### PR TITLE
perf(code-splitting): dedupe the strict-order cycle analysis and cache consumer-local sort keys

### DIFF
--- a/crates/rolldown/src/esm_init_obligations.rs
+++ b/crates/rolldown/src/esm_init_obligations.rs
@@ -232,7 +232,7 @@ pub fn collect_wrapped_esm_init_targets_for_module_namespace(
       &mut visited_symbols,
     );
   }
-  targets.sort_by_key(|target| consumer_local_target_order(ctx, ctx.importer.idx, *target));
+  targets.sort_by_cached_key(|target| consumer_local_target_order(ctx, ctx.importer.idx, *target));
   targets
 }
 
@@ -387,7 +387,7 @@ fn collect_esm_init_targets_for_record(
   }
 
   if route_through_transparent_wrapper {
-    targets.sort_by_key(|target| consumer_local_target_order(ctx, importee_idx, *target));
+    targets.sort_by_cached_key(|target| consumer_local_target_order(ctx, importee_idx, *target));
   }
 
   targets
@@ -419,11 +419,12 @@ fn consumer_local_target_order_path(
   if let WrappedEsmInitTarget::CjsCarrier(key) = target
     && key.importer == forwarder_idx
   {
-    let position = forwarder
-      .import_records
-      .iter_enumerated()
-      .position(|(rec_idx, _)| rec_idx == key.record)
-      .unwrap_or(usize::MAX);
+    // An index vec iterates in index order, so the record's own index is its source position.
+    let position = if key.record.index() < forwarder.import_records.len() {
+      key.record.index()
+    } else {
+      usize::MAX
+    };
     visited.remove(&forwarder_idx);
     return Some(vec![position]);
   }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use arcstr::ArcStr;
 use futures::future::try_join_all;
@@ -128,6 +129,10 @@ pub struct GenerateStage<'a> {
   /// `paths` option, it is resolved asynchronously here before entering sync rendering code,
   /// avoiding the need for `invoke_sync` which can cause deadlocks.
   resolved_paths: Option<PathsOutputOption>,
+  /// Synchronous-cycle facts read only from `import_records` kind/target and module normality,
+  /// which no generate-stage pass mutates — computed lazily once per build and shared by
+  /// pre-chunk probing, order analysis, and lowering.
+  cached_synchronous_cycle_modules: OnceLock<FxHashSet<ModuleIdx>>,
 }
 
 impl<'a> GenerateStage<'a> {
@@ -137,7 +142,22 @@ impl<'a> GenerateStage<'a> {
     options: &'a SharedOptions,
     plugin_driver: &'a SharedPluginDriver,
   ) -> Self {
-    Self { link_output, ast_table, options, plugin_driver, resolved_paths: None }
+    Self {
+      link_output,
+      ast_table,
+      options,
+      plugin_driver,
+      resolved_paths: None,
+      cached_synchronous_cycle_modules: OnceLock::new(),
+    }
+  }
+
+  /// Tarjan SCC over the synchronous `import`/`require` module graph. The graph never changes
+  /// during the generate stage, so every consumer shares one computation.
+  pub(super) fn synchronous_cycle_modules(&self) -> &FxHashSet<ModuleIdx> {
+    self.cached_synchronous_cycle_modules.get_or_init(|| {
+      order_wrapping::synchronous_cycle_modules(&self.link_output.module_table.modules)
+    })
   }
 
   #[tracing::instrument(level = "debug", skip_all)]

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -592,8 +592,7 @@ impl GenerateStage<'_> {
     // retained star re-exports) and the overlay projection sees every eager forwarder's hop. The
     // module's own namespace ref stands in for each not-yet-minted wrapper — projection reads only
     // target identity, never the wrapper symbol's value.
-    let cyclic_modules =
-      super::order_wrapping::synchronous_cycle_modules(&self.link_output.module_table.modules);
+    let cyclic_modules = self.synchronous_cycle_modules();
     let input = super::order_wrapping::OrderLoweringInput {
       plan,
       modules: &self.link_output.module_table.modules,
@@ -606,7 +605,7 @@ impl GenerateStage<'_> {
         .link_output
         .star_reexport_records_by_imported_symbol,
       used_symbols: used_symbol_refs,
-      cyclic_modules: &cyclic_modules,
+      cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };
     for module_idx in plan.modules() {
@@ -662,8 +661,7 @@ impl GenerateStage<'_> {
         probe_state.set_reexport_init_transparent(module_idx);
       }
     }
-    let cyclic_modules =
-      super::order_wrapping::synchronous_cycle_modules(&self.link_output.module_table.modules);
+    let cyclic_modules = self.synchronous_cycle_modules();
     let input = super::order_wrapping::OrderLoweringInput {
       plan,
       modules: &self.link_output.module_table.modules,
@@ -676,7 +674,7 @@ impl GenerateStage<'_> {
         .link_output
         .star_reexport_records_by_imported_symbol,
       used_symbols: used_symbol_refs,
-      cyclic_modules: &cyclic_modules,
+      cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };
     let consumer_local_plan =
@@ -694,6 +692,10 @@ impl GenerateStage<'_> {
     probe_state.set_consumed_reexport_facades(reexport_usage.consumed_facades().clone());
   }
 
+  // Deliberately recomputed per call rather than cached: the facade-chunk optimizer's inclusion
+  // replay can rewrite `metas.is_included` between the pre-chunk probe and the final analysis
+  // (`chunk_optimizer.rs`), so a shared snapshot would need a probe/final coherence decision
+  // first.
   fn wrap_all_order_analysis(&self) -> OrderAnalysis {
     let mut plan = OrderWrapPlan::default();
     // Only membership matters here, so one shared visit-state vector lets every module be

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -459,7 +459,11 @@ impl GenerateStage<'_> {
 
     let runtime_helper = self.esm_runtime_helper();
     let code_splitting_disabled = self.options.code_splitting.is_disabled();
-    let cyclic_modules = synchronous_cycle_modules(&self.link_output.module_table.modules);
+    // Warm the shared cache with a short-lived whole-`self` borrow, then reborrow only the field
+    // so the mutable `symbol_db` borrow in the lowering output stays disjoint.
+    self.synchronous_cycle_modules();
+    let cyclic_modules =
+      self.cached_synchronous_cycle_modules.get().expect("warmed by the call above");
     let input = OrderLoweringInput {
       plan,
       modules: &self.link_output.module_table.modules,
@@ -472,7 +476,7 @@ impl GenerateStage<'_> {
         .link_output
         .star_reexport_records_by_imported_symbol,
       used_symbols: used_symbol_refs,
-      cyclic_modules: &cyclic_modules,
+      cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };
     let mut output =


### PR DESCRIPTION
Strict-execution-order builds recompute unchanged plan inputs: the module-graph cycle scan runs three to five times per build, and ordering one consumer's initialization targets re-derives each target's route position at every sort comparison — quadratic on a wide barrel consumed as a namespace. This PR computes the cycle scan once per build and each ordering key once per target. Emitted output is byte-identical: the full fixture corpus runs with zero snapshot changes.

## Motivation

Every strict build pays the same analysis several times over. The synchronous-cycle facts are derived independently by the pre-chunk placement probe, the on-demand projection, and lowering — three to five full-graph passes per build depending on the mode. Separately, whenever a consumer's initialization targets are sorted into source order, the sort key — the target's position along its re-export route — is recomputed for every comparison rather than once per target, so a barrel with many re-exports consumed as a namespace multiplies a graph walk by the comparison count.

Non-strict builds are untouched either way: with the flag off the order state is empty and neither the scan nor the sorts ever run.

## Changes

The synchronous-cycle scan (`synchronous_cycle_modules`, a Tarjan pass over the whole module graph) is computed lazily once per build on `GenerateStage` and shared by the probe, the projection, and lowering. Its only inputs are import-record kind/target and module normality, which no generate-stage pass mutates. The two consumer-local sorts switch to `sort_by_cached_key` — stable, so equal keys keep their order — and the carrier arm reads its position directly from the record index instead of scanning `import_records`.

Two further dedups are deliberately **not** taken:

- The wrap-all analysis still runs per call. The facade-chunk optimizer (default-on `experimental.mergeCommonChunks`) replays inclusion and rewrites `metas.is_included` between that analysis's two call sites, so caching would silently freeze the pre-optimizer view. That wants an explicit probe/final coherence decision first; the function now carries a comment naming the hazard.
- The route-order DFS keeps its backtracking shape. Memoizing failed subtrees is unsound on cyclic waypoint graphs without taint tracking, and the remaining worst case requires a legal star-re-export diamond among transparent waypoints.

## Validation

- Output is byte-identical: the strict-execution-order fixtures (101/101) and the full `--ignored` integration corpus run with a clean working tree afterward — zero snapshot changes.
- The full corpus failing-test name set is identical to `main` on this machine (62 pre-existing local failures: uninitialized `rollup`/`test262` submodules plus dot-disabled fixtures); no new failures.
- `cargo test -p rolldown --lib`: 104/104
- `cargo clippy -p rolldown --all-targets -- --deny warnings`; `cargo fmt --all -- --check`

Part of #10294.
