### PR TITLE
test(dev): match Vite's renamed full-reload log

### DIFF
--- a/packages/test-dev-server/tests/playground/hmr-accept-outside-circular/__tests__/hmr-accept-outside-circular.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-accept-outside-circular/__tests__/hmr-accept-outside-circular.spec.ts
@@ -37,7 +37,7 @@ describe('hmr-accept-outside-circular', () => {
     // (`main` self-accepts, so a plain no-boundary reason would be a bug).
     await untilBrowserLogAfter(
       () => editFile('c.js', (code) => code.replace("export const c = 'c'", "export const c = 'cc'")),
-      /full reload: circular import chain between `[^`]*b\.js` and `[^`]*c\.js`/,
+      /full reload needed: circular import chain between `[^`]*b\.js` and `[^`]*c\.js`/,
     );
     await expect.poll(() => page.textContent('.chain')).toBe('cc');
 


### PR DESCRIPTION
`hmr-accept-outside-circular` fails on main on every platform (ubuntu 20/22/24, macos, windows) and therefore on every open PR. No rolldown commit is involved.

The dev-server suite runs against an unpinned Vite checkout: `scripts/src/setup-vite/checkout.ts` clones `rolldown-canary` and rebases it onto the latest `origin/main` on every run, so upstream lands here the moment it merges. Between the last green run (vite `35a9946f6`) and the first red one (vite `01ccd3240`), [vitejs/vite#23106](https://github.com/vitejs/vite/pull/23106) went in.

That PR routes every reload decision through `requestFullReload`, which reports to the server instead of navigating so the rebuild finishes before the page moves. It renamed the log line along the way:

```diff
-    this.logger.debug(`full reload: ${reason}`)
+    this.logger.debug(`full reload needed: ${reason}`)
```

The spec waits on that line to check the reload is attributed to the circle and not to a missing boundary (`main` self-accepts, so a plain no-boundary reason would be a bug). Its regex anchors `full reload:` directly against `circular`, so the inserted word breaks the match and `untilBrowserLogAfter` times out.