### PR TITLE
feat: add `tsconfig: string` option to `transform`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_transform_options.rs
+++ b/crates/rolldown_binding/src/options/binding_transform_options.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use napi::Either;
+use napi::{Either, bindgen_prelude::Either3};
 use napi_derive::napi;
 use oxc_napi::get_source_type;
 use oxc_sourcemap::napi::SourceMap;
@@ -171,8 +171,9 @@ pub struct BindingEnhancedTransformOptions {
   // --- Enhanced options ---
   /// Configure tsconfig handling.
   /// - true: Auto-discover and load the nearest tsconfig.json
+  /// - string: Use the tsconfig at the provided path
   /// - TsconfigRawOptions: Use the provided inline tsconfig options
-  pub tsconfig: Option<Either<bool, BindingTsconfigRawOptions>>,
+  pub tsconfig: Option<Either3<bool, String, BindingTsconfigRawOptions>>,
   /// An input source map to collapse with the output source map.
   pub input_map: Option<SourceMap>,
 }
@@ -283,9 +284,10 @@ impl BindingEnhancedTransformOptions {
     let source_type =
       Some(get_source_type(filename, self.lang.as_deref(), self.source_type.as_deref()));
     let tsconfig = match &self.tsconfig {
-      Some(Either::A(true)) => Some(TsconfigOption::Auto),
-      Some(Either::A(false)) => Some(TsconfigOption::Disabled),
-      Some(Either::B(raw)) => Some(TsconfigOption::Config(Arc::new(raw.into()))),
+      Some(Either3::A(true)) => Some(TsconfigOption::Auto),
+      Some(Either3::A(false)) => Some(TsconfigOption::Disabled),
+      Some(Either3::B(path)) => Some(TsconfigOption::Path(PathBuf::from(path))),
+      Some(Either3::C(raw)) => Some(TsconfigOption::Config(Arc::new(raw.into()))),
       None => None,
     };
     let sourcemap = self.sourcemap.unwrap_or(false);

--- a/crates/rolldown_binding/src/transform.rs
+++ b/crates/rolldown_binding/src/transform.rs
@@ -23,7 +23,7 @@ fn resolve_tsconfig_from_cache(
   let Some(tsconfig_cache) = cache else {
     return Ok(());
   };
-  if !matches!(options.tsconfig, Some(TsconfigOption::Auto) | None) {
+  if matches!(options.tsconfig, Some(TsconfigOption::Config(_) | TsconfigOption::Disabled)) {
     return Ok(());
   }
 
@@ -120,7 +120,8 @@ pub fn resolve_tsconfig(
   cache: Option<&TsconfigCache>,
   yarn_pnp: bool,
 ) -> napi::Result<Option<BindingTsconfigResult>> {
-  let tsconfig_cache = if let Some(cache) = cache { cache } else { &TsconfigCache::new(yarn_pnp) };
+  let tsconfig_cache =
+    if let Some(cache) = cache { cache } else { &TsconfigCache::new(yarn_pnp, None) };
 
   match tsconfig_cache.find_tsconfig(Path::new(&filename)) {
     Ok(Some(tsconfig)) => Ok(Some(tsconfig.as_ref().clone().into())),

--- a/crates/rolldown_binding/src/transform_cache.rs
+++ b/crates/rolldown_binding/src/transform_cache.rs
@@ -5,7 +5,10 @@ use std::{
 
 use dashmap::Entry;
 use napi_derive::napi;
-use oxc_resolver::{ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigDiscovery};
+use oxc_resolver::{
+  ResolveError, ResolveOptions, Resolver, TsConfig, TsconfigDiscovery, TsconfigOptions,
+  TsconfigReferences,
+};
 use rolldown_utils::dashmap::FxDashMap;
 
 #[napi]
@@ -16,12 +19,17 @@ pub struct TsconfigCache {
 
 #[napi]
 impl TsconfigCache {
-  /// Create a new transform cache with auto tsconfig discovery enabled.
+  /// Create a new transform cache with auto or manual tsconfig discovery enabled.
   #[napi(constructor)]
-  pub fn new(yarn_pnp: bool) -> Self {
+  pub fn new(yarn_pnp: bool, path_to_tsconfig: Option<String>) -> Self {
     Self {
       resolver: Arc::new(Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigDiscovery::Auto),
+        tsconfig: Some(path_to_tsconfig.map_or(TsconfigDiscovery::Auto, |config_file| {
+          TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: PathBuf::from(config_file),
+            references: TsconfigReferences::Auto,
+          })
+        })),
         yarn_pnp,
         ..Default::default()
       })),
@@ -79,13 +87,13 @@ mod tests {
 
   #[test]
   fn test_cache_creation() {
-    let cache = TsconfigCache::new(false);
+    let cache = TsconfigCache::new(false, None);
     assert_eq!(cache.size(), 0);
   }
 
   #[test]
   fn test_cache_clear() {
-    let cache = TsconfigCache::new(false);
+    let cache = TsconfigCache::new(false, None);
     cache.clear();
     assert_eq!(cache.size(), 0);
   }

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -42,6 +42,8 @@ pub type InjectOptions = Vec<(String, Either<String, Vec<String>>)>;
 pub enum TsconfigOption {
   /// Auto-discover tsconfig.json by walking up from the file's directory.
   Auto,
+  /// Use the tsconfig at the provided path.
+  Path(PathBuf),
   /// Use the provided tsconfig directly.
   Config(Arc<TsConfig>),
   /// Don't use tsconfig options.
@@ -276,6 +278,29 @@ pub fn enhanced_transform(
       let file_path = PathBuf::from(filename);
       let result = oxc_resolver::Resolver::new(oxc_resolver::ResolveOptions {
         tsconfig: Some(oxc_resolver::TsconfigDiscovery::Auto),
+        yarn_pnp,
+        ..Default::default()
+      })
+      .find_tsconfig(file_path);
+      let found = match result {
+        Ok(found) => found,
+        Err(err) => {
+          errors.push(BuildDiagnostic::tsconfig_error(err));
+          return EnhancedTransformResult::new_for_error(errors, warnings, tsconfig_file_paths);
+        }
+      };
+      if let Some(tsconfig) = &found {
+        tsconfig_file_paths.push(tsconfig.path.clone());
+      }
+      found
+    }
+    Some(TsconfigOption::Path(config_file)) => {
+      let file_path = PathBuf::from(filename);
+      let result = oxc_resolver::Resolver::new(oxc_resolver::ResolveOptions {
+        tsconfig: Some(oxc_resolver::TsconfigDiscovery::Manual(oxc_resolver::TsconfigOptions {
+          config_file: config_file.clone(),
+          references: oxc_resolver::TsconfigReferences::Auto,
+        })),
         yarn_pnp,
         ..Default::default()
       })

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1916,8 +1916,8 @@ export declare class TraceSubscriberGuard {
 }
 
 export declare class TsconfigCache {
-  /** Create a new transform cache with auto tsconfig discovery enabled. */
-  constructor(yarnPnp: boolean)
+  /** Create a new transform cache with auto or manual tsconfig discovery enabled. */
+  constructor(yarnPnp: boolean, pathToTsconfig?: string | undefined | null)
   /**
    * Clear the cache.
    *
@@ -2198,9 +2198,10 @@ export interface BindingEnhancedTransformOptions {
   /**
    * Configure tsconfig handling.
    * - true: Auto-discover and load the nearest tsconfig.json
+   * - string: Use the tsconfig at the provided path
    * - TsconfigRawOptions: Use the provided inline tsconfig options
    */
-  tsconfig?: boolean | BindingTsconfigRawOptions
+  tsconfig?: boolean | string | BindingTsconfigRawOptions
   /** An input source map to collapse with the output source map. */
   inputMap?: SourceMap
 }

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -1916,8 +1916,8 @@ export declare class TraceSubscriberGuard {
 }
 
 export declare class TsconfigCache {
-  /** Create a new transform cache with auto tsconfig discovery enabled. */
-  constructor(yarnPnp: boolean)
+  /** Create a new transform cache with auto or manual tsconfig discovery enabled. */
+  constructor(yarnPnp: boolean, pathToTsconfig?: string | undefined | null)
   /**
    * Clear the cache.
    *
@@ -2198,9 +2198,10 @@ export interface BindingEnhancedTransformOptions {
   /**
    * Configure tsconfig handling.
    * - true: Auto-discover and load the nearest tsconfig.json
+   * - string: Use the tsconfig at the provided path
    * - TsconfigRawOptions: Use the provided inline tsconfig options
    */
-  tsconfig?: boolean | BindingTsconfigRawOptions
+  tsconfig?: boolean | string | BindingTsconfigRawOptions
   /** An input source map to collapse with the output source map. */
   inputMap?: SourceMap
 }

--- a/packages/rolldown/src/utils/resolve-tsconfig.ts
+++ b/packages/rolldown/src/utils/resolve-tsconfig.ts
@@ -13,13 +13,15 @@ const yarnPnp = typeof process === 'object' && !!process.versions?.pnp;
  * The cache stores resolved tsconfig configurations keyed by their file paths.
  * When transforming multiple files in the same project, tsconfig lookups are
  * deduplicated, improving performance.
+ * Pass a tsconfig path to use that configuration for every lookup. When the
+ * path is omitted, the nearest tsconfig is discovered automatically.
  *
  * @category Utilities
  * @experimental
  */
 export class TsconfigCache extends OriginalTsconfigCache {
-  constructor() {
-    super(yarnPnp);
+  constructor(pathToTsconfig?: string) {
+    super(yarnPnp, pathToTsconfig);
   }
 }
 

--- a/packages/rolldown/src/utils/transform.ts
+++ b/packages/rolldown/src/utils/transform.ts
@@ -57,7 +57,8 @@ function normalizeBindingWarning(warning: BindingEnhancedTransformResult['warnin
  * @param sourceText The source code to transform.
  * @param options The transform options including tsconfig and inputMap. See {@linkcode TransformOptions} for more information.
  * @param cache Optional tsconfig cache for reusing resolved tsconfig across multiple transforms.
- * Only used when `options.tsconfig` is `true`.
+ * Used when `options.tsconfig` is `true` or a path. For a path, construct the
+ * cache with the same path.
  *
  * @returns a promise that resolves to an object containing the transformed code,
  * source maps, and any errors that occurred during parsing or transformation.
@@ -87,7 +88,8 @@ export async function transform(
  * @param sourceText The source code to transform.
  * @param options The transform options including tsconfig and inputMap. See {@linkcode TransformOptions} for more information.
  * @param cache Optional tsconfig cache for reusing resolved tsconfig across multiple transforms.
- * Only used when `options.tsconfig` is `true`.
+ * Used when `options.tsconfig` is `true` or a path. For a path, construct the
+ * cache with the same path.
  *
  * @returns an object containing the transformed code, source maps, and any errors
  * that occurred during parsing or transformation.

--- a/packages/rolldown/tests/utils/resolve-tsconfig.test.ts
+++ b/packages/rolldown/tests/utils/resolve-tsconfig.test.ts
@@ -38,6 +38,16 @@ describe('resolveTsconfig', () => {
     );
   });
 
+  it('should use an explicit tsconfig with TsconfigCache', () => {
+    const explicitTsconfig = path.join(fixtures, 'extends', 'tsconfig.json');
+    const cache = new TsconfigCache(explicitTsconfig);
+    const result = resolveTsconfig(path.join(fixtures, 'test1.ts'), cache);
+
+    expect(result).not.toBeNull();
+    expect(result!.tsconfig.compilerOptions.experimentalDecorators).toBe(true);
+    expect(result!.tsconfigFilePaths[0]).toBe(explicitTsconfig);
+  });
+
   it('should reload a tsconfig after clearing the cache', () => {
     const fixture = path.join(fixtures, 'cache-clear');
     const tsconfig = path.join(fixture, 'tsconfig.json');
@@ -45,7 +55,7 @@ describe('resolveTsconfig', () => {
     const originalTsconfig = fs.readFileSync(tsconfig, 'utf8');
 
     try {
-      const cache = new TsconfigCache();
+      const cache = new TsconfigCache(tsconfig);
       expect(resolveTsconfig(source, cache)!.tsconfig.compilerOptions.useDefineForClassFields).toBe(
         false,
       );

--- a/packages/rolldown/tests/utils/transform.test.ts
+++ b/packages/rolldown/tests/utils/transform.test.ts
@@ -173,6 +173,26 @@ describe('enhanced transform', () => {
   describe('tsconfig - auto-discovery', () => {
     const fixtures = path.join(import.meta.dirname, 'fixtures');
 
+    it('should use a tsconfig path', () => {
+      const filename = '/nonexistent/path/test.ts';
+      const code = `class Foo { bar = 'bar' }`;
+      const explicitTsconfig = path.join(fixtures, 'tsconfig.json');
+      const expected = transformSync(filename, code, {
+        target: 'esnext',
+        tsconfig: {
+          compilerOptions: { useDefineForClassFields: false },
+        },
+      });
+      const result = transformSync(filename, code, {
+        target: 'esnext',
+        tsconfig: explicitTsconfig,
+      });
+
+      expect(result.code).toBe(expected.code);
+      expect(result.errors).toHaveLength(0);
+      expect(result.tsconfigFilePaths).toStrictEqual([explicitTsconfig]);
+    });
+
     it('should auto-discover tsconfig by default (no tsconfig option)', async () => {
       const result = await transform(
         path.join(fixtures, 'test1.ts'),


### PR DESCRIPTION
Add `tsconfig` option to `transform` function exposed from `rolldown/utils` so that we can specify the tsconfig file from Vite.

needed for https://github.com/vitejs/vite/pull/23310
