### PR TITLE
feat: stabilize `watch` API

### DIFF
--- a/packages/rolldown/src/api/watch/index.ts
+++ b/packages/rolldown/src/api/watch/index.ts
@@ -31,7 +31,6 @@ import { createWatcher } from './watcher';
  * watcher.close();
  * ```
  *
- * @experimental
  * @category Programmatic APIs
  */
 export function watch(input: WatchOptions | WatchOptions[]): RolldownWatcher {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -748,8 +748,6 @@ export interface InputOptions {
    * These options only take effect when running with the [`--watch`](/apis/cli#w-watch) flag, or using {@linkcode watch | watch()} API.
    *
    * {@include ./docs/watch.md}
-   *
-   * @experimental
    */
   watch?: WatcherOptions | false;
   /**


### PR DESCRIPTION
Stabilize the `watch` API. I think we won't / can't change this drastically without an option any more.