### PR TITLE
fix(plugin_timings): reword the warning so it does not contradict itself

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_timings.rs
@@ -44,8 +44,10 @@ pub struct PluginTiming {
 /// One build's worth of JavaScript-side measurement.
 #[derive(Debug, Clone, Default)]
 pub struct PluginTimingsMeasurement {
-  /// Wall time in which *any* measured callback was running, counting overlap once. Unlike
-  /// a sum of spans this cannot outrun the build, which is what makes it usable as a share.
+  /// Wall time in which at least one measured callback ran. Overlap counts once, so the
+  /// value cannot be more than the window the callbacks ran in. That is what makes it
+  /// usable as a share. It can be more than the core build clock, because `closeBundle`
+  /// runs after that clock stops.
   pub busy_ms: f64,
   pub rows: Vec<PluginTiming>,
 }
@@ -61,6 +63,9 @@ pub struct PluginTimings {
   /// Rows the caps dropped, so a bounded view can say what it bounded.
   measured_hidden: usize,
   unmeasurable_hidden: usize,
+  /// Rankable rows under [`MIN_ROW_MS`]. The message never shows them. The remainder
+  /// sentence names them only when they exist.
+  below_floor: usize,
 }
 
 impl PluginTimings {
@@ -72,7 +77,9 @@ impl PluginTimings {
     let (rankable, overlapped): (Vec<_>, Vec<_>) =
       measurement.rows.into_iter().partition(|row| row.rankable);
 
-    let mut measured = rankable.into_iter().filter(|row| row.ms >= MIN_ROW_MS).collect::<Vec<_>>();
+    let (mut measured, below_floor): (Vec<_>, Vec<_>) =
+      rankable.into_iter().partition(|row| row.ms >= MIN_ROW_MS);
+    let below_floor = below_floor.len();
     measured.sort_by(|a, b| b.ms.total_cmp(&a.ms));
     let measured_hidden = measured.len().saturating_sub(MAX_MEASURED_ROWS);
     measured.truncate(MAX_MEASURED_ROWS);
@@ -94,6 +101,7 @@ impl PluginTimings {
       unmeasurable,
       measured_hidden,
       unmeasurable_hidden,
+      below_floor,
     })
   }
 }
@@ -106,27 +114,36 @@ impl BuildEvent for PluginTimings {
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     const DOC_LINK: &str = "https://rolldown.rs/reference/InputOptions.checks#plugintimings";
 
+    #[expect(clippy::cast_possible_truncation)]
+    let percent = |ms: f64| -> i64 { (ms / self.build_ms * 100.0).round() as i64 };
     // `closeBundle` runs after the clock the build was measured with stopped, so a span can
     // outrun the build it is a share of. Clamp rather than print an impossible percentage.
-    let share = |ms: f64| -> u64 {
-      #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-      let percent = (ms / self.build_ms * 100.0).round() as u64;
-      percent.min(100)
-    };
+    let share = |ms: f64| -> i64 { percent(ms).min(100) };
 
-    let mut out = format!(
-      "Your build spent {}% of {} inside plugin hooks ({}).",
-      share(self.busy_ms),
-      format_duration(self.build_ms),
-      format_duration(self.busy_ms)
-    );
+    let mut out = if self.busy_ms > self.build_ms {
+      // Without this branch, the headline reads "7.4s of this 7.1s build". That looks like
+      // a bug.
+      format!(
+        "Plugin hooks ran for {}. The build took {}. Hooks such as `closeBundle` run after \
+         the build ends, so hook time can be more than build time.",
+        format_duration(self.busy_ms),
+        format_duration(self.build_ms)
+      )
+    } else {
+      format!(
+        "Plugin hooks ran for {} of this {} build ({}%).",
+        format_duration(self.busy_ms),
+        format_duration(self.build_ms),
+        share(self.busy_ms)
+      )
+    };
 
     if !self.measured.is_empty() {
       // Not "time they ran": excluding the dispatch queue is what measuring from inside the
       // callback buys, and it does not separate running from awaiting.
       out.push_str(
-        "\nMeasured inside the callback, so queue time is excluded and time the callback \
-         itself awaited is not:",
+        "\nThe slowest hooks, timed inside each callback (the wait before a callback starts \
+         is excluded, the time it awaits is included):",
       );
       let mut listed_ms = 0.0;
       for row in &self.measured {
@@ -143,28 +160,58 @@ impl BuildEvent for PluginTimings {
         );
       }
       if self.measured_hidden > 0 {
-        let _ = write!(out, "\n  … and {} more below 1s or past the cap", self.measured_hidden);
+        // Every hidden row is over the one-second floor. Only the cap dropped it.
+        let _ = write!(out, "\n  … and {} more hooks over 1s", self.measured_hidden);
       }
-      // Without this the gap between the headline and the rows is unexplained, and a reader
-      // cannot tell whether it is unmeasurable callbacks or core work.
-      if !self.unmeasurable.is_empty() || self.measured_hidden > 0 {
-        let _ = write!(
-          out,
-          "\nThose rows are {}% of the build; the rest of the {}% is below.",
-          share(listed_ms),
-          share(self.busy_ms)
+      // These sentences explain the gap between the headline and the rows. Without them, a
+      // reader cannot tell whether the gap is unmeasurable callbacks, hooks under the floor,
+      // or core work. The comparison uses unclamped percentages: with both clamped at 100%,
+      // the shares hide a real difference in either direction. The rows are a sum of spans
+      // and the headline is their union. The sign of the difference is meaningful, but its
+      // size is not: two listed hooks that overlap each other make the difference smaller,
+      // and no omitted hook becomes cheaper. That is why no sentence puts a number on the
+      // gap.
+      let rest = percent(self.busy_ms) - percent(listed_ms);
+      if rest < 0 {
+        // Nesting is the usual cause, but not the only one. `rankable` only checks the
+        // overlap of a hook with itself, so two different `async` hooks can still run at the
+        // same time.
+        out.push_str(
+          "\nThese rows add up to more than the total. Callbacks can overlap, so the same \
+           time counts for more than one row.",
         );
+      } else if rest > 0 {
+        let mut targets = Vec::new();
+        if !self.unmeasurable.is_empty() {
+          targets.push("the hooks below");
+        }
+        if self.measured_hidden > 0 {
+          targets.push("the hooks not listed");
+        } else if self.below_floor > 0 {
+          targets.push("hooks under 1s");
+        }
+        // The sentence shows no numbers. If it showed the sum next to the headline, a reader
+        // would subtract them, and that difference is not the time of the omitted hooks. A
+        // gap with nothing omitted cannot happen, because a union is at most the sum of its
+        // spans. But a sentence that ends in nothing is worse than no sentence, so the check
+        // stays.
+        if !targets.is_empty() {
+          let _ = write!(out, "\nAdditional hook time came from {}.", targets.join(" and from "));
+        }
       }
     }
 
     if !self.unmeasurable.is_empty() {
       let total = self.unmeasurable.len() + self.unmeasurable_hidden;
+      let (verb, its, their) =
+        if total == 1 { ("is", "Its", "its") } else { ("are", "Their", "their") };
       let _ = write!(
         out,
-        "\nNot measurable — {} hook{} whose calls overlap, so elapsed time covers work other \
-         calls were doing. Profile with `node --cpu-prof`:",
+        "\n{} hook{} {verb} listed without a time. {its} calls overlapped, so the time inside \
+         one call includes work from other calls. To find {their} cost, profile the build \
+         with `node --cpu-prof`:",
         total,
-        plural(u32::try_from(total).unwrap_or(u32::MAX))
+        plural(u32::try_from(total).unwrap_or(u32::MAX)),
       );
       for row in &self.unmeasurable {
         let _ =
@@ -234,7 +281,7 @@ mod tests {
         "  - async-plugin resolveId (3000 calls)",
       ]
     );
-    assert!(message.contains("80% of 10.0s"));
+    assert!(message.contains("ran for 8.0s of this 10.0s build (80%)"), "{message}");
     // The 47s row would top any ranking, which is exactly why it gets no number.
     assert!(!message.contains("47.0s"));
     // Below the one-second floor.
@@ -249,17 +296,19 @@ mod tests {
   }
 
   #[test]
-  fn says_what_the_listed_rows_add_up_to() {
-    // Without this the gap between the headline and the rows is unexplained, and a reader
-    // cannot tell whether it is unmeasurable callbacks or core work.
+  fn explains_the_gap_between_the_headline_and_the_rows() {
+    // Without this sentence, a reader cannot tell whether the gap between the headline and
+    // the rows is unmeasurable callbacks or core work.
     let message = render(
       10_000.0,
       9_600.0,
       vec![row("p", "transform", 5_000.0, 3, 1), row("q", "resolveId", 4_000.0, 9, 12)],
     )
     .unwrap();
-    assert!(message.contains("Those rows are 50% of the build"), "{message}");
-    assert!(message.contains("96%"), "{message}");
+    // No row here is under the floor, so the sentence must not name such rows. The sentence
+    // has no arithmetic: the rows are a sum of spans and the headline is their union, so
+    // their difference is not the cost of the omitted hooks.
+    assert!(message.contains("Additional hook time came from the hooks below."), "{message}");
   }
 
   #[test]
@@ -271,9 +320,16 @@ mod tests {
       .map(|i| row("q", "resolveId", 9_000.0, 1, 2 + i));
     let message = render(100_000.0, 90_000.0, measured.chain(overlapped).collect()).unwrap();
 
-    assert!(message.contains("… and 3 more below 1s or past the cap"), "{message}");
+    assert!(message.contains("… and 3 more hooks over 1s"), "{message}");
     assert!(message.contains("… and 2 more"), "{message}");
-    assert!(message.contains("5 hooks whose calls overlap"), "{message}");
+    assert!(message.contains("5 hooks are listed without a time. Their calls"), "{message}");
+    // The remainder went to the unmeasurable rows and to the rows past the cap. "hooks
+    // under 1s" would be wrong here.
+    assert!(
+      message
+        .contains("Additional hook time came from the hooks below and from the hooks not listed."),
+      "{message}"
+    );
   }
 
   #[test]
@@ -291,7 +347,61 @@ mod tests {
     // `closeBundle` runs after the build clock stopped, so its span can exceed the build.
     let message =
       render(4_000.0, 6_000.0, vec![row("late", "closeBundle", 6_000.0, 1, 1)]).unwrap();
-    assert!(message.contains("100% of 4.0s"));
-    assert!(!message.contains("150%"));
+    assert!(message.contains("ran for 6.0s. The build took 4.0s."), "{message}");
+    assert!(message.contains("(100%, 6.0s, 1 call)"), "{message}");
+    assert!(!message.contains("150%"), "{message}");
+  }
+
+  #[test]
+  fn rows_that_add_up_to_more_than_the_total_are_explained_as_overlap() {
+    // A Vite build: a `load` hook runs a nested build, and the transforms inside it count
+    // for both hooks. The rows add up to 125% of the build, and the headline is at 100%. A
+    // sentence such as "the rest is below" would be wrong.
+    let message = render(
+      7_100.0,
+      7_400.0,
+      vec![
+        row("@rolldown/plugin-babel", "transform", 6_200.0, 1_175, 1),
+        row("vite:worker", "load", 1_400.0, 1, 1),
+        row("vite:asset", "load", 3_000.0, 402, 8),
+      ],
+    )
+    .unwrap();
+    assert!(message.contains("These rows add up to more than the total."), "{message}");
+    assert!(!message.contains("Additional hook time"), "{message}");
+  }
+
+  #[test]
+  fn a_remainder_with_nothing_else_listed_names_hooks_under_the_floor() {
+    // 6s of rows against an 8s headline, with no unmeasurable rows and no cap. The gap can
+    // only be callbacks under one second, and the message must tell the reader that they
+    // exist.
+    let message = render(
+      10_000.0,
+      8_000.0,
+      vec![row("p", "transform", 6_000.0, 3, 1), row("tiny", "buildStart", 500.0, 40, 1)],
+    )
+    .unwrap();
+    assert!(message.contains("Additional hook time came from hooks under 1s."), "{message}");
+  }
+
+  #[test]
+  fn a_remainder_past_the_build_carries_no_number() {
+    // 5s of rows on a 4s build with 6s of hook time. A share here would clamp to 100%. A
+    // duration would make the reader subtract a sum from a union.
+    let message = render(
+      4_000.0,
+      6_000.0,
+      vec![row("late", "closeBundle", 5_000.0, 1, 1), row("q", "load", 2_000.0, 9, 4)],
+    )
+    .unwrap();
+    assert!(message.contains("Additional hook time came from the hooks below."), "{message}");
+    assert!(!message.contains("add up to"), "{message}");
+  }
+
+  #[test]
+  fn a_single_overlapped_hook_is_not_pluralised() {
+    let message = render(10_000.0, 8_000.0, vec![row("q", "load", 5_000.0, 9, 4)]).unwrap();
+    assert!(message.contains("1 hook is listed without a time. Its calls overlapped"), "{message}");
   }
 }

--- a/packages/rolldown/src/options/docs/checks-plugin-timings.md
+++ b/packages/rolldown/src/options/docs/checks-plugin-timings.md
@@ -10,10 +10,10 @@ The clock starts and stops **inside the JavaScript callback**, not around the ca
 
 3. **Rows**: up to 12 hooks are listed, sorted by measured time, each shown as a share of total build time with its call count. Only hooks costing at least 1 second get a line. User callbacks configured on the options rather than on a plugin — `external`, `treeshake.moduleSideEffects`, the file-name and addon callbacks, and the [`output.advancedChunks`](/reference/OutputOptions.advancedChunks) `groups[].name` classifier and `groups[].test` predicate — appear under `input options` / `output options`.
 
-   The headline figure is the wall time in which _any_ plugin callback was running, counted once however much they overlap, so it can never exceed the build. Individual rows can add up to more than it, because one callback may run inside another — `this.emitFile()` in `buildStart` invokes your `assetFileNames`, and that time belongs to both.
+   The headline figure is the wall time in which at least one plugin callback ran. Overlap counts once. The figure can be more than the build time, because `closeBundle` runs after the build clock stops. The message says so when that happens. The rows can add up to more than the headline figure, because callbacks can overlap. One callback can run inside another: `this.emitFile()` in `buildStart` runs your `assetFileNames`, and that time counts for both. Two `async` callbacks can also run at the same time.
 
 > [!IMPORTANT]
-> **Some hooks are listed without a number**, under a heading saying they are not measurable.
+> **The message lists some hooks without a time.**
 >
 > A span from callback entry to callback exit can be added to another span only if the two never overlap. A synchronous callback cannot overlap — it holds the thread until it returns. An `async` one can: it may suspend at an `await` and let another call of the same hook begin, and then both spans cover the same wall clock and adding them counts it twice. Overlap also changes what the span means — a hook that awaits Rolldown itself, via `this.resolve` or `this.load`, spends most of its span waiting for the bundler, so its elapsed time describes the bundler rather than your plugin.
 >

--- a/packages/rolldown/src/utils/plugin-timings.ts
+++ b/packages/rolldown/src/utils/plugin-timings.ts
@@ -100,9 +100,10 @@ export interface PluginTimingsRecorder {
    */
   costs: Map<unknown, Map<string, HookCost>>;
   /**
-   * Wall time during which *any* measured callback was running — the union of every span,
-   * so overlapping calls are counted once. Unlike a sum of spans this cannot outrun the
-   * build, which is what makes it usable as a share.
+   * Wall time in which at least one measured callback ran: the union of every span, so
+   * overlapping calls count once. The value cannot be more than the window the callbacks
+   * ran in. That is what makes it usable as a share. It can be more than the core build
+   * clock, because `closeBundle` runs after that clock stops.
    */
   busyMs: number;
   /** Across all hooks, for maintaining {@link PluginTimingsRecorder.busyMs}. */
@@ -318,7 +319,11 @@ export interface PluginTimingRow {
  * as `BindingPluginTimingsMeasurement`.
  */
 export interface PluginTimingsMeasurement {
-  /** Union of every span, so it counts overlap once and cannot outrun the build. */
+  /**
+   * Union of every span, so overlap counts once. The value cannot be more than the window
+   * the callbacks ran in. It can be more than the core build clock, because `closeBundle`
+   * runs after that clock stops.
+   */
   busyMs: number;
   /**
    * First-call order. No significance — ordering is the renderer's call, and this side does


### PR DESCRIPTION
The `[PLUGIN_TIMINGS]` warning said "Those rows are 100% of the build; the rest of the 100% is below" and "100% of 7.1s inside plugin hooks (7.4s)" when the listed rows added up to more than the build, and "… and N more below 1s or past the cap" for rows that were all over 1s.

Before, on a Vite build:

```
[PLUGIN_TIMINGS] Your build spent 100% of 7.1s inside plugin hooks (7.4s).
Measured inside the callback, so queue time is excluded and time the callback itself awaited is not:
  - @rolldown/plugin-babel transform (87%, 6.2s, 1175 calls)
  - vite:worker load (19%, 1.4s, 1 call)
  - vite-plugin-pwa load (18%, 1.3s, 1 call)
Those rows are 100% of the build; the rest of the 100% is below.
Not measurable — 2 hooks whose calls overlap, so elapsed time covers work other calls were doing. Profile with `node --cpu-prof`:
  - vite:asset load (402 calls)
  - pixelarticons-svg-icon load (59 calls)
See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
```

After:

```
[PLUGIN_TIMINGS] Plugin hooks ran for 7.4s. The build took 7.1s. Hooks such as `closeBundle` run after the build ends, so hook time can be more than build time.
The slowest hooks, timed inside each callback (the wait before a callback starts is excluded, the time it awaits is included):
  - @rolldown/plugin-babel transform (87%, 6.2s, 1175 calls)
  - vite:worker load (19%, 1.4s, 1 call)
  - vite-plugin-pwa load (18%, 1.3s, 1 call)
These rows add up to more than the total. Callbacks can overlap, so the same time counts for more than one row.
2 hooks are listed without a time. Their calls overlapped, so the time inside one call includes work from other calls. To find their cost, profile the build with `node --cpu-prof`:
  - vite:asset load (402 calls)
  - pixelarticons-svg-icon load (59 calls)
See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
```

When the rows add up to less than the total, the sentence is "Additional hook time came from the hooks below and from hooks under 1s." with no number, because the rows are a sum of spans and the headline is their union.
