### PR TITLE
chore(deps): tighten `@napi-rs/wasm-runtime` range to `~1.2.2`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ catalogs:
       specifier: ^3.8.2
       version: 3.8.2
     '@napi-rs/wasm-runtime':
-      specifier: ^1.2.2
+      specifier: ~1.2.2
       version: 1.2.2
     '@oxc-node/cli':
       specifier: ^0.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   '@emnapi/runtime': 2.0.0-alpha.3
   '@jridgewell/trace-mapping': ^0.3.31
   '@napi-rs/cli': ^3.8.2
-  '@napi-rs/wasm-runtime': ^1.2.2
+  '@napi-rs/wasm-runtime': ~1.2.2
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
   '@oxc-project/runtime': '=0.143.0'


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/10609

This PR locks the version into a certain range for `napi-rs/wasm-runtime`. This makes `@rolldown/brwoser` only relies on the correpsonding version.

Previous, ` ^1.2.2` can even satifies `2.0` if there is one. The `~1.2.2` in this PR only allows patch versions around `1.2.2`. 

This makes:
- If upperstream releaes an issued version like `1.3`, it won't be installed due to  `~1.2.2`
- All minor version bumps are now explicit so the update PR could be tested via CI

---

napi-rs official already did similar thing https://github.com/napi-rs/napi-rs/pull/3426, but `@rolldown/browser` is maintained manually, so we need to make this change manually.