### PR TITLE
fix(deps): align `@napi-rs/wasm-runtime` catalog range with the wasi binding

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ catalogs:
       specifier: ^3.8.2
       version: 3.8.6
     '@napi-rs/wasm-runtime':
-      specifier: ~1.2.2
+      specifier: ~1.2.3
       version: 1.2.3
     '@oxc-node/cli':
       specifier: ^0.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   '@emnapi/runtime': 2.0.0-alpha.4
   '@jridgewell/trace-mapping': ^0.3.31
   '@napi-rs/cli': ^3.8.2
-  '@napi-rs/wasm-runtime': ~1.2.2
+  '@napi-rs/wasm-runtime': ~1.2.3
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
   '@oxc-project/runtime': '=0.144.0'


### PR DESCRIPTION
The published `@rolldown/browser@1.2.4` declares `@napi-rs/wasm-runtime: ~1.2.2`, but the `@rolldown/binding-wasm32-wasi@1.2.4` glue code it bundles declares `~1.2.3`.

`check-wasi-binding-deps` compares the resolved version rather than the declared range, so it stays green while the lockfile happens to resolve 1.2.3.

refs #10666
