### PR TITLE
fix(rolldown_plugin_vite_dynamic_import_vars): stop blocking a worker thread while resolving globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,6 +3015,7 @@ dependencies = [
  "arcstr",
  "cow-utils",
  "derive_more",
+ "futures",
  "memchr",
  "oxc",
  "rolldown_plugin",

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 arcstr = { workspace = true }
 cow-utils = { workspace = true }
 derive_more = { workspace = true }
+futures = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
@@ -36,6 +36,10 @@ pub struct Edit {
 /// This struct holds owned data only. `transform` can therefore drop the AST
 /// before it calls the resolver. The earlier code kept a `*const Expression`
 /// that pointed into the arena.
+///
+/// The hook cannot await while the AST is alive. The AST is `!Send`, and the
+/// hook future must be `Send`. Do not block the thread to avoid this limit.
+/// A blocked thread deadlocks the runtime (#10664).
 pub struct PendingAsyncImport {
   pub glob: String,
   pub import_span: Span,

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -12,10 +12,7 @@ use rolldown_plugin::{
 };
 use rolldown_plugin_utils::parse_program;
 use rolldown_std_utils::relative_path_as_js_specifier;
-use rolldown_utils::{
-  futures::{block_on, block_on_spawn_all},
-  pattern_filter::StringOrRegex,
-};
+use rolldown_utils::pattern_filter::StringOrRegex;
 use sugar_path::SugarPath as _;
 
 pub const DYNAMIC_IMPORT_HELPER: &str = "\0rolldown_dynamic_import_helper.js";
@@ -79,6 +76,11 @@ impl Plugin for ViteDynamicImportVarsPlugin {
       // This scope parses the code. It then visits the AST. Only owned data
       // leaves the scope. The code below therefore holds no reference to the
       // AST arena.
+      //
+      // The scope also lets the hook await. The AST is `!Send`, and the hook
+      // future must be `Send`. The AST therefore cannot stay alive across the
+      // `await` below. The earlier code blocked the thread instead. That code
+      // deadlocked the runtime on machines with few cores (#10664).
       let (mut edits, async_imports) = {
         let allocator = oxc::allocator::Allocator::default();
         let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
@@ -106,7 +108,7 @@ impl Plugin for ViteDynamicImportVarsPlugin {
           .map(|pending| async { resolver(pending.glob.clone(), args.id.to_string()).await.ok()? });
 
         let importer = args.id.as_path().parent().unwrap();
-        let result = block_on(block_on_spawn_all(task));
+        let result = futures::future::join_all(task).await;
         for (pending, item) in async_imports.iter().zip(result) {
           if let Some(id) = item {
             let id = relative_path_as_js_specifier(id, importer);

--- a/internal-docs/async-runtime/design.md
+++ b/internal-docs/async-runtime/design.md
@@ -1,0 +1,97 @@
+# Async runtime — Design & Principles
+
+## Summary
+
+Rolldown runs its bundling work on one tokio multi-thread runtime.
+`crates/rolldown_binding/src/lib.rs` builds that runtime in `module_init`. It
+then gives the runtime to NAPI-RS through `create_custom_tokio_runtime`. Plugin
+hooks are `async`, and they must return `Send` futures.
+
+The type system does not enforce one more rule. This doc records it: **a hook
+must not block its worker thread while it waits for the runtime.**
+
+## The rule
+
+Do not call `rolldown_utils::futures::block_on` in a plugin hook when the awaited
+work needs the runtime. Do not use another blocking wait either. Use `.await`.
+
+"Needs the runtime" covers more cases than the words suggest. Two examples:
+
+1. A task from `tokio::spawn`. A worker thread must poll that task.
+2. A JS callback that re-enters rolldown. A Vite resolver that routes through a
+   plugin container is one such callback. The NAPI-RS promise behind it resolves
+   on the same runtime.
+
+One case is safe. Work that only waits for the JS thread to answer a
+threadsafe-function call does not need the runtime. The JS thread answers
+through a oneshot channel, and the blocked thread polls that channel itself.
+
+## Why it deadlocks
+
+Two pool sizes control the failure:
+
+1. `worker_threads` defaults to `num_cpus::get_physical() * 3 / 2`. The
+   `ROLLDOWN_WORKER_THREADS` variable overrides it.
+2. `max_blocking_threads` defaults to **4**. The
+   `ROLLDOWN_MAX_BLOCKING_THREADS` variable overrides it.
+
+`block_on` calls `tokio::task::block_in_place`. That function moves the worker's
+scheduler work to a blocking-pool thread, so the runtime continues. Tokio puts
+the hand-off in a queue when the blocking pool is full. Tokio does not make the
+pool larger.
+
+Each blocked hook holds one worker thread and one blocking thread. Approximately
+`worker_threads + max_blocking_threads` hooks can block together. Above that
+number, no thread remains to run the scheduler work. All work that the blocked
+hooks wait for then stops forever.
+
+The number is small on CI:
+
+| Machine        | Physical cores | Concurrent blocked hooks before the deadlock |
+| -------------- | -------------- | -------------------------------------------- |
+| 2-vCPU runner  | 1              | 5                                            |
+| 4-vCPU runner  | 2              | 7                                            |
+| 14-core laptop | 14             | 25                                           |
+
+This difference explains a common report: the build completes on a laptop, and
+it hangs on CI.
+
+Rolldown had this problem in #10664. The `builtin:vite-dynamic-import-vars`
+plugin blocked in `transform`. The plugin spawned tasks to call the JS resolver.
+Those tasks never ran. For the fix, see
+`crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs`. It parses the code
+in an inner scope. It carries owned data out of that scope. It then awaits.
+
+## The wasm target
+
+`crates/rolldown_binding/src/lib.rs` builds the custom runtime only on targets
+that are not wasm. The wasm build uses the NAPI-RS runtime instead, so the pool
+sizes above do not apply to it.
+
+The rule still applies. On wasm, `block_on` calls
+`futures::executor::block_on`, which holds the calling thread. A spawned task
+still needs a worker thread to poll it.
+
+## How to await inside a hook that parses the AST
+
+The oxc AST is `!Send`. A hook therefore cannot hold the AST across an `.await`.
+Do not block the thread to avoid this limit. Do these steps instead:
+
+1. Parse the code in an inner scope. Visit the AST in the same scope.
+2. Return owned data from that scope. Return spans, offsets, and `String`
+   values. Do not return AST references or raw pointers into the arena.
+3. Await outside the scope. Then build the result from that data.
+
+`build_edit` in
+`crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs` shows this
+pattern. It takes spans and strings. Both the visit path and the post-await path
+therefore call it.
+
+## Unresolved Questions
+
+- `max_blocking_threads` is 4 because rolldown has few true blocking tasks. File
+  reads in `crates/rolldown/src/utils/load_source.rs` also use that pool. The
+  safety margin is therefore smaller than the number 4 suggests.
+- Two issues propose a move from tokio to the NAPI-RS scheduler
+  (rolldown#10268 and rolldown#10350). That move would change the pool
+  arithmetic on this page. It would not change the rule above.

--- a/packages/rolldown/tests/builtin-plugin/dynamic-import-vars-deadlock.test.ts
+++ b/packages/rolldown/tests/builtin-plugin/dynamic-import-vars-deadlock.test.ts
@@ -1,0 +1,99 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+// This test covers the regression in
+// https://github.com/rolldown/rolldown/issues/10664.
+//
+// The plugin called the JS `resolver` from a blocked tokio worker thread.
+// `block_in_place` moved that worker's scheduler work to the blocking pool.
+// `ROLLDOWN_MAX_BLOCKING_THREADS` limits that pool. More than
+// `worker_threads + max_blocking_threads` modules then blocked at the same time.
+// No thread remained to run the scheduler work, and the build never finished.
+//
+// The runtime reads both limits when the binding module loads. This test
+// therefore runs a child process. The test allows one worker thread and one
+// blocking thread, so the old code could block only 2 hooks at the same time.
+// `MODULE_COUNT` is much higher than 2.
+const MODULE_COUNT = 20;
+// A run that passes takes less than one second. The large timeout only covers a
+// slow CI machine.
+const TIMEOUT_MS = 30_000;
+
+test(
+  'resolver does not deadlock the runtime when worker threads are scarce',
+  async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rolldown-10664-'));
+    try {
+      await fs.mkdir(path.join(dir, 'data'), { recursive: true });
+      await fs.writeFile(path.join(dir, 'data', 'a.js'), 'export default "a";\n');
+
+      let entry = '';
+      for (let i = 0; i < MODULE_COUNT; i++) {
+        await fs.writeFile(
+          path.join(dir, `mod${i}.js`),
+          // Only a bare specifier sends the glob to the JS resolver.
+          `export const load${i} = (name) => import(\`$lib/data/\${name}.js\`);\n`,
+        );
+        entry += `export { load${i} } from './mod${i}.js';\n`;
+      }
+      await fs.writeFile(path.join(dir, 'entry.js'), entry);
+
+      // The script is in a temporary directory. It cannot resolve `rolldown`
+      // by name.
+      const rolldownUrl = import.meta.resolve('rolldown');
+      const experimentalUrl = import.meta.resolve('rolldown/experimental');
+
+      const script = `
+import { rolldown } from ${JSON.stringify(rolldownUrl)}
+import { viteDynamicImportVarsPlugin } from ${JSON.stringify(experimentalUrl)}
+import path from 'node:path'
+
+const dir = ${JSON.stringify(dir)}
+const bundle = await rolldown({
+  input: path.join(dir, 'entry.js'),
+  plugins: [
+    viteDynamicImportVarsPlugin({
+      async resolver(id) {
+        // This await gives control to the event loop. It makes the deadlock
+        // window wider.
+        await new Promise((r) => setTimeout(r, 5))
+        return path.join(dir, id.slice('$lib/'.length))
+      },
+    }),
+    {
+      name: 'alias',
+      resolveId(id) {
+        return id.startsWith('$lib/') ? path.join(dir, id.slice('$lib/'.length)) : null
+      },
+    },
+  ],
+})
+await bundle.generate({})
+await bundle.close()
+console.log('done')
+`;
+      const scriptPath = path.join(dir, 'build.mjs');
+      await fs.writeFile(scriptPath, script);
+
+      const { stdout } = await execFileAsync(process.execPath, [scriptPath], {
+        cwd: path.dirname(import.meta.dirname),
+        timeout: TIMEOUT_MS,
+        env: {
+          ...process.env,
+          ROLLDOWN_WORKER_THREADS: '1',
+          ROLLDOWN_MAX_BLOCKING_THREADS: '1',
+        },
+      });
+      expect(stdout).toContain('done');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT_MS,
+);


### PR DESCRIPTION
`transform` called the JS resolver through `block_on`. Each blocked hook held one
worker thread and one blocking thread. The build hung when more than
`worker_threads + max_blocking_threads` modules blocked at the same time. That
sum is 5 on a 2-vCPU runner.

`internal-docs/async-runtime/design.md` now records the rule: a hook must not
block its worker thread while it waits for the runtime.

fixes #10664
