### PR TITLE
refactor(rolldown_plugin_vite_dynamic_import_vars): make the visitor emit plain data

### DIFF
--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit.rs
@@ -4,10 +4,10 @@ use cow_utils::CowUtils;
 use oxc::{
   ast::{Comment, ast::Expression},
   ast_visit::{VisitJs, walk_js},
+  span::Span,
 };
 use rolldown_plugin::{LogWithoutPlugin, PluginContext};
 use rolldown_std_utils::relative_path_to_slash;
-use string_wizard::MagicString;
 
 use super::dynamic_import_to_glob::{
   has_special_query_param, should_ignore, template_literal_to_glob, to_valid_glob,
@@ -19,33 +19,133 @@ struct DynamicImportRequest<'a> {
   pub import: bool,
 }
 
-pub struct DynamicImportVarsVisit<'ast, 'b> {
+/// One edit to the source text. `transform` applies it with
+/// `magic_string.update(start, end, replacement)`. This struct holds plain data
+/// only.
+pub struct Edit {
+  pub start: u32,
+  pub end: u32,
+  pub replacement: String,
+}
+
+/// This struct describes one glob with a bare specifier or an alias specifier,
+/// such as ``import(`$lib/data/${name}.js`)``. The JS resolver must find the
+/// file that the specifier points to. This crate builds the replacement only
+/// after the resolver answers.
+///
+/// This struct holds owned data only. `transform` can therefore drop the AST
+/// before it calls the resolver. The earlier code kept a `*const Expression`
+/// that pointed into the arena.
+pub struct PendingAsyncImport {
+  pub glob: String,
+  pub import_span: Span,
+  pub source_span: Span,
+  pub first_quasi_raw: String,
+}
+
+/// This struct holds the data that `build_edit` needs from outside the AST.
+#[derive(Clone, Copy)]
+pub struct RewriteContext<'b> {
   pub ctx: &'b PluginContext,
   pub source_text: &'b str,
   pub root: &'b Path,
   pub importer: &'b Path,
-  pub need_helper: bool,
+}
+
+impl RewriteContext<'_> {
+  /// Builds the `__variableDynamicImportRuntimeHelper(...)` expression that
+  /// replaces one variable dynamic import. This function takes plain data only.
+  /// The caller can therefore call it after `transform` drops the AST.
+  pub fn build_edit(
+    &self,
+    glob: &str,
+    import_span: Span,
+    source_span: Span,
+    first_quasi_raw: &str,
+  ) -> Option<Edit> {
+    let index = memchr::memchr(b'*', glob.as_bytes())?;
+
+    let raw = source_span.shrink(1).source_text(self.source_text);
+    let raw_pattern = if &glob[..index] == first_quasi_raw {
+      Cow::Borrowed(raw)
+    } else {
+      let mut s = String::with_capacity(index + first_quasi_raw.len());
+      s.push_str(&glob[..index]);
+      s.push_str(&raw[first_quasi_raw.len()..]);
+      Cow::Owned(s)
+    };
+
+    let base = self.importer.parent().unwrap_or(self.root);
+    let normalized = if raw_pattern.as_bytes()[0] == b'/' {
+      relative_path_to_slash(self.root.join(&raw_pattern[1..]), base)
+    } else {
+      relative_path_to_slash(base.join(raw_pattern.as_ref()), base)
+    };
+    let new_raw_pattern = if normalized.starts_with("./") || normalized.starts_with("../") {
+      normalized
+    } else {
+      rolldown_utils::concat_string!("./", normalized)
+    };
+
+    let glob = glob.cow_replace("**", "*");
+    let source_text = source_span.source_text(self.source_text);
+
+    let (pattern, glob_params) = {
+      let index = glob.rfind('/').unwrap_or(0);
+      let index = glob[index..].find('?').map_or(glob.len(), |i| i + index);
+
+      let (glob, query) = glob.split_at(index);
+      let glob = match to_valid_glob(glob, source_text) {
+        Ok(glob) => glob,
+        Err(error) => {
+          self.ctx.warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
+          return None;
+        }
+      };
+
+      let params = (!query.is_empty())
+        .then_some(DynamicImportRequest { query, import: has_special_query_param(query) });
+
+      (glob, params)
+    };
+
+    // __variableDynamicImportRuntimeHelper((import.meta.glob(pattern, params)), expr, segments)
+    let segments = pattern.split('/').count();
+    let replacement = format!(
+      "__variableDynamicImportRuntimeHelper(import.meta.glob(\"{pattern}\"{}), `{new_raw_pattern}`, {segments})",
+      glob_params
+        .map(|params| {
+          format!(
+            ", {{ query: \"{}\"{} }}",
+            params.query,
+            if params.import { ", import: \"*\"" } else { "" }
+          )
+        })
+        .unwrap_or_default()
+    );
+
+    Some(Edit { start: import_span.start, end: import_span.end, replacement })
+  }
+}
+
+pub struct DynamicImportVarsVisit<'ast, 'b> {
+  pub rewrite: RewriteContext<'b>,
   pub comments: &'b oxc::allocator::Vec<'ast, Comment>,
   pub current_comment: usize,
-  pub async_imports: Vec<String>,
-  pub async_imports_addrs: Vec<*const Expression<'ast>>,
-  pub magic_string: Option<MagicString<'b>>,
+  pub async_imports: Vec<PendingAsyncImport>,
+  pub edits: Vec<Edit>,
 }
 
 impl<'ast> VisitJs<'ast> for DynamicImportVarsVisit<'ast, '_> {
   fn visit_expression(&mut self, expr: &Expression<'ast>) {
-    if self.rewrite_variable_dynamic_import(expr, None) {
+    if self.rewrite_variable_dynamic_import(expr) {
       walk_js::walk_expression(self, expr);
     }
   }
 }
 
 impl<'ast> DynamicImportVarsVisit<'ast, '_> {
-  pub fn rewrite_variable_dynamic_import(
-    &mut self,
-    expr: &Expression<'ast>,
-    async_imports: Option<&str>,
-  ) -> bool {
+  fn rewrite_variable_dynamic_import(&mut self, expr: &Expression<'ast>) -> bool {
     if let Expression::ImportExpression(import_expr) = expr
       && let Expression::TemplateLiteral(source) = &import_expr.source
     {
@@ -61,105 +161,42 @@ impl<'ast> DynamicImportVarsVisit<'ast, '_> {
           }
         }
       }
-      let glob = match async_imports {
-        Some(glob) => Cow::Borrowed(glob),
-        None => {
-          if source.is_no_substitution_template() {
-            return false;
-          }
 
-          let glob = match template_literal_to_glob(source) {
-            Ok(glob) => glob,
-            Err(error) => {
-              self.ctx.warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
-              return false;
-            }
-          };
+      if source.is_no_substitution_template() {
+        return false;
+      }
 
-          if memchr::memchr(b'*', glob.as_bytes()).is_none() || should_ignore(&glob) {
-            return false;
-          }
-
-          if glob.as_bytes()[0] != b'.' && glob.as_bytes()[0] != b'/' {
-            self.async_imports.push(glob.into_owned());
-            self.async_imports_addrs.push(std::ptr::from_ref(expr));
-            return false;
-          }
-
-          glob
+      let glob = match template_literal_to_glob(source) {
+        Ok(glob) => glob,
+        Err(error) => {
+          self
+            .rewrite
+            .ctx
+            .warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
+          return false;
         }
       };
 
-      let Some(index) = memchr::memchr(b'*', glob.as_bytes()) else {
+      if memchr::memchr(b'*', glob.as_bytes()).is_none() || should_ignore(&glob) {
         return false;
-      };
+      }
 
-      let raw = source.span.shrink(1).source_text(self.source_text);
-      let raw_pattern = if &glob[..index] == source.quasis[0].value.raw {
-        Cow::Borrowed(raw)
-      } else {
-        let mut s = String::with_capacity(index + source.quasis[0].value.raw.len());
-        s.push_str(&glob[..index]);
-        s.push_str(&raw[source.quasis[0].value.raw.len()..]);
-        Cow::Owned(s)
-      };
+      let first_quasi_raw = source.quasis[0].value.raw.as_str();
+      if glob.as_bytes()[0] != b'.' && glob.as_bytes()[0] != b'/' {
+        self.async_imports.push(PendingAsyncImport {
+          glob: glob.into_owned(),
+          import_span: import_expr.span,
+          source_span: source.span,
+          first_quasi_raw: first_quasi_raw.to_owned(),
+        });
+        return false;
+      }
 
-      let base = self.importer.parent().unwrap_or(self.root);
-      let normalized = if raw_pattern.as_bytes()[0] == b'/' {
-        relative_path_to_slash(self.root.join(&raw_pattern[1..]), base)
-      } else {
-        relative_path_to_slash(base.join(raw_pattern.as_ref()), base)
-      };
-      let new_raw_pattern = if normalized.starts_with("./") || normalized.starts_with("../") {
-        normalized
-      } else {
-        rolldown_utils::concat_string!("./", normalized)
-      };
-
-      let glob = glob.cow_replace("**", "*");
-      let source_text = source.span.source_text(self.source_text);
-
-      let (pattern, glob_params) = {
-        let index = glob.rfind('/').unwrap_or(0);
-        let index = glob[index..].find('?').map_or(glob.len(), |i| i + index);
-
-        let (glob, query) = glob.split_at(index);
-        let glob = match to_valid_glob(glob, source_text) {
-          Ok(glob) => glob,
-          Err(error) => {
-            self.ctx.warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
-            return false;
-          }
-        };
-
-        let params = (!query.is_empty())
-          .then_some(DynamicImportRequest { query, import: has_special_query_param(query) });
-
-        (glob, params)
-      };
-
-      // __variableDynamicImportRuntimeHelper((import.meta.glob(pattern, params)), expr, segments)
-      let segments = pattern.split('/').count();
-      let replacement = format!(
-        "__variableDynamicImportRuntimeHelper(import.meta.glob(\"{pattern}\"{}), `{new_raw_pattern}`, {segments})",
-        glob_params
-          .map(|params| {
-            format!(
-              ", {{ query: \"{}\"{} }}",
-              params.query,
-              if params.import { ", import: \"*\"" } else { "" }
-            )
-          })
-          .unwrap_or_default()
-      );
-
-      self
-        .magic_string
-        .get_or_insert_with(|| MagicString::new(self.source_text))
-        .update(import_expr.span.start, import_expr.span.end, replacement)
-        .expect("update should not fail in dynamic import vars plugin");
-
-      self.need_helper = true;
+      if let Some(edit) =
+        self.rewrite.build_edit(&glob, import_expr.span, source.span, first_quasi_raw)
+      {
+        self.edits.push(edit);
+      }
       return false;
     }
     true

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -69,55 +69,73 @@ impl Plugin for ViteDynamicImportVarsPlugin {
       return Ok(None);
     }
     if utils::has_dynamic_import(args.code) {
-      let allocator = oxc::allocator::Allocator::default();
-      let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
-      else {
-        return Ok(None);
-      };
-      let mut visitor = ast_visit::DynamicImportVarsVisit {
+      let rewrite = ast_visit::RewriteContext {
         ctx: &ctx,
         source_text: args.code,
         root: ctx.cwd(),
         importer: args.id.as_path(),
-        need_helper: false,
-        comments: &parser_ret.program.comments,
-        current_comment: 0,
-        async_imports: Vec::default(),
-        async_imports_addrs: Vec::default(),
-        magic_string: None,
       };
 
-      visitor.visit_program(&parser_ret.program);
+      // This scope parses the code. It then visits the AST. Only owned data
+      // leaves the scope. The code below therefore holds no reference to the
+      // AST arena.
+      let (mut edits, async_imports) = {
+        let allocator = oxc::allocator::Allocator::default();
+        let Some(parser_ret) = parse_program(&allocator, args.code, args.module_type, args.id)?
+        else {
+          return Ok(None);
+        };
+        let mut visitor = ast_visit::DynamicImportVarsVisit {
+          rewrite,
+          comments: &parser_ret.program.comments,
+          current_comment: 0,
+          async_imports: Vec::default(),
+          edits: Vec::default(),
+        };
 
-      if !visitor.async_imports.is_empty()
+        visitor.visit_program(&parser_ret.program);
+
+        (visitor.edits, visitor.async_imports)
+      };
+
+      if !async_imports.is_empty()
         && let Some(resolver) = &self.resolver
       {
-        let async_imports = std::mem::take(&mut visitor.async_imports);
         let task = async_imports
-          .into_iter()
-          .map(|glob| async { resolver(glob, args.id.to_string()).await.ok()? });
+          .iter()
+          .map(|pending| async { resolver(pending.glob.clone(), args.id.to_string()).await.ok()? });
 
         let importer = args.id.as_path().parent().unwrap();
         let result = block_on(block_on_spawn_all(task));
-        for (i, item) in result.into_iter().enumerate() {
+        for (pending, item) in async_imports.iter().zip(result) {
           if let Some(id) = item {
             let id = relative_path_as_js_specifier(id, importer);
             if id == "." {
               continue;
             }
 
-            let addr = visitor.async_imports_addrs[i];
-            visitor.rewrite_variable_dynamic_import(unsafe { &*addr }, Some(&id));
+            if let Some(edit) = rewrite.build_edit(
+              &id,
+              pending.import_span,
+              pending.source_span,
+              &pending.first_quasi_raw,
+            ) {
+              edits.push(edit);
+            }
           }
         }
       }
 
-      if let Some(mut magic_string) = visitor.magic_string {
-        if visitor.need_helper {
-          magic_string.prepend(format!(
-            "import __variableDynamicImportRuntimeHelper from \"{DYNAMIC_IMPORT_HELPER}\";"
-          ));
+      if !edits.is_empty() {
+        let mut magic_string = string_wizard::MagicString::new(args.code);
+        for edit in edits {
+          magic_string
+            .update(edit.start, edit.end, edit.replacement)
+            .expect("update should not fail in dynamic import vars plugin");
         }
+        magic_string.prepend(format!(
+          "import __variableDynamicImportRuntimeHelper from \"{DYNAMIC_IMPORT_HELPER}\";"
+        ));
         return Ok(Some(HookTransformOutput {
           code: Some(magic_string.to_string()),
           map: HookTransformOutputMap::from_if_enabled(self.sourcemap, || {


### PR DESCRIPTION
The visitor held a `MagicString`. It also held one `*const Expression<'ast>` for
each glob that needed the JS resolver. It now collects owned `Edit` values
instead.

PR #10666 can therefore await the JS resolver. It does not block the thread.

refs #10664
