### PR TITLE
fix(code-splitting): initialize leaves behind a re-exported namespace import

### DIFF
--- a/crates/rolldown/src/esm_init_obligations.rs
+++ b/crates/rolldown/src/esm_init_obligations.rs
@@ -21,14 +21,16 @@
 //!   reachable (registration is what *makes* it reachable).
 //! - **Project** — the on-demand emergent-cycle fixpoint (`order_analysis`) predicts the chunk
 //!   edges a wrap plan's lowering will add, before anything is minted. It drives the same
-//!   enumerator/collector against a probe [`OrderWrapState`], extended to the excluded re-export
-//!   hops whose registration flows through the metadata pass rather than the included-record path.
+//!   enumerator/collector against a probe [`OrderWrapState`], extended to the excluded records
+//!   whose registration flows through the metadata pass rather than the included-record path.
 //!
 //! Excluded statements are the one structural asymmetry: for Emit and Register their targets are
 //! precomputed once by `compute_wrapped_esm_init_metadata` (post-convergence, returned as
 //! `Sealed<FinalEsmInitMetadata>`), while Project must recompute them per fixpoint round from the
-//! current plan — both through the shared excluded-hop router
-//! [`collect_order_wrap_esm_init_targets`], so the routing itself cannot drift.
+//! current plan — both through the same routers (the excluded-hop router
+//! [`collect_order_wrap_esm_init_targets`] for re-export hops, the shared per-record collector
+//! [`collect_wrapped_esm_init_targets_for_import_record`] for binding-demand plain imports), so
+//! the routing itself cannot drift.
 //!
 //! Purpose contracts are deliberately *not* identical, and each divergence is encoded (and
 //! justified) on [`ObligationPurpose`] rather than re-derived at call sites.
@@ -63,11 +65,14 @@ pub enum ObligationPurpose {
   /// included statements only, nested records skipped — registration and emission must stay in
   /// lockstep or a registered-but-never-emitted wrapper import (or vice versa) appears.
   Register,
-  /// Emergent-cycle edge projection. Included statements *plus* excluded re-export hops (their
-  /// real registration flows through the excluded-statement metadata, which does not exist yet at
-  /// projection time), and nested records are *kept*: projection may over-approximate — an extra
-  /// edge only ever wraps more, and wrapping more is always legal — but must never drop an edge
-  /// source, so it declines the nested-ownership refinement Emit/Register apply.
+  /// Emergent-cycle edge projection. Included statements *plus* excluded re-export hops and
+  /// excluded plain imports that declare bindings (their real registration flows through the
+  /// excluded-statement metadata, which does not exist yet at projection time — re-export hops
+  /// through the hop router, binding-demand plain imports through the shared collector), and
+  /// nested records are *kept*: projection may over-approximate — an extra edge only ever wraps
+  /// more, and wrapping more is always legal — but must never drop an edge source, so it declines
+  /// the nested-ownership refinement Emit/Register apply. A binding-less excluded plain import
+  /// stays out on every purpose: tree shaking stripped that side-effect edge deliberately.
   Project,
 }
 
@@ -77,7 +82,7 @@ pub enum ObligationPurpose {
 pub fn record_is_init_obligation(
   purpose: ObligationPurpose,
   order_state: &OrderWrapState,
-  importer_idx: ModuleIdx,
+  importer: &NormalModule,
   rec: &ResolvedImportRecord,
   rec_idx: ImportRecordIdx,
   stmt_is_included: bool,
@@ -85,18 +90,23 @@ pub fn record_is_init_obligation(
   if rec.kind != ImportKind::Import {
     return false;
   }
-  if order_state.is_consumer_local_reexport_route(importer_idx)
+  if order_state.is_consumer_local_reexport_route(importer.idx)
     && rec.meta.intersects(ImportRecordMeta::IsExportStar | ImportRecordMeta::IsReExportOnly)
   {
     return false;
   }
   match purpose {
     ObligationPurpose::Emit | ObligationPurpose::Register => {
-      stmt_is_included && !order_state.is_nested_reexport_record(importer_idx, rec_idx)
+      stmt_is_included && !order_state.is_nested_reexport_record(importer.idx, rec_idx)
     }
     ObligationPurpose::Project => {
       stmt_is_included
         || rec.meta.intersects(ImportRecordMeta::IsExportStar | ImportRecordMeta::IsReExportOnly)
+        // An excluded plain import that declares bindings can still carry binding demand (folded
+        // member reads, re-exported facades) that the excluded-statement metadata routes for
+        // Emit/Register, so projection must keep the same edge sources (issue #10690). The
+        // collector refines actual demand per binding.
+        || importer.named_imports.values().any(|import| import.record_idx == rec_idx)
     }
   }
 }
@@ -119,7 +129,7 @@ pub fn for_each_init_obligation_record(
       if record_is_init_obligation(
         purpose,
         order_state,
-        importer.idx,
+        importer,
         &importer.import_records[rec_idx],
         rec_idx,
         stmt_is_included,
@@ -449,9 +459,12 @@ fn collect_esm_init_targets_for_record(
           // Liveness is importer-local. A named binding can itself hold a namespace object, so a
           // statically resolved `binding.member` read routes only that member even when the local
           // facade is absent from UsedSymbolRefs. Filtering by the canonical export would let a
-          // different importer that consumes the same leaf resurrect this dead specifier.
+          // different importer that consumes the same leaf resurrect this dead specifier. A
+          // re-exported binding is opaque like a re-exported namespace: it can canonically resolve
+          // to a namespace whose downstream member reads were statically folded (issue #10690).
           let binding_is_opaque = symbol_is_used(*imported_as_ref)
             || ctx.order_wrap_state.is_consumed_reexport_facade(*imported_as_ref)
+            || importer_reexports_binding(ctx.importer, *imported_as_ref)
             || add_wrapped_esm_init_targets_for_static_member_reads(
               ctx,
               *imported_as_ref,
@@ -621,7 +634,12 @@ fn add_wrapped_esm_init_targets_for_namespace_consumer(
   targets: &mut Vec<WrappedEsmInitTarget>,
   visited_symbols: &mut FxHashSet<SymbolRef>,
 ) {
+  // A re-exported namespace binding is opaque to this importer: downstream consumers can read any
+  // member through the importer's export surface, and a statically folded `ns.x` read leaves no
+  // importer-local reference behind for the member-read scan below (issue #10690). Dead leaves
+  // stay pruned by the per-target reachability gates.
   let opaque_namespace_use = symbol_is_used(namespace_ref)
+    || importer_reexports_binding(ctx.importer, namespace_ref)
     || add_wrapped_esm_init_targets_for_static_member_reads(
       ctx,
       namespace_ref,
@@ -642,6 +660,14 @@ fn add_wrapped_esm_init_targets_for_namespace_consumer(
       );
     }
   }
+}
+
+/// Whether the importer re-exports this local import binding. Membership is scan-time export
+/// surface data, deliberately not consumption-gated: a statically folded downstream read leaves no
+/// liveness trace on the facade chain, and a genuinely dead re-export routes nothing anyway
+/// because every target is gated on an included wrapper in a live chunk (issue #10690).
+pub fn importer_reexports_binding(importer: &NormalModule, local_ref: SymbolRef) -> bool {
+  importer.named_exports.values().any(|export| export.referenced == local_ref)
 }
 
 /// Route statically resolved member reads of one local import facade and report whether any use is

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -406,7 +406,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       if record_is_init_obligation(
         ObligationPurpose::Emit,
         self.ctx.order_wrap_state,
-        self.ctx.idx,
+        self.ctx.module,
         rec,
         rec_idx,
         true,
@@ -424,7 +424,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if record_is_init_obligation(
           ObligationPurpose::Emit,
           self.ctx.order_wrap_state,
-          self.ctx.idx,
+          self.ctx.module,
           rec,
           rec_idx,
           true,
@@ -1957,7 +1957,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 if record_is_init_obligation(
                   ObligationPurpose::Emit,
                   self.ctx.order_wrap_state,
-                  self.ctx.idx,
+                  self.ctx.module,
                   rec,
                   rec_idx,
                   true,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -1252,7 +1252,7 @@ impl GenerateStage<'_> {
           if !record_is_init_obligation(
             ObligationPurpose::Project,
             pre_chunk_order_state,
-            module_idx,
+            module,
             record,
             rec_idx,
             stmt_is_included,

--- a/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_wrapped_esm_init_metadata.rs
@@ -5,9 +5,10 @@ use std::ops::Deref;
 use oxc::ast::ast::{Declaration, Statement};
 use oxc_index::IndexVec;
 use rolldown_common::{
-  ChunkIdx, ConcatenateWrappedModuleKind, ImportKind, ImportRecordIdx, ImportRecordMeta,
-  IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, NormalModule, StmtInfoIdx,
-  StmtInfos, WrapKind,
+  ChunkIdx, ConcatenateWrappedModuleKind, ConstExportMeta, ImportKind, ImportRecordIdx,
+  ImportRecordMeta, IndexModules, InlineConstMode, Module, ModuleIdx,
+  ModuleNamespaceIncludedReason, NormalModule, StmtInfoIdx, StmtInfos, SymbolRef, SymbolRefDb,
+  WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_utils::{index_vec_ext::IndexVecRefExt, rayon::ParallelIterator as _};
@@ -16,14 +17,17 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
   chunk_graph::ChunkGraph,
   esm_init_obligations::{
-    WrappedEsmInitTarget, collect_order_wrap_esm_init_targets, reexport_record_owns_hop,
+    WrappedEsmInitTarget, WrappedEsmInitTargetContext, collect_order_wrap_esm_init_targets,
+    collect_wrapped_esm_init_targets_for_import_record, import_record_has_live_binding_consumer,
+    importer_reexports_binding, reexport_record_owns_hop,
   },
-  type_alias::IndexEcmaAst,
+  type_alias::{IndexEcmaAst, IndexStmtInfos},
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
 };
 
 use super::{
   GenerateStage,
+  compute_cross_chunk_links::UsedSymbolRefsView,
   order_wrap_state::{EsmInitOrigin, OrderImportKey, OrderWrapState},
 };
 
@@ -86,6 +90,7 @@ impl GenerateStage<'_> {
     ast_table: &IndexEcmaAst,
     chunk_graph: &ChunkGraph,
     order_state: &OrderWrapState,
+    used_symbol_refs: &dyn UsedSymbolRefsView,
   ) -> Sealed<FinalEsmInitMetadata> {
     let keep_names = self.options.keep_names;
     // Off-strict, lowering never mutates the chunk graph, so the liveness guard cannot fire.
@@ -120,6 +125,11 @@ impl GenerateStage<'_> {
                 order_wrap: matches!(init_target.origin, EsmInitOrigin::ExecutionOrder),
                 execution_dependencies: &meta.execution_dependencies,
                 order_state,
+                stmt_infos_vec,
+                symbol_db: &self.link_output.symbol_db,
+                constant_value_map: &self.link_output.global_constant_symbol_map,
+                inline_const_mode: self.options.optimization.inline_const.map(|config| config.mode),
+                used_symbol_refs,
               },
             )
           })
@@ -144,6 +154,11 @@ struct EsmInitTargetContext<'a> {
   order_wrap: bool,
   execution_dependencies: &'a rolldown_utils::indexmap::FxIndexSet<ModuleIdx>,
   order_state: &'a OrderWrapState,
+  stmt_infos_vec: &'a IndexStmtInfos,
+  symbol_db: &'a SymbolRefDb,
+  constant_value_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
+  inline_const_mode: Option<InlineConstMode>,
+  used_symbol_refs: &'a dyn UsedSymbolRefsView,
 }
 
 /// Whether calling the module's `init_*()` is a no-op because nothing lands inside its `__esm`
@@ -266,6 +281,17 @@ fn transitive_esm_init_targets(
             namespace: namespace_reexport_is_retained,
           },
         ) {
+          // A non-forwarding excluded plain import can still carry importer-local binding demand:
+          // a statically folded member read, or a binding this module re-exports that downstream
+          // consumers reach through its export surface. Those consumers delegate wholesale to this
+          // module's `init_*`, so the wrapper must initialize the leaves that demand selects
+          // (issue #10690). Included plain imports emit at their own statement position instead.
+          if !stmt_is_included && !is_reexport {
+            let record_targets = excluded_plain_import_init_targets(module, meta, ctx, rec_idx);
+            if !record_targets.is_empty() {
+              targets_by_stmt.entry(stmt_idx).or_default().extend(record_targets);
+            }
+          }
           continue;
         }
         if stmt_is_included
@@ -336,6 +362,71 @@ fn transitive_esm_init_targets(
     }
   }
   targets_by_stmt
+}
+
+/// Resolve the binding demand of one excluded, non-forwarding plain-import record through the
+/// shared per-record router — the same resolver Emit runs for included statements — so the
+/// wrapper's excluded-statement metadata owns exactly the leaves and carriers this importer's
+/// consumers reach through it. Registration consumes the same metadata, which is what makes every
+/// collected wrapper reachable; the live-chunk filter below keeps emission from calling a wrapper
+/// that no live chunk declares.
+///
+/// The router runs only when the record carries binding demand: a live binding consumer
+/// (used binding, consumed facade, or member read in this module's included statements) or a
+/// binding this module re-exports, which downstream consumers reach through its export surface
+/// even when every read was statically folded away. A demand-less record — a side-effect-only
+/// import of a side-effect-free module, or dead named imports — was stripped by tree shaking
+/// deliberately, and routing it would resurrect that edge (the router initializes a wrapped
+/// importee wholesale, matching an included import's evaluation semantics).
+fn excluded_plain_import_init_targets(
+  module: &NormalModule,
+  meta: &LinkingMetadata,
+  ctx: &EsmInitTargetContext<'_>,
+  rec_idx: ImportRecordIdx,
+) -> Vec<WrappedEsmInitTarget> {
+  let router_ctx = WrappedEsmInitTargetContext {
+    importer: module,
+    importer_meta: meta,
+    modules: ctx.modules,
+    metas: ctx.metas,
+    stmt_infos: ctx.stmt_infos_vec,
+    symbol_db: ctx.symbol_db,
+    constant_value_map: ctx.constant_value_map,
+    inline_const_mode: ctx.inline_const_mode,
+    order_wrap_state: ctx.order_state,
+    // Only order-wrapped modules reach this router, and order wrapping exists only under strict
+    // execution order.
+    strict_execution_order: true,
+  };
+  let record_reexports_binding = module.named_imports.iter().any(|(imported_as_ref, import)| {
+    import.record_idx == rec_idx && importer_reexports_binding(module, *imported_as_ref)
+  });
+  if !record_reexports_binding
+    && !import_record_has_live_binding_consumer(&router_ctx, rec_idx, |symbol_ref| {
+      ctx.used_symbol_refs.contains(&symbol_ref)
+    })
+  {
+    return Vec::new();
+  }
+  collect_wrapped_esm_init_targets_for_import_record(
+    &router_ctx,
+    rec_idx,
+    |symbol_ref| ctx.used_symbol_refs.contains(&symbol_ref),
+    |_| true,
+    |forwarding_module_idx| ctx.module_to_chunk[forwarding_module_idx] == Some(ctx.chunk_idx),
+  )
+  .into_iter()
+  .filter(|target| match target {
+    WrappedEsmInitTarget::Module(module_idx) => ctx.order_state.esm_init_included_in_live_chunk(
+      &ctx.metas[*module_idx],
+      *module_idx,
+      ctx.chunk_graph,
+    ),
+    WrappedEsmInitTarget::CjsCarrier(key) => {
+      ctx.order_state.order_cjs_carrier_included_in_live_chunk(*key, ctx.chunk_graph)
+    }
+  })
+  .collect()
 }
 
 /// Whether an order-wrapped importer's `init_*` must forward through this static-import record.

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -158,8 +158,12 @@ impl<'a> GenerateStage<'a> {
     self.compute_retained_export_symbols(&used_symbol_refs);
 
     let mut ast_table = std::mem::take(&mut self.ast_table);
-    let final_esm_init_metadata =
-      self.compute_wrapped_esm_init_metadata(&ast_table, &chunk_graph, &order_state);
+    let final_esm_init_metadata = self.compute_wrapped_esm_init_metadata(
+      &ast_table,
+      &chunk_graph,
+      &order_state,
+      &used_symbol_refs,
+    );
 
     self.compute_cross_chunk_links(
       &mut chunk_graph,

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -646,8 +646,12 @@ impl GenerateStage<'_> {
       // `create_order_wrap_entry_facades` bails out on it anyway.
       return index_vec![FxHashSet::default(); chunk_graph.chunk_table.len()];
     }
-    let final_esm_init_metadata =
-      self.compute_wrapped_esm_init_metadata(&self.ast_table, chunk_graph, order_state);
+    let final_esm_init_metadata = self.compute_wrapped_esm_init_metadata(
+      &self.ast_table,
+      chunk_graph,
+      order_state,
+      used_symbol_refs,
+    );
     self.lowered_static_import_edges(
       chunk_graph,
       used_symbol_refs_builder,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/_config.json
@@ -1,0 +1,16 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/artifacts.snap
@@ -1,0 +1,136 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## css.js
+
+```js
+//#region color.js
+const setOpacity = (color, opacity) => `${color}:${opacity}`;
+//#endregion
+//#region css.js
+globalThis.cssResult = setOpacity("a", 1);
+//#endregion
+
+```
+
+## first.js
+
+```js
+import "./css.js";
+import assert from "node:assert";
+//#region first.js
+assert.strictEqual(globalThis.cssResult, "a:1");
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+await import("./first.js");
+await import("./second.js");
+//#endregion
+
+```
+
+## second.js
+
+```js
+import "./css.js";
+import assert from "node:assert";
+//#region second.js
+assert.strictEqual(globalThis.cssResult, "a:1");
+//#endregion
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### css.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region color.js
+var setOpacity;
+function init_color() {
+	return (init_color = __esmMin((() => {
+		setOpacity = (color, opacity) => `${color}:${opacity}`;
+	})))();
+}
+//#endregion
+//#region css.js
+function init_css() {
+	return (init_css = __esmMin((() => {
+		init_color();
+		globalThis.cssResult = setOpacity("a", 1);
+	})))();
+}
+//#endregion
+export { init_css as t };
+
+```
+
+### first.js
+
+```js
+import { t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region first.js
+function init_first() {
+	return (init_first = __esmMin((() => {
+		init_css();
+		assert.strictEqual(globalThis.cssResult, "a:1");
+	})))();
+}
+//#endregion
+init_first();
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await import("./first.js");
+		await import("./second.js");
+	})))();
+}
+//#endregion
+await init_main();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### second.js
+
+```js
+import { t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region second.js
+function init_second() {
+	return (init_second = __esmMin((() => {
+		init_css();
+		assert.strictEqual(globalThis.cssResult, "a:1");
+	})))();
+}
+//#endregion
+init_second();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/color.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/color.js
@@ -1,0 +1,1 @@
+export const setOpacity = (color, opacity) => `${color}:${opacity}`;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/css.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/css.js
@@ -1,0 +1,3 @@
+import * as cssFns from './fns.js';
+
+globalThis.cssResult = cssFns.setOpacity('a', 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/first.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import './css.js';
+
+assert.strictEqual(globalThis.cssResult, 'a:1');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/fns.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/fns.js
@@ -1,0 +1,1 @@
+export { setOpacity } from './color.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/main.js
@@ -1,0 +1,2 @@
+await import('./first.js');
+await import('./second.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/second.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/dead_namespace_import_folded_member/second.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import './css.js';
+
+assert.strictEqual(globalThis.cssResult, 'a:1');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/_config.json
@@ -1,0 +1,16 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/artifacts.snap
@@ -1,0 +1,149 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## css.js
+
+```js
+//#region color.js
+const setOpacity = (color, opacity) => `${color}:${opacity}`;
+//#endregion
+//#region css.js
+globalThis.cssLoaded = true;
+//#endregion
+export { setOpacity as t };
+
+```
+
+## first.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region theme.js
+const theme = setOpacity("red", .5);
+//#endregion
+//#region first.js
+assert.strictEqual(theme, "red:0.5");
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+await import("./first.js");
+await import("./second.js");
+//#endregion
+
+```
+
+## second.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region second.js
+assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+//#endregion
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### css.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region color.js
+var setOpacity;
+function init_color() {
+	return (init_color = __esmMin((() => {
+		setOpacity = (color, opacity) => `${color}:${opacity}`;
+	})))();
+}
+//#endregion
+//#region css.js
+function init_css() {
+	return (init_css = __esmMin((() => {
+		init_color();
+		globalThis.cssLoaded = true;
+	})))();
+}
+//#endregion
+export { init_color as n, setOpacity as r, init_css as t };
+
+```
+
+### first.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region theme.js
+var theme;
+function init_theme() {
+	return (init_theme = __esmMin((() => {
+		init_css();
+		theme = setOpacity("red", .5);
+	})))();
+}
+//#endregion
+//#region first.js
+function init_first() {
+	return (init_first = __esmMin((() => {
+		init_theme();
+		assert.strictEqual(theme, "red:0.5");
+	})))();
+}
+//#endregion
+init_first();
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await import("./first.js");
+		await import("./second.js");
+	})))();
+}
+//#endregion
+await init_main();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### second.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region second.js
+function init_second() {
+	return (init_second = __esmMin((() => {
+		init_css();
+		assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+	})))();
+}
+//#endregion
+init_second();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/color.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/color.js
@@ -1,0 +1,1 @@
+export const setOpacity = (color, opacity) => `${color}:${opacity}`;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/css.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/css.js
@@ -1,0 +1,4 @@
+import { colorNs } from './fns.js';
+
+globalThis.cssLoaded = true;
+export { colorNs };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/first.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { theme } from './theme.js';
+
+assert.strictEqual(theme, 'red:0.5');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/fns.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/fns.js
@@ -1,0 +1,1 @@
+export * as colorNs from './color.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/main.js
@@ -1,0 +1,2 @@
+await import('./first.js');
+await import('./second.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/second.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/second.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { colorNs } from './css.js';
+
+assert.strictEqual(colorNs.setOpacity('blue', 0.2), 'blue:0.2');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/theme.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_literal_namespace_binding/theme.js
@@ -1,0 +1,3 @@
+import { colorNs } from './css.js';
+
+export const theme = colorNs.setOpacity('red', 0.5);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/_config.json
@@ -1,0 +1,16 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/artifacts.snap
@@ -1,0 +1,158 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## css.js
+
+```js
+//#region color.js
+const setOpacity = (color, opacity) => `${color}:${opacity}`;
+globalThis.colorLoaded = (globalThis.colorLoaded ?? 0) + 1;
+//#endregion
+export { setOpacity as t };
+
+```
+
+## first.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region theme.js
+assert.strictEqual(globalThis.colorLoaded, 1);
+const theme = setOpacity("red", .5);
+//#endregion
+//#region first.js
+assert.strictEqual(theme, "red:0.5");
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+await import("./first.js");
+await import("./second.js");
+//#endregion
+
+```
+
+## second.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region second.js
+assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+assert.strictEqual(globalThis.colorLoaded, 1);
+//#endregion
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### css.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region color.js
+var setOpacity;
+function init_color() {
+	return (init_color = __esmMin((() => {
+		setOpacity = (color, opacity) => `${color}:${opacity}`;
+		globalThis.colorLoaded = (globalThis.colorLoaded ?? 0) + 1;
+	})))();
+}
+//#endregion
+//#region fns.js
+function init_fns() {
+	return (init_fns = __esmMin((() => {
+		init_color();
+	})))();
+}
+//#endregion
+//#region css.js
+function init_css() {
+	return (init_css = __esmMin((() => {
+		init_fns();
+	})))();
+}
+//#endregion
+export { init_color as n, setOpacity as r, init_css as t };
+
+```
+
+### first.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region theme.js
+var theme;
+function init_theme() {
+	return (init_theme = __esmMin((() => {
+		init_css();
+		assert.strictEqual(globalThis.colorLoaded, 1);
+		theme = setOpacity("red", .5);
+	})))();
+}
+//#endregion
+//#region first.js
+function init_first() {
+	return (init_first = __esmMin((() => {
+		init_theme();
+		assert.strictEqual(theme, "red:0.5");
+	})))();
+}
+//#endregion
+init_first();
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await import("./first.js");
+		await import("./second.js");
+	})))();
+}
+//#endregion
+await init_main();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### second.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region second.js
+function init_second() {
+	return (init_second = __esmMin((() => {
+		init_css();
+		assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+		assert.strictEqual(globalThis.colorLoaded, 1);
+	})))();
+}
+//#endregion
+init_second();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/color.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/color.js
@@ -1,0 +1,3 @@
+export const setOpacity = (color, opacity) => `${color}:${opacity}`;
+
+globalThis.colorLoaded = (globalThis.colorLoaded ?? 0) + 1;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/css.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/css.js
@@ -1,0 +1,3 @@
+import * as cssFns from './fns.js';
+
+export { cssFns };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/first.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { theme } from './theme.js';
+
+assert.strictEqual(theme, 'red:0.5');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/fns.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/fns.js
@@ -1,0 +1,1 @@
+export { setOpacity } from './color.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/main.js
@@ -1,0 +1,2 @@
+await import('./first.js');
+await import('./second.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/second.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/second.js
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { cssFns } from './css.js';
+
+assert.strictEqual(cssFns.setOpacity('blue', 0.2), 'blue:0.2');
+assert.strictEqual(globalThis.colorLoaded, 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/theme.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_effectful_leaf/theme.js
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { cssFns } from './css.js';
+
+assert.strictEqual(globalThis.colorLoaded, 1);
+export const theme = cssFns.setOpacity('red', 0.5);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/_config.json
@@ -1,0 +1,16 @@
+{
+  "configName": "on-demand",
+  "config": {
+    "external": ["node:assert"],
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  },
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "onDemandWrapping": false
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/_test.mjs
@@ -1,0 +1,1 @@
+await import('./dist/main.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/artifacts.snap
@@ -1,0 +1,149 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## css.js
+
+```js
+//#region color.js
+const setOpacity = (color, opacity) => `${color}:${opacity}`;
+//#endregion
+//#region css.js
+globalThis.cssLoaded = true;
+//#endregion
+export { setOpacity as t };
+
+```
+
+## first.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region theme.js
+const theme = setOpacity("red", .5);
+//#endregion
+//#region first.js
+assert.strictEqual(theme, "red:0.5");
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+await import("./first.js");
+await import("./second.js");
+//#endregion
+
+```
+
+## second.js
+
+```js
+import { t as setOpacity } from "./css.js";
+import assert from "node:assert";
+//#region second.js
+assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+//#endregion
+
+```
+
+# Variant: wrap-all: [on_demand_wrapping: false]
+
+## Assets
+
+### css.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region color.js
+var setOpacity;
+function init_color() {
+	return (init_color = __esmMin((() => {
+		setOpacity = (color, opacity) => `${color}:${opacity}`;
+	})))();
+}
+//#endregion
+//#region css.js
+function init_css() {
+	return (init_css = __esmMin((() => {
+		init_color();
+		globalThis.cssLoaded = true;
+	})))();
+}
+//#endregion
+export { init_color as n, setOpacity as r, init_css as t };
+
+```
+
+### first.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region theme.js
+var theme;
+function init_theme() {
+	return (init_theme = __esmMin((() => {
+		init_css();
+		theme = setOpacity("red", .5);
+	})))();
+}
+//#endregion
+//#region first.js
+function init_first() {
+	return (init_first = __esmMin((() => {
+		init_theme();
+		assert.strictEqual(theme, "red:0.5");
+	})))();
+}
+//#endregion
+init_first();
+
+```
+
+### main.js
+
+```js
+import { t as __esmMin } from "./rolldown-runtime.js";
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		await import("./first.js");
+		await import("./second.js");
+	})))();
+}
+//#endregion
+await init_main();
+
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __esmMin as t };
+
+```
+
+### second.js
+
+```js
+import { r as setOpacity, t as init_css } from "./css.js";
+import { t as __esmMin } from "./rolldown-runtime.js";
+import assert from "node:assert";
+//#region second.js
+function init_second() {
+	return (init_second = __esmMin((() => {
+		init_css();
+		assert.strictEqual(setOpacity("blue", .2), "blue:0.2");
+	})))();
+}
+//#endregion
+init_second();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/color.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/color.js
@@ -1,0 +1,1 @@
+export const setOpacity = (color, opacity) => `${color}:${opacity}`;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/css.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/css.js
@@ -1,0 +1,4 @@
+import * as cssFns from './fns.js';
+
+globalThis.cssLoaded = true;
+export { cssFns };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/first.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/first.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { theme } from './theme.js';
+
+assert.strictEqual(theme, 'red:0.5');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/fns.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/fns.js
@@ -1,0 +1,1 @@
+export { setOpacity } from './color.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/main.js
@@ -1,0 +1,2 @@
+await import('./first.js');
+await import('./second.js');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/second.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/second.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { cssFns } from './css.js';
+
+assert.strictEqual(cssFns.setOpacity('blue', 0.2), 'blue:0.2');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/theme.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/reexported_namespace_pure_barrel/theme.js
@@ -1,0 +1,3 @@
+import { cssFns } from './css.js';
+
+export const theme = cssFns.setOpacity('red', 0.5);

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -245,8 +245,9 @@ the linker registers — so it stays in lockstep with emission instead of forkin
 - **Retained re-export overlays** — an importer's `OrderImportOverlay` referencing an order-wrapped
   target's wrapper, registered with no init-owner gate, so an _eager_ forwarder's cross-chunk hop
   counts too. Admitted only for order-wrapped (not interop `WrapKind::Esm`) non-nested targets.
-- **Included + retained excluded re-export forwarding** — a wrapped importer's included imports and
-  retained excluded re-export hops, via the shared `collect_wrapped_esm_init_targets_for_import_record`.
+- **Included + retained excluded re-export forwarding** — a wrapped importer's included imports,
+  retained excluded re-export hops, and excluded plain imports that declare bindings, via the shared
+  `collect_wrapped_esm_init_targets_for_import_record`.
 - **Non-included forwarder hops** — a wrapped importer's re-export of a _non-included_ forwarder,
   walking the forwarder's every static import (not just its resolved exports), the excluded-statement
   metadata routing.
@@ -533,8 +534,8 @@ link + tree shaking
 - Every import overlay is backed by an immutable link-stage execution dependency or retained re-export contract.
 - Every synthesized init call references a reachable interop or order wrapper.
 - A planned static chunk SCC includes every eligible order-sensitive module in that SCC.
-- Every ordinary-import init obligation corresponds to a link-stage execution dependency.
-- Every excluded-statement init obligation is either a retained re-export obligation or a synthetic obligation backed by an execution dependency.
+- Every ordinary-import init obligation corresponds to a link-stage execution dependency or to importer-local binding demand (a used binding, a statically folded member read, or a re-exported facade a downstream consumer reaches).
+- Every excluded-statement init obligation is a retained re-export obligation, a synthetic obligation backed by an execution dependency, or a binding-demand obligation of an excluded plain import; a binding-less excluded plain import routes nothing.
 - Final cross-chunk registration and finalizer emission require the same `Sealed<FinalEsmInitMetadata>` type; pre-final projection cannot supply one and does not consume final metadata.
 - Wrap-all and on-demand preserve the same link-stage statement and binding liveness; only their wrapper plans may differ.
 - Emit, Register, Project, and pre-chunk placement resolve consumer-local records through the same target model.


### PR DESCRIPTION
Fixes #10690

Notes:

- Tree shaking statically folds every downstream `cssFns.setOpacity` read into a direct reference to the leaf vars, so the `namespace object` doesn't get included.
- `export { setOpacity } from './color.js'` in the middle got skipped, so it doesn't get rewrite to `init_xxx`, which causes the issue
-  Only strictExecutionOrder builds are affected

Input

  ```js
  // css.js
  import * as cssFns from './fns.js'; // fns.js: export { setOpacity } from './color.js'
  globalThis.cssLoaded = true;
  export { cssFns };
  ```

  Before, the generated `init_css` never assigns the leaf:

  ```js
  globalThis.cssLoaded = true;
  // setOpacity is never assigned
  ```

  After, the leaf initializer runs first:

  ```js
  init_color();
  globalThis.cssLoaded = true;
  ```