### PR TITLE
chore(rolldown_utils): drop `block_on_spawn_all` and the `async-scoped` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,17 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,26 +2238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,7 +3239,6 @@ version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
- "async-scoped",
  "base-encode",
  "base64-simd",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,6 @@ append-only-vec = "0.1.8"
 arcstr = { version = "1.2.0", default-features = false }
 ariadne = { package = "rolldown-ariadne", version = "0.6.0" }
 async-channel = "2.5.0"
-async-scoped = "0.9.0"
 base-encode = "0.3.1"
 base64-simd = "0.8.0"
 bitflags = "2.13.0"

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -41,7 +41,7 @@ simdutf8 = { workspace = true }
 smallvec = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 num-bigint = { workspace = true }
 

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -54,8 +54,12 @@ uuid = { workspace = true, features = ["v4"] }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-async-scoped = { workspace = true, features = ["use-tokio"] }
 rayon = { workspace = true }
+# `crate::futures::block_on` uses `block_in_place` and `runtime::Handle` on
+# targets that are not wasm. Both need the `rt-multi-thread` feature. The
+# `async-scoped` dependency supplied that feature before, behind the same target
+# gate.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 criterion2 = { workspace = true }

--- a/crates/rolldown_utils/src/futures.rs
+++ b/crates/rolldown_utils/src/futures.rs
@@ -9,40 +9,22 @@ where
   tokio::spawn(future)
 }
 
-/// `async` here is only used to satisfy the wasm shim version of `block_on_spawn_all`.
-/// This function allow you to spawn non-static futures in parallel and wait for all of them to finish.
-#[expect(clippy::unused_async)]
-pub async fn block_on_spawn_all<Iter, Out>(iter: Iter) -> Vec<Out>
-where
-  Iter: Iterator,
-  Out: Send + 'static,
-  Iter::Item: Future<Output = Out> + Send,
-{
-  #[cfg(target_arch = "wasm32")]
-  {
-    use futures::future::join_all;
-    join_all(iter).await
-  }
-  #[cfg(not(target_arch = "wasm32"))]
-  {
-    use async_scoped::TokioScope;
-    let (_ret, collections) =
-      async_scoped::Scope::scope_and_block(|scope: &mut TokioScope<'_, _>| {
-        iter.into_iter().for_each(|fut| scope.spawn(fut));
-      });
-    collections.into_iter().map(Result::unwrap).collect()
-  }
-}
-
-#[expect(clippy::collection_is_never_read)]
-async fn _test_block_on_spawn_all_non_static_future() {
-  let mut words = String::new();
-  let non_static_future = async {
-    words.push_str("hello");
-  };
-  let _ = block_on_spawn_all(std::iter::once(non_static_future)).await;
-}
-
+/// Blocks the current thread until `f` completes.
+///
+/// Only call this function when `f` can make progress on this thread alone. Two
+/// kinds of work need another thread. A spawned task needs a worker thread to
+/// poll it. A JS callback that re-enters rolldown needs the runtime too. `f`
+/// then never completes, and the build deadlocks (#10664).
+///
+/// On targets that are not wasm, this function calls `block_in_place`. That
+/// function moves this worker thread's scheduler work to the blocking pool.
+/// `ROLLDOWN_MAX_BLOCKING_THREADS` limits that pool to 4 threads by default.
+/// When the pool is full, no thread remains to run the scheduler work.
+///
+/// On wasm, this function calls `futures::executor::block_on`. That function
+/// polls `f` on this thread and holds the thread. The same rule applies.
+///
+/// Use `.await` in place of this function whenever you can.
 pub fn block_on<F: Future>(f: F) -> F::Output {
   #[cfg(target_family = "wasm")]
   {


### PR DESCRIPTION
No code calls `block_on_spawn_all` now. This PR removes it, together with
`async-scoped` and `pin-project`.

`rolldown_utils` now depends on `tokio` directly and enables `rt-multi-thread`.
`rolldown_common` now enables `tokio/sync` explicitly. `async-scoped` supplied
both features before.

refs #10664
