### PR TITLE
fix:Manual code splitting compact rollup

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -238,7 +238,6 @@ impl ManualSplitter<'_> {
           };
           &mut module_groups[idx]
         };
-
         add_module_and_dependencies_to_group_recursively(
           group,
           normal_module.idx,
@@ -338,13 +337,47 @@ impl ManualSplitter<'_> {
     if module_groups.is_empty() {
       return module_groups;
     }
-
+    let module_table = &self.link_output.module_table;
     // - Higher priority group goes first.
     // - If two groups have the same priority, the one with the lower index goes first.
     // - If two groups have the same priority and index, we use dictionary order to sort them.
-    // Outer `Reverse` is due to we're gonna use `pop` consume the vector.
-    module_groups.sort_by_cached_key(|item| {
-      Reverse((Reverse(item.priority), item.match_group_index, item.name.clone()))
+    //   (i.e. modules not shared with the other group) by their minimum `stable_id`.
+    //   The group with the smaller minimum `stable_id` goes first. A group with no
+    //   exclusive modules goes first (it was pulled in by the other group).
+    // - If still tied, fall back to dictionary order on the group name.
+
+    module_groups.sort_by(|a, b| {
+      match a.priority.cmp(&b.priority) {
+        Ordering::Equal => {}
+        ord => return ord,
+      }
+      match b.match_group_index.cmp(&a.match_group_index) {
+        Ordering::Equal => {}
+        ord => return ord,
+      }
+      let a_exclusive: Vec<_> = a.modules.difference(&b.modules).copied().collect();
+      let b_exclusive: Vec<_> = b.modules.difference(&a.modules).copied().collect();
+
+      let a_min = a_exclusive
+        .iter()
+        .filter_map(|&idx| module_table[idx].as_normal().map(|m| &m.stable_id))
+        .min();
+      let b_min = b_exclusive
+        .iter()
+        .filter_map(|&idx| module_table[idx].as_normal().map(|m| &m.stable_id))
+        .min();
+
+      match (a_min, b_min) {
+        (Some(a_id), Some(b_id)) => match b_id.cmp(a_id) {
+          Ordering::Equal => {}
+          ord => return ord,
+        },
+        (Some(_), None) => return Ordering::Less,
+        (None, Some(_)) => return Ordering::Greater,
+        (None, None) => {}
+      }
+
+      b.name.cmp(&a.name)
     });
 
     module_groups

--- a/packages/rolldown/tests/fixtures/misc/manual-code-splitting/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/manual-code-splitting/_config.ts
@@ -1,0 +1,20 @@
+import { defineTest } from 'rolldown-tests';
+import { assert } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: ['./main.js'],
+    output: {
+      manualChunks(id) {
+        if (id.includes('shared-codec')) return 'static-utils';
+        if (id.includes('heavy')) return 'heavy';
+      },
+    },
+  },
+
+  afterTest(output) {
+    const chunks = output.output.filter((o) => o.type === 'chunk');
+    const chunkNames = chunks.map((c) => c.fileName);
+    assert(chunkNames.some((name) => name.includes('static-utils')));
+  },
+});

--- a/packages/rolldown/tests/fixtures/misc/manual-code-splitting/heavy-stack.cjs
+++ b/packages/rolldown/tests/fixtures/misc/manual-code-splitting/heavy-stack.cjs
@@ -1,0 +1,6 @@
+// Heavy CJS stack, reachable ONLY via dynamic import (through heavy.js).
+var codec = require('./shared-codec.cjs');
+module.exports.sign = function sign(tx) {
+  return 'signed:' + codec.decode(tx);
+};
+module.exports.blob = 'x'.repeat(50000);

--- a/packages/rolldown/tests/fixtures/misc/manual-code-splitting/heavy.js
+++ b/packages/rolldown/tests/fixtures/misc/manual-code-splitting/heavy.js
@@ -1,0 +1,2 @@
+import { sign, blob } from './heavy-stack.cjs';
+export { sign, blob };

--- a/packages/rolldown/tests/fixtures/misc/manual-code-splitting/main.js
+++ b/packages/rolldown/tests/fixtures/misc/manual-code-splitting/main.js
@@ -1,0 +1,3 @@
+import { decode } from './shared-codec.cjs'; // boot: static use of the shared dep only
+document.body.textContent = decode('boot');
+window.lazySign = () => import('./heavy.js').then((m) => m.sign('tx')); // heavy: dynamic-only

--- a/packages/rolldown/tests/fixtures/misc/manual-code-splitting/shared-codec.cjs
+++ b/packages/rolldown/tests/fixtures/misc/manual-code-splitting/shared-codec.cjs
@@ -1,0 +1,5 @@
+// Shared CJS dep: needed by BOOT (static import in main.js) AND by the heavy
+// stack (CJS require in heavy-stack.cjs).
+module.exports.decode = function decode(x) {
+  return 'decoded:' + x;
+};


### PR DESCRIPTION
# Summary
close #10614 
In the JS-side configuration like this:

```
manualChunks(id) {
  if (id.includes('shared-codec')) return 'static-utils';
  if (id.includes('heavy')) return 'heavy';
}
```
This gets converted into `Vec<MatchGroup(Func,...)>` on the Rust side, where `static-utils` and `heavy` end up sharing the same `priority` and `match_group_index`. As a result, when sorting the `heavy` and `static-utils` chunks, their order gets inverted, which ultimately causes the `static-utils` chunk to be missing from the final output.

# fix
 when both priority and match_group_index are tied, we should compare the stable_id of the two ModuleGroups (excluding their shared modules).
