### PR TITLE
ci(wasi): retry the Node Test step to absorb the shared-dlmalloc flake

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -42,8 +42,27 @@ jobs:
         run: vp run --filter '@rolldown/test-dev-server' build
 
       # `test:wasi` is `test:main` with `ROLLDOWN_WASI_TEST=1`, which skips the tests that the wasm binding cannot pass; every skip states its own reason.
+      #
+      # The suite is flaky under the wasm binding (~1/3 of runs) because multiple
+      # wasm instances share one dlmalloc heap and corrupt it under concurrent
+      # allocation while the memory grows — a "memory access out of bounds" trap
+      # that has nothing to do with the code under test. See #10697. Retry the
+      # whole step (the crash takes down the wasm process, so a per-test retry
+      # cannot help); a real failure still fails all attempts and reds the job.
       - name: Node Test
-        run: vp run --filter rolldown-tests test:wasi
+        run: |
+          for attempt in 1 2 3; do
+            if vp run --filter rolldown-tests test:wasi; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::wasi Node Test attempt ${attempt} failed; retrying (known flake, see #10697)"
+            else
+              echo "::warning::wasi Node Test attempt ${attempt} failed; no more retries (known flake, see #10697)"
+            fi
+          done
+          exit 1
 
       - name: Stability Test
         run: vp run --filter rolldown-tests test:stability


### PR DESCRIPTION
I noticed wasi job sometimes fails. After investigation, I tracked it down to https://github.com/rolldown/rolldown/issues/10697.

The fundamental fix isn't easy and require upstream works. So Adding a retry mechanism to make things easier for now.