### PR TITLE
test(dev-server): cover import.meta.glob file creation and deletion

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -113,6 +113,15 @@
         "__tests__/*.spec.ts",
       ], // Playwright test with dev config and source files; main.js is a default entry
     },
+    "packages/test-dev-server/tests/playground/hmr-import-glob": {
+      "entry": [
+        "dev.config.mjs",
+        "*.js",
+        "pages/*.js", // glob targets, reached only through `import.meta.glob`, never a static import
+        "nested/**/*.js",
+        "__tests__/*.spec.ts",
+      ],
+    },
     "packages/test-dev-server/tests/playground/initial-build-error": {
       "entry": [
         "dev.config.mjs",

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/__tests__/hmr-import-glob.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/__tests__/hmr-import-glob.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'vitest';
+import {
+  addFile,
+  page,
+  plantReloadMarker,
+  readReloadMarker,
+  removeFile,
+  waitForBuildStable,
+} from '~utils';
+
+// End-to-end check that `import.meta.glob` follows files appearing and disappearing
+// (rolldown#10059). The dev engine only ever watches individual files, so this can only work if the
+// native glob plugin puts the directories it walked into the watch set and then claims the owning
+// module from `hotUpdate`. Under bundled dev, vite's chokidar does not drive HMR at all
+// (`hmr.ts`'s `if (config.experimental.bundledDev) return`), so nothing else can cover for it.
+
+const text = (selector: string) => page.textContent(selector);
+const readRuns = () =>
+  page.evaluate(() => (window as unknown as { __globRuns?: number }).__globRuns ?? -1);
+
+describe('hmr-import-glob', () => {
+  test('renders the initial glob results', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => text('.pages')).toBe('./pages/a.js,./pages/b.js');
+    await expect.poll(() => text('.titles')).toBe('a,b');
+    await expect.poll(() => text('.nested')).toBe('./nested/deep/x.js');
+    // `later/` does not exist yet.
+    await expect.poll(() => text('.later')).toBe('');
+  });
+
+  test('a new matching file joins an eager glob', async () => {
+    await waitForBuildStable();
+
+    addFile('pages/c.js', "export const title = 'c';\n");
+    await expect.poll(() => text('.pages')).toBe('./pages/a.js,./pages/b.js,./pages/c.js');
+    // The glob is eager, so the new module was really imported and executed, not just listed.
+    await expect.poll(() => text('.titles')).toBe('a,b,c');
+    await waitForBuildStable();
+  });
+
+  test('deleting a matching file drops it from the glob', async () => {
+    await waitForBuildStable();
+
+    removeFile('pages/c.js');
+    await expect.poll(() => text('.pages')).toBe('./pages/a.js,./pages/b.js');
+    await expect.poll(() => text('.titles')).toBe('a,b');
+    await waitForBuildStable();
+  });
+
+  test('a non-matching file in a watched directory produces no update', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+    const before = await readRuns();
+
+    // `pages/` is watched, so this event does reach the engine, but no glob matches `.txt`. Watching
+    // directories must not turn every stray file into a rebuild the client can see.
+    addFile('pages/notes.txt', 'not a module\n');
+    await waitForBuildStable();
+
+    expect(await readRuns()).toBe(before);
+    expect(await readReloadMarker()).toBe('alive');
+  });
+
+  test('a match in a brand-new nested directory joins a `**` glob', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+
+    // `nested/fresh/` does not exist yet, so nothing inside it can be watched. Only its own creation
+    // is delivered, through the watch on `nested/`, and the round that follows re-walks the subtree
+    // and picks up `y.js`, which is on disk by then.
+    addFile('nested/fresh/y.js', "export const value = 'y';\n");
+    await expect.poll(() => text('.nested')).toBe('./nested/deep/x.js,./nested/fresh/y.js');
+
+    expect(await readReloadMarker()).toBe('alive');
+    await waitForBuildStable();
+  });
+
+  test('a match under a directory missing at boot joins the glob', async () => {
+    await waitForBuildStable();
+
+    // Nothing under `later/` could be watched while `later/` itself did not exist, so the plugin
+    // watched the nearest existing ancestor instead. `mkdir later` is the only event available, and
+    // the hook has to claim the module for it.
+    addFile('later/z.js', "export const title = 'z';\n");
+    await expect.poll(() => text('.later'), { timeout: 20_000 }).toBe('./later/z.js');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/dev.config.mjs
@@ -1,0 +1,19 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+// No plugin configuration on purpose: on the browser platform Vite installs the native
+// `builtin:vite-import-glob` plugin for the bundled environment itself (`importGlobPlugin`'s
+// `applyToEnvironment` in vite's `plugins/importMetaGlob.ts`), so this playground exercises the real
+// Vite -> rolldown path instead of a hand-wired one.
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.js',
+    },
+    platform: 'browser',
+    treeshake: false,
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/index.html
@@ -1,0 +1,9 @@
+<h1>HMR import.meta.glob</h1>
+
+<div class="pages"></div>
+<div class="titles"></div>
+<div class="nested"></div>
+<div class="later"></div>
+<div class="runs"></div>
+
+<script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/main.js
@@ -1,0 +1,25 @@
+// Three globs, each covering a different part of the feature:
+// - `pages` is eager, so a new match has to reach the module graph and execute, not just show up as
+//   a key.
+// - `nested` is lazy over a `**` pattern, where a match can appear in a directory that did not exist
+//   when the glob was first walked.
+// - `later` points at a directory that does not exist at boot, so nothing under it can be watched
+//   until the directory itself shows up.
+const pages = import.meta.glob('./pages/*.js', { eager: true });
+const nested = import.meta.glob('./nested/**/*.js');
+const later = import.meta.glob('./later/*.js');
+
+window.__globRuns = (window.__globRuns ?? 0) + 1;
+
+const keys = (modules) => Object.keys(modules).sort().join(',');
+
+document.querySelector('.pages').textContent = keys(pages);
+document.querySelector('.titles').textContent = Object.keys(pages)
+  .sort()
+  .map((key) => pages[key].title)
+  .join(',');
+document.querySelector('.nested').textContent = keys(nested);
+document.querySelector('.later').textContent = keys(later);
+document.querySelector('.runs').textContent = `runs:${window.__globRuns}`;
+
+import.meta.hot.accept();

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/nested/deep/x.js
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/nested/deep/x.js
@@ -1,0 +1,1 @@
+export const value = 'x';

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-import-glob",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/pages/a.js
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/pages/a.js
@@ -1,0 +1,1 @@
+export const title = 'a';

--- a/packages/test-dev-server/tests/playground/hmr-import-glob/pages/b.js
+++ b/packages/test-dev-server/tests/playground/hmr-import-glob/pages/b.js
@@ -1,0 +1,1 @@
+export const title = 'b';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-import-glob:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-invalidate-circular:
     devDependencies:
       '@rolldown/test-dev-server':


### PR DESCRIPTION
Part of rolldown/rolldown#10059

#10549 and #10550 make a glob follow files appearing and disappearing. Nothing covered that end to end.

The playground configures no plugin of its own, because Vite installs the native one for the bundled environment. That way the test goes through the real Vite path. A hand-wired config would not, and the whole feature only exists because Vite's watcher stops driving HMR there.