### PR TITLE
fix: treat module-scope `await using` as top-level await

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -335,6 +335,11 @@ impl<'me, 'ast: 'me> VisitJs<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_variable_declaration(&mut self, decl: &ast::VariableDeclaration<'ast>) {
+    // `await using x = …` awaits when the enclosing scope is exited, without any
+    // `AwaitExpression` node, so at module scope it is a top-level await (like `for await`).
+    if decl.kind == ast::VariableDeclarationKind::AwaitUsing && self.is_valid_tla_scope() {
+      self.handle_top_level_await(decl.span());
+    }
     match decl.declarations.as_slice() {
       [decl] => {
         if let (BindingPattern::BindingIdentifier(binding), Some(init)) = (&decl.id, &decl.init) {

--- a/crates/rolldown/tests/rolldown/errors/require_tla_await_using/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/require_tla_await_using/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/require_tla_await_using/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/require_tla_await_using/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## REQUIRE_TLA
+
+```text
+[REQUIRE_TLA] This require call is not allowed because the imported file "dep.js" contains a top-level await
+   ╭─[ main.js:1:1 ]
+   │
+ 1 │ require("./dep.js");
+   │ ─────────┬─────────  
+   │          ╰─────────── The require() call is here:
+   │
+   ├─[ dep.js:4:1 ]
+   │
+ 4 │ await using handle = resource;
+   │ ───────────────┬──────────────  
+   │                ╰──────────────── The top-level await in "dep.js" is here:
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/errors/require_tla_await_using/dep.js
+++ b/crates/rolldown/tests/rolldown/errors/require_tla_await_using/dep.js
@@ -1,0 +1,5 @@
+// `await using` at module scope awaits the disposer when the module body completes, so this
+// module has top-level await even though it contains no AwaitExpression.
+const resource = { async [Symbol.asyncDispose]() {} };
+await using handle = resource;
+export { handle };

--- a/crates/rolldown/tests/rolldown/errors/require_tla_await_using/main.js
+++ b/crates/rolldown/tests/rolldown/errors/require_tla_await_using/main.js
@@ -1,0 +1,1 @@
+require("./dep.js");

--- a/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## UNSUPPORTED_FEATURE
+
+```text
+[UNSUPPORTED_FEATURE] Top-level await is currently not supported with the 'cjs' output format
+   ╭─[ main.js:2:1 ]
+   │
+ 2 │ await using handle = resource;
+   │ ───────────────┬──────────────  
+   │                ╰──────────────── 
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/main.js
+++ b/crates/rolldown/tests/rolldown/errors/tla_await_using_cjs/main.js
@@ -1,0 +1,3 @@
+const resource = { async [Symbol.asyncDispose]() {} };
+await using handle = resource;
+export { handle };

--- a/crates/rolldown/tests/rolldown/topics/tla/await_using/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/tla/await_using/_config.json
@@ -1,0 +1,13 @@
+{
+  "configVariants": [
+    {
+      "_configName": "wrap-all",
+      "strictExecutionOrder": true
+    },
+    {
+      "_configName": "on-demand",
+      "strictExecutionOrder": true,
+      "onDemandWrapping": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/topics/tla/await_using/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/tla/await_using/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { log } from './dist/main.js';
+
+assert.deepStrictEqual(log, ['body', 'disposed']);

--- a/crates/rolldown/tests/rolldown/topics/tla/await_using/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/await_using/artifacts.snap
@@ -1,0 +1,81 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region log.js
+const log = [];
+//#endregion
+//#region main.js
+{
+	await using _ = { async [Symbol.asyncDispose]() {
+		await Promise.resolve();
+		log.push("disposed");
+	} };
+	log.push("body");
+}
+//#endregion
+export { log };
+
+```
+
+# Variant: wrap-all: [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region log.js
+var log;
+function init_log() {
+	return (init_log = __esmMin((() => {
+		log = [];
+	})))();
+}
+//#endregion
+//#region main.js
+function init_main() {
+	return (init_main = __esmMin((async () => {
+		init_log();
+		{
+			await using _ = { async [Symbol.asyncDispose]() {
+				await Promise.resolve();
+				log.push("disposed");
+			} };
+			log.push("body");
+		}
+	})))();
+}
+//#endregion
+await init_main();
+export { log };
+
+```
+
+# Variant: on-demand: [on_demand_wrapping: true] [strict_execution_order: true]
+
+## Assets
+
+### main.js
+
+```js
+//#region log.js
+const log = [];
+//#endregion
+//#region main.js
+{
+	await using _ = { async [Symbol.asyncDispose]() {
+		await Promise.resolve();
+		log.push("disposed");
+	} };
+	log.push("body");
+}
+//#endregion
+export { log };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/tla/await_using/log.js
+++ b/crates/rolldown/tests/rolldown/topics/tla/await_using/log.js
@@ -1,0 +1,1 @@
+export const log = [];

--- a/crates/rolldown/tests/rolldown/topics/tla/await_using/main.js
+++ b/crates/rolldown/tests/rolldown/topics/tla/await_using/main.js
@@ -1,0 +1,11 @@
+import { log } from './log.js';
+{
+  await using _ = {
+    async [Symbol.asyncDispose]() {
+      await Promise.resolve();
+      log.push('disposed');
+    },
+  };
+  log.push('body');
+}
+export { log };


### PR DESCRIPTION
A module-scope `await using` declaration awaits when the module body completes, but the AST scanner only records top-level await for `AwaitExpression` and `for await` — an `await using` has no `AwaitExpression` node, so `visit_variable_declaration` never flagged it.

```js
// dep.js
await using conn = open();
export { conn };
```

Before this change such a module was not treated as TLA: `format: 'cjs'`/`'iife'` emitted it without the "Top-level await is not supported" error, `require('./dep.js')` didn't report `REQUIRE_TLA`, and under `strictExecutionOrder` it was wrapped in a non-async `__esmMin(() => { await using … })` (a syntax error). Now `VariableDeclarationKind::AwaitUsing` at a valid TLA scope goes through `handle_top_level_await` like the other two forms.

Tests: `errors/tla_await_using_cjs` (format error), `errors/require_tla_await_using` (`REQUIRE_TLA`), `topics/tla/await_using` (executes; async init wrapper under both strict-execution-order variants). All three fail without the change.

AI-assisted (Claude Code); reviewed and tested by me.
