### PR TITLE
fix(devtools): resolve log paths against the build cwd

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -53,8 +53,6 @@ jobs:
       - name: Tokio Runtime Lifecycle Test
         run: vp run --filter rolldown-tests test:wasi-runtime
 
-      # `@example/typescript` is excluded because its config enables `devtools`, which currently
-      # panics under WASI when the writer tries to open its log file (crates/rolldown_devtools/src/writer.rs).
       # `@example/native-magic-string` is excluded because it depends on a native-only addon.
       - name: Build Examples
-        run: vp run --filter '@example/*' --filter '!@example/native-magic-string' --filter '!@example/typescript' build
+        run: vp run --filter '@example/*' --filter '!@example/native-magic-string' build

--- a/crates/rolldown_binding/src/classic_bundler.rs
+++ b/crates/rolldown_binding/src/classic_bundler.rs
@@ -169,7 +169,13 @@ impl ClassicBundler {
 
   fn enable_debug_tracing_if_needed(&mut self, options: &BundlerOptions) {
     if self.debug_tracer.is_none() && options.devtools.is_some() {
-      self.debug_tracer = Some(rolldown_devtools::DebugTracer::init(Arc::clone(&self.session_id)));
+      // Mirrors the `cwd` default in `prepare_build_context`; the wasm binding always supplies one because it has no process working directory.
+      let cwd = options
+        .cwd
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
+      self.debug_tracer =
+        Some(rolldown_devtools::DebugTracer::init(Arc::clone(&self.session_id), cwd));
       // Caveat: `Span` must be created after initialization of `DebugTracer`, we need it to inject data to the tracking system.
       let session_span =
         tracing::debug_span!("session", CONTEXT_session_id = self.session_id.as_ref());

--- a/crates/rolldown_devtools/src/init_tracing.rs
+++ b/crates/rolldown_devtools/src/init_tracing.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -16,7 +17,10 @@ pub struct DebugTracer {
 
 impl DebugTracer {
   #[must_use]
-  pub fn init(session_id: Arc<str>) -> Self {
+  pub fn init(session_id: Arc<str>, cwd: PathBuf) -> Self {
+    // Registered per session, before the process-wide subscriber guard, so every session resolves its own log paths.
+    writer::send(LogCommand::SetSessionCwd { session_id: session_id.as_ref().to_string(), cwd });
+
     let tracer = Self { session_id };
     if IS_INITIALIZED.swap(true, std::sync::atomic::Ordering::SeqCst) {
       return tracer;

--- a/crates/rolldown_devtools/src/writer.rs
+++ b/crates/rolldown_devtools/src/writer.rs
@@ -1,7 +1,8 @@
 use std::{
+  collections::hash_map::Entry,
   fs::{File, OpenOptions},
   io::{BufWriter, Write},
-  path::Path,
+  path::PathBuf,
   sync::{
     Arc, LazyLock,
     mpsc::{Sender, channel},
@@ -15,6 +16,8 @@ use serde::ser::{SerializeMap, Serializer as _};
 
 /// Commands sent to the background devtools log-writer thread.
 pub enum LogCommand {
+  /// Bind a session to the directory its relative log paths resolve against; the wasm binding has no process working directory, so relying on one writes outside the project.
+  SetSessionCwd { session_id: String, cwd: PathBuf },
   /// Emit one event. Carries a fully resolved action payload plus the
   /// session/filename the producer has already decided on.
   Write { session_id: String, filename: Arc<str>, action_value: serde_json::Value },
@@ -63,26 +66,46 @@ struct WriterState {
   files: FxHashMap<Arc<str>, BufWriter<File>>,
   files_by_session: FxHashMap<String, FxHashSet<Arc<str>>>,
   exist_hash_by_session: FxHashMap<String, FxHashSet<String>>,
-  dir_ensured: FxHashSet<String>,
+  cwd_by_session: FxHashMap<String, PathBuf>,
+  unopenable_files_by_session: FxHashMap<String, FxHashSet<Arc<str>>>,
 }
 
 impl WriterState {
   fn handle(&mut self, cmd: LogCommand) {
     match cmd {
+      LogCommand::SetSessionCwd { session_id, cwd } => {
+        self.cwd_by_session.insert(session_id, cwd);
+      }
       LogCommand::Write { session_id, filename, action_value } => {
-        if self.dir_ensured.insert(session_id.clone()) {
-          if let Some(parent) = Path::new(filename.as_ref()).parent() {
-            let _ = std::fs::create_dir_all(parent);
-          }
+        let unopenable = self.unopenable_files_by_session.get(&session_id);
+        if unopenable.is_some_and(|files| files.contains(&filename)) {
+          return;
         }
-        let file = self.files.entry(Arc::clone(&filename)).or_insert_with(|| {
-          let f = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filename.as_ref())
-            .unwrap_or_else(|e| panic!("devtools: failed to open log file {filename}: {e}"));
-          BufWriter::new(f)
-        });
+        let file = match self.files.entry(Arc::clone(&filename)) {
+          Entry::Occupied(entry) => entry.into_mut(),
+          Entry::Vacant(entry) => {
+            let path = self
+              .cwd_by_session
+              .get(&session_id)
+              .map_or_else(|| PathBuf::from(filename.as_ref()), |cwd| cwd.join(filename.as_ref()));
+            if let Some(parent) = path.parent() {
+              let _ = std::fs::create_dir_all(parent);
+            }
+            match OpenOptions::new().create(true).append(true).open(&path) {
+              Ok(file) => entry.insert(BufWriter::new(file)),
+              // Losing devtools output must not abort the build; on wasm a panic here traps the whole module.
+              Err(err) => {
+                #[expect(clippy::print_stderr, reason = "no diagnostics channel on this thread")]
+                {
+                  eprintln!("devtools: failed to open log file {}: {err}", path.display());
+                }
+                // Warn once and stop retrying the open for every later event on this file.
+                self.unopenable_files_by_session.entry(session_id).or_default().insert(filename);
+                return;
+              }
+            }
+          }
+        };
         self.files_by_session.entry(session_id.clone()).or_default().insert(Arc::clone(&filename));
         let hashes = self.exist_hash_by_session.entry(session_id).or_default();
         let _ = write_event(file, &action_value, hashes);
@@ -95,8 +118,10 @@ impl WriterState {
             }
           }
         }
+        // The session cwd outlives its files: `close()` queues this command before the `closeBundle` hooks run, so late events still have to resolve.
         self.exist_hash_by_session.remove(&session_id);
-        self.dir_ensured.remove(&session_id);
+        // A late event on a still-broken file warns once more and re-adds its entry, which the next close drops again.
+        self.unopenable_files_by_session.remove(&session_id);
         if let Some(ack) = ack {
           let _ = ack.send(());
         }

--- a/internal-docs/devtools/design.md
+++ b/internal-docs/devtools/design.md
@@ -172,7 +172,6 @@ Regardless of which approach is chosen for subscriber scoping, a **pre-emit chec
 
 ## Unresolved Questions
 
-- **Output location:** Currently hardcoded to `node_modules/.rolldown/` relative to real `process.cwd()`, not `InputOptions.cwd`. This means the devtools output may not land where expected if cwd differs.
 - **Incremental/watch mode:** The devtools system works for both `ClassicBundler` (one-shot) and core `Bundler` (incremental), but successive builds within the same session append to the same `logs.json`. No explicit "rebuild boundary" action exists yet.
 - **Dev engine integration:** `BindingDevEngine` creates a session but uses `Session::dummy()` — devtools is not yet wired up for the dev/HMR engine.
 

--- a/internal-docs/devtools/implementation.md
+++ b/internal-docs/devtools/implementation.md
@@ -29,10 +29,14 @@ CLI equivalent: `--devtools.session-id <id>`.
 When devtools is enabled, rolldown writes JSON-lines files to:
 
 ```
-<CWD>/node_modules/.rolldown/<session_id>/
+<InputOptions.cwd>/node_modules/.rolldown/<session_id>/
   meta.json    # SessionMeta action (one JSON object per build; appended in watch/rebuild)
   logs.json    # All other actions, one JSON object per line
 ```
+
+The formatter emits paths relative to `node_modules/`, and the writer thread joins them onto the session `cwd` it received from `DebugTracer::init` — `InputOptions#cwd`, which defaults to the working directory the build ran from. The process working directory is not a usable fallback: the wasm binding runs on `wasm32-wasip1-threads`, where there is no process `cwd` and a relative path resolves against the `/` preopen instead of the project.
+
+Events with no session span in scope fall back to the `unknown-session` id (`DEFAULT_SESSION_ID` in `crates/rolldown_devtools/src/static_data.rs`), which never receives a `cwd`. Their paths stay relative, so they follow the process working directory natively and the writer warns instead of writing them on wasm. This is the same process-global activation caveat that [design.md](./design.md) tracks under per-build scoping: once any build turns devtools on, later builds in that process keep emitting under `unknown-session`.
 
 Each line is a self-contained JSON object with an `action` discriminator field. Action events also carry `timestamp`, `session_id`, and `build_id` fields. `StringRef` entries contain only `action`, `id`, and `content` (no timestamp). The consumer reads the file and splits on newlines.
 
@@ -62,7 +66,7 @@ Top-level string fields larger than 10 KB are additionally replaced with a `$ref
 
 ### Key Types
 
-- **`DebugTracer`** — Initializes a `tracing_subscriber` registry with the devtools-specific layer and formatter. Singleton init via `AtomicBool`. On drop, sends a best-effort (no-ack) `CloseSession` to the writer thread as a cleanup fallback; the authoritative flush path is `ClassicBundler::close()`, which uses `rolldown_devtools::flush_session(session_id)` and awaits an ack before resolving.
+- **`DebugTracer`** — Initializes a `tracing_subscriber` registry with the devtools-specific layer and formatter. Singleton init via `AtomicBool`, but the session `cwd` it takes is registered with the writer thread on every call, once per session. On drop, sends a best-effort (no-ack) `CloseSession` to the writer thread as a cleanup fallback; the authoritative flush path is `ClassicBundler::close()`, which uses `rolldown_devtools::flush_session(session_id)` and awaits an ack before resolving.
 - **`Session`** — Holds a session `id` (e.g. `sid_0_1710000000000`) and a parent `tracing::Span`. All build spans are children of the session span. A `Session::dummy()` is used when devtools is disabled (no-op span).
 - **`DevtoolsLayer`** — A `tracing_subscriber::Layer` that extracts `CONTEXT_*` prefixed fields from spans and stores them as `ContextData` in span extensions.
 - **`DevtoolsFormatter`** — A `FormatEvent` impl that serializes `devtoolsAction`-tagged events to JSON lines, injects context variables, and writes to the appropriate file.
@@ -163,13 +167,15 @@ Run: `pnpm --filter @rolldown/debug run gen-action-types`
 
 ## Static Data Management
 
-File handles and hash caches are stored in process-global `LazyLock<DashMap>` statics:
+File handles, session directories, and hash caches live in `WriterState`, owned by the background writer thread, so no locking is needed:
 
-- `OPENED_FILE_HANDLES` — one file handle per output file path, preventing duplicate writes
-- `OPENED_FILES_BY_SESSION` — tracks which files belong to which session (for cleanup)
-- `EXIST_HASH_BY_SESSION` — tracks already-emitted `StringRef` hashes per session (for dedup)
+- `files` — one buffered file handle per output file path, preventing duplicate writes
+- `files_by_session` — tracks which files belong to which session (for cleanup)
+- `exist_hash_by_session` — tracks already-emitted `StringRef` hashes per session (for dedup)
+- `cwd_by_session` — the directory each session's relative log paths resolve against, set by `LogCommand::SetSessionCwd`; kept past `CloseSession` because `close()` queues that command before the `closeBundle` hooks run, so it holds one small entry per session for the life of the process
+- `unopenable_files_by_session` — log files whose first open failed, so the writer warns once instead of retrying per event; dropped on `CloseSession`, and a late event on a still-broken file warns once more and re-adds its entry
 
-These are cleaned up when the background writer thread processes a `CloseSession` command — either sent synchronously via `flush_session(...)` from `ClassicBundler::close()` (ack-based, happens-before `close()` resolving) or best-effort from `DebugTracer::drop`.
+Everything except the session cwd is cleaned up when the background writer thread processes a `CloseSession` command — either sent synchronously via `flush_session(...)` from `ClassicBundler::close()` (ack-based, happens-before `close()` resolving) or best-effort from `DebugTracer::drop`.
 
 ## Consumer Side
 
@@ -178,7 +184,7 @@ The `@rolldown/debug` package provides:
 ```ts
 import { parseToEvents, type Event, type StringRef } from '@rolldown/debug';
 
-const data = fs.readFileSync('node_modules/.rolldown/<sid>/logs.json', 'utf8');
+const data = fs.readFileSync('<InputOptions.cwd>/node_modules/.rolldown/<sid>/logs.json', 'utf8');
 const events = parseToEvents(data.trim());
 // events: Array<StringRef | { timestamp, session_id, action: "BuildStart" | "ModuleGraphReady" | "PackageGraphReady" | ... }>
 ```

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -5,10 +5,12 @@ Utilities and generated TypeScript types for reading Rolldown devtools output.
 When `devtools` is enabled, Rolldown writes JSON-lines files to:
 
 ```text
-node_modules/.rolldown/<session_id>/
+<cwd>/node_modules/.rolldown/<session_id>/
   meta.json
   logs.json
 ```
+
+`<cwd>` is the build's `InputOptions#cwd`, which defaults to the working directory the build ran from. Resolve the files against it rather than your own working directory, which may differ.
 
 `logs.json` is complete after `await bundle.close()` resolves.
 
@@ -18,7 +20,7 @@ node_modules/.rolldown/<session_id>/
 import fs from 'node:fs';
 import { parseToEvents, type Event, type StringRef } from '@rolldown/debug';
 
-const data = fs.readFileSync('node_modules/.rolldown/<session_id>/logs.json', 'utf8');
+const data = fs.readFileSync('<cwd>/node_modules/.rolldown/<session_id>/logs.json', 'utf8');
 const events = parseToEvents(data.trim());
 
 type ActionEvent = Exclude<Event, StringRef> & { build_id: string };
@@ -41,7 +43,7 @@ function isActionEvent(event: Event): event is ActionEvent {
   return 'build_id' in event;
 }
 
-const data = fs.readFileSync('node_modules/.rolldown/<session_id>/logs.json', 'utf8');
+const data = fs.readFileSync('<cwd>/node_modules/.rolldown/<session_id>/logs.json', 'utf8');
 const actionEvents = parseToEvents(data.trim()).filter(isActionEvent);
 const buildId = actionEvents.at(-1)?.build_id;
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -768,8 +768,9 @@ export interface InputOptions {
    * Devtools integration options.
    *
    * When enabled, Rolldown writes JSON-lines devtools output under
-   * `node_modules/.rolldown/{session_id}/`. Consumers can parse the output with
-   * `@rolldown/debug` after `await bundle.close()` resolves.
+   * `node_modules/.rolldown/{session_id}/`, resolved against {@linkcode cwd}.
+   * Consumers can parse the output with `@rolldown/debug` after
+   * `await bundle.close()` resolves.
    *
    * @experimental
    */

--- a/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
@@ -2,13 +2,10 @@ import { rolldown } from 'rolldown';
 
 import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-// Relative because this directory's own `package.json` shadows the `rolldown-tests/utils` self-reference other tests use.
-import { isWasiTest } from '../../src/utils';
 import { expect, test } from 'vitest';
 
-// `.rolldown` dir is generated based on real cwd instead of `InputOptions.cwd`. We might be able to solve this in the future.
-// For now, we just live with it.
-const dotRolldownFileName = join(process.cwd(), 'node_modules/.rolldown');
+// The `.rolldown` dir is generated under `InputOptions.cwd`, which `runBundle` sets to this directory.
+const dotRolldownFileName = join(import.meta.dirname, 'node_modules/.rolldown');
 
 function normalizePath(path) {
   return path.replaceAll('\\', '/');
@@ -18,8 +15,7 @@ function expectPathToEndWith(path, suffix) {
   expect(normalizePath(path).endsWith(suffix)).toBe(true);
 }
 
-// Under the wasm binding `crates/rolldown_devtools/src/writer.rs` panics opening its log file (WASI ENOENT). See https://github.com/rolldown/rolldown/issues/10609.
-test.skipIf(isWasiTest)(`emit data for devtool`, async () => {
+test(`emit data for devtool`, async () => {
   // Clean up previous test data if exists
   if (existsSync(dotRolldownFileName)) {
     rmSync(dotRolldownFileName, { recursive: true, force: true });


### PR DESCRIPTION
This makes the `devtools` related logic using `InputOptions#cwd` as the real cwd instead of getting it from the current env, which makes it env-dependent.

This is also an alignment with other rolldown logic, which uses `InputOptions#cwd` for `cwd-required` scenario.