### PR TITLE
refactor: remove deprecated `watch.notify` option

### DIFF
--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -140,8 +140,7 @@ function warnMultiplePollingOptions(bundlerOptions: BundlerOptionWithStopWorker[
   let found = false;
   for (const option of bundlerOptions) {
     const watch = option.inputOptions.watch;
-    const watcher =
-      watch && typeof watch === 'object' ? (watch.watcher ?? watch.notify) : undefined;
+    const watcher = watch && typeof watch === 'object' ? watch.watcher : undefined;
     if (watcher && (watcher.usePolling != null || watcher.pollInterval != null)) {
       if (found) {
         option.onLog(LOG_LEVEL_WARN, logMultipleWatcherOption());

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -153,10 +153,6 @@ export interface WatcherOptions {
    */
   watcher?: WatcherFileWatcherOptions;
   /**
-   * @deprecated Use {@linkcode watcher} instead.
-   */
-  notify?: WatcherFileWatcherOptions;
-  /**
    * Filter to limit the file-watching to certain files.
    *
    * Strings are treated as glob patterns.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -316,11 +316,7 @@ function bindingifyInput(input: InputOptions['input']): BindingInputOptions['inp
 
 function bindingifyWatch(watch: InputOptions['watch']): BindingInputOptions['watch'] {
   if (watch) {
-    if (watch.notify) {
-      console.warn('The "watch.notify" option is deprecated. Please use "watch.watcher" instead.');
-    }
-    // Merge deprecated `notify` into `watcher`, with `watcher` taking precedence
-    const watcher = { ...watch.notify, ...watch.watcher };
+    const watcher = watch.watcher ?? {};
     return {
       buildDelay: watch.buildDelay,
       skipWrite: watch.skipWrite,


### PR DESCRIPTION
Remove the deprecated `watch.notify` option. The `watch` option was experimental, so it's not a breaking change.