### PR TITLE
test: use an absolute filename for transform tsconfig path

### DIFF
--- a/packages/rolldown/tests/utils/transform.test.ts
+++ b/packages/rolldown/tests/utils/transform.test.ts
@@ -174,7 +174,9 @@ describe('enhanced transform', () => {
     const fixtures = path.join(import.meta.dirname, 'fixtures');
 
     it('should use a tsconfig path', () => {
-      const filename = '/nonexistent/path/test.ts';
+      // Must be a real absolute path. `/foo` is not absolute on Windows, so
+      // oxc_resolver treats it as a virtual module and skips tsconfig.
+      const filename = path.resolve('/nonexistent/path/test.ts');
       const code = `class Foo { bar = 'bar' }`;
       const explicitTsconfig = path.join(fixtures, 'tsconfig.json');
       const expected = transformSync(filename, code, {


### PR DESCRIPTION
### Description

Fix failed job: https://github.com/rolldown/rolldown/actions/runs/32363650736/job/96409301585, related to #10727

The test used `'/nonexistent/path/test.ts'`. That is absolute on Unix, but not on Windows (`Path::is_absolute()` is false without a drive letter), so the explicit tsconfig was never loaded and Windows CI failed.

oxc-resolver implements that skip before Manual discovery runs:

```rust
// Don't discover tsconfig for paths inside node_modules
if cached_path.inside_node_modules() {
    return Ok(None);
}
// Skip non-absolute paths (e.g. virtual modules)
if !cached_path.path.is_absolute() {
    return Ok(None);
}
```

When `tsconfig` is an explicit path, that tsconfig should be returned for every file, including virtual modules and modules inside `node_modules`? I'm not sure.

Currently Rolldown's explicit `tsconfig` option also behaves this way: it excludes virtual modules and modules inside `node_modules`.