### PR TITLE
test: single watcher `END` event for all outputs

### DIFF
--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -318,6 +318,52 @@ test.concurrent(
 );
 
 test.concurrent(
+  'watch emits END after all outputs finish rebuilding',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { input, dir } = createTestInputAndOutput('watch-multiple-output-end-event', retryCount);
+    const outputDirs = [path.join(dir, 'dist-a'), path.join(dir, 'dist-b')];
+    const watcher = watch({
+      input,
+      output: outputDirs.map((outputDir) => ({ dir: outputDir })),
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const events: string[] = [];
+    watcher.on('event', async (event) => {
+      events.push(event.code);
+      if (event.code === 'BUNDLE_END') {
+        await event.result.close();
+      }
+    });
+
+    const expectedEvents = [
+      'START',
+      'BUNDLE_START',
+      'BUNDLE_END',
+      'BUNDLE_START',
+      'BUNDLE_END',
+      'END',
+    ];
+    await expect.poll(() => events).toEqual(expectedEvents);
+
+    // Each output has its own watcher. A single input edit must still be
+    // coalesced into one rebuild cycle with END emitted after both outputs.
+    for (let i = 0; i < 5; i++) {
+      events.length = 0;
+      await editFile(input, `console.log(${i + 2})`);
+      await expect.poll(() => events).toEqual(expectedEvents);
+    }
+  },
+);
+
+test.concurrent(
   'watch event off',
   { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
   async ({ task, expect, onTestFinished }) => {


### PR DESCRIPTION
See https://github.com/rolldown/rolldown/issues/10613