### PR TITLE
perf(plugin): clock the build only when it is being measured

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -43,7 +43,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
   #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn write(mut self) -> BuildResult<BundleOutput> {
-    let start = std::time::Instant::now();
+    let start = self.plugin_driver.build_timings.start();
     let result = async {
       self.trace_action_session_meta();
       trace_action!(action::BuildStart { action: "BuildStart" });
@@ -54,14 +54,14 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
       ret
     }
     .await;
-    self.plugin_driver.build_timings.set_total(start.elapsed());
+    self.plugin_driver.build_timings.record_total(start);
     result
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.bundle_span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn generate(mut self) -> BuildResult<BundleOutput> {
-    let start = std::time::Instant::now();
+    let start = self.plugin_driver.build_timings.start();
     let result = async {
       self.trace_action_session_meta();
       trace_action!(action::BuildStart { action: "BuildStart" });
@@ -75,7 +75,7 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
       ret
     }
     .await;
-    self.plugin_driver.build_timings.set_total(start.elapsed());
+    self.plugin_driver.build_timings.record_total(start);
     result
   }
 
@@ -278,10 +278,10 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
   ) -> BuildResult<BundleOutput> {
     // The one stretch of a build with no plugin in it, which is what makes it a usable
     // baseline for "was this build plugin-bound?" — see `BuildTimings`.
-    let link_start = std::time::Instant::now();
+    let link_start = self.plugin_driver.build_timings.start();
     let (mut link_stage_output, ast_table, used_symbol_refs) =
       LinkStage::new(scan_stage_output, &self.options).link();
-    self.plugin_driver.build_timings.set_link_stage(link_start.elapsed());
+    self.plugin_driver.build_timings.record_link_stage(link_start);
 
     let bundle_output =
       GenerateStage::new(&mut link_stage_output, ast_table, &self.options, &self.plugin_driver)

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -98,7 +98,9 @@ impl PluginDriverFactory {
         transform_dependencies,
         context_load_completion_manager: ContextLoadCompletionManager::default(),
         tx,
-        build_timings: BuildTimings::default(),
+        // The JavaScript side registers this callback only when it is measuring, so its
+        // presence is what says a report is coming and the clocks are worth keeping.
+        build_timings: BuildTimings::new(options.plugin_timings.is_some()),
       }
     })
   }

--- a/crates/rolldown_plugin/src/types/build_timings.rs
+++ b/crates/rolldown_plugin/src/types/build_timings.rs
@@ -1,6 +1,6 @@
 use std::{
   sync::atomic::{AtomicU64, Ordering},
-  time::Duration,
+  time::{Duration, Instant},
 };
 
 /// The two wall clocks that decide whether a build was plugin-bound.
@@ -12,24 +12,55 @@ use std::{
 /// with no plugin in it. Non-link time running far ahead of link time is what says the
 /// build is plugin-bound, so these are handed across the binding for the JavaScript side
 /// to gate its report on.
+///
+/// A build nobody is measuring keeps no clock at all: [`Self::start`] hands back `None`,
+/// and every recorder is a no-op on it. Whether it is measured is decided once, where the
+/// driver is built, from the same `checks.pluginTimings` that turns the JavaScript side's
+/// measurement on — the two have to agree, because a report needs both halves.
 #[derive(Debug, Default)]
 pub struct BuildTimings {
+  measured: bool,
   total_micros: AtomicU64,
   link_stage_micros: AtomicU64,
 }
 
 impl BuildTimings {
-  pub fn set_total(&self, elapsed: Duration) {
+  pub fn new(measured: bool) -> Self {
+    Self { measured, ..Self::default() }
+  }
+
+  /// The instant to measure a stretch of the build from, or `None` when it is not being
+  /// measured — then nothing downstream reads the clock, so there is no reason to take one.
+  ///
+  /// Pass what this returns to [`Self::record_total`] or [`Self::record_link_stage`].
+  pub fn start(&self) -> Option<Instant> {
+    self.measured.then(Instant::now)
+  }
+
+  pub fn record_total(&self, start: Option<Instant>) {
+    if let Some(start) = start {
+      self.set_total(start.elapsed());
+    }
+  }
+
+  pub fn record_link_stage(&self, start: Option<Instant>) {
+    if let Some(start) = start {
+      self.set_link_stage(start.elapsed());
+    }
+  }
+
+  fn set_total(&self, elapsed: Duration) {
     self.total_micros.store(Self::micros(elapsed), Ordering::Relaxed);
   }
 
-  pub fn set_link_stage(&self, elapsed: Duration) {
+  fn set_link_stage(&self, elapsed: Duration) {
     self.link_stage_micros.store(Self::micros(elapsed), Ordering::Relaxed);
   }
 
-  /// Zero until [`Self::set_total`] runs, which only the full `write`/`generate` paths do.
-  /// Watch, incremental and dev builds go straight to `bundle_write`/`bundle_generate`, so
-  /// they leave this at zero and nothing is reported for them.
+  /// Zero until [`Self::record_total`] runs, which only the full `write`/`generate` paths
+  /// do, and only when the build is being measured. Watch, incremental and dev builds go
+  /// straight to `bundle_write`/`bundle_generate`, so they leave this at zero and nothing
+  /// is reported for them.
   pub fn total_micros(&self) -> u64 {
     self.total_micros.load(Ordering::Relaxed)
   }
@@ -104,5 +135,22 @@ mod tests {
     assert!(!BuildTimings::default().plugins_are_slow());
     assert!(!timings(10_000_000, 0).plugins_are_slow());
     assert!(!timings(1_000, 10_000).plugins_are_slow());
+  }
+
+  #[test]
+  fn a_build_that_is_not_measured_keeps_no_clock() {
+    // Nobody will ask what it cost, so there is nothing to take: `start` hands back no
+    // instant, and the recorders it feeds have nothing to store.
+    let timings = BuildTimings::new(false);
+    assert!(timings.start().is_none());
+    timings.record_total(timings.start());
+    timings.record_link_stage(timings.start());
+    assert_eq!(timings.total_micros(), 0);
+    assert_eq!(timings.link_stage_micros(), 0);
+  }
+
+  #[test]
+  fn a_measured_build_starts_a_clock() {
+    assert!(BuildTimings::new(true).start().is_some());
   }
 }


### PR DESCRIPTION
Sits on #10509.

## What

`BuildTimings` took an `Instant` on every build, whether or not anyone would read it.

Before #10520 the two clocks lived on the hook timing collector, which only existed when timing was on — so the `Option<Instant>` it handed back *was* the gate. Giving the clocks their own type dropped that, and `bundle.rs` went to a bare `std::time::Instant::now()` in three places.

The gate goes back, this time owned by the type that needs it:

- `BuildTimings::new(measured)` — decided once, where the driver is built.
- `start()` returns `Option<Instant>`: `None` when the build is not being measured.
- `record_total` / `record_link_stage` take what `start()` gave and do nothing with `None`.

The call sites read as they did before the split.

## What decides it

`options.plugin_timings`. The JavaScript side registers that callback only when `measureTimings && checks.pluginTimings !== false`, so its presence is already how this side knows a report is coming. The two halves cannot disagree about whether a build is measured, because a report needs both of them.

## Tests

Two added: a build that is not measured hands back no instant and stores nothing; a measured one does start a clock. The existing gate tests are unchanged.

## Not in scope

The threshold and the ratio, and what any measured build reports. If this PR changes what a build with `checks.pluginTimings` on reports, it is wrong.
