### PR TITLE
chore(renovate): disable oxc auto-updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,28 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["idna_adapter"],
       "enabled": false
+    },
+    {
+      "description": "Lockstep oxc packages are always upgraded manually via the `upgrade-oxc` skill, so the Renovate `oxc` group PR is always superseded (e.g. #10809 superseded #10811). Independently released oxc packages (oxc_resolver, oxc_sourcemap, oxc_index, ...) remain auto-updated.",
+      "matchDatasources": ["crate", "npm"],
+      "matchPackageNames": [
+        "oxc",
+        "oxc_*",
+        "@oxc-project/*",
+        "oxc-parser",
+        "oxc-transform",
+        "oxc-minify"
+      ],
+      "excludePackageNames": [
+        "oxc_index",
+        "oxc_sourcemap",
+        "oxc_resolver",
+        "oxc_resolver_napi",
+        "oxc-miette",
+        "oxc-browserslist",
+        "oxc-resolver"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

The lockstep oxc packages (the `oxc` group: `oxc`, `oxc_*`, `@oxc-project/*`, `oxc-parser`, `oxc-transform`, `oxc-minify`) are **always** upgraded manually via the `upgrade-oxc` skill, since upgrades require codegen, snapshot updates, and breaking-change migration. Renovate's grouped `update oxc` PR is therefore always superseded by a manual one and closed — e.g. #10811 was superseded by #10809.

This re-adds the disable rule (previously added in #9129, then removed by the blanket cleanup in #9257).

Independently released oxc packages that the team does merge from Renovate — `oxc_resolver`, `oxc_resolver_napi`, `oxc-resolver`, `oxc_sourcemap`, `oxc_index`, `oxc-miette`, `oxc-browserslist` (e.g. #10356, #10245) — are excluded from the rule and remain auto-updated.

