### PR TITLE
test(dev): fix hmr-hot-update-hook-vite fixture on Windows

### DIFF
--- a/packages/test-dev-server/src/index.ts
+++ b/packages/test-dev-server/src/index.ts
@@ -6,4 +6,5 @@ export type { DevServerHandle } from './dev-server.js';
 export type { Logger } from './types/logger.js';
 export type { DevConfig } from './utils/define-dev-config.js';
 export { getDevWatchOptionsForCi } from './utils/get-dev-watch-options-for-ci.js';
+export { slash } from './utils/slash.js';
 export { createDevServer, defineDevConfig, loadDevConfig, serve };

--- a/packages/test-dev-server/src/utils/slash.ts
+++ b/packages/test-dev-server/src/utils/slash.ts
@@ -1,0 +1,9 @@
+/**
+ * Convert `\` separators to `/` — a mirror of vite's internal `slash`.
+ * Module-graph lookup keys must be in vite's normalized form (forward
+ * slashes), but playground configs cannot import vite itself, so keys
+ * built with `path.join` go through this instead.
+ */
+export function slash(p: string): string {
+  return p.replaceAll('\\', '/');
+}

--- a/packages/test-dev-server/tests/playground/hmr-hot-update-hook-vite/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-hot-update-hook-vite/dev.config.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { defineDevConfig } from '@rolldown/test-dev-server';
+import { defineDevConfig, slash } from '@rolldown/test-dev-server';
 
 // Mirror of `hmr-hot-update-hook`, but through VITE's plugin contracts: the
 // plugins below sit top-level in vite's plugin array, so the bundled-dev
@@ -61,7 +61,7 @@ const viteHotUpdatePlugin = {
       );
       assert(byId === ctx.modules[0], 'node identity must hold');
       const dep = this.environment.moduleGraph.getModuleById(
-        path.join(dir, 'dep.js'),
+        slash(path.join(dir, 'dep.js')),
       );
       assert(dep != null, 'dep.js must be resolvable from the module graph');
       assert(
@@ -71,7 +71,7 @@ const viteHotUpdatePlugin = {
       // dynamic-import edges: dyn.js is only imported via `import()`; its
       // importer must still be visible through the facade
       const dyn = this.environment.moduleGraph.getModuleById(
-        path.join(dir, 'dyn.js'),
+        slash(path.join(dir, 'dyn.js')),
       );
       assert(dyn != null, 'dyn.js must be resolvable from the module graph');
       assert(
@@ -86,7 +86,7 @@ const viteHotUpdatePlugin = {
     }
     if (ctx.file.endsWith('invalidate.txt')) {
       const dep = this.environment.moduleGraph.getModuleById(
-        path.join(dir, 'dep.js'),
+        slash(path.join(dir, 'dep.js')),
       );
       assert(dep != null, 'dep.js must be resolvable from the module graph');
       // tailwind pattern: buffer dep via invalidateModule; return [] so the
@@ -97,7 +97,7 @@ const viteHotUpdatePlugin = {
     }
     if (ctx.file.endsWith('custom.txt')) {
       const graph = this.environment.moduleGraph;
-      const depId = path.join(dir, 'dep.js');
+      const depId = slash(path.join(dir, 'dep.js'));
       const dep = graph.getModuleById(depId);
       assert(dep != null, 'dep.js must be resolvable from the module graph');
       // facade reads: by-file lookup hands out the SAME node, and the node's
@@ -114,7 +114,7 @@ const viteHotUpdatePlugin = {
         'node.info must expose the engine ModuleInfo',
       );
       // importedModules unions static and dynamic edges (main -> dep, main -> dyn)
-      const main = graph.getModuleById(path.join(dir, 'main.js'));
+      const main = graph.getModuleById(slash(path.join(dir, 'main.js')));
       assert(main != null, 'main.js must be resolvable from the module graph');
       const importedIds = [...main.importedModules].map((m) => m.id);
       assert(
@@ -171,7 +171,7 @@ const byFileSubModulePlugin = {
   name: 'test-by-file-sub-module',
   resolveId(source, importer) {
     if (source.endsWith('widget.js?part=extra') && importer) {
-      return path.join(path.dirname(importer), 'widget.js?part=extra');
+      return slash(path.join(path.dirname(importer), 'widget.js?part=extra'));
     }
   },
   load(id) {
@@ -240,7 +240,7 @@ const legacyReadChainB = {
       'the shared HmrContext must carry plugin A\'s reassigned read',
     );
     const dep = ctx.server.moduleGraph.getModuleById(
-      path.join(path.dirname(ctx.file), 'dep.js'),
+      slash(path.join(path.dirname(ctx.file), 'dep.js')),
     );
     assert(dep != null, 'dep.js must be resolvable from the mixed module graph');
     return [dep]; // positive signal: the patch ships dep, accept count +1

--- a/packages/test-dev-server/tests/playground/test-utils.ts
+++ b/packages/test-dev-server/tests/playground/test-utils.ts
@@ -4,6 +4,8 @@
 
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
+
+export { slash } from '@rolldown/test-dev-server';
 import type { ConsoleMessage, Locator } from 'playwright';
 import { expect } from 'vitest';
 import {


### PR DESCRIPTION
### What

Windows dev-server CI has been red since the `hmr-hot-update-hook-vite` playground landed (for example [this run](https://github.com/rolldown/rolldown/actions/runs/30604121832/job/91073203779)): the 5 lookup-based specs fail on Windows while macOS passes.

### Why

- The engine hands `hotUpdate` hooks vite-normalized paths: `ctx.file` and the module ids use forward slashes on every OS.
- The fixture built its module-graph lookup keys with win32 `path.join`, which produces backslash keys on Windows. Every `getModuleById` lookup missed, the fixture's own asserts threw inside the hook, the HMR update failed, and the recovery full reload wiped the browser counters the specs poll.
- The `resolveId` hook also returned a win32-joined id, so the by-file expansion could not relate `widget.js?part=extra` to the edited base file.

### Fix

- Add a small `slash` helper to `@rolldown/test-dev-server` (playground configs cannot import vite's `normalizePath`) and re-export it from `test-utils` for specs.
- Normalize the six lookup keys and the `resolveId` return with it: `slash(path.join(dir, 'dep.js'))` — the same pattern real vite plugins use on Windows.
- `addWatchFile` calls stay unchanged: the engine normalizes watch registrations itself.

### Tested

- `pnpm vitest run --config vitest.config.e2e.mts playground/hmr-hot-update-hook-vite` passes 8/8 on macOS.
- The `ci: windows` label on this PR runs the Windows job, which is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
