### PR TITLE
fix(renamer): rename nested `require`/`__filename`/`__dirname` bindings in CJS output

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -380,6 +380,11 @@ fn rename_shadowing_symbols_in_nested_scopes<'a>(
       output_format,
       OutputFormat::Iife | OutputFormat::Umd | OutputFormat::Cjs
     ));
+
+    if matches!(output_format, OutputFormat::Cjs) {
+      ctx.rename_bindings_shadowing_cjs_require();
+    }
+
     ctx.rename_cjs_locals_shadowing_referenced_chunk_bindings();
   }
 }

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -382,7 +382,7 @@ fn rename_shadowing_symbols_in_nested_scopes<'a>(
     ));
 
     if matches!(output_format, OutputFormat::Cjs) {
-      ctx.rename_bindings_shadowing_cjs_require();
+      ctx.rename_bindings_shadowing_cjs_ambient_names();
     }
 
     ctx.rename_cjs_locals_shadowing_referenced_chunk_bindings();

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -480,6 +480,41 @@ impl NestedScopeRenamer<'_, '_> {
     }
   }
 
+  /// Rename nested bindings that would shadow the ambient `require` of CommonJS output.
+  ///
+  /// Several rewrites emit a bare `require(...)` call into the module body: external imports, and
+  /// the `import.meta.url` polyfill (`require("url").pathToFileURL(__filename).href`). Those calls
+  /// mean the CommonJS `require`, so a nested binding of the same name must not capture them.
+  ///
+  /// The binding is hoisted, so it shadows even an injected call inside its own initializer:
+  ///
+  /// ```js
+  /// // input, the shape emscripten emits with `-s EXPORT_ES6=1 -s ENVIRONMENT='node'`
+  /// function init() {
+  ///   var require = createRequire(import.meta.url);
+  ///   return require("node:path").sep;
+  /// }
+  /// ```
+  ///
+  /// Without renaming, the polyfill resolves to the still-undefined local and the module throws
+  /// `require is not a function` on first call:
+  ///
+  /// ```js
+  /// var require = createRequire(require("url").pathToFileURL(__filename).href);
+  /// ```
+  pub fn rename_bindings_shadowing_cjs_require(&mut self) {
+    // Skip root scope (index 0), check nested scopes only. Root-scope bindings are already covered
+    // by the renamer's `manual_reserved` list for CommonJS output.
+    for (_, bindings) in self.scoping.iter_bindings().skip(1) {
+      for (&name, symbol_id) in bindings {
+        if name == "require" {
+          let symbol_ref = (self.module_idx, *symbol_id).into();
+          self.renamer.register_nested_scope_symbols(symbol_ref, name.as_str());
+        }
+      }
+    }
+  }
+
   /// Rename a CJS-wrapped module's *root-scope* locals that shadow a chunk-root binding the closure
   /// actually references.
   ///

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -480,13 +480,21 @@ impl NestedScopeRenamer<'_, '_> {
     }
   }
 
-  /// Rename nested bindings that would shadow the ambient `require` of CommonJS output.
+  /// Rename nested bindings that would shadow the ambient names of CommonJS output.
   ///
-  /// Several rewrites emit a bare `require(...)` call into the module body: external imports, and
-  /// the `import.meta.url` polyfill (`require("url").pathToFileURL(__filename).href`). Those calls
-  /// mean the CommonJS `require`, so a nested binding of the same name must not capture them.
+  /// Several rewrites emit bare, renamer-invisible identifiers into the module body, at arbitrary
+  /// nesting depth:
+  /// - `require(...)` — external imports, dynamic-import lowering, and the `import.meta.url`
+  ///   polyfill (`require("url").pathToFileURL(__filename).href`)
+  /// - `__filename` — the argument of that polyfill, and the `import.meta.filename` rewrite
+  /// - `__dirname` — the `import.meta.dirname` rewrite
   ///
-  /// The binding is hoisted, so it shadows even an injected call inside its own initializer:
+  /// Those identifiers mean the CommonJS ambient bindings, so a nested binding of the same name
+  /// must not capture them. `module`/`exports` are deliberately not in the set: nothing injects
+  /// them into nested scopes, and `rename_bindings_shadowing_wrapper_params` already covers the
+  /// CJS-wrapped-module case.
+  ///
+  /// A `var` binding is hoisted, so it shadows even an injected call inside its own initializer:
   ///
   /// ```js
   /// // input, the shape emscripten emits with `-s EXPORT_ES6=1 -s ENVIRONMENT='node'`
@@ -502,12 +510,15 @@ impl NestedScopeRenamer<'_, '_> {
   /// ```js
   /// var require = createRequire(require("url").pathToFileURL(__filename).href);
   /// ```
-  pub fn rename_bindings_shadowing_cjs_require(&mut self) {
+  ///
+  /// The same capture breaks a nested `var __filename`/`var __dirname` the same way
+  /// (`pathToFileURL(__filename)` reads the still-undefined local and throws).
+  pub fn rename_bindings_shadowing_cjs_ambient_names(&mut self) {
     // Skip root scope (index 0), check nested scopes only. Root-scope bindings are already covered
     // by the renamer's `manual_reserved` list for CommonJS output.
     for (_, bindings) in self.scoping.iter_bindings().skip(1) {
       for (&name, symbol_id) in bindings {
-        if name == "require" {
+        if matches!(name.as_str(), "require" | "__filename" | "__dirname") {
           let symbol_ref = (self.module_idx, *symbol_id).into();
           self.renamer.register_nested_scope_symbols(symbol_ref, name.as_str());
         }

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "platform": "node",
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/artifacts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#region main.js
+function init() {
+	const dir = __dirname;
+	var __dirname$1 = "SENTINEL";
+	return [
+		dir,
+		dir,
+		__dirname$1,
+		__dirname$1
+	];
+}
+const [dir, , dirname] = init();
+node_assert.default.equal(typeof dir, "string");
+node_assert.default.ok(!dir.includes("SENTINEL"));
+node_assert.default.equal(dirname, "SENTINEL");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/main.js
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_dirname/main.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+
+// `import.meta.dirname` is rewritten to the bare ambient `__dirname`. A
+// hoisted local of the same name must not capture that reference: the local
+// is still undefined when the rewritten expression runs, silently yielding
+// `undefined` instead of the output directory. Every value is read twice so
+// nothing is inlined past the shadowing declaration.
+function init() {
+  const dir = import.meta.dirname;
+  var __dirname = 'SENTINEL';
+  return [dir, dir, __dirname, __dirname];
+}
+
+const [dir, , dirname] = init();
+assert.equal(typeof dir, 'string');
+assert.ok(!dir.includes('SENTINEL'));
+assert.equal(dirname, 'SENTINEL');

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "platform": "node",
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/artifacts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+//#region main.js
+function init() {
+	const url = require("url").pathToFileURL(__filename).href;
+	var __filename$1 = "SENTINEL";
+	return [
+		url,
+		url,
+		__filename$1,
+		__filename$1
+	];
+}
+const [url, , filename] = init();
+node_assert.default.ok(url.startsWith("file://"));
+node_assert.default.ok(!url.includes("SENTINEL"));
+node_assert.default.equal(filename, "SENTINEL");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/main.js
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_filename/main.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+// The `import.meta.url` polyfill references the ambient `__filename`
+// (`require("url").pathToFileURL(__filename).href`). A hoisted local of the
+// same name must not capture that reference: the local is still undefined
+// when the polyfill runs, so `pathToFileURL` throws `ERR_INVALID_ARG_TYPE`.
+// Every value is read twice so nothing is inlined past the shadowing
+// declaration.
+function init() {
+  const url = import.meta.url;
+  var __filename = 'SENTINEL';
+  return [url, url, __filename, __filename];
+}
+
+const [url, , filename] = init();
+assert.ok(url.startsWith('file://'));
+assert.ok(!url.includes('SENTINEL'));
+assert.equal(filename, 'SENTINEL');

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "platform": "node",
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+let node_module = require("node:module");
+//#region main.js
+function init() {
+	var require$1 = (0, node_module.createRequire)(require("url").pathToFileURL(__filename).href);
+	const path = require$1("node:path");
+	const os = require$1("node:os");
+	return path.sep + os.EOL;
+}
+node_assert.default.equal(typeof init(), "string");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/main.js
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs_shadowed_require/main.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+// A module may declare its own `require` binding, which emscripten does in its
+// generated glue. The polyfill for `import.meta.url` must not resolve to that
+// binding. The local has to be read more than once, otherwise it is inlined
+// into the call expression and no shadowing survives.
+function init() {
+  var require = createRequire(import.meta.url);
+
+  const path = require('node:path');
+  const os = require('node:os');
+
+  return path.sep + os.EOL;
+}
+
+import { createRequire } from 'node:module';
+
+assert.equal(typeof init(), 'string');


### PR DESCRIPTION
Fixes #10654 

CommonJS output rewrites `import.meta.url` to `require("url").pathToFileURL(__filename).href`. The injected identifier is built as a bare, unbound identifier in `try_rewrite_import_meta_prop_expr`, so it is invisible to the renamer. When the module declares its own `require` in an enclosing scope, that binding is hoisted and captures the injected call inside its own initializer:

```js
// input
function init() {
  var require = createRequire(import.meta.url);
  const path = require("node:path");
  const os = require("node:os");
  return path.sep + os.EOL;
}
```

```js
// output before this PR — throws `require is not a function` on the first call
var require = createRequire(require("url").pathToFileURL(__filename).href);
```

The renamer already reserves `require` for CommonJS output, but only for root-scope symbols, so a nested binding is left alone.

#### The change

Adds `rename_bindings_shadowing_cjs_require`, a fifth nested-scope pass alongside the existing ones. It is modelled on the wrapper-params pass, which solves the same shape of problem for `exports` and `module`, and runs only for `OutputFormat::Cjs`.

Output now matches rollup, which deconflicts the local the same way:

```js
var require$1 = createRequire(require("url").pathToFileURL(__filename).href);
```

#### Alternatives considered

Hoisting the polyfill to a chunk-level variable also works and is immune to shadowing, but it changes the emitted shape for every `import.meta.url` user rather than only the shadowing case.

Making the injected identifier a canonical, symbol-backed reference would be the more general fix, since the same bare `require` identifier is emitted for external imports too. Renaming the shadowing binding is the smaller change and follows a pattern already established in this file.

#### Notes for reviewers

The pass renames any nested binding named `require` under CommonJS output, not only those in scopes that actually enclose an injected call. That is deliberately broader than the reference-precise passes above it, because several rewrites emit a bare `require(...)`, not just the `import.meta.url` polyfill. Renaming a local is semantically transparent, and in practice it is inert: the full suite produced no snapshot changes outside the new test. Happy to narrow it to reference-precise if preferred.