### PR TITLE
fix(binding): clamp default worker threads by available parallelism

### DIFF
--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -119,10 +119,12 @@ fn init() {
     let worker_threads = std::env::var("ROLLDOWN_WORKER_THREADS")
       .ok()
       .and_then(|v| v.parse::<usize>().ok())
-      // unlike the web server scenario
-      // rolldown puts a lot of blocking tasks in the worker threads rather than blocking_threads
-      // so we need to increase the worker threads rather than the blocking_threads
-      .unwrap_or(num_cpus::get_physical() * 3 / 2);
+      .unwrap_or_else(|| {
+        default_worker_threads(
+          num_cpus::get_physical(),
+          std::thread::available_parallelism().ok().map(std::num::NonZeroUsize::get),
+        )
+      });
     let mut builder = tokio::runtime::Builder::new_multi_thread();
 
     let rt = builder
@@ -145,5 +147,52 @@ fn init() {
         "\nPlease report this issue at: https://github.com/rolldown/rolldown/issues/new?template=panic_report.yml"
       );
     }));
+  }
+}
+
+/// Default size of the tokio worker pool when `ROLLDOWN_WORKER_THREADS` is unset.
+///
+/// Unlike a web server, rolldown runs most of its CPU-bound work on the runtime workers rather
+/// than on blocking threads, so the pool is oversized relative to the physical core count.
+///
+/// `num_cpus::get_physical()` reads `/proc/cpuinfo` on Linux, which is not namespaced and so
+/// reports the host's cores even inside a container with a cgroup CPU quota. The physical count
+/// is therefore clamped by `std::thread::available_parallelism()`, which does honor cgroup quotas
+/// and affinity masks.
+#[cfg(not(target_family = "wasm"))]
+fn default_worker_threads(physical_cpus: usize, available_parallelism: Option<usize>) -> usize {
+  let cpus = match available_parallelism {
+    Some(available) => physical_cpus.min(available),
+    None => physical_cpus,
+  };
+  (cpus * 3 / 2).max(1)
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+  use super::default_worker_threads;
+
+  #[test]
+  fn unconstrained_host_keeps_physical_heuristic() {
+    // 4 physical / 8 logical cores, no quota: 4 * 3 / 2.
+    assert_eq!(default_worker_threads(4, Some(8)), 6);
+  }
+
+  #[test]
+  fn cgroup_quota_clamps_physical_count() {
+    // 4 physical cores on the host, but the container is limited to 2 CPUs.
+    assert_eq!(default_worker_threads(4, Some(2)), 3);
+    // 48 physical cores on the host, container limited to 24 CPUs.
+    assert_eq!(default_worker_threads(48, Some(24)), 36);
+  }
+
+  #[test]
+  fn unknown_parallelism_falls_back_to_physical_count() {
+    assert_eq!(default_worker_threads(4, None), 6);
+  }
+
+  #[test]
+  fn never_returns_zero_workers() {
+    assert_eq!(default_worker_threads(1, Some(1)), 1);
   }
 }


### PR DESCRIPTION
Fixes #10812.

### Problem

The default tokio worker pool is sized from `num_cpus::get_physical() * 3 / 2`. On Linux `get_physical()` parses `/proc/cpuinfo`, which is not namespaced, so inside a container with a cgroup CPU quota it still reports the host's physical cores. The issue measured 72 `rolldown-worker` threads in a 24-CPU container on a 48-core host, paid on `import` because the runtime is built in `module_init`.

### Fix

Clamp the physical core count by `std::thread::available_parallelism()` (which honors cgroup quotas and affinity masks) before applying the existing `* 3 / 2` heuristic. The heuristic itself is unchanged, so unconstrained hosts get the same pool size as before: there `available_parallelism()` reports logical CPUs, which is never lower than the physical count.

| host physical | quota | before | after |
|---|---|---|---|
| 4 (8 logical) | none | 6 | 6 |
| 4 (8 logical) | `--cpus=2` | 6 | 3 |
| 48 | 24 CPUs | 72 | 36 |

`ROLLDOWN_WORKER_THREADS` still overrides everything.

### Alternatives considered

- Replacing `get_physical()` with `num_cpus::get()` / `available_parallelism()` outright would also change behaviour on unconstrained hosts (logical instead of physical cores), which the issue explicitly called out as undesirable. Clamping keeps the current heuristic and only fixes the container case.

### Tests

The sizing logic is extracted into a pure `default_worker_threads(physical, available)` and covered by unit tests, since a cgroup quota can't be exercised in CI. Note `just test-rust` excludes `rolldown_binding`, so I ran them directly:

```
cargo test -p rolldown_binding --lib tests::
test tests::cgroup_quota_clamps_physical_count ... ok
test tests::never_returns_zero_workers ... ok
test tests::unconstrained_host_keeps_physical_heuristic ... ok
test tests::unknown_parallelism_falls_back_to_physical_count ... ok
```

`cargo fmt --check` and `cargo clippy -p rolldown_binding --all-targets -- --deny warnings` are clean.

### AI disclosure

This PR was written by an AI agent (OpenCode, `claude-fable-5-1`) operating on behalf of the account owner, per the [AI usage policy](https://rolldown.rs/contribution-guide/#ai-usage-policy). The change was compiled, tested and linted locally as described above.
