### PR TITLE
test(define): add expected failure for default parameter scope

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/10779/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/10779/_config.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Tracks https://github.com/rolldown/rolldown/issues/10779; upstream fix: https://github.com/oxc-project/oxc/pull/24033",
+  "snapshot": false,
+  "config": {
+    "define": {
+      "typeof window": "\"undefined\""
+    }
+  },
+  "expectExecutionFailure": {
+    "reason": "define treats a function-body var as visible in a default parameter",
+    "outputContains": ["define should replace typeof window in a default parameter"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/10779/main.js
+++ b/crates/rolldown/tests/rolldown/issues/10779/main.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+
+globalThis.window = {};
+
+function load(value = typeof window !== 'undefined' ? 'browser' : 'server') {
+  var window;
+  return value;
+}
+
+assert.strictEqual(load(), 'server', 'define should replace typeof window in a default parameter');


### PR DESCRIPTION
A expected-failure test to track fix for https://github.com/rolldown/rolldown/issues/10779