### PR TITLE
ci: append benchmark results to storage as JSON lines

### DIFF
--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -85,14 +85,11 @@ jobs:
 
       - name: Save benchmark result
         if: github.event_name == 'push'
-        # https://github.com/dmnemec/copy_file_to_another_repo_action
-        uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083
         env:
           # Results are stored in https://github.com/rolldown/benchmark-results-storage
           API_TOKEN_GITHUB: ${{ secrets.REPO_TOKEN_BENCHMARK_RESULTS }}
-        with:
-          source_file: './tmp/benchmark-node-output.json'
-          destination_repo: 'rolldown/benchmark-results-storage'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          user_name: 'github-actions[bot]'
-          commit_message: 'Update `benchmark-node-output.json`'
+        # Appends this run as Entry-schema JSON lines and dual-writes the nested
+        # JSON during the migration window (see the storage repo's README).
+        # Pushes with a rebase retry, so concurrent runs append instead of
+        # overwriting each other.
+        run: node scripts/misc/benchmark-storage/push-results.mjs

--- a/scripts/misc/benchmark-storage/push-results.mjs
+++ b/scripts/misc/benchmark-storage/push-results.mjs
@@ -1,0 +1,145 @@
+// Pushes one benchmark run's results to rolldown/benchmark-results-storage.
+//
+// Reads the github-action-benchmark data file the action just updated, converts
+// its newest "Node Benchmark" entry into Entry-schema JSON Lines (the format
+// rolldown/metric's `metric.json` uses — see the storage repo's README), appends
+// them to `benchmark-node-output.jsonl`, and dual-writes the nested JSON while
+// the migration window is open. Pushes with a pull-rebase retry loop, so two
+// concurrent main runs append instead of overwriting each other (the previous
+// whole-file copy step silently dropped the losing run).
+//
+// Usage (CI):    node scripts/misc/benchmark-storage/push-results.mjs
+//   env: API_TOKEN_GITHUB — token with push access to the storage repo
+// Usage (local): node .../push-results.mjs --data <file> --dry-run <existing-clone-dir>
+//   Applies the same changes to <existing-clone-dir> and commits, but never pushes.
+//
+// Keep the bench→Entry mapping in sync with `scripts/migrate.mjs` in the
+// storage repo (it applied the same rules to the historical data).
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERIES = 'Node Benchmark';
+const STORAGE_REPO = 'github.com/rolldown/benchmark-results-storage.git';
+const JSONL_FILE = 'benchmark-node-output.jsonl';
+const JSON_FILE = 'benchmark-node-output.json';
+const PEAK_MEMORY_SUFFIX = ' (peak memory)';
+const PUSH_RETRIES = 3;
+
+function parseArgs(argv) {
+  const args = { data: 'tmp/benchmark-node-output.json', dryRun: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--data') args.data = argv[++i];
+    else if (argv[i] === '--dry-run') args.dryRun = argv[++i];
+    else throw new Error(`unknown argument ${argv[i]}`);
+  }
+  return args;
+}
+
+function benchToLine(bench, entry, repoUrl) {
+  const value = Number(bench.value);
+  if (!Number.isFinite(value)) throw new Error(`non-numeric value ${JSON.stringify(bench)}`);
+  let caseName = bench.name;
+  let metric = 'production build time';
+  let unit = 'ms';
+  if (bench.unit === 'bytes' && bench.name.endsWith(PEAK_MEMORY_SUFFIX)) {
+    caseName = bench.name.slice(0, -PEAK_MEMORY_SUFFIX.length);
+    metric = 'peak memory';
+    unit = 'byte';
+  } else if (bench.unit !== 'ms / ops') {
+    throw new Error(`unmapped unit ${JSON.stringify(bench)}`);
+  }
+  return JSON.stringify({
+    case: caseName,
+    metric,
+    timestamp: entry.date,
+    commit: entry.commit.id,
+    unit,
+    records: { rolldown: value },
+    repoUrl,
+  });
+}
+
+function git(cwd, ...args) {
+  const res = spawnSync('git', args, { cwd, stdio: ['ignore', 'inherit', 'inherit'] });
+  return res.status === 0;
+}
+
+function gitOrThrow(cwd, ...args) {
+  if (!git(cwd, ...args)) throw new Error(`git ${args[0]} failed`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+const data = JSON.parse(fs.readFileSync(args.data, 'utf8'));
+const entries = data.entries?.[SERIES];
+if (!entries?.length) throw new Error(`no "${SERIES}" entries in ${args.data}`);
+const entry = entries.at(-1);
+if (!entry.commit?.id || !entry.date || !Array.isArray(entry.benches)) {
+  throw new Error(`unexpected entry shape: ${JSON.stringify(entry).slice(0, 200)}`);
+}
+const repoUrl = entry.commit.url?.split('/commit/')[0] ?? 'https://github.com/rolldown/rolldown';
+const lines = entry.benches.map((bench) => benchToLine(bench, entry, repoUrl));
+
+let workdir = args.dryRun;
+if (!workdir) {
+  const token = process.env.API_TOKEN_GITHUB;
+  if (!token) throw new Error('API_TOKEN_GITHUB is not set');
+  workdir = fs.mkdtempSync('benchmark-storage-');
+  const url = `https://x-access-token:${token}@${STORAGE_REPO}`;
+  const clone = spawnSync('git', ['clone', '--depth', '1', url, workdir], { stdio: 'inherit' });
+  if (clone.status !== 0) throw new Error('clone of the storage repo failed');
+  gitOrThrow(workdir, 'config', 'user.name', 'github-actions[bot]');
+  gitOrThrow(workdir, 'config', 'user.email', 'github-actions[bot]@users.noreply.github.com');
+}
+
+const applyChanges = () => {
+  // Dual-write the nested JSON while the migration window is open.
+  fs.copyFileSync(args.data, path.join(workdir, JSON_FILE));
+
+  // Append this run's lines — unless they are already there (job rerun, or a
+  // rebase retry after our own commit survived). Starts the file when it does
+  // not exist yet, so this step works before the history-migration PR merges.
+  const jsonlPath = path.join(workdir, JSONL_FILE);
+  const existing = fs.existsSync(jsonlPath) ? fs.readFileSync(jsonlPath, 'utf8') : '';
+  const lastLine = existing.trimEnd().split('\n').at(-1);
+  const tail = lastLine ? JSON.parse(lastLine) : {};
+  if (tail.commit === entry.commit.id && tail.timestamp === entry.date) {
+    console.log(`lines for ${entry.commit.id.slice(0, 9)} already present, appending nothing`);
+    return false;
+  }
+  fs.appendFileSync(jsonlPath, lines.join('\n') + '\n', 'utf8');
+  return true;
+};
+
+const appended = applyChanges();
+gitOrThrow(workdir, 'add', JSON_FILE, JSONL_FILE);
+const message = `Append results for rolldown/rolldown@${entry.commit.id.slice(0, 9)}`;
+if (!git(workdir, 'commit', '-m', message)) {
+  console.log('nothing to commit');
+  process.exit(0);
+}
+console.log(`committed: ${message} (${appended ? lines.length : 0} lines appended)`);
+
+if (args.dryRun) {
+  console.log('dry run, not pushing');
+  process.exit(0);
+}
+
+for (let attempt = 1; ; attempt++) {
+  if (git(workdir, 'push')) break;
+  if (attempt >= PUSH_RETRIES) throw new Error(`push failed after ${PUSH_RETRIES} attempts`);
+  console.log(`push rejected, rebasing (attempt ${attempt})`);
+  // Rebase our append commit onto whatever the concurrent run pushed. The jsonl
+  // append can conflict textually; redo the changes on top instead of merging.
+  if (!git(workdir, 'pull', '--rebase')) {
+    gitOrThrow(workdir, 'rebase', '--abort');
+    gitOrThrow(workdir, 'reset', '--hard', 'origin/main');
+    gitOrThrow(workdir, 'pull');
+    applyChanges();
+    gitOrThrow(workdir, 'add', JSON_FILE, JSONL_FILE);
+    if (!git(workdir, 'commit', '-m', message)) break;
+  }
+}
+console.log('pushed');

--- a/scripts/misc/benchmark-storage/window-from-jsonl.mjs
+++ b/scripts/misc/benchmark-storage/window-from-jsonl.mjs
@@ -1,0 +1,73 @@
+// Reconstructs a small github-action-benchmark data file from the tail of the
+// storage repo's Entry-schema JSON Lines.
+//
+// Not wired into the workflow yet: while the migration's dual-write window is
+// open, the action keeps operating on the full nested JSON. At cutover the
+// workflow feeds the action this windowed reconstruction instead (the action
+// only compares against the previous entry, so a small window is enough), and
+// the 17 MB JSON stops being written.
+//
+// Usage: node .../window-from-jsonl.mjs --jsonl <file> --out <file> [--window 50]
+
+import fs from 'node:fs';
+
+const SERIES = 'Node Benchmark';
+const PEAK_MEMORY_METRIC = 'peak memory';
+
+const args = { jsonl: null, out: null, window: 50 };
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === '--jsonl') args.jsonl = argv[++i];
+  else if (argv[i] === '--out') args.out = argv[++i];
+  else if (argv[i] === '--window') args.window = Number(argv[++i]);
+  else throw new Error(`unknown argument ${argv[i]}`);
+}
+if (!args.jsonl || !args.out || !Number.isInteger(args.window) || args.window < 1) {
+  throw new Error('required: --jsonl <file> --out <file> [--window <n>]');
+}
+
+function lineToBench(line) {
+  if (line.metric === PEAK_MEMORY_METRIC) {
+    return { name: `${line.case} (peak memory)`, value: line.records.rolldown, unit: 'bytes' };
+  }
+  return { name: line.case, value: line.records.rolldown, unit: 'ms / ops' };
+}
+
+// Lines are append-ordered and each run's lines are contiguous (one commit per
+// run), so runs split wherever (commit, timestamp) changes.
+const lines = fs
+  .readFileSync(args.jsonl, 'utf8')
+  .split('\n')
+  .filter(Boolean)
+  .map((l) => JSON.parse(l));
+const runs = [];
+for (const line of lines) {
+  const current = runs.at(-1);
+  if (!current || current.commit.id !== line.commit || current.date !== line.timestamp) {
+    runs.push({
+      commit: {
+        // The lines keep only what the action's summary renders (id, url); the
+        // remaining fields exist so the data file stays shape-compatible.
+        author: { name: '', username: '' },
+        committer: { name: '', username: '' },
+        id: line.commit,
+        message: '',
+        timestamp: new Date(line.timestamp).toISOString(),
+        url: `${line.repoUrl}/commit/${line.commit}`,
+      },
+      date: line.timestamp,
+      tool: 'customSmallerIsBetter',
+      benches: [],
+    });
+  }
+  runs.at(-1).benches.push(lineToBench(line));
+}
+
+const windowed = runs.slice(-args.window);
+const data = {
+  lastUpdate: windowed.at(-1)?.date ?? 0,
+  repoUrl: lines.at(-1)?.repoUrl ?? 'https://github.com/rolldown/rolldown',
+  entries: { [SERIES]: windowed },
+};
+fs.writeFileSync(args.out, JSON.stringify(data), 'utf8');
+console.log(`${args.out}: ${windowed.length} runs (of ${runs.length} total) from ${args.jsonl}`);


### PR DESCRIPTION
The save step rewrote the whole 17 MB `benchmark-node-output.json` on every main push, and two concurrent runs silently lost one run's results (last push wins). This replaces the copy action with a script that appends the run as Entry-schema JSON lines (the format rolldown/metric's `metric.json` uses), dual-writes the nested JSON during the migration window, and pushes with a pull-rebase retry.

`window-from-jsonl.mjs` is the cutover piece and is not wired yet.

refs https://github.com/rolldown/benchmark-results-storage/pull/2
refs https://github.com/rolldown/metric/pull/468