### PR TITLE
feat(code-splitting): widen namespace extraction for already-loaded merges

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -212,19 +212,23 @@ impl GenerateStage<'_> {
   /// entry's namespace object from its chunk and rewriting every dynamic importer to
   /// `.then((n) => n.<ns>)` (see `rewrite_dynamic_import_for_merged_entry`).
   fn dynamic_entry_supports_namespace_extraction(&self, entry_module_idx: ModuleIdx) -> bool {
-    if self.options.preserve_modules || !self.options.minify_internal_exports {
-      return false;
-    }
     if self.link_output.module_table[entry_module_idx].as_normal().is_none() {
       return false;
     }
 
-    // If a module exports a `then`, we cannot actually get its namespace from the dynamic import.
-    let symbol_db = &self.link_output.symbol_db;
-    if self.link_output.metas[entry_module_idx].resolved_exports.iter().any(|(name, export)| {
-      name.as_str() == "then"
-        || symbol_db.canonical_ref_for(export.symbol_ref).name(symbol_db) == "then"
-    }) {
+    // A namespace carrying a callable `then` is assimilated by `import()`, so the extraction
+    // callback would receive whatever that `then` produces instead of the namespace. Only the
+    // export *name* can do that, so a local symbol named `then` exported under an alias is
+    // harmless — the alias is what lands in the namespace.
+    //
+    // No other export name can become `then`: the minified generator skips it and
+    // `ConflictResolver` reserves it, so an internal export named `then` deconflicts to
+    // `then$1` (see `THENABLE_HAZARD_EXPORT_NAME` in compute_cross_chunk_links.rs).
+    if self.link_output.metas[entry_module_idx]
+      .resolved_exports
+      .keys()
+      .any(|name| name.as_str() == "then")
+    {
       return false;
     }
 

--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -216,14 +216,14 @@ impl GenerateStage<'_> {
       return false;
     }
 
-    // A namespace carrying a callable `then` is assimilated by `import()`, so the extraction
-    // callback would receive whatever that `then` produces instead of the namespace. Only the
-    // export *name* can do that, so a local symbol named `then` exported under an alias is
-    // harmless — the alias is what lands in the namespace.
+    // `import()` assimilates a namespace that carries a callable `then`. The extraction callback
+    // would then get whatever that `then` returns, not the namespace. Only the export name can do
+    // this. A local symbol named `then` that leaves under an alias is harmless, because the alias
+    // is what lands in the namespace.
     //
-    // No other export name can become `then`: the minified generator skips it and
-    // `ConflictResolver` reserves it, so an internal export named `then` deconflicts to
-    // `then$1` (see `THENABLE_HAZARD_EXPORT_NAME` in compute_cross_chunk_links.rs).
+    // No other export name can become `then`. The minified generator skips it, and
+    // `ConflictResolver` reserves it up front. So an internal export named `then` deconflicts to
+    // `then$1`. See `THENABLE_HAZARD_EXPORT_NAME` in compute_cross_chunk_links.rs.
     if self.link_output.metas[entry_module_idx]
       .resolved_exports
       .keys()

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_aliased_then/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_aliased_then/_test.mjs
@@ -16,6 +16,6 @@ assert.deepEqual(keys, ['done', 'ready']);
 
 const jsFiles = readdirSync(join(import.meta.dirname, 'dist')).filter((f) => f.endsWith('.js'));
 
-// main + app + lazy + vendor: `vendor.js` is not inlined into the dynamic
-// entry chunk today.
-assert.strictEqual(jsFiles.length, 4, `Expected 4 chunks but got: ${jsFiles.join(', ')}`);
+// A namespace that is not thenable no longer blocks inlining:
+// main + app(+vendor) + lazy.
+assert.strictEqual(jsFiles.length, 3, `Expected 3 chunks but got: ${jsFiles.join(', ')}`);

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_aliased_then/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_aliased_then/artifacts.snap
@@ -6,22 +6,31 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## app.js
 
 ```js
-import { t as f0 } from "./vendor.js";
+// HIDDEN [\0rolldown/runtime.js]
+//#region vendor.js
+function f0(x) {
+	return x * 2 + 1;
+}
+//#endregion
 //#region app.js
+var app_exports = /* @__PURE__ */ __exportAll({
+	done: () => done,
+	ready: () => then
+});
 console.log(f0(1));
 const then = "not-a-function";
 const done = import("./lazy.js").then(({ fn }) => {
 	fn();
 });
 //#endregion
-export { done, then as ready };
+export { done, f0 as n, then as ready, app_exports as t };
 
 ```
 
 ## lazy.js
 
 ```js
-import { t as f0 } from "./vendor.js";
+import { n as f0 } from "./app.js";
 //#region lazy.js
 function fn() {
 	console.log(f0(3));
@@ -35,24 +44,12 @@ export { fn };
 
 ```js
 //#region main.js
-const done = import("./app.js").then(async (app) => {
+const done = import("./app.js").then((n) => n.t).then(async (app) => {
 	await app.done;
 	return Object.keys(app).sort();
 });
 //#endregion
 export { done };
-
-```
-
-## vendor.js
-
-```js
-//#region vendor.js
-function f0(x) {
-	return x * 2 + 1;
-}
-//#endregion
-export { f0 as t };
 
 ```
 
@@ -61,22 +58,31 @@ export { f0 as t };
 ## app.js
 
 ```js
-import { f0 } from "./vendor.js";
+// HIDDEN [\0rolldown/runtime.js]
+//#region vendor.js
+function f0(x) {
+	return x * 2 + 1;
+}
+//#endregion
 //#region app.js
+var app_exports = /* @__PURE__ */ __exportAll({
+	done: () => done,
+	ready: () => then
+});
 console.log(f0(1));
 const then = "not-a-function";
 const done = import("./lazy.js").then(({ fn }) => {
 	fn();
 });
 //#endregion
-export { done, then as ready };
+export { app_exports, done, f0, then as ready };
 
 ```
 
 ## lazy.js
 
 ```js
-import { f0 } from "./vendor.js";
+import { f0 } from "./app.js";
 //#region lazy.js
 function fn() {
 	console.log(f0(3));
@@ -90,23 +96,11 @@ export { fn };
 
 ```js
 //#region main.js
-const done = import("./app.js").then(async (app) => {
+const done = import("./app.js").then((n) => n.app_exports).then(async (app) => {
 	await app.done;
 	return Object.keys(app).sort();
 });
 //#endregion
 export { done };
-
-```
-
-## vendor.js
-
-```js
-//#region vendor.js
-function f0(x) {
-	return x * 2 + 1;
-}
-//#endregion
-export { f0 };
 
 ```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_cjs_format/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_cjs_format/_test.mjs
@@ -24,6 +24,6 @@ assert.deepEqual(keys, ['done']);
 
 const jsFiles = readdirSync(join(import.meta.dirname, 'dist')).filter((f) => f.endsWith('.js'));
 
-// main + app + lazy + vendor: `vendor.js` is not inlined into the dynamic
-// entry chunk today.
-assert.strictEqual(jsFiles.length, 4, `Expected 4 chunks but got: ${jsFiles.join(', ')}`);
+// `minifyInternalExports: false` no longer blocks inlining:
+// main + app(+vendor) + lazy.
+assert.strictEqual(jsFiles.length, 3, `Expected 3 chunks but got: ${jsFiles.join(', ')}`);

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/already_loaded_cjs_format/artifacts.snap
@@ -6,24 +6,37 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## app.js
 
 ```js
-const require_vendor = require("./vendor.js");
+// HIDDEN [\0rolldown/runtime.js]
+//#region vendor.js
+function f0(x) {
+	return x * 2 + 1;
+}
+//#endregion
 //#region app.js
-console.log(require_vendor.f0(1));
+var app_exports = /* @__PURE__ */ __exportAll({ done: () => done });
+console.log(f0(1));
 const done = Promise.resolve().then(() => require("./lazy.js")).then(({ fn }) => {
 	fn();
 });
 //#endregion
+Object.defineProperty(exports, "app_exports", {
+	enumerable: true,
+	get: function() {
+		return app_exports;
+	}
+});
 exports.done = done;
+exports.f0 = f0;
 
 ```
 
 ## lazy.js
 
 ```js
-const require_vendor = require("./vendor.js");
+const require_app = require("./app.js");
 //#region lazy.js
 function fn() {
-	console.log(require_vendor.f0(3));
+	console.log(require_app.f0(3));
 }
 //#endregion
 exports.fn = fn;
@@ -35,28 +48,11 @@ exports.fn = fn;
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 //#region main.js
-const done = Promise.resolve().then(() => require("./app.js")).then(async (app) => {
+const done = Promise.resolve().then(() => require("./app.js")).then((n) => n.app_exports).then(async (app) => {
 	await app.done;
 	return Object.keys(app).sort();
 });
 //#endregion
 exports.done = done;
-
-```
-
-## vendor.js
-
-```js
-//#region vendor.js
-function f0(x) {
-	return x * 2 + 1;
-}
-//#endregion
-Object.defineProperty(exports, "f0", {
-	enumerable: true,
-	get: function() {
-		return f0;
-	}
-});
 
 ```


### PR DESCRIPTION
`dynamic_entry_supports_namespace_extraction` refused three cases it does not need to, each costing an extra chunk:

- `preserveModules`. This is dead code, since `generate_chunks` never calls `split_chunks` there.
- `!minifyInternalExports`. This is the default for non-ESM output without minify. So a cjs, iife or umd build lost namespace extraction unless it was minified.
- a declaring symbol named `then`. Only the export name can make a namespace thenable, and `const then = 1; export { then as ready }` puts `ready` in the namespace.

refs #10263
