### PR TITLE
docs: document shared notify rename mapping

### DIFF
--- a/internal-docs/dev-engine/implementation.md
+++ b/internal-docs/dev-engine/implementation.md
@@ -342,19 +342,25 @@ one is present.
 
 ## 6. From fs event to queued task — `handle_watch_event`
 
-`handle_watch_event` (`bundle_coordinator.rs:154-194`) translates a raw
-`notify` event batch into a `FxIndexMap<PathBuf, WatcherChangeKind>`:
+`handle_watch_event` (`bundle_coordinator.rs`) translates a raw
+`notify` event batch into a `FxIndexMap<PathBuf, WatcherChangeKind>`
+via the shared `rolldown_fs_watcher::map_notify_event` helper (same
+mapping as build watch):
 
-| `notify` `EventKind`                          | `WatcherChangeKind` |
-| --------------------------------------------- | ------------------- |
-| `Create(_)`                                   | `Create`            |
-| `Modify(Name(RenameMode::From))`, `Remove(_)` | `Delete`            |
-| `Modify(_)` (other)                           | `Update`            |
-| `Modify(Metadata(_))` on macOS non-polling    | ignored             |
+| `notify` `EventKind`                          | `WatcherChangeKind`                          |
+| --------------------------------------------- | -------------------------------------------- |
+| `Create(_)`                                   | `Create`                                     |
+| `Modify(Name(RenameMode::To))`                | `Create`                                     |
+| `Modify(Name(RenameMode::Both))`              | `Delete` (`paths[0]`), `Create` (`paths[1]`) |
+| `Modify(Name(RenameMode::From))`, `Remove(_)` | `Delete`                                     |
+| `Modify(_)` (other)                           | `Update`                                     |
+| `Modify(Metadata(_))` on macOS non-polling    | ignored (FBM-only; skipped before mapping)   |
+| `Access(_)`                                   | ignored                                      |
 
 It then calls `handle_file_changes`. Note that `rolldown_dev` does no
 debouncing or Delete+Create consolidation of its own — it dispatches each
-raw watcher event batch straight through.
+raw watcher event batch straight through. A `Name(Both)` rename is split
+into `Delete`+`Create` at mapping time; that is not debounce consolidation.
 
 ---
 

--- a/internal-docs/watch-mode/implementation.md
+++ b/internal-docs/watch-mode/implementation.md
@@ -357,6 +357,9 @@ When an import resolves to a non-existent file, the build errors. Watch mode rel
 
 ### Notify Event Mapping
 
+Shared with bundled dev through `rolldown_fs_watcher::map_notify_event`.
+Do not re-implement this table in `rolldown_dev` or `rolldown_watcher`.
+
 ```
 notify::EventKind::Create(_)                              → WatcherChangeKind::Create
 notify::EventKind::Modify(Name(RenameMode::To))           → WatcherChangeKind::Create


### PR DESCRIPTION
### Description

Stacked on #10758.

Update the FBM and watch-mode internal docs to match the shared `rolldown_fs_watcher::map_notify_event` helper.

- `dev-engine/implementation.md`: FBM rename table now includes `Name(To)` / `Name(Both)`, and notes that a `Name(Both)` split is mapping, not debounce consolidation.
- `watch-mode/implementation.md`: the mapping is the shared helper; do not re-implement it in `rolldown_dev` or `rolldown_watcher`.
