### PR TITLE
feat(metrics-lab): node/deno server startup mode

### DIFF
--- a/packages/metrics-lab/AGENTS.md
+++ b/packages/metrics-lab/AGENTS.md
@@ -45,6 +45,30 @@ reports it UNKNOWN with the one config line that enables it — enable it and re
 rather than justifying the gap: it is the cheapest signal in the whole kit (no
 browser run, and it prices every candidate at once).
 
+## If the target is a server, not a page
+
+`node-scan --entry <builtServerScript> --ready <spec>` measures a process coming up
+instead of a page loading. The loop below is unchanged — baseline, one change, measure,
+accept or revert — with three differences that decide whether your work is worth anything:
+
+- **Declare readiness once and never change it.** `--ready port:3000` /
+  `'stdout:listening on'` / `http://127.0.0.1:3000/health` / `exit`. It is pinned with the
+  target; two scans that measured different moments are not comparable, the same way two
+  browser scans under different net scales are not.
+- **Read the ownership line before doing any work.** `node-scan` reports pre-ready CPU
+  split into app modules / runtime+native / engine. When app modules hold a small share,
+  the bundle is not the cost — startup is native addon loading, TLS/crypto init, or a
+  DB handshake — and deferring imports will not move the number no matter how good the
+  deferral is. Say that and stop, rather than shipping edits that cannot help.
+- **Judge small startups by bytes, not milliseconds.** Readiness polling quantizes; when
+  `node-scan` prints the resolution note, the millisecond delta is not evidence and the
+  cold-at-ready byte count is.
+
+`graph`, `what-if`, `cut` and `graph-diff` work exactly as below on a server build —
+a top-level import and a render-blocking import are the same edge in the module graph.
+Bun is not supported (JavaScriptCore, not V8) and edge runtimes can only be analyzed
+statically; do not report a measured number for either.
+
 ## The optimization loop
 
 1. Build the app. `scan --app <appDir>` — the first scan is your baseline.

--- a/packages/metrics-lab/README.md
+++ b/packages/metrics-lab/README.md
@@ -53,6 +53,55 @@ every build also refreshes the build-side report under `state/rolldown-metrics/`
 `--features a,b`) to point at any other built app; candidates are then advisory
 per-module (the agent finds the import seams itself).
 
+## Server startup mode (node / deno)
+
+Same question — "what does the initial load pay for, and what can leave it?" — asked
+of a process coming up instead of a page loading.
+
+```bash
+node harness.mjs node-scan --entry dist/server.js --ready port:3000
+node harness.mjs node-scan            # target + readiness are remembered
+node harness.mjs node-scan --pin      # make this the fixed reference
+```
+
+| Command                                    | What it does                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `node-scan`                                | Timed spawn→ready runs, then two instrumented runs: **what had to execute** to become ready (V8 precise coverage snapshotted at the readiness moment, attributed to source modules through the sourcemap) and **where the pre-ready CPU went** (sampling profile armed while the process is still paused at entry). Then the leads. |
+| `node-measure`                             | Timing only — no instrumented runs.                                                                                                                                                                                                                                                                                                 |
+| `graph` / `what-if` / `cut` / `graph-diff` | Work unchanged on a server build (`--dist <builtDir>` or `--report <dir>`): a top-level import and a render-blocking import are the same edge in the module graph.                                                                                                                                                                  |
+
+**Readiness is part of the target.** A server has no equivalent of first paint, so the
+target declares how it signals "up", and the spec is pinned with it — two scans that
+measured different moments are not comparable.
+
+| `--ready` spec                 | Ready when                                        |
+| ------------------------------ | ------------------------------------------------- |
+| `port:3000`                    | a TCP listener is accepting                       |
+| `stdout:listening on \d+`      | a line matching this regex is printed             |
+| `http://127.0.0.1:3000/health` | an HTTP probe returns 2xx                         |
+| `exit`                         | the process exits 0 (CLIs, lambda-shaped entries) |
+
+Other options: `--cache cold|warm|off`, `--args "..."`, `--exec <bin>` (deno, another
+node), `--cwd <dir>`, `--runs`, `--timeout <seconds>`, `--label`, `--pin`.
+
+Metrics are `runtime.startup_ms`, `runtime.boot_floor_ms` (what an empty script costs on
+this machine) and `runtime.app_startup_ms` (the difference — the part a bundle change can
+actually move), plus the same `delta` / `baselineDelta` shape the browser side writes.
+
+### What this mode does NOT do
+
+- **No throttle.** Server startup does no network I/O, so a throttle would invent a
+  dimension the measurement does not have. There is therefore no net-scale calibration
+  and no cross-scale comparability problem.
+- **The reported timing never runs under the inspector.** `--inspect-brk` shifts startup
+  by tens of ms; the instrumented runs are separate and used for attribution only.
+- **Bun is not supported.** It runs JavaScriptCore, whose inspector is the WebKit
+  protocol and whose profile/coverage formats are not V8's, so attribution cannot work
+  there. Deno is V8 + CDP and rides the same driver via `--exec`.
+- **Edge runtimes cannot be measured this way** — no local process, and cold start is
+  dominated by platform isolate boot. The static half (`graph`, `what-if`, `cut`) still
+  applies to an edge bundle; the measured half does not.
+
 ## The loop protocol (for an agent)
 
 1. **Baseline**: `gen` → `build` → `measure --runs 5 --label baseline` → `baseline`.
@@ -114,7 +163,12 @@ guard catches a defer that broke behavior.
   The signal is the delta between builds under identical conditions.
 - V8 coverage counts a module's top level as executed at evaluation, so real-world
   modules whose weight is top-level data look "used at paint" even if nothing reads
-  them — a known blind spot; judge those by size + manual inspection.
+  them — a known blind spot; judge those by size + manual inspection. The same blind
+  spot applies to `node-scan`'s cold-at-ready list.
+- Server startup readiness discovered by polling (`port:` / `http://`) quantizes to the
+  poll interval. When the addressable time is only a few intervals wide, `node-scan`
+  says so rather than reporting millisecond deltas it cannot resolve — judge byte and
+  module counts there, not milliseconds.
 - `defer`/`undefer` is a marker-block codemod, i.e. demo-app sugar for what an agent
   does on a real codebase: rewriting the import site into a post-paint `import()`.
 - Lab INP is meaningless (no real interaction); field metrics are Phase 3's

--- a/packages/metrics-lab/harness.mjs
+++ b/packages/metrics-lab/harness.mjs
@@ -55,6 +55,26 @@ import {
 } from './lib/module-graph.mjs';
 import { minCut } from './lib/min-cut.mjs';
 import { diffGraphs } from './lib/graph-diff.mjs';
+import {
+  POLL_MS,
+  assertReadyPortFree,
+  describeReady,
+  freshCacheDir,
+  parseReadySpec,
+  runEnv,
+} from './lib/node/launch.mjs';
+import {
+  NOISE_FLOOR_MS as NODE_NOISE_FLOOR_MS,
+  NOISE_FLOOR_PCT as NODE_NOISE_FLOOR_PCT,
+  coldModules,
+  gatherStartupSamples,
+  graphIdCandidates,
+  measureBootFloor,
+  profileStartup,
+  startupCoverage,
+  startupProfile,
+  summarizeStartup,
+} from './lib/node/measure.mjs';
 
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const APP_DIR = path.join(ROOT, 'app');
@@ -2241,6 +2261,417 @@ async function cmdServe(argv) {
 
 // --- dispatch ----------------------------------------------------------------
 
+// --- server-runtime startup mode ---------------------------------------------------
+// The browser half of this harness measures a page load; this half measures a process
+// coming up. They share the question — "what does the initial load pay for, and what
+// can leave it?" — and therefore share the whole static half: `graph`, `what-if`, `cut`
+// and `graph-diff` price a deferral identically for a server bundle, because a
+// top-level import and a render-blocking import are the same edge in the module graph.
+// Only the measurement differs, and it differs completely: no navigation, no paint, no
+// transfer, so no throttle (see lib/node/measure.mjs).
+
+const NODE_TARGET_FILE = path.join(STATE_DIR, 'node-target.json');
+const NODE_CACHE_MODES = new Set(['cold', 'warm', 'off']);
+
+const NODE_TARGET_OPTS = {
+  entry: { type: 'string' },
+  ready: { type: 'string' },
+  args: { type: 'string' },
+  exec: { type: 'string' },
+  cache: { type: 'string' },
+  cwd: { type: 'string' },
+};
+
+function nodeTargetPaths(entry) {
+  const dir = path.join(STATE_DIR, 'node', targetSlug(entry));
+  return {
+    dir,
+    metrics: path.join(dir, 'startup-metrics.json'),
+    state: path.join(dir, '.state.json'),
+    baseline: path.join(dir, 'baseline.json'),
+    history: path.join(dir, 'history.jsonl'),
+  };
+}
+
+/**
+ * Resolve (and remember) the server target. Readiness is part of the target, not of a
+ * single invocation: a scan that measured "port 3000 accepting" and a later one that
+ * measured "process exited" are not comparable, so the spec is pinned with the entry
+ * and reused by every later bare command.
+ */
+function resolveNodeTarget(opts) {
+  const sticky = readJson(NODE_TARGET_FILE);
+  const entryArg = opts.entry ?? sticky?.entry;
+  if (!entryArg) {
+    throw new Error(
+      'no server target yet - name the BUILT entry script (the file you deploy) and how it\n' +
+        'signals readiness, e.g.\n' +
+        `  ${CLI} node-scan --entry dist/server.js --ready port:3000\n` +
+        `  ${CLI} node-scan --entry dist/cli.js --ready exit`,
+    );
+  }
+  const entry = path.resolve(entryArg);
+  if (!fs.existsSync(entry)) {
+    throw new Error(
+      `no such entry script: ${entry}\n` +
+        'Build the app first, then aim --entry at the BUILT file. Never change the build to fit\n' +
+        'this tool - aim the tool at the build instead.',
+    );
+  }
+  const readySpec = opts.ready ?? sticky?.ready ?? 'exit';
+  const cache = opts.cache ?? sticky?.cache ?? 'cold';
+  if (!NODE_CACHE_MODES.has(cache)) {
+    throw new Error(`--cache must be one of cold|warm|off (got ${cache}).`);
+  }
+  const target = {
+    entry,
+    dist: path.dirname(entry),
+    readySpec,
+    ready: parseReadySpec(readySpec),
+    args: (opts.args ?? sticky?.args ?? '').split(' ').filter(Boolean),
+    exec: opts.exec ?? sticky?.exec ?? process.execPath,
+    cwd: path.resolve(opts.cwd ?? sticky?.cwd ?? path.dirname(entry)),
+    cache,
+    paths: nodeTargetPaths(entry),
+  };
+  const changed =
+    sticky?.entry !== entry ||
+    sticky?.ready !== readySpec ||
+    sticky?.cache !== cache ||
+    sticky?.exec !== target.exec ||
+    sticky?.cwd !== target.cwd;
+  if (changed) {
+    writeJson(NODE_TARGET_FILE, {
+      entry,
+      ready: readySpec,
+      args: target.args.join(' '),
+      exec: target.exec,
+      cwd: target.cwd,
+      cache,
+      setAtMs: Date.now(),
+    });
+    console.log(`target: ${entry} (ready: ${describeReady(target.ready)}) - remembered`);
+  }
+  return target;
+}
+
+/**
+ * Run options for run `index`. In cold mode every run gets its own empty compile-cache
+ * dir, so each pays full parse+compile the way a fresh container does; warm mode shares
+ * one dir that the warmup run primes.
+ */
+function nodeRunOptsFactory(target, { timeoutMs = 60_000 } = {}) {
+  const slug = targetSlug(target.entry);
+  const shared = target.cache === 'warm' ? freshCacheDir(STATE_DIR, `${slug}-warm`) : null;
+  return (index) => ({
+    execPath: target.exec,
+    entry: target.entry,
+    args: target.args,
+    cwd: target.cwd,
+    ready: target.ready,
+    timeoutMs,
+    env: runEnv({
+      cacheMode: target.cache,
+      cacheDir: target.cache === 'cold' ? freshCacheDir(STATE_DIR, `${slug}-${index}`) : shared,
+    }),
+  });
+}
+
+function nodeEntrySources(target) {
+  const mapFile = `${target.entry}.map`;
+  if (!fs.existsSync(mapFile)) return null;
+  try {
+    return {
+      code: fs.readFileSync(target.entry, 'utf8'),
+      map: JSON.parse(fs.readFileSync(mapFile, 'utf8')),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function nodeModuleGraph(opts, target) {
+  return loadModuleGraph(
+    moduleGraphCandidates({ reportDir: opts.report, demoMetricsDir: null, dist: target.dist }),
+  );
+}
+
+async function cmdNodeMeasure(argv) {
+  const opts = parse(argv, {
+    ...NODE_TARGET_OPTS,
+    // Startup runs cost milliseconds, not the minutes a throttled navigation costs,
+    // so the default sample count is higher than the browser side's.
+    runs: { type: 'string', default: '7' },
+    warmup: { type: 'string', default: '1' },
+    label: { type: 'string', default: '' },
+    pin: { type: 'boolean', default: false },
+    timeout: { type: 'string', default: '60' },
+  });
+  const target = resolveNodeTarget(opts);
+  await assertReadyPortFree(target.ready);
+  const summary = await runNodeTiming(target, {
+    runs: Number(opts.runs),
+    warmup: Number(opts.warmup),
+    timeoutMs: Number(opts.timeout) * 1000,
+  });
+  const { report, hadBaseline } = writeNodeReport(target, summary, { label: opts.label });
+  printNodeSummary(report, hadBaseline);
+  if (opts.pin) pinNodeBaseline(target);
+  console.log(`\nfull report: ${target.paths.metrics}`);
+}
+
+async function runNodeTiming(target, { runs, warmup, timeoutMs }) {
+  const runOptsFor = nodeRunOptsFactory(target, { timeoutMs });
+  process.stderr.write(`boot floor (empty script on this runtime)...\n`);
+  const floor = await measureBootFloor({ execPath: target.exec });
+  const samples = await gatherStartupSamples(runOptsFor, {
+    runs,
+    warmup,
+    onSample: (i, run) =>
+      process.stderr.write(`run ${i + 1}/${runs}: ready in ${ms(run.elapsedMs)}\n`),
+  });
+  return summarizeStartup(samples, {
+    bootFloorMs: floor.length ? floor.sort((a, b) => a - b)[Math.floor(floor.length / 2)] : null,
+    ready: describeReady(target.ready),
+    // Only the polled probes quantize; stdout and exit are observed on the event itself.
+    resolutionMs: target.ready.kind === 'port' || target.ready.kind === 'http' ? POLL_MS : 0,
+  });
+}
+
+function writeNodeReport(target, summary, { label, coverage = null, profile = null }) {
+  const prev = readJson(target.paths.state);
+  const baseline = readJson(target.paths.baseline);
+  const report = {
+    schemaVersion: 1,
+    generatedAtMs: Date.now(),
+    label: label || null,
+    entry: target.entry,
+    ready: describeReady(target.ready),
+    cache: target.cache,
+    runs: summary.runs,
+    metrics: summary.metrics,
+    guard: summary.guard,
+    coverage,
+    profile,
+    delta: prev ? deltaSection(prev.metrics, summary.metrics) : null,
+    baselineDelta: baseline ? deltaSection(baseline.metrics, summary.metrics) : null,
+    samples: summary.samples,
+  };
+  writeJson(target.paths.metrics, report);
+  writeJson(target.paths.state, {
+    schemaVersion: 1,
+    tsMs: report.generatedAtMs,
+    label: report.label,
+    runs: report.runs,
+    ready: report.ready,
+    cache: report.cache,
+    metrics: report.metrics,
+  });
+  fs.appendFileSync(
+    target.paths.history,
+    `${JSON.stringify({
+      tsMs: report.generatedAtMs,
+      label: report.label,
+      metrics: report.metrics,
+      guard: report.guard,
+    })}\n`,
+  );
+  return { report, hadBaseline: Boolean(baseline) };
+}
+
+function pinNodeBaseline(target) {
+  const state = readJson(target.paths.state);
+  if (!state) throw new Error('nothing to pin - run node-scan first');
+  if (state.runs < 3) {
+    throw new Error(
+      `refusing to pin a ${state.runs}-run measurement - a thin median poisons every later delta. Re-run node-scan with the default sample count.`,
+    );
+  }
+  writeJson(target.paths.baseline, state);
+  console.log(`baseline pinned (startup ${ms(state.metrics['runtime.startup_ms'])})`);
+}
+
+function printNodeSummary(report, hadBaseline) {
+  const m = report.metrics;
+  console.log(
+    `\n${report.label ? `[${report.label}] ` : ''}${report.runs} runs, cache ${report.cache}`,
+  );
+  console.log(
+    `startup ${ms(m['runtime.startup_ms'])} (p75 ${ms(m['runtime.startup_p75_ms'])}) | ` +
+      `runtime boot floor ${ms(m['runtime.boot_floor_ms'])} | ` +
+      `app ${ms(m['runtime.app_startup_ms'])} | ready: ${report.ready}`,
+  );
+  const spread = report.guard.spreadPct;
+  console.log(
+    `guard: ${report.guard.allRunsCompleted ? 'PASS' : 'FAIL (a run never became ready)'}` +
+      `${spread > 25 ? ` - WARNING spread ${spread}% across runs: something outside the bundle moves this number, deltas are not trustworthy` : ''}`,
+  );
+  const limited = report.guard.resolutionLimited;
+  if (limited) {
+    console.log(
+      `  note: ${round(limited.appMs)}ms of addressable startup is only a few ${limited.resolutionMs}ms probe intervals wide -` +
+        ' changes smaller than a few ms cannot be resolved by a readiness poll. Judge byte/module counts here, not milliseconds.',
+    );
+  }
+  const base = report.baselineDelta?.['runtime.app_startup_ms'];
+  if (base) {
+    const floor = Math.max(NODE_NOISE_FLOOR_MS, (NODE_NOISE_FLOOR_PCT / 100) * base.prev);
+    const call =
+      Math.abs(base.delta) < floor
+        ? `within noise (floor ${Math.round(floor)}ms) - no effect proven`
+        : base.delta < 0
+          ? 'IMPROVEMENT beyond noise'
+          : 'REGRESSION beyond noise';
+    console.log(
+      `vs pinned baseline: app startup ${base.delta >= 0 ? '+' : ''}${Math.round(base.delta)}ms (${base.pct}%) - ${call}`,
+    );
+  } else if (!hadBaseline) {
+    console.log('no pinned baseline yet - pass --pin to make this the fixed reference');
+  }
+}
+
+// Everything in one go: timed runs, then the two instrumented runs that say where the
+// time went, then the leads. One command per iteration.
+async function cmdNodeScan(argv) {
+  const opts = parse(argv, {
+    ...NODE_TARGET_OPTS,
+    report: { type: 'string' },
+    runs: { type: 'string', default: '7' },
+    warmup: { type: 'string', default: '1' },
+    label: { type: 'string', default: '' },
+    pin: { type: 'boolean', default: false },
+    top: { type: 'string', default: '10' },
+    timeout: { type: 'string', default: '60' },
+  });
+  const target = resolveNodeTarget(opts);
+  await assertReadyPortFree(target.ready);
+  const timeoutMs = Number(opts.timeout) * 1000;
+  const summary = await runNodeTiming(target, {
+    runs: Number(opts.runs),
+    warmup: Number(opts.warmup),
+    timeoutMs,
+  });
+
+  const runOptsFor = nodeRunOptsFactory(target, { timeoutMs });
+  process.stderr.write('coverage run (what had to execute to become ready)...\n');
+  const cov = await startupCoverage(runOptsFor('cov'), { root: target.dist });
+
+  const sources = nodeEntrySources(target);
+  let profile = null;
+  if (sources) {
+    process.stderr.write('profile run (where the pre-ready time went)...\n');
+    const raw = await startupProfile(runOptsFor('prof'));
+    if (raw) {
+      profile = profileStartup(raw, {
+        code: sources.code,
+        map: sources.map,
+        entryUrlSuffix: `/${path.basename(target.entry)}`,
+      });
+    }
+  }
+
+  const { report, hadBaseline } = writeNodeReport(target, summary, {
+    label: opts.label,
+    coverage: {
+      moduleCount: cov.modules.length,
+      totalBytes: cov.modules.reduce((sum, m) => sum + m.totalBytes, 0),
+      readyBytes: cov.modules.reduce((sum, m) => sum + m.readyBytes, 0),
+      externalScriptCount: cov.externalScriptCount,
+      modules: cov.modules,
+      scripts: cov.scripts,
+    },
+    profile: profile
+      ? { totalMs: profile.totalMs, ownership: profile.ownership, rows: profile.rows.slice(0, 40) }
+      : null,
+  });
+  printNodeSummary(report, hadBaseline);
+  printNodeLeads(report, cov, profile, nodeModuleGraph(opts, target), Number(opts.top));
+  if (opts.pin) pinNodeBaseline(target);
+  console.log(`\nfull report: ${target.paths.metrics}`);
+}
+
+/**
+ * The leads, ordered so the first question answered is whether the bundle is the cost
+ * at all. A harness that always produces deferral advice will get deferral work done on
+ * an app whose startup is 80% native addon loading — and the number will not move.
+ */
+function printNodeLeads(report, cov, profile, graph, top) {
+  if (profile) {
+    const own = profile.ownership;
+    console.log(
+      `\npre-ready CPU ${round(own.accountedMs)}ms: app modules ${round(own.appMs)}ms (${own.appShare ?? 0}%), ` +
+        `runtime/native ${round(own.runtimeMs)}ms, engine ${round(own.engineMs)}ms`,
+    );
+    if ((own.appShare ?? 0) < 25) {
+      console.log(
+        '  the bundle is NOT the main cost here - most pre-ready time is outside your modules',
+      );
+      console.log(
+        '  (native addon load, TLS/crypto init, a DB or socket handshake). Deferring imports will',
+      );
+      console.log('  not move startup until that work moves. Top non-app frames:');
+      for (const row of profile.rows.filter((r) => !r.bucket.startsWith('(engine')).slice(0, 5)) {
+        console.log(`    ${String(round(row.ms)).padStart(7)}ms  ${row.bucket}`);
+      }
+    } else {
+      console.log('  top self-time before ready:');
+      for (const row of profile.rows.slice(0, Math.min(top, 8))) {
+        console.log(`    ${String(round(row.ms)).padStart(7)}ms  ${row.bucket}`);
+      }
+    }
+  } else {
+    console.log(
+      `\n(no boot profile: ${path.basename(report.entry)}.map is missing - build with sourcemaps to attribute pre-ready CPU to modules)`,
+    );
+  }
+
+  const cold = coldModules(cov.modules);
+  const totalBytes = cov.modules.reduce((sum, m) => sum + m.totalBytes, 0);
+  const readyBytes = cov.modules.reduce((sum, m) => sum + m.readyBytes, 0);
+  console.log(
+    `\nevaluated to become ready: ${kb(readyBytes)} of ${kb(totalBytes)} attributed ` +
+      `(${cov.modules.length} modules; ${cov.externalScriptCount} non-local script(s) not attributed)`,
+  );
+  if (cold.length) {
+    console.log(
+      `\ncold at ready - shipped into the startup path, never executed to get there (${cold.length}):`,
+    );
+    for (const mod of cold.slice(0, top)) {
+      const priced = graph ? priceDeferral(graph, mod.source) : null;
+      console.log(
+        `  ${kb(mod.totalBytes).padStart(10)}  ${mod.source}${priced ? `  -> deferring frees ${kb(priced.removedBytes)} / ${priced.removedCount} module(s)` : ''}`,
+      );
+    }
+    console.log(
+      `  next: ${CLI} what-if <module> prices the exact deferral; move the import into the handler that needs it.`,
+    );
+  } else {
+    console.log(
+      '\ncold at ready: none above the floor - the startup path is not carrying dead weight.',
+    );
+  }
+
+  if (!graph) {
+    console.log(
+      '\n(no module-graph.json: a rolldown devtools-metrics build would price every deferral statically -' +
+        ' set devtools = { mode: "metrics" } and rebuild, then `graph` / `what-if` / `cut` work on this target)',
+    );
+  }
+}
+
+/** Price a coverage-derived module against the build graph (see `graphIdCandidates`). */
+function priceDeferral(graph, source) {
+  for (const form of graphIdCandidates(source)) {
+    const hit = resolveModule(graph, form);
+    if (!hit || hit.ambiguous) continue;
+    const result = whatIf(graph, hit.index);
+    if (result.removedCount) return result;
+  }
+  return null;
+}
+
+const round = (v) => (v == null ? 0 : Math.round(v));
+
 async function cmdHelp() {
   console.log(`browser-loading perf harness - measurement + diagnosis; you drive the loop
 
@@ -2289,6 +2720,29 @@ individual commands (same target rules):
   target [<appDir>] [--demo]                show / set / clear the remembered target
          [--net-scale <1|2|4|8>]            ...and/or pin its throttle net-scale without probing
   gen | build | defer <f> | undefer <f> | status | serve    demo-app helpers (README.md)
+
+server startup mode (node/deno - a process coming up, not a page loading):
+  node-scan --entry dist/server.js --ready port:3000    timed spawn->ready runs + what had to
+                            execute to get there + where the pre-ready CPU went + leads.
+                            The entry and its readiness signal are remembered; later
+                            \`node-scan\` runs bare. --pin makes this the baseline.
+  node-measure              timing only, no instrumented runs
+  --ready <spec>            how the target signals it is up. This is part of the target -
+                            two scans with different specs are not comparable:
+                              port:3000            a TCP listener is accepting
+                              'stdout:ready on'    a line matching this regex is printed
+                              http://127.0.0.1:3000/health   an HTTP probe returns 2xx
+                              exit                 the process exits 0 (CLIs, lambda entries)
+  --cache cold|warm|off     V8 compile cache. cold (default) gives every run an empty cache,
+                            which is what a new container pays; warm shares one primed dir.
+                            Measuring warm by accident measures the cache, not the bundle.
+  --args "..." --exec <bin> --cwd <dir>    argv for the entry / the runtime binary (deno,
+                            an older node) / working directory
+  graph | what-if | cut | graph-diff       work unchanged on a server build - pass
+                            --dist <builtDir> or --report <dir>. A top-level import and a
+                            render-blocking import are the same edge in the module graph.
+  There is no throttle in this mode: server startup does no network I/O, so a throttle
+  would invent a dimension the measurement does not have.
 
 the loop:
   1. build the app; scan --app <appDir> (first scan pins the baseline)
@@ -2340,6 +2794,8 @@ const commands = {
   'graph-diff': cmdGraphDiff,
   baseline: cmdBaseline,
   target: cmdTarget,
+  'node-scan': cmdNodeScan,
+  'node-measure': cmdNodeMeasure,
   defer: (argv) => cmdDefer(argv, 'deferred'),
   undefer: (argv) => cmdDefer(argv, 'baseline'),
   status: cmdStatus,

--- a/packages/metrics-lab/lib/cdp.mjs
+++ b/packages/metrics-lab/lib/cdp.mjs
@@ -108,7 +108,12 @@ export async function launchBrowser({ profileDir }) {
   };
 }
 
-function connect(wsUrl) {
+/**
+ * Flat JSON-RPC client for a DevTools endpoint. Exported because Node's inspector
+ * speaks the same protocol on the same transport — `lib/node/launch.mjs` attaches
+ * to `Debugger listening on ws://…` with this exact client, minus the page domains.
+ */
+export function connect(wsUrl) {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(wsUrl);
     let nextId = 1;

--- a/packages/metrics-lab/lib/node/launch.mjs
+++ b/packages/metrics-lab/lib/node/launch.mjs
@@ -40,7 +40,7 @@ const READY_MENU =
 
 /**
  * Parse a `--ready` spec into a probe descriptor. Throws with the full menu — an
- * unparseable spec is the one error where guessing a default would silently
+ * unparsable spec is the one error where guessing a default would silently
  * measure the wrong moment.
  */
 export function parseReadySpec(spec) {

--- a/packages/metrics-lab/lib/node/launch.mjs
+++ b/packages/metrics-lab/lib/node/launch.mjs
@@ -1,0 +1,351 @@
+// Server-runtime startup driver: spawn the runtime, wait for a DECLARED readiness
+// signal, and — for instrumented runs — attach the V8 inspector before any user
+// code evaluates.
+//
+// The browser hands us a readiness moment for free (FCP/LCP are observable from
+// outside the page). A server process has no such universal signal: "up" means
+// accepting connections for one app, a line on stdout for another, and clean exit
+// for a CLI or a lambda-shaped entry. So readiness is part of the TARGET, declared
+// once and pinned with it — the same role `expectedFeatures` plays for the demo app.
+//
+// Two run shapes, deliberately separate:
+//   plain        — no inspector, no profiler. This is the number that gets reported;
+//                  `--inspect-brk` alone shifts startup by tens of ms and would make
+//                  every measurement a measurement of the harness.
+//   instrumented — `--inspect-brk=0`, profiler/coverage armed while the process is
+//                  still paused at entry, then released. Used for ATTRIBUTION only
+//                  (which module cost what), never for the reported timing.
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { connect } from '../cdp.mjs';
+
+// Port/http readiness is discovered by polling, so a sample carries up to one interval
+// of quantization. A local TCP connect attempt costs ~0.1ms, so the practical floor is
+// setTimeout granularity rather than probe cost — poll as tightly as the timer allows.
+// This matters more than it looks: on a target whose addressable startup is ~10ms, a
+// 4ms quantum was 40% of the signal. `summarizeStartup` flags measurements that get
+// close to this floor rather than reporting a precise-looking number it cannot support.
+export const POLL_MS = 1;
+
+const READY_MENU =
+  '  --ready port:3000            a TCP listener is accepting (servers)\n' +
+  "  --ready 'stdout:ready on'    a line matching this regex is printed\n" +
+  '  --ready http://127.0.0.1:3000/health   an HTTP probe returns 2xx\n' +
+  '  --ready exit                 the process exits 0 (CLIs, lambda-shaped entries)';
+
+/**
+ * Parse a `--ready` spec into a probe descriptor. Throws with the full menu — an
+ * unparseable spec is the one error where guessing a default would silently
+ * measure the wrong moment.
+ */
+export function parseReadySpec(spec) {
+  const raw = String(spec ?? '').trim();
+  if (raw === '' || raw === 'exit') return { kind: 'exit' };
+  const port = raw.match(/^port:(\d{1,5})$/);
+  if (port) {
+    const value = Number(port[1]);
+    if (value < 1 || value > 65535) throw new Error(`--ready port:${port[1]} is not a valid port.`);
+    return { kind: 'port', port: value };
+  }
+  const stdout = raw.match(/^stdout:([\s\S]+)$/);
+  if (stdout) {
+    let pattern;
+    try {
+      pattern = new RegExp(stdout[1]);
+    } catch (err) {
+      throw new Error(
+        `--ready stdout:<regex> — ${stdout[1]} is not a valid regex (${err.message}).`,
+      );
+    }
+    return { kind: 'stdout', source: stdout[1], pattern };
+  }
+  if (/^https?:\/\//.test(raw)) return { kind: 'http', url: raw };
+  throw new Error(`unrecognized --ready spec: ${raw}\nSupported forms:\n${READY_MENU}`);
+}
+
+export function describeReady(spec) {
+  switch (spec.kind) {
+    case 'port':
+      return `port ${spec.port} accepting`;
+    case 'stdout':
+      return `stdout matches /${spec.source}/`;
+    case 'http':
+      return `${spec.url} returns 2xx`;
+    default:
+      return 'process exits 0';
+  }
+}
+
+/** True once `port` accepts a connection. Never throws — a refused connect is "not yet". */
+export function portAccepting(port, { host = '127.0.0.1', timeoutMs = 250 } = {}) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host });
+    const done = (value) => {
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(timeoutMs, () => done(false));
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+  });
+}
+
+/**
+ * A port probe on an already-occupied port reports ready instantly and every run
+ * measures nothing. Refuse before spawning rather than emitting a fast, wrong number.
+ */
+export async function assertReadyPortFree(spec) {
+  if (spec.kind !== 'port') return;
+  if (await portAccepting(spec.port, { timeoutMs: 150 })) {
+    throw new Error(
+      `port ${spec.port} is already accepting connections before the target started.\n` +
+        'Every run would report ready immediately and measure nothing. Stop whatever holds\n' +
+        `the port (lsof -i :${spec.port}), or point --ready at the port this build actually uses.`,
+    );
+  }
+}
+
+/** Has the declared readiness moment happened yet? `state` is owned by the runner. */
+async function isReady(spec, state) {
+  switch (spec.kind) {
+    case 'exit':
+      return state.exitCode === 0;
+    case 'stdout':
+      return spec.pattern.test(state.output);
+    case 'port':
+      return await portAccepting(spec.port);
+    case 'http':
+      try {
+        const res = await fetch(spec.url, { signal: AbortSignal.timeout(1000) });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Environment for one run. Two inherited variables would silently corrupt a
+ * measurement and are always neutralized:
+ *   NODE_V8_COVERAGE — makes V8 instrument every script, inflating startup.
+ *   NODE_OPTIONS=--inspect* — a second inspector fights ours for the port and
+ *                             breaks the "Debugger listening on" scrape.
+ *
+ * The compile cache is the server-side equivalent of the browser's service-worker
+ * trap: with a warm cache, runs 2..N measure the cache rather than the bundle.
+ *   cold (default) — a fresh cache dir per run: every run pays parse+compile, which
+ *                    is what a cold start (new container, new lambda) actually pays.
+ *   warm           — one shared dir across runs, primed by the warmup run.
+ *   off            — leave the ambient environment alone, whatever the app does.
+ */
+export function runEnv({ cacheMode = 'cold', cacheDir = null, extraEnv = null } = {}) {
+  const env = { ...process.env, ...extraEnv };
+  delete env.NODE_V8_COVERAGE;
+  if (env.NODE_OPTIONS) {
+    const kept = env.NODE_OPTIONS.split(/\s+/).filter(
+      (flag) => !/^--inspect(-brk|-port)?(=|$)/.test(flag),
+    );
+    if (kept.length) env.NODE_OPTIONS = kept.join(' ');
+    else delete env.NODE_OPTIONS;
+  }
+  if (cacheMode === 'off') delete env.NODE_COMPILE_CACHE;
+  else if (cacheDir) env.NODE_COMPILE_CACHE = cacheDir;
+  return env;
+}
+
+export function freshCacheDir(stateDir, tag) {
+  const dir = path.join(stateDir, 'compile-cache', `${tag}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function killTree(child) {
+  if (child.exitCode != null || child.signalCode != null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const hard = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      resolve();
+    }, 2000);
+    child.once('exit', () => {
+      clearTimeout(hard);
+      resolve();
+    });
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      clearTimeout(hard);
+      resolve();
+    }
+  });
+}
+
+/**
+ * One spawn→ready run.
+ *
+ * `elapsedMs` is wall time from immediately-before-spawn to the first observation
+ * of the readiness signal, so it includes runtime boot, module evaluation and
+ * whatever the app does before declaring itself up — the whole cold path a
+ * deployment pays. `inspector` (when requested) is handed to `arm` while the
+ * process sits paused at entry, before any user code has evaluated.
+ */
+export async function startupRun({
+  execPath = process.execPath,
+  entry,
+  args = [],
+  execArgv = [],
+  cwd,
+  ready,
+  env,
+  timeoutMs = 60_000,
+  inspect = false,
+  arm = null,
+  atReady = null,
+}) {
+  const state = { output: '', exitCode: null, signal: null };
+  const argv = [...execArgv, ...(inspect ? ['--inspect-brk=0'] : []), entry, ...args];
+
+  const started = process.hrtime.bigint();
+  const child = spawn(execPath, argv, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+  const sinceStart = () => Number(process.hrtime.bigint() - started) / 1e6;
+
+  let inspectorUrl = null;
+  const collect = (chunk) => {
+    state.output += chunk;
+    if (state.output.length > 1_000_000) state.output = state.output.slice(-500_000);
+    if (!inspectorUrl) {
+      const match = state.output.match(/Debugger listening on (ws:\/\/\S+)/);
+      if (match) inspectorUrl = match[1];
+    }
+  };
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', collect);
+  child.stderr.on('data', collect);
+  child.once('exit', (code, signal) => {
+    state.exitCode = code;
+    state.signal = signal;
+  });
+
+  let cdp = null;
+  try {
+    if (inspect) {
+      const deadline = Date.now() + 20_000;
+      while (!inspectorUrl) {
+        if (state.exitCode != null) {
+          throw new Error(
+            `the target exited (code ${state.exitCode}) before the inspector attached.\n${tail(state.output)}`,
+          );
+        }
+        if (Date.now() > deadline) throw new Error('no "Debugger listening on" line within 20s.');
+        await sleep(POLL_MS);
+      }
+      cdp = await connect(inspectorUrl);
+      await cdp.send('Runtime.enable');
+      if (arm) await arm(cdp);
+      // Everything above happened while the process was paused at entry, so the
+      // profiler sees module evaluation from its very first frame.
+      await cdp.send('Runtime.runIfWaitingForDebugger');
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    let readyMs = null;
+    for (;;) {
+      if (await isReady(ready, state)) {
+        readyMs = sinceStart();
+        break;
+      }
+      // A non-zero exit can never become ready, whatever the probe is.
+      if (state.exitCode != null && state.exitCode !== 0) {
+        throw new Error(
+          `the target exited with code ${state.exitCode} before becoming ready (${describeReady(ready)}).\n${tail(state.output)}`,
+        );
+      }
+      if (state.exitCode != null && ready.kind !== 'exit') {
+        throw new Error(
+          `the target exited cleanly but never signalled ${describeReady(ready)}.\n` +
+            `If this entry is meant to finish rather than stay up, measure it with --ready exit.\n${tail(state.output)}`,
+        );
+      }
+      if (Date.now() > deadline) {
+        throw new Error(readyTimeoutMessage(ready, timeoutMs, state));
+      }
+      await sleep(POLL_MS);
+    }
+
+    const collected = atReady && cdp ? await atReady(cdp) : null;
+    return { elapsedMs: readyMs, output: state.output, exitCode: state.exitCode, collected };
+  } finally {
+    try {
+      cdp?.close();
+    } catch {
+      /* already closed */
+    }
+    await killTree(child);
+  }
+}
+
+/**
+ * Every readiness timeout is a target-configuration mistake, so the message is the
+ * menu of correct specs rather than a bare "timed out" — an agent that reads only
+ * the last line still learns the fix.
+ */
+function readyTimeoutMessage(ready, timeoutMs, state) {
+  const stillRunning = state.exitCode == null;
+  if (ready.kind === 'exit' && stillRunning) {
+    return (
+      `the target was still running after ${Math.round(timeoutMs / 1000)}s and --ready defaulted to "exit".\n` +
+      'This looks like a long-lived server. Declare how it signals readiness:\n' +
+      `${READY_MENU}\n${tail(state.output)}`
+    );
+  }
+  return (
+    `the target never signalled ${describeReady(ready)} within ${Math.round(timeoutMs / 1000)}s.\n` +
+    `Check the spec matches what this build prints or listens on:\n${READY_MENU}\n${tail(state.output)}`
+  );
+}
+
+function tail(output, lines = 12) {
+  const text = output.trimEnd();
+  if (!text) return '(the target produced no output)';
+  return `--- last output ---\n${text.split('\n').slice(-lines).join('\n')}`;
+}
+
+/**
+ * The floor: what an empty script costs on this machine with this runtime. Startup
+ * work the bundle can never remove (binary load, V8 init, bootstrap) — without it,
+ * "340ms" reads as 340ms of addressable cost when 30ms of it is physics.
+ */
+export async function measureBootFloor({ execPath = process.execPath, runs = 5, env } = {}) {
+  const probe = path.join(os.tmpdir(), `metrics-lab-boot-${process.pid}.mjs`);
+  fs.writeFileSync(probe, 'process.exit(0)\n');
+  try {
+    const samples = [];
+    for (let i = 0; i < runs; i++) {
+      const run = await startupRun({
+        execPath,
+        entry: probe,
+        ready: { kind: 'exit' },
+        env: env ?? runEnv({ cacheMode: 'off' }),
+        timeoutMs: 30_000,
+      });
+      samples.push(run.elapsedMs);
+    }
+    return samples;
+  } finally {
+    fs.rmSync(probe, { force: true });
+  }
+}
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/packages/metrics-lab/lib/node/measure.mjs
+++ b/packages/metrics-lab/lib/node/measure.mjs
@@ -1,0 +1,273 @@
+// Startup measurement for server runtimes: timed spawn→ready runs, plus the two
+// instrumented runs that say WHERE the time went (V8 precise coverage at the ready
+// moment, and a CPU profile covering everything before it).
+//
+// Nothing here re-implements analysis that already exists. `coverageBySource` and
+// `aggregateProfile` are the same pure V8-format transforms the browser side uses —
+// Node emits the identical formats, so only the ACQUISITION differs.
+//
+// What deliberately does NOT carry over from the browser is the throttle model.
+// `DEFAULT_THROTTLE` / net-scale calibration exist because page load is transfer
+// bound; server startup does no network I/O and is disk+CPU bound. Carrying a
+// throttle over (even pinned at x1) would invent a dimension the measurement does
+// not have, so node mode has no throttle at all — and therefore no cross-scale
+// comparability problem either.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { median, quantile } from '../measure.mjs';
+import { coverageBySource } from '../coverage.mjs';
+import { aggregateProfile } from '../profile.mjs';
+import { measureBootFloor, startupRun } from './launch.mjs';
+
+// A module this big that never executes before ready is worth a deferral look. Below
+// it, the win is inside the noise of a single startup and the edit is not worth it.
+export const COLD_MIN_BYTES = 4 * 1024;
+// Startup is far quieter than a throttled page load (no network, no compositor), so
+// the floor is tighter than the browser's 30ms — but never below timer/scheduler jitter.
+export const NOISE_FLOOR_MS = 8;
+export const NOISE_FLOOR_PCT = 2;
+
+const round1 = (v) => (v == null ? null : Math.round(v * 10) / 10);
+
+/**
+ * N timed runs, no inspector — the numbers that get reported. `runOptsFor(index)` is
+ * a factory rather than a fixed object so cold-cache mode can hand every run its own
+ * empty compile-cache dir; warmup runs get index -1..-n so they never share one.
+ */
+export async function gatherStartupSamples(runOptsFor, { runs, warmup, onSample = null }) {
+  for (let i = 0; i < warmup; i++) {
+    process.stderr.write(`warmup ${i + 1}/${warmup}...\n`);
+    await startupRun(runOptsFor(-1 - i));
+  }
+  const samples = [];
+  for (let i = 0; i < runs; i++) {
+    const run = await startupRun(runOptsFor(i));
+    samples.push({ startupMs: run.elapsedMs, exitCode: run.exitCode });
+    onSample?.(i, run);
+  }
+  return samples;
+}
+
+/**
+ * Fold runs into the flat metric-id map. `bootFloorMs` is what an empty script costs
+ * on this machine: subtracting it separates the cost the bundle owns from the runtime
+ * boot it can never remove. Without that split a 340ms startup reads as 340ms of
+ * addressable work when 30ms of it is physics.
+ */
+export function summarizeStartup(
+  samples,
+  { bootFloorMs = null, ready = null, resolutionMs = 0 } = {},
+) {
+  const values = samples.map((s) => s.startupMs).filter((v) => typeof v === 'number');
+  const startup = median(values);
+  const appMs =
+    typeof startup === 'number' && typeof bootFloorMs === 'number'
+      ? Math.max(0, startup - bootFloorMs)
+      : null;
+  return {
+    runs: samples.length,
+    metrics: {
+      'runtime.startup_ms': round1(startup),
+      'runtime.startup_p75_ms': round1(quantile(values, 0.75)),
+      'runtime.boot_floor_ms': round1(bootFloorMs),
+      // The addressable part: total minus the runtime's own boot.
+      'runtime.app_startup_ms': round1(appMs),
+    },
+    guard: {
+      allRunsCompleted: samples.length > 0 && samples.every((s) => typeof s.startupMs === 'number'),
+      readySignal: ready,
+      // A spread this wide means something other than the bundle moves run to run
+      // (disk cache, a port retry, a background daemon) and deltas are not trustworthy.
+      spreadPct:
+        values.length > 1 && startup > 0
+          ? Math.round(((Math.max(...values) - Math.min(...values)) / startup) * 1000) / 10
+          : 0,
+      // When the addressable time is only a few probe intervals wide, the digits after
+      // the decimal point are quantization, not signal. Say so rather than letting an
+      // agent chase a "+2ms regression" that is one poll tick.
+      resolutionLimited:
+        resolutionMs > 0 && typeof appMs === 'number' && appMs < 5 * resolutionMs
+          ? { appMs: round1(appMs), resolutionMs }
+          : null,
+    },
+    samples,
+  };
+}
+
+// --- attribution -----------------------------------------------------------------
+
+/** file:// script URLs that live under `root` and carry a sourcemap next to them. */
+function localScript(url, root) {
+  if (!url?.startsWith('file://')) return null;
+  let file;
+  try {
+    file = fileURLToPath(url);
+  } catch {
+    return null;
+  }
+  const rel = path.relative(root, file);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  const mapFile = `${file}.map`;
+  if (!fs.existsSync(file) || !fs.existsSync(mapFile)) return null;
+  return { file, rel: rel.replaceAll('\\', '/'), mapFile };
+}
+
+/**
+ * One instrumented run: V8 precise coverage armed while the process is paused at
+ * entry, snapshotted the moment it becomes ready. Every byte counted as executed
+ * therefore HAD to run to get the server up.
+ *
+ * The known V8 blind spot applies here exactly as it does in the browser: a module's
+ * top level counts as executed when it evaluates, so weight parked in top-level
+ * literals looks "used". Function bodies are where the signal is clean.
+ */
+export async function startupCoverage(runOpts, { root }) {
+  const run = await startupRun({
+    ...runOpts,
+    inspect: true,
+    arm: async (cdp) => {
+      await cdp.send('Profiler.enable');
+      await cdp.send('Profiler.startPreciseCoverage', { callCount: false, detailed: true });
+    },
+    atReady: async (cdp) => cdp.send('Profiler.takePreciseCoverage'),
+  });
+  return attributeStartupCoverage(run.collected?.result ?? [], { root });
+}
+
+/**
+ * Attribute V8 script coverage to source modules through each script's sourcemap.
+ * Scripts outside `root` (node internals, native deps) are counted but not attributed —
+ * they are real startup cost the bundler cannot address, and hiding them would make
+ * the module list look like the whole story.
+ */
+export function attributeStartupCoverage(scriptCoverage, { root, readFile = null }) {
+  const read = readFile ?? ((file) => fs.readFileSync(file, 'utf8'));
+  const modules = [];
+  const scripts = [];
+  let external = 0;
+  for (const script of scriptCoverage) {
+    const local = localScript(script.url, root);
+    if (!local) {
+      if (script.url && !script.url.startsWith('node:')) external += 1;
+      continue;
+    }
+    let code;
+    let map;
+    try {
+      code = read(local.file);
+      map = JSON.parse(read(local.mapFile));
+    } catch {
+      scripts.push({ file: local.rel, reason: 'unreadable-sourcemap' });
+      continue;
+    }
+    const rows = coverageBySource({
+      code,
+      map,
+      atPaint: script.functions ?? [],
+      atSettle: [],
+    });
+    let totalBytes = 0;
+    let evalBytes = 0;
+    for (const [source, row] of rows.entries()) {
+      modules.push({
+        source,
+        script: local.rel,
+        totalBytes: row.totalBytes,
+        // "paint" in the shared helper is just "the first snapshot"; here that
+        // snapshot is taken at the ready moment.
+        readyBytes: row.paintBytes,
+        readyRatio: row.totalBytes ? row.paintBytes / row.totalBytes : 0,
+      });
+      totalBytes += row.totalBytes;
+      evalBytes += row.paintBytes;
+    }
+    scripts.push({ file: local.rel, totalBytes, readyBytes: evalBytes });
+  }
+  modules.sort((a, b) => b.totalBytes - a.totalBytes);
+  scripts.sort((a, b) => (b.totalBytes ?? 0) - (a.totalBytes ?? 0));
+  return { modules, scripts, externalScriptCount: external };
+}
+
+/**
+ * The names a coverage module might go by in the build's module graph, most specific
+ * first. Coverage sources come from the sourcemap and are relative to the OUTPUT dir
+ * ('../src/reporting.js'); graph ids are project-relative ('src/reporting.js'). Walking
+ * the leading './' and '../' segments off is what lets the measured half and the static
+ * half talk about the same module — without it every cold module prices as "no match"
+ * and the scan quietly stops suggesting deferrals.
+ */
+export function graphIdCandidates(source) {
+  const forms = [];
+  let candidate = String(source).replaceAll('\\', '/');
+  forms.push(candidate);
+  while (/^\.\.?\//.test(candidate)) {
+    candidate = candidate.replace(/^\.\.?\//, '');
+    forms.push(candidate);
+  }
+  return forms;
+}
+
+/** Shipped into the startup path but never executed to get there — deferral candidates. */
+export function coldModules(modules, { minBytes = COLD_MIN_BYTES } = {}) {
+  return modules
+    .filter((m) => m.totalBytes >= minBytes && m.readyRatio <= 0.02)
+    .sort((a, b) => b.totalBytes - a.totalBytes);
+}
+
+/**
+ * One instrumented run sampling from entry until ready: what RAN, and for how long.
+ * This is the signal that can say "the bundle is not your problem" — if the self-time
+ * sits in native addon loading or a TLS/DB handshake rather than in module evaluation,
+ * no amount of deferral moves the number.
+ */
+export async function startupProfile(runOpts, { intervalUs = 200 } = {}) {
+  const run = await startupRun({
+    ...runOpts,
+    inspect: true,
+    arm: async (cdp) => {
+      await cdp.send('Profiler.enable');
+      await cdp.send('Profiler.setSamplingInterval', { interval: intervalUs });
+      await cdp.send('Profiler.start');
+    },
+    atReady: async (cdp) => cdp.send('Profiler.stop'),
+  });
+  return run.collected?.profile ?? null;
+}
+
+/**
+ * Split profile self-time into what the bundle owns and what it never will.
+ * `appSources` is the entry sourcemap's source list — a bucket naming one of those
+ * is app code; `(engine*)` is V8 itself; anything else is runtime/native frames.
+ */
+export function splitProfileOwnership(rows, appSources) {
+  const app = new Set(appSources.map((s) => String(s).replaceAll('\\', '/')));
+  let appMs = 0;
+  let engineMs = 0;
+  let runtimeMs = 0;
+  for (const row of rows) {
+    if (app.has(row.bucket)) appMs += row.ms;
+    else if (row.bucket.startsWith('(engine')) engineMs += row.ms;
+    else runtimeMs += row.ms;
+  }
+  const total = appMs + engineMs + runtimeMs;
+  return {
+    appMs: round1(appMs),
+    engineMs: round1(engineMs),
+    runtimeMs: round1(runtimeMs),
+    // The three parts always sum to this. `aggregateProfile` drops sub-0.5ms buckets,
+    // so its `totalMs` is slightly larger — reporting that as the headline next to a
+    // split derived from the kept rows makes the numbers look like they fail to add up.
+    accountedMs: round1(total),
+    appShare: total > 0 ? Math.round((appMs / total) * 1000) / 10 : null,
+  };
+}
+
+export function profileStartup(profile, { code, map, entryUrlSuffix }) {
+  const { rows, totalMs } = aggregateProfile(profile, { code, map, entryUrlSuffix });
+  return { rows, totalMs, ownership: splitProfileOwnership(rows, map.sources ?? []) };
+}
+
+export { measureBootFloor };

--- a/packages/metrics-lab/package.json
+++ b/packages/metrics-lab/package.json
@@ -2,7 +2,7 @@
   "name": "@rolldown/metrics-lab",
   "version": "0.0.0",
   "private": true,
-  "description": "Browser-loading perf harness for agent loops: throttled runs, first-paint coverage, boot CPU profile, fused verdict.",
+  "description": "Load-performance harness for agent loops: throttled browser runs with first-paint coverage and boot profile, node/deno startup runs, static deferral planning on the module graph.",
   "bin": {
     "metrics-lab": "./harness.mjs"
   },

--- a/packages/metrics-lab/test/node-startup.test.mjs
+++ b/packages/metrics-lab/test/node-startup.test.mjs
@@ -1,0 +1,284 @@
+// Server-startup mode. The parts worth pinning are the ones a wrong answer makes
+// SILENT: a readiness spec that parses into the wrong probe measures the wrong moment,
+// an inherited env var inflates every run, and coverage attribution that drops a script
+// makes a heavy module look absent rather than cold.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { parseReadySpec, describeReady, runEnv } from '../lib/node/launch.mjs';
+import {
+  attributeStartupCoverage,
+  coldModules,
+  graphIdCandidates,
+  splitProfileOwnership,
+  summarizeStartup,
+} from '../lib/node/measure.mjs';
+import { makeGraph } from './graph-fixtures.mjs';
+import { resolveModule } from '../lib/module-graph.mjs';
+
+// --- readiness specs --------------------------------------------------------------
+
+test('every supported --ready form parses to its own probe kind', () => {
+  assert.deepEqual(parseReadySpec('exit'), { kind: 'exit' });
+  assert.deepEqual(parseReadySpec(''), { kind: 'exit' });
+  assert.deepEqual(parseReadySpec('port:3000'), { kind: 'port', port: 3000 });
+  assert.equal(parseReadySpec('http://127.0.0.1:3000/health').kind, 'http');
+  const stdout = parseReadySpec('stdout:listening on \\d+');
+  assert.equal(stdout.kind, 'stdout');
+  assert.ok(stdout.pattern.test('server listening on 3000'));
+  assert.ok(!stdout.pattern.test('still booting'));
+});
+
+test('an unparseable ready spec names every supported form', () => {
+  assert.throws(
+    () => parseReadySpec('whenever'),
+    (err) => {
+      // The message IS the fix: an agent that reads only the error still learns the menu.
+      for (const form of ['port:', 'stdout:', 'http', 'exit'])
+        assert.match(err.message, new RegExp(form));
+      return true;
+    },
+  );
+  assert.throws(() => parseReadySpec('port:99999'), /not a valid port/);
+  assert.throws(() => parseReadySpec('stdout:[unclosed'), /not a valid regex/);
+});
+
+test('describeReady round-trips into something a report can be compared on', () => {
+  assert.equal(describeReady(parseReadySpec('port:8080')), 'port 8080 accepting');
+  assert.equal(describeReady(parseReadySpec('exit')), 'process exits 0');
+});
+
+// --- run environment --------------------------------------------------------------
+
+test('inherited coverage and inspector settings never reach the measured process', () => {
+  const env = runEnv({
+    cacheMode: 'cold',
+    cacheDir: '/tmp/cache-1',
+    extraEnv: {
+      NODE_V8_COVERAGE: '/tmp/cov',
+      NODE_OPTIONS: '--inspect=9229 --max-old-space-size=4096',
+    },
+  });
+  // Coverage instrumentation would inflate every run; a second inspector would steal
+  // the port our own attach scrapes.
+  assert.equal(env.NODE_V8_COVERAGE, undefined);
+  assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096');
+  assert.equal(env.NODE_COMPILE_CACHE, '/tmp/cache-1');
+});
+
+test('NODE_OPTIONS disappears when it held nothing but inspector flags', () => {
+  const env = runEnv({ cacheMode: 'off', extraEnv: { NODE_OPTIONS: '--inspect-brk' } });
+  assert.equal(env.NODE_OPTIONS, undefined);
+});
+
+test('cache mode decides who owns NODE_COMPILE_CACHE', () => {
+  assert.equal(runEnv({ cacheMode: 'cold', cacheDir: '/tmp/a' }).NODE_COMPILE_CACHE, '/tmp/a');
+  assert.equal(runEnv({ cacheMode: 'warm', cacheDir: '/tmp/b' }).NODE_COMPILE_CACHE, '/tmp/b');
+  // off = leave the ambient environment alone, even if the caller passed a dir.
+  assert.equal(
+    runEnv({ cacheMode: 'off', cacheDir: '/tmp/c', extraEnv: { NODE_COMPILE_CACHE: '/tmp/x' } })
+      .NODE_COMPILE_CACHE,
+    undefined,
+  );
+});
+
+// --- summarize --------------------------------------------------------------------
+
+test('app startup is total minus the runtime boot floor, never negative', () => {
+  const summary = summarizeStartup([{ startupMs: 300 }, { startupMs: 340 }, { startupMs: 320 }], {
+    bootFloorMs: 30,
+    ready: 'port 3000 accepting',
+  });
+  assert.equal(summary.metrics['runtime.startup_ms'], 320);
+  assert.equal(summary.metrics['runtime.boot_floor_ms'], 30);
+  assert.equal(summary.metrics['runtime.app_startup_ms'], 290);
+
+  // A target that comes up faster than the measured floor (floor sampled under load)
+  // must report 0 addressable time, not a negative budget.
+  const fast = summarizeStartup([{ startupMs: 25 }], { bootFloorMs: 30 });
+  assert.equal(fast.metrics['runtime.app_startup_ms'], 0);
+});
+
+test('run-to-run spread is reported so untrustworthy deltas can be refused', () => {
+  const steady = summarizeStartup([{ startupMs: 100 }, { startupMs: 102 }, { startupMs: 101 }], {});
+  assert.ok(steady.guard.spreadPct < 5);
+  const noisy = summarizeStartup([{ startupMs: 100 }, { startupMs: 400 }, { startupMs: 120 }], {});
+  assert.ok(noisy.guard.spreadPct > 25);
+  assert.equal(noisy.guard.allRunsCompleted, true);
+});
+
+// --- coverage attribution ---------------------------------------------------------
+
+// Two source modules in one generated chunk. Line 0 maps to src/a.ts, line 2 to
+// src/b.ts — mappings are written literally rather than VLQ-encoded in the test so the
+// fixture stays readable: "AAAA" = all-zero deltas, "ACAA" = source index +1.
+const CHUNK_CODE = ['const A = 1;', '// filler', 'const B = 2;'].join('\n');
+const CHUNK_MAP = {
+  version: 3,
+  sources: ['src/a.ts', 'src/b.ts'],
+  mappings: 'AAAA;;ACAA',
+};
+
+function writeChunk(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'server.js');
+  fs.writeFileSync(file, CHUNK_CODE);
+  fs.writeFileSync(`${file}.map`, JSON.stringify(CHUNK_MAP));
+  return file;
+}
+
+function tmpRoot(tag) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `metrics-lab-${tag}-`));
+}
+
+test('executed-at-ready bytes attribute to the source module that ran', (t) => {
+  const root = tmpRoot('cov');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const file = writeChunk(root);
+  const bStart = CHUNK_CODE.indexOf('const B');
+
+  const result = attributeStartupCoverage(
+    [
+      {
+        url: pathToFileURL(file).href,
+        functions: [
+          // Top level ran to the end of module a; module b's region never executed.
+          {
+            functionName: '',
+            ranges: [{ startOffset: 0, endOffset: CHUNK_CODE.length, count: 1 }],
+          },
+          {
+            functionName: 'b',
+            ranges: [{ startOffset: bStart, endOffset: CHUNK_CODE.length, count: 0 }],
+          },
+        ],
+      },
+    ],
+    { root },
+  );
+
+  const byName = Object.fromEntries(result.modules.map((m) => [m.source, m]));
+  assert.equal(byName['src/a.ts'].readyBytes, byName['src/a.ts'].totalBytes);
+  assert.equal(byName['src/a.ts'].readyRatio, 1);
+  assert.equal(byName['src/b.ts'].readyBytes, 0);
+  assert.equal(byName['src/b.ts'].readyRatio, 0);
+});
+
+test('scripts outside the build are counted, not silently dropped', (t) => {
+  const root = tmpRoot('external');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  writeChunk(root);
+  const outside = tmpRoot('outside');
+  t.after(() => fs.rmSync(outside, { recursive: true, force: true }));
+  const strayFile = path.join(outside, 'native-dep.js');
+  fs.writeFileSync(strayFile, 'x');
+
+  const result = attributeStartupCoverage(
+    [
+      // Node internals are runtime cost, not startup weight the bundler chose.
+      { url: 'node:internal/modules/esm/loader', functions: [] },
+      { url: pathToFileURL(strayFile).href, functions: [] },
+    ],
+    { root },
+  );
+
+  assert.equal(result.modules.length, 0);
+  // The stray script counts; node: internals do not — otherwise every report would
+  // claim dozens of unattributed scripts and the number would mean nothing.
+  assert.equal(result.externalScriptCount, 1);
+});
+
+test('a local script without a sourcemap is reported, never counted as zero-weight', (t) => {
+  const root = tmpRoot('nomap');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const file = path.join(root, 'server.js');
+  fs.writeFileSync(file, CHUNK_CODE);
+
+  const result = attributeStartupCoverage([{ url: pathToFileURL(file).href, functions: [] }], {
+    root,
+  });
+  // No map means localScript rejects it: it lands in the external count rather than
+  // contributing 0 bytes to the module table and looking like dead weight.
+  assert.equal(result.modules.length, 0);
+  assert.equal(result.externalScriptCount, 1);
+});
+
+// --- leads ------------------------------------------------------------------------
+
+test('cold modules are the big ones that never ran, ordered by what they cost', () => {
+  const cold = coldModules([
+    { source: 'src/heavy-unused.ts', totalBytes: 40_000, readyRatio: 0 },
+    { source: 'src/small-unused.ts', totalBytes: 500, readyRatio: 0 },
+    { source: 'src/hot.ts', totalBytes: 90_000, readyRatio: 0.9 },
+    { source: 'src/medium-unused.ts', totalBytes: 9_000, readyRatio: 0.01 },
+  ]);
+  assert.deepEqual(
+    cold.map((m) => m.source),
+    ['src/heavy-unused.ts', 'src/medium-unused.ts'],
+  );
+});
+
+test('a sourcemap source resolves to the graph id it corresponds to', () => {
+  // The regression this pins: coverage names the module relative to the OUTPUT dir, the
+  // graph names it relative to the PROJECT. Matching only the literal string silently
+  // priced every cold module as "no match" and the scan stopped suggesting deferrals.
+  assert.deepEqual(graphIdCandidates('../src/reporting.js'), [
+    '../src/reporting.js',
+    'src/reporting.js',
+  ]);
+  assert.deepEqual(graphIdCandidates('../../packages/app/src/x.ts'), [
+    '../../packages/app/src/x.ts',
+    '../packages/app/src/x.ts',
+    'packages/app/src/x.ts',
+  ]);
+  assert.deepEqual(graphIdCandidates('src/plain.ts'), ['src/plain.ts']);
+  assert.deepEqual(graphIdCandidates('..\\src\\win.ts'), ['../src/win.ts', 'src/win.ts']);
+
+  // ...and the candidate list actually finds the module in a real graph.
+  const graph = makeGraph(
+    [
+      { id: 'src/server.js', bytes: 10, imports: [[1, false]] },
+      { id: 'src/reporting.js', bytes: 900, imports: [] },
+    ],
+    ['src/server.js'],
+  );
+  const hit = graphIdCandidates('../src/reporting.js')
+    .map((form) => resolveModule(graph, form))
+    .find((r) => r && !r.ambiguous);
+  assert.equal(graph.modules[hit.index].id, 'src/reporting.js');
+});
+
+test('a measurement only a few probe intervals wide says so', () => {
+  const tight = summarizeStartup([{ startupMs: 33 }], { bootFloorMs: 30, resolutionMs: 1 });
+  // 3ms of addressable time at 1ms resolution: real, but not resolvable in ms.
+  assert.deepEqual(tight.guard.resolutionLimited, { appMs: 3, resolutionMs: 1 });
+
+  const roomy = summarizeStartup([{ startupMs: 330 }], { bootFloorMs: 30, resolutionMs: 1 });
+  assert.equal(roomy.guard.resolutionLimited, null);
+  // Event-observed probes (stdout/exit) do not quantize at all.
+  assert.equal(
+    summarizeStartup([{ startupMs: 33 }], { bootFloorMs: 30 }).guard.resolutionLimited,
+    null,
+  );
+});
+
+test('profile ownership separates what the bundle owns from what it never will', () => {
+  const rows = [
+    { bucket: 'src/app.ts', ms: 40 },
+    { bucket: 'src/db.ts', ms: 10 },
+    { bucket: '(engine: gc)', ms: 5 },
+    { bucket: 'binding.node', ms: 245 },
+  ];
+  const split = splitProfileOwnership(rows, ['src/app.ts', 'src/db.ts']);
+  assert.equal(split.appMs, 50);
+  assert.equal(split.engineMs, 5);
+  assert.equal(split.runtimeMs, 245);
+  // 25% is the threshold the scan uses to say "the bundle is not your problem";
+  // 50 of 300ms must land below it.
+  assert.equal(split.appShare, 16.7);
+});

--- a/packages/metrics-lab/test/node-startup.test.mjs
+++ b/packages/metrics-lab/test/node-startup.test.mjs
@@ -34,7 +34,7 @@ test('every supported --ready form parses to its own probe kind', () => {
   assert.ok(!stdout.pattern.test('still booting'));
 });
 
-test('an unparseable ready spec names every supported form', () => {
+test('an unparsable ready spec names every supported form', () => {
   assert.throws(
     () => parseReadySpec('whenever'),
     (err) => {


### PR DESCRIPTION
Adds `node-scan` / `node-measure` to the lab, measuring a server process coming up the way the browser half measures a page loading: timed spawn→ready runs, V8 precise coverage snapshotted at the readiness moment, and a sampling profile armed while the process is still paused at entry. A server has no equivalent of first paint, so readiness is declared per target (`port:3000` / `stdout:<regex>` / an HTTP probe / clean exit) and pinned with it.

The static half — `graph`, `what-if`, `cut`, `graph-diff` — needed no changes: a top-level import and a render-blocking import are the same edge in the module graph.

Not supported, and reported as such rather than approximated: Bun (JavaScriptCore, so V8 profile and coverage formats do not apply) and edge runtimes (no local process to measure; only the static half applies).

requires #10365
