### PR TITLE
perf: batch `sourcemapIgnoreList` calls

### DIFF
--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -45,28 +45,48 @@ pub async fn prepare_sourcemap(
   let map_path = file_dir.join(&map_filename);
 
   if let Some(source_map_ignore_list) = &options.sourcemap_ignore_list {
-    let mut x_google_ignore_list = vec![];
-    for (index, source) in map.get_sources().enumerate() {
-      let source = source.as_path().relative(file_dir);
-      let should_ignore = match source_map_ignore_list {
-        rolldown_common::SourceMapIgnoreList::Boolean(_)
-        | rolldown_common::SourceMapIgnoreList::StringOrRegex(_) => {
-          // Fast path: no async overhead for static values (boolean/string/regex)
-          source_map_ignore_list.exec_static(source.to_string_lossy().as_ref())
-        }
-        rolldown_common::SourceMapIgnoreList::Fn(_) => {
-          // Slow path: async function call only when needed
-          source_map_ignore_list
-            .exec_dynamic(source.to_string_lossy().as_ref(), map_path.to_string_lossy().as_ref())
-            .await?
-        }
-      };
+    let relative_sources = map
+      .get_sources()
+      .map(|source| source.as_path().relative(file_dir).to_string_lossy().into_owned())
+      .collect::<Vec<_>>();
 
-      if should_ignore {
-        #[expect(clippy::cast_possible_truncation)]
-        x_google_ignore_list.push(index as u32);
+    let ignored = match source_map_ignore_list {
+      rolldown_common::SourceMapIgnoreList::Boolean(_)
+      | rolldown_common::SourceMapIgnoreList::StringOrRegex(_) => {
+        // Fast path: no async overhead for static values (boolean/string/regex)
+        relative_sources
+          .iter()
+          .map(|source| source_map_ignore_list.exec_static(source))
+          .collect::<Vec<_>>()
       }
-    }
+      rolldown_common::SourceMapIgnoreList::Fn(_) => {
+        // Slow path: one call decides every source, so the napi boundary is crossed once per
+        // sourcemap instead of once per source.
+        let source_count = relative_sources.len();
+        let ignored = source_map_ignore_list
+          .exec_dynamic(relative_sources, map_path.to_string_lossy().as_ref())
+          .await?;
+        if ignored.len() != source_count {
+          return Err(
+            anyhow::anyhow!(
+              "`sourcemapIgnoreList` returned {} results for {} sources",
+              ignored.len(),
+              source_count
+            )
+            .into(),
+          );
+        }
+        ignored
+      }
+    };
+
+    #[expect(clippy::cast_possible_truncation)]
+    let x_google_ignore_list = ignored
+      .into_iter()
+      .enumerate()
+      .filter_map(|(index, should_ignore)| should_ignore.then_some(index as u32))
+      .collect::<Vec<_>>();
+
     if !x_google_ignore_list.is_empty() {
       map.set_x_google_ignore_list(x_google_ignore_list);
     }

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -6,7 +6,7 @@ mod binding_pre_rendered_chunk;
 use binding_pre_rendered_asset::BindingPreRenderedAsset;
 use derive_more::Debug;
 use napi::Either;
-use napi::bindgen_prelude::{Either3, FnArgs};
+use napi::bindgen_prelude::{Either3, FnArgs, Uint8Array};
 use rustc_hash::FxHashMap;
 
 pub use binding_comments_options::BindingCommentsOptions;
@@ -32,8 +32,11 @@ pub type GlobalsOutputOption =
 pub type PathsOutputOption =
   Either<FxHashMap<String, String>, JsCallback<FnArgs<(String,)>, String>>;
 pub type SanitizeFileName = Either<bool, JsCallback<FnArgs<(String,)>, String>>;
+/// The JS side wraps the user's per-source function in one shim. The result holds one byte per
+/// source, and a nonzero byte ignores that source. See
+/// `packages/rolldown/src/utils/bindingify-output-options.ts`.
 pub type SourcemapIgnoreListOutputOption =
-  Either3<bool, BindingStringOrRegex, JsCallback<FnArgs<(String, String)>, bool>>;
+  Either3<bool, BindingStringOrRegex, JsCallback<FnArgs<(Vec<String>, String)>, Uint8Array>>;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
@@ -127,7 +130,7 @@ pub struct BindingOutputOptions<'env> {
   pub sourcemap_base_url: Option<String>,
   #[debug(skip)]
   #[napi(
-    ts_type = "boolean | string | RegExp | ((source: string, sourcemapPath: string) => boolean)"
+    ts_type = "boolean | string | RegExp | ((sources: Array<string>, sourcemapPath: string) => Uint8Array)"
   )]
   pub sourcemap_ignore_list: Option<SourcemapIgnoreListOutputOption>,
   pub sourcemap_debug_ids: Option<bool>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -289,16 +289,16 @@ fn normalize_sourcemap_ignore_list_option(
       rolldown::SourceMapIgnoreList::from_string_or_regex(string_or_regex.inner())
     }
     Either3::C(ts_fn) => {
-      rolldown::SourceMapIgnoreList::new(Arc::new(move |source, sourcemap_path| {
+      rolldown::SourceMapIgnoreList::new(Arc::new(move |sources, sourcemap_path| {
         let ts_fn = Arc::clone(&ts_fn);
-        let source = source.to_string();
         let sourcemap_path = sourcemap_path.to_string();
         Box::pin(async move {
           ts_fn
-            .invoke_async((source, sourcemap_path).into())
+            .invoke_async((sources, sourcemap_path).into())
             .await
             .context("sourcemapIgnoreList option")
             .map_err(anyhow::Error::from)
+            .map(|flags| flags.iter().map(|flag| *flag != 0).collect())
         })
       }))
     }

--- a/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
@@ -4,7 +4,14 @@ use std::{future::Future, pin::Pin};
 use derive_more::Debug;
 use rolldown_utils::pattern_filter::StringOrRegex;
 
-pub type SourceMapIgnoreListFn = dyn Fn(&str, &str) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send + 'static>>
+/// Decides a whole batch of sources in one call.
+///
+/// A JS callback implements this function, and every call crosses the napi boundary. The returned
+/// `Vec` must match the source list by index. The caller rejects any other length.
+pub type SourceMapIgnoreListFn = dyn Fn(
+    /* sources */ Vec<String>,
+    /* sourcemap path */ &str,
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<bool>>> + Send + 'static>>
   + Send
   + Sync;
 
@@ -42,12 +49,16 @@ impl SourceMapIgnoreList {
     }
   }
 
-  pub async fn exec_dynamic(&self, source: &str, sourcemap_path: &str) -> anyhow::Result<bool> {
+  pub async fn exec_dynamic(
+    &self,
+    sources: Vec<String>,
+    sourcemap_path: &str,
+  ) -> anyhow::Result<Vec<bool>> {
     match self {
       Self::Boolean(_) | Self::StringOrRegex(_) => {
         unreachable!("exec_dynamic should only be called for Fn variant")
       }
-      Self::Fn(f) => f(source, sourcemap_path).await,
+      Self::Fn(f) => f(sources, sourcemap_path).await,
     }
   }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2667,7 +2667,7 @@ export interface BindingOutputOptions {
   sourcemap?: 'file' | 'inline' | 'hidden'
   sourcemapFileNames?: string | ((chunk: PreRenderedChunk) => string)
   sourcemapBaseUrl?: string
-  sourcemapIgnoreList?: boolean | string | RegExp | ((source: string, sourcemapPath: string) => boolean)
+  sourcemapIgnoreList?: boolean | string | RegExp | ((sources: Array<string>, sourcemapPath: string) => Uint8Array)
   sourcemapDebugIds?: boolean
   sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
   sourcemapExcludeSources?: boolean

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2667,7 +2667,7 @@ export interface BindingOutputOptions {
   sourcemap?: 'file' | 'inline' | 'hidden'
   sourcemapFileNames?: string | ((chunk: PreRenderedChunk) => string)
   sourcemapBaseUrl?: string
-  sourcemapIgnoreList?: boolean | string | RegExp | ((source: string, sourcemapPath: string) => boolean)
+  sourcemapIgnoreList?: boolean | string | RegExp | ((sources: Array<string>, sourcemapPath: string) => Uint8Array)
   sourcemapDebugIds?: boolean
   sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
   sourcemapExcludeSources?: boolean

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -93,11 +93,13 @@ export function bindingifyOutputOptions(
       sourcemapFileNames,
     ),
     sourcemapExcludeSources,
-    sourcemapIgnoreList: measureIfFunction(
-      timings,
-      OUTPUT_OPTIONS_OWNER,
-      'sourcemapIgnoreList',
-      sourcemapIgnoreList ?? /node_modules/,
+    sourcemapIgnoreList: batchSourcemapIgnoreList(
+      measureIfFunction(
+        timings,
+        OUTPUT_OPTIONS_OWNER,
+        'sourcemapIgnoreList',
+        sourcemapIgnoreList ?? /node_modules/,
+      ),
     ),
     sourcemapPathTransform: measureIfFunction(
       timings,
@@ -458,6 +460,40 @@ function batchName(
         );
       }
       results.push(result);
+    }
+    return results;
+  };
+}
+
+/**
+ * Wraps a per-source `sourcemapIgnoreList` in the batched shim that the binding expects.
+ *
+ * The loop runs in JS so that a sourcemap makes one napi crossing, not one per source. The old
+ * Rust loop also awaited each call before it started the next.
+ *
+ * The result is a `Uint8Array`, which crosses as a buffer instead of one tagged value per source.
+ *
+ * A boolean, string or regular expression passes through. Rust reads those without a call.
+ */
+function batchSourcemapIgnoreList(
+  ignoreList: OutputOptions['sourcemapIgnoreList'],
+): BindingOutputOptions['sourcemapIgnoreList'] {
+  if (typeof ignoreList !== 'function') {
+    return ignoreList;
+  }
+  return (sources, sourcemapPath) => {
+    const results = new Uint8Array(sources.length);
+    for (let index = 0; index < sources.length; index++) {
+      const result = ignoreList(sources[index], sourcemapPath);
+      // napi reports the type of the array, not of the bad element, so the check runs here.
+      if (typeof result !== 'boolean') {
+        throw new TypeError(
+          `\`output.sourcemapIgnoreList\` returned ${typeof result} for source "${
+            sources[index]
+          }", but expected a boolean.`,
+        );
+      }
+      results[index] = result ? 1 : 0;
     }
     return results;
   };

--- a/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/_config.ts
@@ -1,0 +1,39 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// One call decides every source of a sourcemap. The call order still follows the source order,
+// and the returned flags still line up with it by index.
+const seen: string[] = [];
+
+export default defineTest({
+  sequential: true,
+  config: {
+    output: {
+      dir: 'dist',
+      sourcemap: true,
+      sourcemapIgnoreList: (source) => {
+        seen.push(source);
+        return source.includes('vendor');
+      },
+    },
+  },
+  afterTest: (output) => {
+    const map = output.output.find(
+      (asset) => asset.type === 'asset' && asset.fileName.endsWith('.map'),
+    );
+
+    if (map?.type !== 'asset') {
+      throw new Error('should emit a sourcemap');
+    }
+
+    const parsed = JSON.parse(map.source as string);
+    const ignored = parsed.x_google_ignoreList as number[];
+    const vendorIndex = (parsed.sources as string[]).findIndex((source) =>
+      source.includes('vendor'),
+    );
+
+    expect(vendorIndex).toBeGreaterThanOrEqual(0);
+    expect(ignored).toStrictEqual([vendorIndex]);
+    expect(seen).toStrictEqual(parsed.sources);
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/local.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/local.js
@@ -1,0 +1,1 @@
+export const local = 'local';

--- a/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/main.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/main.js
@@ -1,0 +1,4 @@
+import { helper } from './vendor/helper.js';
+import { local } from './local.js';
+
+console.log(helper, local);

--- a/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/vendor/helper.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-ignore-list/fn-batch/vendor/helper.js
@@ -1,0 +1,1 @@
+export const helper = 'helper';


### PR DESCRIPTION
A function `sourcemapIgnoreList` ran once per source of a sourcemap, and the Rust loop awaited each call before it started the next, so a chunk with N sources paid N serial napi crossings.

The JS side now takes the whole source list in one shim and loops in JS. The shim answers with one byte per source, which crosses as a buffer instead of as N tagged values. A boolean, string or regular expression still takes the static path in Rust and makes no call.

refs #10745
