### PR TITLE
docs: describe how import.meta.glob follows file changes

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -24,6 +24,7 @@ pub struct ViteImportGlobPlugin {
   pub root: Option<String>,
   pub sourcemap: bool,
   pub restore_query_extension: bool,
+  /// See `internal-docs/import-meta-glob/implementation.md`.
   pub glob_matchers: FxDashMap<ArcStr, Vec<GlobMatcher>>,
 }
 

--- a/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
@@ -22,6 +22,8 @@ impl ViteImportGlobPlugin {
 
 /// Replays the accept/reject decision of the build-time walk in
 /// [`crate::utils::GlobImportVisit`] without re-walking the filesystem, so the two cannot drift.
+///
+/// See `internal-docs/import-meta-glob/design.md`.
 #[derive(Debug)]
 pub struct GlobMatcher {
   /// In original case: the walk itself is never case-folded, only the glob comparison is.

--- a/internal-docs/dev-engine/implementation.md
+++ b/internal-docs/dev-engine/implementation.md
@@ -568,6 +568,8 @@ Per changed file:
    scan, nothing is queued in `pending_rescans`, so the lost edits
    reach the graph only when a later change touches those files
    again — the same contract as `watchChange`.
+   The builtin `import.meta.glob` plugin is the in-tree consumer of this
+   chain — see [import-meta-glob](../import-meta-glob/implementation.md).
 3. **Delete handling** — a deleted module cannot be re-fetched; the
    update starts from its importers instead.
 

--- a/internal-docs/import-meta-glob/design.md
+++ b/internal-docs/import-meta-glob/design.md
@@ -1,0 +1,103 @@
+# `import.meta.glob` — Design & Principles
+
+## Summary
+
+`crates/rolldown_plugin_vite_import_glob` expands `import.meta.glob(...)` into a literal object of
+imports at `transform` time. That is a snapshot of the filesystem, so in dev mode the snapshot has to
+be refreshed whenever a file that matches the glob appears or disappears — otherwise a new route,
+locale, or content file stays invisible until the server restarts.
+
+This doc records why the refresh works the way it does. The machinery is in
+[implementation.md](./implementation.md).
+
+## Where the responsibility sits
+
+Unbundled Vite gets most of this for free: chokidar watches the project root recursively, and the JS
+plugin (`packages/vite/src/node/plugins/importMetaGlob.ts`) only has to answer "which modules care
+about this file?" from a `hotUpdate` hook.
+
+Under Vite's bundled dev (full bundle mode) neither half is free:
+
+- `importGlobPlugin`'s `applyToEnvironment` replaces the whole JS plugin with the native one for the
+  bundled environment, so the `hotUpdate` hook disappears with it.
+- Vite's chokidar stops driving HMR — `hmr.ts` returns early on `config.experimental.bundledDev` and
+  leaves file events to rolldown's own dev-engine watcher, which registers **individual files** from
+  the module graph. A file that is not in the graph yet cannot produce an event at all.
+
+So the native plugin owns both halves: it must put the directories it read into the watch set, and it
+must implement `hotUpdate`. See [rolldown#10059](https://github.com/rolldown/rolldown/issues/10059).
+
+## Principles
+
+1. **The hook replays the build-time walk, it does not re-implement it.** `GlobMatcher` stores the
+   same inputs the walk used (walk root, the `(static prefix, pattern)` split, `exhaustive`,
+   `caseSensitive`) and reaches its verdict with the same `fast_glob` call and the same pruning rules.
+   Two independent predicates would drift, and both directions of drift are bugs: a laxer hook
+   re-runs modules whose glob output cannot have changed, a stricter one silently drops updates.
+
+   This is also why the hook does **not** copy vite's matcher verbatim. Vite's matcher treats "only
+   negative patterns" as matching everything (`affirmed.length === 0 || affirmedMatcher(file)`), while
+   rolldown's walk yields nothing for that input. Following vite there would make the hook wider than
+   the build.
+
+2. **Watch the directories the walk actually visited, not the glob's root recursively.** A recursive
+   watch is one syscall on macOS but one inotify watch per subdirectory on Linux, and it cannot be
+   told to skip `node_modules`. The walk already enumerates exactly the directories the glob reads,
+   with dotfiles and `node_modules` pruned, so reusing its output costs nothing extra and keeps the
+   watch set proportional to what the glob covers.
+
+   The gap this leaves is a directory created _below_ an already-watched one: it is not watched, so
+   nothing inside it will ever produce an event. What is delivered is the new directory's own
+   creation, through its parent's watch — and `GlobMatcher::may_gain_matches_below` claims the module
+   for it even though a directory matches no pattern. The round that follows re-walks, picks up
+   whatever already landed inside, and registers the directory for what lands later. One rebuild of
+   latency, and it is a rebuild the round was going to do anyway.
+
+   That predicate is deliberately gated on the path actually being a directory (one `is_dir` call per
+   round, and only when the exact predicates all miss). Without the gate, every stray file under a
+   `**` glob's tree would invalidate the module — which is precisely the imprecision the pruned watch
+   set exists to avoid. Deleted directories need no equivalent: their children are removed first, and
+   those events are exact matches.
+
+3. **A missing glob root is watched through its nearest existing ancestor.** `walkdir` yields nothing
+   for a directory that does not exist, which would leave `import.meta.glob('./pages/*.vue')`
+   permanently blind if `pages/` is created later — a normal scaffolding flow. Watching the closest
+   existing ancestor makes `mkdir pages` observable, and `GlobMatcher::touches_base` is what turns
+   that event into an invalidation. The ancestor is watched non-recursively, so the cost is bounded
+   even when several path segments are missing.
+
+4. **Only dev mode pays for any of this.** `hotUpdate` is a dev-only hook, so outside dev mode the
+   predicate table and the directory registrations would be pure overhead — and the directories would
+   also show up in `this.getWatchFiles()` for ordinary builds. Both are gated on
+   `options().is_dev_mode_enabled()`.
+
+5. **The predicate table is maintained per module, never globally reset.** `buildStart` is the obvious
+   place for a reset (vite clears its map there) but it is wrong here: rolldown calls `buildStart` for
+   _every_ scan, including the partial scans that re-transform only the changed modules. A reset would
+   drop the predicates of every module the scan left alone. Since `transform` runs on every re-fetch,
+   upserting and removing per module is both accurate and self-healing — it also covers a user
+   deleting the `import.meta.glob` call.
+
+6. **The hook adds to the affected set, it does not replace it.** Same as vite's
+   `[...oldModules, ...modules]`. A file can be both a glob match and a module in its own right; the
+   glob owner joining the update must not push the file's own update out of it.
+
+## Unresolved questions
+
+- **`rolldown --watch` is not covered.** `hotUpdate` only runs in the dev engine, so a plain watch
+  build still misses new glob matches. Closing that would mean teaching `rolldown_watcher` to consult
+  the glob predicates directly, or giving `hotUpdate` a meaning outside dev mode.
+- **`caseSensitive: false` is ASCII-only**, in the hook exactly as in the walk: `fast_glob` has no
+  nocase flag, so both sides are lowercased. Character-class ranges (`[A-Z]`) and non-ASCII case
+  folding can diverge from picomatch's `nocase`.
+- **The watch set only grows.** The dev coordinator never unwatches, so a directory that stops being
+  covered by any glob stays watched for the life of the server. This is the pre-existing watch-mode
+  behaviour (see `../watch-mode/implementation.md`), not something this feature adds.
+
+## Related
+
+- [implementation.md](./implementation.md) — the machinery that realizes this
+- `../dev-engine/implementation.md` — where `hotUpdate` runs in the HMR stage
+- `../watch-mode/implementation.md` — how watch files reach the fs watcher
+- [rolldown#10059](https://github.com/rolldown/rolldown/issues/10059) — the feature request
+- [rolldown#10019](https://github.com/rolldown/rolldown/issues/10019) — full bundle mode phase 2

--- a/internal-docs/import-meta-glob/implementation.md
+++ b/internal-docs/import-meta-glob/implementation.md
@@ -1,0 +1,135 @@
+# `import.meta.glob` — Implementation
+
+> The rationale and principles behind this live in [design.md](./design.md).
+
+## Summary
+
+`crates/rolldown_plugin_vite_import_glob` does two jobs. `transform` rewrites each
+`import.meta.glob(...)` call into a literal object of imports by walking the filesystem, and — in dev
+mode only — the same walk feeds two side outputs that keep that rewrite fresh: the directories it read
+go into the watch set, and a `GlobMatcher` per call is kept so `hotUpdate` can map a created or deleted
+file back to the module that has to be re-transformed.
+
+## Concept → file map
+
+| Concept                                          | Location                                                               |
+| ------------------------------------------------ | ---------------------------------------------------------------------- |
+| Plugin, `hotUpdate`                              | `src/lib.rs`                                                           |
+| Predicate table ops, post-build predicate        | `src/matcher.rs`                                                       |
+| AST visit, glob resolution, the walk             | `src/utils.rs`                                                         |
+| `hotUpdate` chain over plugins                   | `crates/rolldown_plugin/src/plugin_driver/watch_hooks.rs`              |
+| Where the chain runs in an HMR round             | `crates/rolldown/src/hmr/hmr_stage.rs`                                 |
+| Watch files → fs watcher (dev)                   | `crates/rolldown_dev/src/bundle_coordinator.rs` (`update_watch_paths`) |
+
+## Build-time walk (`utils.rs`)
+
+`GlobImportVisit::eval_glob_expr` resolves every glob in one call to a `PathWithGlob`
+— a `(static prefix, pattern)` pair where the prefix is a real directory path and the pattern keeps the
+leading separator, so matching is `path.strip_prefix(prefix)` followed by `fast_glob::glob_match`.
+`get_common_base` then reduces the positive prefixes to the directory `walkdir` is rooted at, and
+`filter_entry` prunes dot entries and `node_modules` unless `exhaustive` is set.
+
+Two fields on the visitor turn on the dev-only side outputs:
+
+- `is_dev_mode` — `ctx.options().is_dev_mode_enabled()`, threaded in from `lib.rs`.
+- `matchers` — one `GlobMatcher` per glob call, drained by `transform`.
+
+Inside the walk loop, directory entries are registered with `PluginContext::add_watch_file` and skipped.
+Note that `utils.rs` holds the _inner_ `PluginContext`, not the transform context, so this is a plain
+watch registration: it does not add a transform dependency and does not skip `\0` virtual modules.
+Registrations are non-recursive; `design.md` principle 2 explains why that is enough.
+
+When the walk root does not exist, the visitor walks up `Path::ancestors` to the closest existing
+directory and registers that instead (principle 3).
+
+## Predicate (`matcher.rs`)
+
+`GlobMatcher` holds the walk's inputs and `matches(file)` replays its decision in the same order the
+walk reaches it:
+
+1. `file` must live under `walk_root` — compared on separator boundaries, so `/a/bc.js` is not read as
+   living inside `/a/b`. This is also the cheap early exit for the common case of an unrelated edit.
+2. Unless `exhaustive`, no segment of `file` _relative to_ `walk_root` may start with `.` or be
+   `node_modules`. Testing only the relative segments is what reproduces `filter_entry`'s `depth() == 0`
+   exemption: a dot directory that is part of the glob's own root (`./.storybook/*.js`) is fine, one
+   below it is not.
+3. `!negated.any(rule) && positive.any(rule)`, with `rule` the same strip-prefix-then-`glob_match` pair
+   the walk uses. `caseSensitive: false` lowercases both sides, matching the walk's approximation.
+
+`touches_base(path)` is separate and answers a different question: is `path` one of the positive static
+prefixes, or an ancestor of one? That is the signal for "a directory this glob is derived from came or
+went", which is the only thing observable while the prefix itself does not exist.
+
+`may_gain_matches_below(dir)` is the third predicate: `dir` is strictly inside the walk root, survives
+the prune check, and some positive pattern reaches deeper than its own directory (a separator past
+the anchoring one, or `**`). A brand-new directory matches no pattern and is not
+watched yet, so this is what makes the round that sees its creation re-walk. It is only consulted for a
+path that really is a directory — see `design.md` principle 2 for why the gate matters.
+
+## Predicate table and `hotUpdate` (`lib.rs`, `matcher.rs`)
+
+`glob_matchers: FxDashMap<ArcStr, Vec<GlobMatcher>>` is keyed by slash-normalized module id. The plugin
+instance lives in `PluginDriverFactory.plugins` for the bundler's lifetime, so the table survives
+incremental rebuilds even though a fresh `PluginDriver` (and a fresh `watch_files` set) is created per
+build.
+
+`transform` keeps it honest per module rather than resetting it globally — `set_globs` upserts (and
+removes when a module's matchers come back empty), `remove_globs` drops a module that no longer
+contains a glob or no longer parses. Both early-return paths call `remove_globs`, guarded by
+`!glob_matchers.is_empty()` so projects without globs never pay for id normalization. Principle 5 in
+`design.md` explains why `buildStart` is the wrong place.
+
+`hot_update`:
+
+- Declines `WatcherChangeKind::Update` outright, like vite: a content edit cannot change a glob's
+  result _set_, and the engine's default mapping already covers the file's own module.
+- Collects every module id whose matchers report `matches(file) || touches_base(file)`, skipping the id
+  that equals `file` itself (the walk excludes a glob's own module to avoid a self-import; the hook must
+  not put it back).
+- Falls back to `may_gain_matches_below(file)` only when those miss and `file` is a directory. The
+  `is_dir` call is resolved lazily and at most once per round.
+- Returns `None` when nothing matched — declining leaves the engine's default set untouched, which is
+  what makes a stray non-matching file in a watched directory end the round as a noop.
+- Otherwise returns `args.modules` with the matched ids appended, deduplicated. Appending rather than
+  replacing mirrors vite's `[...oldModules, ...modules]`.
+
+`register_hook_usage` therefore reports `Transform | HotUpdate`.
+
+## One round end to end
+
+Creating `pages/c.js` under `import.meta.glob('./pages/*.js')` in `main.js`:
+
+1. `pages/` is in the fs watcher because the previous build's walk registered it. The create event
+   reaches `BundleCoordinator::handle_watch_event`, which does not filter by watch set, and is queued as
+   an `Hmr` task.
+2. `HmrStage::compute_hmr_update_for_file_changes` computes the default affected set for
+   `…/pages/c.js` — empty, since no module and no transform dependency point at it — and runs the
+   `hotUpdate` chain anyway.
+3. The plugin's matcher for `main.js` matches, so the hook returns `[main.js]`. Hook-returned modules are
+   exempt from the unchanged-output suppression, so the update ships even though `main.js`'s source is
+   byte-identical.
+4. `main.js` is re-fetched: `transform` walks `pages/` again, emits the object with `./pages/c.js` in it,
+   and re-registers the directories (all already known).
+5. The partial scan pulls `pages/c.js` into the graph and the patch ships. `main.js` self-accepts, so the
+   client re-runs it in place.
+
+Deleting a file is the same, except step 2's default set contains the deleted module itself and the
+engine expands to its importers.
+
+## Tests
+
+- `src/matcher.rs` unit tests cover the predicate: single-level vs `**` patterns, separator-boundary
+  rejection, negated patterns, the positive-hit requirement, dot / `node_modules` pruning,
+  `exhaustive`, case folding, `touches_base`, and `may_gain_matches_below`.
+- `packages/rolldown/tests/fixtures/builtin-plugin/import-glob/*` are the build-time snapshots. They must
+  not move: none of this changes what `transform` emits.
+- `packages/test-dev-server/tests/playground/hmr-import-glob` is the end-to-end check (add, delete,
+  non-matching file, new nested directory, directory missing at boot). It runs on the browser platform,
+  where vite installs the native plugin itself, so it exercises the real integration. Running it locally
+  needs `just setup-vite`.
+
+## Related
+
+- [design.md](./design.md) — the principles and trade-offs behind this
+- `../dev-engine/implementation.md` — the HMR round this hooks into
+- `../watch-mode/implementation.md` — watch-file registration and its known gaps

--- a/internal-docs/import-meta-glob/implementation.md
+++ b/internal-docs/import-meta-glob/implementation.md
@@ -12,14 +12,14 @@ file back to the module that has to be re-transformed.
 
 ## Concept → file map
 
-| Concept                                          | Location                                                               |
-| ------------------------------------------------ | ---------------------------------------------------------------------- |
-| Plugin, `hotUpdate`                              | `src/lib.rs`                                                           |
-| Predicate table ops, post-build predicate        | `src/matcher.rs`                                                       |
-| AST visit, glob resolution, the walk             | `src/utils.rs`                                                         |
-| `hotUpdate` chain over plugins                   | `crates/rolldown_plugin/src/plugin_driver/watch_hooks.rs`              |
-| Where the chain runs in an HMR round             | `crates/rolldown/src/hmr/hmr_stage.rs`                                 |
-| Watch files → fs watcher (dev)                   | `crates/rolldown_dev/src/bundle_coordinator.rs` (`update_watch_paths`) |
+| Concept                                   | Location                                                               |
+| ----------------------------------------- | ---------------------------------------------------------------------- |
+| Plugin, `hotUpdate`                       | `src/lib.rs`                                                           |
+| Predicate table ops, post-build predicate | `src/matcher.rs`                                                       |
+| AST visit, glob resolution, the walk      | `src/utils.rs`                                                         |
+| `hotUpdate` chain over plugins            | `crates/rolldown_plugin/src/plugin_driver/watch_hooks.rs`              |
+| Where the chain runs in an HMR round      | `crates/rolldown/src/hmr/hmr_stage.rs`                                 |
+| Watch files → fs watcher (dev)            | `crates/rolldown_dev/src/bundle_coordinator.rs` (`update_watch_paths`) |
 
 ## Build-time walk (`utils.rs`)
 


### PR DESCRIPTION
Closes rolldown/rolldown#10059

Two things about this feature are not recoverable from the diff. Why the hook replays the build-time walk instead of matching the glob directly, and why the directories the walk visited are registered one by one rather than watching the glob root recursively. Both are decisions with a cost on the other side, so the reasoning is worth keeping.

The same file records what the feature does not cover, which is easy to mistake for an oversight later: `rolldown --watch` still misses new matches because the hook is dev-only, case-insensitive matching is ASCII-only, and the watch set never shrinks.