### PR TITLE
fix: initialize re-exported wrapped ESM modules at the entry chunk

### DIFF
--- a/crates/rolldown/src/esm_init_obligations.rs
+++ b/crates/rolldown/src/esm_init_obligations.rs
@@ -33,10 +33,12 @@
 //! Purpose contracts are deliberately *not* identical, and each divergence is encoded (and
 //! justified) on [`ObligationPurpose`] rather than re-derived at call sites.
 
+use oxc_str::CompactStr;
 use rolldown_common::{
-  ChunkIdx, ConstExportMeta, ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta,
-  IndexModules, InlineConstMode, Module, ModuleIdx, NormalModule, ResolvedImportRecord, Specifier,
-  SymbolOrMemberExprRef, SymbolRef, SymbolRefDb, WrapKind,
+  ChunkIdx, ConcatenateWrappedModuleKind, ConstExportMeta, ExportsKind, ImportKind,
+  ImportRecordIdx, ImportRecordMeta, IndexModules, InlineConstMode, Module, ModuleIdx,
+  NormalModule, ResolvedImportRecord, Specifier, SymbolOrMemberExprRef, SymbolRef, SymbolRefDb,
+  WrapKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -140,6 +142,106 @@ pub fn reexport_record_owns_hop(
   is_reexport: bool,
 ) -> bool {
   is_reexport && !order_state.is_nested_reexport_record(importer_idx, rec_idx)
+}
+
+/// An ESM-wrapped module whose `init_*` an entry must run because the entry re-exports one of its
+/// bindings (issue #10543).
+pub struct EntryReexportedWrapperInit {
+  pub owner: ModuleIdx,
+  pub wrapper_ref: SymbolRef,
+  /// A TLA-tainted wrapper renders as `await init_*()`. This can only surface in `esm` output:
+  /// the scanner rejects top-level await under every other format
+  /// (`AstScanner::handle_top_level_await`), so a TLA-tainted module never reaches emission
+  /// there.
+  pub tla_tainted: bool,
+}
+
+/// The record-less, off-strict obligation surface: the ESM-wrapped modules backing an entry's
+/// re-exported bindings. Named re-exports resolve symbol-to-symbol, so when every forwarding
+/// statement between the entry and such a module is tree-shaken, none of the record-scoped
+/// consumers above ever sees the obligation — yet ESM semantics require the module to be
+/// evaluated before the entry's bindings are read (issue #10543).
+///
+/// This is the single copy of the walk. Cross-chunk registration
+/// (`collect_depended_symbols`'s entry branch) consumes it with `canonical_names: None` to import
+/// every wrapper the entry may need; emission (the finalizer's entry body prelude and
+/// `render_wrapped_entry_chunk`'s tail path) consumes it with the chunk's assigned names to call
+/// exactly the reachable ones — so "everything emission calls, registration imported" is a fact
+/// about the code rather than two enumerations kept in sync by hand.
+///
+/// Same-chunk owners are deliberately kept: an unwrapped barrel gets no excluded-statement init
+/// metadata at all, so a fully tree-shaken same-chunk chain has no other call site. The one shape
+/// where same-chunk owners are always covered — an entry wrapped by propagation, whose whole
+/// static graph is wrapped with it — is filtered at its call site instead.
+///
+/// Results are in module execution order (dependencies before dependents). Both emission callers
+/// gate on `!is_strict_execution_order_enabled()`: strict execution order routes entry
+/// initialization through order-wrap lowering instead.
+pub fn collect_entry_reexported_wrapper_inits(
+  entry_id: ModuleIdx,
+  entry_meta: &LinkingMetadata,
+  metas: &LinkingMetadataVec,
+  modules: &IndexModules,
+  symbol_db: &SymbolRefDb,
+  canonical_names: Option<&FxHashMap<SymbolRef, CompactStr>>,
+) -> Vec<EntryReexportedWrapperInit> {
+  // Filter before sorting: entries whose exports resolve to no wrapped module at all — the
+  // overwhelmingly common case — should not pay for sorting their whole export map (a dep
+  // optimizer barrel entry can have thousands of exports).
+  let mut qualifying = entry_meta
+    .resolved_exports
+    .iter()
+    .filter_map(|(name, resolved_export)| {
+      if resolved_export.came_from_commonjs {
+        return None;
+      }
+      let canonical_ref = symbol_db.canonical_ref_resolving_namespace(resolved_export.symbol_ref);
+      if canonical_ref.owner == entry_id {
+        return None;
+      }
+      let owner_meta = &metas[canonical_ref.owner];
+      if !matches!(owner_meta.wrap_kind(), WrapKind::Esm)
+        // An inner concatenated module's body runs via its group's shared wrapper; its own
+        // `wrapper_ref` is not a callable declaration (mirrors the finalizer's emission skip).
+        || matches!(
+          owner_meta.concatenated_wrapped_module_kind,
+          ConcatenateWrappedModuleKind::Inner
+        )
+      {
+        return None;
+      }
+      let wrapper_ref = owner_meta.wrapper_ref?;
+      if wrapper_ref == canonical_ref {
+        return None;
+      }
+      let canonical_wrapper_ref = symbol_db.canonical_ref_for(wrapper_ref);
+      // Emission may only call a wrapper the chunk declares or imports; anything else would
+      // render as a dangling identifier. Registration passes `None`: it runs before chunk names
+      // exist and is what makes a wrapper reachable in the first place.
+      if let Some(canonical_names) = canonical_names
+        && !canonical_names.contains_key(&canonical_wrapper_ref)
+      {
+        return None;
+      }
+      Some((name, canonical_ref.owner, wrapper_ref, canonical_wrapper_ref, owner_meta))
+    })
+    .collect::<Vec<_>>();
+  // The export map iterates in hash order; sort the (rare) survivors by export name so the
+  // first-export-wins dedup below is deterministic.
+  qualifying.sort_unstable_by_key(|(name, ..)| *name);
+  let mut seen_wrappers = FxHashSet::default();
+  let mut inits = qualifying
+    .into_iter()
+    .filter_map(|(_, owner, wrapper_ref, canonical_wrapper_ref, owner_meta)| {
+      seen_wrappers.insert(canonical_wrapper_ref).then_some(EntryReexportedWrapperInit {
+        owner,
+        wrapper_ref,
+        tla_tainted: owner_meta.is_tla_or_contains_tla_dependency,
+      })
+    })
+    .collect::<Vec<_>>();
+  inits.sort_unstable_by_key(|init| modules[init.owner].exec_order());
+  inits
 }
 
 pub struct WrappedEsmInitTargetContext<'a> {

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -186,6 +186,14 @@ impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
 
     let last_import_stmt_idx = self.remove_unused_top_level_stmt(program);
 
+    // Runs after `remove_unused_top_level_stmt` so statement-position init calls already sit in
+    // the dedup set, and splices at the same after-imports index the HMR header uses (an HMR
+    // header spliced below lands before these calls, which is fine — it is registration glue).
+    let entry_init_prelude = self.entry_reexported_wrapper_init_prelude();
+    if !entry_init_prelude.is_empty() {
+      program.body.splice(last_import_stmt_idx..last_import_stmt_idx, entry_init_prelude);
+    }
+
     if self.ctx.options.is_dev_mode_enabled() {
       let hmr_header = if self.ctx.runtime.id() == self.ctx.module.idx {
         vec![]

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -12,8 +12,8 @@ use oxc::{
   span::{GetSpan, GetSpanMut, SPAN, Span},
 };
 use rolldown_common::{
-  AstScopes, Chunk, ChunkIdx, ConcatenateWrappedModuleKind, ExportsKind, ImportRecordIdx,
-  ImportRecordMeta, InlineConstMode, MemberExprRefResolution, Module, ModuleIdx,
+  AstScopes, Chunk, ChunkIdx, ChunkKind, ConcatenateWrappedModuleKind, ExportsKind,
+  ImportRecordIdx, ImportRecordMeta, InlineConstMode, MemberExprRefResolution, Module, ModuleIdx,
   ModuleNamespaceIncludedReason, ModuleType, NamespaceAlias, NormalModule, OutputExports,
   OutputFormat, Platform, RenderedConcatenatedModuleParts, Specifier, SymbolRef, WrapKind,
 };
@@ -40,7 +40,8 @@ use sugar_path::SugarPath;
 
 use crate::esm_init_obligations::{
   ObligationPurpose, WrappedEsmInitTarget, WrappedEsmInitTargetContext,
-  collect_wrapped_esm_init_targets_for_import_record, record_is_init_obligation,
+  collect_entry_reexported_wrapper_inits, collect_wrapped_esm_init_targets_for_import_record,
+  record_is_init_obligation,
 };
 use crate::stages::generate_stage::order_wrap_state::OrderCjsCarrierKey;
 use crate::utils;
@@ -343,6 +344,44 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       ast::Expression::new_sequence_expression(SPAN, exprs, &ast_builder),
       &ast_builder,
     ))
+  }
+
+  /// Off-strict, initialize the ESM-wrapped modules backing this entry's re-exported bindings
+  /// before the entry module's own body: ESM evaluates dependencies (including re-export
+  /// sources) before the importer's body, but when every connecting statement is tree-shaken no
+  /// statement position owns those `init_*()` calls (issue #10543). Only the missing ones are
+  /// prepended — a module already initialized at an included statement position keeps that call
+  /// (the shared `generated_init_esm_importee_ids` dedup). Facade entry chunks (entry hosted in
+  /// another chunk, so no body renders here) and wrapped entries (their body runs inside the
+  /// wrapper invoked at the chunk tail, after these calls' tail counterparts) take the
+  /// `render_wrapped_entry_chunk` path instead.
+  fn entry_reexported_wrapper_init_prelude(&mut self) -> Vec<Statement<'ast>> {
+    if self.ctx.options.is_strict_execution_order_enabled() {
+      return vec![];
+    }
+    let ChunkKind::EntryPoint { module: entry_id, .. } = self.ctx.chunk.kind else {
+      return vec![];
+    };
+    if entry_id != self.ctx.idx || !matches!(self.ctx.wrapper_mode(), ModuleWrapperMode::None) {
+      return vec![];
+    }
+    let inits = collect_entry_reexported_wrapper_inits(
+      entry_id,
+      self.ctx.linking_info,
+      self.ctx.linking_infos,
+      self.ctx.modules,
+      self.ctx.symbol_db,
+      Some(&self.ctx.chunk.canonical_names),
+    );
+    let mut stmts = vec![];
+    for init in inits {
+      if !self.generated_init_esm_importee_ids.insert(init.owner) {
+        continue;
+      }
+      let init_expr = self.wrapped_esm_init_call_expr(init.owner, SPAN, true, true);
+      stmts.push(ast::Statement::new_expression_statement(SPAN, init_expr, self));
+    }
+    stmts
   }
 
   /// If return true the import stmt should be removed,

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -2,7 +2,8 @@ use super::{FinalEsmInitMetadata, GenerateStage, Sealed};
 use crate::chunk_graph::ChunkGraph;
 use crate::esm_init_obligations::{
   ObligationPurpose, WrappedEsmInitTarget, WrappedEsmInitTargetContext,
-  collect_wrapped_esm_init_targets_for_import_record, for_each_init_obligation_record,
+  collect_entry_reexported_wrapper_inits, collect_wrapped_esm_init_targets_for_import_record,
+  for_each_init_obligation_record,
 };
 use crate::utils::chunk::conflict_resolver::{ConflictResolver, deconflict_order_key};
 use crate::utils::chunk::normalize_preserve_entry_signature;
@@ -633,22 +634,13 @@ impl GenerateStage<'_> {
           let entry_meta = &self.link_output.metas[entry.idx];
 
           if !matches!(entry_meta.wrap_kind(), WrapKind::Cjs) {
-            for export_ref in entry_meta
-              .resolved_exports
-              .iter()
-              .sorted_unstable_by_key(|(name, _)| *name)
-              .map(|(_, export)| export)
-              // A chunk should always consume a cjs export symbol by property access, so filter
-              // out a exported symbol that came from a cjs module.
-              .filter(|resolved_export| !resolved_export.came_from_commonjs)
-            {
-              self.add_depended_symbol_with_wrapped_esm_init(
-                chunk_graph,
-                order_state,
-                depended_symbols,
-                symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref),
-              );
-            }
+            self.register_entry_export_depended_symbols(
+              chunk_graph,
+              order_state,
+              depended_symbols,
+              entry.idx,
+              entry_meta,
+            );
           }
 
           if matches!(entry_meta.wrap_kind(), WrapKind::Cjs) {
@@ -744,6 +736,56 @@ impl GenerateStage<'_> {
     let symbols = &mut self.link_output.symbol_db;
     for (symbol_ref, chunk_idx) in &table.map {
       symbols.get_mut(*symbol_ref).chunk_idx = Some(*chunk_idx);
+    }
+  }
+
+  /// Register what a non-CJS entry's export signature makes the chunk depend on: the canonical
+  /// symbol of every re-exported binding, plus — off-strict — the `init_*` wrapper of every
+  /// ESM-wrapped module backing one. The wrappers come from the same walk entry emission
+  /// consumes (`collect_entry_reexported_wrapper_inits`), so everything the entry chunk may call
+  /// is imported by construction; `None` for the names because registration runs before chunk
+  /// names exist — it is what makes a wrapper reachable. The entry's own wrapper is not part of
+  /// the walk; the caller's `esm_init_target` arm covers it.
+  fn register_entry_export_depended_symbols(
+    &self,
+    chunk_graph: &ChunkGraph,
+    order_state: &super::order_wrap_state::OrderWrapState,
+    depended_symbols: &mut FxIndexSet<SymbolRef>,
+    entry_idx: ModuleIdx,
+    entry_meta: &crate::types::linking_metadata::LinkingMetadata,
+  ) {
+    let symbols = &self.link_output.symbol_db;
+    let sorted_export_refs = entry_meta
+      .resolved_exports
+      .iter()
+      .sorted_unstable_by_key(|(name, _)| *name)
+      .map(|(_, export)| export)
+      // A chunk should always consume a cjs export symbol by property access, so filter
+      // out a exported symbol that came from a cjs module.
+      .filter(|resolved_export| !resolved_export.came_from_commonjs);
+    if self.options.is_strict_execution_order_enabled() {
+      for export_ref in sorted_export_refs {
+        self.add_depended_symbol_with_wrapped_esm_init(
+          chunk_graph,
+          order_state,
+          depended_symbols,
+          symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref),
+        );
+      }
+    } else {
+      for export_ref in sorted_export_refs {
+        depended_symbols.insert(symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref));
+      }
+      for init in collect_entry_reexported_wrapper_inits(
+        entry_idx,
+        entry_meta,
+        &self.link_output.metas,
+        &self.link_output.module_table.modules,
+        symbols,
+        None,
+      ) {
+        depended_symbols.insert(init.wrapper_ref);
+      }
     }
   }
 

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -13,7 +13,7 @@ use rolldown_utils::{
 };
 use rustc_hash::FxHashSet;
 
-use crate::esm_init_obligations::WrappedEsmInitTarget;
+use crate::esm_init_obligations::{WrappedEsmInitTarget, collect_entry_reexported_wrapper_inits};
 use crate::{stages::link_stage::LinkStageOutput, types::generator::GenerateContext};
 
 pub fn render_wrapped_entry_chunk(
@@ -83,6 +83,8 @@ pub fn render_wrapped_entry_chunk(
       return Some(rendered);
     }
 
+    let reexport_init_calls = render_entry_reexported_wrapper_init_calls(ctx, entry_id, entry_meta);
+
     match ctx.esm_init_target(entry_id) {
       Some(target) => {
         let wrapper_ref_name = ctx.finalized_string_pattern_for_symbol_ref(
@@ -90,17 +92,93 @@ pub fn render_wrapped_entry_chunk(
           ctx.chunk_idx,
           &ctx.chunk.canonical_names,
         );
-        if target.tla_tainted {
-          Some(concat_string!("await ", wrapper_ref_name, "();"))
+        let own_init_call = if target.tla_tainted {
+          concat_string!("await ", wrapper_ref_name, "();")
         } else {
-          Some(concat_string!(wrapper_ref_name, "();"))
+          concat_string!(wrapper_ref_name, "();")
+        };
+        match reexport_init_calls {
+          Some(mut calls) => {
+            calls.push_str(&own_init_call);
+            Some(calls)
+          }
+          None => Some(own_init_call),
         }
       }
-      None => None,
+      None => reexport_init_calls,
     }
   } else {
     None
   }
+}
+
+/// Off-strict, an entry can re-export bindings owned by an ESM-wrapped module hosted in another
+/// chunk while every statement that could call that module's `init_*` was tree-shaken (a pure
+/// re-export barrel chain resolves bindings symbol-to-symbol, keeping the barrels' forwarding
+/// statements excluded). Cross-chunk registration still imports each such wrapper — the non-strict
+/// arm of `add_depended_symbol_with_wrapped_esm_init` pairs every depended binding with its
+/// wrapper — but nothing ever calls it, so the wrapped module never evaluates and its bindings
+/// read as `undefined` at runtime (issue #10543).
+///
+/// The entry chunk owns these calls: it already imports every such wrapper (no new chunk-graph
+/// edges, hence no new cyclic-evaluation hazards for eager top-level init calls in shared
+/// chunks). ESM evaluates dependencies before the importer's body, so an entry hosting its own
+/// body gets the calls as a body prelude from the finalizer
+/// (`entry_reexported_wrapper_init_prelude`); this chunk-tail path serves the remaining shapes,
+/// where the tail still precedes the entry body: a facade chunk hosts no body at all, and a
+/// wrapped entry's body only runs inside the wrapper invoked right after these calls.
+fn render_entry_reexported_wrapper_init_calls(
+  ctx: &GenerateContext<'_>,
+  entry_id: ModuleIdx,
+  entry_meta: &crate::types::linking_metadata::LinkingMetadata,
+) -> Option<String> {
+  if ctx.options.is_strict_execution_order_enabled() {
+    // Strict execution order routes entry initialization through order-wrap lowering
+    // (consumer-local targets and entry facades) instead.
+    return None;
+  }
+  let entry_hosted_here = ctx.chunk_graph.module_to_chunk[entry_id] == Some(ctx.chunk_idx);
+  let entry_is_wrapped = ctx.esm_init_target(entry_id).is_some();
+  if entry_hosted_here && !entry_is_wrapped {
+    return None;
+  }
+  let inits = collect_entry_reexported_wrapper_inits(
+    entry_id,
+    entry_meta,
+    &ctx.link_output.metas,
+    &ctx.link_output.module_table.modules,
+    &ctx.link_output.symbol_db,
+    Some(&ctx.chunk.canonical_names),
+  );
+  let mut rendered = String::new();
+  for init in inits {
+    // An in-chunk wrapped entry was wrapped together with its whole static graph (wrap
+    // propagation), so a same-chunk owner's init is already covered inside the chunk — by a
+    // statement-position call or the excluded-statement metadata's same-chunk arm — and calling
+    // it again here would be a pure duplicate. A facade chunk gets no such guarantee for the
+    // modules it hosts, so only the in-chunk wrapped entry filters.
+    if entry_hosted_here && ctx.chunk_graph.module_to_chunk[init.owner] == Some(ctx.chunk_idx) {
+      continue;
+    }
+    let wrapper_name = ctx.finalized_string_pattern_for_symbol_ref(
+      init.wrapper_ref,
+      ctx.chunk_idx,
+      &ctx.chunk.canonical_names,
+    );
+    if init.tla_tainted {
+      // Defensive parity with `wrapped_esm_init_call_expr`'s `await_if_tla`; believed
+      // unreachable today. Non-`esm` formats reject top-level await at scan time
+      // (`AstScanner::handle_top_level_await`), so this cannot produce an `await` inside a
+      // plain iife/umd/cjs factory. Under `esm`, every off-strict `WrapKind::Esm` cause is
+      // blocked from combining with TLA: a `require` reaching a TLA subtree is a build error
+      // (`REQUIRE_TLA`), and the dynamic-import-with-splitting-disabled cause is single-chunk,
+      // where a statement-position or metadata init always covers the module first.
+      writeln!(rendered, "await {wrapper_name}();").expect("writing to a string cannot fail");
+    } else {
+      writeln!(rendered, "{wrapper_name}();").expect("writing to a string cannot fail");
+    }
+  }
+  (!rendered.is_empty()).then_some(rendered)
 }
 
 #[expect(clippy::too_many_lines)] // Dispatches over every output format and export mode inline.

--- a/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/wrapped_esm_init_interop/ambiguous_star_reexport/artifacts.snap
@@ -39,7 +39,9 @@ export { mod_a_exports as a, init_mod_a as i, init_mod_b as n, __exportAll as o,
 ```js
 import { i as init_mod_a, n as init_mod_b, o as __exportAll, s as __reExport, t as barrel_exports } from "./barrel.js";
 //#region main.js
-__reExport(/* @__PURE__ */ __exportAll({}), barrel_exports);
+var main_exports = /* @__PURE__ */ __exportAll({});
+init_mod_a();
+__reExport(main_exports, barrel_exports);
 globalThis.__log.push("BEFORE_REQUIRE");
 init_mod_a();
 init_mod_b();

--- a/crates/rolldown/tests/rolldown/issues/10543/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10543/_config.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "styles",
+        "import": "./styles.js"
+      },
+      {
+        "name": "icon",
+        "import": "./icon.js"
+      },
+      {
+        "name": "lab",
+        "import": "./lab.cjs"
+      }
+    ],
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  },
+  "_comment": "Regression test for rolldown/rolldown#10543: the `styles` entry re-exports bindings owned by the ESM-wrapped `w.js` (wrapping propagates from `lab.cjs` requiring `top.js`), `icon` pulls `w.js` into a wider shared chunk than the re-export barrels', and the barrels' forwarding statements are all tree-shaken (declared side-effect-free, like the `sideEffects: false` packages in the original report, while `w.js` carries a real side effect). No included statement owns `w.js`'s init, so the entry must call the cross-chunk `init_w` itself \u2014 and, per ESM evaluation order, before its own body: the entry body's probe observes `w.js`'s side effect."
+}

--- a/crates/rolldown/tests/rolldown/issues/10543/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/10543/_test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+
+// #10543: `styles` re-exports `V`/`P`/`util` from a subtree that is ESM-wrapped
+// (`lab.cjs` requires `top.js`; wrapping propagates to `system.js`, `mid.js`, `w.js`),
+// `icon.js` pulls `w.js` into a wider shared chunk than the barrels', and every
+// forwarding statement between the entry and `w.js` is tree-shaken (declared
+// side-effect-free). The entry chunk must call the cross-chunk `init_w` itself;
+// previously it was defined and exported but called nowhere and `V` stayed
+// uninitialized.
+const { P, V, util } = await import('./dist/styles.js');
+assert.equal(V, 'v18');
+assert.equal(P(), 'v18');
+assert.equal(util, 1);
+// ESM evaluates dependencies before the importer's body, so the entry body must
+// already observe `w.js`'s side effect — the init calls have to precede the entry
+// module's own statements, not sit at the chunk tail.
+assert.equal(globalThis.__entry_body_saw_w, 'ran');

--- a/crates/rolldown/tests/rolldown/issues/10543/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10543/artifacts.snap
@@ -1,0 +1,79 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## icon.js
+
+```js
+import { r as init_w, t as P } from "./w.js";
+//#region icon.js
+init_w();
+const iconP = P;
+//#endregion
+export { iconP };
+
+```
+
+## lab.js
+
+```js
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region top.js
+var top_exports = /* @__PURE__ */ __exportAll({ t: () => 2 });
+var init_top = __esmMin((() => {}));
+//#endregion
+//#region lab.cjs
+var require_lab = /* @__PURE__ */ __commonJSMin(((exports) => {
+	const { t } = (init_top(), __toCommonJS(top_exports));
+	exports.t = t;
+}));
+//#endregion
+export default require_lab();
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
+## styles.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+import { n as V, r as init_w, t as P } from "./w.js";
+//#region system.js
+var util;
+//#endregion
+//#region styles.js
+__esmMin((() => {
+	util = 1;
+}))();
+init_w();
+globalThis.__entry_body_saw_w = globalThis.__w_side_effect;
+//#endregion
+export { P, V, util };
+
+```
+
+## w.js
+
+```js
+import { n as __esmMin } from "./rolldown-runtime.js";
+//#region w.js
+function P() {
+	return "v18";
+}
+var V;
+var init_w = __esmMin((() => {
+	globalThis.__w_side_effect = "ran";
+	V = "v18";
+}));
+//#endregion
+export { V as n, init_w as r, P as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10543/icon.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/icon.js
@@ -1,0 +1,2 @@
+import { P } from './w.js';
+export const iconP = P;

--- a/crates/rolldown/tests/rolldown/issues/10543/lab.cjs
+++ b/crates/rolldown/tests/rolldown/issues/10543/lab.cjs
@@ -1,0 +1,2 @@
+const { t } = require('./top.js');
+exports.t = t;

--- a/crates/rolldown/tests/rolldown/issues/10543/mid.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/mid.js
@@ -1,0 +1,1 @@
+export { P, V } from './w.js';

--- a/crates/rolldown/tests/rolldown/issues/10543/styles.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/styles.js
@@ -1,0 +1,2 @@
+globalThis.__entry_body_saw_w = globalThis.__w_side_effect;
+export { P, V, util } from './system.js';

--- a/crates/rolldown/tests/rolldown/issues/10543/system.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/system.js
@@ -1,0 +1,2 @@
+export { P, V } from './mid.js';
+export const util = 1;

--- a/crates/rolldown/tests/rolldown/issues/10543/top.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/top.js
@@ -1,0 +1,2 @@
+import './system.js';
+export const t = 2;

--- a/crates/rolldown/tests/rolldown/issues/10543/w.js
+++ b/crates/rolldown/tests/rolldown/issues/10543/w.js
@@ -1,0 +1,5 @@
+globalThis.__w_side_effect = 'ran';
+export const V = 'v18';
+export function P() {
+  return V;
+}


### PR DESCRIPTION
Fixes https://github.com/rolldown/rolldown/issues/10543.

The issue is that after wrapping, rolldown should output the entry chunk with a `init_xxx` call to ensure the execution of the wrapped module.

```js
// @mui_material_styles.js — before
import { …, v as StyledEngineProvider } from "./styles-BcPZjlv2.js";
export { StyledEngineProvider, … };   // nothing ever runs the module body that assigns `v`

// after
import { …, v as StyledEngineProvider, y as init_StyledEngineProvider } from "./styles-6TFHfymC.js";
init_StyledEngineProvider();          // evaluates the wrapped module first
export { StyledEngineProvider, … };
```

--edited

While this PR does fix the issue, I feel that the complexity around "wrappers" are increases significantly, we need to find a way to abstract them.