### PR TITLE
ci: scope the binding artifact download to `bindings-*`

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: packages/rolldown/artifacts
+          pattern: bindings-*
 
       - name: Create rolldown/npm dirs
         run: vp exec --filter rolldown napi create-npm-dirs

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: packages/rolldown/artifacts
+          pattern: bindings-*
 
       - name: Create rolldown/npm dirs
         run: vp exec --filter rolldown napi create-npm-dirs


### PR DESCRIPTION
Fixes the `Move Binding Artifacts` failure in [this Pkg Preview run](https://github.com/rolldown/rolldown/actions/runs/30447217864/job/90562545006), hit by the release PR #10524.

## Cause

`Download Binding Artifacts` specified neither `name` nor `pattern`, so `actions/download-artifact` pulled **every** artifact of the run into `packages/rolldown/artifacts/`. Both `bindings-wasm32-wasip1-threads` and `browser-artifact` ship a `rolldown-binding.wasm32-wasi.wasm`, since `@rolldown/browser` bundles the wasm into its own `dist`.

`napi artifacts` recurses the output directory and keys binaries by filename, ignoring which subdirectory they came from. Two copies of the same name means two entries under one identity:

```
Internal Error: Multiple artifacts found for binary artifact identities: rolldown-binding.wasm32-wasi.wasm:
  packages/rolldown/artifacts/bindings-wasm32-wasip1-threads/rolldown-binding.wasm32-wasi.wasm,
  packages/rolldown/artifacts/browser-artifact/rolldown-binding.wasm32-wasi.wasm.
```

The unfiltered download has always been wrong, but only became fatal when #10506 raised `@napi-rs/cli` to `^3.8.0`, which added a `rejectDuplicateArtifactIdentities` check. Earlier releases silently tolerated the collision.

#10506's own CI was green because `Node Validation` never touches the artifact merge path, so the regression surfaced only on the next release PR.

## Fix

Added `pattern: bindings-*` to the `Download Binding Artifacts` step in:

- `.github/workflows/publish-to-pkg.pr.new.yml`
- `.github/workflows/publish-to-npm.yml`

`pattern` rather than `name` because the bindings are 15 separate artifacts. The prefix mirrors the upload side (`reusable-release-build.yml`, `name: bindings-${{ matrix.target }}` plus the freebsd special case), so the naming stays defined in one place and follows the matrix automatically.

`merge-multiple` stays at its default of `false`, so each matched artifact keeps its own subdirectory. The layout `napi artifacts` sees for bindings is unchanged; the change only removes the four non-binding entries.

`publish-to-npm.yml` carried an identical copy of the step and would have failed the same way during a real release.

## Verification

Checked the pattern against the artifact list of the failing run:

- 15 matched, exactly the 15 targets in `packages/rolldown/package.json` `napi.targets`, so no binding is dropped.
- 4 excluded: `browser-artifact`, `debug-artifact`, `node-artifact`, `rolldown-version`.

Each excluded artifact is downloaded again later in the same job under an explicit `name`, into `packages/rolldown/dist`, `packages/browser/dist`, `packages/debug/dist`, and the workspace root. Nothing between the two downloads reads them from `artifacts/`, and the following step `check-wasi-binding-deps.mjs` reads `packages/rolldown/npm/wasm32-wasi/package.json`, not `artifacts/`.

An audit of all 14 `download-artifact` usages under `.github/workflows/` found these two were the only ones without a `name` or `pattern`.

Workflow changes cannot be exercised locally, so the real confirmation is rerunning the failed job on #10524 after this merges.

## Out of scope

#10506 also moved `@emnapi/core` and `@emnapi/runtime` from `1.11.2` to `2.0.0-alpha.3`, a prerelease major that is now on `main`. The generated napi glue changed with it: `emnapiAsyncWorkPlugin` and `emnapiTSFNPlugin` are now passed to `instantiateNapiModule`, and the context comes from `createContext` in `@emnapi/runtime` instead of `getDefaultContext`. This PR only unblocks the artifact merge. Whether the alpha is intended, and whether wasm runtime behaviour changed, is worth confirming separately.
