### PR TITLE
docs(development-guide): update config.json link line reference

### DIFF
--- a/docs/development-guide/testing.md
+++ b/docs/development-guide/testing.md
@@ -41,7 +41,7 @@ We use Rust's built-in test framework for writing and running tests. Test cases 
 
 A data-driven test case is a folder that contains a `_config.json` file. The test runner will read the configuration from `_config.json`, bundle the input files, and execute the output files to verify the behavior.
 
-`_config.json` contains the configuration for the test suite. If everything works right, you should be able to have auto-completion while editing `_config.json` due to the [config](https://github.com/rolldown/rolldown/blob/main/.vscode/settings.json#L36-L40).
+`_config.json` contains the configuration for the test suite. If everything works right, you should be able to have auto-completion while editing `_config.json` due to the [config](https://github.com/rolldown/rolldown/blob/main/.vscode/settings.json#L40-L43).
 
 For all available options, you could refer to
 


### PR DESCRIPTION
Fixes an outdated line number reference, updating it from `L36-L40` to `L40-L43` so the link points to the correct VS Code settings section.