### PR TITLE
refactor(code-splitting): declare CJS carrier namespaces initializer-free

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -42,28 +42,23 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
       debug_assert_eq!(importee, self.ctx.idx);
 
       let namespace_name = self.canonical_name_for(namespace_ref);
-      program.body.push(Statement::new_var_decl(
-        namespace_name,
-        ast::Expression::new_void_0(SPAN, &ast_builder),
-        &ast_builder,
-      ));
+      program.body.push(Statement::new_var_decl_no_init(namespace_name, &ast_builder));
 
       let importee_wrapper_ref =
         self.ctx.linking_info.wrapper_ref.expect("carrier importee should have a CJS wrapper");
       let (importee_wrapper_expr, hint) =
         self.finalized_expr_for_symbol_ref(importee_wrapper_ref, false, false);
-      let require_call = if hint.contains(FinalizedExprProcessHint::FromCjsWrapKindEntry) {
-        importee_wrapper_expr
-      } else {
-        ast::Expression::new_call_expression(
-          SPAN,
-          importee_wrapper_expr,
-          NONE,
-          [],
-          false,
-          &ast_builder,
-        )
-      };
+      // The carrier is appended by its own CJS importee's finalizer, so this wrapper reference is
+      // same-chunk and can never finalize into another chunk's CJS entry namespace value.
+      debug_assert!(!hint.contains(FinalizedExprProcessHint::FromCjsWrapKindEntry));
+      let require_call = ast::Expression::new_call_expression(
+        SPAN,
+        importee_wrapper_expr,
+        NONE,
+        [],
+        false,
+        &ast_builder,
+      );
       let init_expr = if needs_to_esm {
         Expression::new_to_esm_wrapper(
           self.finalized_expr_for_runtime_symbol("__toESM"),

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_carrier_pure_value_gap/artifacts.snap
@@ -64,7 +64,7 @@ import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
 var require_pure_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { snapshot: globalThis.__strict_order_value ?? "stale" };
 }));
-var import_pure_cjs = void 0;
+var import_pure_cjs;
 function init_pure_carrier_cjs_0() {
 	return (init_pure_carrier_cjs_0 = __esmMin((() => {
 		import_pure_cjs = require_pure_cjs();
@@ -215,7 +215,7 @@ import { n as __esmMin, t as __commonJSMin } from "./rolldown-runtime.js";
 var require_pure_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { snapshot: globalThis.__strict_order_value ?? "stale" };
 }));
-var import_pure_cjs = void 0;
+var import_pure_cjs;
 function init_pure_carrier_cjs_0() {
 	return (init_pure_carrier_cjs_0 = __esmMin((() => {
 		import_pure_cjs = require_pure_cjs();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_consumer_local/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_consumer_local/artifacts.snap
@@ -37,7 +37,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -176,7 +176,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -344,7 +344,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -454,7 +454,7 @@ var require_clone_deep = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin(
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = require_rolldown_runtime.__esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ require_rolldown_runtime.__toESM(require_clone_deep(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_monolithic_esm_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_monolithic_esm_namespace/artifacts.snap
@@ -23,7 +23,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -82,7 +82,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_monolithic_require_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_monolithic_require_namespace/artifacts.snap
@@ -21,7 +21,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -85,7 +85,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_namespace_routing/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_namespace_routing/artifacts.snap
@@ -60,7 +60,7 @@ var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-a");
 	module.exports = "a";
 }));
-var import_a = void 0;
+var import_a;
 function init_namespace_barrel_cjs_0() {
 	return (init_namespace_barrel_cjs_0 = __esmMin((() => {
 		import_a = /* @__PURE__ */ __toESM(require_a(), 1);
@@ -72,7 +72,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-b");
 	module.exports = "b";
 }));
-var import_b = void 0;
+var import_b;
 function init_namespace_barrel_cjs_1() {
 	return (init_namespace_barrel_cjs_1 = __esmMin((() => {
 		import_b = /* @__PURE__ */ __toESM(require_b(), 1);
@@ -202,7 +202,7 @@ var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-a");
 	module.exports = "a";
 }));
-var import_a = void 0;
+var import_a;
 function init_namespace_barrel_cjs_0() {
 	return (init_namespace_barrel_cjs_0 = __esmMin((() => {
 		import_a = /* @__PURE__ */ __toESM(require_a(), 1);
@@ -214,7 +214,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-b");
 	module.exports = "b";
 }));
-var import_b = void 0;
+var import_b;
 function init_namespace_barrel_cjs_1() {
 	return (init_namespace_barrel_cjs_1 = __esmMin((() => {
 		import_b = /* @__PURE__ */ __toESM(require_b(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_nested_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_nested_namespace/artifacts.snap
@@ -23,7 +23,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
@@ -75,7 +75,7 @@ var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		return JSON.parse(JSON.stringify(value));
 	};
 }));
-var import_clone_deep = void 0;
+var import_clone_deep;
 function init_pure_barrel_cjs_0() {
 	return (init_pure_barrel_cjs_0 = __esmMin((() => {
 		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_per_record_chunks/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_per_record_chunks/artifacts.snap
@@ -50,7 +50,7 @@ var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-a");
 	module.exports = "a";
 }));
-var import_a = void 0;
+var import_a;
 function init_split_barrel_cjs_0() {
 	return (init_split_barrel_cjs_0 = __esmMin((() => {
 		import_a = /* @__PURE__ */ __toESM(require_a(), 1);
@@ -82,7 +82,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-b");
 	module.exports = "b";
 }));
-var import_b = void 0;
+var import_b;
 function init_split_barrel_cjs_1() {
 	return (init_split_barrel_cjs_1 = __esmMin((() => {
 		import_b = /* @__PURE__ */ __toESM(require_b(), 1);
@@ -168,7 +168,7 @@ var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-a");
 	module.exports = "a";
 }));
-var import_a = void 0;
+var import_a;
 function init_split_barrel_cjs_0() {
 	return (init_split_barrel_cjs_0 = __esmMin((() => {
 		import_a = /* @__PURE__ */ __toESM(require_a(), 1);
@@ -200,7 +200,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("cjs-b");
 	module.exports = "b";
 }));
-var import_b = void 0;
+var import_b;
 function init_split_barrel_cjs_1() {
 	return (init_split_barrel_cjs_1 = __esmMin((() => {
 		import_b = /* @__PURE__ */ __toESM(require_b(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shared_importee/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shared_importee/artifacts.snap
@@ -83,13 +83,13 @@ var require_shared = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("shared-cjs");
 	module.exports = "shared";
 }));
-var import_shared$1 = void 0;
+var import_shared$1;
 function init_barrel_a_cjs_0() {
 	return (init_barrel_a_cjs_0 = __esmMin((() => {
 		import_shared$1 = /* @__PURE__ */ __toESM(require_shared(), 1);
 	})))();
 }
-var import_shared = void 0;
+var import_shared;
 function init_barrel_b_cjs_1() {
 	return (init_barrel_b_cjs_1 = __esmMin((() => {
 		import_shared = /* @__PURE__ */ __toESM(require_shared(), 1);
@@ -177,13 +177,13 @@ var require_shared = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	globalThis.__events.push("shared-cjs");
 	module.exports = "shared";
 }));
-var import_shared$1 = void 0;
+var import_shared$1;
 function init_barrel_a_cjs_0() {
 	return (init_barrel_a_cjs_0 = __esmMin((() => {
 		import_shared$1 = /* @__PURE__ */ __toESM(require_shared(), 1);
 	})))();
 }
-var import_shared = void 0;
+var import_shared;
 function init_barrel_b_cjs_1() {
 	return (init_barrel_b_cjs_1 = __esmMin((() => {
 		import_shared = /* @__PURE__ */ __toESM(require_shared(), 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_side_effect_boundary/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_side_effect_boundary/artifacts.snap
@@ -12,7 +12,7 @@ var require_nested_effectful_clone = /* @__PURE__ */ __commonJSMin(((exports, mo
 	globalThis.__events.push("nested-effectful-clone");
 	module.exports = (value) => ({ ...value });
 }));
-var import_nested_effectful_clone = void 0;
+var import_nested_effectful_clone;
 function init_inner_effectful_barrel_cjs_0() {
 	return (init_inner_effectful_barrel_cjs_0 = __esmMin((() => {
 		import_nested_effectful_clone = /* @__PURE__ */ __toESM(require_nested_effectful_clone(), 1);
@@ -91,7 +91,7 @@ var require_effectful_clone = /* @__PURE__ */ __commonJSMin(((exports, module) =
 	globalThis.__events.push("effectful-clone");
 	module.exports = (value) => ({ ...value });
 }));
-var import_effectful_clone = void 0;
+var import_effectful_clone;
 function init_pure_boundary_barrel_cjs_1() {
 	return (init_pure_boundary_barrel_cjs_1 = __esmMin((() => {
 		import_effectful_clone = /* @__PURE__ */ __toESM(require_effectful_clone(), 1);
@@ -128,7 +128,7 @@ var require_nested_effectful_clone = /* @__PURE__ */ __commonJSMin(((exports, mo
 	globalThis.__events.push("nested-effectful-clone");
 	module.exports = (value) => ({ ...value });
 }));
-var import_nested_effectful_clone = void 0;
+var import_nested_effectful_clone;
 function init_inner_effectful_barrel_cjs_0() {
 	return (init_inner_effectful_barrel_cjs_0 = __esmMin((() => {
 		import_nested_effectful_clone = /* @__PURE__ */ __toESM(require_nested_effectful_clone(), 1);
@@ -201,7 +201,7 @@ var require_effectful_clone = /* @__PURE__ */ __commonJSMin(((exports, module) =
 	globalThis.__events.push("effectful-clone");
 	module.exports = (value) => ({ ...value });
 }));
-var import_effectful_clone = void 0;
+var import_effectful_clone;
 function init_pure_boundary_barrel_cjs_1() {
 	return (init_pure_boundary_barrel_cjs_1 = __esmMin((() => {
 		import_effectful_clone = /* @__PURE__ */ __toESM(require_effectful_clone(), 1);

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -608,6 +608,37 @@ pub trait StatementFactoryExt<'ast> {
     )
   }
 
+  /// `var <name>;`
+  fn new_var_decl_no_init<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
+    name: &str,
+    builder: &B,
+  ) -> Statement<'ast> {
+    let declarations = oxc::allocator::Vec::from_value_in(
+      VariableDeclarator::new(
+        SPAN,
+        VariableDeclarationKind::Var,
+        BindingPattern::new_binding_identifier(
+          SPAN,
+          oxc::ast::ast::Str::from_str_in(name, builder),
+          builder,
+        ),
+        NONE,
+        None,
+        false,
+        builder,
+      ),
+      builder,
+    );
+
+    Statement::new_variable_declaration(
+      SPAN,
+      VariableDeclarationKind::Var,
+      declarations,
+      false,
+      builder,
+    )
+  }
+
   /// `export default <expr>`
   fn new_export_default_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     expr: Expression<'ast>,


### PR DESCRIPTION
A CJS re-export carrier's namespace was the one closure-assigned hoisted binding in strict output declared with an initializer. It is now declared initializer-free, like every other binding that is assigned inside an init closure:

```diff
- var import_clone_deep = void 0;
+ var import_clone_deep;
```

Semantics are unchanged — `var` declarations have no temporal dead zone, so both forms read `undefined` before the carrier runs — and the change exists only in strict-execution-order output.

## Motivation

The two forms are equivalent today because the declaration provably executes before any carrier call (carriers are never minted for cyclic importees; those shapes fall back to a monolithic barrel, pinned by the `*_cycle_fallback` fixtures). The initializer-free form is the safer shape by construction: `= void 0` is a real assignment, so any future statement reordering that ran the declaration after the carrier initialized would silently wipe the namespace back to `undefined` behind the memoized guard — a bare declaration cannot. It also matches how every other closure-assigned hoisted binding in scope-hoisted output is declared; the initializer only existed because the statement factory required one.

## Changes

The statement factory gains an initializer-free variant (`new_var_decl_no_init`) and the carrier declaration uses it. From the same review pass: the finalizer branch that handled a carrier's wrapper resolving through another chunk's CJS entry namespace — unreachable, because a carrier is emitted by its own importee's finalizer and is therefore always a same-chunk reference — is replaced by a `debug_assert!` stating that argument.

## Validation

- Snapshot-only: 28 changed lines across 9 strict fixtures, every one a `var x = void 0;` → `var x;` declaration.
- strict-execution-order fixtures: 101/101; `cargo test -p rolldown --lib`: 104/104
- `cargo clippy -p rolldown -p rolldown_ecmascript_utils --all-targets -- --deny warnings`; `cargo fmt --all -- --check`
- Non-strict output is untouched: carriers exist only in strict builds.

Part of #10294.
