### PR TITLE
chore(deps): upgrade oxc to 0.144.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 [[package]]
 name = "oxc"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "ropey",
 ]
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "napi",
  "napi-build",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "napi",
  "napi-build",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "napi",
  "napi-build",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "itertools",
  "memchr",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "compact_str 0.10.0",
  "oxc-miette",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "napi",
  "napi-build",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "base64",
  "compact_str 0.10.0",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
+source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 [[package]]
 name = "oxc"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "ropey",
 ]
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "napi",
  "napi-build",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "napi",
  "napi-build",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "napi",
  "napi-build",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "itertools",
  "memchr",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "compact_str 0.10.0",
  "oxc-miette",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "napi",
  "napi-build",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "base64",
  "compact_str 0.10.0",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=6be314f22605c3ea83cfe8d5d22c2bad76212a35#6be314f22605c3ea83cfe8d5d22c2bad76212a35"
+source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,8 +1565,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 [[package]]
 name = "oxc"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531adfdf5125834915ec86946c7e3e0ded20b9bc9d86a88756e7f191a530475d"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1629,8 +1628,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c603f4ff4617fc04377aa7557396eaa17c77f82e64ffb22947731f75605951f"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1643,8 +1641,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf40d60818cd9ff034774fb371c67d915aa3a6bb0129fdfcb0157a72bda840ff"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1661,8 +1658,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd7135befda5e9fab0d549031bf6c0763966bdf596b5429a74c70f0307fcdf5"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1673,8 +1669,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2fe96292c0c8752825d95641696be3252be8ddd32a161257cf03874468884"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1685,8 +1680,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a945c0ab712d5c14f5962867d9336753f4ef363a69a85a5a9fc7f1a0dcdc2b5"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1706,8 +1700,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887da9e634f5d76da0778674a7303d883e103683fcbc7985cecc9114ce4747ca"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1719,8 +1712,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2aa418d3599ef5e9880d1a359b27bffff242d4a59e0d62ffe08ebf40acdd99"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "ropey",
 ]
@@ -1728,8 +1720,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cdd1fcc5edb6d4666ffc82f1647d9784aa15338e671434b8c70211dd44cb66"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1739,8 +1730,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33440685fff66ad5af668cce75130267db8a864938e6433bc264975cd40b2f2c"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1760,8 +1750,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2267dd438727a1afe72883eb7bf1533511ee713a5ace72cb59ea439f6bc74dca"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1782,8 +1771,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee7c46d0d291d8ac4c035ccf1b2543d2101bcc07d73d20195d0f0bdf97abbd7"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1800,8 +1788,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eec62c37b157f6d7e5502740333740ba3a1068cdd26d12c16abef07efed4806"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1819,8 +1806,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d50fd0b8794dafe409e41cca3dad851310a0f4850b1f10fd2622cfe847c9ab2"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1844,8 +1830,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261290a1ad54ce10728aae0a7402a041ef933d4a40db7ddb5560c7132b55bf87"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "napi",
  "napi-build",
@@ -1865,8 +1850,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb88a8947ff778bc92fe6077f67bfc8dedb9cb8651e3a78b3e75bdb25d94af04"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "napi",
  "napi-build",
@@ -1881,8 +1865,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f6b2ea4e4b0538aa7925d98af33a68cc246c1a85d5543a9540cde24101c7e2"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1905,8 +1888,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c86db84b1f4e7aa50d9f4a86fb6e819e34098dd44d6860ee783b6db47dcbcbc"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "napi",
  "napi-build",
@@ -1922,8 +1904,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde40ebbc9bd3d9a35fa67e518197a2ef92da71c6a0b1496eb7443b5014f3fa9"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1980,8 +1961,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0c6133ad34ad58b9f00ee277fe044e9f47f1c064dd1cb4cf428fce21a8efe5"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "itertools",
  "memchr",
@@ -2019,8 +1999,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d7e5d38e008df87a3ec92b2c228b8555e6acd56f7befbaff315d4900c3438bb"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "compact_str 0.10.0",
  "oxc-miette",
@@ -2034,8 +2013,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66064b0255f08443382c4b79cf98d0695ad0a40b62644fe3dc232461afd7b941"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
@@ -2047,8 +2025,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb571d2462c910943c527d0230064702513c7354a63b107aa6d953e46a0696c1"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2068,8 +2045,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421e6efe4e43dee261f3228309abefb57605c265ae7ffb608b7ae2516cccbc51"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "napi",
  "napi-build",
@@ -2083,8 +2059,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1984c305b3a99c5c4d74b9053132e5751b424d97600c0305ce46e8324304100"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "base64",
  "compact_str 0.10.0",
@@ -2113,8 +2088,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720a5cd0f3d14ee9794a3fedd7ece4e68d6abb3aac880bb640cb4bafe3595387"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2136,8 +2110,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.143.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c6a9163ad8299391c8e8696b4db6b8a6bf140d566b1b169e9554d6cb5f1bf"
+source = "git+https://github.com/oxc-project/oxc?rev=44fd320324e011deceaf016fc8ee60d23778225c#44fd320324e011deceaf016fc8ee60d23778225c"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -604,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1564,8 +1564,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbeaf92280ba8365dc2f25390a388cfe74d48a6d3de6ff2f5ec6469777f8b92"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1600,35 +1601,23 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0df30faa68797917ca4263e7a2f889ec829e4da2dcb3d6dc752f7a494180f3"
+checksum = "330e07b3807046e0afa8fcc94f1fe976e93831b370d148bfe1168cb53da1b913"
 dependencies = [
- "cfg-if",
+ "bytecount",
  "memchr",
  "owo-colors",
- "oxc-miette-derive",
  "textwrap",
- "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
-name = "oxc-miette-derive"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc072d11d45ebe7801459b4e829184ba0934d68027fdc51d327335b53a95a49"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "oxc_allocator"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9262c7bbd58c8c32c2c60d1a7b6c274cd2aeaff1b726a2fb86081b75084698cb"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1640,8 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8134809b665d524d9a0ddeee87a5d3602776aa2410a10a0439fd25eeb594a5d"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1657,8 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac120c6863a9d036c78a42a5e4d2f58bb27c5df795d61d904f6e19e48c681a37"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1668,8 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a57626cd6ef87f5173110a301868e3c438fd8e0576f489d9a61540ef133f686"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1679,8 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8a30cbe510caef092aa75fe29e8d37576ca8eb2ab3e9ab34a453a92863e7f0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1699,8 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca8b4e5fc1b038d063aef726deeb0639460b0a3f4dfa9cc3f1b52b4b231bbf7"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1711,26 +1705,31 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a71efea56db93d3ce9e88e1d9f74f6d50fc2b06092444cdd08579f5827fd8db"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff8638533094ecdcd38a63930c003c261d81650e4531c3bc805c797aec2a52"
 dependencies = [
  "cow-utils",
+ "memchr",
  "oxc-miette",
  "percent-encoding",
+ "smallvec",
 ]
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c7a326f49f06da37affdcad2fb3ebab46ac4ada8953a428f7cbd04e5cc9e6e"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1749,8 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8275fcb9674a1c320f0bdbc2f534ba9bb09fcb8b1c9fe306c9595d262a06bfcb"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1770,8 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba22c46bf2b6dc717be28b0cb5bfdd7c6dadb81b6ff47e3bee85ba0a9637733"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1787,8 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d44069ca70dbae736cd232b04fe21f5ed354396be2365b5ed16adcf86248a09"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1805,8 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb4a27820aa9c98438a7ed41d72747690111fc2075fbd178e81f94e55ae16ea"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1829,8 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59664968ec86932143f0ce439d85b84f6193dab60678572d44c34a26a2f638db"
 dependencies = [
  "napi",
  "napi-build",
@@ -1849,8 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37292d00477aef3aa4abd697b0856c677ae992e50e41ba0435575ca69bc64d6"
 dependencies = [
  "napi",
  "napi-build",
@@ -1864,8 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13016de81370106ea4065cfabe4a278dc09e82523cfe22bb6a8ab8e993b4c3a"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1887,8 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db092436303bbd448889c4ca3cf122a6eebc7dac97aab695710b5619330b6c12"
 dependencies = [
  "napi",
  "napi-build",
@@ -1903,8 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375b89d88ec03301b0e62528715699551871861197aa39148e95a1422e1ae9b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1960,8 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8d80604c4220c8f5b1c19682216921397fb45a616db47d3a044474662f0c2e"
 dependencies = [
  "itertools",
  "memchr",
@@ -1998,8 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd732008dbfb09984106925f7ff7268687c8020b89bd7ee0f0b695c5bb07950"
 dependencies = [
  "compact_str 0.10.0",
  "oxc-miette",
@@ -2012,8 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d2ccb0f5aa4da9fc98ef70f59553c2779e28e064a8b271fcb1e88c11a63607"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
@@ -2024,8 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ff0e987ab15a71dae36fd544b9859513e76639e2cc6c5e25895081162755b1"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2044,8 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2182d00b6cb0b1fce0d9a93f2f160ac88b14236d768c00a868d07e4bb59d1508"
 dependencies = [
  "napi",
  "napi-build",
@@ -2058,8 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f78841ae7b3fdeb86cbc6ee625e2ea844e663fd7b0b320cd361a8514eae34f7"
 dependencies = [
  "base64",
  "compact_str 0.10.0",
@@ -2087,8 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9b1a4f823435ac5c089a8692a76887b16603ac33781a96f7925f5b0b86e102"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2109,8 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.143.0"
-source = "git+https://github.com/oxc-project/oxc?rev=a33788e13ee9b0f9491bb62247ed4479d081d176#a33788e13ee9b0f9491bb62247ed4479d081d176"
+version = "0.144.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb740c9102d898615f894864044ca0b7926374981cef1b6c667e59e2b397ff9"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3334,7 +3350,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3664,7 +3680,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3683,7 +3699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4087,7 +4103,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176", features = [
+oxc = { version = "0.144.0", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -273,16 +273,14 @@ oxc = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176", features = [
-  "pool",
-] }
-oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
-oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_allocator = { version = "0.144.0", features = ["pool"] }
+oxc_ecmascript = { version = "0.144.0" }
+oxc_napi = { version = "0.144.0" }
+oxc_str = { version = "0.144.0" }
+oxc_minify_napi = { version = "0.144.0" }
+oxc_parser_napi = { version = "0.144.0" }
+oxc_transform_napi = { version = "0.144.0" }
+oxc_traverse = { version = "0.144.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -273,16 +273,16 @@ oxc = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf0
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c", features = [
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35", features = [
   "pool",
 ] }
-oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
-oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -273,16 +273,16 @@ oxc = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35", features = [
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176", features = [
   "pool",
 ] }
-oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
-oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "6be314f22605c3ea83cfe8d5d22c2bad76212a35" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "a33788e13ee9b0f9491bb62247ed4479d081d176" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { version = "0.143.0", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -273,14 +273,16 @@ oxc = { version = "0.143.0", features = [
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { version = "0.143.0", features = ["pool"] }
-oxc_ecmascript = { version = "0.143.0" }
-oxc_napi = { version = "0.143.0" }
-oxc_str = { version = "0.143.0" }
-oxc_minify_napi = { version = "0.143.0" }
-oxc_parser_napi = { version = "0.143.0" }
-oxc_transform_napi = { version = "0.143.0" }
-oxc_traverse = { version = "0.143.0" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c", features = [
+  "pool",
+] }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "44fd320324e011deceaf016fc8ee60d23778225c" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
+++ b/crates/rolldown/src/ast_scanner/stmt_eval_analyzer/mod.rs
@@ -815,7 +815,7 @@ impl<'analyzer, 'ctx> EagerEvaluationOrderReasonCollector<'analyzer, 'ctx> {
     for decorator in &class.decorators {
       self.visit_expression(&decorator.expression);
     }
-    if let Some(super_class) = &class.super_class {
+    if let Some(super_class) = class.heritage_expression() {
       self.visit_expression(super_class);
     }
 

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -446,7 +446,6 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       ast::VariableDeclarationKind::Var,
       [ast::VariableDeclarator::new(
         SPAN,
-        ast::VariableDeclarationKind::Var,
         ast::BindingPattern::new_binding_identifier(
           SPAN,
           Str::from_str_in(binding_name, self),

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -78,7 +78,6 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           oxc::allocator::Vec::from_value_in(
             ast::VariableDeclarator::new(
               SPAN,
-              ast::VariableDeclarationKind::Var,
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_MODULE_REF_IDENT,
@@ -101,7 +100,6 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           oxc::allocator::Vec::from_value_in(
             ast::VariableDeclarator::new(
               SPAN,
-              ast::VariableDeclarationKind::Var,
               ast::BindingPattern::new_binding_identifier(
                 SPAN,
                 CJS_ROLLDOWN_EXPORTS_REF_IDENT,

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -107,7 +107,6 @@ pub trait HmrAstBuilder<'any, 'ast> {
         // var $hot_name
         ast::VariableDeclarator::new(
           SPAN,
-          ast::VariableDeclarationKind::Const,
           ast::BindingPattern::new_binding_identifier(
             SPAN,
             self.alias_name_for_import_meta_hot(),

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -334,7 +334,6 @@ impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           let decorations = self.top_level_var_bindings.iter().map(|var_name| {
             ast::VariableDeclarator::new(
               SPAN,
-              ast::VariableDeclarationKind::Var,
               ast::BindingPattern::new_binding_identifier(SPAN, *var_name, ast_builder),
               None,
               None,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -911,7 +911,8 @@ impl<'ast> VisitJsMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       ast::Declaration::TSTypeAliasDeclaration(_)
       | ast::Declaration::TSInterfaceDeclaration(_)
       | ast::Declaration::TSEnumDeclaration(_)
-      | ast::Declaration::TSModuleDeclaration(_)
+      | ast::Declaration::TSExternalModuleDeclaration(_)
+      | ast::Declaration::TSNamespaceDeclaration(_)
       | ast::Declaration::TSImportEqualsDeclaration(_)
       | ast::Declaration::TSGlobalDeclaration(_) => unreachable!(),
     }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1530,7 +1530,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       VariableDeclarationKind::Var,
       [ast::VariableDeclarator::new(
         SPAN,
-        VariableDeclarationKind::Var,
         ast::BindingPattern::BindingIdentifier(oxc::allocator::Box::new_in(id, self)),
         None,
         Some(Expression::ClassExpression(class)),
@@ -2232,9 +2231,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if self.ctx.options.top_level_var {
           if let Statement::VariableDeclaration(var_decl) = &mut top_stmt {
             var_decl.kind = ast::VariableDeclarationKind::Var;
-            for decl in &mut var_decl.declarations {
-              decl.kind = VariableDeclarationKind::Var;
-            }
           }
           if let Statement::ClassDeclaration(class_decl) = top_stmt {
             top_stmt = match self.get_transformed_class_decl(class_decl) {

--- a/crates/rolldown_ecmascript_utils/src/ast_factory.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_factory.rs
@@ -580,7 +580,6 @@ pub trait StatementFactoryExt<'ast> {
     let declarations = oxc::allocator::Vec::from_value_in(
       VariableDeclarator::new(
         SPAN,
-        VariableDeclarationKind::Var,
         BindingPattern::new_binding_identifier(
           SPAN,
           oxc::ast::ast::Str::from_str_in(name, builder),
@@ -611,7 +610,6 @@ pub trait StatementFactoryExt<'ast> {
     let declarations = oxc::allocator::Vec::from_value_in(
       VariableDeclarator::new(
         SPAN,
-        VariableDeclarationKind::Var,
         BindingPattern::new_binding_identifier(
           SPAN,
           oxc::ast::ast::Str::from_str_in(name, builder),

--- a/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
+++ b/crates/rolldown_plugin_lazy_compilation/src/runtime_injector.rs
@@ -108,7 +108,6 @@ pub fn create_unwrap_lazy_compilation_entry_helper(allocator: &Allocator) -> Sta
     oxc::ast::ast::VariableDeclarationKind::Var,
     [VariableDeclarator::new(
       SPAN,
-      oxc::ast::ast::VariableDeclarationKind::Var,
       BindingPattern::new_binding_identifier(SPAN, "e", &ast_builder),
       None,
       Some(Expression::new_computed_member_expression(

--- a/crates/rolldown_plugin_oxc_runtime/src/generated/embedded_helpers.rs
+++ b/crates/rolldown_plugin_oxc_runtime/src/generated/embedded_helpers.rs
@@ -2,12 +2,12 @@
 // To edit this generated file you have to edit `tasks/generator/src/generators/oxc_runtime_helper.rs`
 
 // This file contains embedded @oxc-project/runtime helpers (both ESM and CJS variants).
-// @oxc-project/runtime version: 0.143.0
+// @oxc-project/runtime version: 0.144.0
 
 use arcstr::ArcStr;
 use phf::{Map, phf_map};
 
-pub const RUNTIME_HELPER_PREFIX: &str = "@oxc-project+runtime@0.143.0/helpers/";
+pub const RUNTIME_HELPER_PREFIX: &str = "@oxc-project+runtime@0.144.0/helpers/";
 pub const RUNTIME_HELPER_UNVERSIONED_PREFIX: &str = "@oxc-project/runtime/helpers/";
 
 /// Map of all helpers from `@oxc-project/runtime/src/helpers/esm/`.

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_utils.rs
@@ -163,7 +163,6 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
             VariableDeclarationKind::Const,
             [VariableDeclarator::new(
               SPAN,
-              VariableDeclarationKind::Const,
               BindingPattern::ObjectPattern(object_pat.clone_in(self.ast_builder.allocator())),
               None,
               Some(await_expr),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ catalogs:
       specifier: ^0.1.0
       version: 0.1.0
     '@oxc-project/runtime':
-      specifier: '=0.143.0'
-      version: 0.143.0
+      specifier: '=0.144.0'
+      version: 0.144.0
     '@oxc-project/types':
-      specifier: '=0.143.0'
-      version: 0.143.0
+      specifier: '=0.144.0'
+      version: 0.144.0
     '@pnpm/find-workspace-packages':
       specifier: ^6.0.9
       version: 6.0.9
@@ -136,11 +136,11 @@ catalogs:
       specifier: ^4.0.8
       version: 4.0.8
     oxc-parser:
-      specifier: '=0.143.0'
-      version: 0.143.0
+      specifier: '=0.144.0'
+      version: 0.144.0
     oxc-transform:
-      specifier: '=0.143.0'
-      version: 0.143.0
+      specifier: '=0.144.0'
+      version: 0.144.0
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
@@ -272,7 +272,7 @@ importers:
         version: 0.1.0
       '@oxc-project/runtime':
         specifier: 'catalog:'
-        version: 0.143.0
+        version: 0.144.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.3
@@ -407,7 +407,7 @@ importers:
         version: link:../../packages/rolldown
       unplugin-isolated-decl:
         specifier: ^0.8.1
-        version: 0.8.3(oxc-transform@0.143.0)(rollup@4.62.3)(supports-color@10.2.2)(typescript@6.0.3)
+        version: 0.8.3(oxc-transform@0.144.0)(rollup@4.62.3)(supports-color@10.2.2)(typescript@6.0.3)
 
   examples/lazy-compilation:
     devDependencies:
@@ -422,7 +422,7 @@ importers:
     devDependencies:
       oxc-walker:
         specifier: ^0.5.2
-        version: 0.5.2(oxc-parser@0.143.0)
+        version: 0.5.2(oxc-parser@0.144.0)
       rolldown:
         specifier: workspace:*
         version: link:../../packages/rolldown
@@ -569,7 +569,7 @@ importers:
     dependencies:
       '@oxc-project/types':
         specifier: 'catalog:'
-        version: 0.143.0
+        version: 0.144.0
       '@rolldown/pluginutils':
         specifier: 'catalog:'
         version: 1.0.1
@@ -606,7 +606,7 @@ importers:
         version: 13.0.6
       oxc-parser:
         specifier: 'catalog:'
-        version: 0.143.0
+        version: 0.144.0
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -736,7 +736,7 @@ importers:
         version: 11.7.6
       oxc-transform:
         specifier: 'catalog:'
-        version: 0.143.0
+        version: 0.144.0
       source-map-support:
         specifier: catalog:rollup-tests
         version: 0.5.21
@@ -3673,8 +3673,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.143.0':
-    resolution: {integrity: sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==}
+  '@oxc-parser/binding-android-arm-eabi@0.144.0':
+    resolution: {integrity: sha512-IaoGBEp/huvja99PxI/b72TbKFzA/UzxxAka7f233dc/Tg/rRTX9Qn8IquFLWwWf4IddN/5TaJ8S4Subbjq7wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -3685,8 +3685,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.143.0':
-    resolution: {integrity: sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==}
+  '@oxc-parser/binding-android-arm64@0.144.0':
+    resolution: {integrity: sha512-u6fJu8XQXP99+9pYO3jq7F1D7V9fyFuDBShYFlr+gY+GcJzhveeN/zoMfuXxX6XBquJO0kjqKd7BjhJ7pClWXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3697,8 +3697,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.143.0':
-    resolution: {integrity: sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==}
+  '@oxc-parser/binding-darwin-arm64@0.144.0':
+    resolution: {integrity: sha512-o9xGSmMQcboJLjwI+acFf6xa7nYdp0/nRFE8ry4Xrt8OviQ9ITFDBUkAXVJMOLchSV9Pu981GxJuW0mt4i6vQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -3714,8 +3714,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.143.0':
-    resolution: {integrity: sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==}
+  '@oxc-parser/binding-darwin-x64@0.144.0':
+    resolution: {integrity: sha512-2yNm4tX++W3KLbyziVhs5alSb74a3C1uNDu/1P/AQj1ux8yZYuvbCAeJCCrGkr8J18ZmnBAzDthdTZBEAEb71w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3731,8 +3731,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.143.0':
-    resolution: {integrity: sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==}
+  '@oxc-parser/binding-freebsd-x64@0.144.0':
+    resolution: {integrity: sha512-TG4CjY1OjynplkF9nAQ9m9zboPJksnbAF+U/9xQGSXyIt+5sQRitwfQrUgjrG17/up9G8k/boNjLD2zp4xq1Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -3743,8 +3743,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
-    resolution: {integrity: sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.144.0':
+    resolution: {integrity: sha512-i0T9NagVmqc+rbSyBr5mDKj7TCMIBRrSteQlQJt1WhWIH/sZeOP9GB09H9w98YdinuZkDIPmO7Fz0jDC7bMvSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3755,8 +3755,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
-    resolution: {integrity: sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.144.0':
+    resolution: {integrity: sha512-YUsEqM3WMS3mOON+TFf7RzS0QthzEifx7tpUQu0GSF2MsT+D6t154ZBs6WhWaCZNl0GuVDEvndCyEAUBHzSHGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3768,8 +3768,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
-    resolution: {integrity: sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.144.0':
+    resolution: {integrity: sha512-LlWH4kt+IET3qIAe0e0IFLNlQ3CVUAfN//UFsA6N0/FghMh/FBk1e+wzvgG+t8WSnXkvf8B1TovquS2EJras9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3788,8 +3788,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
-    resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
+  '@oxc-parser/binding-linux-arm64-musl@0.144.0':
+    resolution: {integrity: sha512-ajXbXIWBWUD4U3IQxr2p6DiXwD7GPHEBLa+JteKhIfvLmBEBdTjO28lP+5r3AF2qal8cxLERfTnGs64Z22ZuXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3808,8 +3808,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
-    resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.144.0':
+    resolution: {integrity: sha512-/+sDzL/4cWEwdqenKo/DX3gkkxu7H7ytFAtealDey/Gd59yPWn64obVk6wXKVjVfXMciUUUTySxZG9AIMX3RNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3822,8 +3822,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
-    resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.144.0':
+    resolution: {integrity: sha512-dMVhPBbrd8y6aeLd7Ihn9OZhKO8QgCQVtLBTRgbmf4lKrcR61SpaQRJPJuocTc/Cn5SJMm+alHYPnzkbOGM7Dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -3836,8 +3836,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
-    resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.144.0':
+    resolution: {integrity: sha512-jQ8O0+b6J2IhJgm0DnqEJq8hG9OocmF1b4TBWCk08CRWqTmLZj/+lYs7w3OA60nb2SiqOmthQyJPacrCi7y+oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -3850,8 +3850,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
-    resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.144.0':
+    resolution: {integrity: sha512-/mZxZtcGrzuvqPLPV7gjavbROYs/dHy6+yQ2Sl/2to/+qoC/v6CcruGFnfQPzQbXXTYReXJzLb5QY9KmgCbJOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -3864,8 +3864,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
-    resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
+  '@oxc-parser/binding-linux-x64-gnu@0.144.0':
+    resolution: {integrity: sha512-/caRGFHcarHZlBrucBwQwBbzqhD+UfZZ/r7soocS0/mp6/5KTq+1Zl/OQx5lFLcN+GpUPYszbrvQU9MCFLEzJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3884,8 +3884,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.143.0':
-    resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
+  '@oxc-parser/binding-linux-x64-musl@0.144.0':
+    resolution: {integrity: sha512-qFtwAo6BWuWDjh57QDdZdYi746GW0mIeoZSGK2jJqlxIjo389Y/7lrriTOI+ou7tTvusOrSYGQZ+e+nDswt2vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3903,8 +3903,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.143.0':
-    resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
+  '@oxc-parser/binding-openharmony-arm64@0.144.0':
+    resolution: {integrity: sha512-n+NgMGWWEYpH+rlkMhDvLR2k8vJDHQp3j8SoS86IS6J0hc4kuDaiYAAvu9dF86xjeGYy+h9WLj12sylmBJV9sg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3920,8 +3920,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
-    resolution: {integrity: sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.144.0':
+    resolution: {integrity: sha512-fShxpJiCBOdG4+jBAvahTTFUDI5djXc/+IPC1ldeC8LbyCW0h9m/7oP8DRZWI7WT2Ahv8sHtZz4ugECylCFpTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3937,8 +3937,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
-    resolution: {integrity: sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.144.0':
+    resolution: {integrity: sha512-vFrYV+C3lJhIiSdNhdkZHnZ0YIClgTSluXaPMYjlGslVPD+uJg6K1s2xNL/X/gdBcy9IIbjbp0vNBwQhdMMdkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
@@ -3949,8 +3949,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
-    resolution: {integrity: sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==}
+  '@oxc-parser/binding-win32-x64-msvc@0.144.0':
+    resolution: {integrity: sha512-0ASbKSwdeihMekyy7y4jC0CwW3XBDZk5Sw64m/W7IReVQHaduqLYssF9KCJA2oHG9oldnl/1CMxqCoImXfqQkA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3968,8 +3968,8 @@ packages:
     resolution: {integrity: sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/runtime@0.143.0':
-    resolution: {integrity: sha512-zIuXUf+YGIgsPk0xlQmzTY8NCSc8jE/pSfDodlQ9H3EGZABmr+AtIjXRrnpQAXuXzhDSNqZz9cuhud8hDDLvpg==}
+  '@oxc-project/runtime@0.144.0':
+    resolution: {integrity: sha512-Ps9oSujoaerkIY8SV7onfD6ldNL6oHlVaZDVuFftDX+JAV3ZqHVx5HMBBa9n0qNkig5K/WcgNbeD94rJrSwjQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.101.0':
@@ -3984,8 +3984,8 @@ packages:
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
-  '@oxc-project/types@0.143.0':
-    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
   '@oxc-project/types@0.37.0':
     resolution: {integrity: sha512-9shvIr/cpoNo5cX8nWdZmviHLJSidjZy4M0MyfR6ucREZBtABTNBIa1a4emWUJ3qAMwJW6G1v0zm8K2rj9Pf4A==}
@@ -4093,124 +4093,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-transform/binding-android-arm-eabi@0.143.0':
-    resolution: {integrity: sha512-Rufrk7btlzkIAofJyrm3COzSrn4iNYOnHNYOahBDQly/PgleJv6QIVCHsPTqC6qfX/EJNoAeNshALvVfKSTY5A==}
+  '@oxc-transform/binding-android-arm-eabi@0.144.0':
+    resolution: {integrity: sha512-Sskiy+uGMIjOFI9D1OZdYgT2NzVuvkOU5HDWAdp36BNuBbOoBFpNTVAT2D9PGfRQJEKJ/K/Wb2L0gA2VC23UUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-transform/binding-android-arm64@0.143.0':
-    resolution: {integrity: sha512-EwdR7ynio7zcg3CCaArr/FllpJX8fxmCCQlDdo6o4rZuCSXuIE04hRgcOgRRd5r5AKu81s/XP0TBulXWXaWpmQ==}
+  '@oxc-transform/binding-android-arm64@0.144.0':
+    resolution: {integrity: sha512-osVA5RRHE63G9effQf2ME3HOscX0zDTTG1O9Xz6tIdxY11y+Pj51l6XD2lk4m3scUa8biI6qUhDInH7IKGUopw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-transform/binding-darwin-arm64@0.143.0':
-    resolution: {integrity: sha512-+o1gLw5mefaKDFfhpIyxKEyeE9kAopy8uA/JCUG0D3stDeY35b3vjeWHgTTBwkOgLXWblq8OvZee1yEJ9Xd40Q==}
+  '@oxc-transform/binding-darwin-arm64@0.144.0':
+    resolution: {integrity: sha512-gRpF9QorjIHzvPQ+ix7Tu0gDViikaU8iGZN/FkZSW8AJCqJrlInJpnugZisgmBDmWlPD9XuEuWPR0kXDI70nww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-transform/binding-darwin-x64@0.143.0':
-    resolution: {integrity: sha512-lKEnKHSspm8c+aR+lspmP6m8g09f5VivzMCRpLTrMJLgaWmipUCflBsS8qTKcmRp/hYZl3ARfJ3K00SHSIFb2g==}
+  '@oxc-transform/binding-darwin-x64@0.144.0':
+    resolution: {integrity: sha512-EyxYXw5qm/Z1wi2DJQr2IXTOvYNHKFzI6sITYvwRBdWt6mRNrskUNXq5Jqr47183kSb8w1f5ygVQLS2x2k2yVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-transform/binding-freebsd-x64@0.143.0':
-    resolution: {integrity: sha512-8Rir0D6CpKuh0tWuCjnZgk+r8XmKsGXncGBp6lmcYXwC5baLI3DK3T9I/CM1+khoF7JbFE3PqAmoF4HxGysxUQ==}
+  '@oxc-transform/binding-freebsd-x64@0.144.0':
+    resolution: {integrity: sha512-aKhXnBEvbUJBxTgh5ai9RGGjZOCL8Y9IZM0IfG7WQOdQc2aha4IukyBQ3/V1c5DQFZl8hblGzf95D3Es2uNV2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.143.0':
-    resolution: {integrity: sha512-4F+ErMGgG6f7ydN42VwD+4F1UHhYBb4vELUT/0+gOhuGBN1wwhOPNLhHeJJnZQHZM2JYERdS6wn9uBoBiXw3gw==}
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.144.0':
+    resolution: {integrity: sha512-wWGIK7+bG1gQRR0VEhaQrUOSQqwc6Mo3NuHlBIXt20YLxHSzeghFHU/KuIs2S7xcOZOaWqM4aRKB86fxV1QKeA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.143.0':
-    resolution: {integrity: sha512-XqEYetdBUbFJE8IQUOtDUlyAmoec7I5xkLBFW5wdMI6oRaRJeFFTAK4jg/5sSRzNLU/OFTBTWCn5soQ/iLbwHQ==}
+  '@oxc-transform/binding-linux-arm-musleabihf@0.144.0':
+    resolution: {integrity: sha512-R8XAHI6gxenWpzpNe7hll2KXAtfIaDL/6w/oFuuVZ3/bpKwEYH/U1fdSmq3ImbtJbIZXAhGGOTOeaWoKLLhF2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.143.0':
-    resolution: {integrity: sha512-LXswrXbEouF3X/q5s+X3Im4VCCNu8aZDj6gRI/s32WDlBqwGosW/A8Ci5MgvCEnU3efVacXhAPPF9zbFE42OAg==}
+  '@oxc-transform/binding-linux-arm64-gnu@0.144.0':
+    resolution: {integrity: sha512-PBGyvBcPeSHujvTNDNj5lVEZGI2CEszyBIKBnQsuhXE6PbkXsXN+ar1tAv9MDFByIppTa6eHCkBCx2wLRGRd5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-arm64-musl@0.143.0':
-    resolution: {integrity: sha512-/TKz33dR/kqEdmLwGYsAKuVbjDEPhFKq0PAyIMVCLbqglBy7BRQCw7w7g78X5PLFXso0LgfCFCz/C5dDtBDj/Q==}
+  '@oxc-transform/binding-linux-arm64-musl@0.144.0':
+    resolution: {integrity: sha512-vbXqLri/fGsRzvFm9sUDjEadBq3OlGfmb5c33pyfKVM+AjP685LXb7smUNzjfbmKpGkXB18tHvqpt/QXNadZTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-linux-ppc64-gnu@0.143.0':
-    resolution: {integrity: sha512-2mVVq6P4cCXElahTV/GKufxdqRUWZtPHD3EQP2GFigjXRSAXl3HGelIgpYT8I8eoU7QNq6qk+avYsXImt9Hb+Q==}
+  '@oxc-transform/binding-linux-ppc64-gnu@0.144.0':
+    resolution: {integrity: sha512-0SYHjw+KLnjFI1rdZAf0TfgoIqDIDvjsedNZ0U0rxZiHVNJyDltaB8m75rvNToTMfcmV76k61HXOmW6Neylo/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.143.0':
-    resolution: {integrity: sha512-kkZtkNIqljF8KP9jrZYkhtY1Vbg35jaRj7mZCOinWUPwZIR8PYJwe2KkUVNII+148mYyxlCuf8DZXHiJJ9SNgg==}
+  '@oxc-transform/binding-linux-riscv64-gnu@0.144.0':
+    resolution: {integrity: sha512-n7uZFeZimHxuasIpwnwybw9UXQ0AxLHkGeOmHGMtcqey2mYmdVdW/5M+tliPVgPwVGu4HlBqv/riWsqWmrVQEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-riscv64-musl@0.143.0':
-    resolution: {integrity: sha512-GRJr0FmQ6C8pbAl0ZyPh/VQwb1/hiXtwrb3IoK93LNsqMWNjbqKFP39lZlLQOdeU8QQADlZM8Qx75YQAOFkbSw==}
+  '@oxc-transform/binding-linux-riscv64-musl@0.144.0':
+    resolution: {integrity: sha512-Dc/pGt10QuqCO4tG51hZ+zp/+BNnUVTcDFS7FHCR67X8IaoEE8J7Pr0DkAcn8uPTvvSFzzNkhPwSx/L4XCUb/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.143.0':
-    resolution: {integrity: sha512-k4fpvbh7zGvSLXgOJznv7zPGLgFSYvaMWgVhebxmXZqJgax1kWVOhiJ92L+K/Aqq3tgLEQwkQ8wWGcArSM/O4g==}
+  '@oxc-transform/binding-linux-s390x-gnu@0.144.0':
+    resolution: {integrity: sha512-BeZ9tDcUVwfHlUl76GBwuDxrqmRLqdugPrq+LXuFRJ2mCzn3oFe4vOGCDMLW9ObIRAISR7+NIPH3CUyxM8VgOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-x64-gnu@0.143.0':
-    resolution: {integrity: sha512-utU2SgpVcipJsQ2lHmZm1twk5ke75/Xt1PivxGV8Va55vrXdIXK+At6ERv+6BikB28qauCe7vv2yovtkEuvmQQ==}
+  '@oxc-transform/binding-linux-x64-gnu@0.144.0':
+    resolution: {integrity: sha512-6U5R564AZ/ormt8iXXFETByq9dtADi9j2zEs4IEu0/5nvx27I+M7WTwGYBmWvYr1CfHTkM3a5KgNU0Vn3VoQPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-x64-musl@0.143.0':
-    resolution: {integrity: sha512-T+cQ/IcWiQ5XVC1cG+DczewthN7c2Vujw0JyO2ugcr6B7TCQiucDd/erVxJSaY59X8d6970+lPtng8Z8XiyGYg==}
+  '@oxc-transform/binding-linux-x64-musl@0.144.0':
+    resolution: {integrity: sha512-gpEHX25aa33npfw/GcjHT+Hrk3n7kNrKdsDcNB43u5XIyvCgyVR/S/YncSbYI1Woko30YfiE77jKsDx1WrkauQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-openharmony-arm64@0.143.0':
-    resolution: {integrity: sha512-3uyqUj+d9hccXdL5WiJW+SVojwckAqSGz+eEBjwIs0/2SXavVpasH8n4E2N5CbCOa4NJdaRKmquHa52s/DN1yQ==}
+  '@oxc-transform/binding-openharmony-arm64@0.144.0':
+    resolution: {integrity: sha512-1kEUpTvm8ADkrUCX5xMop3/8szkTANZ1rLSbuiLGQ6KtbWWQm7hJUDvj78Sig8rZ8TqZS+BwUI4dcw4lK+Yysw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.143.0':
-    resolution: {integrity: sha512-5x4/nWog5kjADuMVoZx9KOpbrzJNRuz59oA5jFW95NvV69lZikgubJDIM7WwBReS0mIoIF+QC2r3pAiJtKrYJQ==}
+  '@oxc-transform/binding-win32-arm64-msvc@0.144.0':
+    resolution: {integrity: sha512-/02/Bsw7WPxPQhhEfU80oRtOakHWPzE3MuPVkU4aTACPhismESGl2iIWVsTBddTiViyj30VxyqiEN/022LQnNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-transform/binding-win32-ia32-msvc@0.143.0':
-    resolution: {integrity: sha512-z/hozOHz6t/iB68GQPskKJMGxBMpBYqKhOmik3wOprnvnpwOeEyOQ89xuWgvQvX4B69LnxGyAWpJWjSK5zUVzA==}
+  '@oxc-transform/binding-win32-ia32-msvc@0.144.0':
+    resolution: {integrity: sha512-nNxuvrVG9xR06XyZqPqGxt2kNkcYyseki1CFpzHSw+8iZs22EyaGVocjirIsp5t5SBj8Zd+xOLHmT9ldn6ZOTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-transform/binding-win32-x64-msvc@0.143.0':
-    resolution: {integrity: sha512-8AaiwIM4M/gEcvXWD71SZDCpY70z7J99G110+fSBws/MHa9PaaWu0IVp5clEG/0alWPQiPZcZRFE3ZIhSd5fng==}
+  '@oxc-transform/binding-win32-x64-msvc@0.144.0':
+    resolution: {integrity: sha512-2mqtOa1KR/v8F85Cf8l1jX411AM7dYDO1HUDzucPXvO9LX63AaHxwafv+Uds1NzxSqnZtlpd1/OKUXrb0KvUFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -7567,8 +7567,8 @@ packages:
     resolution: {integrity: sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-parser@0.143.0:
-    resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
+  oxc-parser@0.144.0:
+    resolution: {integrity: sha512-eacM4wMgGWXctHubY262yo+50E76qtQBqe+uK73YEV1IT3qP12Acbnf9Nc8t+agIAdnko9iVT4KF83/d0EjY5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-parser@0.37.0:
@@ -7577,8 +7577,8 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxc-transform@0.143.0:
-    resolution: {integrity: sha512-DBx6urRQRwA2pu3sMxmmVONu2fFlOoi3cU63DGyNsuB5YuAeR/AujdfBv7qqRRq0SnWlPsrHNrzoF8Zf43fIsg==}
+  oxc-transform@0.144.0:
+    resolution: {integrity: sha512-a6mYoz3PPIlwbU4xtHAmWJHD0SvXh9ayAHI1D0+LJEKvln+koaD2M9AAAm5bAN5kkT2AWxN37IVhL1EAzXUyfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-walker@0.5.2:
@@ -11184,19 +11184,19 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.143.0':
+  '@oxc-parser/binding-android-arm-eabi@0.144.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.143.0':
+  '@oxc-parser/binding-android-arm64@0.144.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.143.0':
+  '@oxc-parser/binding-darwin-arm64@0.144.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.37.0':
@@ -11205,7 +11205,7 @@ snapshots:
   '@oxc-parser/binding-darwin-x64@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.143.0':
+  '@oxc-parser/binding-darwin-x64@0.144.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.37.0':
@@ -11214,25 +11214,25 @@ snapshots:
   '@oxc-parser/binding-freebsd-x64@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.143.0':
+  '@oxc-parser/binding-freebsd-x64@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.37.0':
@@ -11241,7 +11241,7 @@ snapshots:
   '@oxc-parser/binding-linux-arm64-musl@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.37.0':
@@ -11250,31 +11250,31 @@ snapshots:
   '@oxc-parser/binding-linux-ppc64-gnu@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.37.0':
@@ -11283,7 +11283,7 @@ snapshots:
   '@oxc-parser/binding-linux-x64-musl@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.143.0':
+  '@oxc-parser/binding-linux-x64-musl@0.144.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.37.0':
@@ -11292,7 +11292,7 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-openharmony-arm64@0.143.0':
+  '@oxc-parser/binding-openharmony-arm64@0.144.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.140.0':
@@ -11305,7 +11305,7 @@ snapshots:
   '@oxc-parser/binding-win32-arm64-msvc@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.144.0':
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.37.0':
@@ -11314,13 +11314,13 @@ snapshots:
   '@oxc-parser/binding-win32-ia32-msvc@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.144.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.140.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.144.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.37.0':
@@ -11330,7 +11330,7 @@ snapshots:
 
   '@oxc-project/runtime@0.141.0': {}
 
-  '@oxc-project/runtime@0.143.0': {}
+  '@oxc-project/runtime@0.144.0': {}
 
   '@oxc-project/types@0.101.0': {}
 
@@ -11340,7 +11340,7 @@ snapshots:
 
   '@oxc-project/types@0.142.0': {}
 
-  '@oxc-project/types@0.143.0': {}
+  '@oxc-project/types@0.144.0': {}
 
   '@oxc-project/types@0.37.0': {}
 
@@ -11405,61 +11405,61 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
-  '@oxc-transform/binding-android-arm-eabi@0.143.0':
+  '@oxc-transform/binding-android-arm-eabi@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-android-arm64@0.143.0':
+  '@oxc-transform/binding-android-arm64@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-arm64@0.143.0':
+  '@oxc-transform/binding-darwin-arm64@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-x64@0.143.0':
+  '@oxc-transform/binding-darwin-x64@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-freebsd-x64@0.143.0':
+  '@oxc-transform/binding-freebsd-x64@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.143.0':
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.143.0':
+  '@oxc-transform/binding-linux-arm-musleabihf@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.143.0':
+  '@oxc-transform/binding-linux-arm64-gnu@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-musl@0.143.0':
+  '@oxc-transform/binding-linux-arm64-musl@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-ppc64-gnu@0.143.0':
+  '@oxc-transform/binding-linux-ppc64-gnu@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.143.0':
+  '@oxc-transform/binding-linux-riscv64-gnu@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-riscv64-musl@0.143.0':
+  '@oxc-transform/binding-linux-riscv64-musl@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.143.0':
+  '@oxc-transform/binding-linux-s390x-gnu@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-gnu@0.143.0':
+  '@oxc-transform/binding-linux-x64-gnu@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-musl@0.143.0':
+  '@oxc-transform/binding-linux-x64-musl@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-openharmony-arm64@0.143.0':
+  '@oxc-transform/binding-openharmony-arm64@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.143.0':
+  '@oxc-transform/binding-win32-arm64-msvc@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-win32-ia32-msvc@0.143.0':
+  '@oxc-transform/binding-win32-ia32-msvc@0.144.0':
     optional: true
 
-  '@oxc-transform/binding-win32-x64-msvc@0.143.0':
+  '@oxc-transform/binding-win32-x64-msvc@0.144.0':
     optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.60.0':
@@ -14517,29 +14517,29 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.140.0
       '@oxc-parser/binding-win32-x64-msvc': 0.140.0
 
-  oxc-parser@0.143.0:
+  oxc-parser@0.144.0:
     dependencies:
-      '@oxc-project/types': 0.143.0
+      '@oxc-project/types': 0.144.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.143.0
-      '@oxc-parser/binding-android-arm64': 0.143.0
-      '@oxc-parser/binding-darwin-arm64': 0.143.0
-      '@oxc-parser/binding-darwin-x64': 0.143.0
-      '@oxc-parser/binding-freebsd-x64': 0.143.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.143.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.143.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.143.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.143.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.143.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-x64-musl': 0.143.0
-      '@oxc-parser/binding-openharmony-arm64': 0.143.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.143.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.143.0
+      '@oxc-parser/binding-android-arm-eabi': 0.144.0
+      '@oxc-parser/binding-android-arm64': 0.144.0
+      '@oxc-parser/binding-darwin-arm64': 0.144.0
+      '@oxc-parser/binding-darwin-x64': 0.144.0
+      '@oxc-parser/binding-freebsd-x64': 0.144.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.144.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.144.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.144.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.144.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.144.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.144.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.144.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.144.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.144.0
+      '@oxc-parser/binding-linux-x64-musl': 0.144.0
+      '@oxc-parser/binding-openharmony-arm64': 0.144.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.144.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.144.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.144.0
 
   oxc-parser@0.37.0:
     dependencies:
@@ -14576,32 +14576,32 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxc-transform@0.143.0:
+  oxc-transform@0.144.0:
     optionalDependencies:
-      '@oxc-transform/binding-android-arm-eabi': 0.143.0
-      '@oxc-transform/binding-android-arm64': 0.143.0
-      '@oxc-transform/binding-darwin-arm64': 0.143.0
-      '@oxc-transform/binding-darwin-x64': 0.143.0
-      '@oxc-transform/binding-freebsd-x64': 0.143.0
-      '@oxc-transform/binding-linux-arm-gnueabihf': 0.143.0
-      '@oxc-transform/binding-linux-arm-musleabihf': 0.143.0
-      '@oxc-transform/binding-linux-arm64-gnu': 0.143.0
-      '@oxc-transform/binding-linux-arm64-musl': 0.143.0
-      '@oxc-transform/binding-linux-ppc64-gnu': 0.143.0
-      '@oxc-transform/binding-linux-riscv64-gnu': 0.143.0
-      '@oxc-transform/binding-linux-riscv64-musl': 0.143.0
-      '@oxc-transform/binding-linux-s390x-gnu': 0.143.0
-      '@oxc-transform/binding-linux-x64-gnu': 0.143.0
-      '@oxc-transform/binding-linux-x64-musl': 0.143.0
-      '@oxc-transform/binding-openharmony-arm64': 0.143.0
-      '@oxc-transform/binding-win32-arm64-msvc': 0.143.0
-      '@oxc-transform/binding-win32-ia32-msvc': 0.143.0
-      '@oxc-transform/binding-win32-x64-msvc': 0.143.0
+      '@oxc-transform/binding-android-arm-eabi': 0.144.0
+      '@oxc-transform/binding-android-arm64': 0.144.0
+      '@oxc-transform/binding-darwin-arm64': 0.144.0
+      '@oxc-transform/binding-darwin-x64': 0.144.0
+      '@oxc-transform/binding-freebsd-x64': 0.144.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.144.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.144.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.144.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.144.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.144.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.144.0
+      '@oxc-transform/binding-linux-x64-musl': 0.144.0
+      '@oxc-transform/binding-openharmony-arm64': 0.144.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.144.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.144.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.144.0
 
-  oxc-walker@0.5.2(oxc-parser@0.143.0):
+  oxc-walker@0.5.2(oxc-parser@0.144.0):
     dependencies:
       magic-regexp: 0.10.0
-      oxc-parser: 0.143.0
+      oxc-parser: 0.144.0
 
   oxfmt@0.60.0(vite-plus@0.2.7(@types/node@24.10.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.22)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
@@ -15681,7 +15681,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-isolated-decl@0.8.3(oxc-transform@0.143.0)(rollup@4.62.3)(supports-color@10.2.2)(typescript@6.0.3):
+  unplugin-isolated-decl@0.8.3(oxc-transform@0.144.0)(rollup@4.62.3)(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       debug: 4.4.3(supports-color@10.2.2)
@@ -15689,7 +15689,7 @@ snapshots:
       oxc-parser: 0.37.0
       unplugin: 1.16.1
     optionalDependencies:
-      oxc-transform: 0.143.0
+      oxc-transform: 0.144.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - rollup

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,8 +45,8 @@ catalog:
   '@napi-rs/wasm-runtime': ~1.2.2
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
-  '@oxc-project/runtime': '=0.143.0'
-  '@oxc-project/types': '=0.143.0'
+  '@oxc-project/runtime': '=0.144.0'
+  '@oxc-project/types': '=0.144.0'
   '@pnpm/find-workspace-packages': ^6.0.9
   '@rolldown/pluginutils': ^1.0.0
   '@rollup/plugin-commonjs': ^29.0.0
@@ -78,8 +78,8 @@ catalog:
   glob: ^13.0.0
   lodash-es: ^4.17.21
   micromatch: ^4.0.8
-  oxc-parser: '=0.143.0'
-  oxc-transform: '=0.143.0'
+  oxc-parser: '=0.144.0'
+  oxc-transform: '=0.144.0'
   pathe: ^2.0.3
   react: ^19.0.0
   react-dom: ^19.0.0


### PR DESCRIPTION
This PR updates oxc to 0.144.0, and migrates rolldown following the breaking changes.

Please review commit by commit

 - https://github.com/oxc-project/oxc/pull/25284 [dc3f407](https://github.com/rolldown/rolldown/pull/10657/commits/dc3f4073cf1ecb15d6e371921f02ec8a18723e06)
 - https://github.com/oxc-project/oxc/pull/25319 [a8a7931](https://github.com/rolldown/rolldown/pull/10657/commits/a8a79318ec4d760ebac9b96d0b8bb072b4e87fd6)
 - https://github.com/oxc-project/oxc/pull/25360 [e6db5d1](https://github.com/rolldown/rolldown/pull/10657/commits/e6db5d16b29d46082f7b3cb43315305d040953d0)