### PR TITLE
fix(dev): resolve in-flight `ensureLatestBuildOutput` when the engine closes

### DIFF
--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -230,7 +230,9 @@ impl DevEngine {
     Ok(status.into())
   }
 
-  // Ensure there's latest bundle output available for browser loading/reloading scenarios
+  /// Ensure there's latest bundle output available for browser loading/reloading scenarios.
+  ///
+  /// If the `DevEngine` is closed while waiting, this method will return early without error.
   pub async fn ensure_latest_bundle_output(&self) -> BuildResult<()> {
     self.create_error_if_closed()?;
 
@@ -250,16 +252,26 @@ impl DevEngine {
         break;
       }
       let (reply_sender, reply_receiver) = tokio::sync::oneshot::channel();
-      self
+      if let Err(err) = self
         .coordinator_sender
         .send(CoordinatorMsg::EnsureLatestBundleOutput { reply: reply_sender })
-        .map_err_to_unhandleable()
-        .context("DevEngine: failed to send EnsureLatestBundleOutput to coordinator")?;
+      {
+        if self.is_closed() {
+          return Ok(());
+        }
+        return (Err(err))
+          .map_err_to_unhandleable()
+          .context("DevEngine: failed to send EnsureLatestBundleOutput to coordinator")?;
+      }
 
-      let received = reply_receiver
-        .await
-        .map_err_to_unhandleable()
-        .context("DevEngine: coordinator closed before responding to EnsureLatestBundleOutput")?;
+      let Ok(received) = reply_receiver.await else {
+        if self.is_closed() {
+          return Ok(());
+        }
+        return Err(anyhow::anyhow!(
+          "DevEngine: coordinator closed before responding to EnsureLatestBundleOutput"
+        ))?;
+      };
 
       // Wait for the build if one is running or was scheduled
       if let Some(ret) = received {

--- a/internal-docs/dev-engine/implementation.md
+++ b/internal-docs/dev-engine/implementation.md
@@ -1044,8 +1044,10 @@ Examples:
 
 These are the binding consumer's responsibility — Vite must sequence its
 calls so they don't race with `close()`. When the race happens anyway we
-report rather than swallow (§16d), so the consumer can detect and fix the
-ordering bug.
+report rather than swallow (§16d) by default, so the consumer can detect and
+fix the ordering bug. The waiting methods listed in §16d are the exception:
+they return `Ok` because "what you were waiting for can no longer happen" is
+a complete answer.
 
 The two categories share the `BuildResult<T>` type today — there is no
 static distinction. Code that needs to react differently must inspect
@@ -1139,6 +1141,13 @@ Current methods that take the exception:
   semantically correct. The doc comment on the method spells this out.
 - `BindingDevEngine::ensure_current_build_finish` (the napi wrapper used
   by `DevEngine.ensureCurrentBuildFinish` in JS) — same shape, PR #9564.
+- `DevEngine::ensure_latest_bundle_output` — only for a `close()` that races
+  a call already past the entry guard. The method does request work, so it
+  keeps `create_error_if_closed()` at entry and still surfaces a channel
+  failure while the engine is open; once `close()` has begun, the output it
+  would wait for can never be produced. Consumers float this call on page
+  requests, so a rejection lands as an unhandled rejection with no useful
+  recovery (rolldown#10729).
 
 Every other lifecycle error path should surface. When adding a new method,
 **default to surfacing**; only take the exception when there's an

--- a/packages/rolldown/tests/dev/dev-close-ensure-latest.test.ts
+++ b/packages/rolldown/tests/dev/dev-close-ensure-latest.test.ts
@@ -1,0 +1,83 @@
+import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import type { InputOptions, OutputOptions } from 'rolldown';
+import type { DevEngine, DevOptions } from 'rolldown/experimental';
+import { dev as _dev } from 'rolldown/experimental';
+import { isWasiTest } from 'rolldown-tests/utils';
+import { expect, test } from 'vitest';
+
+const TEST_TIMEOUT = 60_000;
+
+function dev(
+  inputOptions: InputOptions,
+  outputOptions: OutputOptions,
+  devOptions: DevOptions,
+): Promise<DevEngine> {
+  return _dev(inputOptions, outputOptions, {
+    ...devOptions,
+    watch: {
+      ...getDevWatchOptionsForCi(),
+      ...devOptions.watch,
+    },
+  });
+}
+
+// Sibling of the `ensureCurrentBuildFinish` case fixed for #9365
+// (see dev-close.test.ts): a close that races an *in-flight* call, rather
+// than a call made after close has already returned.
+//
+// Closing a dev server is normal, so an in-flight `ensureLatestBuildOutput()`
+// resolves on close rather than rejecting. Embedders float this promise
+// without a rejection handler (Vite does, in `triggerBundleRegenerationIfStale`),
+// so rejecting here surfaces as an unhandled rejection that fails the host.
+test.skipIf(isWasiTest)(
+  'in-flight ensureLatestBuildOutput resolves when the engine is closed',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-close-ensure-latest-${uniqueId}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const input = path.join(dir, 'main.js');
+    fs.writeFileSync(input, 'console.log(1)');
+
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const engine = await dev(
+      {
+        input,
+        experimental: { devMode: true },
+        plugins: [
+          {
+            name: 'slow-build',
+            // Keep the rebuild running long enough that close() lands while
+            // it is still in flight.
+            async transform(code) {
+              await sleep(300);
+              return code;
+            },
+          },
+        ],
+      },
+      { dir: path.join(dir, 'dist') },
+      {},
+    );
+
+    await engine.run();
+
+    engine.triggerFullBuild();
+    const inFlight = engine.ensureLatestBuildOutput();
+
+    // Let the rebuild get started, then close underneath it.
+    await sleep(50);
+    await engine.close();
+
+    await expect(inFlight).resolves.toBeUndefined();
+  },
+);


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

Closes https://github.com/rolldown/rolldown/issues/10729

Should fix https://github.com/vitejs/vite/actions/runs/32221446912/job/95972569681?pr=23302#step:15:38
