### PR TITLE
fix: name the module when a `codeSplitting` group callback returns a wrong type

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -213,7 +213,7 @@ impl ManualSplitter<'_> {
               .into(),
             );
           }
-          results.into_iter().map(Option::unwrap_or_default).collect_vec()
+          results
         }
       };
 

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -1,5 +1,8 @@
 use derive_more::Debug;
-use napi::{Either, bindgen_prelude::FnArgs};
+use napi::{
+  Either,
+  bindgen_prelude::{FnArgs, Uint8Array},
+};
 use rolldown::ChunkingContext;
 
 use crate::types::{
@@ -19,12 +22,11 @@ pub struct BindingManualCodeSplittingOptions {
   pub max_module_size: Option<f64>,
 }
 
-/// The JS side wraps the user's per-id function in one shim per group. The returned array matches
-/// the id array by index. See `packages/rolldown/src/utils/bindingify-output-options.ts`.
-type BindingMatchGroupTest = Either<
-  BindingStringOrRegex,
-  JsCallback<FnArgs<(/*module ids*/ Vec<String>,)>, Vec<Option<bool>>>,
->;
+/// The JS side wraps the user's per-id function in one shim per group. The result holds one byte
+/// per id, and a nonzero byte captures the module. See
+/// `packages/rolldown/src/utils/bindingify-output-options.ts`.
+type BindingMatchGroupTest =
+  Either<BindingStringOrRegex, JsCallback<FnArgs<(/*module ids*/ Vec<String>,)>, Uint8Array>>;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
@@ -35,7 +37,7 @@ pub struct BindingMatchGroup {
   #[debug("MatchGroupName(...)")]
   pub name:
     Either<String, JsCallback<FnArgs<(Vec<String>, BindingChunkingContext)>, Vec<Option<String>>>>,
-  #[napi(ts_type = "string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)")]
+  #[napi(ts_type = "string | RegExp | ((ids: Array<string>) => Uint8Array)")]
   #[debug("MatchGroupTest(...)")]
   pub test: Option<BindingMatchGroupTest>,
   // pub share_count: Option<u32>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -418,6 +418,7 @@ fn normalize_code_splitting(
                                 .await
                                 .context("advancedChunks group test option")
                                 .map_err(anyhow::Error::from)
+                                .map(|flags| flags.iter().map(|flag| *flag != 0).collect())
                             })
                           },
                         ))),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -82,7 +82,7 @@ pub struct MatchGroup {
 /// The returned `Vec` must match `module_ids` by index. The caller rejects any other length.
 type MatchGroupTestFn = dyn Fn(
     /* module ids */ Vec<String>,
-  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<Option<bool>>>> + Send + 'static>>
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<bool>>> + Send + 'static>>
   + Send
   + Sync;
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2591,7 +2591,7 @@ export interface BindingManualCodeSplittingOptions {
 
 export interface BindingMatchGroup {
   name: string | ((ids: Array<string>, ctx: BindingChunkingContext) => Array<VoidNullable<string>>)
-  test?: string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)
+  test?: string | RegExp | ((ids: Array<string>) => Uint8Array)
   priority?: number
   minSize?: number
   minShareCount?: number

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2591,7 +2591,7 @@ export interface BindingManualCodeSplittingOptions {
 
 export interface BindingMatchGroup {
   name: string | ((ids: Array<string>, ctx: BindingChunkingContext) => Array<VoidNullable<string>>)
-  test?: string | RegExp | ((ids: Array<string>) => Array<VoidNullable<boolean>>)
+  test?: string | RegExp | ((ids: Array<string>) => Uint8Array)
   priority?: number
   minSize?: number
   minShareCount?: number

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -404,14 +404,23 @@ function bindingifyCodeSplitting(
  * Wraps a per-id `test` in the batched shim that the binding expects.
  *
  * The loop runs in JS so that a group makes one napi crossing, not one per module.
+ *
+ * The result is a `Uint8Array`, which crosses as a buffer instead of one tagged value per id.
  */
-function batchTest(
-  test: CodeSplittingTestFunction,
-): (ids: string[]) => ReturnType<CodeSplittingTestFunction>[] {
+function batchTest(test: CodeSplittingTestFunction): (ids: string[]) => Uint8Array {
   return (ids) => {
-    const results: ReturnType<CodeSplittingTestFunction>[] = [];
+    const results = new Uint8Array(ids.length);
     for (let index = 0; index < ids.length; index++) {
-      results.push(test(ids[index]));
+      const result = test(ids[index]);
+      // napi reports the type of the array, not of the bad element, so the check runs here.
+      if (result != null && typeof result !== 'boolean') {
+        throw new TypeError(
+          `\`output.codeSplitting.groups[].test\` returned ${typeof result} for module "${
+            ids[index]
+          }", but expected a boolean, null or undefined.`,
+        );
+      }
+      results[index] = result === true ? 1 : 0;
     }
     return results;
   };
@@ -432,7 +441,16 @@ function batchName(
     const context = new ChunkingContextImpl(bindingContext, pluginContextData);
     const results: ReturnType<CodeSplittingNameFunction>[] = [];
     for (let index = 0; index < ids.length; index++) {
-      results.push(name(ids[index], context));
+      const result = name(ids[index], context);
+      // napi reports the type of the array, not of the bad element, so the check runs here.
+      if (result != null && typeof result !== 'string') {
+        throw new TypeError(
+          `\`output.codeSplitting.groups[].name\` returned ${typeof result} for module "${
+            ids[index]
+          }", but expected a string, null or undefined.`,
+        );
+      }
+      results.push(result);
     }
     return results;
   };

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/_config.ts
@@ -1,0 +1,26 @@
+import { stripAnsi } from 'consola/utils';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// napi reports only the type of the batch array, so the shim checks each result and names the
+// module.
+export default defineTest({
+  config: {
+    // @ts-expect-error - this is intentionally wrong to trigger the error
+    output: {
+      codeSplitting: {
+        groups: [
+          {
+            name: (id: string) => id.length,
+          },
+        ],
+      },
+    },
+  },
+  catchError(err: any) {
+    const message = stripAnsi(err.toString());
+    expect(message).toContain('`output.codeSplitting.groups[].name` returned number for module');
+    expect(message).toContain('main.js');
+    expect(message).toContain('but expected a string, null or undefined.');
+  },
+});

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/a.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/main.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-name-fn-invalid-return/main.js
@@ -1,0 +1,3 @@
+import { a } from './a.js';
+
+console.log(a);

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/_config.ts
@@ -1,0 +1,30 @@
+import { stripAnsi } from 'consola/utils';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// napi reports only the type of the batch array, so the shim checks each result and names the
+// module.
+export default defineTest({
+  config: {
+    optimization: {
+      inlineConst: false,
+    },
+    // @ts-expect-error - this is intentionally wrong to trigger the error
+    output: {
+      codeSplitting: {
+        groups: [
+          {
+            name: 'ab',
+            test: (id: string) => (id.endsWith('a.js') ? 'yes' : false),
+          },
+        ],
+      },
+    },
+  },
+  catchError(err: any) {
+    const message = stripAnsi(err.toString());
+    expect(message).toContain('`output.codeSplitting.groups[].test` returned string for module');
+    expect(message).toContain('a.js');
+    expect(message).toContain('but expected a boolean, null or undefined.');
+  },
+});

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/a.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/b.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/main.js
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/groups-test-fn-invalid-return/main.js
@@ -1,0 +1,4 @@
+import { a } from './a.js';
+import { b } from './b.js';
+
+console.log(a, b);


### PR DESCRIPTION
One call classifies or names a whole batch, so napi validates the array and reports its type rather than the offending element's. A plain JS config that returned a string from `test` produced `The function returned object, but expected object`.

Both shims now check each result before the batch crosses, so the error names the module and the type it expected. `test` crosses as a byte array, which also drops a per-element conversion. `name` still crosses as strings.

refs #10745