### PR TITLE
perf: reduce release debug formatting

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -826,8 +826,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   fn resolve_symbol_from_reference(&self, id_ref: &IdentifierReference) -> Option<SymbolId> {
     let ref_id = id_ref.reference_id.get().unwrap_or_else(|| {
       panic!(
-        "{id_ref:#?} must have reference id in code```\n{}\n```\n",
-        self.current_stmt_info.unwrap_debug_label()
+        "Identifier `{}` at {}..{} must have a reference id",
+        id_ref.name, id_ref.span.start, id_ref.span.end
       )
     });
     self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id)

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -267,8 +267,8 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             &self.ast_builder,
           ));
         }
-        unhandled_kind => {
-          unreachable!("Unexpected export default declaration kind: {unhandled_kind:#?}");
+        _ => {
+          unreachable!("Unexpected export default declaration kind");
         }
       },
       ast::Statement::ExportAllDeclaration(export_all_decl) => {

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use arcstr::ArcStr;
+use itertools::Itertools;
 use oxc::ast::builder::AstBuilder;
 use oxc_traverse::traverse_mut;
 use rolldown_common::{
@@ -101,9 +102,12 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     last_build_errored: bool,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     tracing::trace!(
-      "[HmrStage] starts computing HMR updates\n - changed_file_paths: {:#?}\n - clients: {:#?}",
-      changed_file_paths,
-      clients.iter().map(|c| c.client_id).collect::<Vec<_>>(),
+      changed_files = %changed_file_paths
+        .iter()
+        .map(|(path, kind)| format!("{path}:{kind}"))
+        .join(", "),
+      clients = %clients.iter().map(|client| client.client_id).join(", "),
+      "[HmrStage] starts computing HMR updates"
     );
 
     // 1. Identify changed modules — per changed file: compute the default affected set, then (if
@@ -196,11 +200,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     }
 
     tracing::trace!(
-      "[HmrStage] map changed file paths to module idxs\n - changed_modules: {:#?}",
-      changed_modules
+      changed_modules = %changed_modules
         .iter()
         .map(|module_idx| self.module_table().modules[*module_idx].stable_id())
-        .collect::<Vec<_>>(),
+        .join(", "),
+      "[HmrStage] mapped changed file paths to modules"
     );
 
     // Files re-queued by an earlier failed scan (`pending_rescans`) get
@@ -307,11 +311,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
 
       tracing::debug!(
         target: "hmr",
-        "New added modules: {:?}",
-        new_added_modules
+        new_modules = %new_added_modules
           .iter()
           .map(|module_idx| module_loader_output.module_table.get(*module_idx).stable_id())
-          .collect::<Vec<_>>(),
+          .join(", "),
+        "added modules"
       );
 
       let plugin_driver = Arc::clone(&self.plugin_driver);
@@ -351,11 +355,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
     if !output_unchanged_modules.is_empty() {
       tracing::debug!(
         target: "hmr",
-        "skip modules whose rebuilt output is unchanged: {:?}",
-        output_unchanged_modules
+        unchanged_modules = %output_unchanged_modules
           .iter()
           .map(|module_idx| self.module_table().modules[*module_idx].stable_id())
-          .collect::<Vec<_>>(),
+          .join(", "),
+        "skip modules whose rebuilt output is unchanged"
       );
       changed_modules.retain(|module_idx| !output_unchanged_modules.contains(module_idx));
     }
@@ -511,7 +515,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
   ) -> BuildResult<HmrLazyChunkOutput> {
     tracing::debug!(
       target: "hmr",
-      "compile_lazy_entry: module_id: {:?}",
+      "compile_lazy_entry: module_id: {}",
       module_id,
     );
 

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -593,7 +593,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             // Scoped symbols don't get assigned a `ChunkIdx`. There are skipped for performance reason, because they are surely
             // belong to the chunk they are declared in and won't link to other chunks.
             let symbol_name = canonical_ref.name(self.ctx.symbol_db);
-            panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected");
+            let module_id = self.ctx.modules[canonical_ref.owner].stable_id();
+            panic!(
+              "Symbol `{symbol_name}` in module `{module_id}` is not in any chunk, which is unexpected"
+            );
           });
           let cur_chunk_idx = self.ctx.chunk_graph.module_to_chunk[self.ctx.idx]
             .expect("This module should be in a chunk");
@@ -2550,9 +2553,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           } else if let Some(targets) = consumer_local_targets {
             let Some(ns_name) = namespace_export_name else {
               tracing::warn!(
-                "Consumer-local dynamic entry {:?} in chunk {:?} has no namespace export.",
-                importee_idx,
-                importee_chunk_idx
+                module = %importee.stable_id,
+                chunk = importee_chunk_idx.index(),
+                "Consumer-local dynamic entry has no namespace export."
               );
               return None;
             };
@@ -2565,9 +2568,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 .and_then(|names| names.first())
               else {
                 tracing::warn!(
-                  "Consumer-local dynamic entry {:?} in chunk {:?} is missing an init-target export.",
-                  importee_idx,
-                  importee_chunk_idx
+                  module = %importee.stable_id,
+                  chunk = importee_chunk_idx.index(),
+                  "Consumer-local dynamic entry is missing an init-target export."
                 );
                 return None;
               };
@@ -2592,9 +2595,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               Some(Expression::CallExpression(call_expr))
             } else {
               tracing::warn!(
-                "ESM wrapped module {:?} in chunk {:?} has wrapper but no namespace export.",
-                importee_idx,
-                importee_chunk_idx
+                module = %importee.stable_id,
+                chunk = importee_chunk_idx.index(),
+                "ESM wrapped module has wrapper but no namespace export."
               );
               None
             }
@@ -2605,11 +2608,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         }
         None => {
           tracing::warn!(
-            "Merged dynamic entry module {:?} in chunk {:?} has no export name in exports_to_other_chunks. \
+            module = %importee.stable_id,
+            chunk = importee_chunk_idx.index(),
+            "Merged dynamic entry module has no export name in exports_to_other_chunks. \
             This indicates an inconsistent state in the chunk graph where the module is marked as merged \
-            but its namespace export is not properly tracked.",
-            importee_idx,
-            importee_chunk_idx
+            but its namespace export is not properly tracked."
           );
           None
         }

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -35,7 +35,7 @@ impl<Fs: FileSystem> ExternalModuleTask<Fs> {
     Self { ctx, module_idx: idx, resolved_id, user_defined_entries }
   }
 
-  #[tracing::instrument(name="ExternalModuleTask::run", level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
+  #[tracing::instrument(name="ExternalModuleTask::run", level = "trace", skip_all, fields(module_id = %self.resolved_id.id))]
   pub async fn run(self) {
     if let Err(errs) = self.run_inner().await {
       self

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -897,7 +897,11 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
     // if it is in incremental mode, we skip the runtime module, since it is always there
     // so use a dummy runtime_brief as a placeholder
     let runtime = if self.is_full_scan {
-      tracing::debug!("changed_resolved_ids: {fetch_mode:#?}");
+      tracing::debug!(
+        scan_mode = if fetch_mode.is_full() { "full" } else { "partial" },
+        changed_resolved_ids = %changed_resolved_ids.iter().map(|id| &id.id).join(", "),
+        "module fetch completed"
+      );
       runtime_brief.expect("Failed to find runtime module. This should not happen")
     } else {
       RuntimeModuleBrief::dummy()

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -76,7 +76,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
     }
   }
 
-  #[tracing::instrument(name="NormalModuleTask::run", level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
+  #[tracing::instrument(name="NormalModuleTask::run", level = "trace", skip_all, fields(module_id = %self.resolved_id.id))]
   pub async fn run(mut self) {
     if let Err(errs) = self.run_inner().await {
       self.ctx.plugin_driver.mark_context_load_modules_loaded(self.resolved_id.id.clone());
@@ -315,7 +315,7 @@ impl<Fs: FileSystem + Clone + 'static> ModuleTask<Fs> {
       // e.g.
       // sass -> recommended npm install `sass` etc
       Err(anyhow::anyhow!(
-        "`{:?}` is not specified module type,  rolldown can't handle this asset correctly. Please use the load/transform hook to transform the resource",
+        "`{}` is not specified module type,  rolldown can't handle this asset correctly. Please use the load/transform hook to transform the resource",
         self.resolved_id.id
       ))?;
     }

--- a/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
@@ -78,10 +78,12 @@ impl ChunkDebugExt for Chunk {
         entry_module_id: debug_id,
         name: entry_point_name,
       } => {
+        let entry_point_name =
+          entry_point_name.map_or("<none>", |name| name.as_str()).escape_debug();
         if is_user_defined_entry {
-          format!("User-defined Entry: [Entry-Module-Id: {debug_id}] [Name: {entry_point_name:?}]")
+          format!("User-defined Entry: [Entry-Module-Id: {debug_id}] [Name: {entry_point_name}]")
         } else {
-          format!("Dynamic Entry: [Entry-Module-Id: {debug_id}] [Name: {entry_point_name:?}]")
+          format!("Dynamic Entry: [Entry-Module-Id: {debug_id}] [Name: {entry_point_name}]")
         }
       }
       ChunkCreationReason::CommonChunk { bits, link_output } => {

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -1462,7 +1462,7 @@ impl GenerateStage<'_> {
               let symbol_owner = &self.link_output.module_table[import_ref.owner];
               let symbol_name = import_ref.name(&self.link_output.symbol_db);
               panic!(
-                "Symbol {:?} in {:?} should belong to a chunk",
+                "Symbol `{}` in `{}` should belong to a chunk",
                 symbol_name,
                 symbol_owner.id().as_str()
               )

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -119,6 +119,17 @@ pub enum MatchImportKind {
 }
 
 impl MatchImportKind {
+  fn kind_name(&self) -> &'static str {
+    match self {
+      Self::Normal(_) => "normal",
+      Self::Namespace { .. } => "namespace",
+      Self::NormalAndNamespace { .. } => "normal-and-namespace",
+      Self::Cycle { .. } => "cycle",
+      Self::Ambiguous { .. } => "ambiguous",
+      Self::NoMatch => "no-match",
+    }
+  }
+
   /// The symbol a resolution binds to, if it has one. Used to describe a resolution when reporting
   /// an ambiguous export.
   fn bound_symbol(&self) -> Option<SymbolRef> {
@@ -160,6 +171,21 @@ pub enum ImportStatus {
 
   /// The imported file is external and has unknown exports
   External(SymbolRef),
+}
+
+impl ImportStatus {
+  fn kind_name(&self) -> &'static str {
+    match self {
+      Self::NoMatch => "no-match",
+      Self::Found { .. } => "found",
+      Self::CommonJS => "commonjs",
+      Self::DynamicFallback { .. } => "dynamic-fallback",
+      Self::DynamicFallbackWithCommonjsReference { .. } => {
+        "dynamic-fallback-with-commonjs-reference"
+      }
+      Self::External(_) => "external",
+    }
+  }
 }
 
 impl LinkStage<'_> {
@@ -1192,7 +1218,7 @@ impl BindImportsAndExportsContext<'_> {
         },
       );
 
-      tracing::trace!("Got match result {:?}", ret);
+      tracing::trace!(result = ret.kind_name(), "matched import with export");
       match ret {
         MatchImportKind::Cycle { importer, imported } => {
           self.diagnostics.push(BuildDiagnostic::circular_reexport(
@@ -1459,7 +1485,7 @@ impl BindImportsAndExportsContext<'_> {
       }
       ctx.tracker_stack.push(tracker.clone());
       let import_status = self.advance_import_tracker(ctx);
-      tracing::trace!("Got import_status {:?}", import_status);
+      tracing::trace!(status = import_status.kind_name(), "advanced import tracker");
       let importer = &self.index_modules[tracker.importer];
       let named_import = &importer.as_normal().unwrap().named_imports[&tracker.imported_as];
       let importer_record = &importer.as_normal().unwrap().import_records[named_import.record_idx];
@@ -1590,8 +1616,11 @@ impl BindImportsAndExportsContext<'_> {
       break kind;
     };
 
-    tracing::trace!("ambiguous_results {:#?}", ambiguous_results);
-    tracing::trace!("ret {:#?}", ret);
+    tracing::trace!(
+      ambiguous_results = ambiguous_results.len(),
+      result = ret.kind_name(),
+      "matched import with export"
+    );
     let (ret, deduped_ambiguous_results, promoted) =
       Self::promote_first_surviving_star_branch(ret, ambiguous_results);
 

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -247,7 +247,12 @@ impl<'a> LinkStage<'a> {
     self.include_statements(&unreachable_import_expression_node_ids);
     self.patch_module_dependencies();
 
-    tracing::trace!("meta {:#?}", self.metas.iter_enumerated().collect::<Vec<_>>());
+    tracing::trace!(
+      modules = self.metas.len(),
+      included_modules = self.metas.iter().filter(|meta| meta.is_included).count(),
+      resolved_exports = self.metas.iter().map(|meta| meta.resolved_exports.len()).sum::<usize>(),
+      "link metadata ready"
+    );
 
     (
       LinkStageOutput {

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -477,18 +477,10 @@ impl LinkStage<'_> {
     }
 
     tracing::trace!(
-      "included statements {:#?}",
-      self
-        .module_table
-        .modules
-        .iter()
-        .filter_map(Module::as_normal)
-        .map(|m| m.to_debug_normal_module_for_tree_shaking(
-          &self.stmt_infos[m.idx],
-          self.metas[m.idx].is_included,
-          &self.metas[m.idx].stmt_info_included
-        ))
-        .collect::<Vec<_>>()
+      included_modules = self.metas.iter().filter(|meta| meta.is_included).count(),
+      included_statements =
+        self.metas.iter().map(|meta| meta.stmt_info_included.bit_count()).sum::<u32>(),
+      "tree shaking inclusion ready"
     );
   }
 }
@@ -641,9 +633,13 @@ fn include_side_effectful_dependencies(ctx: &mut IncludeContext, module: &Normal
     }
   });
   tracing::trace!(
-    "{}:\n module_meta dependencies: {:#?}",
-    module.stable_id,
-    module_meta.dependencies.iter().map(|idx| { ctx.modules[*idx].id().to_string() }).collect_vec()
+    module = %module.stable_id,
+    dependencies = %module_meta
+      .dependencies
+      .iter()
+      .map(|idx| ctx.modules[*idx].id())
+      .join(", "),
+    "module dependencies"
   );
 }
 

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -95,7 +95,10 @@ impl GenerateContext<'_> {
           // Scoped symbols don't get assigned a `ChunkIdx`. There are skipped for performance reason, because they are surely
           // belong to the chunk they are declared in and won't link to other chunks.
           let symbol_name = canonical_ref.name(symbol_db);
-          panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which is unexpected");
+          let module_id = self.link_output.module_table[canonical_ref.owner].stable_id();
+          panic!(
+            "Symbol `{symbol_name}` in module `{module_id}` is not in any chunk, which is unexpected"
+          );
         });
 
         let is_symbol_in_other_chunk = cur_chunk_idx != chunk_idx_of_canonical_symbol;

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: entry-a]
 import "./vendor.js";
 
 ```
@@ -14,7 +14,7 @@ import "./vendor.js";
 ## entry-b.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: entry-b]
 import "./vendor.js";
 
 ```
@@ -22,7 +22,7 @@ import "./vendor.js";
 ## entry-c.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: entry-c]
 import "./vendor.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: entry-a]
 import "./vendor~entry-a~entry-b~entry-c.js";
 import "./vendor~entry-a~entry-b.js";
 import "./vendor~entry-a.js";
@@ -16,7 +16,7 @@ import "./vendor~entry-a.js";
 ## entry-b.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: entry-b]
 import "./vendor~entry-a~entry-b~entry-c.js";
 import "./vendor~entry-a~entry-b.js";
 
@@ -25,7 +25,7 @@ import "./vendor~entry-a~entry-b.js";
 ## entry-c.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: entry-c]
 import "./vendor~entry-a~entry-b~entry-c.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: entry-a]
 import "./utils~entry-a~entry-b.js";
 //#region utils/debounce.js
 console.log("debounce");
@@ -17,7 +17,7 @@ console.log("debounce");
 ## entry-b.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: entry-b]
 import "./utils~entry-a~entry-b.js";
 import "./utils~entry-b~entry-c.js";
 
@@ -26,7 +26,7 @@ import "./utils~entry-b~entry-c.js";
 ## entry-c.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: entry-c]
 import "./utils~entry-b~entry-c.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-a.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: entry-a]
 import "./vendor~entry-a~entry-b~entry-c.js";
 import "./vendor~entry-a~entry-b.js";
 import "./vendor~entry-a.js";
@@ -16,7 +16,7 @@ import "./vendor~entry-a.js";
 ## entry-b.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: entry-b]
 import "./vendor~entry-a~entry-b~entry-c.js";
 import "./vendor~entry-a~entry-b.js";
 
@@ -25,7 +25,7 @@ import "./vendor~entry-a~entry-b.js";
 ## entry-c.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: entry-c]
 import "./vendor~entry-a~entry-b~entry-c.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import "./vendor-similarity.js";
 import "./vendor-similarity2.js";
 //#region src/app-shell.js

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
@@ -22,7 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 //! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-a.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
 //! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-b.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
 // HIDDEN [\0rolldown/runtime.js]
@@ -49,7 +49,7 @@ console.log(a, b);
 ### dynamic-a.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: dynamic-a.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: dynamic-a.js] [Name: <none>]
 import { t as a } from "./dynamic-a2.js";
 export { a };
 
@@ -69,7 +69,7 @@ export { a as t };
 ### dynamic-b.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: dynamic-b.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: dynamic-b.js] [Name: <none>]
 import { t as b } from "./dynamic-b2.js";
 export { b };
 
@@ -89,7 +89,7 @@ export { b as t };
 ### main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import { t as a } from "./dynamic-a2.js";
 import { t as b } from "./dynamic-b2.js";
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry\nconsole.log(\"injected\")",
+        "import": "./main.js"
+      }
+    ],
+    "entryFilenames": "entry.js",
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: entry\nconsole.log(\"injected\")]
+//#region main.js
+console.log("main");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/escape_entry_name/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## A.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("A")]
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: A]
 import "./shared.js";
 import "./Splitted.js";
 //#region entry-a.js
@@ -19,7 +19,7 @@ import("./dyn-entry.js").then(console.log);
 ## B.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("B")]
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: B]
 import "./shared.js";
 import "./Splitted.js";
 //#region entry-b.js
@@ -41,7 +41,7 @@ console.log("share-splitted");
 ## dyn-entry.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: dyn-entry.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: dyn-entry.js] [Name: <none>]
 import "./shared.js";
 //#region dyn-entry.js
 console.log("dyn-entry");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_dynamic_entry_external_star_keeps_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_dynamic_entry_external_star_keeps_facade/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region main.js
@@ -79,7 +79,7 @@ Object.defineProperty(exports, "__esmMin", {
 ## target.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 //! Common Chunk: [Shared-By: target.js]
 const require_reader = require("./reader.js");
 const require_rolldown_runtime = require("./rolldown-runtime.js");
@@ -112,7 +112,7 @@ Object.defineProperty(exports, "x", {
 ## target2.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 const require_target = require("./target.js");
 require_target.init_target();
 exports.x = require_target.x;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_dynamic_entry_transitive_external_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/cjs_dynamic_entry_transitive_external_star/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const require_rolldown_runtime = require("./rolldown-runtime.js");
 //#region main.js
@@ -115,7 +115,7 @@ Object.defineProperty(exports, "__reExport", {
 ## target.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 //! Common Chunk: [Shared-By: target.js]
 const require_reader = require("./reader.js");
 const require_rolldown_runtime = require("./rolldown-runtime.js");
@@ -154,7 +154,7 @@ Object.defineProperty(exports, "x", {
 ## target2.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 const require_target = require("./target.js");
 require_target.init_target();
 exports.x = require_target.x;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_dynamic_entry_external_star_keeps_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_dynamic_entry_external_star_keeps_facade/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var loaded;
@@ -62,7 +62,7 @@ export { __esmMin as t };
 ## target.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 //! Common Chunk: [Shared-By: target.js]
 import { n as read, t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
@@ -84,7 +84,7 @@ export { x as n, init_target as t };
 ## target2.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 import { n as x, t as init_target } from "./target.js";
 export * from "external";
 init_target();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_dynamic_entry_transitive_external_star_keeps_facade/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esm_dynamic_entry_transitive_external_star_keeps_facade/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import { t as __esmMin } from "./rolldown-runtime.js";
 //#region main.js
 var loaded;
@@ -86,7 +86,7 @@ export { __exportAll as n, __reExport as r, __esmMin as t };
 ## target.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 //! Common Chunk: [Shared-By: target.js]
 import { n as read, t as init_reader } from "./reader.js";
 import { t as __esmMin } from "./rolldown-runtime.js";
@@ -114,7 +114,7 @@ export { x as n, init_target as t };
 ## target2.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: target.js] [Name: <none>]
 import { n as x, t as init_target } from "./target.js";
 export * from "external";
 init_target();

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4880/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4880/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: dynamic.js] [Name: Some("dynamic")]
+//! User-defined Entry: [Entry-Module-Id: dynamic.js] [Name: dynamic]
 import assert from "node:assert";
 //#region dynamic.js
 (async () => {
@@ -20,7 +20,7 @@ import assert from "node:assert";
 ## foo.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: foo.js] [Name: Some("foo")]
+//! User-defined Entry: [Entry-Module-Id: foo.js] [Name: foo]
 //#region foo.js
 var foo_default = "foo";
 //#endregion
@@ -31,7 +31,7 @@ export { foo_default as default };
 ## foo2.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: foo2.js] [Name: Some("foo2")]
+//! User-defined Entry: [Entry-Module-Id: foo2.js] [Name: foo2]
 //#region foo2.js
 var foo2_default = "foo2";
 //#endregion
@@ -42,7 +42,7 @@ export { foo2_default as default };
 ## main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import foo2_default from "./foo2.js";
 import assert from "node:assert";
 //#region main.js
@@ -58,7 +58,7 @@ assert.strictEqual(foo2_default, "foo2");
 ### dynamic.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: dynamic.js] [Name: Some("dynamic")]
+//! User-defined Entry: [Entry-Module-Id: dynamic.js] [Name: dynamic]
 import assert from "node:assert";
 //#region dynamic.js
 (async () => {
@@ -72,7 +72,7 @@ import assert from "node:assert";
 ### foo.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: foo.js] [Name: Some("foo")]
+//! User-defined Entry: [Entry-Module-Id: foo.js] [Name: foo]
 //#region foo.js
 var foo_default = "foo";
 //#endregion
@@ -83,7 +83,7 @@ export { foo_default as default };
 ### foo2.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: foo2.js] [Name: Some("foo2")]
+//! User-defined Entry: [Entry-Module-Id: foo2.js] [Name: foo2]
 //#region foo2.js
 var foo2_default = "foo2";
 //#endregion
@@ -94,7 +94,7 @@ export { foo2_default as default };
 ### main.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: main]
 import foo2_default from "./foo2.js";
 import assert from "node:assert";
 //#region main.js

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_facade_reexport_merges_into_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_facade_reexport_merges_into_entry/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## child.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: child.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: child.js] [Name: <none>]
 import { t as require_b } from "./entry.js";
 //#region child.js
 var import_b = require_b();
@@ -18,7 +18,7 @@ console.log("child", (0, import_b.b)());
 ## entry.js
 
 ```js
-//! User-defined Entry: [Entry-Module-Id: entry.js] [Name: Some("entry")]
+//! User-defined Entry: [Entry-Module-Id: entry.js] [Name: entry]
 // HIDDEN [\0rolldown/runtime.js]
 //#region a-impl.js
 var require_a_impl = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -53,7 +53,7 @@ export { require_a as n, __toESM as r, require_b as t };
 ## route.js
 
 ```js
-//! Dynamic Entry: [Entry-Module-Id: route.js] [Name: None]
+//! Dynamic Entry: [Entry-Module-Id: route.js] [Name: <none>]
 import { n as require_a, r as __toESM, t as require_b } from "./entry.js";
 //#region route.js
 var import_a = /* @__PURE__ */ __toESM(require_a());

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -334,7 +334,7 @@ where
       Ok(Some(RawMinifyOptions::DeadCodeEliminationOnly))
     }
     None => Ok(None),
-    _ => unreachable!("Unexpected value for minify {:?}", deserialized),
+    _ => unreachable!("Unexpected value for minify"),
   }
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -97,7 +97,7 @@ where
   let transformed = deserialized
     .map(|inner| HybridRegex::new(&inner))
     .transpose()
-    .map_err(|e| serde::de::Error::custom(format!("failed to deserialize {e:?} to HybridRegex")))?;
+    .map_err(|e| serde::de::Error::custom(format!("failed to deserialize {e} to HybridRegex")))?;
   Ok(transformed.map(MatchGroupTest::Regex))
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/platform.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/platform.rs
@@ -21,7 +21,7 @@ impl TryFrom<&str> for Platform {
       "node" => Ok(Self::Node),
       "browser" => Ok(Self::Browser),
       "neutral" => Ok(Self::Neutral),
-      _ => Err(format!("Unknown platform: {value:?}")),
+      _ => Err(format!("Unknown platform: {value}")),
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/strict_mode.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/strict_mode.rs
@@ -35,7 +35,7 @@ impl TryFrom<String> for StrictMode {
   fn try_from(value: String) -> Result<Self, Self::Error> {
     match value.as_str() {
       "auto" => Ok(Self::Auto),
-      _ => Err(format!("Unknown strict mode: {value:?}")),
+      _ => Err(format!("Unknown strict mode: {value}")),
     }
   }
 }

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -61,7 +61,7 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
         let len = map.len();
         map
           .get_mut(&i)
-          .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={len})"))
+          .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {} (len={len})", i.index()))
       }
     }
   }
@@ -79,9 +79,9 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
   pub fn get(&self, i: I) -> &T {
     match self {
       HybridIndexVec::IndexVec(index_vec) => &index_vec[i],
-      HybridIndexVec::Map(map) => map
-        .get(&i)
-        .unwrap_or_else(|| panic!("HybridIndexVec::Map missing idx {i:?} (len={})", map.len())),
+      HybridIndexVec::Map(map) => map.get(&i).unwrap_or_else(|| {
+        panic!("HybridIndexVec::Map missing idx {} (len={})", i.index(), map.len())
+      }),
     }
   }
 

--- a/crates/rolldown_common/src/types/import_kind.rs
+++ b/crates/rolldown_common/src/types/import_kind.rs
@@ -40,7 +40,7 @@ impl TryFrom<&str> for ImportKind {
       "url-token" => Self::UrlImport,
       "new-url" => Self::NewUrl,
       "hot-accept" => Self::HotAccept,
-      _ => return Err(format!("Invalid import kind: {value:?}")),
+      _ => return Err(format!("Invalid import kind: {value}")),
     })
   }
 }

--- a/crates/rolldown_common/src/types/source_mutation.rs
+++ b/crates/rolldown_common/src/types/source_mutation.rs
@@ -1,9 +1,17 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use string_wizard::MagicString;
 
-pub trait SourceMutation: Debug + Send + Sync {
+/// `Debug` is implemented on the trait object below instead of being a supertrait so concrete
+/// mutation formatters are not retained in release binaries solely through erased vtables.
+pub trait SourceMutation: Send + Sync {
   fn apply(&self, magic_string: &mut MagicString<'_>);
+}
+
+impl fmt::Debug for dyn SourceMutation {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("SourceMutation")
+  }
 }
 
 pub type ArcSourceMutation = Arc<dyn SourceMutation>;

--- a/crates/rolldown_utils/src/js_regex.rs
+++ b/crates/rolldown_utils/src/js_regex.rs
@@ -1,16 +1,29 @@
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, fmt, ops::Range};
 
 use crate::concat_string;
 
 /// Uses `regex` for common JavaScript patterns and falls back to `regress` for
 /// features such as backreferences and lookaround assertions.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HybridRegex(HybridRegexInner);
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 enum HybridRegexInner {
   Optimized(regex::Regex),
   Ecma(regress::Regex),
+}
+
+impl fmt::Debug for HybridRegex {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match &self.0 {
+      HybridRegexInner::Optimized(regex) => {
+        f.debug_tuple("Optimized").field(&regex.as_str()).finish()
+      }
+      // `regress::Regex`'s derived formatter walks its compiled instruction program. Apart from
+      // producing noisy output, calling it retains every instruction's formatter in release builds.
+      HybridRegexInner::Ecma(_) => f.write_str("Ecma(..)"),
+    }
+  }
 }
 
 /// An iterator over matches from the ECMAScript fallback engine.


### PR DESCRIPTION
Replace release-path structural Debug formatting with compact scalar and Display fields, plus shallow formatters for erased mutation and regex types.

Reduces the darwin-arm64 release NAPI binding by 178.8 KiB (1.07%).