### PR TITLE
test(vite-tests): drop the dead `@rolldown/pluginutils` pnpm override

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -6,8 +6,7 @@ import { x } from 'tinyexec';
 const VITE_DIR = path.resolve(import.meta.dirname, '../../vite');
 const REPO_PATH = path.resolve(import.meta.dirname, './repo');
 const OVERRIDES = [
-  `  rolldown: ${path.resolve(import.meta.dirname, '../rolldown')}`,
-  `  "@rolldown/pluginutils": ${path.resolve(import.meta.dirname, '../pluginutils')}`
+  `  rolldown: ${path.resolve(import.meta.dirname, '../rolldown')}`
 ];
 
 function printTitle(title: string) {


### PR DESCRIPTION
`packages/pluginutils` moved to https://github.com/rolldown/plugins in #9317, so this override points at a directory that no longer exists in the repo. It is inert rather than broken: `@rolldown/pluginutils` is not in the vite checkout's dependency graph, so pnpm never resolves the override.

refs #10574
