### PR TITLE
refactor(renamer): move the cjs check into `rename_bindings_shadowing_cjs_ambient_names`

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -381,10 +381,7 @@ fn rename_shadowing_symbols_in_nested_scopes<'a>(
       OutputFormat::Iife | OutputFormat::Umd | OutputFormat::Cjs
     ));
 
-    if matches!(output_format, OutputFormat::Cjs) {
-      ctx.rename_bindings_shadowing_cjs_ambient_names();
-    }
-
+    ctx.rename_bindings_shadowing_cjs_ambient_names(output_format);
     ctx.rename_cjs_locals_shadowing_referenced_chunk_bindings();
   }
 }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -513,7 +513,13 @@ impl NestedScopeRenamer<'_, '_> {
   ///
   /// The same capture breaks a nested `var __filename`/`var __dirname` the same way
   /// (`pathToFileURL(__filename)` reads the still-undefined local and throws).
-  pub fn rename_bindings_shadowing_cjs_ambient_names(&mut self) {
+  ///
+  /// Only CommonJS output injects these names. The pass does nothing for the other formats.
+  pub fn rename_bindings_shadowing_cjs_ambient_names(&mut self, output_format: OutputFormat) {
+    if !matches!(output_format, OutputFormat::Cjs) {
+      return;
+    }
+
     // Skip root scope (index 0), check nested scopes only. Root-scope bindings are already covered
     // by the renamer's `manual_reserved` list for CommonJS output.
     for (_, bindings) in self.scoping.iter_bindings().skip(1) {


### PR DESCRIPTION
Take the output format as an argument and check it inside the pass. The call site then drops its `if` block, and it does not have to know which formats the pass applies to.

refs #10655