### PR TITLE
test(binding): cover Android ARM64 Cortex-A53

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       # A Windows CI request runs the complete Windows suite, even for paths outside the normal filters.
       rust-changes: "${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
       node-changes: "${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
-      android-binding-changes: "${{ (steps.filter.outputs.android-binding-changes == 'true') || (github.ref_name == 'main') }}"
       # Allows opting into Windows CI per-PR by adding the `ci: windows` label.
       run-windows: "${{ steps.pr-labels.outputs.run-windows == 'true' }}"
       # Allows opting into the WebContainer smoke test per-PR by adding the `ci: webcontainer` label.
@@ -77,19 +76,6 @@ jobs:
               - '.gitattributes'
               - 'justfile'
               - 'test262'
-            android-binding-changes:
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/reusable-release-build.yml'
-              - '.cargo/**'
-              - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - 'packages/rolldown/build-binding.ts'
-              - 'packages/rolldown/package.json'
             node-changes:
               - *rust-changes
               - 'packages/**'
@@ -100,7 +86,6 @@ jobs:
         run: |
           echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
           echo "Node changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
-          echo "Android binding changes: ${{ (steps.filter.outputs.android-binding-changes == 'true') || (github.ref_name == 'main') }}"
 
   rust-validation:
     name: Rust Validation
@@ -142,7 +127,7 @@ jobs:
   android-arm64-cortex-a53:
     name: Android ARM64 Cortex-A53
     needs: changes
-    if: ${{ needs.changes.outputs.android-binding-changes == 'true' }}
+    if: ${{ needs.changes.outputs.rust-changes == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       # A Windows CI request runs the complete Windows suite, even for paths outside the normal filters.
       rust-changes: "${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
       node-changes: "${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
+      android-binding-changes: "${{ (steps.filter.outputs.android-binding-changes == 'true') || (github.ref_name == 'main') }}"
       # Allows opting into Windows CI per-PR by adding the `ci: windows` label.
       run-windows: "${{ steps.pr-labels.outputs.run-windows == 'true' }}"
       # Allows opting into the WebContainer smoke test per-PR by adding the `ci: webcontainer` label.
@@ -76,6 +77,19 @@ jobs:
               - '.gitattributes'
               - 'justfile'
               - 'test262'
+            android-binding-changes:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/reusable-release-build.yml'
+              - '.cargo/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'packages/rolldown/build-binding.ts'
+              - 'packages/rolldown/package.json'
             node-changes:
               - *rust-changes
               - 'packages/**'
@@ -86,6 +100,7 @@ jobs:
         run: |
           echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
           echo "Node changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') || (steps.pr-labels.outputs.run-windows == 'true') }}"
+          echo "Android binding changes: ${{ (steps.filter.outputs.android-binding-changes == 'true') || (github.ref_name == 'main') }}"
 
   rust-validation:
     name: Rust Validation
@@ -123,6 +138,42 @@ jobs:
     with:
       os: ${{ matrix.target }}
       changed: ${{ needs.changes.outputs.rust-changes == 'true' }}
+
+  android-arm64-cortex-a53:
+    name: Android ARM64 Cortex-A53
+    needs: changes
+    if: ${{ needs.changes.outputs.android-binding-changes == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Setup Rust
+        uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
+        with:
+          cache-key: android-arm64-cortex-a53
+          save-cache: ${{ github.ref_name == 'main' }}
+
+      - name: Add Android target
+        run: rustup target add aarch64-linux-android
+
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+        with:
+          version: '0.2.1'
+          cache: true
+
+      - name: Install QEMU and APEX tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends e2fsprogs qemu-user unzip
+
+      - name: Build Android ARM64 binding
+        run: vp run ci:build-release-binding --target aarch64-linux-android
+        env:
+          TARGET_CC: clang # for mimalloc
+
+      - name: Test binding on Cortex-A53
+        run: bash crates/rolldown_binding/tests/android_arm64_cortex_a53/run.sh packages/rolldown/src/rolldown-binding.android-arm64.node
 
   node-test-windows:
     needs: [changes, build-rolldown-windows]

--- a/crates/rolldown_binding/tests/android_arm64_cortex_a53/loader.c
+++ b/crates/rolldown_binding/tests/android_arm64_cortex_a53/loader.c
@@ -1,0 +1,18 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: %s <shared-object>\n", argv[0]);
+    return 2;
+  }
+
+  void *handle = dlopen(argv[1], RTLD_LAZY | RTLD_LOCAL);
+  if (handle == NULL) {
+    fprintf(stderr, "dlopen(%s) failed: %s\n", argv[1], dlerror());
+    return 1;
+  }
+
+  printf("loaded %s\n", argv[1]);
+  return 0;
+}

--- a/crates/rolldown_binding/tests/android_arm64_cortex_a53/lse_probe.S
+++ b/crates/rolldown_binding/tests/android_arm64_cortex_a53/lse_probe.S
@@ -1,0 +1,21 @@
+// The probe succeeds when FEAT_LSE is available and traps otherwise.
+.arch armv8.1-a+lse
+
+.text
+.global _start
+.type _start, %function
+_start:
+  adrp x2, lse_word
+  add x2, x2, :lo12:lse_word
+  mov x0, #0
+  mov x1, #1
+  casal x0, x1, [x2]
+  mov x0, #0
+  mov x8, #93
+  svc #0
+.size _start, .-_start
+
+.data
+.balign 8
+lse_word:
+  .quad 0

--- a/crates/rolldown_binding/tests/android_arm64_cortex_a53/run.sh
+++ b/crates/rolldown_binding/tests/android_arm64_cortex_a53/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly runtime_apex_url='https://android.googlesource.com/platform/prebuilts/runtime/+/7b5a7c7117dbd3243344b8f9d9076ea983e1afb0/mainline/runtime/apex/com.android.runtime-arm64.apex?format=TEXT'
+readonly runtime_apex_sha256='ec2500bcef83fc2856433d20fda8dd7adf14a7c430375c1c8441d2c4ba6acb0f'
+readonly known_bad_binding_url='https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz'
+readonly known_bad_binding_sha256='aa01416cbdb2df106fe4224e1434636c74d29842b0b191f44b27660b6de5df57'
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <android-arm64-binding>" >&2
+  exit 2
+fi
+
+readonly binding_path="$1"
+if [[ ! -f "$binding_path" ]]; then
+  echo "binding does not exist: $binding_path" >&2
+  exit 2
+fi
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work_dir="$(mktemp -d)"
+readonly work_dir
+
+cleanup() {
+  if [[ -n "${work_dir:-}" && -d "$work_dir" ]]; then
+    rm -rf -- "$work_dir"
+  fi
+}
+trap cleanup EXIT
+
+download() {
+  local url="$1"
+  local destination="$2"
+  curl --fail --location --retry 3 --retry-all-errors --silent --show-error "$url" --output "$destination"
+}
+
+verify_sha256() {
+  local expected="$1"
+  local file="$2"
+  printf '%s  %s\n' "$expected" "$file" | sha256sum --check --status
+}
+
+find_ndk() {
+  local ndk_home="${ANDROID_NDK_LATEST_HOME:-${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}}"
+  if [[ -n "$ndk_home" && -d "$ndk_home" ]]; then
+    printf '%s\n' "$ndk_home"
+    return
+  fi
+
+  local sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+  if [[ -n "$sdk_root" && -d "$sdk_root/ndk" ]]; then
+    find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1
+  fi
+}
+
+run_on_cpu() {
+  local cpu="$1"
+  shift
+  timeout --signal=KILL 30s qemu-aarch64 -cpu "$cpu" -L "$runtime_root" "$@"
+}
+
+readonly ndk_home="$(find_ndk)"
+readonly android_clang="$ndk_home/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+if [[ ! -x "$android_clang" ]]; then
+  echo "Android NDK compiler does not exist: $android_clang" >&2
+  exit 2
+fi
+
+readonly runtime_root="$work_dir/root"
+mkdir -p "$runtime_root/system/bin" "$runtime_root/system/lib64"
+
+echo 'Downloading the pinned 7.6 MiB AOSP Runtime APEX'
+download "$runtime_apex_url" "$work_dir/runtime.apex.base64"
+base64 --decode < "$work_dir/runtime.apex.base64" > "$work_dir/runtime.apex"
+verify_sha256 "$runtime_apex_sha256" "$work_dir/runtime.apex"
+unzip -p "$work_dir/runtime.apex" apex_payload.img > "$work_dir/apex_payload.img"
+
+debugfs -R 'cat /bin/linker64' "$work_dir/apex_payload.img" > "$runtime_root/system/bin/linker64"
+debugfs -R 'cat /lib64/bionic/libc.so' "$work_dir/apex_payload.img" > "$runtime_root/system/lib64/libc.so"
+debugfs -R 'cat /lib64/bionic/libdl.so' "$work_dir/apex_payload.img" > "$runtime_root/system/lib64/libdl.so"
+debugfs -R 'cat /lib64/bionic/libm.so' "$work_dir/apex_payload.img" > "$runtime_root/system/lib64/libm.so"
+chmod 755 "$runtime_root/system/bin/linker64"
+
+"$android_clang" -O2 -Wall -Wextra -Werror "$script_dir/loader.c" -ldl -o "$runtime_root/loader"
+"$android_clang" -nostdlib -static -Wl,--build-id=none -Wl,-e,_start "$script_dir/lse_probe.S" -o "$work_dir/lse-probe"
+
+echo 'Checking that the selected QEMU CPU rejects Arm LSE instructions'
+run_on_cpu max "$work_dir/lse-probe"
+set +e
+run_on_cpu cortex-a53 "$work_dir/lse-probe" > "$work_dir/lse-probe.log" 2>&1
+probe_status=$?
+set -e
+if [[ $probe_status -eq 0 ]]; then
+  echo 'Cortex-A53 unexpectedly executed an Arm LSE instruction' >&2
+  exit 1
+fi
+if [[ $probe_status -eq 124 || $probe_status -eq 137 ]]; then
+  echo 'Arm LSE probe timed out' >&2
+  exit 1
+fi
+
+echo 'Checking the Bionic loader with an ordinary system library'
+run_on_cpu cortex-a53 "$runtime_root/loader" /system/lib64/libm.so
+
+echo 'Checking that the published v1.2.3 binding reproduces the original SIGILL'
+download "$known_bad_binding_url" "$work_dir/known-bad-binding.tgz"
+verify_sha256 "$known_bad_binding_sha256" "$work_dir/known-bad-binding.tgz"
+mkdir -p "$work_dir/known-bad-binding"
+tar -xzf "$work_dir/known-bad-binding.tgz" -C "$work_dir/known-bad-binding"
+cp "$work_dir/known-bad-binding/package/rolldown-binding.android-arm64.node" "$runtime_root/known-bad.node"
+
+set +e
+run_on_cpu cortex-a53 "$runtime_root/loader" /known-bad.node > "$work_dir/known-bad.log" 2>&1
+known_bad_status=$?
+set -e
+cat "$work_dir/known-bad.log"
+if [[ $known_bad_status -eq 0 ]]; then
+  echo 'The known-bad binding unexpectedly loaded on Cortex-A53' >&2
+  exit 1
+fi
+if [[ $known_bad_status -eq 124 || $known_bad_status -eq 137 ]]; then
+  echo 'The known-bad binding timed out instead of raising SIGILL' >&2
+  exit 1
+fi
+if ! grep -Fq 'Fatal signal 4 (SIGILL)' "$work_dir/known-bad.log"; then
+  echo 'The known-bad binding failed without the expected SIGILL' >&2
+  exit 1
+fi
+
+echo 'Checking the binding built from the current commit'
+cp "$binding_path" "$runtime_root/current.node"
+run_on_cpu cortex-a53 "$runtime_root/loader" /current.node
+
+echo 'Cortex-A53 regression check passed'


### PR DESCRIPTION
## How this works

1. Cross-compile the Rolldown native binding and a tiny loader for Android ARM64 on a GitHub-hosted x64 Linux runner.
2. Extract Android's `linker64` and Bionic libraries from a pinned official AOSP Runtime APEX.
3. Use QEMU user-mode with `-cpu cortex-a53` to run the loader, which `dlopen()`s the `.node` binding.
4. Verify that the known-bad v1.2.3 binding reproduces the `SIGILL` from #6342, while the binding built from the current commit loads successfully.

This covers loading, relocation, and native constructors. It does not run Rolldown APIs or emulate a complete Android system.