### PR TITLE
fix(dev): map dev rename events like build watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,7 +3330,6 @@ dependencies = [
  "futures",
  "oxc_index",
  "rolldown",
- "rolldown-notify",
  "rolldown_common",
  "rolldown_error",
  "rolldown_fs_watcher",

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -7,10 +7,13 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use futures::FutureExt;
+#[cfg(target_os = "macos")]
 use notify::EventKind;
 use rolldown_common::WatcherChangeKind;
 use rolldown_error::BuildResult;
-use rolldown_fs_watcher::{FsEventResult, FsWatcher, RecursiveMode};
+use rolldown_fs_watcher::{
+  FsChangeKind, FsEventResult, FsWatcher, RecursiveMode, map_notify_event,
+};
 use rolldown_utils::{dashmap::FxDashSet, indexmap::FxIndexMap, pattern_filter};
 use sugar_path::SugarPath;
 use tokio::sync::Mutex;
@@ -158,40 +161,33 @@ impl BundleCoordinator {
     }
   }
 
-  /// Handle file change events from watcher
+  /// Handle file change events from watcher.
+  ///
+  /// Rename mapping is shared with build watch via [`map_notify_event`].
+  /// See `internal-docs/dev-engine/implementation.md` ("From fs event to queued task").
   async fn handle_watch_event(&mut self, watch_event: FsEventResult) {
     match watch_event {
       Ok(batched_events) => {
         let mut changed_files = FxIndexMap::default();
-        batched_events.into_iter().for_each(|batched_event| {
-          match &batched_event.detail.kind {
-            EventKind::Create(_create_kind) => {
-              for path in batched_event.detail.paths {
-                changed_files.insert(path, WatcherChangeKind::Create);
-              }
-            }
-            #[cfg(target_os = "macos")]
+        for batched_event in batched_events {
+          #[cfg(target_os = "macos")]
+          if matches!(
+            batched_event.detail.kind,
             EventKind::Modify(notify::event::ModifyKind::Metadata(_))
-              if !self.ctx.options.use_polling =>
-            {
-              // When using kqueue on mac, ignore metadata changes as it happens frequently and doesn't affect the build in most cases
-              // Note that when using polling, we shouldn't ignore metadata changes as the polling watcher prefer to emit them over
-              // content change events
-            }
-            EventKind::Modify(notify::event::ModifyKind::Name(notify::event::RenameMode::From))
-            | EventKind::Remove(_) => {
-              for path in batched_event.detail.paths {
-                changed_files.insert(path, WatcherChangeKind::Delete);
-              }
-            }
-            EventKind::Modify(_modify_kind) => {
-              for path in batched_event.detail.paths {
-                changed_files.insert(path, WatcherChangeKind::Update);
-              }
-            }
-            _ => {}
+          ) && !self.ctx.options.use_polling
+          {
+            // kqueue on mac emits metadata events often; they do not affect the
+            // build in most cases. Polling prefers metadata over content events,
+            // so those must still be mapped.
+            continue;
           }
-        });
+
+          for (path, kind) in
+            map_notify_event(&batched_event.detail.kind, batched_event.detail.paths)
+          {
+            changed_files.insert(path, watcher_change_kind(kind));
+          }
+        }
 
         self.handle_file_changes(changed_files).await;
       }
@@ -511,5 +507,13 @@ impl BundleCoordinator {
     }
     paths_mut.commit()?;
     Ok(())
+  }
+}
+
+fn watcher_change_kind(kind: FsChangeKind) -> WatcherChangeKind {
+  match kind {
+    FsChangeKind::Create => WatcherChangeKind::Create,
+    FsChangeKind::Update => WatcherChangeKind::Update,
+    FsChangeKind::Delete => WatcherChangeKind::Delete,
   }
 }

--- a/crates/rolldown_fs_watcher/Cargo.toml
+++ b/crates/rolldown_fs_watcher/Cargo.toml
@@ -18,5 +18,4 @@ rolldown_error = { workspace = true }
 workspace = true
 
 [lib]
-test = false
 doctest = false

--- a/crates/rolldown_fs_watcher/src/event_map.rs
+++ b/crates/rolldown_fs_watcher/src/event_map.rs
@@ -1,0 +1,137 @@
+use std::path::PathBuf;
+
+use notify::{
+  EventKind,
+  event::{ModifyKind, RenameMode},
+};
+
+/// Rolldown-level change kind produced from a notify event.
+///
+/// This is intentionally a local type so `rolldown_fs_watcher` does not depend
+/// on `rolldown_common`. Callers map it onto `WatcherChangeKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsChangeKind {
+  Create,
+  Update,
+  Delete,
+}
+
+/// Map a notify event to `(path, kind)` pairs.
+///
+/// Rename events are mapped the same way in build watch and bundled dev:
+///
+/// - `Name(From)` → `Delete` (move out of a watched path)
+/// - `Name(To)` → `Create` (move onto a watched path)
+/// - `Name(Both)` → `Delete` for `paths[0]`, `Create` for `paths[1]` (rename in place)
+///
+/// `Access` and other unhandled kinds produce no changes. `Access` is ignored
+/// because reading watched files on Linux would otherwise loop (`IN_OPEN`).
+///
+/// See `internal-docs/watch-mode/implementation.md` ("Notify Event Mapping")
+/// and `internal-docs/dev-engine/implementation.md` ("From fs event to queued task").
+pub fn map_notify_event(kind: &EventKind, paths: Vec<PathBuf>) -> Vec<(PathBuf, FsChangeKind)> {
+  match kind {
+    EventKind::Create(_) | EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+      paths.into_iter().map(|path| (path, FsChangeKind::Create)).collect()
+    }
+    EventKind::Modify(ModifyKind::Name(RenameMode::From)) | EventKind::Remove(_) => {
+      paths.into_iter().map(|path| (path, FsChangeKind::Delete)).collect()
+    }
+    EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => map_rename_both(paths),
+    EventKind::Modify(_) => paths.into_iter().map(|path| (path, FsChangeKind::Update)).collect(),
+    _ => Vec::new(),
+  }
+}
+
+/// `RenameMode::Both` carries `[from_path, to_path]`. Extra paths are ignored.
+fn map_rename_both(paths: Vec<PathBuf>) -> Vec<(PathBuf, FsChangeKind)> {
+  let mut paths = paths.into_iter();
+  let mut result = Vec::new();
+  if let Some(from) = paths.next() {
+    result.push((from, FsChangeKind::Delete));
+  }
+  if let Some(to) = paths.next() {
+    result.push((to, FsChangeKind::Create));
+  }
+  result
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use notify::{
+    EventKind,
+    event::{AccessKind, CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode},
+  };
+
+  use super::{FsChangeKind, map_notify_event};
+
+  fn path(s: &str) -> PathBuf {
+    PathBuf::from(s)
+  }
+
+  #[test]
+  fn create_maps_to_create() {
+    let got = map_notify_event(&EventKind::Create(CreateKind::File), vec![path("a.js")]);
+    assert_eq!(got, vec![(path("a.js"), FsChangeKind::Create)]);
+  }
+
+  #[test]
+  fn remove_maps_to_delete() {
+    let got = map_notify_event(&EventKind::Remove(RemoveKind::File), vec![path("a.js")]);
+    assert_eq!(got, vec![(path("a.js"), FsChangeKind::Delete)]);
+  }
+
+  #[test]
+  fn content_modify_maps_to_update() {
+    let got = map_notify_event(
+      &EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+      vec![path("a.js")],
+    );
+    assert_eq!(got, vec![(path("a.js"), FsChangeKind::Update)]);
+  }
+
+  #[test]
+  fn rename_from_maps_to_delete() {
+    let got = map_notify_event(
+      &EventKind::Modify(ModifyKind::Name(RenameMode::From)),
+      vec![path("old.js")],
+    );
+    assert_eq!(got, vec![(path("old.js"), FsChangeKind::Delete)]);
+  }
+
+  #[test]
+  fn rename_to_maps_to_create() {
+    let got =
+      map_notify_event(&EventKind::Modify(ModifyKind::Name(RenameMode::To)), vec![path("new.js")]);
+    assert_eq!(got, vec![(path("new.js"), FsChangeKind::Create)]);
+  }
+
+  #[test]
+  fn rename_both_maps_to_delete_then_create() {
+    let got = map_notify_event(
+      &EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+      vec![path("old.js"), path("new.js")],
+    );
+    assert_eq!(
+      got,
+      vec![(path("old.js"), FsChangeKind::Delete), (path("new.js"), FsChangeKind::Create)]
+    );
+  }
+
+  #[test]
+  fn rename_both_with_only_from_path_maps_to_delete() {
+    let got = map_notify_event(
+      &EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+      vec![path("old.js")],
+    );
+    assert_eq!(got, vec![(path("old.js"), FsChangeKind::Delete)]);
+  }
+
+  #[test]
+  fn access_is_ignored() {
+    let got = map_notify_event(&EventKind::Access(AccessKind::Read), vec![path("a.js")]);
+    assert!(got.is_empty());
+  }
+}

--- a/crates/rolldown_fs_watcher/src/lib.rs
+++ b/crates/rolldown_fs_watcher/src/lib.rs
@@ -3,10 +3,12 @@
 
 mod config;
 mod event;
+mod event_map;
 mod notify;
 mod watcher;
 
 pub use ::notify::RecursiveMode;
 pub use config::FsWatcherConfig;
 pub use event::{FsEvent, FsEventHandler, FsEventResult};
+pub use event_map::{FsChangeKind, map_notify_event};
 pub use watcher::{FsWatcher, PathsMut};

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -23,7 +23,6 @@ rolldown = { workspace = true, features = ["experimental"] }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_fs_watcher = { workspace = true }
-rolldown-notify = { workspace = true }
 rolldown_utils = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = { workspace = true }

--- a/crates/rolldown_watcher/src/task_fs_event_handler.rs
+++ b/crates/rolldown_watcher/src/task_fs_event_handler.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
-
 use crate::file_change_event::FileChangeEvent;
 use crate::watch_task::WatchTaskIdx;
 use crate::watcher_msg::WatcherMsg;
 use rolldown_common::WatcherChangeKind;
-use rolldown_fs_watcher::{FsEventHandler, FsEventResult};
+use rolldown_fs_watcher::{FsChangeKind, FsEventHandler, FsEventResult, map_notify_event};
 use tokio::sync::mpsc;
 
 /// Bridge that maps raw notify events to `FileChangeEvent`s and forwards them
@@ -14,48 +12,11 @@ pub struct TaskFsEventHandler {
   pub tx: mpsc::UnboundedSender<WatcherMsg>,
 }
 
-impl TaskFsEventHandler {
-  /// Map a notify `EventKind` to a `WatcherChangeKind`.
-  ///
-  /// Returns `None` for event kinds that should not trigger a rebuild.
-  /// In particular, `Access` events (file open/read/close) are ignored because
-  /// the build process itself reads watched source files, which would otherwise
-  /// cause an infinite rebuild loop on Linux where inotify emits `IN_OPEN` events.
-  ///
-  /// Aligned with `BundleCoordinator::handle_watch_event` in `rolldown_dev`.
-  fn map_raw_event_kind_to_watcher_event_kind(
-    kind: &notify::EventKind,
-  ) -> Option<WatcherChangeKind> {
-    match kind {
-      notify::EventKind::Create(_)
-      | notify::EventKind::Modify(notify::event::ModifyKind::Name(notify::event::RenameMode::To)) => {
-        Some(WatcherChangeKind::Create)
-      }
-      notify::EventKind::Modify(notify::event::ModifyKind::Name(
-        notify::event::RenameMode::From,
-      ))
-      | notify::EventKind::Remove(_) => Some(WatcherChangeKind::Delete),
-      notify::EventKind::Modify(_) => Some(WatcherChangeKind::Update),
-      _ => None,
-    }
-  }
-
-  /// `RenameMode::Both` carries `[from_path, to_path]` — emit `Delete` for the
-  /// source and `Create` for the destination so both signals are preserved.
-  fn map_rename_to_delete_create_changes(
-    paths: impl IntoIterator<Item = PathBuf>,
-  ) -> Vec<FileChangeEvent> {
-    let mut paths = paths.into_iter();
-    let mut result = Vec::new();
-    if let Some(from) = paths.next() {
-      result
-        .push(FileChangeEvent::new(from.to_string_lossy().into_owned(), WatcherChangeKind::Delete));
-    }
-    if let Some(to) = paths.next() {
-      result
-        .push(FileChangeEvent::new(to.to_string_lossy().into_owned(), WatcherChangeKind::Create));
-    }
-    result
+fn watcher_change_kind(kind: FsChangeKind) -> WatcherChangeKind {
+  match kind {
+    FsChangeKind::Create => WatcherChangeKind::Create,
+    FsChangeKind::Update => WatcherChangeKind::Update,
+    FsChangeKind::Delete => WatcherChangeKind::Delete,
   }
 }
 
@@ -63,29 +24,17 @@ impl FsEventHandler for TaskFsEventHandler {
   fn handle_event(&mut self, event: FsEventResult) {
     match event {
       Ok(fs_events) => {
+        // Shared with bundled dev via `map_notify_event`.
+        // See `internal-docs/watch-mode/implementation.md` ("Notify Event Mapping").
         let changes: Vec<FileChangeEvent> = fs_events
           .into_iter()
-          .filter_map(|fs_event| {
-            if matches!(
-              fs_event.detail.kind,
-              notify::EventKind::Modify(notify::event::ModifyKind::Name(
-                notify::event::RenameMode::Both
-              ))
-            ) {
-              return Some(Self::map_rename_to_delete_create_changes(fs_event.detail.paths));
-            }
-
-            let kind = Self::map_raw_event_kind_to_watcher_event_kind(&fs_event.detail.kind)?;
-            Some(
-              fs_event
-                .detail
-                .paths
-                .into_iter()
-                .map(|path| FileChangeEvent::new(path.to_string_lossy().into_owned(), kind))
-                .collect(),
+          .flat_map(|fs_event| {
+            map_notify_event(&fs_event.detail.kind, fs_event.detail.paths).into_iter().map(
+              |(path, kind)| {
+                FileChangeEvent::new(path.to_string_lossy().into_owned(), watcher_change_kind(kind))
+              },
             )
           })
-          .flatten()
           .collect();
 
         if !changes.is_empty() {


### PR DESCRIPTION
### Description

Bundled dev mapped rename events (`Name(To)` and `Name(Both)`) to `Update`. Build watch already maps them to Create / Delete+Create. Moving or renaming a file therefore sent the wrong change kind into HMR.

This PR moves the mapping into `rolldown_fs_watcher::map_notify_event` and uses it from both `rolldown_dev` and `rolldown_watcher`, so the two sides cannot drift again.

| notify event | FBM before | after (same as build watch) |
| --- | --- | --- |
| `Name(From)` — move out | Delete | Delete |
| `Name(To)` — move in | **Update** | Create |
| `Name(Both)` — rename in place | **Update** | Delete + Create |