### PR TITLE
test(deconflict): pin renaming the external process binding away from the global

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/5449/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5449/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs",
+    "codeSplitting": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/5449/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/5449/_test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+// Regression test for #5449. Before #7022 reserved global names ahead of deconflicting, merging
+// the dynamic imports into the entry chunk hoisted
+// `let process = require("process"); process = __toESM(process)` for process-importer.js, shadowing
+// the global `process` for global-user.js, whose `process.on(...)` then threw
+// `Cannot set property _eventsCount of #<process> which has only a getter` on the read-only copy.
+const require = createRequire(import.meta.url);
+const { done } = require('./dist/main.js');
+await done;
+
+assert.ok(globalThis.__globalProcessOk, 'global-user.js must reach the real global `process`');
+assert.equal(globalThis.__importedProcessPid, process.pid);

--- a/crates/rolldown/tests/rolldown/issues/5449/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5449/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+// HIDDEN [\0rolldown/runtime.js]
+let process$1 = require("process");
+process$1 = __toESM(process$1);
+//#region global-user.js
+var require_global_user = /* @__PURE__ */ __commonJSMin((() => {
+	process.on("beforeExit", () => {});
+	globalThis.__globalProcessOk = true;
+}));
+//#endregion
+//#region process-importer.js
+var process_importer_exports = /* @__PURE__ */ __exportAll({});
+var init_process_importer = __esmMin((() => {
+	globalThis.__importedProcessPid = process$1.default.pid;
+}));
+//#endregion
+//#region main.js
+const done = Promise.all([Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_global_user())), Promise.resolve().then(() => (init_process_importer(), process_importer_exports))]);
+//#endregion
+exports.done = done;
+
+```

--- a/crates/rolldown/tests/rolldown/issues/5449/global-user.js
+++ b/crates/rolldown/tests/rolldown/issues/5449/global-user.js
@@ -1,0 +1,3 @@
+// Uses the global `process`; the external binding hoisted for process-importer.js must not shadow it.
+process.on('beforeExit', () => {});
+globalThis.__globalProcessOk = true;

--- a/crates/rolldown/tests/rolldown/issues/5449/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5449/main.js
@@ -1,0 +1,1 @@
+export const done = Promise.all([import('./global-user.js'), import('./process-importer.js')]);

--- a/crates/rolldown/tests/rolldown/issues/5449/process-importer.js
+++ b/crates/rolldown/tests/rolldown/issues/5449/process-importer.js
@@ -1,0 +1,3 @@
+import process from 'process';
+
+globalThis.__importedProcessPid = process.pid;


### PR DESCRIPTION
With `format: 'cjs'` and code splitting disabled, a bundle whose dynamically imported modules collapse into the entry chunk used to crash at runtime when one merged module imported `process` as an external and another called `process.on(...)` on the global (#5449).

This PR adds a regression test that executes that exact shape and pins the fixed output.

Before (≤ 1.0.0-beta.45), the entry chunk shadowed the global:

  ```js
  let process = require("process");
  process = __toESM(process);
  // another module in the same chunk:
  process.on("beforeExit", () => {});
  // TypeError: Cannot set property _eventsCount of #<process> which has only a getter

//   After (≥ 1.0.0-beta.51, fixed by #7022):

  let process$1 = require("process");
  process$1 = __toESM(process$1);
  process.on("beforeExit", () => {}); // reaches the real global