### PR TITLE
refactor(plugin): give the build's own clocks their own type

### DIFF
--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -33,6 +33,7 @@ pub use crate::{
   },
   plugin_driver::{PluginDriver, PluginDriverFactory, SharedPluginDriver},
   pluginable::Pluginable,
+  types::build_timings::BuildTimings,
   types::custom_field::CustomField,
   types::hook_addon_args::HookAddonArgs,
   types::hook_build_end_args::HookBuildEndArgs,

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -27,7 +27,7 @@ use crate::{
   PluginContext,
   plugin_driver::hook_orders::PluginHookOrders,
   type_aliases::{IndexPluginContext, IndexPluginable},
-  types::hook_timing::HookTimingCollector,
+  types::{build_timings::BuildTimings, hook_timing::HookTimingCollector},
 };
 
 pub type SharedPluginDriver = Arc<PluginDriver>;
@@ -47,6 +47,8 @@ pub struct PluginDriver {
   pub(crate) tx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<ModuleLoaderMsg>>>>,
   /// Timing collector for plugin hooks (None if plugin timing is disabled)
   pub hook_timing_collector: Option<Arc<HookTimingCollector>>,
+  /// Wall clocks for the build as a whole, as opposed to what any one plugin cost.
+  pub build_timings: BuildTimings,
 }
 
 impl PluginDriver {
@@ -143,18 +145,16 @@ impl PluginDriver {
   /// Set total build time from start instant
   #[inline]
   pub fn set_total_build_time(&self, start: Option<std::time::Instant>) {
-    if let (Some(collector), Some(start)) = (&self.hook_timing_collector, start) {
-      #[expect(clippy::cast_possible_truncation)]
-      collector.set_total_build_micros(start.elapsed().as_micros() as u64);
+    if let Some(start) = start {
+      self.build_timings.set_total(start.elapsed());
     }
   }
 
   /// Set link stage time from start instant
   #[inline]
   pub fn set_link_stage_time(&self, start: Option<std::time::Instant>) {
-    if let (Some(collector), Some(start)) = (&self.hook_timing_collector, start) {
-      #[expect(clippy::cast_possible_truncation)]
-      collector.set_link_stage_micros(start.elapsed().as_micros() as u64);
+    if let Some(start) = start {
+      self.build_timings.set_link_stage(start.elapsed());
     }
   }
 
@@ -168,7 +168,7 @@ impl PluginDriver {
     const MAX_ROWS: usize = 5;
     const ONE_SECOND_MICROS: u64 = 1_000_000;
     let collector = self.hook_timing_collector.as_ref()?;
-    if !collector.plugins_are_slow() {
+    if !self.build_timings.plugins_are_slow() {
       return None;
     }
     let mut summary = collector.get_summary();

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -15,7 +15,7 @@ use crate::{
   plugin_context::{NativePluginContextImpl, PluginContextMeta},
   plugin_driver::{ContextLoadCompletionManager, hook_orders::PluginHookOrders},
   type_aliases::{IndexPluginContext, IndexPluginable},
-  types::hook_timing::HookTimingCollector,
+  types::{build_timings::BuildTimings, hook_timing::HookTimingCollector},
 };
 use rolldown_error::EventKindSwitcher;
 
@@ -112,6 +112,7 @@ impl PluginDriverFactory {
         context_load_completion_manager: ContextLoadCompletionManager::default(),
         tx,
         hook_timing_collector: hook_timing_collector.clone(),
+        build_timings: BuildTimings::default(),
       }
     })
   }

--- a/crates/rolldown_plugin/src/types/build_timings.rs
+++ b/crates/rolldown_plugin/src/types/build_timings.rs
@@ -1,0 +1,102 @@
+use std::{
+  sync::atomic::{AtomicU64, Ordering},
+  time::Duration,
+};
+
+/// The two wall clocks that decide whether a build was plugin-bound.
+///
+/// Kept apart from [`crate::HookTimingCollector`], which measures what individual plugins
+/// cost: these are properties of the build itself, they are set once each rather than
+/// accumulated per call, and the question they answer — "is this worth reporting on at
+/// all?" — is asked before any per-plugin number is looked at.
+#[derive(Debug, Default)]
+pub struct BuildTimings {
+  total_micros: AtomicU64,
+  link_stage_micros: AtomicU64,
+}
+
+impl BuildTimings {
+  pub fn set_total(&self, elapsed: Duration) {
+    self.total_micros.store(Self::micros(elapsed), Ordering::Relaxed);
+  }
+
+  pub fn set_link_stage(&self, elapsed: Duration) {
+    self.link_stage_micros.store(Self::micros(elapsed), Ordering::Relaxed);
+  }
+
+  /// Zero until [`Self::set_total`] runs, which only the full `write`/`generate` paths do.
+  /// Watch, incremental and dev builds go straight to `bundle_write`/`bundle_generate`, so
+  /// they leave this at zero and nothing is reported for them.
+  pub fn total_micros(&self) -> u64 {
+    self.total_micros.load(Ordering::Relaxed)
+  }
+
+  pub fn link_stage_micros(&self) -> u64 {
+    self.link_stage_micros.load(Ordering::Relaxed)
+  }
+
+  /// Whether the build looks plugin-bound: over `MIN_BUILD_MICROS` long, with non-link time
+  /// more than `PLUGIN_TIME_OVER_LINK_TIME` times the link stage.
+  ///
+  /// This works because plugins run during the scan and generate stages, not the link
+  /// stage, which makes the link stage the one stretch of a build with no plugin in it. The
+  /// multiplier was settled by studying plugin impact on real-world projects, and the
+  /// minimum build time keeps fast builds quiet.
+  pub fn plugins_are_slow(&self) -> bool {
+    Self::is_plugin_bound(self.total_micros(), self.link_stage_micros())
+  }
+
+  /// The same test over totals supplied by the caller, so a build that produced several
+  /// outputs can sum its clocks before asking.
+  #[expect(clippy::cast_precision_loss)]
+  pub fn is_plugin_bound(total_micros: u64, link_stage_micros: u64) -> bool {
+    const MIN_BUILD_MICROS: u64 = 3_000_000;
+    const PLUGIN_TIME_OVER_LINK_TIME: f64 = 100.0;
+
+    if total_micros < MIN_BUILD_MICROS || link_stage_micros == 0 || link_stage_micros > total_micros
+    {
+      return false;
+    }
+    (total_micros - link_stage_micros) as f64 / link_stage_micros as f64
+      > PLUGIN_TIME_OVER_LINK_TIME
+  }
+
+  #[expect(clippy::cast_possible_truncation)]
+  fn micros(elapsed: Duration) -> u64 {
+    elapsed.as_micros() as u64
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn timings(total_micros: u64, link_micros: u64) -> BuildTimings {
+    let timings = BuildTimings::default();
+    timings.set_total(Duration::from_micros(total_micros));
+    timings.set_link_stage(Duration::from_micros(link_micros));
+    timings
+  }
+
+  #[test]
+  fn a_fast_build_is_never_slow() {
+    // However lopsided the ratio, two seconds of build is not worth interrupting anyone for.
+    assert!(!timings(2_000_000, 1).plugins_are_slow());
+  }
+
+  #[test]
+  fn a_build_whose_link_stage_is_not_dwarfed_is_not_plugin_bound() {
+    // 60s build, 1s link: non-link time is 59x link time, under the bar.
+    assert!(!timings(60_000_000, 1_000_000).plugins_are_slow());
+    assert!(timings(60_000_000, 500_000).plugins_are_slow());
+  }
+
+  #[test]
+  fn a_build_that_never_ran_is_not_slow() {
+    // Watch, incremental and dev builds never set the total, and a link stage cannot be
+    // zero-length in a build that happened — either way there is no ratio to take.
+    assert!(!BuildTimings::default().plugins_are_slow());
+    assert!(!timings(10_000_000, 0).plugins_are_slow());
+    assert!(!timings(1_000, 10_000).plugins_are_slow());
+  }
+}

--- a/crates/rolldown_plugin/src/types/hook_timing.rs
+++ b/crates/rolldown_plugin/src/types/hook_timing.rs
@@ -23,10 +23,6 @@ struct PluginTimingData {
 pub struct HookTimingCollector {
   /// Map from plugin_idx to timing data (only non-internal plugins are registered)
   plugins: DashMap<PluginIdx, PluginTimingData>,
-  /// Total build time in microseconds
-  total_build_micros: AtomicU64,
-  /// Link stage time in microseconds (pure Rust core, no plugins)
-  link_stage_micros: AtomicU64,
   /// Accumulated time (microseconds) for the `output.codeSplitting` / `advancedChunks`
   /// `groups[].name` chunk-name classifier — a user JS callback invoked directly from the
   /// Rust core (NOT a plugin hook), so it is invisible to per-plugin timing yet can
@@ -53,34 +49,6 @@ impl HookTimingCollector {
   /// `advancedChunks` `groups[].name` chunk-name classifier.
   pub fn record_code_splitting_name(&self, micros: u64) {
     self.code_splitting_name_micros.fetch_add(micros, Ordering::Relaxed);
-  }
-
-  /// Set total build time in microseconds
-  pub(crate) fn set_total_build_micros(&self, micros: u64) {
-    self.total_build_micros.store(micros, Ordering::Relaxed);
-  }
-
-  /// Set link stage time in microseconds
-  pub(crate) fn set_link_stage_micros(&self, micros: u64) {
-    self.link_stage_micros.store(micros, Ordering::Relaxed);
-  }
-
-  /// Check if plugins are taking too much time.
-  ///
-  /// Returns `true` if plugin time (total - link stage) is more than 100x the link stage time.
-  /// This works because plugins primarily run during the scan and generate stages, not the link stage.
-  /// This 100x threshold was determined by studying plugin impact on real-world projects.
-  ///
-  /// To avoid noisy warnings for fast builds, the warning only triggers when total build time exceeds 3 seconds.
-  #[expect(clippy::cast_precision_loss)]
-  pub(crate) fn plugins_are_slow(&self) -> bool {
-    const MIN_BUILD_TIME_MICROS: u64 = 3_000_000;
-    let total = self.total_build_micros.load(Ordering::Relaxed);
-    let link = self.link_stage_micros.load(Ordering::Relaxed);
-    if total == 0 || link == 0 || link > total || total < MIN_BUILD_TIME_MICROS {
-      return false;
-    }
-    (total - link) as f64 / link as f64 > 100.0
   }
 
   /// Get timing summary for all plugins

--- a/crates/rolldown_plugin/src/types/mod.rs
+++ b/crates/rolldown_plugin/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod build_timings;
 pub mod custom_field;
 pub mod hook_addon_args;
 pub mod hook_build_end_args;


### PR DESCRIPTION
First of four. Pure refactor — no behaviour change — to make the three PRs above it smaller.

## What

`HookTimingCollector` held two things that are not the same kind of thing:

- what each plugin's hooks cost, accumulated per call, keyed by `PluginIdx`;
- the build's total and link-stage wall clocks, set exactly once each.

The second pair also answers a different question. `plugins_are_slow` decides whether the build is worth reporting on *at all*, and it is asked before any per-plugin number is looked at — it does not read the plugin map.

So they split. `BuildTimings` owns the two clocks and the gate, and sits on `PluginDriver` beside the collector.

## Also

`is_plugin_bound(total, link)` exposes the same test over totals the caller supplies. Nothing needs that yet; #10521 does, because a build that produced several outputs has to sum its clocks before asking.

The gate now has unit tests — the fast-build floor, the ratio, and the cases where there is no ratio to take. It had none before.

## Not in scope

The threshold itself (3s, 100×) is unchanged, as is every caller. If this PR changes what any build reports, it is wrong.
