### PR TITLE
test(webcontainer): smoke test the packed WASI artifacts inside a WebContainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       node-changes: "${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
       # Allows opting into Windows CI per-PR by adding the `ci: windows` label.
       run-windows: "${{ steps.pr-labels.outputs.run-windows == 'true' }}"
+      # Allows opting into the WebContainer smoke test per-PR by adding the `ci: webcontainer` label.
+      run-webcontainer: "${{ steps.pr-labels.outputs.run-webcontainer == 'true' }}"
     steps:
       # Reruns keep the original event payload, so query the current labels instead.
       - name: Read pull request labels
@@ -40,11 +42,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if ! run_windows="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '[.labels[].name] | any(. == "ci: windows")')"; then
-            echo "::warning::Could not read pull request labels; running Windows CI."
+          if ! labels="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')"; then
+            echo "::warning::Could not read pull request labels; running Windows CI and skipping the WebContainer smoke test."
             run_windows=true
+            # fail closed: this lane runs third-party code fetched at test time, so never opt in without a maintainer label
+            run_webcontainer=false
+          else
+            run_windows="$(jq 'any(. == "ci: windows")' <<< "$labels")"
+            run_webcontainer="$(jq 'any(. == "ci: webcontainer")' <<< "$labels")"
           fi
           echo "run-windows=${run_windows}" >> "$GITHUB_OUTPUT"
+          echo "run-webcontainer=${run_webcontainer}" >> "$GITHUB_OUTPUT"
 
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -164,6 +172,13 @@ jobs:
     uses: ./.github/workflows/reusable-wasi.yml
     with:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+
+  # Opt-in only: this lane never runs on path changes or on main, just on the `ci: webcontainer` label.
+  webcontainer:
+    needs: changes
+    uses: ./.github/workflows/reusable-webcontainer.yml
+    with:
+      changed: ${{ needs.changes.outputs.run-webcontainer == 'true' }}
 
   node-dev-server-test-windows:
     needs: [changes, build-rolldown-windows]

--- a/.github/workflows/reusable-webcontainer.yml
+++ b/.github/workflows/reusable-webcontainer.yml
@@ -1,0 +1,51 @@
+name: WebContainer
+
+# This lane runs an unpinned runtime fetched from stackblitz.com at test time, so it must never be granted secrets or a non-empty permissions block.
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        required: true
+        type: boolean
+
+jobs:
+  run:
+    name: WebContainer
+    if: ${{ inputs.changed }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
+        with:
+          tools: just
+          # reads the cache the WASI lane saves on main; both build the same debug wasm32 target
+          cache-key: debug-build-wasi
+          save-cache: false
+
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+        with:
+          version: '0.2.1'
+          cache: true
+
+      - name: Add WASI target
+        run: rustup target add wasm32-wasip1-threads
+
+      # no browser download: the vitest config points Playwright at the runner's system Chrome
+      - name: WebContainer Smoke Test
+        run: just test-webcontainer
+
+      - name: Upload failure screenshots
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: webcontainer-screenshots
+          path: packages/browser-tests/.vitest-attachments
+          retention-days: 7
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,11 @@ IMPORTANT: The project uses `just` as a task runner. Always prefer `just` comman
 
 - For Windows coverage on a PR, add the `ci: windows` label, then rerun all jobs in the latest `CI` workflow run whose event is `pull_request` and whose head SHA matches the PR. Adding the label alone does not start a workflow. Keep the label so later PR pushes also run the Windows jobs.
 
+# WebContainer CI
+
+- The `ci: webcontainer` label runs a smoke test that installs and builds the packed `rolldown` / `@rolldown/browser` artifacts inside a WebContainer. Activation works exactly like `ci: windows` above. Locally: `just test-webcontainer` (needs network — WebContainer boots from StackBlitz's CDN).
+- **ALWAYS add this label when a PR touches anything napi-rs related** (napi / emnapi / wasm-runtime versions, the binding loader and glue, the `napi` config, `webcontainer-fallback.cjs`, binding packaging or publish steps). Pure wasm behavior changes don't need it — the default CI's `wasi` job already runs the test suite against the wasm binding; this label checks that the packed packages install and work inside WebContainer.
+
 # Common Pitfalls & Best Practices
 
 - **`AGENTS.md` is the source of truth.** `CLAUDE.md` is a symlink to it.

--- a/justfile
+++ b/justfile
@@ -103,6 +103,10 @@ test-node-hmr-only *args:
 test-vite: # We don't use `test-node-vite` because it's not expected to run in `just test-node`.
   vp run --filter vite-tests test
 
+# Build the WASI artifacts and smoke test them inside a WebContainer. Opt-in only, needs network.
+test-webcontainer:
+  vp run --filter browser-tests test:webcontainer
+
 # --- `t` series commands provide scenario-specific shortcut commands for testing compared to `test` series commands.
 
 # Run both Rolldown's tests and Rollup's test suite without building Rolldown.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -90,6 +90,9 @@
         "src/dev-engine-close-child.mjs", // spawned by dev-engine-close.test.ts via execa
       ],
     },
+    "packages/browser-tests": {
+      "ignore": ["tests/fixtures/**"], // mounted into the container and built there, not here
+    },
     "scripts": {
       "entry": ["misc/**", "lint/index.ts"],
     },

--- a/packages/browser-tests/.gitignore
+++ b/packages/browser-tests/.gitignore
@@ -1,0 +1,6 @@
+# produced by scripts/prepare-fixture.mjs
+tests/fixtures/browser/rolldown-browser.tgz
+tests/fixtures/node/rolldown.tgz
+tests/fixtures/node/rolldown-binding-wasm32-wasi.tgz
+# vitest browser mode failure screenshots
+.vitest-attachments/

--- a/packages/browser-tests/package.json
+++ b/packages/browser-tests/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "browser-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prepare-fixture": "node ./scripts/prepare-fixture.mjs",
+    "test:webcontainer": "node ./scripts/prepare-fixture.mjs && vitest run"
+  },
+  "devDependencies": {
+    "@vitest/browser-playwright": "^4.1.6",
+    "@webcontainer/test": "^0.3.0",
+    "playwright": "^1.62.0",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/browser-tests/scripts/check-fixture-freshness.mjs
+++ b/packages/browser-tests/scripts/check-fixture-freshness.mjs
@@ -1,0 +1,55 @@
+// vitest globalSetup: refuse to run against fixtures that prepare-fixture.mjs has not refreshed.
+//
+// The tarballs are gitignored build output. Without this, `vitest run` on its own would happily
+// mount a tarball packed from an earlier branch and report a green run for code it never built.
+import { statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(packageRoot, '../..');
+const fixtures = join(packageRoot, 'tests/fixtures');
+
+// each tarball must be at least as new as the build output it was packed from
+const CHECKS = [
+  {
+    tarball: join(fixtures, 'browser/rolldown-browser.tgz'),
+    source: join(repoRoot, 'packages/browser/dist/rolldown-binding.wasm32-wasi.wasm'),
+  },
+  {
+    tarball: join(fixtures, 'node/rolldown.tgz'),
+    source: join(repoRoot, 'packages/rolldown/dist/index.mjs'),
+  },
+  {
+    tarball: join(fixtures, 'node/rolldown-binding-wasm32-wasi.tgz'),
+    source: join(repoRoot, 'packages/rolldown/src/rolldown-binding.wasm32-wasi.wasm'),
+  },
+];
+
+function fail(reason) {
+  throw new Error(
+    `${reason}\n\nRun \`just test-webcontainer\` (or \`pnpm run --filter browser-tests test:webcontainer\`), which builds the artifacts and packs them before running the suite.`,
+  );
+}
+
+export function setup() {
+  for (const { tarball, source } of CHECKS) {
+    const tarballStat = statSync(tarball, { throwIfNoEntry: false });
+    if (!tarballStat) {
+      fail(`Missing fixture tarball ${relative(repoRoot, tarball)}.`);
+    }
+
+    const sourceStat = statSync(source, { throwIfNoEntry: false });
+    if (!sourceStat) {
+      fail(
+        `Missing build output ${relative(repoRoot, source)}, so the fixtures cannot be trusted.`,
+      );
+    }
+
+    if (tarballStat.mtimeMs < sourceStat.mtimeMs) {
+      fail(
+        `Stale fixture tarball ${relative(repoRoot, tarball)}: ${relative(repoRoot, source)} was rebuilt after it was packed.`,
+      );
+    }
+  }
+}

--- a/packages/browser-tests/scripts/prepare-fixture.mjs
+++ b/packages/browser-tests/scripts/prepare-fixture.mjs
@@ -1,0 +1,98 @@
+// Packs the real publishable rolldown artifacts into the WebContainer fixtures.
+//
+//   node ./scripts/prepare-fixture.mjs [browser|node|all] [--no-build]
+//
+// Each scenario packs its tarballs into tests/fixtures/<scenario>, which the test mounts as an
+// overlay on top of the shared app in tests/fixtures/app.
+//
+// browser: @rolldown/browser, the single self-contained package the StackBlitz starter uses.
+// node:    the plain `rolldown` package plus the separate @rolldown/binding-wasm32-wasi package.
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(packageRoot, '../..');
+const fixtures = join(packageRoot, 'tests/fixtures');
+const rolldownPackage = join(repoRoot, 'packages/rolldown');
+
+const args = process.argv.slice(2);
+const shouldBuild = !args.includes('--no-build');
+const scenario = args.find((arg) => !arg.startsWith('--')) ?? 'all';
+
+if (!['browser', 'node', 'all'].includes(scenario)) {
+  throw new Error(`Unknown scenario "${scenario}", expected one of browser, node, all`);
+}
+
+// files the @rolldown/binding-wasm32-wasi package publishes, produced by `build-binding:wasi`
+const WASI_ARTIFACTS = [
+  'rolldown-binding.wasm32-wasi.wasm',
+  'rolldown-binding.wasi.cjs',
+  'rolldown-binding.wasi.d.cts',
+  'rolldown-binding.wasi-browser.js',
+  'wasi-worker.mjs',
+  'wasi-worker-browser.mjs',
+];
+
+// TARGET decides which package `build-node` writes into, so an ambient value would silently
+// change the artifact shape; every build below sets it explicitly or drops it
+function run(command, commandArgs, cwd, target) {
+  const env = { ...process.env };
+  delete env.TARGET;
+  if (target) {
+    env.TARGET = target;
+  }
+  execFileSync(command, commandArgs, { cwd, stdio: 'inherit', env });
+}
+
+// `pnpm pack` names the tarball after the package version; the fixtures pin stable names
+function pack(sourceDir, fixtureDir, packed, name) {
+  const target = join(fixtureDir, name);
+  rmSync(target, { force: true });
+  run('pnpm', ['pack', '--pack-destination', fixtureDir], sourceDir);
+
+  const produced = readdirSync(fixtureDir).find((file) => packed.test(file));
+  if (!produced) {
+    throw new Error(`pnpm pack did not produce a ${packed} tarball in ${fixtureDir}`);
+  }
+  renameSync(join(fixtureDir, produced), target);
+
+  console.log(`[prepare-fixture] ${name}: ${(statSync(target).size / 1024 / 1024).toFixed(2)} MB`);
+}
+
+if (scenario === 'browser' || scenario === 'all') {
+  if (shouldBuild) {
+    run('pnpm', ['run', '--filter', 'rolldown', 'build-browser-pkg:debug'], repoRoot, 'browser');
+  }
+  pack(
+    join(repoRoot, 'packages/browser'),
+    join(fixtures, 'browser'),
+    /^rolldown-browser-\d.*\.tgz$/,
+    'rolldown-browser.tgz',
+  );
+}
+
+if (scenario === 'node' || scenario === 'all') {
+  if (shouldBuild) {
+    run('pnpm', ['run', '--filter', 'rolldown', 'build-binding:wasi'], repoRoot);
+    // TARGET is dropped so `dist` keeps the published shape, without the wasm inlined
+    run('pnpm', ['run', '--filter', 'rolldown', 'build-node'], repoRoot);
+  }
+
+  // always regenerated, so the binding package.json cannot keep a version the tarball outgrew
+  const npmDir = join(rolldownPackage, 'npm/wasm32-wasi');
+  run('pnpm', ['exec', 'napi', 'create-npm-dirs'], rolldownPackage);
+  for (const file of WASI_ARTIFACTS) {
+    copyFileSync(join(rolldownPackage, 'src', file), join(npmDir, file));
+  }
+
+  const fixtureDir = join(fixtures, 'node');
+  pack(rolldownPackage, fixtureDir, /^rolldown-\d.*\.tgz$/, 'rolldown.tgz');
+  pack(
+    npmDir,
+    fixtureDir,
+    /^rolldown-binding-wasm32-wasi-\d.*\.tgz$/,
+    'rolldown-binding-wasm32-wasi.tgz',
+  );
+}

--- a/packages/browser-tests/tests/browser.test.ts
+++ b/packages/browser-tests/tests/browser.test.ts
@@ -1,0 +1,8 @@
+import { defineScenario } from './scenario';
+
+// Mirrors rolldown-starter-stackblitz: one self-contained package, no separate binding.
+defineScenario({
+  overlay: 'tests/fixtures/browser',
+  subject: 'packed @rolldown/browser',
+  build: 'pnpm run build',
+});

--- a/packages/browser-tests/tests/fixtures/app/rolldown.config.mjs
+++ b/packages/browser-tests/tests/fixtures/app/rolldown.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'rolldown';
+
+export default defineConfig({
+  input: ['./src/entry.js', './src/other-entry.js'],
+});

--- a/packages/browser-tests/tests/fixtures/app/src/cube.js
+++ b/packages/browser-tests/tests/fixtures/app/src/cube.js
@@ -1,0 +1,6 @@
+import square from './square.js';
+
+// Shared by both entries, so it lands in a common chunk
+export default function cube(x) {
+  return square(x) * x;
+}

--- a/packages/browser-tests/tests/fixtures/app/src/entry.js
+++ b/packages/browser-tests/tests/fixtures/app/src/entry.js
@@ -1,0 +1,3 @@
+import hyperCube from './hyper-cube.js';
+
+console.log(hyperCube(5));

--- a/packages/browser-tests/tests/fixtures/app/src/hyper-cube.js
+++ b/packages/browser-tests/tests/fixtures/app/src/hyper-cube.js
@@ -1,0 +1,6 @@
+import cube from './cube.js';
+
+// Only imported by one entry, so it shares that entry's chunk
+export default function hyperCube(x) {
+  return cube(x) * x;
+}

--- a/packages/browser-tests/tests/fixtures/app/src/other-entry.js
+++ b/packages/browser-tests/tests/fixtures/app/src/other-entry.js
@@ -1,0 +1,3 @@
+import cube from './cube.js';
+
+console.log(cube(5));

--- a/packages/browser-tests/tests/fixtures/app/src/square.js
+++ b/packages/browser-tests/tests/fixtures/app/src/square.js
@@ -1,0 +1,4 @@
+// Shared between both entry chunks
+export default function square(x) {
+  return x * x;
+}

--- a/packages/browser-tests/tests/fixtures/browser/package.json
+++ b/packages/browser-tests/tests/fixtures/browser/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rolldown-starter",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "RD_LOG=error rolldown -c ./rolldown.config.mjs"
+  },
+  "dependencies": {
+    "rolldown": "file:./rolldown-browser.tgz"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "pnpm install && pnpm build"
+  }
+}

--- a/packages/browser-tests/tests/fixtures/node/package.json
+++ b/packages/browser-tests/tests/fixtures/node/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rolldown-node-starter",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "RD_LOG=error rolldown -c ./rolldown.config.mjs"
+  },
+  "dependencies": {
+    "@rolldown/binding-wasm32-wasi": "file:./rolldown-binding-wasm32-wasi.tgz",
+    "rolldown": "file:./rolldown.tgz"
+  }
+}

--- a/packages/browser-tests/tests/globals.d.ts
+++ b/packages/browser-tests/tests/globals.d.ts
@@ -1,0 +1,2 @@
+// injected by `define` in vitest.config.mts
+declare const __ROLLDOWN_VERSION__: string;

--- a/packages/browser-tests/tests/node.test.ts
+++ b/packages/browser-tests/tests/node.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'vitest';
+import { defineScenario } from './scenario';
+import { FORCE_WASI, run } from './utils';
+
+// The plain `rolldown` package, which carries no binding and must pick up the packed
+// @rolldown/binding-wasm32-wasi instead of the copy its WebContainer fallback downloads.
+defineScenario({
+  overlay: 'tests/fixtures/node',
+  subject: 'packed rolldown plus its WASI binding',
+  build: `${FORCE_WASI} pnpm run build`,
+  async verifyInstall(container) {
+    // the published `rolldown` package carries no binding of its own, so the only way the build
+    // can succeed is through the separately packed @rolldown/binding-wasm32-wasi
+    const distLocal = await run(
+      container,
+      'ls node_modules/rolldown/dist/rolldown-binding.wasi.cjs',
+    );
+    expect(
+      distLocal.exitCode,
+      `rolldown/dist ships its own WASI binding, so the binding package is not under test:\n${distLocal.output}`,
+    ).not.toBe(0);
+
+    // `rolldown` does not declare the WASI binding, so the require inside its bundled
+    // dist/shared/binding-*.mjs resolves through pnpm's hidden hoisted store at
+    // node_modules/.pnpm/node_modules. Resolve from the package's real path, not the symlink.
+    const resolved = await container.runCommand('node', [
+      '-e',
+      "const { createRequire } = require('module'); const { realpathSync } = require('fs'); const { dirname, join } = require('path'); const pkg = realpathSync(createRequire(join(process.cwd(), 'x.js')).resolve('rolldown/package.json')); console.log(createRequire(join(dirname(pkg), 'dist/shared/binding.mjs')).resolve('@rolldown/binding-wasm32-wasi'))",
+    ]);
+    expect(resolved).toContain('/.pnpm/');
+    expect(resolved).toContain('@rolldown/binding-wasm32-wasi/rolldown-binding.wasi.cjs');
+  },
+});

--- a/packages/browser-tests/tests/scenario.ts
+++ b/packages/browser-tests/tests/scenario.ts
@@ -1,0 +1,70 @@
+import { test } from '@webcontainer/test';
+import { expect } from 'vitest';
+import {
+  type Container,
+  expectFreshArtifact,
+  expectNoPreexistingDist,
+  expectNoRegistryFallback,
+  run,
+} from './utils';
+
+// the app under test, shared by every scenario; only the dependencies differ
+const APP = 'tests/fixtures/app';
+
+export interface Scenario {
+  /** fixture directory holding this scenario's package.json and packed tarballs */
+  overlay: string;
+  /** what is under test, shown in the test name */
+  subject: string;
+  /** build command run inside the container */
+  build: string;
+  /** scenario-specific checks on the installed tree, between install and build */
+  verifyInstall?: (container: Container) => Promise<void>;
+}
+
+// Each scenario stays in its own test file so vitest runs them in parallel browser instances,
+// which roughly halves wall time compared to two tests in one file.
+export function defineScenario(scenario: Scenario) {
+  test(`the ${scenario.subject} builds the shared app inside WebContainer`, async ({
+    webcontainer,
+  }) => {
+    // CI runs the runner's system Chrome, which drifts with the runner image, so a failing
+    // run has to record which browser it ran on
+    console.log(navigator.userAgent);
+
+    // mount() overlays rather than replaces, so the scenario's overlay lands on the shared app
+    await webcontainer.mount(APP);
+    await webcontainer.mount(scenario.overlay);
+    await expectNoPreexistingDist(webcontainer);
+
+    const install = await run(webcontainer, 'pnpm install --no-frozen-lockfile');
+    expect(install, install.output).toMatchObject({ exitCode: 0 });
+
+    await expectFreshArtifact(webcontainer);
+    await scenario.verifyInstall?.(webcontainer);
+
+    const build = await run(webcontainer, scenario.build);
+    expect(build, build.output).toMatchObject({ exitCode: 0 });
+    expectNoRegistryFallback(build.output);
+
+    // two entries plus one shared chunk for the code both entries reach
+    const dist = (await webcontainer.readdir('/dist')).sort();
+    expect(dist).toHaveLength(3);
+    expect(dist).toContain('entry.js');
+    expect(dist).toContain('other-entry.js');
+    const sharedChunk = dist.find((name) => /^cube-.*\.js$/.test(name));
+    expect(sharedChunk, `no shared chunk in ${dist.join(', ')}`).toBeTruthy();
+
+    const entry = await webcontainer.readFile('/dist/entry.js');
+    expect(entry).toContain('console.log(hyperCube(5))');
+    expect(entry).toContain(`from "./${sharedChunk}"`);
+
+    const otherEntry = await webcontainer.readFile('/dist/other-entry.js');
+    expect(otherEntry).toContain('console.log(cube(5))');
+    expect(otherEntry).toContain(`from "./${sharedChunk}"`);
+
+    const shared = await webcontainer.readFile(`/dist/${sharedChunk}`);
+    expect(shared).toContain('function square');
+    expect(shared).toContain('function cube');
+  });
+}

--- a/packages/browser-tests/tests/utils.ts
+++ b/packages/browser-tests/tests/utils.ts
@@ -1,0 +1,43 @@
+import { expect } from 'vitest';
+
+export interface Container {
+  runCommand: (cmd: string, args: string[]) => PromiseLike<string>;
+  readdir: (path: string) => Promise<string[]>;
+  readFile: (path: string) => Promise<string>;
+}
+
+// `error` (not `true`) so a missing WASI binding fails instead of silently falling back
+export const FORCE_WASI = 'NAPI_RS_FORCE_WASI=error';
+
+// runCommand does not surface an exit code, so the shell echoes it into the output.
+// The last marker wins, so output that happens to contain the token cannot mask a failure.
+export async function run(container: Container, script: string) {
+  const output = await container.runCommand('sh', ['-c', `${script}; echo "__exit=$?"`]);
+  const markers = [...output.matchAll(/__exit=(\d+)/g)];
+  const exitCode = Number(markers.at(-1)?.[1] ?? NaN);
+  return { output, exitCode };
+}
+
+// The tarballs are gitignored build output, so a stale one from an earlier build would
+// otherwise pass silently. Pin the version actually running inside the container.
+export async function expectFreshArtifact(container: Container) {
+  // safe for both scenarios: @rolldown/browser has no napi loader, so the variable is inert there
+  const version = await run(container, `${FORCE_WASI} pnpm exec rolldown --version`);
+  expect(version, version.output).toMatchObject({ exitCode: 0 });
+  expect(version.output).toContain(__ROLLDOWN_VERSION__);
+  expectNoRegistryFallback(version.output);
+}
+
+// packages/rolldown/src/webcontainer-fallback.cjs downloads @rolldown/binding-wasm32-wasi from
+// npm when the binding is missing inside a WebContainer, which would test the released artifact
+// instead of the packed one
+export function expectNoRegistryFallback(output: string) {
+  expect(output).not.toContain('[rolldown] Downloading');
+}
+
+// mount() snapshots the fixture directory as-is, so a dist/ left behind on the host would
+// be mounted and could satisfy the output assertions without the container building anything
+export async function expectNoPreexistingDist(container: Container) {
+  const listing = await run(container, 'ls dist');
+  expect(listing.exitCode, `dist/ existed before the build:\n${listing.output}`).not.toBe(0);
+}

--- a/packages/browser-tests/tsconfig.json
+++ b/packages/browser-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["tests/**/*.ts", "vitest.config.mts"],
+  "exclude": ["tests/fixtures/**"],
+  "compilerOptions": {
+    "types": ["node"],
+    "rootDir": "./",
+    "isolatedDeclarations": false
+  }
+}

--- a/packages/browser-tests/vitest.config.mts
+++ b/packages/browser-tests/vitest.config.mts
@@ -1,0 +1,34 @@
+import { createRequire } from 'node:module';
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+import { vitestWebContainers } from '@webcontainer/test/plugin';
+
+const { version } = createRequire(import.meta.url)('../rolldown/package.json');
+
+export default defineConfig({
+  plugins: [vitestWebContainers()],
+  define: {
+    __ROLLDOWN_VERSION__: JSON.stringify(version),
+  },
+  test: {
+    include: ['tests/*.test.ts'],
+    exclude: ['tests/fixtures/**'],
+    // refuses to run against tarballs that prepare-fixture.mjs has not refreshed
+    globalSetup: ['./scripts/check-fixture-freshness.mjs'],
+    // booting WebContainer + installing and building inside it is slow
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    // WebContainer boots from a CDN, so the network is in the critical path
+    retry: process.env.CI ? 2 : 0,
+    browser: {
+      enabled: true,
+      provider: playwright({
+        // CI uses the runner's system Chrome: closer to what real StackBlitz users run, and it
+        // skips the browser download. Locally, Playwright's pinned Chromium keeps versions stable.
+        launchOptions: { channel: process.env.CI ? 'chrome' : undefined },
+      }),
+      instances: [{ browser: 'chromium' }],
+      headless: true,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,7 +299,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: ^0.2.7
-        version: 0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   crates/rolldown/tests/rolldown/topics/npm_packages:
     dependencies:
@@ -544,6 +544,21 @@ importers:
         specifier: 'catalog:'
         version: 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
 
+  packages/browser-tests:
+    devDependencies:
+      '@vitest/browser-playwright':
+        specifier: ^4.1.6
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@webcontainer/test':
+        specifier: ^0.3.0
+        version: 0.3.0(vitest@4.1.10)
+      playwright:
+        specifier: ^1.62.0
+        version: 1.62.1
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/debug:
     devDependencies:
       '@oxc-node/cli':
@@ -630,7 +645,7 @@ importers:
         version: 8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     devDependencies:
       '@jridgewell/trace-mapping':
         specifier: 'catalog:'
@@ -792,7 +807,7 @@ importers:
         version: 6.1.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ws:
         specifier: 'catalog:'
         version: 8.21.1
@@ -3032,6 +3047,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
 
   '@napi-rs/cli@3.8.2':
     resolution: {integrity: sha512-iFmp3Lo/ipXoJI1I/6V/xU4hQV42bXS3A7j8C+Wt3LOtYY7HFCilkhyUkN1igLJFXWMICq95kNxhNcwzNRd+Kw==}
@@ -5316,6 +5335,12 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
   '@vitest/browser-preview@4.1.10':
     resolution: {integrity: sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ==}
     peerDependencies:
@@ -5569,6 +5594,18 @@ packages:
     resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
     peerDependencies:
       vue: ^3.5.0
+
+  '@webcontainer/api@1.6.4':
+    resolution: {integrity: sha512-r9sHCXg1FcC1AMgppGwAc0vYWaQhqvg282cnsuPbJEzYnWifAdCVvg+8ngJUEHyHcomhJJp+/zuytite4ITHLw==}
+
+  '@webcontainer/snapshot@0.1.0':
+    resolution: {integrity: sha512-PTIGQ3osUpTbK/dqB8RYbcZGv8IK+DJACx709z5sFbeIlngB3hUFpTEYFYs1SbUvr/AEQqvd0/bhc4ectrPRRw==}
+    engines: {node: '>=16'}
+
+  '@webcontainer/test@0.3.0':
+    resolution: {integrity: sha512-Apl27MWndoSKLNWg1dTVa8QjDJbIXBbCP3eLO27xs7g+LyijAktOFqb+CFSJQo8DIdQDjRjvMm7o9B/5behYzw==}
+    peerDependencies:
+      vitest: ^4
 
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     resolution: {integrity: sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg==}
@@ -10651,6 +10688,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@msgpack/msgpack@3.1.3': {}
+
   '@napi-rs/cli@3.8.2(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.10.3)(supports-color@10.2.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.10.3)
@@ -12342,12 +12381,39 @@ snapshots:
       vite: rolldown-vite@7.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.40(typescript@6.0.3)
 
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/browser-preview@4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12360,7 +12426,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12376,7 +12442,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -12394,7 +12460,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -12628,6 +12694,18 @@ snapshots:
   '@vueuse/shared@14.3.0(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       vue: 3.5.40(typescript@6.0.3)
+
+  '@webcontainer/api@1.6.4': {}
+
+  '@webcontainer/snapshot@0.1.0':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+
+  '@webcontainer/test@0.3.0(vitest@4.1.10)':
+    dependencies:
+      '@webcontainer/api': 1.6.4
+      '@webcontainer/snapshot': 0.1.0
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     optional: true
@@ -12929,7 +13007,7 @@ snapshots:
       pg: 8.22.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -14525,7 +14603,7 @@ snapshots:
       magic-regexp: 0.10.0
       oxc-parser: 0.143.0
 
-  oxfmt@0.60.0(vite-plus@0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.60.0(vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -14548,7 +14626,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.60.0
       '@oxfmt/binding-win32-ia32-msvc': 0.60.0
       '@oxfmt/binding-win32-x64-msvc': 0.60.0
-      vite-plus: 0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -14559,7 +14637,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.75.0
       '@oxlint/binding-android-arm64': 1.75.0
@@ -14581,7 +14659,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.75.0
       '@oxlint/binding-win32-x64-msvc': 1.75.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   p-defer@1.0.0: {}
 
@@ -15674,7 +15752,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.141.0
       '@oxlint/plugins': 1.73.0
@@ -15688,11 +15766,12 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
-      oxfmt: 0.60.0(vite-plus@0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxfmt: 0.60.0(vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.7
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.7
       '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.7
@@ -15857,36 +15936,7 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.10.3
-      '@vitest/browser-preview': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-    transitivePeerDependencies:
-      - msw
-    optional: true
-
-  vitest@4.1.10(@types/node@24.10.3)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -15910,6 +15960,66 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+    optional: true
+
+  vitest@4.1.10(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "./crates/rolldown_plugin_hmr/src/runtime" },
     { "path": "./crates/rolldown_testing/src" },
     { "path": "./packages/bench" },
+    { "path": "./packages/browser-tests" },
     { "path": "./packages/rolldown" },
     { "path": "./packages/rolldown/tests" },
     { "path": "./packages/rollup-tests" },


### PR DESCRIPTION
This PR will use `pnpm pack` to pack the rolldown dist ouput into a `.tgz` file and upload it into webcontainer.

The pkg json in webcontainer will look like

```json
{
"rolldown": "file:./rolldown.tgz"
}
```

and then npm will download correspending napi-rs wasi runtime written in package.json inside of `.tgz` file and do a smoke test to ensure everything works.

Becuase the webcontainer's engine is required to be downloaded from official cdn, so I don't think it's proper to make this as a default on ci workflow or part of local tests.

---

How this PR does?

It opens a headless browser and use `@webcontainer/sdk` to interact with the webcontainer env and check behaviors.

---

I assigned the PR to Jerry but also @sapphi-red cc