### PR TITLE
fix(rolldown_binding): make `PreRenderedChunk.facadeModuleId` nullable like Rollup

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_chunk.rs
@@ -1,4 +1,7 @@
-#[napi_derive::napi(object, object_from_js = false)]
+// `use_nullable` makes `facade_module_id: None` reach JS as `null` instead of a
+// missing property, so `RenderedChunk` stays assignable to `PreRenderedChunk`
+// like in Rollup (https://github.com/rolldown/rolldown/issues/10804).
+#[napi_derive::napi(object, object_from_js = false, use_nullable = true)]
 #[derive(Default, Debug)]
 pub struct PreRenderedChunk {
   /// The name of this chunk, which is used in naming patterns.

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -3191,7 +3191,7 @@ export interface PreRenderedChunk {
   /** Whether this chunk is a dynamic entry point. */
   isDynamicEntry: boolean
   /** The id of a module that this chunk corresponds to. */
-  facadeModuleId?: string
+  facadeModuleId: string | null
   /** The list of ids of modules included in this chunk. */
   moduleIds: Array<string>
   /** Exported variable names from this chunk. */

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -3191,7 +3191,7 @@ export interface PreRenderedChunk {
   /** Whether this chunk is a dynamic entry point. */
   isDynamicEntry: boolean
   /** The id of a module that this chunk corresponds to. */
-  facadeModuleId?: string
+  facadeModuleId: string | null
   /** The list of ids of modules included in this chunk. */
   moduleIds: Array<string>
   /** Exported variable names from this chunk. */

--- a/packages/rolldown/tests/rollup-compat.test-d.ts
+++ b/packages/rolldown/tests/rollup-compat.test-d.ts
@@ -3,9 +3,19 @@ import {
   type InputOptions,
   type OutputOptions,
   type Plugin as RolldownRawPlugin,
+  type PreRenderedChunk,
+  type RenderedChunk,
 } from 'rolldown';
 import type { Plugin as RollupPlugin } from 'rollup';
 import { describe, expectTypeOf, test } from 'vitest';
+
+describe('chunk type compatibility', () => {
+  // https://github.com/rolldown/rolldown/issues/10804
+  test('`RenderedChunk` is assignable to `PreRenderedChunk`', () => {
+    const renderedChunk = undefined as unknown as RenderedChunk;
+    expectTypeOf(renderedChunk).toExtend<PreRenderedChunk>();
+  });
+});
 
 describe('plugin type compatibility', () => {
   type PluginsOption = InputOptions['plugins'];


### PR DESCRIPTION
`RenderedChunk` was not assignable to `PreRenderedChunk` because the generated type declared `facadeModuleId?: string` instead of `string | null`. Callbacks like `chunkFileNames` now receive `facadeModuleId: null` instead of a missing property when the chunk has no facade module, matching Rollup.

fixes #10804