### PR TITLE
test(node-wasi): run the full node test suite against the WASI binding

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Build Rolldown with WASI Binding
         run: just build-rolldown-wasi
 
+      - name: Build `@rolldown/test-dev-server`
+        run: vp run --filter '@rolldown/test-dev-server' build
+
+      # `test:wasi` is `test:main` with `ROLLDOWN_WASI_TEST=1`, which skips the tests that the wasm binding cannot pass; they are tracked in https://github.com/rolldown/rolldown/issues/10609.
+      - name: Node Test
+        run: vp run --filter rolldown-tests test:wasi
+
       - name: Stability Test
         run: vp run --filter rolldown-tests test:stability
 

--- a/justfile
+++ b/justfile
@@ -93,6 +93,10 @@ test-node *args="": build-rolldown build-rolldown-test-dev-server
   just test-node-rolldown {{ args }}
   just test-node-rollup
 
+# Run Rolldown's tests against the WASI binding, mirroring the WASI CI lane. Replaces any native `dist`, so run `just build-rolldown` afterwards.
+test-wasi *args="": build-rolldown-wasi build-rolldown-test-dev-server
+  vp run --filter rolldown-tests test:wasi {{ args }}
+
 test-node-hmr *args: build build-test-dev-server
   just test-node-hmr-only {{ args }}
 

--- a/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
@@ -2,6 +2,8 @@ import { rolldown } from 'rolldown';
 
 import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+// Relative because this directory's own `package.json` shadows the `rolldown-tests/utils` self-reference other tests use.
+import { isWasiTest } from '../../src/utils';
 import { expect, test } from 'vitest';
 
 // `.rolldown` dir is generated based on real cwd instead of `InputOptions.cwd`. We might be able to solve this in the future.
@@ -16,7 +18,8 @@ function expectPathToEndWith(path, suffix) {
   expect(normalizePath(path).endsWith(suffix)).toBe(true);
 }
 
-test(`emit data for devtool`, async () => {
+// Under the wasm binding `crates/rolldown_devtools/src/writer.rs` panics opening its log file (WASI ENOENT). See https://github.com/rolldown/rolldown/issues/10609.
+test.skipIf(isWasiTest)(`emit data for devtool`, async () => {
   // Clean up previous test data if exists
   if (existsSync(dotRolldownFileName)) {
     rmSync(dotRolldownFileName, { recursive: true, force: true });

--- a/packages/rolldown/tests/dev/dev-close.test.ts
+++ b/packages/rolldown/tests/dev/dev-close.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import type { InputOptions, OutputOptions } from 'rolldown';
 import type { DevEngine, DevOptions } from 'rolldown/experimental';
 import { dev as _dev } from 'rolldown/experimental';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect, test } from 'vitest';
 
 const TEST_TIMEOUT = 60_000;
@@ -35,7 +36,9 @@ function dev(
 //
 // Fix: after `close()`, `ensureCurrentBuildFinish()` is a no-op rather than
 // an error — there is no ongoing bundle to wait for.
-test(
+//
+// Under the wasm binding `close()` tears down the shared tokio runtime, so the no-op call panics with "Access tokio runtime failed in spawn". See https://github.com/rolldown/rolldown/issues/10609.
+test.skipIf(isWasiTest)(
   'ensureCurrentBuildFinish after close resolves instead of rejecting',
   { timeout: TEST_TIMEOUT },
   async ({ onTestFinished }) => {

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'rolldown';
 import { rolldown } from 'rolldown';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { describe, expect, test, vi } from 'vitest';
 
 async function buildWithPlugin(plugin: Plugin) {
@@ -164,7 +165,8 @@ test('call transformContext error', async () => {
 });
 
 // #4141
-test('should print original error if it can not be assigned', async () => {
+// Under the wasm binding the `structuredClone` failure degrades to a plain `Error`, losing the `DataCloneError` name. See https://github.com/rolldown/rolldown/issues/10609.
+test.skipIf(isWasiTest)('should print original error if it can not be assigned', async () => {
   const error = await buildWithPlugin({
     name: 'test',
     transform() {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/follow-symlinks/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/follow-symlinks/_config.ts
@@ -1,4 +1,5 @@
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { viteImportGlobPlugin } from 'rolldown/experimental';
 import { existsSync, lstatSync, unlinkSync, renameSync } from 'node:fs';
 import { symlink } from 'node:fs/promises';
@@ -11,6 +12,8 @@ const targetPath = join(__dirname, 'packages', 'my-lib');
 const backupPath = linkPath + '.bak';
 
 export default defineTest({
+  // Under the wasm binding the glob matches 0 modules through the symlink; the cause has not been diagnosed yet. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [viteImportGlobPlugin()],
   },

--- a/packages/rolldown/tests/fixtures/misc/error/load/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/load/_config.ts
@@ -1,7 +1,10 @@
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
@@ -1,8 +1,11 @@
 import { join } from 'node:path';
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
+  // Under the wasm binding the error arrives as a bare `my-error`, without the `[plugin my-plugin] <id>:1:4` diagnostic asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/misc/error/render-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/render-chunk/_config.ts
@@ -1,7 +1,10 @@
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/misc/error/resolve-id/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/resolve-id/_config.ts
@@ -1,7 +1,10 @@
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
@@ -1,8 +1,11 @@
 import { join } from 'node:path';
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
@@ -1,9 +1,12 @@
 import { defineTest } from 'rolldown-tests';
+import { isWasiTest } from 'rolldown-tests/utils';
 import { expect, vi } from 'vitest';
 
 const fn = vi.fn();
 
 export default defineTest({
+  // Under the wasm binding the error arrives with a `wasm://` stack and none of the `Caused by:` chain asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  skip: isWasiTest,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -18,6 +18,7 @@
     "test:main": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --exclude '**/dev-watch.test.ts' --reporter verbose --hideSkippedTests",
     "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts dev-watch.test.ts --reporter verbose --hideSkippedTests",
     "test:cli": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run cli-e2e.test.ts --reporter verbose --hideSkippedTests",
+    "test:wasi": "ROLLDOWN_WASI_TEST=1 vp run test:main",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
     "test:wasi-runtime": "node ./wasi/runtime-lifecycle.mjs",
     "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests"

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -8,6 +8,9 @@ import type {
   RolldownOutput as RollupOutput,
 } from 'rolldown';
 
+/** `true` when the suite runs against the WASI binding, set by the WASI lane and `just test-wasi`; the tests it skips are tracked in https://github.com/rolldown/rolldown/issues/10609. */
+export const isWasiTest = process.env.ROLLDOWN_WASI_TEST === '1';
+
 /**
  * @description
  * Matches a reference id returned by `PluginContext.emitFile`.

--- a/packages/rolldown/tests/wasi/binding.test.ts
+++ b/packages/rolldown/tests/wasi/binding.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from 'node:module';
+import { isWasiTest } from 'rolldown-tests/utils';
+import { expect, test } from 'vitest';
+
+// A stale `dist` would silently turn the WASI lane into a native run or vice versa, so assert the suite runs on the binding flavor it is configured for.
+const WASM_GLUE = ['@napi-rs/wasm-runtime', '@tybys/wasm-util', '@emnapi/'];
+// Both native layouts use this filename: the dist-local addon and the `@rolldown/binding-*` package whose `main` it is. Unrelated addons like fsevents must not match.
+const NATIVE_BINDING = /\/rolldown-binding\.[^/]+\.node$/;
+
+test('loads the binding the suite is configured for', async () => {
+  await import('rolldown');
+
+  const cached = Object.keys(createRequire(import.meta.url).cache).map((id) =>
+    id.replaceAll('\\', '/'),
+  );
+  const wasmGlue = cached.filter((id) => WASM_GLUE.some((pkg) => id.includes(pkg)));
+  const nativeBinding = cached.filter((id) => NATIVE_BINDING.test(id));
+
+  if (isWasiTest) {
+    const hint =
+      'ROLLDOWN_WASI_TEST=1 but the wasm binding was not loaded. Run ' +
+      '`just build-rolldown-wasi` so `packages/rolldown/dist` holds the wasm binding instead of a ' +
+      '`.node` file.';
+    expect(wasmGlue, hint).not.toEqual([]);
+    expect(nativeBinding, hint).toEqual([]);
+  } else {
+    const hint =
+      'the wasm binding was loaded without ROLLDOWN_WASI_TEST=1. Run the suite through ' +
+      '`just test-wasi`, which sets the flag the wasm-specific skips are keyed on.';
+    expect(nativeBinding, hint).not.toEqual([]);
+    expect(wasmGlue, hint).toEqual([]);
+  }
+});


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/10609.

This unlocks the wasi test suite for all tests. Only a few got skipped due to arbitrary reasons. We could investigate them later, but let's have a test for wasi first!

Notice this is for `node-wasi` target, which shares the same `.wasi` binary with `@rolldown/browser`, but they're not same package.

This is for path `rolldown` -> `@rolldown/binding-node-wasi`