### PR TITLE
perf: deduplicate used symbol ref readers

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -279,13 +279,13 @@ impl<Fs: FileSystem + Clone + 'static> Bundle<Fs> {
     // The one stretch of a build with no plugin in it, which is what makes it a usable
     // baseline for "was this build plugin-bound?" — see `BuildTimings`.
     let link_start = self.plugin_driver.build_timings.start();
-    let (mut link_stage_output, ast_table, used_symbol_refs) =
+    let (mut link_stage_output, ast_table, used_symbol_refs_builder) =
       LinkStage::new(scan_stage_output, &self.options).link();
     self.plugin_driver.build_timings.record_link_stage(link_start);
 
     let bundle_output =
       GenerateStage::new(&mut link_stage_output, ast_table, &self.options, &self.plugin_driver)
-        .generate(used_symbol_refs)
+        .generate(used_symbol_refs_builder)
         .await; // Notice we don't use `?` to break the control flow here.
 
     // `create_output`/`make_copy` strip symbol-table scoping from the cache for

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -991,7 +991,7 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
     module_is_assigned: &mut IndexBitSet<ModuleIdx>,
     temp_chunk_opt_graph: &ChunkOptimizationGraph,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) {
     // Find empty dynamic entry chunks that should be merged with their target common chunks
     let (mut facade_eliminations, common_chunk_merges, emitted_chunk_groups) =
@@ -1011,12 +1011,15 @@ impl GenerateStage<'_> {
     );
 
     for elimination in &facade_eliminations {
-      self.narrow_namespace_stmt_to_used_symbols(elimination.entry_module_idx, used_symbol_refs);
+      self.narrow_namespace_stmt_to_used_symbols(
+        elimination.entry_module_idx,
+        used_symbol_refs_builder,
+      );
     }
 
     let mut runtime_dependent_chunks = FxHashSet::default();
 
-    self.replay_link_stage_inclusion(used_symbol_refs, |context| {
+    self.replay_link_stage_inclusion(used_symbol_refs_builder, |context| {
       let mut needs_export_all_helper = false;
       for elimination in &facade_eliminations {
         let FacadeChunkElimination { reason, entry_module_idx, from_chunk_idx, to_chunk_idx } =

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -53,7 +53,7 @@ impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn generate_chunks(
     &mut self,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) -> BuildResult<ChunkGraph> {
     // Count total entry points (not unique modules) to handle duplicates correctly
     let entries_len: u32 = self
@@ -65,7 +65,7 @@ impl GenerateStage<'_> {
       .try_into()
       .expect("Too many entries, u32 overflowed.");
     let mut chunk_graph = ChunkGraph::new(self.link_output.module_table.modules.len());
-    let pre_chunk_order_state = self.pre_chunk_order_state(used_symbol_refs);
+    let pre_chunk_order_state = self.pre_chunk_order_state(used_symbol_refs_builder);
     chunk_graph.chunk_table.chunks.reserve(entries_len as usize);
 
     let mut index_splitting_info: IndexSplittingInfo = oxc_index::index_vec![SplittingInfo {
@@ -170,12 +170,12 @@ impl GenerateStage<'_> {
           &mut chunk_graph,
           &mut bits_to_chunk,
           &input_base,
-          used_symbol_refs,
+          used_symbol_refs_builder,
           &pre_chunk_order_state,
         )
         .await?;
     }
-    self.merge_external_import_symbols(&chunk_graph, used_symbol_refs);
+    self.merge_external_import_symbols(&chunk_graph, used_symbol_refs_builder);
 
     chunk_graph.sort_chunk_modules(self.link_output, self.options);
 
@@ -279,7 +279,7 @@ impl GenerateStage<'_> {
   fn merge_external_import_symbols(
     &mut self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) {
     // Merge external import namespaces at chunk level.
     for symbol_set in self.link_output.external_import_namespace_merger.values() {
@@ -297,7 +297,8 @@ impl GenerateStage<'_> {
           continue;
         }
         group.sort_unstable_by_key(|item| self.link_output.module_table[item.owner].exec_order());
-        let Some(idx) = group.iter().position(|item| used_symbol_refs.contains(item)) else {
+        let Some(idx) = group.iter().position(|item| used_symbol_refs_builder.contains(item))
+        else {
           continue;
         };
         // In the extreme case, idx would eq to group.len() - 1, which means the first symbol is the only one that is used.
@@ -930,7 +931,7 @@ impl GenerateStage<'_> {
     chunk_graph: &mut ChunkGraph,
     bits_to_chunk: &mut FxHashMap<BitSet, ChunkIdx>,
     input_base: &ArcStr,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
     pre_chunk_order_state: &super::order_wrap_state::OrderWrapState,
   ) -> BuildResult<()> {
     // Determine which modules belong to which chunk. A module could belong to multiple chunks.
@@ -951,7 +952,7 @@ impl GenerateStage<'_> {
         entry_index.try_into().expect("Too many entries, u32 overflowed."),
         index_splitting_info,
         is_user_defined_entry,
-        used_symbol_refs,
+        used_symbol_refs_builder,
         pre_chunk_order_state,
       );
     }
@@ -980,7 +981,7 @@ impl GenerateStage<'_> {
         index_splitting_info,
         chunk_graph,
         entries_len,
-        used_symbol_refs,
+        used_symbol_refs_builder,
       );
     }
     self.extract_standalone_runtime_chunk(
@@ -1083,7 +1084,7 @@ impl GenerateStage<'_> {
         input_base,
         &mut module_is_assigned,
         &temp_chunk_graph,
-        used_symbol_refs,
+        used_symbol_refs_builder,
       );
     }
 
@@ -1146,7 +1147,7 @@ impl GenerateStage<'_> {
     entry_index: u32,
     index_splitting_info: &mut IndexSplittingInfo,
     is_user_defined_entry: bool,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     pre_chunk_order_state: &super::order_wrap_state::OrderWrapState,
   ) {
     debug_assert!(
@@ -1246,7 +1247,7 @@ impl GenerateStage<'_> {
           }
           let has_live_binding =
             import_record_has_live_binding_consumer(&ctx, rec_idx, |symbol_ref| {
-              used_symbol_refs.contains(&symbol_ref)
+              used_symbol_refs_builder.contains(&symbol_ref)
             });
           if !record_is_init_obligation(
             ObligationPurpose::Project,
@@ -1266,7 +1267,7 @@ impl GenerateStage<'_> {
           let placement_targets = collect_wrapped_esm_init_targets_for_import_record(
             &ctx,
             rec_idx,
-            |symbol_ref| used_symbol_refs.contains(&symbol_ref),
+            |symbol_ref| used_symbol_refs_builder.contains(&symbol_ref),
             |_| true,
             |_| false,
           );

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -15,7 +15,8 @@ use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, CrossChunkImportItem, EntryPointKind, ExportsKind, ImportKind,
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PostChunkOptimizationOperation,
   PreserveEntrySignatures, RUNTIME_HELPER_NAMES, ResolvedImportRecord, RuntimeHelper, SymbolRef,
-  SymbolRefDb, TaggedSymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder, WrapKind,
+  SymbolRefDb, TaggedSymbolRef, UsedSymbolRefs, UsedSymbolRefsBuilder, UsedSymbolRefsView,
+  WrapKind,
 };
 use rolldown_utils::index_vec_ext::IndexVecRefExt as _;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -98,22 +99,6 @@ impl SymbolChunkTable {
   }
 }
 
-pub(super) trait UsedSymbolRefsView: Sync {
-  fn contains(&self, symbol_ref: &SymbolRef) -> bool;
-}
-
-impl UsedSymbolRefsView for UsedSymbolRefs {
-  fn contains(&self, symbol_ref: &SymbolRef) -> bool {
-    UsedSymbolRefs::contains(self, symbol_ref)
-  }
-}
-
-impl UsedSymbolRefsView for UsedSymbolRefsBuilder {
-  fn contains(&self, symbol_ref: &SymbolRef) -> bool {
-    UsedSymbolRefsBuilder::contains(self, symbol_ref)
-  }
-}
-
 impl GenerateStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub fn compute_cross_chunk_links(
@@ -135,7 +120,7 @@ impl GenerateStage<'_> {
       symbol_chunk_table,
     } = self.compute_cross_chunk_link_state(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs.view(),
       order_state,
       FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
     );
@@ -161,7 +146,7 @@ impl GenerateStage<'_> {
     #[cfg(debug_assertions)]
     self.debug_assert_module_level_static_import_prediction(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs.view(),
       &index_imports_from_other_chunks,
     );
 
@@ -304,12 +289,12 @@ impl GenerateStage<'_> {
   pub(super) fn predicted_static_import_edges(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     let empty_order_state = super::order_wrap_state::OrderWrapState::default();
     let state = self.compute_cross_chunk_link_state(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs_builder.view(),
       &empty_order_state,
       FinalEsmInitMetadataAvailability::Unavailable,
     );
@@ -341,13 +326,13 @@ impl GenerateStage<'_> {
   pub(super) fn lowered_static_import_edges(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: &Sealed<FinalEsmInitMetadata>,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     let state = self.compute_cross_chunk_link_state(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs_builder.view(),
       order_state,
       FinalEsmInitMetadataAvailability::Sealed(final_esm_init_metadata),
     );
@@ -388,7 +373,7 @@ impl GenerateStage<'_> {
   fn debug_assert_module_level_static_import_prediction(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     index_imports_from_other_chunks: &IndexImportsFromOtherChunks,
   ) {
     if self.options.is_strict_execution_order_enabled() || self.options.preserve_modules {
@@ -426,7 +411,7 @@ impl GenerateStage<'_> {
         let mut service_targets = vec![];
         self.entry_export_service_targets(
           entry_module_idx,
-          used_symbol_refs,
+          used_symbol_refs_view,
           false,
           &mut service_targets,
         );
@@ -483,7 +468,7 @@ impl GenerateStage<'_> {
   fn compute_cross_chunk_link_state(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
   ) -> CrossChunkLinkState {
@@ -527,7 +512,7 @@ impl GenerateStage<'_> {
       &mut index_chunk_direct_imports_from_external_modules,
       &mut index_cross_chunk_dynamic_imports,
       &mut index_chunk_dynamic_imports_from_external_modules,
-      used_symbol_refs,
+      used_symbol_refs_view,
       order_state,
       final_esm_init_metadata,
     );
@@ -540,7 +525,7 @@ impl GenerateStage<'_> {
       &mut index_cross_chunk_imports,
       &mut index_imports_from_other_chunks,
       &mut index_chunk_indirect_imports_from_external_modules,
-      used_symbol_refs,
+      used_symbol_refs_view,
       order_state,
       &order_live_symbols,
       &symbol_chunk_table,
@@ -619,7 +604,7 @@ impl GenerateStage<'_> {
     index_chunk_imports_from_external_modules: &mut IndexChunkImportsFromExternalModules,
     index_cross_chunk_dynamic_imports: &mut IndexCrossChunkDynamicImports,
     index_chunk_dynamic_imports_from_external_modules: &mut IndexChunkDynamicImportsFromExternalModules,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
   ) -> SymbolChunkTable {
@@ -738,7 +723,7 @@ impl GenerateStage<'_> {
           );
           self.add_module_esm_init_depended_symbols(
             chunk_graph,
-            used_symbol_refs,
+            used_symbol_refs_view,
             order_state,
             final_esm_init_metadata,
             depended_symbols,
@@ -971,7 +956,7 @@ impl GenerateStage<'_> {
   fn add_module_esm_init_depended_symbols(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     order_state: &super::order_wrap_state::OrderWrapState,
     final_esm_init_metadata: FinalEsmInitMetadataAvailability<'_>,
     depended_symbols: &mut FxIndexSet<SymbolRef>,
@@ -988,7 +973,7 @@ impl GenerateStage<'_> {
     }
     self.add_included_import_esm_init_depended_symbols(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs_view,
       order_state,
       depended_symbols,
       module_idx,
@@ -1104,7 +1089,7 @@ impl GenerateStage<'_> {
   fn add_included_import_esm_init_depended_symbols(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     order_state: &super::order_wrap_state::OrderWrapState,
     depended_symbols: &mut FxIndexSet<SymbolRef>,
     module_idx: ModuleIdx,
@@ -1149,7 +1134,7 @@ impl GenerateStage<'_> {
         let targets = collect_wrapped_esm_init_targets_for_import_record(
           &ctx,
           rec_idx,
-          |symbol_ref| used_symbol_refs.contains(&symbol_ref),
+          |symbol_ref| used_symbol_refs_view.contains(&symbol_ref),
           |_| true,
           |forwarding_module_idx| {
             chunk_graph.module_to_chunk[forwarding_module_idx] == Some(chunk_idx)
@@ -1209,7 +1194,7 @@ impl GenerateStage<'_> {
     index_cross_chunk_imports: &mut IndexCrossChunkImports,
     index_imports_from_other_chunks: &mut IndexImportsFromOtherChunks,
     index_chunk_indirect_imports_from_external_modules: &mut IndexChunkAllImportsFromExternalModules,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     order_state: &super::order_wrap_state::OrderWrapState,
     order_live_symbols: &FxHashSet<SymbolRef>,
     symbol_chunk_table: &SymbolChunkTable,
@@ -1420,7 +1405,7 @@ impl GenerateStage<'_> {
           {
             self.link_output.metas[import_ref.owner].namespace_included
           } else {
-            non_namespace_symbol_is_live(used_symbol_refs, order_live_symbols, import_ref)
+            non_namespace_symbol_is_live(used_symbol_refs_view, order_live_symbols, import_ref)
           };
           if !is_live {
             continue;
@@ -1730,7 +1715,7 @@ impl GenerateStage<'_> {
         {
           self.link_output.metas[chunk_export.owner].namespace_included
         } else {
-          non_namespace_symbol_is_live(used_symbol_refs, order_live_symbols, *chunk_export)
+          non_namespace_symbol_is_live(used_symbol_refs.view(), order_live_symbols, *chunk_export)
         };
         if !is_live {
           continue;
@@ -1785,11 +1770,11 @@ impl GenerateStage<'_> {
 }
 
 fn non_namespace_symbol_is_live(
-  used_symbol_refs: &impl UsedSymbolRefsView,
+  used_symbol_refs_view: UsedSymbolRefsView<'_>,
   order_live_symbols: &FxHashSet<SymbolRef>,
   symbol_ref: SymbolRef,
 ) -> bool {
-  used_symbol_refs.contains(&symbol_ref) || order_live_symbols.contains(&symbol_ref)
+  used_symbol_refs_view.contains(&symbol_ref) || order_live_symbols.contains(&symbol_ref)
 }
 
 // The same implementation with https://github.com/oxc-project/oxc/blob/crates_v0.86.0/crates/oxc_mangler/src/base54.rs#L30-L31

--- a/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
+++ b/crates/rolldown/src/stages/generate_stage/dynamic_already_loaded.rs
@@ -4,7 +4,8 @@ use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleIdx,
   PreserveEntrySignatures, RuntimeHelper, StmtInfoIdx, SymbolOrMemberExprRef, SymbolRef,
-  UsedSymbolRefsBuilder, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
+  UsedSymbolRefsBuilder, UsedSymbolRefsView, WrapKind,
+  dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_utils::BitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -13,7 +14,7 @@ use crate::chunk_graph::ChunkGraph;
 use crate::esm_init_obligations::collect_entry_reexported_wrapper_inits;
 
 use super::{
-  GenerateStage, code_splitting::IndexSplittingInfo, compute_cross_chunk_links::UsedSymbolRefsView,
+  GenerateStage, code_splitting::IndexSplittingInfo,
   simulated_facade_inclusion::include_simulated_facade_namespace,
 };
 
@@ -57,7 +58,7 @@ impl GenerateStage<'_> {
     index_splitting_info: &mut IndexSplittingInfo,
     chunk_graph: &mut ChunkGraph,
     entries_len: u32,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) {
     let mut namespace_extractions = FxHashSet::default();
     let DynamicEntryAnalysis {
@@ -76,7 +77,7 @@ impl GenerateStage<'_> {
     }
     let module_to_atom_idx = self.compute_module_to_atom_idx(&atoms);
     let atom_dependencies =
-      self.compute_atom_dependencies(&atoms, &module_to_atom_idx, used_symbol_refs);
+      self.compute_atom_dependencies(&atoms, &module_to_atom_idx, used_symbol_refs_builder);
 
     let static_dependency_atoms_by_entry = self.compute_static_dependency_atoms_by_entry(
       entries_len as usize,
@@ -145,7 +146,7 @@ impl GenerateStage<'_> {
     self.apply_dynamic_entry_namespace_extractions(
       chunk_graph,
       &namespace_extractions,
-      used_symbol_refs,
+      used_symbol_refs_builder,
     );
   }
 
@@ -258,17 +259,17 @@ impl GenerateStage<'_> {
     &mut self,
     chunk_graph: &mut ChunkGraph,
     namespace_extractions: &FxHashSet<(ChunkIdx, ModuleIdx)>,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) {
     if namespace_extractions.is_empty() {
       return;
     }
 
     for &(_, entry_module_idx) in namespace_extractions {
-      self.narrow_namespace_stmt_to_used_symbols(entry_module_idx, used_symbol_refs);
+      self.narrow_namespace_stmt_to_used_symbols(entry_module_idx, used_symbol_refs_builder);
     }
 
-    self.replay_link_stage_inclusion(used_symbol_refs, |context| {
+    self.replay_link_stage_inclusion(used_symbol_refs_builder, |context| {
       let mut needs_export_all_helper = false;
       for &(entry_chunk_idx, entry_module_idx) in namespace_extractions {
         chunk_graph
@@ -333,7 +334,7 @@ impl GenerateStage<'_> {
   // hosted by its own entry chunk, because emission hangs those imports on the entry (facade)
   // chunk, not on whichever shared chunk hosts the module. `cycle` must contain every edge the
   // emitted chunks might have: its service edges are attached to the hosting atom regardless,
-  // with no liveness gate — `used_symbol_refs` still grows after this pass (namespace-extraction
+  // with no liveness gate — `used_symbol_refs_builder` still grows after this pass (namespace-extraction
   // and facade-elimination replays), so an export dead here can be live at emission. A facade's
   // own service edges cannot close a cycle (facades have zero static in-degree), so attributing
   // them to the hosting atom only over-approximates. The price of the ungated edges is that a
@@ -346,7 +347,7 @@ impl GenerateStage<'_> {
     &self,
     atoms: &[ChunkAtom],
     module_to_atom_idx: &IndexVec<ModuleIdx, Option<usize>>,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) -> AtomDependencyGraphs {
     let strict_execution_order = self.options.is_strict_execution_order_enabled();
     let flattened_entry_modules: Vec<ModuleIdx> = self
@@ -383,7 +384,12 @@ impl GenerateStage<'_> {
         }
 
         let mut service_targets = vec![];
-        self.entry_export_service_targets(module_idx, used_symbol_refs, true, &mut service_targets);
+        self.entry_export_service_targets(
+          module_idx,
+          used_symbol_refs_builder.view(),
+          true,
+          &mut service_targets,
+        );
         for dep_module_idx in service_targets {
           add(dep_module_idx, &mut cycle_deps);
         }
@@ -396,7 +402,7 @@ impl GenerateStage<'_> {
           let mut service_targets = vec![];
           self.entry_export_service_targets(
             module_idx,
-            used_symbol_refs,
+            used_symbol_refs_builder.view(),
             false,
             &mut service_targets,
           );
@@ -458,12 +464,12 @@ impl GenerateStage<'_> {
   ///
   /// With `assume_all_live: false` the liveness gate mirrors emission exactly: a dead export
   /// produces no import. `assume_all_live: true` skips the gate for consumers that need a stable
-  /// over-approximation — `used_symbol_refs` keeps growing after the fold's decisions, so a
+  /// over-approximation — `used_symbol_refs_builder` keeps growing after the fold's decisions, so a
   /// dead-here export can still emit an import later.
   pub(super) fn entry_export_service_targets(
     &self,
     module_idx: ModuleIdx,
-    used_symbol_refs: &impl UsedSymbolRefsView,
+    used_symbol_refs_view: UsedSymbolRefsView<'_>,
     assume_all_live: bool,
     targets: &mut Vec<ModuleIdx>,
   ) {
@@ -487,7 +493,7 @@ impl GenerateStage<'_> {
         {
           self.link_output.metas[served.owner].namespace_included
         } else {
-          used_symbol_refs.contains(&served)
+          used_symbol_refs_view.contains(&served)
         };
       if is_live {
         targets.push(served.owner);
@@ -502,7 +508,7 @@ impl GenerateStage<'_> {
       symbol_db,
       None,
     ) {
-      if assume_all_live || used_symbol_refs.contains(&init.wrapper_ref) {
+      if assume_all_live || used_symbol_refs_view.contains(&init.wrapper_ref) {
         targets.push(init.wrapper_ref.owner);
       }
     }

--- a/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_chunk_plan.rs
@@ -20,7 +20,7 @@ impl GenerateStage<'_> {
   pub(super) fn finalize_chunk_plan(
     &mut self,
     chunk_graph: &mut ChunkGraph,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) -> BuildResult<OrderWrapState> {
     // The order analysis reuses cross-chunk linking logic, which reads finalized namespace and
     // external-export facts. Prepare those inputs on the provisional topology first.
@@ -28,9 +28,9 @@ impl GenerateStage<'_> {
     let mut order_state = OrderWrapState::default();
     self.finalized_module_namespace_ref_usage(chunk_graph, &order_state);
 
-    let order_analysis = self.analyze_execution_order(chunk_graph, used_symbol_refs);
+    let order_analysis = self.analyze_execution_order(chunk_graph, used_symbol_refs_builder);
     if let Some(analysis) = &order_analysis
-      && self.apply_order_wraps(chunk_graph, analysis, used_symbol_refs, &mut order_state)
+      && self.apply_order_wraps(chunk_graph, analysis, used_symbol_refs_builder, &mut order_state)
     {
       #[cfg(debug_assertions)]
       self.assert_order_wrap_plan_applied(chunk_graph, &analysis.plan, &order_state);
@@ -44,7 +44,7 @@ impl GenerateStage<'_> {
     if order_state.required_runtime_helpers().is_empty() {
       let runtime_idx = self.link_output.runtime.id();
       let runtime_chunk_before = chunk_graph.module_to_chunk[runtime_idx];
-      self.sweep_unused_runtime_module(chunk_graph, used_symbol_refs);
+      self.sweep_unused_runtime_module(chunk_graph, used_symbol_refs_builder);
       if runtime_chunk_before.is_some() && chunk_graph.module_to_chunk[runtime_idx].is_none() {
         // The sweep removed the runtime from its chunk. When that chunk is still live (the runtime
         // co-hosted with user modules), its `modules[0]` changed, so the `exec_order` the

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -145,16 +145,16 @@ impl<'a> GenerateStage<'a> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn generate(
     &mut self,
-    mut used_symbol_refs: UsedSymbolRefsBuilder,
+    mut used_symbol_refs_builder: UsedSymbolRefsBuilder,
   ) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
-    let mut chunk_graph = self.generate_chunks(&mut used_symbol_refs).await?;
+    let mut chunk_graph = self.generate_chunks(&mut used_symbol_refs_builder).await?;
 
-    let order_state = self.finalize_chunk_plan(&mut chunk_graph, &mut used_symbol_refs)?;
+    let order_state = self.finalize_chunk_plan(&mut chunk_graph, &mut used_symbol_refs_builder)?;
 
     // Order lowering and the unused-runtime sweep have had their last chance to update liveness.
     // Sealing consumes the builder, so nothing downstream can mutate the set.
-    let used_symbol_refs = used_symbol_refs.seal();
+    let used_symbol_refs = used_symbol_refs_builder.seal();
     self.compute_retained_export_symbols(&used_symbol_refs);
 
     let mut ast_table = std::mem::take(&mut self.ast_table);

--- a/crates/rolldown/src/stages/generate_stage/order_analysis.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_analysis.rs
@@ -104,21 +104,21 @@ impl GenerateStage<'_> {
   /// needs the same physical chunk placement even though it will not need an `init_*` call.
   pub(super) fn pre_chunk_order_state(
     &self,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) -> super::order_wrap_state::OrderWrapState {
     let mut state = super::order_wrap_state::OrderWrapState::default();
     if !self.options.is_strict_execution_order_enabled() {
       return state;
     }
     let plan = self.wrap_all_order_analysis().plan;
-    self.populate_probe_order_targets(&plan, used_symbol_refs, &mut state);
+    self.populate_probe_order_targets(&plan, used_symbol_refs_builder, &mut state);
     state
   }
 
   pub(super) fn analyze_execution_order(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) -> Option<OrderAnalysis> {
     if !self.options.is_strict_execution_order_enabled() {
       return None;
@@ -131,7 +131,7 @@ impl GenerateStage<'_> {
       return Some(self.wrap_all_order_analysis());
     }
 
-    let import_edges = self.predicted_static_import_edges(chunk_graph, used_symbol_refs);
+    let import_edges = self.predicted_static_import_edges(chunk_graph, used_symbol_refs_builder);
     let chunk_cycles = ChunkCycles::from_import_edges(&import_edges);
     let mut all_at_risk = FxHashSet::default();
     let mut roots = Vec::new();
@@ -184,7 +184,7 @@ impl GenerateStage<'_> {
     // placement and couple all of the routes again. The structural candidate check excludes
     // synchronous import/require SCCs, so this monotone addition keeps the existing conservative
     // cycle fallback.
-    let placement_state = self.pre_chunk_order_state(used_symbol_refs);
+    let placement_state = self.pre_chunk_order_state(used_symbol_refs_builder);
     all_at_risk.extend(placement_state.order_cjs_carrier_keys().map(|key| key.importer));
 
     let mut plan = self.build_order_wrap_plan(
@@ -213,7 +213,7 @@ impl GenerateStage<'_> {
         chunk_graph,
         &plan,
         &import_edges,
-        used_symbol_refs,
+        used_symbol_refs_builder,
         &reverse_static_imports,
       );
       let post_cycles = ChunkCycles::from_import_edges(&post_edges);
@@ -322,12 +322,12 @@ impl GenerateStage<'_> {
     chunk_graph: &ChunkGraph,
     plan: &OrderWrapPlan,
     baseline: &IndexVec<ChunkIdx, FxHashSet<ChunkIdx>>,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     reverse_static_imports: &IndexVec<ModuleIdx, Vec<ModuleIdx>>,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     let mut edges = baseline.clone();
     let probe_state =
-      self.probe_order_state(chunk_graph, plan, used_symbol_refs, reverse_static_imports);
+      self.probe_order_state(chunk_graph, plan, used_symbol_refs_builder, reverse_static_imports);
 
     for module in self.link_output.module_table.modules.iter().filter_map(Module::as_normal) {
       let importer_idx = module.idx;
@@ -348,7 +348,7 @@ impl GenerateStage<'_> {
         self.project_collector_edges(
           chunk_graph,
           &probe_state,
-          used_symbol_refs,
+          used_symbol_refs_builder,
           module,
           importer_chunk,
           &mut targets,
@@ -473,7 +473,7 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &ChunkGraph,
     probe_state: &super::order_wrap_state::OrderWrapState,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     module: &NormalModule,
     importer_chunk: ChunkIdx,
     targets: &mut Vec<WrappedEsmInitTarget>,
@@ -505,7 +505,7 @@ impl GenerateStage<'_> {
         targets.extend(collect_wrapped_esm_init_targets_for_import_record(
           &ctx,
           rec_idx,
-          |symbol_ref| used_symbol_refs.contains(&symbol_ref),
+          |symbol_ref| used_symbol_refs_builder.contains(&symbol_ref),
           |_| true,
           |forwarding_module_idx| {
             chunk_graph.module_to_chunk[forwarding_module_idx] == Some(importer_chunk)
@@ -580,11 +580,11 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &ChunkGraph,
     plan: &OrderWrapPlan,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     reverse_static_imports: &IndexVec<ModuleIdx, Vec<ModuleIdx>>,
   ) -> super::order_wrap_state::OrderWrapState {
     let mut probe_state = super::order_wrap_state::OrderWrapState::default();
-    self.populate_probe_order_targets(plan, used_symbol_refs, &mut probe_state);
+    self.populate_probe_order_targets(plan, used_symbol_refs_builder, &mut probe_state);
 
     // Populate exactly the nested re-export records and per-record overlays `lower_order_state`
     // mints for this plan, so the transitive excluded-hop projection restricts each barrel's walk
@@ -605,7 +605,7 @@ impl GenerateStage<'_> {
       star_reexport_records_by_imported_symbol: &self
         .link_output
         .star_reexport_records_by_imported_symbol,
-      used_symbols: used_symbol_refs,
+      used_symbol_refs_builder,
       cyclic_modules: &cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };
@@ -640,7 +640,7 @@ impl GenerateStage<'_> {
   fn populate_probe_order_targets(
     &self,
     plan: &OrderWrapPlan,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     probe_state: &mut super::order_wrap_state::OrderWrapState,
   ) {
     for module_idx in plan.modules() {
@@ -675,7 +675,7 @@ impl GenerateStage<'_> {
       star_reexport_records_by_imported_symbol: &self
         .link_output
         .star_reexport_records_by_imported_symbol,
-      used_symbols: used_symbol_refs,
+      used_symbol_refs_builder,
       cyclic_modules: &cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };

--- a/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/order_wrapping.rs
@@ -53,7 +53,7 @@ pub(super) struct OrderLoweringInput<'a> {
   pub(super) export_chains: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
   pub(super) star_reexport_records_by_imported_symbol:
     &'a FxHashMap<SymbolRef, Vec<Vec<(ModuleIdx, ImportRecordIdx)>>>,
-  pub(super) used_symbols: &'a UsedSymbolRefsBuilder,
+  pub(super) used_symbol_refs_builder: &'a UsedSymbolRefsBuilder,
   pub(super) cyclic_modules: &'a FxHashSet<ModuleIdx>,
   pub(super) tree_shaking: bool,
 }
@@ -434,7 +434,7 @@ impl GenerateStage<'_> {
     &mut self,
     chunk_graph: &mut ChunkGraph,
     analysis: &OrderAnalysis,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     order_state: &mut OrderWrapState,
   ) -> bool {
     let plan = &analysis.plan;
@@ -459,7 +459,12 @@ impl GenerateStage<'_> {
     // module produce identical bit sets, so one entry module still means the routes moved
     // nothing.
     if plan.is_empty() && code_splitting_disabled && self.link_output.entries.len() <= 1 {
-      return self.apply_inert_order_wrap_plan(chunk_graph, used_symbol_refs, order_state, plan);
+      return self.apply_inert_order_wrap_plan(
+        chunk_graph,
+        used_symbol_refs_builder,
+        order_state,
+        plan,
+      );
     }
     let runtime_helper = self.esm_runtime_helper();
     let cyclic_modules = synchronous_cycle_modules(&self.link_output.module_table.modules);
@@ -474,13 +479,18 @@ impl GenerateStage<'_> {
       star_reexport_records_by_imported_symbol: &self
         .link_output
         .star_reexport_records_by_imported_symbol,
-      used_symbols: used_symbol_refs,
+      used_symbol_refs_builder,
       cyclic_modules: &cyclic_modules,
       tree_shaking: self.options.treeshake.is_some(),
     };
     let consumer_local_plan = consumer_local_reexport_plan(&input, order_state);
     if plan.is_empty() && consumer_local_plan.is_empty() {
-      return self.apply_inert_order_wrap_plan(chunk_graph, used_symbol_refs, order_state, plan);
+      return self.apply_inert_order_wrap_plan(
+        chunk_graph,
+        used_symbol_refs_builder,
+        order_state,
+        plan,
+      );
     }
 
     let mut output =
@@ -563,7 +573,8 @@ impl GenerateStage<'_> {
     // spare the query entirely when no entry could need a facade in the first place.
     let candidates = self.entry_facade_candidates(plan);
     if !candidates.is_empty() {
-      let import_edges = self.entry_facade_import_edges(chunk_graph, used_symbol_refs, order_state);
+      let import_edges =
+        self.entry_facade_import_edges(chunk_graph, used_symbol_refs_builder, order_state);
       self.create_order_wrap_entry_facades(chunk_graph, candidates, &import_edges, order_state);
       // `create_order_wrap_entry_facades` may replace a newly-created dynamic facade with a
       // call-site trigger. Its simulated namespace adds late runtime-helper demand after the
@@ -596,7 +607,7 @@ impl GenerateStage<'_> {
   fn apply_inert_order_wrap_plan(
     &self,
     chunk_graph: &mut ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     order_state: &mut OrderWrapState,
     plan: &OrderWrapPlan,
   ) -> bool {
@@ -604,7 +615,8 @@ impl GenerateStage<'_> {
     if candidates.is_empty() {
       return false;
     }
-    let import_edges = self.entry_facade_import_edges(chunk_graph, used_symbol_refs, order_state);
+    let import_edges =
+      self.entry_facade_import_edges(chunk_graph, used_symbol_refs_builder, order_state);
     if !self.create_order_wrap_entry_facades(chunk_graph, candidates, &import_edges, order_state) {
       return false;
     }
@@ -626,7 +638,7 @@ impl GenerateStage<'_> {
   fn entry_facade_import_edges(
     &self,
     chunk_graph: &ChunkGraph,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
     order_state: &OrderWrapState,
   ) -> IndexVec<ChunkIdx, FxHashSet<ChunkIdx>> {
     if self.options.code_splitting.is_disabled() {
@@ -638,7 +650,7 @@ impl GenerateStage<'_> {
       self.compute_wrapped_esm_init_metadata(&self.ast_table, chunk_graph, order_state);
     self.lowered_static_import_edges(
       chunk_graph,
-      used_symbol_refs,
+      used_symbol_refs_builder,
       order_state,
       &final_esm_init_metadata,
     )
@@ -1551,7 +1563,7 @@ pub(super) fn collect_frozen_reexport_usage(
 ) -> FrozenReexportUsage {
   let mut consumed_facades = FxHashSet::default();
   for (used_ref, chain) in input.export_chains {
-    if input.used_symbols.contains(used_ref) {
+    if input.used_symbol_refs_builder.contains(used_ref) {
       consumed_facades.extend(chain.iter().copied());
     }
   }
@@ -1583,7 +1595,7 @@ pub(super) fn collect_frozen_reexport_usage(
         // this gate exists for — is a link-time fact the provisional pass already observes.
         input.linking[imported_as_ref.owner].namespace_included
       } else {
-        input.used_symbols.contains(imported_as_ref)
+        input.used_symbol_refs_builder.contains(imported_as_ref)
           || consumed_facades.contains(imported_as_ref)
           || input.linking[root.0]
             .referenced_symbols_by_entry_point_chunk
@@ -1680,7 +1692,7 @@ fn retained_order_reexport_path(
   }
 
   let facade_is_retained = |facade_ref: SymbolRef| {
-    input.used_symbols.contains(&facade_ref)
+    input.used_symbol_refs_builder.contains(&facade_ref)
       || reexport_usage.consumed_facades.contains(&facade_ref)
   };
   (importer

--- a/crates/rolldown/src/stages/generate_stage/runtime_module_sweep.rs
+++ b/crates/rolldown/src/stages/generate_stage/runtime_module_sweep.rs
@@ -38,7 +38,7 @@ impl GenerateStage<'_> {
   pub fn sweep_unused_runtime_module(
     &mut self,
     chunk_graph: &mut ChunkGraph,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
   ) {
     // Without tree-shaking, inclusion is not demand-based; leave everything in place.
     if self.options.treeshake.is_none() {
@@ -68,9 +68,9 @@ impl GenerateStage<'_> {
     // Stale references to runtime symbols may survive on included statements (e.g. a namespace
     // statement that `finalized_module_namespace_ref_usage` decided not to render keeps its
     // `__exportAll` reference, and chunk-level `depended_runtime_helper` flags keep their bits).
-    // Downstream passes filter those against `used_symbol_refs`, so purging the runtime's
+    // Downstream passes filter those against `used_symbol_refs_builder`, so purging the runtime's
     // symbols here is what actually severs every cross-chunk edge to it.
-    used_symbol_refs.remove_owned_by(runtime_idx);
+    used_symbol_refs_builder.remove_owned_by(runtime_idx);
 
     if let Some(chunk_idx) = chunk_graph.module_to_chunk[runtime_idx] {
       chunk_graph.module_to_chunk[runtime_idx] = None;

--- a/crates/rolldown/src/stages/generate_stage/simulated_facade_inclusion.rs
+++ b/crates/rolldown/src/stages/generate_stage/simulated_facade_inclusion.rs
@@ -23,7 +23,7 @@ impl GenerateStage<'_> {
   pub(super) fn narrow_namespace_stmt_to_used_symbols(
     &mut self,
     entry_module_idx: ModuleIdx,
-    used_symbol_refs: &UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &UsedSymbolRefsBuilder,
   ) {
     let runtime_module_idx = self.link_output.runtime.id();
     let wrap_kind = self.link_output.metas[entry_module_idx].wrap_kind();
@@ -40,7 +40,7 @@ impl GenerateStage<'_> {
         .retain(|item| match item {
           rolldown_common::SymbolOrMemberExprRef::Symbol(symbol_ref) => {
             // module namespace symbol requires `__exportAll` runtime helper
-            used_symbol_refs.contains(symbol_ref) || symbol_ref.owner == runtime_module_idx
+            used_symbol_refs_builder.contains(symbol_ref) || symbol_ref.owner == runtime_module_idx
           }
           rolldown_common::SymbolOrMemberExprRef::MemberExpr(_member_expr_ref) => true,
         });
@@ -53,7 +53,7 @@ impl GenerateStage<'_> {
   /// When `f` returns `true`, the `__exportAll` runtime helper is included as well.
   pub(super) fn replay_link_stage_inclusion(
     &mut self,
-    used_symbol_refs: &mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &mut UsedSymbolRefsBuilder,
     f: impl FnOnce(&mut IncludeContext<'_>) -> bool,
   ) {
     let (mut stmt_info_included_vec, mut module_included_vec, mut module_namespace_reason_vec) =
@@ -77,7 +77,7 @@ impl GenerateStage<'_> {
       tree_shaking: self.options.treeshake.is_some(),
       runtime_idx: self.link_output.runtime.id(),
       metas: &self.link_output.metas,
-      used_symbol_refs,
+      used_symbol_refs_builder,
       used_external_symbols: &mut self.link_output.used_external_symbols,
       constant_symbol_map: &self.link_output.global_constant_symbol_map,
       options: self.options,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -107,7 +107,7 @@ pub struct LinkStage<'a> {
   pub diagnostics: Diagnostics,
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
-  pub used_symbol_refs: UsedSymbolRefsBuilder,
+  pub used_symbol_refs_builder: UsedSymbolRefsBuilder,
   pub used_external_symbols: UsedExternalSymbols,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
@@ -214,7 +214,7 @@ impl<'a> LinkStage<'a> {
       ast_table: scan_stage_output.index_ecma_ast,
       dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
       options,
-      used_symbol_refs: UsedSymbolRefsBuilder::default(),
+      used_symbol_refs_builder: UsedSymbolRefsBuilder::default(),
       used_external_symbols: UsedExternalSymbols::default(),
       safely_merge_cjs_ns_map: FxHashMap::default(),
       normal_symbol_exports_chain_map: FxHashMap::default(),
@@ -278,7 +278,7 @@ impl<'a> LinkStage<'a> {
         has_enum_inlining: self.has_enum_inlining,
       },
       self.ast_table,
-      self.used_symbol_refs,
+      self.used_symbol_refs_builder,
     )
   }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -73,7 +73,7 @@ pub struct IncludeContext<'a> {
   pub inline_const_smart: bool,
   pub runtime_idx: ModuleIdx,
   pub metas: &'a LinkingMetadataVec,
-  pub used_symbol_refs: &'a mut UsedSymbolRefsBuilder,
+  pub used_symbol_refs_builder: &'a mut UsedSymbolRefsBuilder,
   pub used_external_symbols: &'a mut UsedExternalSymbols,
   pub constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
   pub options: &'a NormalizedBundlerOptions,
@@ -121,7 +121,7 @@ impl<'a> IncludeContext<'a> {
     is_module_included_vec: &'a mut ModuleInclusionVec,
     runtime_idx: ModuleIdx,
     metas: &'a LinkingMetadataVec,
-    used_symbol_refs: &'a mut UsedSymbolRefsBuilder,
+    used_symbol_refs_builder: &'a mut UsedSymbolRefsBuilder,
     used_external_symbols: &'a mut UsedExternalSymbols,
     constant_symbol_map: &'a FxHashMap<SymbolRef, ConstExportMeta>,
     options: &'a NormalizedBundlerOptions,
@@ -140,7 +140,7 @@ impl<'a> IncludeContext<'a> {
       inline_const_smart: options.optimization.is_inline_const_smart_mode(),
       runtime_idx,
       metas,
-      used_symbol_refs,
+      used_symbol_refs_builder,
       used_external_symbols,
       constant_symbol_map,
       options,
@@ -266,7 +266,7 @@ impl LinkStage<'_> {
         m.as_normal().map_or(IndexBitSet::default(), |_| IndexBitSet::new(stmt_infos.len()))
       })
       .collect::<IndexVec<ModuleIdx, _>>();
-    let mut used_symbol_refs = UsedSymbolRefsBuilder::default();
+    let mut used_symbol_refs_builder = UsedSymbolRefsBuilder::default();
     let mut used_external_symbols = UsedExternalSymbols::default();
     let mut is_module_included_vec: ModuleInclusionVec =
       IndexBitSet::new(self.module_table.modules.len());
@@ -293,7 +293,7 @@ impl LinkStage<'_> {
       &mut is_module_included_vec,
       self.runtime.id(),
       &self.metas,
-      &mut used_symbol_refs,
+      &mut used_symbol_refs_builder,
       &mut used_external_symbols,
       &self.global_constant_symbol_map,
       self.options,
@@ -454,7 +454,7 @@ impl LinkStage<'_> {
       &mut is_module_included_vec,
       self.runtime.id(),
       &self.metas,
-      &mut used_symbol_refs,
+      &mut used_symbol_refs_builder,
       &mut used_external_symbols,
       &self.global_constant_symbol_map,
       self.options,
@@ -465,7 +465,7 @@ impl LinkStage<'_> {
     );
     include_runtime_symbol(context, &self.runtime, depended_runtime_helper);
 
-    self.used_symbol_refs = used_symbol_refs;
+    self.used_symbol_refs_builder = used_symbol_refs_builder;
     self.used_external_symbols = used_external_symbols;
     // Store the final statement inclusion results back to metas.
     is_stmt_info_included_vec.into_iter_enumerated().for_each(|(module_idx, stmt_included_vec)| {
@@ -675,7 +675,7 @@ fn handle_include_symbol(
   }
 
   // Also include the symbol that points to the canonical ref.
-  ctx.used_symbol_refs.insert(symbol_ref);
+  ctx.used_symbol_refs_builder.insert(symbol_ref);
   if ctx.modules[symbol_ref.owner].is_external() {
     ctx.used_external_symbols.insert(symbol_ref);
   }
@@ -691,7 +691,7 @@ fn handle_include_symbol(
   let is_simulated_facade_chunk =
     note_namespace_inclusion_reason(ctx, canonical_ref, include_reason);
 
-  ctx.used_symbol_refs.insert(canonical_ref);
+  ctx.used_symbol_refs_builder.insert(canonical_ref);
   if ctx.modules[canonical_ref.owner].is_external() {
     ctx.used_external_symbols.insert(canonical_ref);
     note_external_interop_use(ctx, symbol_ref, alias_holder_ref, canonical_ref);

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/passes.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/passes.rs
@@ -105,7 +105,7 @@ pub fn include_runtime_symbol(
 /// it. `#9122`'s `wrapper` keeps `StateCode`/`getX` because the entry imports them *through*
 /// `wrapper` (`export { … } from './wrapper.js'`). The synthetic runtime module is excluded.
 ///
-/// Must run once, after the inclusion fixpoint has settled `used_symbol_refs`. It only includes
+/// Must run once, after the inclusion fixpoint has settled `used_symbol_refs_builder`. It only includes
 /// re-export statements that reference already-retained canonicals, so it introduces no new
 /// reachable values and needs no further convergence.
 pub(super) fn preserve_reexported_interfaces(ctx: &mut IncludeContext) {
@@ -116,7 +116,7 @@ pub(super) fn preserve_reexported_interfaces(ctx: &mut IncludeContext) {
   // symbol — these are the facades consumed through their own module.
   let mut consumed_facades: FxHashSet<SymbolRef> = FxHashSet::default();
   for (imported_as_ref, reexports) in ctx.normal_symbol_exports_chain_map {
-    if ctx.used_symbol_refs.contains(imported_as_ref) {
+    if ctx.used_symbol_refs_builder.contains(imported_as_ref) {
       consumed_facades.extend(reexports.iter().copied());
     }
   }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -220,7 +220,7 @@ pub use crate::{
     GetLocalDb, GetLocalDbMut, SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags,
   },
   types::used_external_symbols::{ExternalInteropUse, UsedExternalSymbols},
-  types::used_symbol_refs::{UsedSymbolRefs, UsedSymbolRefsBuilder},
+  types::used_symbol_refs::{UsedSymbolRefs, UsedSymbolRefsBuilder, UsedSymbolRefsView},
   types::watch::WatcherChangeKind,
   types::wrap_kind::WrapKind,
 };

--- a/crates/rolldown_common/src/types/used_symbol_refs.rs
+++ b/crates/rolldown_common/src/types/used_symbol_refs.rs
@@ -29,7 +29,29 @@ pub struct UsedSymbolRefs {
 
 impl UsedSymbolRefs {
   #[inline]
+  pub fn view(&self) -> UsedSymbolRefsView<'_> {
+    UsedSymbolRefsView { inner: &self.inner }
+  }
+
+  #[inline]
   pub fn contains(&self, symbol_ref: &SymbolRef) -> bool {
+    self.inner.contains(symbol_ref)
+  }
+}
+
+/// A shared read-only borrow of either phase of used-symbol collection.
+///
+/// Keeping this view concrete lets readers shared by the mutable and sealed phases compile once
+/// without exposing mutation or allowing a builder to satisfy an API that requires the sealed
+/// [`UsedSymbolRefs`] artifact.
+#[derive(Clone, Copy)]
+pub struct UsedSymbolRefsView<'a> {
+  inner: &'a FxHashSet<SymbolRef>,
+}
+
+impl UsedSymbolRefsView<'_> {
+  #[inline]
+  pub fn contains(self, symbol_ref: &SymbolRef) -> bool {
     self.inner.contains(symbol_ref)
   }
 }
@@ -43,6 +65,11 @@ pub struct UsedSymbolRefsBuilder {
 }
 
 impl UsedSymbolRefsBuilder {
+  #[inline]
+  pub fn view(&self) -> UsedSymbolRefsView<'_> {
+    UsedSymbolRefsView { inner: &self.inner }
+  }
+
   #[inline]
   pub fn insert(&mut self, symbol_ref: SymbolRef) {
     self.inner.insert(symbol_ref);

--- a/internal-docs/code-splitting/design.md
+++ b/internal-docs/code-splitting/design.md
@@ -399,7 +399,7 @@ pub struct OrderLoweringInput<'a> {
   pub export_chains: &'a FxHashMap<SymbolRef, Vec<SymbolRef>>,
   pub star_reexport_records_by_imported_symbol:
     &'a FxHashMap<SymbolRef, Vec<Vec<(ModuleIdx, ImportRecordIdx)>>>,
-  pub used_symbols: &'a UsedSymbolRefsBuilder,
+  pub used_symbol_refs_builder: &'a UsedSymbolRefsBuilder,
   pub cyclic_modules: &'a FxHashSet<ModuleIdx>,
   pub tree_shaking: bool,
 }


### PR DESCRIPTION
Replace generic `&impl UsedSymbolRefsView` parameters with a concrete borrowed `UsedSymbolRefsView<'_>` to deduplicate reader monomorphizations while preserving `UsedSymbolRefsBuilder` and `UsedSymbolRefs` as the mutable and sealed owners.

Rename related variables and parameters to match their actual phase: `used_symbol_refs_builder`, `used_symbol_refs`, and `used_symbol_refs_view`.

Reduces measured release `.text` by about 33 KiB.