### PR TITLE
feat(rolldown_plugin_vite_transform): add `tsconfig` option

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Default)]
 pub struct BindingViteTransformPluginConfig {
   pub root: String,
+  pub tsconfig: Option<String>,
 
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
@@ -48,7 +49,10 @@ impl From<BindingViteTransformPluginConfig> for ViteTransformPlugin {
         .transform_options
         .map(normalize_binding_transform_options)
         .unwrap_or_default(),
-      resolver: ViteTransformPlugin::new_resolver(value.yarn_pnp.unwrap_or_default()),
+      resolver: ViteTransformPlugin::new_resolver(
+        value.yarn_pnp.unwrap_or_default(),
+        value.tsconfig.map(PathBuf::from),
+      ),
     }
   }
 }

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -27,9 +27,14 @@ pub struct ViteTransformPlugin {
 }
 
 impl ViteTransformPlugin {
-  pub fn new_resolver(yarn_pnp: bool) -> oxc_resolver::Resolver {
+  pub fn new_resolver(yarn_pnp: bool, tsconfig: Option<PathBuf>) -> oxc_resolver::Resolver {
     oxc_resolver::Resolver::new(oxc_resolver::ResolveOptions {
-      tsconfig: Some(oxc_resolver::TsconfigDiscovery::Auto),
+      tsconfig: Some(tsconfig.map_or(oxc_resolver::TsconfigDiscovery::Auto, |config_file| {
+        oxc_resolver::TsconfigDiscovery::Manual(oxc_resolver::TsconfigOptions {
+          config_file,
+          references: oxc_resolver::TsconfigReferences::Auto,
+        })
+      })),
       yarn_pnp,
       ..Default::default()
     })

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3075,6 +3075,7 @@ export interface BindingViteResolvePluginResolveOptions {
 
 export interface BindingViteTransformPluginConfig {
   root: string
+  tsconfig?: string
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   jsxRefreshInclude?: Array<BindingStringOrRegex>

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -3075,6 +3075,7 @@ export interface BindingViteResolvePluginResolveOptions {
 
 export interface BindingViteTransformPluginConfig {
   root: string
+  tsconfig?: string
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   jsxRefreshInclude?: Array<BindingStringOrRegex>


### PR DESCRIPTION
Add `tsconfig` option to rolldown_plugin_vite_transform so that we can specify the tsconfig file from Vite.

needed for https://github.com/vitejs/vite/pull/23310
