### PR TITLE
fix(scripts): keep the Vite checkout usable when canary does not rebase

### DIFF
--- a/scripts/src/setup-vite/checkout.ts
+++ b/scripts/src/setup-vite/checkout.ts
@@ -37,7 +37,7 @@ const capture = (cmd: string, cwd: string): string =>
 export function ensureViteCheckout(): void {
   if (!nodeFs.existsSync(nodePath.join(viteDir, 'package.json'))) {
     run('git clone --branch rolldown-canary https://github.com/vitejs/vite.git vite', repoRoot);
-    run('git rebase origin/main', viteDir);
+    rebaseOntoMain();
   } else {
     updateViteCheckout();
   }
@@ -60,5 +60,22 @@ function updateViteCheckout(): void {
     return;
   }
   run('git checkout -B rolldown-canary origin/rolldown-canary', viteDir);
-  run('git rebase origin/main', viteDir);
+  rebaseOntoMain();
+}
+
+// `rolldown-canary` stops rebasing onto `main` whenever it falls behind a
+// conflicting upstream change, and only the Vite side can resolve that. Every
+// job here needs a Vite checkout, so keep the unrebased branch instead of
+// failing: the canary line is still tested, just without the newest `main`.
+function rebaseOntoMain(): void {
+  try {
+    run('git rebase origin/main', viteDir);
+  } catch {
+    console.log('[setup-vite] rolldown-canary does not rebase onto main, using it as-is');
+    try {
+      run('git rebase --abort', viteDir);
+    } catch {
+      // The rebase failed before it started, so there is nothing to abort.
+    }
+  }
 }


### PR DESCRIPTION
Every Vite and dev-server job has been failing since `rolldown-canary` stopped rebasing onto vite `main`:

```
[setup-vite] git rebase origin/main
CONFLICT (content): Merge conflict in packages/vite/src/node/server/bundledDev.ts
error: could not apply ce95136b4... feat(dev): support `hotUpdate` hook
Error: Command failed: git rebase origin/main
```

https://github.com/rolldown/rolldown/actions/runs/30887815760/job/91923369505 (`main` at 7b8249440)

Only the Vite side can resolve that conflict, so `ensureViteCheckout` now aborts the rebase and uses `rolldown-canary` as-is, like it already does when the fetch fails.
