### PR TITLE
perf: batch `codeSplitting` group `test` / `name` calls

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -1,4 +1,5 @@
 use std::{
+  borrow::Cow,
   cmp::{Ordering, Reverse},
   collections::BinaryHeap,
   path::Path,
@@ -10,7 +11,8 @@ use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
   Chunk, ChunkKind, ChunkingContext, EntryPoint, ManualCodeSplittingOptions, MatchGroup,
-  MatchGroupTest, Module, ModuleIdx, ModuleTable, ModuleTagBitSet, ModuleTagRegistry, NormalModule,
+  MatchGroupName, MatchGroupTest, Module, ModuleIdx, ModuleTable, ModuleTagBitSet,
+  ModuleTagRegistry, NormalModule,
 };
 use rolldown_error::BuildResult;
 use rolldown_plugin::SharedPluginDriver;
@@ -112,8 +114,9 @@ impl ManualSplitter<'_> {
     Ok(())
   }
 
-  /// Whether `module` clears the group's module-level constraints: required tags, the module size
-  /// bounds, and the share count.
+  /// Runs the checks that sit between a group's `test` call and its `name` call.
+  ///
+  /// They read data that only Rust holds. That is why `test` and `name` need two calls.
   fn passes_static_filters(
     &self,
     match_group_index: usize,
@@ -169,7 +172,7 @@ impl ManualSplitter<'_> {
     // Without this, a stateful function would produce different chunk assignments across runs
     // because `ModuleIdx` is assigned in module-load completion order, which varies with
     // parallel `resolveId`/`load`.
-    let sorted_normal_modules = self
+    let candidate_modules = self
       .link_output
       .module_table
       .modules
@@ -178,33 +181,70 @@ impl ManualSplitter<'_> {
       .filter(|module| {
         metas[module.idx].is_included && !self.module_to_assigned.has_bit(module.idx)
       })
-      .sorted_unstable_by(|a, b| a.stable_id.cmp(&b.stable_id));
+      .sorted_unstable_by(|a, b| a.stable_id.cmp(&b.stable_id))
+      .collect_vec();
 
+    // `test` and `name` are JS callbacks, so one call per module would cross the napi boundary
+    // M * G times. One batched call per group replaces that.
+    //
+    // A group cannot narrow `candidate_modules` to what earlier groups left behind. Priority
+    // resolves the overlap later, in `emit_chunk_from_group`. If this loop dropped matched
+    // modules, a module would go to the first group in the list, not to the group with the
+    // highest priority.
     let ctx = ChunkingContext::new(Arc::clone(&self.plugin_driver.module_infos));
 
-    for normal_module in sorted_normal_modules {
-      for (match_group_index, match_group) in self.match_groups.iter().copied().enumerate() {
-        let is_matched = match &match_group.test {
-          None => true,
-          Some(MatchGroupTest::Regex(reg)) => reg.matches(&normal_module.id),
-          Some(MatchGroupTest::Function(func)) => {
-            func(&normal_module.id).await?.unwrap_or_default()
+    for (match_group_index, match_group) in self.match_groups.iter().copied().enumerate() {
+      let matched = match &match_group.test {
+        None => vec![true; candidate_modules.len()],
+        Some(MatchGroupTest::Regex(reg)) => {
+          candidate_modules.iter().map(|module| reg.matches(&module.id)).collect_vec()
+        }
+        Some(MatchGroupTest::Function(func)) => {
+          let module_ids =
+            candidate_modules.iter().map(|module| module.id.to_string()).collect_vec();
+          let results = func(module_ids).await?;
+          if results.len() != candidate_modules.len() {
+            return Err(
+              anyhow::anyhow!(
+                "a `codeSplitting` group `test` function returned {} results for {} modules",
+                results.len(),
+                candidate_modules.len()
+              )
+              .into(),
+            );
           }
-        };
-
-        if !is_matched {
-          continue;
+          results.into_iter().map(Option::unwrap_or_default).collect_vec()
         }
+      };
 
-        if !self.passes_static_filters(match_group_index, match_group, normal_module) {
-          continue;
+      let captured = candidate_modules
+        .iter()
+        .copied()
+        .zip(matched)
+        .filter(|(module, is_matched)| {
+          *is_matched && self.passes_static_filters(match_group_index, match_group, module)
+        })
+        .map(|(module, _)| module)
+        .collect_vec();
+
+      if captured.is_empty() {
+        continue;
+      }
+
+      let names = match &match_group.name {
+        MatchGroupName::Static(name) => vec![Some(Cow::Borrowed(name.as_str())); captured.len()],
+        MatchGroupName::Dynamic(_) => {
+          let module_ids = captured.iter().map(|module| module.id.to_string()).collect_vec();
+          match_group.name.values(&ctx, module_ids).await?
         }
+      };
 
-        let Some(group_name) = match_group.name.value(&ctx, &normal_module.id).await? else {
+      for (normal_module, group_name) in captured.into_iter().zip(names) {
+        let Some(group_name) = group_name else {
           // Group which doesn't have a name will be ignored.
           continue;
         };
-        let group_name = ArcStr::from(group_name);
+        let group_name = ArcStr::from(group_name.as_ref());
 
         let entries_aware = match_group.entries_aware.unwrap_or(false);
         let module_group_id = ModuleGroupId { match_group_index, name: group_name.clone() };
@@ -842,6 +882,9 @@ fn derive_entries_aware_chunk_name(
   }
 }
 
+/// `visited` guards one walk against cycles and repeated paths, and nothing more. A set shared
+/// across matched modules gave no measured gain. It would also have to belong to one
+/// `ModuleGroup`, because a dynamic `name` splits one match group across several groups.
 fn add_module_and_dependencies_to_group_recursively(
   module_group: &mut ModuleGroup,
   module_idx: ModuleIdx,

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -19,16 +19,23 @@ pub struct BindingManualCodeSplittingOptions {
   pub max_module_size: Option<f64>,
 }
 
-type BindingMatchGroupTest =
-  Either<BindingStringOrRegex, JsCallback<FnArgs<(/*module id*/ String,)>, Option<bool>>>;
+/// The JS side wraps the user's per-id function in one shim per group. The returned array matches
+/// the id array by index. See `packages/rolldown/src/utils/bindingify-output-options.ts`.
+type BindingMatchGroupTest = Either<
+  BindingStringOrRegex,
+  JsCallback<FnArgs<(/*module ids*/ Vec<String>,)>, Vec<Option<bool>>>,
+>;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
 pub struct BindingMatchGroup {
-  #[napi(ts_type = "string | ((id: string, ctx: BindingChunkingContext) => VoidNullable<string>)")]
+  #[napi(
+    ts_type = "string | ((ids: Array<string>, ctx: BindingChunkingContext) => Array<VoidNullable<string>>)"
+  )]
   #[debug("MatchGroupName(...)")]
-  pub name: Either<String, JsCallback<FnArgs<(String, BindingChunkingContext)>, Option<String>>>,
-  #[napi(ts_type = "string | RegExp | ((id: string) => VoidNullable<boolean>)")]
+  pub name:
+    Either<String, JsCallback<FnArgs<(Vec<String>, BindingChunkingContext)>, Vec<Option<String>>>>,
+  #[napi(ts_type = "string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)")]
   #[debug("MatchGroupTest(...)")]
   pub test: Option<BindingMatchGroupTest>,
   // pub share_count: Option<u32>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -383,14 +383,13 @@ fn normalize_code_splitting(
                     Either::A(name) => MatchGroupName::Static(name),
                     Either::B(func) => {
                       let func = Arc::clone(&func);
-                      MatchGroupName::Dynamic(Arc::new(move |module_id, ctx| {
-                        let module_id = module_id.to_string();
+                      MatchGroupName::Dynamic(Arc::new(move |module_ids, ctx| {
                         let func = Arc::clone(&func);
                         let owned_ctx = ctx.clone();
                         Box::pin(async move {
                           func
                             .invoke_async(
-                              (module_id, BindingChunkingContext::new(owned_ctx)).into(),
+                              (module_ids, BindingChunkingContext::new(owned_ctx)).into(),
                             )
                             .await
                             .context("advancedChunks group name option")
@@ -410,19 +409,18 @@ fn normalize_code_splitting(
                             ))
                           })?))
                         }
-                        Either::B(func) => {
-                          Ok(rolldown::MatchGroupTest::Function(Arc::new(move |id: &str| {
-                            let id = id.to_string();
+                        Either::B(func) => Ok(rolldown::MatchGroupTest::Function(Arc::new(
+                          move |module_ids: Vec<String>| {
                             let func = Arc::clone(&func);
                             Box::pin(async move {
                               func
-                                .invoke_async((id,).into())
+                                .invoke_async((module_ids,).into())
                                 .await
                                 .context("advancedChunks group test option")
                                 .map_err(anyhow::Error::from)
                             })
-                          })))
-                        }
+                          },
+                        ))),
                       }
                     })
                     .transpose()?,

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -77,7 +77,12 @@ pub struct MatchGroup {
   pub include_dependencies_recursively: Option<bool>,
 }
 
-type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>
+/// Classifies a whole batch of module ids in one call.
+///
+/// The returned `Vec` must match `module_ids` by index. The caller rejects any other length.
+type MatchGroupTestFn = dyn Fn(
+    /* module ids */ Vec<String>,
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<Option<bool>>>> + Send + 'static>>
   + Send
   + Sync;
 
@@ -101,10 +106,12 @@ where
   Ok(transformed.map(MatchGroupTest::Regex))
 }
 
+/// Names a whole batch of module ids in one call. The returned `Vec` follows the same rule as
+/// [`MatchGroupTestFn`].
 type MatchGroupNameFn = dyn Fn(
-    /* module id */ &str,
+    /* module ids */ Vec<String>,
     /* chunking context */ &ChunkingContext,
-  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<String>>> + Send + 'static>>
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<Option<String>>>> + Send + 'static>>
   + Send
   + Sync;
 
@@ -116,16 +123,28 @@ pub enum MatchGroupName {
 }
 
 impl MatchGroupName {
-  pub async fn value<'a>(
+  /// Resolves the group name of every id in `module_ids`, in the same order. The result always
+  /// has the same length as `module_ids`.
+  pub async fn values<'a>(
     &'a self,
     ctx: &ChunkingContext,
-    module_id: &str,
-  ) -> BuildResult<Option<Cow<'a, str>>> {
+    module_ids: Vec<String>,
+  ) -> BuildResult<Vec<Option<Cow<'a, str>>>> {
     match self {
-      Self::Static(name) => Ok(Some(Cow::Borrowed(name))),
+      Self::Static(name) => Ok(vec![Some(Cow::Borrowed(name.as_str())); module_ids.len()]),
       Self::Dynamic(func) => {
-        let name = func(module_id, ctx).await?;
-        Ok(name.map(Cow::Owned))
+        let expected = module_ids.len();
+        let names = func(module_ids, ctx).await?;
+        if names.len() != expected {
+          return Err(
+            anyhow::anyhow!(
+              "a `codeSplitting` group `name` function returned {} names for {expected} modules",
+              names.len()
+            )
+            .into(),
+          );
+        }
+        Ok(names.into_iter().map(|name| name.map(Cow::Owned)).collect())
       }
     }
   }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2590,8 +2590,8 @@ export interface BindingManualCodeSplittingOptions {
 }
 
 export interface BindingMatchGroup {
-  name: string | ((id: string, ctx: BindingChunkingContext) => VoidNullable<string>)
-  test?: string | RegExp | ((id: string) => VoidNullable<boolean>)
+  name: string | ((ids: Array<string>, ctx: BindingChunkingContext) => Array<VoidNullable<string>>)
+  test?: string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)
   priority?: number
   minSize?: number
   minShareCount?: number

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -825,6 +825,10 @@ export type CodeSplittingGroup = {
    * :::warning
    * Constraints like `minSize`, `maxSize`, etc. are applied separately for different names returned by the function.
    * :::
+   *
+   * :::warning
+   * Rolldown calls a function `name` once for each captured module, in a deterministic order. It calls `test` for every candidate module of the group first. Do not read a "current module" variable that `test` wrote, because that variable holds the last module `test` saw. Store such state under the module id instead.
+   * :::
    */
   name: string | CodeSplittingNameFunction;
   /**
@@ -839,6 +843,10 @@ export type CodeSplittingGroup = {
    * When using regular expression, it's recommended to use `[\\/]` to match the path separator instead of `/` to avoid potential issues on Windows.
    * - ✅ Recommended: `/node_modules[\\/]react/`
    * - ❌ Not recommended: `/node_modules/react/`
+   * :::
+   *
+   * :::warning
+   * Rolldown calls a function `test` once for each candidate module, in a deterministic order. It makes every `test` call of a group before it makes the first `name` call of that group. Rolldown processes the groups in the order that you declare them.
    * :::
    */
   test?: StringOrRegExp | CodeSplittingTestFunction;

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2590,8 +2590,8 @@ export interface BindingManualCodeSplittingOptions {
 }
 
 export interface BindingMatchGroup {
-  name: string | ((id: string, ctx: BindingChunkingContext) => VoidNullable<string>)
-  test?: string | RegExp | ((id: string) => VoidNullable<boolean>)
+  name: string | ((ids: Array<string>, ctx: BindingChunkingContext) => Array<VoidNullable<string>>)
+  test?: string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)
   priority?: number
   minSize?: number
   minShareCount?: number

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,5 +1,9 @@
 import type { BindingChunkingContext, BindingOutputOptions } from '../binding.cjs';
-import type { OutputOptions } from '../options/output-options';
+import type {
+  CodeSplittingNameFunction,
+  CodeSplittingTestFunction,
+  OutputOptions,
+} from '../options/output-options';
 import type { PluginContextData } from '../plugin/plugin-context-data';
 import { ChunkingContextImpl } from '../types/chunking-context';
 import { transformAssetSource } from './asset-source';
@@ -361,19 +365,28 @@ function bindingifyCodeSplitting(
           ...restGroup,
           test:
             typeof test === 'function'
-              ? measureHookCost(timings, OUTPUT_OPTIONS_OWNER, 'codeSplitting groups[].test', test)
+              ? batchTest(
+                  measureHookCost(
+                    timings,
+                    OUTPUT_OPTIONS_OWNER,
+                    'codeSplitting groups[].test',
+                    test,
+                  ),
+                )
               : test,
           // The core calls this classifier directly rather than through a plugin, so it
           // belongs to no plugin's rows — and it runs once per module, which is how it ends
           // up dominating a build.
           name:
             typeof name === 'function'
-              ? measureHookCost(
-                  timings,
-                  OUTPUT_OPTIONS_OWNER,
-                  'codeSplitting groups[].name',
-                  (id: string, ctx: BindingChunkingContext) =>
-                    name(id, new ChunkingContextImpl(ctx, pluginContextData)),
+              ? batchName(
+                  measureHookCost(
+                    timings,
+                    OUTPUT_OPTIONS_OWNER,
+                    'codeSplitting groups[].name',
+                    name,
+                  ),
+                  pluginContextData,
                 )
               : name,
         };
@@ -384,5 +397,43 @@ function bindingifyCodeSplitting(
   return {
     inlineDynamicImports,
     advancedChunks: advancedChunksResult,
+  };
+}
+
+/**
+ * Wraps a per-id `test` in the batched shim that the binding expects.
+ *
+ * The loop runs in JS so that a group makes one napi crossing, not one per module.
+ */
+function batchTest(
+  test: CodeSplittingTestFunction,
+): (ids: string[]) => ReturnType<CodeSplittingTestFunction>[] {
+  return (ids) => {
+    const results: ReturnType<CodeSplittingTestFunction>[] = [];
+    for (let index = 0; index < ids.length; index++) {
+      results.push(test(ids[index]));
+    }
+    return results;
+  };
+}
+
+/**
+ * This is the `name` equivalent of {@linkcode batchTest}. The context wrapper holds no per-call
+ * state, so one instance serves the whole batch.
+ */
+function batchName(
+  name: CodeSplittingNameFunction,
+  pluginContextData: PluginContextData,
+): (
+  ids: string[],
+  bindingContext: BindingChunkingContext,
+) => ReturnType<CodeSplittingNameFunction>[] {
+  return (ids, bindingContext) => {
+    const context = new ChunkingContextImpl(bindingContext, pluginContextData);
+    const results: ReturnType<CodeSplittingNameFunction>[] = [];
+    for (let index = 0; index < ids.length; index++) {
+      results.push(name(ids[index], context));
+    }
+    return results;
   };
 }


### PR DESCRIPTION
Function-valued `codeSplitting.groups[].test` and `.name` are JS callbacks, and each call crossed the napi boundary on its own, so a build with M modules and G function groups paid M * G crossings before it rendered a chunk.

The JS side now hands the binding one shim per callback that takes the whole id array and loops in JS, so a group crosses at most twice. A group's calls are contiguous now instead of interleaved with the other groups', and a group's whole `test` pass runs before its first `name` call, but each callback still sees its own ids in `stable_id` order.

<details><summary>benchmark</summary>

20k leaf modules shared across 200 dynamic entries, 6 groups with function `test` + `name`. Best of 11 `generate()` calls, release builds of all three, byte-identical output.

| | `generate()` | the 86,856 `test` calls alone |
|---|---|---|
| main | 1243 ms | 803 ms |
| #10740 | 412 ms | 57 ms |
| this PR | 361 ms | 18 ms |

The second column comes from timing the same app again with the six `test` functions replaced by regexes that match identically. The output stays byte-identical, so the only difference is that those calls never leave Rust. #10740 overlaps one crossing per call with `try_join_all`, which leaves 656 ns each; batching the payload leaves 207 ns.

What is left is mostly not the user's code — replaying those same 86,856 calls in plain JS costs 0.7 ms, so ~95% of the 18 ms is marshalling one id string per module per group. Sending the id list once for all groups would cut that further.

Benchmark produced with Claude Code.

</details>

This and #10740 solve the same problem and cannot both land.



