### PR TITLE
fix: synchronize sourcemap assets after generateBundle mutations

### DIFF
--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -73,8 +73,8 @@ impl JsChangedOutputs {
     outputs: &mut Vec<rolldown_common::Output>,
   ) -> anyhow::Result<()> {
     let mut result = Ok(());
-    let mut sourcemap_updates = HashMap::<String, String, FxBuildHasher>::default();
-    let mut explicitly_updated_assets = HashSet::<String, FxBuildHasher>::default();
+    let mut sourcemap_updates = None;
+    let mut explicitly_updated_assets = None;
     if !self.deleted.is_empty() || !self.changes.is_empty() {
       outputs.retain_mut(|output| {
         if result.is_err() {
@@ -91,11 +91,15 @@ impl JsChangedOutputs {
               } else if let (Some(filename), Some(map)) =
                 (&old_chunk.sourcemap_filename, &old_chunk.map)
               {
-                sourcemap_updates.insert(filename.clone(), map.to_json_string());
+                sourcemap_updates
+                  .get_or_insert_with(HashMap::default)
+                  .insert(filename.clone(), map.to_json_string());
               }
             }
             (v @ rolldown_common::Output::Asset(_), Either::B(asset)) => {
-              explicitly_updated_assets.insert(asset.filename.clone());
+              explicitly_updated_assets
+                .get_or_insert_with(HashSet::default)
+                .insert(asset.filename.clone());
               *v = rolldown_common::Output::Asset(Arc::new(asset.into()));
             }
             _ => {}
@@ -104,21 +108,29 @@ impl JsChangedOutputs {
         true
       });
     }
-    if !sourcemap_updates.is_empty() {
-      for output in outputs.iter_mut() {
-        let rolldown_common::Output::Asset(asset) = output else {
-          continue;
-        };
-        if explicitly_updated_assets.contains(asset.filename.as_str()) {
-          continue;
-        }
-        let Some(source) = sourcemap_updates.get(asset.filename.as_str()) else {
-          continue;
-        };
-        Arc::make_mut(asset).source = source.clone().into();
-      }
+    if let Some(sourcemap_updates) = sourcemap_updates {
+      sync_sourcemap_assets(outputs, &sourcemap_updates, explicitly_updated_assets.as_ref());
     }
     result
+  }
+}
+
+fn sync_sourcemap_assets(
+  outputs: &mut [rolldown_common::Output],
+  sourcemap_updates: &HashMap<String, String, FxBuildHasher>,
+  explicitly_updated_assets: Option<&HashSet<String, FxBuildHasher>>,
+) {
+  for output in outputs {
+    let rolldown_common::Output::Asset(asset) = output else {
+      continue;
+    };
+    if explicitly_updated_assets.is_some_and(|assets| assets.contains(asset.filename.as_str())) {
+      continue;
+    }
+    let Some(source) = sourcemap_updates.get(asset.filename.as_str()) else {
+      continue;
+    };
+    Arc::make_mut(asset).source = source.clone().into();
   }
 }
 

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -73,23 +73,29 @@ impl JsChangedOutputs {
     outputs: &mut Vec<rolldown_common::Output>,
   ) -> anyhow::Result<()> {
     let mut result = Ok(());
+    let mut sourcemap_updates = HashMap::<String, String, FxBuildHasher>::default();
+    let mut explicitly_updated_assets = HashSet::<String, FxBuildHasher>::default();
     if !self.deleted.is_empty() || !self.changes.is_empty() {
       outputs.retain_mut(|output| {
         if result.is_err() {
           return true;
         }
-        let filename = output.filename();
-        if self.deleted.contains(filename) {
+        if self.deleted.contains(output.filename()) {
           return false;
         }
-        if let Some(change) = self.changes.remove(filename) {
+        if let Some(change) = self.changes.remove(output.filename()) {
           match (output, change) {
             (rolldown_common::Output::Chunk(old_chunk), Either::A(chunk)) => {
               if let Err(err) = update_output_chunk(old_chunk, chunk) {
                 result = Err(err);
+              } else if let (Some(filename), Some(map)) =
+                (&old_chunk.sourcemap_filename, &old_chunk.map)
+              {
+                sourcemap_updates.insert(filename.clone(), map.to_json_string());
               }
             }
             (v @ rolldown_common::Output::Asset(_), Either::B(asset)) => {
+              explicitly_updated_assets.insert(asset.filename.clone());
               *v = rolldown_common::Output::Asset(Arc::new(asset.into()));
             }
             _ => {}
@@ -97,6 +103,20 @@ impl JsChangedOutputs {
         }
         true
       });
+    }
+    if !sourcemap_updates.is_empty() {
+      for output in outputs.iter_mut() {
+        let rolldown_common::Output::Asset(asset) = output else {
+          continue;
+        };
+        if explicitly_updated_assets.contains(asset.filename.as_str()) {
+          continue;
+        }
+        let Some(source) = sourcemap_updates.get(asset.filename.as_str()) else {
+          continue;
+        };
+        Arc::make_mut(asset).source = source.clone().into();
+      }
     }
     result
   }

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync-no-map/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync-no-map/_config.ts
@@ -1,0 +1,28 @@
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { getOutputAsset, getOutputChunk } from 'rolldown-tests/utils';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'mutate-inline-sourcemap-chunk',
+        generateBundle(_options, bundle) {
+          const chunk = bundle['main.js'] as RolldownOutputChunk;
+          chunk.code = `${chunk.code}\nconsole.error('updated');`;
+          const map = chunk.map;
+          expect(map).not.toBeNull();
+          chunk.map = map;
+        },
+      },
+    ],
+    output: {
+      sourcemap: 'inline',
+    },
+  },
+  afterTest: (output) => {
+    expect(getOutputChunk(output)).toHaveLength(1);
+    expect(getOutputAsset(output)).toHaveLength(0);
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync-no-map/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync-no-map/main.js
@@ -1,0 +1,1 @@
+console.log('inline');

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/_config.ts
@@ -1,0 +1,72 @@
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { getOutputAsset, getOutputChunk } from 'rolldown-tests/utils';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: ['main.js', 'automatic.js', 'deleted.js'],
+    plugins: [
+      {
+        name: 'mutate-output-chunks',
+        generateBundle(_options, bundle) {
+          const main = bundle['main.js'] as RolldownOutputChunk;
+          const automatic = bundle['automatic.js'] as RolldownOutputChunk;
+          const deleted = bundle['deleted.js'] as RolldownOutputChunk;
+
+          main.code = 'console.error("main")';
+          const mainMap = main.map!;
+          mainMap.file = 'renamed-main.js';
+          mainMap.mappings = `;${mainMap.mappings}`;
+          mainMap.sources.push('updated-main.js');
+          main.map = mainMap;
+          main.fileName = 'renamed-main.js';
+
+          automatic.code = 'console.error("automatic")';
+          const automaticMap = automatic.map!;
+          automaticMap.mappings = `;${automaticMap.mappings}`;
+          automaticMap.sources.push('updated-automatic.js');
+          automatic.map = automaticMap;
+
+          const deletedMap = deleted.map!;
+          deletedMap.mappings = `;${deletedMap.mappings}`;
+          deleted.map = deletedMap;
+          delete bundle[deleted.sourcemapFileName!];
+
+          const explicitAsset = bundle[main.sourcemapFileName!];
+          expect(explicitAsset?.type).toBe('asset');
+          if (explicitAsset?.type === 'asset') {
+            explicitAsset.source = 'plugin-owned-sourcemap';
+          }
+        },
+      },
+    ],
+    output: {
+      chunkFileNames: '[name].js',
+      sourcemap: true,
+      sourcemapFileNames: 'maps/[name].map',
+    },
+  },
+  afterTest: (output) => {
+    const chunks = getOutputChunk(output);
+    const assets = getOutputAsset(output);
+
+    const main = chunks.find((chunk) => chunk.fileName === 'renamed-main.js');
+    const automatic = chunks.find((chunk) => chunk.fileName === 'automatic.js');
+    const deleted = chunks.find((chunk) => chunk.fileName === 'deleted.js');
+    expect(main).toBeDefined();
+    expect(automatic).toBeDefined();
+    expect(deleted).toBeDefined();
+
+    const mainAsset = assets.find((asset) => asset.fileName === main!.sourcemapFileName);
+    expect(mainAsset?.source).toBe('plugin-owned-sourcemap');
+
+    const automaticAsset = assets.find((asset) => asset.fileName === automatic!.sourcemapFileName);
+    expect(automaticAsset).toBeDefined();
+    expect(JSON.parse(automaticAsset!.source as string)).toStrictEqual(
+      JSON.parse(automatic!.map!.toString()),
+    );
+
+    expect(assets.some((asset) => asset.fileName === deleted!.sourcemapFileName)).toBe(false);
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/automatic.js
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/automatic.js
@@ -1,0 +1,1 @@
+console.log('automatic');

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/deleted.js
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/deleted.js
@@ -1,0 +1,1 @@
+console.log('deleted');

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
 import { defineTest } from 'rolldown-tests';
-import { getOutputChunk } from 'rolldown-tests/utils';
+import { getOutputAsset, getOutputChunk } from 'rolldown-tests/utils';
 import { expect } from 'vitest';
 
 const entry = path.join(__dirname, './main.js');
@@ -109,5 +109,11 @@ export default defineTest({
     expect(Object.values(chunks[0].modules)[0].code).toBe(
       '//#region main.js\nconsole.log();\n\n//#endregion',
     );
+    const mapAsset = getOutputAsset(output).find(
+      (asset) => asset.fileName === chunks[0].sourcemapFileName,
+    );
+    expect(mapAsset).toBeDefined();
+    const emittedMap = JSON.parse(mapAsset!.source as string) as { mappings: string };
+    expect(emittedMap.mappings).toBe(chunks[0].map!.mappings);
   },
 });


### PR DESCRIPTION
`generateBundle` can mutate both `chunk.code` and `chunk.map`. Rolldown applies those chunk changes, but the materialized `.map` asset is created before the hook and can retain stale mappings.

This PR keeps sourcemap assets synchronized with successfully updated chunks in the native binding layer.

## What changed

- Refresh the asset identified by the chunk's stable `sourcemapFileName` after a chunk mutation.
- Keep explicit asset updates, renames, and deletions authoritative over automatic synchronization.
- Never recreate an asset that a plugin deleted.
- Lazily allocate tracking state and skip the synchronization pass when no changed chunk has a sourcemap.

The JavaScript bridge still transfers complete changed chunk snapshots. Deep tracking of nested `chunk.map` mutations is intentionally out of scope for this focused fix.

Fixes #10676

Reproduction: https://github.com/icebreaker-demo/rolldown-generate-bundle-sourcemap-repro

## Validation

- `cargo check --ignore-rust-version -p rolldown_binding`
- `cargo fmt --all -- --check`
- `pnpm exec vp lint packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync/_config.ts packages/rolldown/tests/fixtures/plugin/generate-bundle-sourcemap-asset-sync-no-map/_config.ts`
- `pnpm exec vitest run fixtures-concurrent.test.ts -t 'plugin/generate-bundle' --reporter verbose --hideSkippedTests`

Codspeed is used to detect regressions in the native output-application path. The fix adds no extra JS-to-Rust calls and avoids allocating or traversing synchronization state when it is not needed.

AI disclosure: AI tools were used to assist with repository exploration and drafting. I reviewed and verified the implementation and tests.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
