### PR TITLE
fix(rolldown_plugin_vite_reporter): avoid ANSI erase-line escape in non-TTY output

### DIFF
--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -70,7 +70,7 @@ impl Plugin for ViteReporterPlugin {
         *self.latest_checkpoint.write().unwrap() = now;
       }
     } else if transformed_count == 0 {
-      utils::write_line("transforming...");
+      utils::log_info("transforming...");
     }
     Ok(None)
   }


### PR DESCRIPTION
Fixes #10671