### PR TITLE
feat(rolldown_plugin_vite_import_glob): watch the directories each glob reads

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -47,6 +47,7 @@ impl Plugin for ViteImportGlobPlugin {
         import_decls: Vec::new(),
         errors: Vec::new(),
         restore_query_extension: self.restore_query_extension,
+        is_dev_mode: ctx.options().is_dev_mode_enabled(),
       };
       visitor.visit_program(&parser_ret.program);
       if let Some(err) = visitor.errors.into_iter().next() {

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -27,6 +27,7 @@ pub struct GlobImportVisit<'a> {
   pub magic_string: Option<MagicString<'a>>,
   pub import_decls: Vec<String>,
   pub errors: Vec<anyhow::Error>,
+  pub is_dev_mode: bool,
 }
 
 impl<'ast> VisitJs<'ast> for GlobImportVisit<'_> {
@@ -475,7 +476,19 @@ impl GlobImportVisit<'_> {
     }
 
     let common = self.get_common_base(&positive_globs);
-    let entries = walkdir::WalkDir::new(common.as_ref())
+    let common_path = Path::new(common.as_ref());
+
+    // `walkdir` yields nothing for a directory that does not exist, so the walk below cannot
+    // register anything. Watching the nearest existing ancestor makes its creation observable.
+    if self.is_dev_mode
+      && !common_path.is_dir()
+      && let Some(ancestor) =
+        common_path.ancestors().skip(1).find(|dir| dir.is_dir()).and_then(Path::to_str)
+    {
+      self.ctx.add_watch_file(ancestor);
+    }
+
+    let entries = walkdir::WalkDir::new(common_path)
       .follow_links(true)
       .sort_by(|a, b| a.file_name().cmp(b.file_name()))
       .into_iter()
@@ -488,11 +501,18 @@ impl GlobImportVisit<'_> {
           path.to_str().is_none_or(|s| s != "node_modules")
         }
       })
-      .filter_map(Result::ok)
-      .filter(|e| !e.file_type().is_dir());
+      .filter_map(Result::ok);
 
     for entry in entries {
       let file = entry.path();
+
+      if entry.file_type().is_dir() {
+        if self.is_dev_mode {
+          self.ctx.add_watch_file(&file.to_slash_lossy());
+        }
+        continue;
+      }
+
       let path = file.to_slash_lossy();
 
       // Skip the file itself if it matches the glob pattern, to avoid self-importing.


### PR DESCRIPTION
Part of rolldown/rolldown#10059

`import.meta.glob` is expanded at transform time by walking the filesystem, so its result is a snapshot. Keeping it fresh in dev means noticing when a matching file appears or disappears, and right now nothing does.

The dev engine only watches files it already knows about, so a file that is not in the module graph yet produces no event at all. Vite's own watcher would normally cover that, but under bundled dev it stops driving HMR and leaves file events to rolldown.

This PR makes those events reachable. Acting on them is #10550.