### PR TITLE
fix(dev): register an empty exports object for a module without exports

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -803,6 +803,11 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       return;
     };
 
+    if rec.meta.contains(ImportRecordMeta::IsRequireUnused) {
+      *it = self.make_init_module_call(&self.modules[importee_idx]);
+      return;
+    }
+
     let is_importee_cjs = importee.exports_kind == rolldown_common::ExportsKind::CommonJs;
 
     // Use stable module ID for consistent runtime lookup

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -43,7 +43,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
     )
   }
 
-  /// `__rolldown_runtime__.registerModule(moduleId, module)`
+  /// `__rolldown_runtime__.registerModule(moduleId[, module])`
   fn create_register_module_stmt(&self) -> ast::Statement<'ast> {
     let module_exports = match self.module().exports_kind {
       rolldown_common::ExportsKind::Esm => {
@@ -56,7 +56,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
         );
 
         // { exports: namespace }
-        ast::Argument::new_object_expression(
+        Some(ast::Argument::new_object_expression(
           SPAN,
           [ast::ObjectPropertyKind::new_object_property(
             SPAN,
@@ -69,26 +69,26 @@ pub trait HmrAstBuilder<'any, 'ast> {
             &self.builder(),
           )],
           &self.builder(),
-        )
+        ))
       }
       rolldown_common::ExportsKind::CommonJs => {
         // `module`
-        ast::Argument::new_identifier(SPAN, Self::cjs_module_name(), &self.builder())
+        Some(ast::Argument::new_identifier(SPAN, Self::cjs_module_name(), &self.builder()))
       }
-      rolldown_common::ExportsKind::None => {
-        // `{}`
-        ast::Argument::new_object_expression(SPAN, [], &self.builder())
-      }
+      rolldown_common::ExportsKind::None => None,
     };
 
-    // __rolldown_runtime__.registerModule(moduleId, module)
+    // __rolldown_runtime__.registerModule(moduleId[, module])
     // moduleId is either `__rolldown_module_id__` (HMR/lazy path) or the stable-id
     // string literal (main-bundle path).
     let register_call = ast::Expression::new_call_expression(
       SPAN,
       ast::Expression::new_identifier(SPAN, "__rolldown_runtime__.registerModule", &self.builder()),
       None,
-      [self.module_id_argument(), module_exports],
+      oxc::allocator::Vec::from_iter_in(
+        std::iter::once(self.module_id_argument()).chain(module_exports),
+        &self.builder(),
+      ),
       false,
       &self.builder(),
     );

--- a/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
@@ -15,7 +15,7 @@ __rolldown_runtime__.registerGraph({
 });
 //#region entry.js
 __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", {});
+__rolldown_runtime__.registerModule("entry.js");
 console.log("input\n");
 //#endregion
 
@@ -30,7 +30,7 @@ __rolldown_runtime__.registerGraph({ids:["entry.js"],localCount:1,edges:[[]],dyn
 //#region entry.js
 __rolldown_runtime__.registerFactory("entry.js", "esm", (function(__rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__);
 		const hot_entry = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		const content = "input2\n";
 		console.log(content);

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
@@ -41,7 +41,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
+__rolldown_runtime__.registerModule("main.js");
 require_a();
 require_b();
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import_edit_importer/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import_edit_importer/artifacts.snap
@@ -64,7 +64,7 @@ __rolldown_runtime__.registerGraph({ids:["app.js","foo.js"],localCount:1,edges:[
 //#region app.js
 __rolldown_runtime__.registerFactory("app.js", "esm", (function(__rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__);
 		const hot_app = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		hot_app.accept();
 		(__rolldown_runtime__.initModule("foo.js"), Promise.resolve().then(() => __rolldown_runtime__.loadExports("foo.js"))).then((mod) => {

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import_self_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import_self_accept/artifacts.snap
@@ -64,7 +64,7 @@ __rolldown_runtime__.registerGraph({ids:["app.js","foo.js"],localCount:2,edges:[
 //#region app.js
 __rolldown_runtime__.registerFactory("app.js", "esm", (function(__rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__);
 		const hot_app = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		hot_app.accept();
 		(__rolldown_runtime__.initModule("foo.js"), Promise.resolve().then(() => __rolldown_runtime__.loadExports("foo.js"))).then((mod) => {

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
@@ -36,7 +36,7 @@ __rolldown_runtime__.registerGraph({
 });
 //#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
+__rolldown_runtime__.registerModule("main.js");
 console.log("main.js");
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -77,7 +77,7 @@ __rolldown_runtime__.registerGraph({
 });
 //#region main.js
 __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
+__rolldown_runtime__.registerModule("main.js");
 import("./foo.js"), import("./bar.js");
 //#endregion
 export { __exportAll as t };

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -15,7 +15,7 @@ __rolldown_runtime__.registerGraph({
 });
 //#region entry.js
 __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", {});
+__rolldown_runtime__.registerModule("entry.js");
 console.log("entry");
 //#endregion
 
@@ -33,7 +33,7 @@ __rolldown_runtime__.registerGraph({
 });
 //#region index.js
 __rolldown_runtime__.createModuleHotContext("index.js");
-__rolldown_runtime__.registerModule("index.js", {});
+__rolldown_runtime__.registerModule("index.js");
 console.log("index");
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -427,7 +427,7 @@ __rolldown_runtime__.registerFactory("main.js", "esm", (function(__rolldown_modu
 //#region trigger-dep.js
 __rolldown_runtime__.registerFactory("trigger-dep.js", "esm", (function(__rolldown_module_id__) {
 	try {
-		__rolldown_runtime__.registerModule(__rolldown_module_id__, {});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__);
 		const hot_trigger_dep = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
 		console.log("hmr");
 	} finally {}

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -147,9 +147,9 @@ export class DevRuntime {
 
   /**
    * @param {string} id
-   * @param {{ exports: any }} exportsHolder
+   * @param {{ exports: any }} [exportsHolder]
    */
-  registerModule(id, exportsHolder) {
+  registerModule(id, exportsHolder = { exports: {} }) {
     const module = new Module(id);
     module.exportsHolder = exportsHolder;
     this.moduleCache.set(id, module);

--- a/internal-docs/lazy-compilation/implementation.md
+++ b/internal-docs/lazy-compilation/implementation.md
@@ -93,7 +93,7 @@ The server-side race window still exists (two `/lazy` requests in rapid successi
 
 ### Link-Stage-Synthesized Exports (JSON, text, base64, dataurl)
 
-Modules whose exports are synthesized at link time are **broken inside lazy chunks** (and HMR patches): JSON/text/base64/dataurl modules are scanned as a bare expression statement with `ExportsKind::None`, and the `export default` is materialized only by the link stage's `generate_lazy_export` — which the lazy/HMR render path never runs (it renders pristine scan-time AST clones). The lazy chunk registers them as `registerModule(id, {})`, so importers see **empty exports on first lazy load**; after the background rebuild + a page refresh the full build applies the transform and the same import works. No playground fixture covers this yet.
+Modules whose exports are synthesized at link time are **broken inside lazy chunks** (and HMR patches): JSON/text/base64/dataurl modules are scanned as a bare expression statement with `ExportsKind::None`, and the `export default` is materialized only by the link stage's `generate_lazy_export` — which the lazy/HMR render path never runs (it renders pristine scan-time AST clones). The lazy chunk registers them with no exports holder — `registerModule(id)`, which the runtime fills in as `{ exports: {} }` — so importers see **empty exports on first lazy load**; after the background rebuild + a page refresh the full build applies the transform and the same import works. No playground fixture covers this yet.
 
 ### CSS
 

--- a/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
+++ b/packages/rolldown/tests/dev/dev-lazy-compile.test.ts
@@ -2,6 +2,7 @@ import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import vm from 'node:vm';
 import type { InputOptions, OutputOptions, Plugin } from 'rolldown';
 import type { DevEngine, DevOptions } from 'rolldown/experimental';
 import { dev as _dev } from 'rolldown/experimental';
@@ -522,5 +523,79 @@ test(
     expect(chunk.code).not.toMatch(/loadExports\("external-dep"\)/);
     // and the one binding is declared once, so the import is not shadowed
     expect(chunk.code).not.toMatch(new RegExp(`var\\s+${bindings[0]}\\b`));
+  },
+);
+
+// Every module registers an exports holder with the runtime, and `loadExports` reads
+// `exports` straight off that holder. A module with no exports is no exception: it has to
+// register `{ exports: {} }`, matching what a normal build gives such a module. Registering a
+// bare `{}` reads back as `undefined`, and every consumer of it then breaks — `__toCommonJS`
+// throws "Cannot convert undefined or null to object".
+test(
+  'a module without exports still registers an empty exports object',
+  { timeout: TEST_TIMEOUT },
+  async ({ onTestFinished }) => {
+    const uniqueId = crypto.randomUUID().slice(0, 8);
+    const dir = path.join(import.meta.dirname, 'temp', `dev-lazy-require-unused-${uniqueId}`);
+    const pkg = path.join(dir, 'pkg');
+    fs.mkdirSync(pkg, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'main.js'), `import('./pkg/cjs.js');\n`);
+    // A `package.json` without `type` makes the files below CommonJS. That is what stops a
+    // module with no exports from registering an exports object at all, which is the state
+    // the bug needed.
+    fs.writeFileSync(path.join(pkg, 'package.json'), `{ "name": "pkg", "main": "cjs.js" }\n`);
+    fs.writeFileSync(
+      path.join(pkg, 'cjs.js'),
+      `require('./side-effect.js');\n\nmodule.exports = 'loaded';\n`,
+    );
+    fs.writeFileSync(path.join(pkg, 'side-effect.js'), `globalThis.sideEffectRan = true;\n`);
+
+    const engine = await dev(
+      {
+        input: path.join(dir, 'main.js'),
+        experimental: { devMode: { lazy: true, implement: '', skipCommonRuntimeInjection: true } },
+      },
+      { dir: path.join(dir, 'dist'), format: 'esm' },
+      {},
+    );
+
+    onTestFinished(async () => {
+      await engine.close();
+      delete (globalThis as Record<string, unknown>).sideEffectRan;
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    await engine.run();
+    await engine.registerClient('require-unused-client');
+    const chunk = await engine.compileEntry(
+      `${path.join(pkg, 'cjs.js')}?rolldown-lazy=1`,
+      'require-unused-client',
+    );
+
+    // `require('./side-effect.js')` is a statement, so its result is thrown away and only the
+    // init call is emitted — the same shape a normal build produces for an unused require.
+    expect(chunk.code).toMatch(/initModule\("[^"]*side-effect\.js"\)/);
+    expect(chunk.code).not.toMatch(/loadExports\("[^"]*side-effect\.js"\)/);
+
+    const { DevRuntime } = await import(import.meta.resolve('rolldown/experimental/runtime'));
+    const runtime = new DevRuntime('require-unused-client');
+    runtime.hooks = {
+      createModuleHotContext: () => ({}),
+      onModuleCacheRemoval: () => {},
+    };
+    vm.runInThisContext(`(__rolldown_runtime__) => {\n${chunk.code}\n}`)(runtime);
+
+    // The registry is keyed by the stable id, which is relative to the process cwd.
+    const stableId = (suffix: string) =>
+      new RegExp(`registerFactory\\("([^"]*${suffix})"`).exec(chunk.code)![1];
+
+    const lazyExports = runtime.loadExports(stableId('cjs\\.js\\?rolldown-lazy=1'));
+    expect(await lazyExports['rolldown:exports']).toBe('loaded');
+    expect((globalThis as Record<string, unknown>).sideEffectRan).toBe(true);
+
+    // The module has no exports, so its exports are empty — never `undefined`.
+    expect(runtime.loadExports(stableId('side-effect\\.js'))).toEqual({});
   },
 );


### PR DESCRIPTION
fixes #10769

1. register empty exports object if a module has no exports
2. remove empty object in `registerModule` for a module has no exports (4 bytes smaller)
3. remove `__toCommonJS` interop helper if the result is not used