### PR TITLE
feat(dev): expose module graph queries on the dev engine handle

### DIFF
--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -125,8 +125,10 @@ impl BundleFactory {
     };
 
     if bundle_mode.is_full_build() {
-      // Reset module infos for full bundle and store it for potential incremental builds
-      self.module_infos_for_incremental_build = Arc::default();
+      // A full build starts from an empty module-info set. Clear the shared map in place
+      // instead of replacing it, so long-lived handles (the dev engine's module queries)
+      // keep observing the current build.
+      self.module_infos_for_incremental_build.clear();
       // Also reset transform dependencies for full builds
       self.transform_dependencies_for_incremental_build = Arc::default();
     }
@@ -141,9 +143,16 @@ impl BundleFactory {
     fs: Fs,
     resolver: SharedResolver<Fs>,
   ) -> Bundle<Fs> {
-    self.module_infos_for_incremental_build = Arc::default();
+    self.module_infos_for_incremental_build.clear();
     self.transform_dependencies_for_incremental_build = Arc::default();
     self.build_bundle(fs, resolver, ScanStageCache::default())
+  }
+
+  /// Live handle to the plugin-facing module infos. The `Arc` identity is stable for the
+  /// factory's lifetime — full builds clear the map in place — so a held clone always
+  /// observes the latest build.
+  pub fn module_infos(&self) -> SharedModuleInfoDashMap {
+    Arc::clone(&self.module_infos_for_incremental_build)
   }
 
   fn build_bundle<Fs: FileSystem + Clone + 'static>(

--- a/crates/rolldown/src/bundler/impl_bundler_getter.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_getter.rs
@@ -21,6 +21,11 @@ impl Bundler {
     self.bundle_factory.options.transform_options.clear_transform_tsconfig_cache();
   }
 
+  /// See [`crate::bundle::bundle_factory::BundleFactory::module_infos`].
+  pub fn module_infos(&self) -> rolldown_common::SharedModuleInfoDashMap {
+    self.bundle_factory.module_infos()
+  }
+
   pub fn watch_files(&self) -> &Arc<FxDashSet<ArcStr>> {
     static EMPTY_SET: LazyLock<Arc<FxDashSet<ArcStr>>> =
       LazyLock::new(|| Arc::new(FxDashSet::default()));

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use napi_derive::napi;
 use rolldown_dev::{
   BundleState, OnAdditionalAssetsCallback, OnHmrUpdatesCallback, OnOutputCallback,
@@ -9,6 +10,7 @@ use crate::binding_dev_options::BindingDevOptions;
 use crate::types::binding_bundler_options::BindingBundlerOptions;
 use crate::types::binding_client_hmr_update::BindingClientHmrUpdate;
 use crate::types::binding_error_stage::BindingErrorStage;
+use crate::types::binding_module_info::BindingModuleInfo;
 use crate::types::binding_outputs::{BindingOutputs, to_binding_error};
 use crate::types::error::{BindingErrors, BindingResult};
 use crate::utils::{
@@ -311,6 +313,18 @@ impl BindingDevEngine {
         })
         .map_err(|e| napi::Error::from_reason(format!("Failed to compile lazy entry: {e:#?}")))
     })
+  }
+
+  /// Same data the plugin-context `getModuleInfo` returns, readable from the engine
+  /// handle at any time (no hook context needed).
+  #[napi]
+  pub fn get_module_info(&self, module_id: String) -> Option<BindingModuleInfo> {
+    self.inner.get_module_info(&module_id).map(BindingModuleInfo::new)
+  }
+
+  #[napi]
+  pub fn get_module_ids<'env>(&self, env: &'env Env) -> napi::Result<Vec<napi::JsString<'env>>> {
+    self.inner.get_module_ids().iter().map(|id| env.create_string(id)).try_collect()
   }
 }
 

--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -55,6 +55,10 @@ pub struct DevEngine {
   /// filenames — so two independent counters would let two different payloads
   /// collide on one key.
   next_hmr_patch_id: Arc<AtomicU32>,
+  /// Live handle to the plugin-facing module infos — the same map plugin contexts read.
+  /// Full builds clear it in place (the `Arc` identity is stable), so lock-free reads
+  /// here always observe the latest build. Powers the engine-level module queries.
+  module_infos: rolldown_common::SharedModuleInfoDashMap,
 }
 
 impl DevEngine {
@@ -65,6 +69,7 @@ impl DevEngine {
       .with_plugins(config.plugins)
       .build()?;
 
+    let module_infos = bundler.module_infos();
     let bundler = Arc::new(Mutex::new(bundler));
 
     let normalized_options = normalize_dev_options(options);
@@ -123,7 +128,18 @@ impl DevEngine {
       clients,
       is_closed: AtomicBool::new(false),
       next_hmr_patch_id,
+      module_infos,
     })
+  }
+
+  /// Same data the plugin-context `getModuleInfo` returns, readable from the engine
+  /// handle at any time (no hook context needed).
+  pub fn get_module_info(&self, module_id: &str) -> Option<Arc<rolldown_common::ModuleInfo>> {
+    self.module_infos.get(module_id).map(|entry| Arc::clone(entry.value()))
+  }
+
+  pub fn get_module_ids(&self) -> Vec<arcstr::ArcStr> {
+    self.module_infos.iter().map(|entry| entry.key().clone()).collect()
   }
 
   pub async fn run(&self) -> BuildResult<()> {

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -4,6 +4,7 @@ import {
   BindingDevEngine,
   type BindingDevOptions,
   type BindingLazyChunkOutput,
+  type BindingModuleInfo,
   BindingRebuildStrategy,
   type BindingResult,
   shutdownAsyncRuntime,
@@ -18,10 +19,51 @@ import { normalizedStringOrRegex } from '../../utils/normalize-string-or-regex';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 import type { DevOptions } from './dev-options';
 
+/**
+ * The part of the binding engine the module graph reads from.
+ *
+ * Typed structurally instead of as `BindingDevEngine`: a public constructor
+ * parameter type is emitted into the public dts, and naming the binding class
+ * there would pull the whole binding type chain into the public surface.
+ */
+interface ModuleGraphSource {
+  getModuleInfo(moduleId: string): BindingModuleInfo | null;
+  getModuleIds(): Array<string>;
+}
+
+/** Read-only view over the engine's module graph, kept current across rebuilds. */
+export class DevEngineModuleGraph {
+  #inner: ModuleGraphSource;
+
+  constructor(inner: ModuleGraphSource) {
+    this.#inner = inner;
+  }
+
+  /**
+   * Get additional information about the module in question.
+   *
+   * @returns Module information for that module. `null` if the module could not be found.
+   */
+  getModuleInfo(moduleId: string): BindingModuleInfo | null {
+    return this.#inner.getModuleInfo(moduleId) ?? null;
+  }
+
+  /**
+   * Get all module ids in the current module graph.
+   *
+   * @returns An array of module ids.
+   */
+  getModuleIds(): string[] {
+    return this.#inner.getModuleIds();
+  }
+}
+
 export class DevEngine {
   #inner: BindingDevEngine;
   #cachedBuildFinishPromise: Promise<void> | null = null;
   #asyncRuntimeReleased = false;
+
+  readonly moduleGraph: DevEngineModuleGraph;
 
   static async create(
     inputOptions: InputOptions,
@@ -99,6 +141,7 @@ export class DevEngine {
 
   private constructor(inner: BindingDevEngine) {
     this.#inner = inner;
+    this.moduleGraph = new DevEngineModuleGraph(inner);
   }
 
   async run(): Promise<void> {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1627,6 +1627,12 @@ export declare class BindingDevEngine {
    * actual module and its dependencies.
    */
   compileEntry(moduleId: string, clientId: string): Promise<BindingLazyChunkOutput>
+  /**
+   * Same data the plugin-context `getModuleInfo` returns, readable from the engine
+   * handle at any time (no hook context needed).
+   */
+  getModuleInfo(moduleId: string): BindingModuleInfo | null
+  getModuleIds(): Array<string>
 }
 
 export declare class BindingLoadPluginContext {

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -1627,6 +1627,12 @@ export declare class BindingDevEngine {
    * actual module and its dependencies.
    */
   compileEntry(moduleId: string, clientId: string): Promise<BindingLazyChunkOutput>
+  /**
+   * Same data the plugin-context `getModuleInfo` returns, readable from the engine
+   * handle at any time (no hook context needed).
+   */
+  getModuleInfo(moduleId: string): BindingModuleInfo | null
+  getModuleIds(): Array<string>
 }
 
 export declare class BindingLoadPluginContext {

--- a/packages/rolldown/tests/dev/dev-module-info.test.ts
+++ b/packages/rolldown/tests/dev/dev-module-info.test.ts
@@ -1,0 +1,54 @@
+import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { dev } from 'rolldown/experimental';
+import { expect, test } from 'vitest';
+
+const TEST_TIMEOUT = 60_000;
+
+test(
+  'module queries on the engine handle',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-module-info-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const input = path.join(dir, 'main.js');
+    const dep = path.join(dir, 'dep.js');
+    fs.writeFileSync(input, 'import { value } from "./dep.js";\nconsole.log(value);\n');
+    fs.writeFileSync(dep, 'export const value = 1;\n');
+
+    const engine = await dev(
+      { input, experimental: { devMode: true }, treeshake: false },
+      { dir: path.join(dir, 'dist') },
+      { watch: getDevWatchOptionsForCi() },
+    );
+    onTestFinished(async () => {
+      await engine.close();
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    engine.run().catch(() => {});
+    await engine.ensureCurrentBuildFinish();
+
+    const { moduleGraph } = engine;
+    const ids = moduleGraph.getModuleIds();
+    expect(ids).toContain(input);
+    expect(ids).toContain(dep);
+
+    const info = moduleGraph.getModuleInfo(input);
+    expect(info).not.toBeNull();
+    expect(info!.importedIds).toContain(dep);
+    expect(moduleGraph.getModuleInfo(path.join(dir, 'missing.js'))).toBeNull();
+
+    // The graph stays current across a full rebuild — full builds clear the
+    // shared map in place instead of replacing it.
+    engine.triggerFullBuild();
+    await engine.ensureLatestBuildOutput();
+    expect(moduleGraph.getModuleIds()).toContain(input);
+    expect(moduleGraph.getModuleInfo(dep)).not.toBeNull();
+  },
+);


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

Expose module graph queries on the dev engine handle. 

This removes a [workaround](https://github.com/vitejs/vite/pull/22956/changes#diff-a1c7f1d86f12f79788f6155f2404862627b56592ae8ac8baba6a942a509e0f4bR78-R81
) in Vite's `hotUpdate` hook support. 