### PR TITLE
chore: ignore napi-rs temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+# Temporary files created by NAPI-RS
+.napi-rs-filesystem-reconciliation.*
+.napi-rs-filesystem-transaction.*
+.src.napi-stage-*
+
 # Dependency directories
 node_modules/
 jspm_packages/


### PR DESCRIPTION
These files are generated during a test run, add to `.gitignore` so they don't show up in git

<img width="452" height="887" alt="Screenshot 2026-08-10 at 11 49 28" src="https://github.com/user-attachments/assets/bdebae1a-b7bc-4fd4-88e9-e9ccaf84057e" />
