### PR TITLE
test(dev): expect a hot update across a circular import

### DIFF
--- a/packages/test-dev-server/tests/playground/hmr-accept-outside-circular/__tests__/hmr-accept-outside-circular.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-accept-outside-circular/__tests__/hmr-accept-outside-circular.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { editFile, page, untilBrowserLogAfter, waitForBuildStable } from '~utils';
+import { editFile, page, waitForBuildStable } from '~utils';
 
 // Port of the removed Rust fixture
 // `crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular`: same
@@ -12,10 +12,10 @@ import { editFile, page, untilBrowserLogAfter, waitForBuildStable } from '~utils
 // callback (dead code — it dereferenced `newMod.a` on a module with no
 // exports) becomes a bare self-accept, which registers the same boundary.
 //
-// Today the client walk treats any circular import chain as a reload reason
-// (`bubble()` stops when it re-meets an ancestor). If the walk ever learns to
-// cross circles to an outside boundary (Vite's `propagateUpdate` behavior),
-// this becomes a hot update — flip the marker assertion to `'alive'`.
+// Reaching the `b`/`c` back edge used to end the walk in a full reload. Vite's
+// bundled-dev client now skips a parent it is already inside of and keeps
+// going (vitejs/vite#23259), so the walk reaches `main`'s self-accept outside
+// the circle and this is a hot update. The marker assertion tells them apart.
 
 /** Plant a marker on `window`; any full page reload wipes it. */
 const plantMarker = () =>
@@ -29,21 +29,16 @@ describe('hmr-accept-outside-circular', () => {
     await expect.poll(() => page.textContent('.chain')).toBe('c');
   });
 
-  test('editing inside the circle reloads onto fresh content', async () => {
+  test('editing inside the circle hot-updates via the boundary outside it', async () => {
     await waitForBuildStable();
     await plantMarker();
 
-    // The reload must be attributed to the circle, not to a missing boundary
-    // (`main` self-accepts, so a plain no-boundary reason would be a bug).
-    await untilBrowserLogAfter(
-      () => editFile('c.js', (code) => code.replace("export const c = 'c'", "export const c = 'cc'")),
-      /full reload needed: circular import chain between `[^`]*b\.js` and `[^`]*c\.js`/,
-    );
+    editFile('c.js', (code) => code.replace("export const c = 'c'", "export const c = 'cc'"));
     await expect.poll(() => page.textContent('.chain')).toBe('cc');
 
-    // A reload, never a silently stale page: the marker is gone AND the fresh
-    // value rendered.
-    await expect.poll(readMarker).toBe(null);
+    // A hot update, never a reload onto the same content: `cc` rendered AND the
+    // marker survived.
+    expect(await readMarker()).toBe('alive');
     await waitForBuildStable();
   });
 });


### PR DESCRIPTION
Fix dev test ci error found in https://github.com/rolldown/rolldown/pull/10699

The dev-server harness builds whatever `vitejs/vite` `rolldown-canary` rebased onto `main` gives it, so this arrived without any rolldown change: the last green run is 06:12Z and the first red one is 07:39Z, with vitejs/vite#23259 landing at 07:26Z between them. Every `Node Dev Server Test` job has been red since, on every branch and every Node version, including `main`.

### The playground

```
main.js  →  a.js  →  b.js  ⇄  c.js
   ↑                    b and c import each other
   └── only main calls import.meta.hot.accept()
```

### What changed upstream

Editing `c.js` makes the HMR client walk up the importers looking for a module that accepts updates:

```
c.js → imported by b; b does not accept, keep going
b.js → imported by a and by c
         via a: a → main, and main accepts ✓
         via c: that is where the walk started, it loops back
```

It used to drop the whole walk the moment it looped back — including the `main` boundary it had already found — and reload the page:

```
full reload needed: circular import chain between `b.js` and `c.js`
```

vitejs/vite#23259 makes it skip the path it already walked and keep the boundary it found, so the edit is applied through `main` and the page stays. Vite's unbundled dev has behaved this way since vitejs/vite#14867; bundled dev was the outlier.

### Why the test broke

`hmr-accept-outside-circular` pinned the old behavior: wait for that log line, then assert the page reloaded (a marker planted on `window` is gone). Neither holds now — the log is deleted, so the wait times out with `Timeout waiting for browser logs`, and the marker survives.

The spec now asserts the hot update: the edit renders and the marker survives. The marker also carries the original guarantee, which the log used to carry — if the walk missed `main`'s boundary entirely, the page would reload and wipe it, so a "content is fresh" assertion alone cannot pass by accident.

Validation: the full browser suite passes locally against Vite `main` at c0f2fc607, which contains the change — 104 passed / 12 skipped, exactly CI's counts with the one failure flipped. Not verified: the new assertion has not been run against a pre-#23259 Vite.
