### PR TITLE
feat: support Baseline queries in transform target

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, path::Path, sync::Arc};
 
 use arcstr::ArcStr;
 use itertools::Either;
-use oxc::{transformer::EngineTargets, transformer_plugins::InjectGlobalVariablesConfig};
+use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, CodeSplittingMode, GlobalsOutputOption, InjectImport, JsxOptions, JsxPreset,
   LegalComments, ManualCodeSplittingOptions, MinifyOptions, ModuleType, NormalizedBundlerOptions,
@@ -319,12 +319,7 @@ pub fn prepare_build_context(
   let transform_options = {
     let mut raw_transform_options = raw_options.transform.unwrap_or_default();
 
-    let target = match &raw_transform_options.target {
-      Some(Either::Left(target)) => EngineTargets::from_target(target),
-      Some(Either::Right(targets)) => EngineTargets::from_target_list(targets),
-      None => Ok(EngineTargets::default()),
-    }
-    .map_err(|message| {
+    let target = raw_transform_options.resolve_target().map_err(|message| {
       let hint = message
         .contains("Invalid target")
         .then(|| "Rolldown only supports ES2015 (ES6) and later.".to_owned());

--- a/crates/rolldown_binding/src/options/binding_transform_options.rs
+++ b/crates/rolldown_binding/src/options/binding_transform_options.rs
@@ -142,10 +142,12 @@ pub struct BindingEnhancedTransformOptions {
   /// Sets the target environment for the generated JavaScript.
   ///
   /// The lowest target is `es2015`.
+  /// Browserslist queries such as `baseline widely available` are also supported.
   ///
   /// Example:
   ///
   /// * `'es2015'`
+  /// * `'baseline widely available'`
   /// * `['es2020', 'chrome58', 'edge16', 'firefox57', 'node12', 'safari11']`
   ///
   /// @default `esnext` (No transformation)

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_option/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_option/mod.rs
@@ -4,7 +4,7 @@ mod jsx_options;
 mod plugin_options;
 mod typescript_options;
 
-use oxc::transformer::{EnvOptions, HelperLoaderOptions};
+use oxc::transformer::{EngineTargets, EnvOptions, HelperLoaderOptions};
 
 pub use itertools::Either;
 pub use {
@@ -23,10 +23,12 @@ pub struct TransformOptions {
   /// Sets the target environment for the generated JavaScript.
   ///
   /// The lowest target is `es2015`.
+  /// Browserslist queries such as `baseline widely available` are also supported.
   ///
   /// Example:
   ///
   /// * `'es2015'`
+  /// * `'baseline widely available'`
   /// * `['es2020', 'chrome58', 'edge16', 'firefox57', 'node12', 'safari11']`
   ///
   /// @default `esnext` (No transformation)
@@ -48,6 +50,23 @@ pub struct TransformOptions {
 
   /// Behaviour for runtime helpers.
   pub helpers: Option<HelperLoaderOptions>,
+}
+
+impl TransformOptions {
+  /// Resolve esbuild-style engine targets, falling back to a Browserslist query.
+  pub fn resolve_target(&self) -> Result<EngineTargets, String> {
+    match &self.target {
+      Some(Either::Left(target)) => match EngineTargets::from_target(target) {
+        Ok(targets) => Ok(targets),
+        Err(error) => EngineTargets::try_from_query(target).map_err(|_| error),
+      },
+      Some(Either::Right(targets)) => match EngineTargets::from_target_list(targets) {
+        Ok(targets) => Ok(targets),
+        Err(error) => EngineTargets::try_from_query(&targets.join(", ")).map_err(|_| error),
+      },
+      None => Ok(EngineTargets::default()),
+    }
+  }
 }
 
 impl From<crate::utils::enhanced_transform::EnhancedTransformOptions> for TransformOptions {
@@ -90,11 +109,7 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
   type Error = String;
 
   fn try_from(options: TransformOptions) -> Result<Self, Self::Error> {
-    let env = match options.target {
-      Some(Either::Left(s)) => EnvOptions::from_target(&s)?,
-      Some(Either::Right(list)) => EnvOptions::from_target_list(&list)?,
-      _ => EnvOptions::default(),
-    };
+    let env = EnvOptions::from(options.resolve_target()?);
     Ok(Self {
       // cwd: options.cwd.map(PathBuf::from).unwrap_or_default(),
       assumptions: options.assumptions.map(Into::into).unwrap_or_default(),
@@ -125,5 +140,20 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
       plugins: oxc::transformer::PluginsOptions::from(options.plugins.unwrap_or_default()),
       ..Default::default()
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn baseline_widely_available_is_a_valid_target() {
+    let options = TransformOptions {
+      target: Some(Either::Left("baseline widely available".to_string())),
+      ..Default::default()
+    };
+
+    oxc::transformer::TransformOptions::try_from(options).expect("Baseline query should parse");
   }
 }

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -99,6 +99,7 @@ pub struct EnhancedTransformOptions {
   pub jsx: Option<Either<String, JsxOptions>>,
 
   /// Sets the target environment for the generated JavaScript.
+  /// Browserslist queries such as `baseline widely available` are supported.
   pub target: Option<Either<String, Vec<String>>>,
 
   /// Set assumptions in order to produce smaller output.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2165,10 +2165,12 @@ export interface BindingEnhancedTransformOptions {
    * Sets the target environment for the generated JavaScript.
    *
    * The lowest target is `es2015`.
+   * Browserslist queries such as `baseline widely available` are also supported.
    *
    * Example:
    *
    * * `'es2015'`
+   * * `'baseline widely available'`
    * * `['es2020', 'chrome58', 'edge16', 'firefox57', 'node12', 'safari11']`
    *
    * @default `esnext` (No transformation)

--- a/packages/rolldown/src/options/docs/transform.md
+++ b/packages/rolldown/src/options/docs/transform.md
@@ -3,3 +3,21 @@
 Rolldown uses Oxc under the hood for transformation.
 
 While Oxc does not support lowering the latest decorators proposal yet, Rolldown is able to bundle them.
+
+#### Browserslist
+
+`transform.target` accepts [Browserslist queries](https://github.com/browserslist/browserslist#full-list), resolved by [oxc-browserslist](https://github.com/oxc-project/oxc-browserslist).
+
+For example, set it to `baseline widely available` to lower JavaScript for browsers that support the [Baseline Widely Available](https://web-platform-dx.github.io/web-features/) feature set:
+
+```js [rolldown.config.js]
+export default defineConfig({
+  transform: {
+    target: 'baseline widely available',
+  },
+});
+```
+
+The selected browser versions can change when Rolldown updates its bundled Browserslist data. For a reproducible target, use a dated query such as `baseline widely available on 2026-08-26`.
+
+The target controls JavaScript syntax lowering. It does not add polyfills for web APIs.


### PR DESCRIPTION
Support Baseline queries in `transform.target`.

Document Baseline query behavior and reproducibility considerations.