### PR TITLE
fix: silence two wasm-only warnings

### DIFF
--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -1,6 +1,7 @@
-use rayon::iter::ParallelIterator;
 use rolldown_common::{Module, ModuleIdx, RuntimeHelper, SymbolRef};
-use rolldown_utils::{index_vec_ext::IndexVecRefExt, indexmap::FxIndexSet};
+use rolldown_utils::{
+  index_vec_ext::IndexVecRefExt, indexmap::FxIndexSet, rayon::ParallelIterator,
+};
 use rustc_hash::FxHashSet;
 
 use super::LinkStage;

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -248,6 +248,11 @@ async fn report_plugin_timings(handles: &[BundleHandle]) -> anyhow::Result<()> {
 impl BindingBundler {
   fn normalize_binding_options(option: BindingBundlerOptions) -> napi::Result<BundlerConfig> {
     let BindingBundlerOptions { input_options, output_options, parallel_plugins_registry } = option;
+    // Only the parallel-plugin worker pool reads the registry, and wasm has no
+    // threads for that pool. Borrow it so the binding counts as used. Do not
+    // bind it to `_`: that would drop it here instead of at the end of scope.
+    #[cfg(target_family = "wasm")]
+    let _ = &parallel_plugins_registry;
 
     #[cfg(not(target_family = "wasm"))]
     let worker_count =

--- a/crates/rolldown_binding/src/utils/create_bundler_config_from_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/create_bundler_config_from_binding_options.rs
@@ -9,6 +9,11 @@ pub fn create_bundler_config_from_binding_options(
   option: BindingBundlerOptions,
 ) -> napi::Result<BundlerConfig> {
   let BindingBundlerOptions { input_options, output_options, parallel_plugins_registry } = option;
+  // Only the parallel-plugin worker pool reads the registry, and wasm has no
+  // threads for that pool. Borrow it so the binding counts as used. Do not
+  // bind it to `_`: that would drop it here instead of at the end of scope.
+  #[cfg(target_family = "wasm")]
+  let _ = &parallel_plugins_registry;
 
   #[cfg(not(target_family = "wasm"))]
   let worker_count =


### PR DESCRIPTION
`cargo check -p rolldown_binding --target wasm32-wasip1-threads` warned about an unused `rayon::iter::ParallelIterator` import and an unused `parallel_plugins_registry` binding. Both are wasm-only, so a native build never shows them.