### PR TITLE
fix(plugin): report plugin timings after closeBundle has run

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -55,7 +55,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     }
     .await;
     self.plugin_driver.set_total_build_time(start);
-    self.append_plugin_timings_warning(result)
+    result
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
@@ -76,7 +76,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     }
     .await;
     self.plugin_driver.set_total_build_time(start);
-    self.append_plugin_timings_warning(result)
+    result
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
@@ -410,19 +410,6 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
         file: self.options.file.clone(),
       });
     }
-  }
-
-  /// Append plugin timings warning to result if applicable.
-  fn append_plugin_timings_warning(
-    &self,
-    result: BuildResult<BundleOutput>,
-  ) -> BuildResult<BundleOutput> {
-    result.map(|mut output| {
-      if let Some(plugins) = self.plugin_driver.get_plugin_timings_info() {
-        output.warnings.push(BuildDiagnostic::plugin_timings(plugins).with_severity_warning());
-      }
-      output
-    })
   }
 }
 

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -15,12 +15,17 @@ use crate::{
 use napi::{Env, bindgen_prelude::PromiseRaw};
 use napi_derive::napi;
 use rolldown::{BundleHandle, BundlerConfig};
+use rolldown_error::BuildDiagnostic;
+use rolldown_plugin::BuildTimings;
 use std::sync::Arc;
 
 #[napi]
 pub struct BindingBundler {
   inner: ClassicBundler,
-  last_bundle_handle: Option<BundleHandle>,
+  /// Every build this bundler has run, in order. A `RolldownBuild` may `generate` more
+  /// than once, so the plugin-timing report at close sums their clocks rather than reading
+  /// only the last.
+  bundle_handles: Vec<BundleHandle>,
 }
 
 #[napi]
@@ -28,7 +33,7 @@ impl BindingBundler {
   #[napi(constructor)]
   pub fn new() -> Self {
     let inner = ClassicBundler::new();
-    Self { inner, last_bundle_handle: None }
+    Self { inner, bundle_handles: Vec::new() }
   }
 
   #[napi]
@@ -45,7 +50,7 @@ impl BindingBundler {
     let maybe_bundle = self.inner.create_bundle(normalized.options, normalized.plugins);
     if let Ok(bundle) = &maybe_bundle {
       // Extract bundle handle before consuming the bundle
-      self.last_bundle_handle = Some(bundle.context());
+      self.bundle_handles.push(bundle.context());
     }
 
     let fut = async move {
@@ -94,7 +99,7 @@ impl BindingBundler {
     let maybe_bundle = self.inner.create_bundle(normalized.options, normalized.plugins);
     if let Ok(bundle) = &maybe_bundle {
       // Extract bundle handle before consuming the bundle
-      self.last_bundle_handle = Some(bundle.context());
+      self.bundle_handles.push(bundle.context());
     }
 
     let fut = async move {
@@ -142,7 +147,7 @@ impl BindingBundler {
     let maybe_bundle = self.inner.create_bundle(normalized.options, normalized.plugins);
     if let Ok(bundle) = &maybe_bundle {
       // Extract bundle handle before consuming the bundle
-      self.last_bundle_handle = Some(bundle.context());
+      self.bundle_handles.push(bundle.context());
     }
 
     let fut = async move {
@@ -179,9 +184,12 @@ impl BindingBundler {
   // - This also affects how the code is written in `Bundler::close()/inner.close()`, see the implementation there for more details.
   pub fn close<'env>(&mut self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
     let cleanup_fut = self.inner.close();
+    let handles = std::mem::take(&mut self.bundle_handles);
     spawn_boxed_future(env, async move {
       let res = cleanup_fut.await;
       handle_result(res)?;
+      // After the cleanup, so `closeBundle`'s cost is part of what gets reported.
+      handle_result(report_plugin_timings(&handles).await)?;
       Ok(())
     })
   }
@@ -194,11 +202,42 @@ impl BindingBundler {
   #[napi]
   pub fn get_watch_files(&self) -> Vec<String> {
     self
-      .last_bundle_handle
-      .as_ref()
+      .bundle_handles
+      .last()
       .map(|handle| handle.watch_files().iter().map(|s| s.to_string()).collect())
       .unwrap_or_default()
   }
+}
+
+/// Warn about slow plugins, once the build is closing.
+///
+/// Emitted here rather than from `Bundle::write`/`generate` because `closeBundle` runs
+/// inside `close()`: reporting before it means measuring that hook and then discarding the
+/// measurement. The clocks are summed across every output for the same reason the report is
+/// deferred — one `RolldownBuild` may `generate` more than once, and each output's plugin
+/// work counts.
+async fn report_plugin_timings(handles: &[BundleHandle]) -> anyhow::Result<()> {
+  let Some(last) = handles.last() else {
+    return Ok(());
+  };
+  let total_micros: u64 =
+    handles.iter().map(|handle| handle.plugin_driver().build_timings.total_micros()).sum();
+  let link_micros: u64 =
+    handles.iter().map(|handle| handle.plugin_driver().build_timings.link_stage_micros()).sum();
+  if !BuildTimings::is_plugin_bound(total_micros, link_micros) {
+    return Ok(());
+  }
+
+  let summaries =
+    handles.iter().flat_map(|handle| handle.plugin_driver().plugin_timing_summaries()).collect();
+  let Some(plugins) = rolldown_plugin::plugin_timings_info(summaries) else {
+    return Ok(());
+  };
+  handle_warnings(
+    vec![BuildDiagnostic::plugin_timings(plugins).with_severity_warning()],
+    last.options(),
+  )
+  .await
 }
 
 impl BindingBundler {

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::{
   types::hook_resolve_id_args::HookResolveIdArgs,
   types::hook_resolve_id_output::HookResolveIdOutput,
   types::hook_timing::HookTimingCollector,
+  types::hook_timing::plugin_timings_info,
   types::hook_transform_args::HookTransformArgs,
   types::hook_transform_ast_args::HookTransformAstArgs,
   types::hook_transform_output::{HookTransformOutput, HookTransformOutputMap},

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -27,7 +27,10 @@ use crate::{
   PluginContext,
   plugin_driver::hook_orders::PluginHookOrders,
   type_aliases::{IndexPluginContext, IndexPluginable},
-  types::{build_timings::BuildTimings, hook_timing::HookTimingCollector},
+  types::{
+    build_timings::BuildTimings,
+    hook_timing::{HookTimingCollector, PluginTimingSummary},
+  },
 };
 
 pub type SharedPluginDriver = Arc<PluginDriver>;
@@ -158,37 +161,17 @@ impl PluginDriver {
     }
   }
 
-  /// Get plugin timings summary if timing collection is enabled and plugins are taking significant time.
-  /// Returns a list of (name, percentage) pairs at or above average time (min 1 second).
-  /// Includes both plugin hooks and non-plugin output-option callbacks (e.g. the
-  /// `output.codeSplitting` `groups[].name` chunk classifier), so the report is not blind
-  /// to user callbacks invoked directly from the Rust core rather than via a plugin hook.
-  #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
-  pub fn get_plugin_timings_info(&self) -> Option<Vec<rolldown_error::PluginTimingInfo>> {
-    const MAX_ROWS: usize = 5;
-    const ONE_SECOND_MICROS: u64 = 1_000_000;
-    let collector = self.hook_timing_collector.as_ref()?;
-    if !self.build_timings.plugins_are_slow() {
-      return None;
-    }
-    let mut summary = collector.get_summary();
-    summary.extend(collector.get_output_callback_summary());
-    let total_micros: u64 = summary.iter().map(|s| s.total_duration_micros).sum();
-    if summary.is_empty() || total_micros == 0 {
-      return None;
-    }
-    summary.sort_by_key(|s| std::cmp::Reverse(s.total_duration_micros));
-    let threshold = (total_micros / summary.len() as u64).max(ONE_SECOND_MICROS);
-    let result = summary
-      .iter()
-      .filter(|s| s.total_duration_micros >= threshold)
-      .take(MAX_ROWS)
-      .map(|s| rolldown_error::PluginTimingInfo {
-        name: s.plugin_name.to_string(),
-        percent: (s.total_duration_micros as f64 / total_micros as f64 * 100.0).round() as u8,
-      })
-      .collect::<Vec<_>>();
-    if result.is_empty() { None } else { Some(result) }
+  /// What each plugin, and each core-invoked output callback, cost this build.
+  ///
+  /// Raw and unaggregated: a build may produce several outputs, each with its own driver,
+  /// and the report merges them — see `plugin_timings_info`.
+  pub fn plugin_timing_summaries(&self) -> Vec<PluginTimingSummary> {
+    let Some(collector) = self.hook_timing_collector.as_ref() else {
+      return Vec::new();
+    };
+    let mut summaries = collector.get_summary();
+    summaries.extend(collector.get_output_callback_summary());
+    summaries
   }
 }
 

--- a/crates/rolldown_plugin/src/types/hook_timing.rs
+++ b/crates/rolldown_plugin/src/types/hook_timing.rs
@@ -89,6 +89,45 @@ impl HookTimingCollector {
   }
 }
 
+/// Merge every output's summaries and pick the rows worth showing, or `None` when none are.
+///
+/// Whether the build was plugin-bound at all is asked before this, from
+/// [`crate::BuildTimings`] — these numbers only decide *what* to name once it has been.
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+pub fn plugin_timings_info(
+  summaries: Vec<PluginTimingSummary>,
+) -> Option<Vec<rolldown_error::PluginTimingInfo>> {
+  const MAX_ROWS: usize = 5;
+  const ONE_SECOND_MICROS: u64 = 1_000_000;
+
+  // Merged by name: one build may run several outputs, each with its own driver and so its
+  // own `PluginIdx`, and the same plugin's work across them is one cost to the user.
+  let mut merged: Vec<PluginTimingSummary> = Vec::new();
+  for summary in summaries {
+    match merged.iter_mut().find(|existing| existing.plugin_name == summary.plugin_name) {
+      Some(existing) => existing.total_duration_micros += summary.total_duration_micros,
+      None => merged.push(summary),
+    }
+  }
+
+  let total_micros: u64 = merged.iter().map(|s| s.total_duration_micros).sum();
+  if merged.is_empty() || total_micros == 0 {
+    return None;
+  }
+  merged.sort_by_key(|s| std::cmp::Reverse(s.total_duration_micros));
+  let threshold = (total_micros / merged.len() as u64).max(ONE_SECOND_MICROS);
+  let result = merged
+    .iter()
+    .filter(|s| s.total_duration_micros >= threshold)
+    .take(MAX_ROWS)
+    .map(|s| rolldown_error::PluginTimingInfo {
+      name: s.plugin_name.to_string(),
+      percent: (s.total_duration_micros as f64 / total_micros as f64 * 100.0).round() as u8,
+    })
+    .collect::<Vec<_>>();
+  if result.is_empty() { None } else { Some(result) }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -110,5 +149,31 @@ mod tests {
 
     collector.clear();
     assert!(collector.get_output_callback_summary().is_empty());
+  }
+
+  fn summary(name: &str, micros: u64) -> PluginTimingSummary {
+    PluginTimingSummary { plugin_name: ArcStr::from(name), total_duration_micros: micros }
+  }
+
+  #[test]
+  fn one_plugin_across_two_outputs_is_one_row() {
+    // Each output has its own driver, so the same plugin arrives twice. Left unmerged it
+    // would compete with itself for the row cap and halve its own share.
+    let rows = plugin_timings_info(vec![
+      summary("slow", 3_000_000),
+      summary("slow", 3_000_000),
+      summary("fast", 1_000_000),
+    ])
+    .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "slow");
+    assert_eq!(rows[0].percent, 86);
+  }
+
+  #[test]
+  fn nothing_worth_naming_is_no_report() {
+    assert!(plugin_timings_info(vec![]).is_none());
+    assert!(plugin_timings_info(vec![summary("quick", 10)]).is_none());
   }
 }


### PR DESCRIPTION
Second of four. Stacked on #10520.

## The bug

`closeBundle` is instrumented like every other hook — `output_hooks.rs` brackets the call and records it. But the warning is pushed into `output.warnings` from `Bundle::write` / `Bundle::generate`, and those return **before** `BundleHandle::close()` invokes the hook.

So its cost is measured and then thrown away. A plugin whose expense is concentrated in `closeBundle` can never appear in `[PLUGIN_TIMINGS]`, however slow it is.

## The fix

Emit from `BindingBundler::close` instead, after the cleanup future resolves. It still goes through the existing `handle_warnings`, so `checks.pluginTimings` filters it like any other check and the message renders through `Diagnostic::render_batch` as before.

## What deferring forces

One `RolldownBuild` may `generate` more than once. Until now each output emitted its own self-consistent report; a single report at close has to account for all of them. So `BindingBundler` keeps every `BundleHandle` rather than only the last, and:

- **the gate** sums the build and link clocks across all outputs — otherwise a slow first output followed by a fast one would fall under the 3s floor and be suppressed entirely;
- **the rows** merge the per-plugin summaries by name — each output has its own driver and so its own `PluginIdx`, so the same plugin arrives once per output and would otherwise compete with itself for the five-row cap and halve its own share.

## Verification

A plugin whose only cost is a slow `closeBundle`, alongside another that makes the build qualify:

```
[PLUGIN_TIMINGS] Your build spent significant time in plugin `slow-closebundle`.
```

Before this PR it is absent from the report entirely. Plus unit tests for the cross-output merge.
