### PR TITLE
test(code-splitting): pin CJS barrel fallback triggers and flag-off equivalence

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/_config.json
@@ -14,10 +14,6 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
-    },
-    {
-      "_configName": "flag-off",
-      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/_test.mjs
@@ -30,28 +30,23 @@ function staticClosure(root) {
   return [...seen].map((name) => files.get(name)).join('\n');
 }
 
-const mainClosure = staticClosure('main.js');
-const routeFile = /import\(["']\.\/([^"']*route[^"']*)["']\)/.exec(mainClosure)?.[1];
-assert.ok(routeFile, 'main must retain the dynamic route boundary');
-assert.doesNotMatch(mainClosure, /effectful-clone/);
-assert.match(staticClosure(routeFile), /effectful-clone/);
-assert.match(staticClosure(routeFile), /nested-effectful-clone/);
+// A CJS `export *` gives the barrel a dynamic namespace, which rejects consumer-local routing;
+// the monolithic barrel keeps every leaf eager for the entry.
+assert.match(staticClosure('main.js'), /clone-deep\.cjs/);
 
 globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['cn', 'ancestor', 'main:cn:nested-cn']);
-assert.deepStrictEqual((await entry.loadRoute()).value, [{ value: 1 }, { value: 2 }]);
-// Both modes run the same lazy set on the route. Flag-off hoists the generated CJS interop of
-// the nested barrel above the outer one (lazy-init transfer); strict mode keeps the re-export
-// source order across both barrel hops.
+assert.deepStrictEqual(globalThis.__events, ['extra', 'cn', 'clone-deep', 'main:a b']);
+
+const route = await entry.loadRoute();
+
+assert.deepStrictEqual(route.value, { value: 1 });
 assert.deepStrictEqual(globalThis.__events, [
+  'extra',
   'cn',
-  'ancestor',
-  'main:cn:nested-cn',
-  ...(globalThis.__configName === 'flag-off'
-    ? ['nested-effectful-clone', 'effectful-clone']
-    : ['effectful-clone', 'nested-effectful-clone']),
-  'route',
+  'clone-deep',
+  'main:a b',
+  'route:extra',
 ]);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/artifacts.snap
@@ -1,0 +1,200 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## cn.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((() => {
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+export { init_cn as n, cn as t };
+
+```
+
+## main.js
+
+```js
+import { t as cn } from "./cn.js";
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadRoute() {
+	return import("./route.js").then((n) => (n.t(), n.n));
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+init_main();
+export { loadRoute };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __reExport as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## route.js
+
+```js
+import { n as init_cn, t as cn } from "./cn.js";
+import { a as __toESM, i as __reExport, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/extra.cjs
+var require_extra = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__events.push("extra");
+	exports.extraValue = "extra";
+}));
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var pure_barrel_exports = /* @__PURE__ */ __exportAll({
+	cloneDeep: () => import_clone_deep.default,
+	cn: () => cn
+});
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((() => {
+		__reExport(pure_barrel_exports, /* @__PURE__ */ __toESM(require_extra(), 1));
+		init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+function init_route() {
+	return (init_route = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`route:${pure_barrel_exports.extraValue}`);
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { route_exports as n, init_pure_barrel as r, init_route as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### cn.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((() => {
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+export { init_cn as n, cn as t };
+
+```
+
+### main.js
+
+```js
+import { t as cn } from "./cn.js";
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadRoute() {
+	return import("./route.js").then((n) => (n.t(), n.n));
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+init_main();
+export { loadRoute };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __reExport as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+### route.js
+
+```js
+import { n as init_cn, t as cn } from "./cn.js";
+import { a as __toESM, i as __reExport, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/extra.cjs
+var require_extra = /* @__PURE__ */ __commonJSMin(((exports) => {
+	globalThis.__events.push("extra");
+	exports.extraValue = "extra";
+}));
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var pure_barrel_exports = /* @__PURE__ */ __exportAll({
+	cloneDeep: () => import_clone_deep.default,
+	cn: () => cn
+});
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((() => {
+		__reExport(pure_barrel_exports, /* @__PURE__ */ __toESM(require_extra(), 1));
+		init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+function init_route() {
+	return (init_route = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`route:${pure_barrel_exports.extraValue}`);
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { route_exports as n, init_pure_barrel as r, init_route as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/main.js
@@ -1,0 +1,7 @@
+import { cn } from 'pure-barrel';
+
+globalThis.__events.push(`main:${cn('a', 'b')}`);
+
+export function loadRoute() {
+  return import('./route.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/clone-deep.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/clone-deep.cjs
@@ -1,0 +1,5 @@
+globalThis.__events.push('clone-deep');
+
+module.exports = function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/cn.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/cn.js
@@ -1,0 +1,5 @@
+globalThis.__events.push('cn');
+
+export function cn(...values) {
+  return values.filter(Boolean).join(' ');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/extra.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/extra.cjs
@@ -1,0 +1,3 @@
+globalThis.__events.push('extra');
+
+exports.extraValue = 'extra';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/index.js
@@ -1,0 +1,3 @@
+export * from './extra.cjs';
+export { cn } from './cn.js';
+export { default as cloneDeep } from './clone-deep.cjs';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/node_modules/pure-barrel/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pure-barrel",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/route.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_cjs_export_star_fallback/route.js
@@ -1,0 +1,5 @@
+import { cloneDeep, extraValue } from 'pure-barrel';
+
+globalThis.__events.push(`route:${extraValue}`);
+
+export const value = cloneDeep({ value: 1 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/_config.json
@@ -7,6 +7,7 @@
         "import": "./main.js"
       }
     ],
+    "codeSplitting": false,
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension"
   },
@@ -14,10 +15,6 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
-    },
-    {
-      "_configName": "flag-off",
-      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/_test.mjs
@@ -30,28 +30,31 @@ function staticClosure(root) {
   return [...seen].map((name) => files.get(name)).join('\n');
 }
 
-const mainClosure = staticClosure('main.js');
-const routeFile = /import\(["']\.\/([^"']*route[^"']*)["']\)/.exec(mainClosure)?.[1];
-assert.ok(routeFile, 'main must retain the dynamic route boundary');
-assert.doesNotMatch(mainClosure, /effectful-clone/);
-assert.match(staticClosure(routeFile), /effectful-clone/);
-assert.match(staticClosure(routeFile), /nested-effectful-clone/);
+// With code splitting disabled everything shares one chunk. Wrap-all still routes the barrel per
+// consumer — the carrier keeps the unrelated CJS leaf lazy behind the inlined route trigger. The
+// on-demand plan sees no cross-chunk hazard in a single chunk, leaves the barrel out of its wrap
+// plan, and its monolithic interop body makes the leaf eager. Both orders respect source order —
+// only the eager set differs between the two plans, in wrap-all's favor.
+assert.deepStrictEqual([...files.keys()], ['main.js']);
+const onDemand = globalThis.__configName === 'on-demand';
+if (onDemand) {
+  assert.doesNotMatch(files.get('main.js'), /init_pure_barrel_cjs/);
+} else {
+  assert.match(files.get('main.js'), /init_pure_barrel_cjs/);
+}
 
 globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['cn', 'ancestor', 'main:cn:nested-cn']);
-assert.deepStrictEqual((await entry.loadRoute()).value, [{ value: 1 }, { value: 2 }]);
-// Both modes run the same lazy set on the route. Flag-off hoists the generated CJS interop of
-// the nested barrel above the outer one (lazy-init transfer); strict mode keeps the re-export
-// source order across both barrel hops.
+const entryEvents = onDemand ? ['cn', 'clone-deep', 'main:a b'] : ['cn', 'main:a b'];
+assert.deepStrictEqual(globalThis.__events, entryEvents);
+
+const route = await entry.loadRoute();
+
+assert.deepStrictEqual(route.value, { value: 1 });
 assert.deepStrictEqual(globalThis.__events, [
-  'cn',
-  'ancestor',
-  'main:cn:nested-cn',
-  ...(globalThis.__configName === 'flag-off'
-    ? ['nested-effectful-clone', 'effectful-clone']
-    : ['effectful-clone', 'nested-effectful-clone']),
+  ...entryEvents,
+  ...(onDemand ? [] : ['clone-deep']),
   'route',
 ]);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/artifacts.snap
@@ -1,0 +1,108 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+var init_cn = __esmMin((() => {
+	globalThis.__events.push("cn");
+}));
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+var import_clone_deep;
+function init_pure_barrel_cjs_0() {
+	return (init_pure_barrel_cjs_0 = __esmMin((() => {
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region node_modules/pure-barrel/index.js
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+var init_route = __esmMin((() => {
+	init_pure_barrel_cjs_0();
+	globalThis.__events.push("route");
+	value = (0, import_clone_deep.default)({ value: 1 });
+}));
+//#endregion
+//#region main.js
+function loadRoute() {
+	return Promise.resolve().then(() => (init_route(), route_exports));
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_cn();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+init_main();
+export { loadRoute };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+var init_cn = __esmMin((() => {
+	globalThis.__events.push("cn");
+}));
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var import_clone_deep;
+var init_pure_barrel = __esmMin((() => {
+	init_cn();
+	import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+}));
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+var init_route = __esmMin((() => {
+	init_pure_barrel();
+	globalThis.__events.push("route");
+	value = (0, import_clone_deep.default)({ value: 1 });
+}));
+//#endregion
+//#region main.js
+init_pure_barrel();
+globalThis.__events.push(`main:${cn("a", "b")}`);
+function loadRoute() {
+	return Promise.resolve().then(() => (init_route(), route_exports));
+}
+//#endregion
+export { loadRoute };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/main.js
@@ -1,0 +1,7 @@
+import { cn } from 'pure-barrel';
+
+globalThis.__events.push(`main:${cn('a', 'b')}`);
+
+export function loadRoute() {
+  return import('./route.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/clone-deep.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/clone-deep.cjs
@@ -1,0 +1,5 @@
+globalThis.__events.push('clone-deep');
+
+module.exports = function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/cn.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/cn.js
@@ -1,0 +1,5 @@
+globalThis.__events.push('cn');
+
+export function cn(...values) {
+  return values.filter(Boolean).join(' ');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/index.js
@@ -1,0 +1,2 @@
+export { cn } from './cn.js';
+export { default as cloneDeep } from './clone-deep.cjs';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/node_modules/pure-barrel/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pure-barrel",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/route.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_code_splitting_disabled/route.js
@@ -1,0 +1,5 @@
+import { cloneDeep } from 'pure-barrel';
+
+globalThis.__events.push('route');
+
+export const value = cloneDeep({ value: 1 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/_config.json
@@ -18,6 +18,10 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
+    },
+    {
+      "_configName": "flag-off",
+      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/_test.mjs
@@ -56,15 +56,15 @@ globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['effect-before', 'cn', 'effect-after', 'main:a b']);
+// Both modes execute the same eager set. Flag-off hoists the generated CJS interop above the
+// barrel's leaves (lazy-init transfer); strict mode pins each require to its re-export source
+// position, which is the ordering this fixture family protects.
+const entryEvents =
+  globalThis.__configName === 'flag-off'
+    ? ['effect-before', 'effect-after', 'cn', 'main:a b']
+    : ['effect-before', 'cn', 'effect-after', 'main:a b'];
+assert.deepStrictEqual(globalThis.__events, entryEvents);
 
 await entry.loadRoute();
 
-assert.deepStrictEqual(globalThis.__events, [
-  'effect-before',
-  'cn',
-  'effect-after',
-  'main:a b',
-  'stack',
-  'route',
-]);
+assert.deepStrictEqual(globalThis.__events, [...entryEvents, 'stack', 'route']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_effectful_carrier/artifacts.snap
@@ -252,3 +252,76 @@ init_route();
 export { stack };
 
 ```
+
+# Variant: flag-off: [strict_execution_order: false]
+
+## Assets
+
+### bare.js
+
+```js
+import "./outer.js";
+//#region bare.js
+globalThis.__events.push("bare");
+//#endregion
+
+```
+
+### main.js
+
+```js
+import "./outer.js";
+//#region node_modules/pure-leaves/cn.js
+globalThis.__events.push("cn");
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+//#endregion
+//#region main.js
+globalThis.__events.push(`main:${cn("a", "b")}`);
+function loadRoute() {
+	return import("./route.js");
+}
+//#endregion
+export { loadRoute };
+
+```
+
+### outer.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region effect-before.cjs
+var require_effect_before = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("effect-before");
+	module.exports = {};
+}));
+//#endregion
+//#region effect-after.cjs
+var require_effect_after = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("effect-after");
+	module.exports = {};
+}));
+//#endregion
+//#region barrel.js
+require_effect_before();
+require_effect_after();
+//#endregion
+
+```
+
+### route.js
+
+```js
+import "./outer.js";
+//#region node_modules/pure-leaves/stack.js
+globalThis.__events.push("stack");
+var Stack = class {};
+//#endregion
+//#region route.js
+globalThis.__events.push("route");
+const stack = new Stack();
+//#endregion
+export { stack };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/_config.json
@@ -7,6 +7,7 @@
         "import": "./main.js"
       }
     ],
+    "external": ["ext-lib"],
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension"
   },
@@ -14,10 +15,6 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
-    },
-    {
-      "_configName": "flag-off",
-      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/_test.mjs
@@ -30,28 +30,25 @@ function staticClosure(root) {
   return [...seen].map((name) => files.get(name)).join('\n');
 }
 
-const mainClosure = staticClosure('main.js');
-const routeFile = /import\(["']\.\/([^"']*route[^"']*)["']\)/.exec(mainClosure)?.[1];
-assert.ok(routeFile, 'main must retain the dynamic route boundary');
-assert.doesNotMatch(mainClosure, /effectful-clone/);
-assert.match(staticClosure(routeFile), /effectful-clone/);
-assert.match(staticClosure(routeFile), /nested-effectful-clone/);
+// An `export *` from an external module gives the barrel dynamic exports, which rejects
+// consumer-local routing. The monolithic barrel couples every consumer to its complete dependency
+// set: the unrelated CJS leaf and the external import both join the eager entry phase.
+assert.match(staticClosure('main.js'), /clone-deep\.cjs/);
 
 globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['cn', 'ancestor', 'main:cn:nested-cn']);
-assert.deepStrictEqual((await entry.loadRoute()).value, [{ value: 1 }, { value: 2 }]);
-// Both modes run the same lazy set on the route. Flag-off hoists the generated CJS interop of
-// the nested barrel above the outer one (lazy-init transfer); strict mode keeps the re-export
-// source order across both barrel hops.
-assert.deepStrictEqual(globalThis.__events, [
-  'cn',
-  'ancestor',
-  'main:cn:nested-cn',
-  ...(globalThis.__configName === 'flag-off'
-    ? ['nested-effectful-clone', 'effectful-clone']
-    : ['effectful-clone', 'nested-effectful-clone']),
-  'route',
-]);
+// The external import's position differs between the plans (wrap-all hoists the deferred chunk's
+// static imports ahead of every wrapper; on-demand keeps the eager barrel body at its source
+// position), but both keep the whole monolithic barrel — external included — in the eager phase.
+const entryEvents =
+  globalThis.__configName === 'on-demand'
+    ? ['cn', 'ext-lib', 'clone-deep', 'main:a b']
+    : ['ext-lib', 'cn', 'clone-deep', 'main:a b'];
+assert.deepStrictEqual(globalThis.__events, entryEvents);
+
+const route = await entry.loadRoute();
+
+assert.deepStrictEqual(route.value, { value: 1 });
+assert.deepStrictEqual(globalThis.__events, [...entryEvents, 'route:ext']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/artifacts.snap
@@ -1,0 +1,184 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## cn.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((() => {
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+export { init_cn as n, cn as t };
+
+```
+
+## main.js
+
+```js
+import { t as cn } from "./cn.js";
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadRoute() {
+	return import("./route.js").then((n) => (n.t(), n.n));
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+init_main();
+export { loadRoute };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __reExport as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## route.js
+
+```js
+import { n as init_cn, t as cn } from "./cn.js";
+import { a as __toESM, i as __reExport, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var pure_barrel_exports = /* @__PURE__ */ __exportAll({
+	cloneDeep: () => import_clone_deep.default,
+	cn: () => cn
+});
+import * as import_ext_lib from "ext-lib";
+__reExport(pure_barrel_exports, import_ext_lib);
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((() => {
+		init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+function init_route() {
+	return (init_route = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`route:${pure_barrel_exports.extLibValue}`);
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { route_exports as n, init_pure_barrel as r, init_route as t };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### cn.js
+
+```js
+//#region node_modules/pure-barrel/cn.js
+globalThis.__events.push("cn");
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+//#endregion
+export { cn as t };
+
+```
+
+### main.js
+
+```js
+import { t as cn } from "./cn.js";
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function loadRoute() {
+	return import("./route.js").then((n) => (n.t(), n.n));
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+init_main();
+export { loadRoute };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __reExport as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+### route.js
+
+```js
+import { t as cn } from "./cn.js";
+import { a as __toESM, i as __reExport, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var pure_barrel_exports = /* @__PURE__ */ __exportAll({
+	cloneDeep: () => import_clone_deep.default,
+	cn: () => cn
+});
+import * as import_ext_lib from "ext-lib";
+__reExport(pure_barrel_exports, import_ext_lib);
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((() => {
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var route_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var value;
+function init_route() {
+	return (init_route = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`route:${pure_barrel_exports.extLibValue}`);
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { route_exports as n, init_pure_barrel as r, init_route as t };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/main.js
@@ -1,0 +1,7 @@
+import { cn } from 'pure-barrel';
+
+globalThis.__events.push(`main:${cn('a', 'b')}`);
+
+export function loadRoute() {
+  return import('./route.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/ext-lib/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/ext-lib/index.js
@@ -1,0 +1,3 @@
+globalThis.__events.push('ext-lib');
+
+export const extLibValue = 'ext';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/ext-lib/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/ext-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ext-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/clone-deep.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/clone-deep.cjs
@@ -1,0 +1,5 @@
+globalThis.__events.push('clone-deep');
+
+module.exports = function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/cn.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/cn.js
@@ -1,0 +1,5 @@
+globalThis.__events.push('cn');
+
+export function cn(...values) {
+  return values.filter(Boolean).join(' ');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/index.js
@@ -1,0 +1,3 @@
+export * from 'ext-lib';
+export { cn } from './cn.js';
+export { default as cloneDeep } from './clone-deep.cjs';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/node_modules/pure-barrel/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pure-barrel",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/route.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_external_star_fallback/route.js
@@ -1,0 +1,5 @@
+import { cloneDeep, extLibValue } from 'pure-barrel';
+
+globalThis.__events.push(`route:${extLibValue}`);
+
+export const value = cloneDeep({ value: 1 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/_config.json
@@ -7,6 +7,7 @@
         "import": "./main.js"
       }
     ],
+    "shimMissingExports": true,
     "strictExecutionOrder": true,
     "preserveEntrySignatures": "allow-extension"
   },
@@ -14,10 +15,6 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
-    },
-    {
-      "_configName": "flag-off",
-      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/_test.mjs
@@ -30,28 +30,17 @@ function staticClosure(root) {
   return [...seen].map((name) => files.get(name)).join('\n');
 }
 
-const mainClosure = staticClosure('main.js');
-const routeFile = /import\(["']\.\/([^"']*route[^"']*)["']\)/.exec(mainClosure)?.[1];
-assert.ok(routeFile, 'main must retain the dynamic route boundary');
-assert.doesNotMatch(mainClosure, /effectful-clone/);
-assert.match(staticClosure(routeFile), /effectful-clone/);
-assert.match(staticClosure(routeFile), /nested-effectful-clone/);
+// A shimmed missing export on the barrel rejects consumer-local routing; the monolithic barrel
+// keeps the unrelated CJS leaf eager and the shimmed binding reads undefined.
+assert.match(staticClosure('main.js'), /clone-deep\.cjs/);
 
 globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['cn', 'ancestor', 'main:cn:nested-cn']);
-assert.deepStrictEqual((await entry.loadRoute()).value, [{ value: 1 }, { value: 2 }]);
-// Both modes run the same lazy set on the route. Flag-off hoists the generated CJS interop of
-// the nested barrel above the outer one (lazy-init transfer); strict mode keeps the re-export
-// source order across both barrel hops.
-assert.deepStrictEqual(globalThis.__events, [
-  'cn',
-  'ancestor',
-  'main:cn:nested-cn',
-  ...(globalThis.__configName === 'flag-off'
-    ? ['nested-effectful-clone', 'effectful-clone']
-    : ['effectful-clone', 'nested-effectful-clone']),
-  'route',
-]);
+assert.deepStrictEqual(globalThis.__events, ['cn', 'clone-deep', 'main:a b:true']);
+
+const route = await entry.loadRoute();
+
+assert.deepStrictEqual(route.value, { value: 1 });
+assert.deepStrictEqual(globalThis.__events, ['cn', 'clone-deep', 'main:a b:true', 'route']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/artifacts.snap
@@ -1,0 +1,148 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { n as loadRoute, t as init_main } from "./main2.js";
+init_main();
+export { loadRoute };
+
+```
+
+## main2.js
+
+```js
+import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((() => {
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var import_clone_deep, missing;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((() => {
+		init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+		missing = void 0;
+	})))();
+}
+//#endregion
+//#region main.js
+function loadRoute() {
+	return import("./route.js");
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}:${missing === void 0}`);
+	})))();
+}
+//#endregion
+export { init_pure_barrel as i, loadRoute as n, import_clone_deep as r, init_main as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+## route.js
+
+```js
+import { i as init_pure_barrel, r as import_clone_deep } from "./main2.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region route.js
+var value;
+function init_route() {
+	return (init_route = __esmMin((() => {
+		init_pure_barrel();
+		globalThis.__events.push("route");
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+init_route();
+export { value };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+import { n as loadRoute, t as init_main } from "./main2.js";
+init_main();
+export { loadRoute };
+
+```
+
+### main2.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region node_modules/pure-barrel/cn.js
+globalThis.__events.push("cn");
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+//#endregion
+//#region node_modules/pure-barrel/clone-deep.cjs
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var import_clone_deep = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+})))(), 1);
+var missing = void 0;
+//#endregion
+//#region main.js
+function loadRoute() {
+	return import("./route.js");
+}
+function init_main() {
+	return (init_main = __esmMin((() => {
+		globalThis.__events.push(`main:${cn("a", "b")}:${missing === void 0}`);
+	})))();
+}
+//#endregion
+export { loadRoute as n, import_clone_deep as r, init_main as t };
+
+```
+
+### route.js
+
+```js
+import { r as import_clone_deep } from "./main2.js";
+//#region route.js
+globalThis.__events.push("route");
+const value = (0, import_clone_deep.default)({ value: 1 });
+//#endregion
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/main.js
@@ -1,0 +1,7 @@
+import { cn, missing } from 'pure-barrel';
+
+globalThis.__events.push(`main:${cn('a', 'b')}:${missing === undefined}`);
+
+export function loadRoute() {
+  return import('./route.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/clone-deep.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/clone-deep.cjs
@@ -1,0 +1,5 @@
+globalThis.__events.push('clone-deep');
+
+module.exports = function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/cn.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/cn.js
@@ -1,0 +1,5 @@
+globalThis.__events.push('cn');
+
+export function cn(...values) {
+  return values.filter(Boolean).join(' ');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/index.js
@@ -1,0 +1,2 @@
+export { cn } from './cn.js';
+export { default as cloneDeep } from './clone-deep.cjs';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/node_modules/pure-barrel/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pure-barrel",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/route.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_shimmed_export_fallback/route.js
@@ -1,0 +1,5 @@
+import { cloneDeep } from 'pure-barrel';
+
+globalThis.__events.push('route');
+
+export const value = cloneDeep({ value: 1 });

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_side_effect_boundary/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_side_effect_boundary/artifacts.snap
@@ -224,3 +224,73 @@ init_route();
 export { value };
 
 ```
+
+# Variant: flag-off: [strict_execution_order: false]
+
+## Assets
+
+### inner-effectful-barrel.js
+
+```js
+import { n as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/nested-effectful-clone/index.cjs
+//#endregion
+//#region node_modules/inner-effectful-barrel/index.js
+var import_nested_effectful_clone = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("nested-effectful-clone");
+	module.exports = (value) => ({ ...value });
+})))(), 1);
+//#endregion
+export { import_nested_effectful_clone as t };
+
+```
+
+### main.js
+
+```js
+//#region node_modules/pure-boundary-barrel/cn.js
+globalThis.__events.push("cn");
+const cn = () => "cn";
+//#endregion
+//#region node_modules/pure-nested-leaf/index.js
+const nestedCn = () => "nested-cn";
+//#endregion
+//#region ancestor.js
+globalThis.__events.push("ancestor");
+//#endregion
+//#region main.js
+globalThis.__events.push(`main:${cn()}:${nestedCn()}`);
+const loadRoute = () => import("./route.js");
+//#endregion
+export { loadRoute };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
+
+```
+
+### route.js
+
+```js
+import { n as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+import { t as import_nested_effectful_clone } from "./inner-effectful-barrel.js";
+//#region node_modules/effectful-clone/index.cjs
+//#endregion
+//#region node_modules/pure-boundary-barrel/index.js
+var import_effectful_clone = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("effectful-clone");
+	module.exports = (value) => ({ ...value });
+})))(), 1);
+//#endregion
+//#region route.js
+globalThis.__events.push("route");
+const value = [(0, import_effectful_clone.default)({ value: 1 }), (0, import_nested_effectful_clone.default)({ value: 2 })];
+//#endregion
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/_config.json
@@ -14,10 +14,6 @@
     {
       "_configName": "on-demand",
       "onDemandWrapping": true
-    },
-    {
-      "_configName": "flag-off",
-      "strictExecutionOrder": false
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/_test.mjs
@@ -30,28 +30,17 @@ function staticClosure(root) {
   return [...seen].map((name) => files.get(name)).join('\n');
 }
 
-const mainClosure = staticClosure('main.js');
-const routeFile = /import\(["']\.\/([^"']*route[^"']*)["']\)/.exec(mainClosure)?.[1];
-assert.ok(routeFile, 'main must retain the dynamic route boundary');
-assert.doesNotMatch(mainClosure, /effectful-clone/);
-assert.match(staticClosure(routeFile), /effectful-clone/);
-assert.match(staticClosure(routeFile), /nested-effectful-clone/);
+// A TLA-tainted barrel rejects consumer-local routing, so the monolithic barrel init keeps the
+// unrelated CJS leaf in the eager entry closure.
+assert.match(staticClosure('main.js'), /clone-deep\.cjs/);
 
 globalThis.__events = [];
 
 const entry = await import('./dist/main.js');
 
-assert.deepStrictEqual(globalThis.__events, ['cn', 'ancestor', 'main:cn:nested-cn']);
-assert.deepStrictEqual((await entry.loadRoute()).value, [{ value: 1 }, { value: 2 }]);
-// Both modes run the same lazy set on the route. Flag-off hoists the generated CJS interop of
-// the nested barrel above the outer one (lazy-init transfer); strict mode keeps the re-export
-// source order across both barrel hops.
-assert.deepStrictEqual(globalThis.__events, [
-  'cn',
-  'ancestor',
-  'main:cn:nested-cn',
-  ...(globalThis.__configName === 'flag-off'
-    ? ['nested-effectful-clone', 'effectful-clone']
-    : ['effectful-clone', 'nested-effectful-clone']),
-  'route',
-]);
+assert.deepStrictEqual(globalThis.__events, ['cn', 'clone-deep', 'main:a b']);
+
+const route = await entry.loadRoute();
+
+assert.deepStrictEqual(route.value, { value: 1 });
+assert.deepStrictEqual(globalThis.__events, ['cn', 'clone-deep', 'main:a b', 'route']);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/artifacts.snap
@@ -1,0 +1,194 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { n as loadRoute, t as init_main } from "./main2.js";
+await init_main();
+export { loadRoute };
+
+```
+
+## main2.js
+
+```js
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((async () => {
+		await Promise.resolve();
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+//#region main.js
+function loadRoute() {
+	return import("./route2.js");
+}
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+export { loadRoute as n, init_cn as r, init_main as t };
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+## route.js
+
+```js
+import { r as init_cn } from "./main2.js";
+import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((async () => {
+		await init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var value;
+function init_route() {
+	return (init_route = __esmMin((async () => {
+		await init_pure_barrel();
+		globalThis.__events.push("route");
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { value as n, init_pure_barrel as r, init_route as t };
+
+```
+
+## route2.js
+
+```js
+import { n as value, t as init_route } from "./route.js";
+await init_route();
+export { value };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true]
+
+## Assets
+
+### main.js
+
+```js
+import { n as loadRoute, t as init_main } from "./main2.js";
+await init_main();
+export { loadRoute };
+
+```
+
+### main2.js
+
+```js
+import { r as init_pure_barrel } from "./route.js";
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/cn.js
+function cn(...values) {
+	return values.filter(Boolean).join(" ");
+}
+function init_cn() {
+	return (init_cn = __esmMin((async () => {
+		await Promise.resolve();
+		globalThis.__events.push("cn");
+	})))();
+}
+//#endregion
+//#region main.js
+function loadRoute() {
+	return import("./route2.js");
+}
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await init_pure_barrel();
+		globalThis.__events.push(`main:${cn("a", "b")}`);
+	})))();
+}
+//#endregion
+export { loadRoute as n, init_cn as r, init_main as t };
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as n, __toESM as r, __commonJSMin as t };
+
+```
+
+### route.js
+
+```js
+import { r as init_cn } from "./main2.js";
+import { n as __esmMin, r as __toESM, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region node_modules/pure-barrel/clone-deep.cjs
+var require_clone_deep = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	globalThis.__events.push("clone-deep");
+	module.exports = function cloneDeep(value) {
+		return JSON.parse(JSON.stringify(value));
+	};
+}));
+//#endregion
+//#region node_modules/pure-barrel/index.js
+var import_clone_deep;
+function init_pure_barrel() {
+	return (init_pure_barrel = __esmMin((async () => {
+		await init_cn();
+		import_clone_deep = /* @__PURE__ */ __toESM(require_clone_deep(), 1);
+	})))();
+}
+//#endregion
+//#region route.js
+var value;
+function init_route() {
+	return (init_route = __esmMin((async () => {
+		await init_pure_barrel();
+		globalThis.__events.push("route");
+		value = (0, import_clone_deep.default)({ value: 1 });
+	})))();
+}
+//#endregion
+export { value as n, init_pure_barrel as r, init_route as t };
+
+```
+
+### route2.js
+
+```js
+import { n as value, t as init_route } from "./route.js";
+await init_route();
+export { value };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/main.js
@@ -1,0 +1,7 @@
+import { cn } from 'pure-barrel';
+
+globalThis.__events.push(`main:${cn('a', 'b')}`);
+
+export function loadRoute() {
+  return import('./route.js');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/clone-deep.cjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/clone-deep.cjs
@@ -1,0 +1,5 @@
+globalThis.__events.push('clone-deep');
+
+module.exports = function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/cn.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/cn.js
@@ -1,0 +1,6 @@
+await Promise.resolve();
+globalThis.__events.push('cn');
+
+export function cn(...values) {
+  return values.filter(Boolean).join(' ');
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/index.js
@@ -1,0 +1,2 @@
+export { cn } from './cn.js';
+export { default as cloneDeep } from './clone-deep.cjs';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/node_modules/pure-barrel/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pure-barrel",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/route.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_reexport_barrel_tla_fallback/route.js
@@ -1,0 +1,5 @@
+import { cloneDeep } from 'pure-barrel';
+
+globalThis.__events.push('route');
+
+export const value = cloneDeep({ value: 1 });


### PR DESCRIPTION
The fallback decisions from #10488 — which barrel shapes must give up per-consumer routing — were mostly untested: of the rejecting triggers, only cycles and direct `require()` targets had fixtures, so a regressed decision would surface only as snapshot drift in unrelated fixtures. This PR pins every constructible trigger, plus the claim that a `moduleSideEffects: false` barrel executes the same set with the flag on and off, as runnable assertions. For example:

```js
// barrel: one leaf carries top-level await → the whole barrel refuses routing
export { cn } from './cn.js';                            // contains `await Promise.resolve()`
export { default as cloneDeep } from './clone-deep.cjs';

// pinned: the entry initializes clone-deep eagerly —
// asserted as runtime events ['cn', 'clone-deep', 'main:a b'], not only as a snapshot
```

Stacked on #10513 (the carrier-declaration change) so the snapshots carry the final declaration shape.

## Motivation

The routing side of the barrel fix is heavily fixtured, but the refusing side is load-bearing semantics with one-sided coverage. A wrong fallback decision — routing a shape that must stay monolithic, or vice versa — would not fail any test today; it would only drift snapshots elsewhere, which reads as noise. The strict/non-strict same-execution-set claim for side-effect boundaries was likewise argued in review, not asserted by a test.

## New fixtures

Each fallback fixture runs a wrap-all and an on-demand cell and asserts both placement (the entry's static import closure) and runtime event order on Node:

- `cjs_reexport_barrel_tla_fallback` — a top-level-await taint keeps the barrel monolithic: the unrelated CJS leaf joins the eager entry.
- `cjs_reexport_barrel_external_star_fallback` — `export *` from an external module (dynamic exports) keeps the barrel monolithic; the external import and the CJS leaf both become eager.
- `cjs_reexport_barrel_cjs_export_star_fallback` — `export *` from a CJS module keeps the barrel monolithic; star bindings resolve through the namespace merge.
- `cjs_reexport_barrel_shimmed_export_fallback` — a shimmed missing export keeps the barrel monolithic; the shimmed binding reads `undefined`.
- `cjs_reexport_barrel_code_splitting_disabled` — single-chunk output (`codeSplitting: false`, the current spelling of `inlineDynamicImports`). One observation here: the plans diverge. Wrap-all still routes per consumer, so the CJS leaf stays lazy behind the inlined `import()` trigger; on-demand sees no cross-chunk hazard in one chunk, leaves the barrel out of its wrap plan, and the monolithic interop body makes the leaf eager. Source order holds in both, and the eager-set gap is in wrap-all's favor, so the "wrap-all never executes more user code than on-demand" invariant stands — flagged in case on-demand should match wrap-all's laziness here, which this fixture would now catch.
- `cjs_reexport_barrel_effectful_carrier` / `cjs_reexport_barrel_side_effect_boundary` gain a `flag-off` cell each: strict and non-strict execute the same eager and lazy sets, with one legitimate order difference the cells document — non-strict hoists generated CJS interop via lazy-init transfer, strict keeps each require at its re-export source position.

A concatenated-wrapper × barrel fixture is not constructible today: `ConcatenateWrappedModuleKind::Inner`/`Root` never arises on this branch (see the `concatenate_basic` fixture's `_comment`), so that eligibility guard remains future-proofing.

## Validation

All fixtures pin current behavior — green here by construction; their value is turning a future fallback regression from silent snapshot drift into a named failure.

- strict-execution-order fixtures: 106/106 (101 on the base branch, +5 new)
- full `--ignored` integration corpus: no new failures relative to the base branch on this machine; this PR adds 5 passes
- Test-only: no source files change in this PR.

Part of #10294.
