### PR TITLE
fix(dev): copy star re-exports before initializing dependencies

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -278,10 +278,21 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         let importee = &self.modules[importee_idx];
         self.dependencies.insert(importee_idx);
         let binding_name = self.ensure_static_import_info(importee_idx, rec_id).to_string();
-        if let Some(stmt) =
-          self.create_importee_binding_stmt(importee, &binding_name, export_all_decl.span)
-        {
-          program_body.push(stmt);
+        // Only two of the three `export *` shapes refer to the importee binding by name:
+        //
+        //   export * from './dep.js'          // no binding. The copy, emitted in `exit_program`
+        //                                     // before the body, reads `loadExports("dep.js")`
+        //                                     // inline - a `var` here would be declared too late.
+        //   export * from 'node:util'         // `__reExport(exports, import_node_util_24)`, where
+        //                                     // the hoisted `import * as import_node_util_24` is
+        //                                     // registered by this call.
+        //   export * as ns from './dep.js'    // `ns: () => import_dep_20`.
+        if export_all_decl.exported.is_some() || matches!(importee, Module::External(_)) {
+          if let Some(stmt) =
+            self.create_importee_binding_stmt(importee, &binding_name, export_all_decl.span)
+          {
+            program_body.push(stmt);
+          }
         }
         if let Some(exported) = &export_all_decl.exported {
           // `export * as ns from './dep.js'` binds the importee's namespace object to a
@@ -295,10 +306,8 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             !is_validate_identifier_name(&exported_name),
             &self.ast_builder,
           ));
-        } else if let Some(stmt) =
-          self.create_re_export_call_stmt(importee, &binding_name, export_all_decl.span)
-        {
-          program_body.push(stmt);
+        } else {
+          self.re_export_all_dependencies.insert(importee_idx);
         }
       }
       // Every other statement is kept as-is. That's ordinary statements, which need no
@@ -485,16 +494,34 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     self.generated_static_import_stmts_from_external.insert(importee.idx, stmt);
   }
 
-  fn create_re_export_call_stmt(
-    &mut self,
-    importee: &Module,
-    binding_name: &str,
-    span: Span,
-  ) -> Option<Statement<'ast>> {
-    if self.re_export_all_dependencies.contains(&importee.idx()) {
-      return None;
-    }
-    self.re_export_all_dependencies.insert(importee.idx());
+  /// `__rolldown_runtime__.__reExport(<this module's exports>, <the importee's namespace>)` for one `export * from`
+  pub fn create_re_export_call_stmt(&self, importee: &Module) -> Statement<'ast> {
+    let source = match importee {
+      Module::Normal(importee) => {
+        let load_exports_call = Expression::new_call_with_arg(
+          Expression::new_member_access_expr("__rolldown_runtime__", "loadExports", self),
+          ast::Expression::new_string_literal(
+            SPAN,
+            Str::from_str_in(importee.stable_id.as_ref(), self),
+            None,
+            self,
+          ),
+          false,
+          self,
+        );
+        Expression::new_to_esm_call_with_interop(
+          "__rolldown_runtime__.__toESM",
+          load_exports_call,
+          self.module.interop(importee),
+          self,
+        )
+      }
+      Module::External(_) => Expression::new_id_ref_expr(
+        SPAN,
+        &self.generated_static_import_infos[&importee.idx()],
+        self,
+      ),
+    };
 
     let self_exports = self.module_exports_name();
 
@@ -505,7 +532,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       oxc::allocator::Vec::from_iter_in(
         [
           ast::Argument::from(Expression::new_id_ref_expr(SPAN, self_exports, self)),
-          ast::Argument::from(Expression::new_id_ref_expr(SPAN, binding_name, self)),
+          ast::Argument::from(source),
         ],
         self,
       ),
@@ -513,7 +540,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       self,
     );
 
-    Some(ast::Statement::new_expression_statement(span, call_expr, self))
+    ast::Statement::new_expression_statement(SPAN, call_expr, self)
   }
 
   fn generate_declaration_of_module_namespace_object(

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -9,6 +9,7 @@ use rolldown_ecmascript::{
   CJS_ROLLDOWN_EXPORTS_REF_IDENT, CJS_ROLLDOWN_MODULE_REF, CJS_ROLLDOWN_MODULE_REF_IDENT,
 };
 use rolldown_ecmascript_utils::ExpressionFactoryExt as _;
+use rustc_hash::FxHashSet;
 
 use crate::hmr::{
   hmr_ast_finalizer::HmrAstFinalizer,
@@ -38,16 +39,66 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     // `initModule("<stable id>")` for EVERY static dep, uniformly registry-gated: a
     // co-carried factory runs, a resident module short-circuits. No payload-membership
     // split exists in the emitted bytes.
-    let dependencies_init_fn_stmts: Vec<_> = self
-      .dependencies
-      .iter()
-      .filter_map(|dep| {
-        let module = &self.modules[*dep];
-        module.as_normal().map(|_| {
-          ast::Statement::new_expression_statement(SPAN, self.make_init_module_call(module), self)
-        })
-      })
-      .collect();
+    // Each `export * from` becomes a `__reExport(...)` copy onto this module's namespace.
+    // The copies are emitted here, before the body, in this order:
+    //
+    //   for each dep in `dependencies` (first-reference order):
+    //     initModule(dep)
+    //     copy every `export *` source that is now ready, in `export *` order,
+    //     and stop at the first one that is not ready yet
+    //
+    // Rule 1: copy as early as possible. Example (the cycle from vitejs/vite#21626):
+    //
+    //   // index.js                     // b.js
+    //   export * from './a.js'          import { valueA } from './index.js'
+    //   export { fn } from './b.js'     export const fn = () => valueA.concat('!')
+    //
+    //   initModule("a.js")
+    //   __reExport(exports, loadExports("a.js"))   // `valueA` is on the namespace now
+    //   initModule("b.js")                         // b.js runs here and reads `valueA`
+    //
+    // b.js runs inside `initModule("b.js")`, before this body. If the copy of a.js came after
+    // all `initModule` calls, b.js would read `valueA` as `undefined`.
+    //
+    // Rule 2: keep `export *` order. `__reExport` skips a name the target already has, so the
+    // first copy owns a name that two sources export. Example:
+    //
+    //   import { helper } from './b.js'   // `dependencies` = [b, c]
+    //   export * from './c.js'            // `re_export_all_dependencies` = [c, b]
+    //   export * from './b.js'            // both c.js and b.js export `foo`
+    //
+    //   initModule("b.js")                           // c.js is not ready, so no copy yet
+    //   initModule("c.js")
+    //   __reExport(exports, loadExports("c.js"))     // `foo` comes from c.js
+    //   __reExport(exports, loadExports("b.js"))     // `foo` already set, skipped
+    //
+    // Copying b.js right after `initModule("b.js")` would give `foo` to b.js, only because an
+    // unrelated import mentioned b.js first.
+    //
+    // An external needs no `initModule`. Its `import * as` binding is hoisted, so it is always
+    // ready to copy.
+    let mut dependencies_init_fn_stmts: Vec<ast::Statement<'ast>> = Vec::new();
+    let mut initialized = FxHashSet::default();
+    let mut next_copy = 0;
+    for dep in &self.dependencies {
+      let module = &self.modules[*dep];
+      if module.as_normal().is_some() {
+        dependencies_init_fn_stmts.push(ast::Statement::new_expression_statement(
+          SPAN,
+          self.make_init_module_call(module),
+          self,
+        ));
+      }
+      initialized.insert(*dep);
+      while let Some(source) = self.re_export_all_dependencies.get_index(next_copy) {
+        let source_module = &self.modules[*source];
+        if source_module.as_normal().is_some() && !initialized.contains(source) {
+          break;
+        }
+        dependencies_init_fn_stmts.push(self.create_re_export_call_stmt(source_module));
+        next_copy += 1;
+      }
+    }
 
     let runtime_module_register = self.generate_runtime_module_register_for_hmr(ctx.scoping());
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/reexport_external/artifacts.snap
@@ -136,10 +136,9 @@ __rolldown_runtime__.registerFactory("reexport.js", "esm", (function(__rolldown_
 		});
 		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		__rolldown_runtime__.initModule("dep.js");
-		const hot_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
-		var import_dep_20 = __rolldown_runtime__.loadExports("dep.js");
-		__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep_20);
+		__rolldown_runtime__.__reExport(__rolldown_exports__, __rolldown_runtime__.loadExports("dep.js"));
 		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_util_24);
+		const hot_reexport = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 	} finally {}
 }));
 
@@ -151,10 +150,9 @@ __rolldown_runtime__.registerFactory("shadow.js", "esm", (function(__rolldown_mo
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ shadowWorks: () => shadowWorks });
 		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
 		__rolldown_runtime__.initModule("dep.js");
-		const hot_shadow = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
-		var import_dep_31 = __rolldown_runtime__.loadExports("dep.js");
-		__rolldown_runtime__.__reExport(__rolldown_exports__, import_dep_31);
+		__rolldown_runtime__.__reExport(__rolldown_exports__, __rolldown_runtime__.loadExports("dep.js"));
 		__rolldown_runtime__.__reExport(__rolldown_exports__, import_node_assert_30);
+		const hot_shadow = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const shadowWorks = typeof import_node_assert_30.deepStrictEqual === "function";
 	} finally {}
 }));

--- a/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/star-reexport-order.spec.ts
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/__tests__/star-reexport-order.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { page, serverUrl, waitForBuildStable } from '~utils';
+
+// `entry-plain.js` and `entry-with-import.js` have the same two `export *` lines in the
+// same order. The only difference is an unrelated `import` from b.js at the top of the
+// second file. Which module owns the shared name `foo` must not depend on that line.
+describe('lazy-compilation: star re-export order', () => {
+  test('an unrelated import does not change which `export *` wins', async () => {
+    await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('#star-reexport-order-status')).toBe('ready');
+
+    await page.click('#star-reexport-order-btn');
+    await expect.poll(() => page.textContent('#star-reexport-order-status')).not.toBe('loading');
+    expect(await page.textContent('#star-reexport-order-status')).toBe(
+      'plain=from-c with-import=from-c',
+    );
+  });
+});

--- a/packages/test-dev-server/tests/playground/lazy-compilation/index.html
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/index.html
@@ -54,6 +54,12 @@
       <pre id="lazy-init-error-unhandled"></pre>
     </section>
 
+    <section id="star-reexport-order">
+      <h2>star-reexport-order</h2>
+      <button id="star-reexport-order-btn">load</button>
+      <div id="star-reexport-order-status">pending</div>
+    </section>
+
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/packages/test-dev-server/tests/playground/lazy-compilation/main.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/main.js
@@ -8,3 +8,4 @@ import './shared-module/setup.js';
 import './nested-dynamic-import/setup.js';
 import './emitted-asset/setup.js';
 import './lazy-init-error/setup.js';
+import './star-reexport-order/setup.js';

--- a/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/b.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/b.js
@@ -1,0 +1,2 @@
+export const helper = 'helper';
+export const foo = 'from-b';

--- a/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/c.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/c.js
@@ -1,0 +1,1 @@
+export const foo = 'from-c';

--- a/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/entry-plain.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/entry-plain.js
@@ -1,0 +1,2 @@
+export * from './c.js';
+export * from './b.js';

--- a/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/entry-with-import.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/entry-with-import.js
@@ -1,0 +1,7 @@
+// Same as entry-plain.js, plus one unrelated import that references b.js first.
+import { helper } from './b.js';
+
+export * from './c.js';
+export * from './b.js';
+
+export const usesHelper = helper;

--- a/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/setup.js
+++ b/packages/test-dev-server/tests/playground/lazy-compilation/star-reexport-order/setup.js
@@ -1,0 +1,14 @@
+const status = document.getElementById('star-reexport-order-status');
+
+status.textContent = 'ready';
+
+document.getElementById('star-reexport-order-btn').addEventListener('click', async () => {
+  status.textContent = 'loading';
+  try {
+    const plain = await import('./entry-plain.js');
+    const withImport = await import('./entry-with-import.js');
+    status.textContent = `plain=${plain.foo} with-import=${withImport.foo}`;
+  } catch (error) {
+    status.textContent = `error: ${error.message}`;
+  }
+});


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->

Fixed an issue where re-exports not being able to access even though it's loaded at the time of execution.

This PR adds a special case for re-export order that with multiple same name exports, the order should be respected.

Fixes the case in https://github.com/rolldown/rolldown/pull/10563
