### PR TITLE
feat(rolldown_plugin_vite_import_glob): follow file creation and deletion via hotUpdate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "itoa",
  "oxc",
  "path-posix",
+ "rolldown_common",
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,7 @@ dependencies = [
  "itoa",
  "oxc",
  "path-posix",
+ "rolldown_common",
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -24,6 +24,7 @@ fast-glob = { workspace = true }
 itoa = { workspace = true }
 oxc = { workspace = true }
 path-posix = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -1,11 +1,18 @@
 mod matcher;
 mod utils;
 
-use std::{borrow::Cow, path::PathBuf};
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
 
 use arcstr::ArcStr;
 use oxc::ast_visit::VisitJs;
-use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
+use rolldown_common::WatcherChangeKind;
+use rolldown_plugin::{
+  HookHotUpdateArgs, HookHotUpdateReturn, HookTransformOutput, HookTransformOutputMap, HookUsage,
+  Plugin, PluginContext,
+};
 use rolldown_plugin_utils::parse_program;
 use rolldown_utils::dashmap::FxDashMap;
 use sugar_path::SugarPath as _;
@@ -26,7 +33,7 @@ impl Plugin for ViteImportGlobPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::Transform
+    HookUsage::Transform | HookUsage::HotUpdate
   }
 
   async fn transform(
@@ -83,5 +90,51 @@ impl Plugin for ViteImportGlobPlugin {
       }));
     }
     Ok(None)
+  }
+
+  async fn hot_update(
+    &self,
+    _ctx: &PluginContext,
+    args: &HookHotUpdateArgs,
+  ) -> HookHotUpdateReturn {
+    // A content edit cannot change which files a glob matches, so `update` is declined
+    if matches!(args.kind, WatcherChangeKind::Update) || self.glob_matchers.is_empty() {
+      return Ok(None);
+    }
+
+    let mut selected = Vec::new();
+    let is_dir = Path::new(args.file.as_str()).is_dir();
+    for entry in &self.glob_matchers {
+      let id = entry.key();
+
+      // The walk excludes the glob's own module to keep it from importing itself
+      if id.as_str() == args.file.as_str() {
+        continue;
+      }
+
+      let matchers = entry.value();
+      let touched = matchers
+        .iter()
+        .any(|matcher| matcher.matches(&args.file) || matcher.touches_base(&args.file))
+        || (is_dir && matchers.iter().any(|matcher| matcher.may_gain_matches_below(&args.file)));
+
+      if touched {
+        selected.push(id.clone());
+      }
+    }
+
+    if selected.is_empty() {
+      return Ok(None);
+    }
+
+    // Appending rather than replacing, like vite's `[...oldModules, ...modules]`
+    let mut modules = Vec::with_capacity(args.modules.len() + selected.len());
+    modules.extend_from_slice(&args.modules);
+    for id in selected {
+      if !modules.contains(&id) {
+        modules.push(id);
+      }
+    }
+    Ok(Some(modules))
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -1,11 +1,18 @@
 mod matcher;
 mod utils;
 
-use std::{borrow::Cow, path::PathBuf};
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
 
 use arcstr::ArcStr;
 use oxc::ast_visit::VisitJs;
-use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
+use rolldown_common::WatcherChangeKind;
+use rolldown_plugin::{
+  HookHotUpdateArgs, HookHotUpdateReturn, HookTransformOutput, HookTransformOutputMap, HookUsage,
+  Plugin, PluginContext,
+};
 use rolldown_plugin_utils::parse_program;
 use rolldown_utils::dashmap::FxDashMap;
 use sugar_path::SugarPath as _;
@@ -26,7 +33,7 @@ impl Plugin for ViteImportGlobPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::Transform
+    HookUsage::Transform | HookUsage::HotUpdate
   }
 
   async fn transform(
@@ -83,5 +90,52 @@ impl Plugin for ViteImportGlobPlugin {
       }));
     }
     Ok(None)
+  }
+
+  async fn hot_update(
+    &self,
+    _ctx: &PluginContext,
+    args: &HookHotUpdateArgs,
+  ) -> HookHotUpdateReturn {
+    // A content edit cannot change which files a glob matches, so `update` is declined
+    if matches!(args.kind, WatcherChangeKind::Update) || self.glob_matchers.is_empty() {
+      return Ok(None);
+    }
+
+    let mut selected = Vec::new();
+    // A directory that just appeared matches no pattern, yet the files already inside it are
+    // unreachable until some module re-walks. Stat'd lazily, so an ordinary file event never pays.
+    let mut is_dir = None;
+    for entry in &self.glob_matchers {
+      let id = entry.key();
+      // The walk excludes the glob's own module to keep it from importing itself.
+      if id.as_str() == args.file.as_str() {
+        continue;
+      }
+      let matchers = entry.value();
+      let touched = matchers
+        .iter()
+        .any(|matcher| matcher.matches(&args.file) || matcher.touches_base(&args.file))
+        || (*is_dir.get_or_insert_with(|| Path::new(args.file.as_str()).is_dir())
+          && matchers.iter().any(|matcher| matcher.may_gain_matches_below(&args.file)));
+      if touched {
+        selected.push(id.clone());
+      }
+    }
+
+    if selected.is_empty() {
+      return Ok(None);
+    }
+
+    // Appending rather than replacing, like vite's `[...oldModules, ...modules]`: a file can be both
+    // a glob match and a module of its own, and it still has to ship itself.
+    let mut modules = Vec::with_capacity(args.modules.len() + selected.len());
+    modules.extend_from_slice(&args.modules);
+    for id in selected {
+      if !modules.contains(&id) {
+        modules.push(id);
+      }
+    }
+    Ok(Some(modules))
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use sugar_path::SugarPath as _;
 
 use crate::ViteImportGlobPlugin;
@@ -29,4 +31,67 @@ pub struct GlobMatcher {
   pub negated: Vec<(String, String)>,
   pub exhaustive: bool,
   pub case_sensitive: bool,
+}
+
+impl GlobMatcher {
+  /// `file` is a slash-normalized absolute path.
+  pub fn matches(&self, file: &str) -> bool {
+    let Some(relative) = strip_dir_prefix(file, &self.walk_root) else {
+      return false;
+    };
+
+    // Only the segments below the root: the walk's `filter_entry` exempts the root itself.
+    if !self.exhaustive && relative.split('/').any(is_pruned_segment) {
+      return false;
+    }
+
+    let file = self.fold(file);
+    let matches_rule = |(prefix, glob): &(String, String)| {
+      let prefix = self.fold(prefix);
+      let glob = self.fold(glob);
+      (*file).strip_prefix(&*prefix).is_some_and(|rest| fast_glob::glob_match(&*glob, rest))
+    };
+    !self.negated.iter().any(matches_rule) && self.positive.iter().any(matches_rule)
+  }
+
+  /// Whether `path` is a static glob prefix or an ancestor of one, the only signal available
+  /// while the prefix itself does not exist.
+  pub fn touches_base(&self, path: &str) -> bool {
+    self.positive.iter().any(|(prefix, _)| {
+      prefix.strip_prefix(path).is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+    })
+  }
+
+  /// Whether a file inside the directory `dir` could join the result set. The caller ensures
+  /// `dir` really is a directory.
+  pub fn may_gain_matches_below(&self, dir: &str) -> bool {
+    let Some(relative) = strip_dir_prefix(dir, &self.walk_root) else {
+      return false;
+    };
+    if !self.exhaustive && relative.split('/').any(is_pruned_segment) {
+      return false;
+    }
+    // `strip_dir_prefix` rejects `dir == prefix`, which is `touches_base`'s business instead.
+    // A pattern reaches below `dir` only past a second separator: the first one is its anchor.
+    self.positive.iter().any(|(prefix, glob)| {
+      (glob.trim_start_matches('/').contains('/') || glob.contains("**"))
+        && strip_dir_prefix(dir, prefix).is_some()
+    })
+  }
+
+  /// `fast_glob` has no case-insensitive flag, so folding lowercases both sides, same as the walk.
+  fn fold<'a>(&self, path: &'a str) -> Cow<'a, str> {
+    if self.case_sensitive { Cow::Borrowed(path) } else { Cow::Owned(path.to_lowercase()) }
+  }
+}
+
+/// Compares on separator boundaries, so `/a/bc.js` is not read as living inside `/a/b`.
+fn strip_dir_prefix<'a>(file: &'a str, dir: &str) -> Option<&'a str> {
+  let rest = file.strip_prefix(dir)?;
+  // Only a filesystem root (`/`, `C:/`) keeps a trailing separator.
+  if dir.ends_with('/') { Some(rest) } else { rest.strip_prefix('/') }
+}
+
+fn is_pruned_segment(segment: &str) -> bool {
+  segment.starts_with('.') || segment == "node_modules"
 }


### PR DESCRIPTION
Part of rolldown/rolldown#10059

Vite's JS plugin keeps a glob's result set fresh from a `hotUpdate` hook. Under bundled dev that hook is gone, because the native plugin takes over for the bundled environment and only ever implemented the transform half.

#10549 made file events under glob directories reachable. This PR is the missing half: deciding which modules a given event invalidates, so the glob is re-expanded and nothing else is.
