### PR TITLE
chore(wasi): point the wasm skips at the right place

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build `@rolldown/test-dev-server`
         run: vp run --filter '@rolldown/test-dev-server' build
 
-      # `test:wasi` is `test:main` with `ROLLDOWN_WASI_TEST=1`, which skips the tests that the wasm binding cannot pass; they are tracked in https://github.com/rolldown/rolldown/issues/10609.
+      # `test:wasi` is `test:main` with `ROLLDOWN_WASI_TEST=1`, which skips the tests that the wasm binding cannot pass; every skip states its own reason.
       - name: Node Test
         run: vp run --filter rolldown-tests test:wasi
 

--- a/packages/rolldown/tests/dev/dev-close.test.ts
+++ b/packages/rolldown/tests/dev/dev-close.test.ts
@@ -37,7 +37,7 @@ function dev(
 // Fix: after `close()`, `ensureCurrentBuildFinish()` is a no-op rather than
 // an error — there is no ongoing bundle to wait for.
 //
-// Under the wasm binding `close()` tears down the shared tokio runtime, so the no-op call panics with "Access tokio runtime failed in spawn". See https://github.com/rolldown/rolldown/issues/10609.
+// Under the wasm binding `close()` tears down the shared tokio runtime, so the no-op call panics with "Access tokio runtime failed in spawn". See https://github.com/rolldown/rolldown/issues/10639.
 test.skipIf(isWasiTest)(
   'ensureCurrentBuildFinish after close resolves instead of rejecting',
   { timeout: TEST_TIMEOUT },

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -165,7 +165,7 @@ test('call transformContext error', async () => {
 });
 
 // #4141
-// Under the wasm binding the `structuredClone` failure degrades to a plain `Error`, losing the `DataCloneError` name. See https://github.com/rolldown/rolldown/issues/10609.
+// Under the wasm binding the `structuredClone` failure degrades to a plain `Error`, losing the `DataCloneError` name.
 test.skipIf(isWasiTest)('should print original error if it can not be assigned', async () => {
   const error = await buildWithPlugin({
     name: 'test',

--- a/packages/rolldown/tests/fixtures/misc/error/load/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/load/_config.ts
@@ -3,7 +3,7 @@ import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
-  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
@@ -4,7 +4,7 @@ import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
-  // Under the wasm binding the error arrives as a bare `my-error`, without the `[plugin my-plugin] <id>:1:4` diagnostic asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives as a bare `my-error`, without the `[plugin my-plugin] <id>:1:4` diagnostic asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/fixtures/misc/error/render-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/render-chunk/_config.ts
@@ -3,7 +3,7 @@ import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
-  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/fixtures/misc/error/resolve-id/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/resolve-id/_config.ts
@@ -3,7 +3,7 @@ import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
-  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
@@ -4,7 +4,7 @@ import { isWasiTest } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 export default defineTest({
-  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives with a `wasm://` stack, without the `at errorFn1` / `at errorFn2` frames asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
@@ -5,7 +5,7 @@ import { expect, vi } from 'vitest';
 const fn = vi.fn();
 
 export default defineTest({
-  // Under the wasm binding the error arrives with a `wasm://` stack and none of the `Caused by:` chain asserted below. See https://github.com/rolldown/rolldown/issues/10609.
+  // Under the wasm binding the error arrives with a `wasm://` stack and none of the `Caused by:` chain asserted below.
   skip: isWasiTest,
   config: {
     plugins: [

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -8,7 +8,7 @@ import type {
   RolldownOutput as RollupOutput,
 } from 'rolldown';
 
-/** `true` when the suite runs against the WASI binding, set by the WASI lane and `just test-wasi`; the tests it skips are tracked in https://github.com/rolldown/rolldown/issues/10609. */
+/** `true` when the suite runs against the WASI binding, set by the `wasi` CI job and `just test-wasi`; every test it skips states its own reason. */
 export const isWasiTest = process.env.ROLLDOWN_WASI_TEST === '1';
 
 /**


### PR DESCRIPTION
https://github.com/rolldown/rolldown/issues/10609 is closed.

Some test are skipped in WASI on purpose. This PR updates some stale information.

- `misc/error` tests are skipped because wasi throw different stack message due to the wasi env.
- `packages/rolldown/tests/dev/dev-close.test.ts` is deliberately tracked at https://github.com/rolldown/rolldown/issues/10639
- `builtin-plugin/import-glob/follow-symlinks` is left untouched on purpose: https://github.com/rolldown/rolldown/pull/10624 removes that skip entirely, so editing the same lines here would only create a conflict.
