### PR TITLE
fix: clear resolution cache when `TsconfigCache::clear` is called

### DIFF
--- a/crates/rolldown_binding/src/transform_cache.rs
+++ b/crates/rolldown_binding/src/transform_cache.rs
@@ -34,6 +34,7 @@ impl TsconfigCache {
   /// Call this when tsconfig files have changed to ensure fresh resolution.
   #[napi]
   pub fn clear(&self) {
+    self.resolver.clear_cache();
     self.cache.clear();
   }
 

--- a/packages/rolldown/tests/utils/fixtures/cache-clear/source.ts
+++ b/packages/rolldown/tests/utils/fixtures/cache-clear/source.ts
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/packages/rolldown/tests/utils/fixtures/cache-clear/tsconfig.json
+++ b/packages/rolldown/tests/utils/fixtures/cache-clear/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "useDefineForClassFields": false
+  }
+}

--- a/packages/rolldown/tests/utils/resolve-tsconfig.test.ts
+++ b/packages/rolldown/tests/utils/resolve-tsconfig.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import fs from 'node:fs';
 import { resolveTsconfig } from 'rolldown/experimental';
 import { TsconfigCache } from 'rolldown/utils';
 import { expect, describe, it } from 'vitest';
@@ -35,6 +36,32 @@ describe('resolveTsconfig', () => {
     expect(result1!.tsconfig.compilerOptions.useDefineForClassFields).toBe(
       result2!.tsconfig.compilerOptions.useDefineForClassFields,
     );
+  });
+
+  it('should reload a tsconfig after clearing the cache', () => {
+    const fixture = path.join(fixtures, 'cache-clear');
+    const tsconfig = path.join(fixture, 'tsconfig.json');
+    const source = path.join(fixture, 'source.ts');
+    const originalTsconfig = fs.readFileSync(tsconfig, 'utf8');
+
+    try {
+      const cache = new TsconfigCache();
+      expect(resolveTsconfig(source, cache)!.tsconfig.compilerOptions.useDefineForClassFields).toBe(
+        false,
+      );
+
+      fs.writeFileSync(
+        tsconfig,
+        JSON.stringify({ compilerOptions: { useDefineForClassFields: true } }),
+      );
+      cache.clear();
+
+      expect(resolveTsconfig(source, cache)!.tsconfig.compilerOptions.useDefineForClassFields).toBe(
+        true,
+      );
+    } finally {
+      fs.writeFileSync(tsconfig, originalTsconfig);
+    }
   });
 
   it('should resolve extended tsconfig options', () => {


### PR DESCRIPTION
This clear call was missing.