### PR TITLE
fix: prevent UMD dependencies from using host AMD loaders

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -256,6 +256,8 @@ impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         };
 
         let (commonjs_ref_expr, _) = self.finalized_expr_for_symbol_ref(commonjs_ref, false, false);
+        let shadows_amd_define =
+          self.scope.scoping().root_unresolved_references().contains_key("define");
 
         let mut stmts_inside_closure = allocator::Vec::new_in(self);
         stmts_inside_closure.append(&mut program.body);
@@ -264,6 +266,7 @@ impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           wrap_ref_name,
           commonjs_ref_expr,
           stmts_inside_closure,
+          shadows_amd_define,
           self.ctx.module.ast_usage,
           self.ctx.options.profiler_names,
           &self.ctx.module.stable_id,

--- a/crates/rolldown/tests/rolldown/issues/10631/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10631/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "format": "iife"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/10631/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/10631/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+
+let amdCalls = 0;
+globalThis.define = Object.assign(
+  () => {
+    amdCalls += 1;
+  },
+  { amd: true },
+);
+
+await import(`./dist/main.js?${Date.now()}`);
+
+assert.equal(globalThis.result, 'hello from umd dep');
+assert.equal(amdCalls, 0);

--- a/crates/rolldown/tests/rolldown/issues/10631/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10631/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+(function() {
+	// HIDDEN [\0rolldown/runtime.js]
+	//#region umd-dep.cjs
+	//#endregion
+	//#region main.js
+	var import_umd_dep = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+		var define;
+		(function(root, factory) {
+			if (typeof define === "function" && define.amd) define([], factory);
+			else if (typeof module === "object" && module.exports) module.exports = factory();
+			else root.umdDep = factory();
+		})(exports, function() {
+			return { hello() {
+				return "hello from umd dep";
+			} };
+		});
+	})))());
+	globalThis.result = import_umd_dep.default.hello();
+	//#endregion
+})();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/10631/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10631/main.js
@@ -1,0 +1,3 @@
+import umdDep from './umd-dep.cjs';
+
+globalThis.result = umdDep.hello();

--- a/crates/rolldown/tests/rolldown/issues/10631/umd-dep.cjs
+++ b/crates/rolldown/tests/rolldown/issues/10631/umd-dep.cjs
@@ -1,0 +1,15 @@
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.umdDep = factory();
+  }
+})(exports, function () {
+  return {
+    hello() {
+      return 'hello from umd dep';
+    },
+  };
+});

--- a/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#endregion
 //#region leaflet-toolbar.js
 (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	var define;
 	(function(global, factory) {
 		typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.leaflet = {}));
 	})(exports, function(exports$1) {

--- a/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
@@ -10,6 +10,7 @@ import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
 //#region leaflet.js
 var require_leaflet = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	var define;
 	(function(global, factory) {
 		typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.leaflet = {}));
 	})(exports, function(exports$1) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -104,6 +104,7 @@ var require_cjs_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region cases/require/umd-lib.js
 var require_umd_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	var define;
 	init_trigger_dep();
 	__rolldown_runtime__.createModuleHotContext("cases/require/umd-lib.js");
 	__rolldown_runtime__.registerModule("cases/require/umd-lib.js", module);

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -743,13 +743,19 @@ pub trait StatementFactoryExt<'ast> {
   fn new_commonjs_wrapper_stmt<B: GetAstBuilder<'ast> + GetAllocator<'ast>>(
     binding_name: &str,
     commonjs_expr: Expression<'ast>,
-    statements: allocator::Vec<'ast, Statement<'ast>>,
+    mut statements: allocator::Vec<'ast, Statement<'ast>>,
+    shadows_amd_define: bool,
     ast_usage: EcmaModuleAstUsage,
     profiler_names: bool,
     stable_id: &str,
     is_async: bool,
     builder: &B,
   ) -> Statement<'ast> {
+    // Keep bundled UMD dependencies on their CommonJS path when a host AMD loader exists.
+    if shadows_amd_define {
+      statements.insert(0, Statement::new_var_decl_no_init("define", builder));
+    }
+
     let mut params = FormalParameters::boxed(
       SPAN,
       FormalParameterKind::Signature,


### PR DESCRIPTION
Fixes #10631

## Summary

Prevents bundled UMD-shaped CommonJS dependencies from registering with a host AMD loader.

## Root cause

The generated CommonJS wrapper preserved an unresolved `define` reference. On pages with `define.amd`, a dependency's UMD wrapper took its AMD branch before reaching `module.exports`, leaving the bundled import empty.

This change shadows `define` only inside generated CommonJS wrappers for modules that reference the unresolved global. The UMD dependency therefore takes its existing CommonJS branch without changing normal wrappers or the outer UMD entry wrapper.

## Tests

- Added a focused `issues/10631` fixture with a host `define.amd` stub.
- Verified the fixture fails on current main and passes with this change.
- Rebuilt and ran the reporter's original reproduction: both the no-AMD and AMD-loader cases return `hello from umd dep` with zero AMD calls.
- Ran `just lint-rust`.
- Ran `just test-rust` successfully after initializing the repository-pinned `test262` submodule.

## AI assistance

AI tooling assisted with investigation and implementation. I reviewed the change and ran the validation commands above.