### PR TITLE
feat(rolldown_plugin_vite_import_glob): record a matcher per glob call in dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ name = "rolldown_plugin_vite_import_glob"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "fast-glob",
  "itoa",
  "oxc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,6 +3039,7 @@ name = "rolldown_plugin_vite_import_glob"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "fast-glob",
  "itoa",
  "oxc",

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_import_glob_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_import_glob_plugin_config.rs
@@ -14,6 +14,7 @@ impl From<BindingViteImportGlobPluginConfig> for ViteImportGlobPlugin {
       root: value.root,
       sourcemap: value.sourcemap.unwrap_or_default(),
       restore_query_extension: value.restore_query_extension.unwrap_or_default(),
+      ..Default::default()
     }
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+arcstr = { workspace = true }
 fast-glob = { workspace = true }
 itoa = { workspace = true }
 oxc = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -1,17 +1,23 @@
+mod matcher;
 mod utils;
 
 use std::{borrow::Cow, path::PathBuf};
 
+use arcstr::ArcStr;
 use oxc::ast_visit::VisitJs;
 use rolldown_plugin::{HookTransformOutput, HookTransformOutputMap, HookUsage, Plugin};
 use rolldown_plugin_utils::parse_program;
+use rolldown_utils::dashmap::FxDashMap;
 use sugar_path::SugarPath as _;
+
+use crate::matcher::GlobMatcher;
 
 #[derive(Debug, Default)]
 pub struct ViteImportGlobPlugin {
   pub root: Option<String>,
   pub sourcemap: bool,
   pub restore_query_extension: bool,
+  pub glob_matchers: FxDashMap<ArcStr, Vec<GlobMatcher>>,
 }
 
 impl Plugin for ViteImportGlobPlugin {
@@ -28,44 +34,53 @@ impl Plugin for ViteImportGlobPlugin {
     ctx: rolldown_plugin::SharedTransformPluginContext,
     args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
-    if args.code.contains("import.meta.glob") {
-      let allocator = oxc::allocator::Allocator::default();
-      let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
-      else {
-        return Ok(None);
-      };
-      let id = args.id.to_slash_lossy();
-      let root = self.root.as_ref().map(PathBuf::from);
-      let root = root.as_ref().unwrap_or(ctx.cwd());
-      let mut visitor = utils::GlobImportVisit {
-        ctx: &ctx,
-        root,
-        id: &id,
-        current: 0,
-        code: args.code,
-        magic_string: None,
-        import_decls: Vec::new(),
-        errors: Vec::new(),
-        restore_query_extension: self.restore_query_extension,
-        is_dev_mode: ctx.options().is_dev_mode_enabled(),
-      };
-      visitor.visit_program(&parser_ret.program);
-      if let Some(err) = visitor.errors.into_iter().next() {
-        return Err(err);
-      }
-      if let Some(magic_string) = visitor.magic_string {
-        return Ok(Some(HookTransformOutput {
-          code: Some(magic_string.to_string()),
-          map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {
-            magic_string.source_map(string_wizard::SourceMapOptions {
-              hires: string_wizard::Hires::Boundary,
-              source: args.id.into(),
-              ..Default::default()
-            })
-          }),
-          ..Default::default()
-        }));
-      }
+    if !args.code.contains("import.meta.glob") {
+      self.remove_globs(args.id);
+      return Ok(None);
+    }
+
+    let allocator = oxc::allocator::Allocator::default();
+    let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)? else {
+      self.remove_globs(args.id);
+      return Ok(None);
+    };
+
+    let id = args.id.to_slash_lossy();
+    let root = self.root.as_ref().map(PathBuf::from);
+    let root = root.as_ref().unwrap_or(ctx.cwd());
+    let is_dev_mode = ctx.options().is_dev_mode_enabled();
+    let mut visitor = utils::GlobImportVisit {
+      ctx: &ctx,
+      root,
+      id: &id,
+      current: 0,
+      code: args.code,
+      magic_string: None,
+      import_decls: Vec::new(),
+      errors: Vec::new(),
+      restore_query_extension: self.restore_query_extension,
+      is_dev_mode,
+      matchers: Vec::new(),
+    };
+    visitor.visit_program(&parser_ret.program);
+    if let Some(err) = visitor.errors.into_iter().next() {
+      return Err(err);
+    }
+    if is_dev_mode {
+      self.set_globs(&id, visitor.matchers);
+    }
+    if let Some(magic_string) = visitor.magic_string {
+      return Ok(Some(HookTransformOutput {
+        code: Some(magic_string.to_string()),
+        map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {
+          magic_string.source_map(string_wizard::SourceMapOptions {
+            hires: string_wizard::Hires::Boundary,
+            source: args.id.into(),
+            ..Default::default()
+          })
+        }),
+        ..Default::default()
+      }));
     }
     Ok(None)
   }

--- a/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/matcher.rs
@@ -1,0 +1,32 @@
+use sugar_path::SugarPath as _;
+
+use crate::ViteImportGlobPlugin;
+
+impl ViteImportGlobPlugin {
+  pub(crate) fn set_globs(&self, id: &str, matchers: Vec<GlobMatcher>) {
+    if matchers.is_empty() {
+      self.glob_matchers.remove(id);
+    } else {
+      self.glob_matchers.insert(arcstr::ArcStr::from(id), matchers);
+    }
+  }
+
+  pub(crate) fn remove_globs(&self, id: &str) {
+    if !self.glob_matchers.is_empty() {
+      self.glob_matchers.remove(&*id.to_slash_lossy());
+    }
+  }
+}
+
+/// Replays the accept/reject decision of the build-time walk in
+/// [`crate::utils::GlobImportVisit`] without re-walking the filesystem, so the two cannot drift.
+#[derive(Debug)]
+pub struct GlobMatcher {
+  /// In original case: the walk itself is never case-folded, only the glob comparison is.
+  pub walk_root: String,
+  /// `(static prefix, pattern)` pairs as `PathWithGlob` splits them.
+  pub positive: Vec<(String, String)>,
+  pub negated: Vec<(String, String)>,
+  pub exhaustive: bool,
+  pub case_sensitive: bool,
+}

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -17,6 +17,8 @@ use rolldown_std_utils::relative_path_to_slash;
 use string_wizard::MagicString;
 use sugar_path::SugarPath;
 
+use crate::matcher::GlobMatcher;
+
 pub struct GlobImportVisit<'a> {
   pub ctx: &'a PluginContext,
   pub id: &'a str,
@@ -28,6 +30,7 @@ pub struct GlobImportVisit<'a> {
   pub import_decls: Vec<String>,
   pub errors: Vec<anyhow::Error>,
   pub is_dev_mode: bool,
+  pub matchers: Vec<GlobMatcher>,
 }
 
 impl<'ast> VisitJs<'ast> for GlobImportVisit<'_> {
@@ -75,6 +78,11 @@ impl<'a> PathWithGlob<'a> {
     let i = Self::find_glob_syntax(&glob[glob.len() - j..]);
     path.truncate(path.len() - i);
     Self { path, glob: &glob[glob.len() - i..] }
+  }
+
+  /// Owned copy for the long-lived [`GlobMatcher`]
+  fn to_owned_parts(&self) -> (String, String) {
+    (self.path.clone(), self.glob.to_string())
   }
 
   fn find_glob_syntax(path: &str) -> usize {
@@ -475,17 +483,26 @@ impl GlobImportVisit<'_> {
       return None;
     }
 
-    let common = self.get_common_base(&positive_globs);
-    let common_path = Path::new(common.as_ref());
+    let common = self.get_common_base(&positive_globs).into_owned();
+    let common_path = Path::new(&common);
 
-    // `walkdir` yields nothing for a directory that does not exist, so the walk below cannot
-    // register anything. Watching the nearest existing ancestor makes its creation observable.
-    if self.is_dev_mode
-      && !common_path.is_dir()
-      && let Some(ancestor) =
-        common_path.ancestors().skip(1).find(|dir| dir.is_dir()).and_then(Path::to_str)
-    {
-      self.ctx.add_watch_file(ancestor);
+    if self.is_dev_mode {
+      self.matchers.push(GlobMatcher {
+        walk_root: common.clone(),
+        positive: positive_globs.iter().map(PathWithGlob::to_owned_parts).collect(),
+        negated: negated_globs.iter().map(PathWithGlob::to_owned_parts).collect(),
+        exhaustive: options.exhaustive,
+        case_sensitive,
+      });
+
+      // `walkdir` yields nothing for a directory that does not exist, so the walk below cannot
+      // register anything. Watching the nearest existing ancestor makes its creation observable.
+      if !common_path.is_dir()
+        && let Some(ancestor) =
+          common_path.ancestors().skip(1).find(|dir| dir.is_dir()).and_then(Path::to_str)
+      {
+        self.ctx.add_watch_file(ancestor);
+      }
     }
 
     let entries = walkdir::WalkDir::new(common_path)


### PR DESCRIPTION
Part of rolldown/rolldown#10059

The build-time walk decides which files a glob covers, and that decision evaporates the moment `transform` returns. Reacting to file creation and deletion later means being able to re-ask it for an arbitrary path without re-walking anything.

So the walk now leaves a record: one `GlobMatcher` per glob call, holding the same inputs the walk used (walk root, prefix/pattern split, `exhaustive`, `caseSensitive`), keyed by the owning module. The table lives on the plugin so it survives incremental rebuilds, and `transform` upserts or removes per module, which keeps it honest without a global reset.

Nothing consumes the table yet, hence the `expect(dead_code)` on the module. Acting on it is #10550.