### PR TITLE
fix(browser): avoid using node builtin modules

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -32,7 +32,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "imports": {
-    "#default-runtime": "./dist/experimental-default-runtime.mjs"
+    "#default-runtime": "./dist/experimental-default-runtime.mjs",
+    "#runtime": "./dist/experimental-runtime.mjs"
   },
   "exports": {
     ".": {

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -56,6 +56,18 @@ const buildMeta = (function makeBuildMeta() {
 const bindingFile = nodePath.resolve('src/binding.cjs');
 const bindingFileWasi = nodePath.resolve('src/rolldown-binding.wasi.cjs');
 const bindingFileWasiBrowser = nodePath.resolve('src/rolldown-binding.wasi-browser.js');
+const commonRuntimeInputFile = nodePath.resolve(
+  __dirname,
+  '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js',
+);
+const runtimeBaseInputFile = nodePath.resolve(
+  __dirname,
+  '../../crates/rolldown/src/runtime/runtime-base.js',
+);
+const defaultRuntimeInputFile = nodePath.resolve(
+  __dirname,
+  '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js',
+);
 
 const configs: BuildOptions[] = [
   withShared({
@@ -149,6 +161,9 @@ function withShared({
       target: 'node22',
       define: {
         'import.meta.browserBuild': String(isBrowserBuild),
+        __RUNTIME_STRING__: isBrowserBuild
+          ? JSON.stringify(readDefaultDevRuntimeSource())
+          : 'undefined',
       },
     },
   };
@@ -237,23 +252,11 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
 // The default runtime loader removes this generated first line before injecting the source into a
 // bundle, where the same helpers are already in scope.
 function generateRuntimeEntry() {
-  const commonRuntimeInputFile = nodePath.resolve(
-    __dirname,
-    '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js',
-  );
-  const runtimeBaseInputFile = nodePath.resolve(
-    __dirname,
-    '../../crates/rolldown/src/runtime/runtime-base.js',
-  );
-  const defaultInputFile = nodePath.resolve(
-    __dirname,
-    '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js',
-  );
   const outputFile = nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime.d.ts');
 
   console.log(styleText('green', '[build:done]'), 'Generating dts from', commonRuntimeInputFile);
 
-  const commonRuntimeSource = fs.readFileSync(commonRuntimeInputFile, 'utf-8');
+  const { commonRuntimeSource, defaultRuntimeSource } = readDevRuntimeSources();
   const runtimeHelperImport =
     "import { __exportAll, __reExport, __toCommonJS, __toESM } from './experimental-runtime-base.mjs';\n";
   fs.writeFileSync(
@@ -264,9 +267,9 @@ function generateRuntimeEntry() {
     runtimeBaseInputFile,
     nodePath.resolve(buildMeta.buildOutputDir, 'experimental-runtime-base.mjs'),
   );
-  fs.copyFileSync(
-    defaultInputFile,
+  fs.writeFileSync(
     nodePath.resolve(buildMeta.buildOutputDir, 'experimental-default-runtime.mjs'),
+    defaultRuntimeSource,
   );
 
   const result = ts.transpileDeclaration(commonRuntimeSource, {
@@ -287,6 +290,18 @@ function generateRuntimeEntry() {
   } else {
     throw new Error('Failed to generate d.ts from runtime-extra-dev.js');
   }
+}
+
+function readDevRuntimeSources() {
+  return {
+    commonRuntimeSource: fs.readFileSync(commonRuntimeInputFile, 'utf-8'),
+    defaultRuntimeSource: fs.readFileSync(defaultRuntimeInputFile, 'utf-8'),
+  };
+}
+
+function readDefaultDevRuntimeSource() {
+  const { commonRuntimeSource, defaultRuntimeSource } = readDevRuntimeSources();
+  return `${commonRuntimeSource}\n${defaultRuntimeSource}`;
 }
 
 function getTsconfigCompilerOptionsForFile(file: string) {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -34,6 +34,7 @@
   "types": "./dist/index.d.mts",
   "imports": {
     "#default-runtime": "./dist/experimental-default-runtime.mjs",
+    "#runtime": "./dist/experimental-runtime.mjs",
     "#parallel-plugin-worker": "./dist/parallel-plugin-worker.mjs"
   },
   "exports": {

--- a/packages/rolldown/src/utils/default-dev-runtime.ts
+++ b/packages/rolldown/src/utils/default-dev-runtime.ts
@@ -1,14 +1,18 @@
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+// defined in the build step
+declare const __RUNTIME_STRING__: string | undefined;
+
 // The public entry's generated first line imports helpers for standalone ESM use. Remove it before
 // appending the source to Rolldown's internal runtime module, where those helpers are already in
 // scope.
 export function getDefaultDevRuntime(host = 'localhost', port = 3000): string {
-  const runtimeEntry = fs.readFileSync(
-    fileURLToPath(import.meta.resolve('rolldown/experimental/runtime')),
-    'utf8',
-  );
+  if (typeof __RUNTIME_STRING__ !== 'undefined') {
+    return __RUNTIME_STRING__.replaceAll('$ADDR', `${host}:${port}`);
+  }
+
+  const runtimeEntry = fs.readFileSync(fileURLToPath(import.meta.resolve('#runtime')), 'utf8');
   const runtimeHelperImportEnd = runtimeEntry.indexOf('\n');
   if (!runtimeEntry.startsWith('import ') || runtimeHelperImportEnd === -1) {
     throw new Error('Expected the standalone runtime to start with a helper import');

--- a/packages/rolldown/tests/exports-consistency.test.ts
+++ b/packages/rolldown/tests/exports-consistency.test.ts
@@ -16,4 +16,13 @@ describe('package.json exports consistency', () => {
 
     expect(exportsKeys).toStrictEqual(publishExportsKeys);
   });
+
+  test('browser package.json imports keys match normal package imports keys except parallel plugin worker', () => {
+    const importsKeys = Object.keys(pkg.imports)
+      .filter((key) => key !== '#parallel-plugin-worker')
+      .sort();
+    const browserImportsKeys = Object.keys(browserPkg.imports).sort();
+
+    expect(browserImportsKeys).toStrictEqual(importsKeys);
+  });
 });


### PR DESCRIPTION
Avoid using node builtin modules in browser builds.

fixes https://github.com/rolldown/rolldown/issues/10535

refs #10338

