### PR TITLE
perf: batch `sourcemapPathTransform` calls

### DIFF
--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use futures::future::try_join_all;
 use oxc::ast::CommentKind;
 use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
 use rolldown_error::{BuildResult, ResultExt};
@@ -94,21 +93,32 @@ pub async fn prepare_sourcemap(
 
   if let Some(sourcemap_path_transform) = &options.sourcemap_path_transform {
     let map_path = map_path.to_string_lossy();
-    let sources = try_join_all(map.get_sources().map(async |source| {
-      let source = source.as_path().relative(file_dir);
-      let source =
-        sourcemap_path_transform.call(source.to_string_lossy().as_ref(), map_path.as_ref()).await?;
-      #[cfg(windows)]
-      {
-        // Normalize the windows path.
-        Ok::<_, anyhow::Error>(source.replace(std::path::MAIN_SEPARATOR, "/"))
-      }
-      #[cfg(not(windows))]
-      {
-        Ok::<_, anyhow::Error>(source)
-      }
-    }))
-    .await?;
+    let relative_sources = map
+      .get_sources()
+      .map(|source| source.as_path().relative(file_dir).to_string_lossy().into_owned())
+      .collect::<Vec<_>>();
+    let source_count = relative_sources.len();
+
+    // One call rewrites every source, so the napi boundary is crossed once per sourcemap instead
+    // of once per source.
+    let sources = sourcemap_path_transform.call(relative_sources, map_path.as_ref()).await?;
+    if sources.len() != source_count {
+      return Err(
+        anyhow::anyhow!(
+          "`sourcemapPathTransform` returned {} results for {} sources",
+          sources.len(),
+          source_count
+        )
+        .into(),
+      );
+    }
+
+    #[cfg(windows)]
+    // Normalize the windows path.
+    let sources = sources
+      .into_iter()
+      .map(|source| source.replace(std::path::MAIN_SEPARATOR, "/"))
+      .collect::<Vec<_>>();
 
     map.set_sources(sources);
   } else if cfg!(windows) {

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -135,8 +135,10 @@ pub struct BindingOutputOptions<'env> {
   pub sourcemap_ignore_list: Option<SourcemapIgnoreListOutputOption>,
   pub sourcemap_debug_ids: Option<bool>,
   #[debug(skip)]
-  #[napi(ts_type = "(source: string, sourcemapPath: string) => string")]
-  pub sourcemap_path_transform: Option<JsCallback<FnArgs<(String, String)>, String>>,
+  /// Batched like `sourcemapIgnoreList` above. One call rewrites every source of a sourcemap,
+  /// and the returned array matches the source array by index.
+  #[napi(ts_type = "(sources: Array<string>, sourcemapPath: string) => Array<string>")]
+  pub sourcemap_path_transform: Option<JsCallback<FnArgs<(Vec<String>, String)>, Vec<String>>>,
   pub sourcemap_exclude_sources: Option<bool>,
   // sourcemapFile: string | undefined;
   #[napi(ts_type = "boolean | 'auto'")]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -306,16 +306,15 @@ fn normalize_sourcemap_ignore_list_option(
 }
 
 fn normalize_sourcemap_path_transform_option(
-  sourcemap_path_transform: Option<JsCallback<FnArgs<(String, String)>, String>>,
+  sourcemap_path_transform: Option<JsCallback<FnArgs<(Vec<String>, String)>, Vec<String>>>,
 ) -> Option<rolldown::SourceMapPathTransform> {
   sourcemap_path_transform.map(|ts_fn| {
-    rolldown::SourceMapPathTransform::new(Arc::new(move |source, sourcemap_path| {
+    rolldown::SourceMapPathTransform::new(Arc::new(move |sources, sourcemap_path| {
       let ts_fn = Arc::clone(&ts_fn);
-      let source = source.to_string();
       let sourcemap_path = sourcemap_path.to_string();
       Box::pin(async move {
         ts_fn
-          .invoke_async((source, sourcemap_path).into())
+          .invoke_async((sources, sourcemap_path).into())
           .await
           .context("sourcemapPathTransform option")
           .map_err(anyhow::Error::from)

--- a/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_path_transform.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_path_transform.rs
@@ -2,7 +2,14 @@ use derive_more::Debug;
 use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
-type SourceMapPathTransformFn = dyn Fn(&str, &str) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'static>>
+/// Rewrites a whole batch of sources in one call.
+///
+/// A JS callback implements this function, and every call crosses the napi boundary. The returned
+/// `Vec` must match the source list by index. The caller rejects any other length.
+type SourceMapPathTransformFn = dyn Fn(
+    /* sources */ Vec<String>,
+    /* sourcemap path */ &str,
+  ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<String>>> + Send + 'static>>
   + Send
   + Sync;
 
@@ -15,7 +22,11 @@ impl SourceMapPathTransform {
     Self(f)
   }
 
-  pub async fn call(&self, source: &str, sourcemap_path: &str) -> anyhow::Result<String> {
-    self.0(source, sourcemap_path).await
+  pub async fn call(
+    &self,
+    sources: Vec<String>,
+    sourcemap_path: &str,
+  ) -> anyhow::Result<Vec<String>> {
+    self.0(sources, sourcemap_path).await
   }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2669,7 +2669,11 @@ export interface BindingOutputOptions {
   sourcemapBaseUrl?: string
   sourcemapIgnoreList?: boolean | string | RegExp | ((sources: Array<string>, sourcemapPath: string) => Uint8Array)
   sourcemapDebugIds?: boolean
-  sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
+  /**
+   * Batched like `sourcemapIgnoreList` above. One call rewrites every source of a sourcemap,
+   * and the returned array matches the source array by index.
+   */
+  sourcemapPathTransform?: (sources: Array<string>, sourcemapPath: string) => Array<string>
   sourcemapExcludeSources?: boolean
   strict?: boolean | 'auto'
   minify?: boolean | 'dce-only' | MinifyOptions

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2669,7 +2669,11 @@ export interface BindingOutputOptions {
   sourcemapBaseUrl?: string
   sourcemapIgnoreList?: boolean | string | RegExp | ((sources: Array<string>, sourcemapPath: string) => Uint8Array)
   sourcemapDebugIds?: boolean
-  sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
+  /**
+   * Batched like `sourcemapIgnoreList` above. One call rewrites every source of a sourcemap,
+   * and the returned array matches the source array by index.
+   */
+  sourcemapPathTransform?: (sources: Array<string>, sourcemapPath: string) => Array<string>
   sourcemapExcludeSources?: boolean
   strict?: boolean | 'auto'
   minify?: boolean | 'dce-only' | MinifyOptions

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -101,11 +101,13 @@ export function bindingifyOutputOptions(
         sourcemapIgnoreList ?? /node_modules/,
       ),
     ),
-    sourcemapPathTransform: measureIfFunction(
-      timings,
-      OUTPUT_OPTIONS_OWNER,
-      'sourcemapPathTransform',
-      sourcemapPathTransform,
+    sourcemapPathTransform: batchSourcemapPathTransform(
+      measureIfFunction(
+        timings,
+        OUTPUT_OPTIONS_OWNER,
+        'sourcemapPathTransform',
+        sourcemapPathTransform,
+      ),
     ),
     banner: bindingifyAddon(banner, 'banner', timings),
     footer: bindingifyAddon(footer, 'footer', timings),
@@ -494,6 +496,35 @@ function batchSourcemapIgnoreList(
         );
       }
       results[index] = result ? 1 : 0;
+    }
+    return results;
+  };
+}
+
+/**
+ * The `sourcemapPathTransform` counterpart of {@linkcode batchSourcemapIgnoreList}.
+ *
+ * A path cannot be reduced to a byte, so this batch is still an array of strings. napi reports the
+ * type of the array, not of the bad element, so the check runs here.
+ */
+function batchSourcemapPathTransform(
+  pathTransform: OutputOptions['sourcemapPathTransform'],
+): BindingOutputOptions['sourcemapPathTransform'] {
+  if (typeof pathTransform !== 'function') {
+    return pathTransform;
+  }
+  return (sources, sourcemapPath) => {
+    const results: string[] = [];
+    for (let index = 0; index < sources.length; index++) {
+      const result = pathTransform(sources[index], sourcemapPath);
+      if (typeof result !== 'string') {
+        throw new TypeError(
+          `\`output.sourcemapPathTransform\` returned ${typeof result} for source "${
+            sources[index]
+          }", but expected a string.`,
+        );
+      }
+      results.push(result);
     }
     return results;
   };

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/_config.ts
@@ -1,0 +1,34 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// One call rewrites every source of a sourcemap. The call order still follows the source order,
+// and the returned paths still line up with it by index.
+const seen: string[] = [];
+
+export default defineTest({
+  sequential: true,
+  config: {
+    output: {
+      dir: 'dist',
+      sourcemap: true,
+      sourcemapPathTransform: (source) => {
+        seen.push(source);
+        return `prefixed/${source}`;
+      },
+    },
+  },
+  afterTest: (output) => {
+    const map = output.output.find(
+      (asset) => asset.type === 'asset' && asset.fileName.endsWith('.map'),
+    );
+
+    if (map?.type !== 'asset') {
+      throw new Error('should emit a sourcemap');
+    }
+
+    const sources = JSON.parse(map.source as string).sources as string[];
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(sources).toStrictEqual(seen.map((source) => `prefixed/${source}`));
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/a.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/a.js
@@ -1,0 +1,3 @@
+export function a() {
+  return 'a';
+}

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/b.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/b.js
@@ -1,0 +1,3 @@
+export function b() {
+  return 'b';
+}

--- a/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/main.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap-filenames/path-transform-batch/main.js
@@ -1,0 +1,4 @@
+import { a } from './a.js';
+import { b } from './b.js';
+
+console.log(a(), b());


### PR DESCRIPTION
`sourcemapPathTransform` ran once per source of a sourcemap. `try_join_all` overlapped the calls, but a chunk with N sources still paid N napi crossings.

The JS side now takes the whole source list in one shim and loops in JS. A path cannot be reduced to a byte, so the batch is still an array of strings, and the shim checks each result so a wrong type names its source.

refs #10762
