### PR TITLE
docs: update outdated pluginutils references

### DIFF
--- a/docs/apis/plugin-api/hook-filters.md
+++ b/docs/apis/plugin-api/hook-filters.md
@@ -82,7 +82,7 @@ See [`HookFilter`](/reference/Interface.HookFilter) as well.
 
 ## Composable Filters
 
-For more complex filtering logic, Rolldown provides composable filter expressions via the [`@rolldown/pluginutils`](https://github.com/rolldown/rolldown/tree/main/packages/pluginutils) package. These allow you to build filters using logical operators like `and`, `or`, and `not`.
+For more complex filtering logic, Rolldown provides composable filter expressions via the [`@rolldown/pluginutils`](https://github.com/rolldown/plugins/tree/main/packages/pluginutils) package. These allow you to build filters using logical operators like `and`, `or`, and `not`.
 
 > [!WARNING]
 > Composable filters are not yet supported in Vite or unplugin. They can be used in Rolldown plugins only.
@@ -117,7 +117,7 @@ export default function myPlugin() {
 - `include(expr)` / `exclude(expr)` — Top-level include/exclude wrappers.
 - `queries(obj)` — Compose multiple query filters.
 
-See the [`@rolldown/pluginutils` README](https://github.com/rolldown/rolldown/tree/main/packages/pluginutils#readme) for the full API reference.
+See the [`@rolldown/pluginutils` README](https://github.com/rolldown/plugins/tree/main/packages/pluginutils#readme) for the full API reference.
 
 ## Interoperability
 

--- a/docs/development-guide/building-and-running.md
+++ b/docs/development-guide/building-and-running.md
@@ -16,7 +16,7 @@ You could get a list of available commands by running the command `just` only.
 - `just test` - Runs all tests.
 - `just lint` - Format and lint the codebase.
 - `just fix` - Fix formatting and linting issues.
-- `just build` - Build the `rolldown` node package (and `@rolldown/pluginutils` node package).
+- `just build` - Build the `rolldown` node package.
 - `just run` - Run the `rolldown` cli using node.
 
 > Most of commands will run both Rust and Node.js scripts. To only target one, append `-rust` or `-node` to the just command. For example, `just lint-rust` or `just test-node`.


### PR DESCRIPTION
- update the `@rolldown/pluginutils` repository and README links in the hook filter documentation
- correct the `just build` description now that `@rolldown/pluginutils` is no longer part of this workspace

