### PR TITLE
ci: build the benchmark comparison window from the JSON lines

### DIFF
--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Run benchmarks
         run: vp run --filter bench bench-ci
 
+      # The action compares the new run against the previous entry only, so it
+      # needs a short window of history rather than the whole series. Rebuilding
+      # it from the JSON lines is what lets the 17 MB nested JSON stay frozen.
+      - name: Build the comparison window
+        run: node scripts/misc/benchmark-storage/window-from-jsonl.mjs --jsonl tmp/benchmark-node-output.jsonl --out tmp/window.json
+
       - name: Show/Update benchmark result
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
@@ -75,7 +81,7 @@ jobs:
           # Where the output from the benchmark tool is stored
           output-file-path: tmp/new-benchmark-node-output.json
           # Where the previous data file is stored
-          external-data-json-path: tmp/benchmark-node-output.json
+          external-data-json-path: tmp/window.json
           fail-on-alert: false
           summary-always: true
           comment-always: false
@@ -88,8 +94,7 @@ jobs:
         env:
           # Results are stored in https://github.com/rolldown/benchmark-results-storage
           API_TOKEN_GITHUB: ${{ secrets.REPO_TOKEN_BENCHMARK_RESULTS }}
-        # Appends this run as Entry-schema JSON lines and dual-writes the nested
-        # JSON during the migration window (see the storage repo's README).
-        # Pushes with a rebase retry, so concurrent runs append instead of
-        # overwriting each other.
+        # Appends this run as Entry-schema JSON lines (see the storage repo's
+        # README). Pushes with a rebase retry, so concurrent runs append instead
+        # of overwriting each other.
         run: node scripts/misc/benchmark-storage/push-results.mjs

--- a/scripts/misc/benchmark-storage/push-results.mjs
+++ b/scripts/misc/benchmark-storage/push-results.mjs
@@ -2,11 +2,10 @@
 //
 // Reads the github-action-benchmark data file the action just updated, converts
 // its newest "Node Benchmark" entry into Entry-schema JSON Lines (the format
-// rolldown/metric's `metric.json` uses — see the storage repo's README), appends
-// them to `benchmark-node-output.jsonl`, and dual-writes the nested JSON while
-// the migration window is open. Pushes with a pull-rebase retry loop, so two
-// concurrent main runs append instead of overwriting each other (the previous
-// whole-file copy step silently dropped the losing run).
+// rolldown/metric's `metric.json` uses — see the storage repo's README), and
+// appends them to `benchmark-node-output.jsonl`. Pushes with a pull-rebase retry
+// loop, so two concurrent main runs append instead of overwriting each other
+// (the previous whole-file copy step silently dropped the losing run).
 //
 // Usage (CI):    node scripts/misc/benchmark-storage/push-results.mjs
 //   env: API_TOKEN_GITHUB — token with push access to the storage repo
@@ -23,12 +22,11 @@ import path from 'node:path';
 const SERIES = 'Node Benchmark';
 const STORAGE_REPO = 'github.com/rolldown/benchmark-results-storage.git';
 const JSONL_FILE = 'benchmark-node-output.jsonl';
-const JSON_FILE = 'benchmark-node-output.json';
 const PEAK_MEMORY_SUFFIX = ' (peak memory)';
 const PUSH_RETRIES = 3;
 
 function parseArgs(argv) {
-  const args = { data: 'tmp/benchmark-node-output.json', dryRun: null };
+  const args = { data: 'tmp/window.json', dryRun: null };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--data') args.data = argv[++i];
     else if (argv[i] === '--dry-run') args.dryRun = argv[++i];
@@ -95,12 +93,8 @@ if (!workdir) {
 }
 
 const applyChanges = () => {
-  // Dual-write the nested JSON while the migration window is open.
-  fs.copyFileSync(args.data, path.join(workdir, JSON_FILE));
-
   // Append this run's lines — unless they are already there (job rerun, or a
-  // rebase retry after our own commit survived). Starts the file when it does
-  // not exist yet, so this step works before the history-migration PR merges.
+  // rebase retry after our own commit survived).
   const jsonlPath = path.join(workdir, JSONL_FILE);
   const existing = fs.existsSync(jsonlPath) ? fs.readFileSync(jsonlPath, 'utf8') : '';
   const lastLine = existing.trimEnd().split('\n').at(-1);
@@ -114,7 +108,7 @@ const applyChanges = () => {
 };
 
 const appended = applyChanges();
-gitOrThrow(workdir, 'add', JSON_FILE, JSONL_FILE);
+gitOrThrow(workdir, 'add', JSONL_FILE);
 const message = `Append results for rolldown/rolldown@${entry.commit.id.slice(0, 9)}`;
 if (!git(workdir, 'commit', '-m', message)) {
   console.log('nothing to commit');
@@ -138,7 +132,7 @@ for (let attempt = 1; ; attempt++) {
     gitOrThrow(workdir, 'reset', '--hard', 'origin/main');
     gitOrThrow(workdir, 'pull');
     applyChanges();
-    gitOrThrow(workdir, 'add', JSON_FILE, JSONL_FILE);
+    gitOrThrow(workdir, 'add', JSONL_FILE);
     if (!git(workdir, 'commit', '-m', message)) break;
   }
 }


### PR DESCRIPTION
The action only compares the new run against the previous entry, so it does not need the whole 17 MB `benchmark-node-output.json` — a 50-run window rebuilt from `benchmark-node-output.jsonl` is 38 KB and carries the same information. With that in place the nested JSON stops being written, and a push appends six lines instead of rewriting 17 MB.

The reconstructed entries keep only the commit id and url, so the previous run's author and message render blank in the job summary.

`benchmark-node-output.json` stays in the storage repo, frozen. Deleting it would reclaim nothing because the blobs stay in history.

refs #10682
