### PR TITLE
test(rolldown_plugin_vite_import_glob): cover the glob predicate

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -12,7 +12,6 @@ description = "Rolldown plugin for glob imports"
 
 [lib]
 doctest = false
-test = false
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
@@ -95,3 +95,137 @@ fn strip_dir_prefix<'a>(file: &'a str, dir: &str) -> Option<&'a str> {
 fn is_pruned_segment(segment: &str) -> bool {
   segment.starts_with('.') || segment == "node_modules"
 }
+
+#[cfg(test)]
+mod tests {
+  use super::GlobMatcher;
+
+  /// Splits an absolute glob the way `PathWithGlob` does: at the last separator before the first
+  /// glob metacharacter, with that separator kept on the pattern side.
+  fn split(glob: &str) -> (String, String) {
+    let first_meta = glob.find(['*', '?', '[', '{', '\\']).unwrap_or(glob.len());
+    let at = glob[..first_meta].rfind('/').expect("test globs are absolute");
+    (glob[..at].to_string(), glob[at..].to_string())
+  }
+
+  fn matcher_with(
+    walk_root: &str,
+    positive: &[&str],
+    negated: &[&str],
+    exhaustive: bool,
+    case_sensitive: bool,
+  ) -> GlobMatcher {
+    GlobMatcher {
+      walk_root: walk_root.to_string(),
+      positive: positive.iter().copied().map(split).collect(),
+      negated: negated.iter().copied().map(split).collect(),
+      exhaustive,
+      case_sensitive,
+    }
+  }
+
+  fn matcher(walk_root: &str, positive: &[&str], negated: &[&str]) -> GlobMatcher {
+    matcher_with(walk_root, positive, negated, false, true)
+  }
+
+  #[test]
+  fn matches_a_single_level_pattern() {
+    let m = matcher("/p/src/pages", &["/p/src/pages/*.js"], &[]);
+    assert!(m.matches("/p/src/pages/a.js"));
+    assert!(!m.matches("/p/src/pages/a.ts"));
+    // `*` does not cross a separator, and the sibling directory is outside the walk root.
+    assert!(!m.matches("/p/src/pages/nested/a.js"));
+    assert!(!m.matches("/p/src/main.js"));
+  }
+
+  #[test]
+  fn rejects_paths_outside_the_walk_root_even_on_a_shared_string_prefix() {
+    let m = matcher("/p/src/pages", &["/p/src/pages/*.js"], &[]);
+    assert!(!m.matches("/p/src/pages-legacy/a.js"));
+  }
+
+  #[test]
+  fn matches_a_globstar_pattern_across_levels() {
+    let m = matcher("/p/src/pages", &["/p/src/pages/**/*.js"], &[]);
+    assert!(m.matches("/p/src/pages/a.js"));
+    assert!(m.matches("/p/src/pages/nested/deep/a.js"));
+    assert!(!m.matches("/p/src/pages/nested/a.css"));
+  }
+
+  #[test]
+  fn honors_negated_patterns() {
+    let m = matcher("/p/src/pages", &["/p/src/pages/*.js"], &["/p/src/pages/*.test.js"]);
+    assert!(m.matches("/p/src/pages/a.js"));
+    assert!(!m.matches("/p/src/pages/a.test.js"));
+  }
+
+  #[test]
+  fn requires_a_positive_hit() {
+    // Only negated globs: the build-time walk yields nothing, so neither may the matcher.
+    let m = matcher("/p/src", &[], &["/p/src/*.js"]);
+    assert!(!m.matches("/p/src/a.js"));
+    assert!(!m.matches("/p/src/b.ts"));
+  }
+
+  #[test]
+  fn prunes_dot_and_node_modules_segments_below_the_walk_root() {
+    let m = matcher("/p/src", &["/p/src/**/*.js"], &[]);
+    assert!(m.matches("/p/src/a.js"));
+    assert!(!m.matches("/p/src/.cache/a.js"));
+    assert!(!m.matches("/p/src/.hidden.js"));
+    assert!(!m.matches("/p/src/node_modules/dep/a.js"));
+    // A dot segment inside the walk root is part of the root, not something the walk pruned.
+    let m = matcher("/p/.storybook", &["/p/.storybook/*.js"], &[]);
+    assert!(m.matches("/p/.storybook/a.js"));
+  }
+
+  #[test]
+  fn exhaustive_keeps_dot_and_node_modules_segments() {
+    let m = matcher_with("/p/src", &["/p/src/**/*.js"], &[], true, true);
+    assert!(m.matches("/p/src/.cache/a.js"));
+    assert!(m.matches("/p/src/node_modules/dep/a.js"));
+  }
+
+  #[test]
+  fn folds_case_when_case_sensitive_is_off() {
+    let sensitive = matcher_with("/p/src", &["/p/src/*.JS"], &[], false, true);
+    assert!(!sensitive.matches("/p/src/a.js"));
+
+    let insensitive = matcher_with("/p/src", &["/p/src/*.JS"], &[], false, false);
+    assert!(insensitive.matches("/p/src/a.js"));
+  }
+
+  #[test]
+  fn touches_base_covers_the_prefix_and_its_ancestors() {
+    let m = matcher("/p/src", &["/p/src/pages/*.js", "/p/src/layouts/*.js"], &[]);
+    assert!(m.touches_base("/p/src/pages"));
+    assert!(m.touches_base("/p/src/layouts"));
+    assert!(m.touches_base("/p/src"));
+    assert!(m.touches_base("/p"));
+    // Not on the path to any prefix.
+    assert!(!m.touches_base("/p/src/pages/a.js"));
+    assert!(!m.touches_base("/p/src/pages-legacy"));
+    assert!(!m.touches_base("/other"));
+  }
+
+  #[test]
+  fn may_gain_matches_below_only_for_patterns_that_reach_deeper() {
+    let single = matcher("/p/src/pages", &["/p/src/pages/*.js"], &[]);
+    // `*.js` can never match below `pages/`, so a new subdirectory changes nothing.
+    assert!(!single.may_gain_matches_below("/p/src/pages/sub"));
+
+    let deep = matcher("/p/src/pages", &["/p/src/pages/**/*.js"], &[]);
+    assert!(deep.may_gain_matches_below("/p/src/pages/sub"));
+    assert!(deep.may_gain_matches_below("/p/src/pages/sub/deeper"));
+    // The base itself is `touches_base`'s job, and anything outside the walk root is irrelevant.
+    assert!(!deep.may_gain_matches_below("/p/src/pages"));
+    assert!(!deep.may_gain_matches_below("/p/src/other"));
+    // Pruned directories are not descended into, so they cannot contribute either.
+    assert!(!deep.may_gain_matches_below("/p/src/pages/.cache"));
+    assert!(!deep.may_gain_matches_below("/p/src/pages/node_modules"));
+
+    // A pattern spanning segments without a globstar counts too.
+    let two = matcher("/p/src/pages", &["/p/src/pages/*/index.js"], &[]);
+    assert!(two.may_gain_matches_below("/p/src/pages/sub"));
+  }
+}


### PR DESCRIPTION
Part of rolldown/rolldown#10059

`GlobMatcher` decides which modules a file event invalidates by replaying the accept/reject decision of the build-time filesystem walk. The two are separate code paths over the same inputs, so they can drift, and drift is silent in both directions: a looser predicate re-runs modules whose glob output cannot have changed, a stricter one drops updates that should have shipped.

The cases that pin it down are the ones where the walk and a naive reading of the pattern disagree: separator boundaries, so `/a/bc.js` is not treated as living inside `/a/b`; the walk exempting its own root from pruning, so `./.storybook/*.js` still matches while `./**/.hidden/*.js` does not; and a pattern that cannot reach below its own directory, where a new subdirectory changes nothing.

The crate had `test = false`, so this also turns the harness on.