### PR TITLE
feat(bench): record per-suite peak memory in the node benchmark

### DIFF
--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -61,7 +61,10 @@ jobs:
         run: just setup-bench
 
       - name: Build packages
-        run: just build-rolldown-release
+        # The tracking variant also records per-suite peak Rust-side memory
+        # (`(peak memory)` series). It shifts timing numbers by at most ~2.3%
+        # once — far below the 110% alert threshold.
+        run: just build-rolldown-release-tracking
 
       - name: Run benchmarks
         run: vp run --filter bench bench-ci

--- a/justfile
+++ b/justfile
@@ -214,6 +214,11 @@ build-rolldown-wasi:
 build-rolldown-release:
   vp run --filter rolldown build-native:release
 
+# Same as `build-rolldown-release`, plus the tracking allocator, so benchmarks can record Rust-side memory usage. Costs ~1-2% build time.
+build-rolldown-release-tracking:
+  vp run --filter rolldown build-binding:release --features tracking_allocator
+  vp run --filter rolldown build-js-glue
+
 # Build `rolldown` located in `packages/rolldown` itself and its `.node` binding in profile mode.
 build-rolldown-profile:
   vp run --filter rolldown build-native:profile

--- a/packages/bench/benches/ci.js
+++ b/packages/bench/benches/ci.js
@@ -1,6 +1,7 @@
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
 import nodeUrl from 'node:url';
+import { getNativeMemoryStats, resetNativeMemoryStats } from 'rolldown/experimental';
 import * as tinyBench from 'tinybench';
 import { getRolldownSuiteList, runRolldown } from '../src/run-bundler.js';
 import { expandSuitesWithDerived, suitesForCI } from '../src/suites/index.js';
@@ -15,12 +16,38 @@ const bench = new tinyBench.Bench({
 });
 bench.threshold = 1;
 
+// Peak Rust-side memory per suite, in bytes. Only recorded when the binding was
+// built with `--features tracking_allocator` (`just build-rolldown-release-tracking`,
+// which the benchmark workflow uses); a stock binding returns null and no memory
+// rows are emitted.
+const peakMemoryBySuite = new Map();
+
 for (const suite of expandSuitesWithDerived(suitesForCI)) {
   const rolldownSuiteList = getRolldownSuiteList(suite);
   for (const rolldownSuite of rolldownSuiteList) {
-    bench.add(`${suite.title} (${rolldownSuite.suiteName})`, async () => {
-      await runRolldown(rolldownSuite);
-    });
+    const taskName = `${suite.title} (${rolldownSuite.suiteName})`;
+    // Suites share the process, so memory retained by earlier suites is the
+    // floor this suite starts from. Record the peak ABOVE that floor — the
+    // suite's own demand — so later suites are not charged for earlier residue.
+    let liveAtStart = 0;
+    bench.add(
+      taskName,
+      async () => {
+        await runRolldown(rolldownSuite);
+      },
+      {
+        beforeAll: () => {
+          resetNativeMemoryStats();
+          liveAtStart = getNativeMemoryStats()?.liveBytes ?? 0;
+        },
+        afterAll: () => {
+          const stats = getNativeMemoryStats();
+          if (stats) {
+            peakMemoryBySuite.set(taskName, Math.max(0, Math.round(stats.peakBytes - liveAtStart)));
+          }
+        },
+      },
+    );
   }
 }
 
@@ -37,6 +64,14 @@ const dataForGitHubBenchmarkAction = bench.tasks.map((task) => {
     unit: 'ms / ops',
   };
 });
+
+for (const [taskName, peakBytes] of peakMemoryBySuite) {
+  dataForGitHubBenchmarkAction.push({
+    name: `${taskName} (peak memory)`,
+    value: peakBytes,
+    unit: 'bytes',
+  });
+}
 
 const serialized = JSON.stringify(dataForGitHubBenchmarkAction, null, 2);
 

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -4,13 +4,16 @@ export type { DevOptions, DevWatchOptions } from './api/dev/dev-options';
 export { freeExternalMemory, scan } from './api/experimental';
 export {
   type BindingClientHmrUpdate,
+  type BindingNativeMemoryStats,
   BindingRebuildStrategy,
+  getNativeMemoryStats,
   isolatedDeclaration,
   type IsolatedDeclarationsOptions,
   type IsolatedDeclarationsResult,
   isolatedDeclarationSync,
   moduleRunnerTransform,
   type NapiResolveOptions as ResolveOptions,
+  resetNativeMemoryStats,
   type ResolveResult,
   ResolverFactory,
 } from './binding.cjs';


### PR DESCRIPTION
This PR makes the node benchmark build with the `tracking_allocator` feature and record each suite's peak Rust-side memory above its starting floor, emitted as `<suite> (peak memory)` rows (unit `bytes`) in the JSON the benchmark action already tracks. The allocator tier is used instead of `process.memoryUsage()` because allocator peaks stay stable across fresh-process rounds (CV 0.03-3.1% per suite) while polled RSS deltas swing (CV 2.9-136%). On a stock binding the stats return null and the output is unchanged.

requires #10703