### PR TITLE
fix(error): make Diagnostic::add_file idempotent

### DIFF
--- a/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## AMBIGUOUS_EXTERNAL_NAMESPACES
+
+```text
+[AMBIGUOUS_EXTERNAL_NAMESPACES] Found ambiguous export.
+   ╭─[ main.js:1:10 ]
+   │
+ 1 │ import { x as y } from "./barrel.js";
+   │          ┬  
+   │          ╰── "barrel.js" re-exports "x"
+   │ 
+ 4 │ export const x = 1;
+   │              ┬  
+   │              ╰── One matching export is here.
+   │
+   ├─[ other.js:1:14 ]
+   │
+ 1 │ export const x = 2;
+   │              ┬  
+   │              ╰── One matching export is here.
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/barrel.js
+++ b/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/barrel.js
@@ -1,0 +1,2 @@
+export * from "./main.js";
+export * from "./other.js";

--- a/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/main.js
+++ b/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/main.js
@@ -1,0 +1,4 @@
+import { x as y } from "./barrel.js";
+
+console.log(y);
+export const x = 1;

--- a/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/other.js
+++ b/crates/rolldown/tests/rolldown/errors/ambiguous_external_namespace_importer_is_exporter/other.js
@@ -1,0 +1,1 @@
+export const x = 2;

--- a/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
+++ b/crates/rolldown_error/src/build_diagnostic/diagnostic.rs
@@ -75,9 +75,7 @@ impl Diagnostic {
     content: impl Into<ArcStr>,
   ) -> DiagnosticFileId {
     let filename = DiagnosticFileId::from(filename.into());
-    let content = content.into();
-    debug_assert!(!self.files.contains_key(&filename));
-    self.files.insert(filename.clone(), content);
+    self.files.entry(filename.clone()).or_insert_with(|| content.into());
     filename
   }
 


### PR DESCRIPTION
Follow-up from https://github.com/rolldown/rolldown/pull/10445#discussion_r3656702195. The fixture trips the debug_assert on current main with no cycle involved: the importing module is also one of the ambiguous exporters, so on_diagnostic adds its file twice.