### PR TITLE
feat(rolldown_plugin_vite_resolve): add top-level `tsconfig` option

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -22,6 +22,7 @@ use crate::{
 #[derive(Debug)]
 pub struct BindingViteResolvePluginConfig {
   pub resolve_options: BindingViteResolvePluginResolveOptions,
+  pub tsconfig: Option<String>,
   pub environment_consumer: String,
   pub environment_name: String,
   pub builtins: Vec<BindingStringOrRegex>,
@@ -71,6 +72,7 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
 
     Self {
       resolve_options: value.resolve_options.into(),
+      tsconfig: value.tsconfig,
       environment_consumer: value.environment_consumer,
       environment_name: value.environment_name,
       builtins: bindingify_string_or_regex_array(value.builtins),

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -5,7 +5,10 @@ use std::{
   sync::Arc,
 };
 
-use oxc_resolver::{FileSystem as _, FileSystemOs, PackageJson, ResolveOptions, TsconfigDiscovery};
+use oxc_resolver::{
+  FileSystem as _, FileSystemOs, PackageJson, ResolveOptions, TsconfigDiscovery, TsconfigOptions,
+  TsconfigReferences,
+};
 use rolldown_common::side_effects::HookSideEffects;
 use rolldown_plugin::{HookResolveIdOutput, HookResolveIdReturn};
 use rolldown_utils::{dashmap::FxDashSet, url::clean_url};
@@ -33,6 +36,7 @@ pub struct BaseOptions<'a> {
   pub root: PathBuf,
   pub preserve_symlinks: bool,
   pub tsconfig_paths: bool,
+  pub tsconfig: Option<PathBuf>,
   pub yarn_pnp: bool,
 }
 
@@ -180,7 +184,14 @@ fn get_resolve_options(
   let main_fields = base_options.main_fields.clone();
 
   oxc_resolver::ResolveOptions {
-    tsconfig: base_options.tsconfig_paths.then_some(TsconfigDiscovery::Auto),
+    tsconfig: base_options.tsconfig_paths.then(|| {
+      base_options.tsconfig.as_ref().map_or(TsconfigDiscovery::Auto, |config_file| {
+        TsconfigDiscovery::Manual(TsconfigOptions {
+          config_file: config_file.clone(),
+          references: TsconfigReferences::Auto,
+        })
+      })
+    }),
     alias_fields: if base_options.main_fields.iter().any(|field| field == "browser") {
       vec![vec!["browser".to_string()]]
     } else {
@@ -629,7 +640,41 @@ impl ResolverLock {
 
 #[cfg(test)]
 mod tests {
-  use super::get_path_with_prefix;
+  use std::path::PathBuf;
+
+  use oxc_resolver::TsconfigDiscovery;
+
+  use super::{AdditionalOptions, BaseOptions, get_path_with_prefix, get_resolve_options};
+
+  #[test]
+  fn uses_explicit_tsconfig_instead_of_auto_discovery() {
+    let main_fields = Vec::new();
+    let conditions = Vec::new();
+    let extensions = Vec::new();
+    let try_prefix = None;
+    let tsconfig = PathBuf::from("explicit.tsconfig.json");
+    let base_options = BaseOptions {
+      main_fields: &main_fields,
+      conditions: &conditions,
+      extensions: &extensions,
+      is_production: false,
+      try_index: true,
+      try_prefix: &try_prefix,
+      as_src: false,
+      root: PathBuf::new(),
+      preserve_symlinks: false,
+      tsconfig_paths: true,
+      tsconfig: Some(tsconfig.clone()),
+      yarn_pnp: false,
+    };
+
+    let options = get_resolve_options(&base_options, AdditionalOptions::new(false, false));
+
+    let Some(TsconfigDiscovery::Manual(options)) = options.tsconfig else {
+      panic!("expected manual tsconfig discovery");
+    };
+    assert_eq!(options.config_file, tsconfig);
+  }
 
   #[test]
   fn prefixes_bare_deep_imports_with_posix_separators() {
@@ -685,6 +730,7 @@ mod tests {
         root: root.clone(),
         preserve_symlinks: false,
         tsconfig_paths: false,
+        tsconfig: None,
         yarn_pnp: true,
       },
       &Vec::new(),

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -39,6 +39,7 @@ const FS_PREFIX: &str = "/@fs/";
 #[derive(Debug)]
 pub struct ViteResolveOptions {
   pub resolve_options: ViteResolveResolveOptions,
+  pub tsconfig: Option<String>,
   pub environment_consumer: String,
   pub environment_name: String,
   pub builtins: Vec<StringOrRegex>,
@@ -153,6 +154,7 @@ impl ViteResolvePlugin {
       root: PathBuf::from(&options.resolve_options.root),
       preserve_symlinks: options.resolve_options.preserve_symlinks,
       tsconfig_paths: options.resolve_options.tsconfig_paths,
+      tsconfig: options.tsconfig.map(PathBuf::from),
       yarn_pnp: options.yarn_pnp,
     };
     let builtin_checker = Arc::new(BuiltinChecker::new(options.builtins));

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3038,6 +3038,7 @@ export interface BindingViteReporterPluginConfig {
 
 export interface BindingViteResolvePluginConfig {
   resolveOptions: BindingViteResolvePluginResolveOptions
+  tsconfig?: string
   environmentConsumer: string
   environmentName: string
   builtins: Array<BindingStringOrRegex>

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -3038,6 +3038,7 @@ export interface BindingViteReporterPluginConfig {
 
 export interface BindingViteResolvePluginConfig {
   resolveOptions: BindingViteResolvePluginResolveOptions
+  tsconfig?: string
   environmentConsumer: string
   environmentName: string
   builtins: Array<BindingStringOrRegex>


### PR DESCRIPTION
Add `tsconfig` option to rolldown_plugin_vite_resolve so that we can specify the tsconfig file from Vite.

needed for https://github.com/vitejs/vite/pull/23310
