### PR TITLE
fix(dev): keep `?rolldown-lazy` proxy ids out of user `resolveId` hooks

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -99,6 +99,14 @@ impl PluginDriver {
       if skipped_plugins.has_bit(plugin_idx) {
         continue;
       }
+      if should_skip_plugin_for_lazy_proxy(
+        self.should_skip_user_plugins_for_lazy_proxy_modules,
+        args.specifier,
+        plugin_idx,
+        self.lazy_compilation_plugin_idx,
+      ) {
+        continue;
+      }
       let ret = async {
         trace_action!(action::HookResolveIdCallStart {
           action: "HookResolveIdCallStart",

--- a/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/lazy_compilation_plugin.rs
@@ -79,6 +79,20 @@ impl Plugin for LazyCompilationPlugin {
     ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
+    // Re-resolution of a known proxy id (e.g. the dev server resolving the stub id to
+    // serve a lazy compilation request) is claimed here; unknown proxy ids fall through
+    // and stay unresolvable (cf. the unknown-lazy-id rejection in
+    // `HmrStage::compile_lazy_entry`).
+    if args.specifier.ends_with("?rolldown-lazy=1") && self.lazy_entries.contains(args.specifier) {
+      return Ok(Some(HookResolveIdOutput {
+        id: args.specifier.into(),
+        external: None,
+        normalize_external_id: None,
+        side_effects: None,
+        package_json_path: None,
+      }));
+    }
+
     if matches!(args.kind, ImportKind::DynamicImport) {
       // If the importer is a fetched proxy module, don't create another proxy.
       // This allows the fetched template's `import($MODULE_ID)` to resolve

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -145,11 +145,13 @@ When `resolve_id` is called for a dynamic import:
 1. If the importer is a **fetched proxy** (`?rolldown-lazy=1` + in `fetched_entries`) → return `None` (skip proxy creation, resolve to actual module)
 2. Otherwise → resolve the specifier via `ctx.resolve` (`skip_self: true`, forwarding `args.custom`) and append `?rolldown-lazy=1`. The append is **idempotent** (#9439): `ctx.resolve` can re-enter other plugins' resolve hooks (e.g. an alias plugin), so if the resolved id already ends with the marker it is reused — a doubled suffix would desync the proxy id from the runtime invalidation key in the stub template (regression vitejs/vite#22454, pinned by the aliased-import spec)
 
+Re-resolution of a known proxy id (any import kind — e.g. a dev server resolving the stub id as an entry to serve a lazy compilation request) is claimed by the lazy plugin itself: if the specifier ends with `?rolldown-lazy=1` and is present in `lazy_entries`, it resolves to itself. Unknown proxy ids fall through and stay unresolvable (cf. the #9969 gate below). User-land `resolve_id` hooks never see proxy ids at all — the `PluginDriver` skips them for `?rolldown-lazy=1` specifiers — because a virtual-module plugin would not recognize its own id with the query appended and nothing else can resolve a virtual id (regression vitejs/vite#23124, pinned by `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`).
+
 When `load` is called for a proxy module:
 
 1. Only ids present in `lazy_entries` are served at all — any other `?rolldown-lazy=1` id falls through to `Ok(None)`
 2. If in `fetched_entries` → return fetched template; otherwise → return stub template
-3. User-land build hooks are skipped for proxy ids (`?rolldown-lazy=1`) so plugins only see real modules; the lazy plugin itself still runs to serve the stub/fetched template.
+3. User-land build hooks (`resolve_id`, `load`, `transform`, `transform_ast`, `module_parsed`) are skipped for proxy ids (`?rolldown-lazy=1`) so plugins only see real modules; the lazy plugin itself still runs to serve the stub/fetched template.
 
 **Security gate — unknown module rejection (#9969)**: the id passed to `compileEntry` / `compile_lazy_entry` is treated purely as a lookup key into the build cache, never resolved as a filesystem path. An id not present from a prior build is rejected in `HmrStage::compile_lazy_entry` with `Lazy entry module not found in cache` — so a malicious `/@vite/lazy` request cannot bundle an arbitrary file (analogous to Vite's `server.fs.strict`; pinned by `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`). Note the ordering: `DevEngine::compile_lazy_entry` calls `mark_as_fetched` unconditionally **before** this validation, so an unknown id still lands in `fetched_entries` (harmless, but worth knowing when debugging).
 

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -2,7 +2,7 @@ import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { InputOptions, OutputOptions } from 'rolldown';
+import type { InputOptions, OutputOptions, Plugin } from 'rolldown';
 import type { DevEngine, DevOptions } from 'rolldown/experimental';
 import { dev as _dev } from 'rolldown/experimental';
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
@@ -285,6 +285,83 @@ test(
     expect(seenTransformIds.some((id) => id.endsWith('lazy.js'))).toBe(true);
     expect(seenModuleParsedIds.some((id) => id.includes('?rolldown-lazy=1'))).toBe(false);
     expect(seenModuleParsedIds.some((id) => id.endsWith('lazy.js'))).toBe(true);
+  },
+);
+
+// A virtual module behind a lazy proxy must stay loadable: re-resolving the proxy id
+// (`\0virtual:lazy-me?rolldown-lazy=1`) is claimed by the lazy compilation plugin itself
+// and never reaches user `resolveId` hooks, which only recognize the bare id.
+test(
+  'lazy proxy ids resolve without reaching user resolveId hooks',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-virtual-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const main = path.join(dir, 'main.js');
+    fs.writeFileSync(main, `globalThis.load = () => import('virtual:lazy-me');\n`);
+
+    const virtualId = '\0virtual:lazy-me';
+    const lazyProxyId = `${virtualId}?rolldown-lazy=1`;
+
+    const seenByOwner: string[] = [];
+    const seenByObserver: string[] = [];
+    let resolvedProxyId: string | null | undefined;
+    const virtualOwner: Plugin = {
+      name: 'virtual-owner',
+      resolveId(source) {
+        seenByOwner.push(source);
+        if (source === 'virtual:lazy-me' || source === virtualId) {
+          return virtualId;
+        }
+      },
+      load(id) {
+        if (id === virtualId) {
+          return `export const value = 1;\n`;
+        }
+      },
+      // The real module is only parsed once the proxy is fetched, so by now the proxy
+      // id is a registered lazy entry and re-resolving it must work.
+      async moduleParsed(moduleInfo) {
+        if (moduleInfo.id === virtualId) {
+          resolvedProxyId = (await this.resolve(lazyProxyId))?.id;
+        }
+      },
+    };
+    const observer: Plugin = {
+      name: 'observe-resolve-ids',
+      resolveId(source) {
+        seenByObserver.push(source);
+      },
+    };
+
+    const engine = await dev(
+      {
+        input: main,
+        plugins: [virtualOwner, observer],
+        experimental: { devMode: { lazy: true } },
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await engine.registerClient('c1');
+    const chunk = await engine.compileEntry(lazyProxyId, 'c1');
+
+    expect(chunk.code).toContain('value');
+    expect(resolvedProxyId).toBe(lazyProxyId);
+    expect(seenByOwner.some((id) => id.includes('?rolldown-lazy=1'))).toBe(false);
+    expect(seenByObserver.some((id) => id.includes('?rolldown-lazy=1'))).toBe(false);
+    expect(seenByOwner).toContain('virtual:lazy-me');
+    expect(seenByOwner).toContain(virtualId);
   },
 );
 


### PR DESCRIPTION
## Summary

Fixes vitejs/vite#23124 — re-resolving a lazy proxy id (`?rolldown-lazy=1`) no longer leaks to user `resolveId` hooks, and known proxy ids are claimed by the lazy compilation plugin itself.

## Why

A plugin virtual module reached through a dynamic import becomes a lazy entry whose proxy id carries the internal `?rolldown-lazy=1` query. When that stub id is re-resolved (e.g. entry resolution for a lazy compilation request), virtual-module plugins no longer recognize their own id with the query appended, and nothing else can resolve a virtual id → `UNRESOLVED_ENTRY` on first page load.

#10426 covered `load` / `transform` / `transform_ast` / `module_parsed` but not `resolve_id`; Vite's own workaround (#22778) likewise only wraps `transform`.

## What changed

- `LazyCompilationPlugin::resolve_id`: claim proxy ids present in `lazy_entries` for any import kind. Unknown proxy ids still fall through and stay unresolvable (cf. the #9969 gate).
- `PluginDriver`: extend the `should_skip_plugin_for_lazy_proxy` skip to `resolve_id`, so user plugins never see the internal query; the lazy plugin itself still runs to claim the id. Matching is on the specifier only — the fetched proxy's `import($MODULE_ID)` (importer = proxy id) still resolves the real module through user plugins normally.
- Regression test in `packages/rolldown/tests/dev/dev-lazy-compile.test.ts`: a virtual module behind a lazy proxy — asserts user `resolveId` hooks never see the proxy id, the proxy id re-resolves to itself, and the real module still compiles into the lazy chunk.
- Update `internal-docs/lazy-compilation/implementation.md` with the new `resolve_id` contract.

## Validation

- `pnpm --filter rolldown run build-native:debug`
- `pnpm --filter rolldown-tests exec vitest run dev/dev-lazy-compile.test.ts` (8/8)
- Negative control: with the Rust changes stashed and a full rebuild, the new test fails (`this.resolve(proxyId)` returns `null`)
- E2E with the issue's repro (vite-bundleddev-virtual-lazy-repro, local vite + this rolldown via pnpm overrides):
  - Baseline (npm rolldown 1.2.1): server logs `[UNRESOLVED_ENTRY] Cannot resolve entry module \0virtual:lazy-me?rolldown-lazy=1`, page shows `ERR Failed to fetch dynamically imported module`
  - This change: first lazy compile succeeds, page renders `hello from a virtual module`, zero server/console errors

Note: the repro's plugin must also recognize its own `\0`-prefixed id in `resolveId` (the canonical virtual-module pattern, which real-world plugins like @embroider/vite follow). Without it, the fetched proxy's import of the *real* module id can't resolve — a separate behavior difference from classic Vite dev (rolldown re-resolves the real id), better handled as a follow-up.

## AI disclosure

This PR was developed with AI assistance. All generated changes were reviewed, tested, and adjusted before submission.