### PR TITLE
fix: remove deleted property from output bundle proxy target

### DIFF
--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -183,6 +183,7 @@ export function transformToOutputBundle(
       if (typeof property === 'string') {
         changed.deleted.add(property);
       }
+      delete target[property as keyof typeof target];
       return true;
     },
   });

--- a/packages/rolldown/tests/fixtures/misc/remove-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/remove-chunk/_config.ts
@@ -1,4 +1,5 @@
 import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
 
 export default defineTest({
   config: {
@@ -7,6 +8,9 @@ export default defineTest({
         name: 'remove-chunk',
         generateBundle(outputOptions, bundle) {
           delete bundle['main.js'];
+          expect(bundle['main.js']).toBeUndefined();
+          expect('main.js' in bundle).toBe(false);
+          expect(Object.keys(bundle)).not.toContain('main.js');
         },
       },
     ],


### PR DESCRIPTION
The issue is this: when a plugin does `delete bundle[key]`, Rolldown **records** that the file should be removed from the final output, but it **does not immediately remove it from the JavaScript `bundle` object**.

As a result, within the same hook, you get some unexpected behavior:

* `bundle[key]` still returns the file;
* `key in bundle` → `true`;
* `Object.keys(bundle)` still includes the file.

In Rollup, after `delete`, the file immediately disappears from the object, as expected.

Importantly, **the file is still removed from the final build output**. In other words, Rolldown does not emit an extra chunk. The bug only affects what plugin code sees **after `delete` within the same hook**.

The test is correct: it fails without the fix and passes with it. The fix itself is very small — the `deleteProperty` handler simply needs to actually delete the property from `target`.

The other 69 failing tests and the TypeScript errors **are unrelated to this change**: their counts are identical before and after the fix.


**AI disclosure**: this change was developed with the assistance of Claude Code. I have reviewed, tested, and understand the change.