### PR TITLE
chore(deps): upgrade oxc to 0.149.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1560,8 +1560,7 @@ checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 [[package]]
 name = "oxc"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09c8735a25d3d1bf46bdcd8e0871a66d5b28ebf7f62c26032d5b9df323e5f6b"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1599,8 +1598,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4721a6dea1ed51a31597a8865aac718c89ac6d6c91e1d67d1f632078a0518d97"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1613,8 +1611,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5c392641cfc4bd1a93881ee681f144d0213b1456288b2b6612f7eb8d2e02aa"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1631,8 +1628,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c233646788d3ae40492affb98185d167bdcc86c8b88ca661d784157404f4f62"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1643,8 +1639,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ec60272a8dead7c6fb21dd9709f66e4033194399296603a2c9f85dc63b5540"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1655,8 +1650,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fff57cbadb9802b778b9941e6e5268df8f54305f75c55399c8e835ee8b366f3"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1677,8 +1671,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caef0301ad6c51d21b805600c0b2e30175c4637e41444dff8e8ea9d21d8c4c1c"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1690,8 +1683,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe5adfd511d39d3619ce02317368553c79aa290abf1acaf0b4525cec9594e94"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "ropey",
 ]
@@ -1699,8 +1691,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606cda8ae718447dc41af63ec4fc53e99b104bde2fd7a3b9e3b9a4976020aa86"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bytecount",
  "cow-utils",
@@ -1717,8 +1708,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6e7b1ffc464822d838a33858ae95cc672481089c545a883771b8df9ac1d223"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1738,8 +1728,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac33adcec9582af677f3007e282530f7c8c507df7a3cb335383b79c0c57f574"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1760,8 +1749,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3043cb862897df8dfa10fea292feef5d226b41f0f8b27417a2a9b8be413f247f"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1778,8 +1766,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435c9d8fd34e9764d25a61c39c57a060f1132dba7410be22646e4a58c9ccfe28"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1797,8 +1784,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a778f7d247c7d5e1c6b6a393424fc1f03e9a93ba44d3ed98ba5660927e376f"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1823,8 +1809,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b713f142c8f53d2580e4ffd1a43b9a32c1d96b9dca952ae5f62ecd5c2f502918"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "lazy-regex",
  "napi",
@@ -1846,8 +1831,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b9f729ae3acf46915b90802fee0f02501ee329caf62f1e6cf708a79751220f"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "napi",
  "napi-build",
@@ -1862,8 +1846,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7efce258a7587eac02e028db4121ac5c6935e4e2d46ea9cba7f54aa1919459"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1886,8 +1869,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81ed0e6e95d693ed2eaf004567c0d1b1d2405cd6e97249f8e374c6c35cc8df"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "napi",
  "napi-build",
@@ -1903,8 +1885,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4d2d6468b4c6c02595c735e337386d77b093ba91f71dd64242c12560b0f586"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1961,8 +1942,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183e66113ce154ec259a4843eee1ba465306d12ff08374f5a72eae6e773c3a49"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "itertools",
  "memchr",
@@ -2000,8 +1980,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d038b28e7037ab6dfded105eb35d12cdc58f6b9959dee9ae3244142fd45852"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "compact_str",
  "oxc_allocator",
@@ -2014,8 +1993,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463caa681dcd52935465805af52f4fc8661c723b6ba36c6822222efb6078e655"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -2027,8 +2005,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460be58ae9013ebe0604cdfc0f558e71109e2ee948da5f9b40bc493056631e2d"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2048,8 +2025,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de7442c06373719d1125aeaeb001d90f008ef81d2677dbda5141801b83760d3"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "napi",
  "napi-build",
@@ -2063,8 +2039,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fbbb040e74db7b98e74cd2e2098fc6bdcb47c10d9b55428f5194926a62ce14"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "base64",
  "compact_str",
@@ -2093,8 +2068,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf786ca7093850f881abd378e23325ae3791aa97f1880595e75e26359cecc3a"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2116,8 +2090,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.148.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fed7411606d1abcd794eed551320c387a744a5ca5c3a489a5a5e8a95d1e724"
+source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3346,7 +3319,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3676,7 +3649,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3695,7 +3668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4099,7 +4072,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 [[package]]
 name = "oxc"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "ropey",
 ]
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bytecount",
  "cow-utils",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "lazy-regex",
  "napi",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "napi",
  "napi-build",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "napi",
  "napi-build",
@@ -1885,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "itertools",
  "memchr",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "compact_str",
  "oxc_allocator",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "oxc_str"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "napi",
  "napi-build",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "base64",
  "compact_str",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7#bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7"
+source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,8 +1559,9 @@ checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 
 [[package]]
 name = "oxc"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689ab90be0e2cbd3448dc88794ef7645196b82da6f3943c20c8710c34ac5d290"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1597,8 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c2dbd560f65d113e7114eb5857e346493062ac665d3bd49426d50a02cc1969"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
@@ -1610,8 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9bdb56efa22b6eb5c213f512a838521a2433905d25da4e3021d3fac0bc7d1d"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1627,8 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8a6c6decb4887b04e0dc49c8dd862037d1f6b274cd32d931faf37184a5e5dd"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1638,8 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83aaab313b5275faea8cee175d489589f6271a6223b128ec9abaa48339d0a66b"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1649,8 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a313a091df12abad72542deeba21e6b44e37dd4a2ed66bf3159acc1aa68f0ef0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1670,8 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367175d382eca8c9c2c931d4350fe66b7b10fc73f57b691acdf557fd8003c91d"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1682,16 +1689,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac25bee569c0af652786ab2e39dc7815957ca3767dc2c3e3e2776f5028f8d30d"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92d1704adbad84b5d8a4e9d34e3937da7d230883726f0d96d7f2757a2b60aba"
 dependencies = [
  "bytecount",
  "cow-utils",
@@ -1707,8 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3cb15b9e142737d38e50366be0ead824f7d16bee3ac47c79839d50deb2324b"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma",
@@ -1727,8 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c7a17be65f4c12b02e2e62eb9368272f2ed794801552b437fa654253ce06dd"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1748,8 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0993224aefb691db2297dd0a8d095fc15fe2ede8484273d8258004da0caa777"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1765,8 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53188efb7700e8c17a6c65a7cc89b8f964de3eea8cf0012def779f35f54c23b7"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -1783,8 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7fa9470010de2d1ac8388b18a4c4165d3fa0cd137cb03a2a5066e56c3a8f5f"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -1808,8 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9e066d91ab3fe945c5f65eb0f85d77b2efb59ad5e3fe6810ffd640ba0c9f5a"
 dependencies = [
  "lazy-regex",
  "napi",
@@ -1830,8 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addcb06542d4aaf6a8d72dac224fe63fd7b7d07873e1fd8b56fd041937408e2b"
 dependencies = [
  "napi",
  "napi-build",
@@ -1845,8 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ac968fd0450309168e18c761dee4b68377bc0bbd4e1eb4e23d1c4d2e2cc825"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1868,8 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a3af77c208130bc8e30a97e951c9596bc652a2d0bc0f564d131c40b7e2cd6d"
 dependencies = [
  "napi",
  "napi-build",
@@ -1884,8 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ef364ac0d7e5beda9e59a3fea4ba050da6e34720c10c7c0a16b3993373ba52"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1941,8 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62853caf83c33ff2da0dd2d5a7b2ed6f907a29306aae34ec65807d8bf10c2c68"
 dependencies = [
  "itertools",
  "memchr",
@@ -1979,8 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8305f2b3c5e2030658fba8457260d313dbf5fe442c40c184f54a3a50eb42365c"
 dependencies = [
  "compact_str",
  "oxc_allocator",
@@ -1992,8 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16486b3832d8f1355283030ae048c5ae530d8a57e2cdfd9514e0d6cdbd4c5506"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.1",
@@ -2004,8 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c10f6276b8d5e3df514299a6a93241276531f2801853c3309a86805be278664"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -2024,8 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ed3fb63c806d75067e12457678c39838cf6622d3d37d1a4f7b6ef36c9a782"
 dependencies = [
  "napi",
  "napi-build",
@@ -2038,8 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801fc17aeac563535b2809ba775a73f7ba343412e36943d5733855f7a3c7be3e"
 dependencies = [
  "base64",
  "compact_str",
@@ -2067,8 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36a4772e42d0c3c21de41f5cc6e2755af559aee0b326fc4dbc179e94fcdd1df"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2089,8 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.148.0"
-source = "git+https://github.com/oxc-project/oxc?rev=66744f0eb942c375c298689a0c19d11efab2a2e2#66744f0eb942c375c298689a0c19d11efab2a2e2"
+version = "0.149.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd746d75af6792d45df91d68a7252834a9aab30f0ea2cedf270137ad6e7dde6"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { version = "0.148.0", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -277,14 +277,16 @@ oxc = { version = "0.148.0", features = [
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { version = "0.148.0", features = ["pool"] }
-oxc_ecmascript = { version = "0.148.0" }
-oxc_napi = { version = "0.148.0" }
-oxc_str = { version = "0.148.0" }
-oxc_minify_napi = { version = "0.148.0" }
-oxc_parser_napi = { version = "0.148.0" }
-oxc_transform_napi = { version = "0.148.0" }
-oxc_traverse = { version = "0.148.0" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7", features = [
+  "pool",
+] }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7", features = [
+oxc = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -277,16 +277,16 @@ oxc = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7", features = [
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2", features = [
   "pool",
 ] }
-oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
-oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ napi-build = { version = "2" }
 napi-derive = { version = "3", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
-oxc = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2", features = [
+oxc = { version = "0.149.0", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -277,16 +277,14 @@ oxc = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c2986
   "isolated_declarations",
   "regular_expression",
 ] }
-oxc_allocator = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2", features = [
-  "pool",
-] }
-oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_str = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
-oxc_traverse = { git = "https://github.com/oxc-project/oxc", rev = "66744f0eb942c375c298689a0c19d11efab2a2e2" }
+oxc_allocator = { version = "0.149.0", features = ["pool"] }
+oxc_ecmascript = { version = "0.149.0" }
+oxc_napi = { version = "0.149.0" }
+oxc_str = { version = "0.149.0" }
+oxc_minify_napi = { version = "0.149.0" }
+oxc_parser_napi = { version = "0.149.0" }
+oxc_transform_napi = { version = "0.149.0" }
+oxc_traverse = { version = "0.149.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -90,14 +90,13 @@ impl PreProcessEcmaAst {
         EventKind::ParseError,
       ))?;
     };
-    // Surface invalid pure annotations flagged by oxc (issue #8898).
-    // oxc marks `/* #__PURE__ */` / `/* @__PURE__ */` comments with
-    // `CommentContent::PureNotApplied` when their position prevents the parser
-    // from applying them (expression-level, statement-level, or variable declarator).
+    // Surface invalid annotations flagged by oxc (issue #8898).
+    // oxc marks misplaced `PURE` and `NO_SIDE_EFFECTS` comments with their
+    // respective `NotApplied` variants when the parser cannot apply them.
     // Aligns with Rollup's `INVALID_ANNOTATION` log code.
     if should_warn_on_invalid_annotation {
       warnings.extend(ast.program.with_dependent(|_owner, dep| {
-        invalid_pure_annotation_warnings(&dep.program, &source, resolved_id)
+        invalid_annotation_warnings(&dep.program, &source, resolved_id)
       }));
     }
 
@@ -355,31 +354,41 @@ impl<'ast> VisitJs<'ast> for FunctionDeclarationStartMatcher {
   }
 }
 
-fn invalid_pure_annotation_warnings(
+fn invalid_annotation_warnings(
   program: &Program<'_>,
   source: &ArcStr,
   resolved_id: &str,
 ) -> Vec<BuildDiagnostic> {
-  let pure_not_applied_comments: Vec<_> =
-    program.comments.iter().filter(|c| c.content == CommentContent::PureNotApplied).collect();
+  let not_applied_comments: Vec<_> = program
+    .comments
+    .iter()
+    .filter(|comment| {
+      matches!(
+        comment.content,
+        CommentContent::PureNotApplied | CommentContent::NoSideEffectsNotApplied
+      )
+    })
+    .collect();
 
-  if pure_not_applied_comments.is_empty() {
+  if not_applied_comments.is_empty() {
     return Vec::new();
   }
 
   let target_statement_starts: FxHashSet<u32> =
-    pure_not_applied_comments.iter().map(|comment| comment.attached_to).collect();
+    not_applied_comments.iter().map(|comment| comment.attached_to).collect();
   let mut function_declaration_start_matcher =
     FunctionDeclarationStartMatcher::new(target_statement_starts);
   function_declaration_start_matcher.visit_program(program);
 
-  pure_not_applied_comments
+  not_applied_comments
     .into_iter()
     .map(|comment| {
       let span = comment.span;
       let annotation = source[span.start as usize..span.end as usize].to_string();
-      let is_before_function_declaration =
-        function_declaration_start_matcher.matched_statement_starts.contains(&comment.attached_to);
+      let is_before_function_declaration = comment.content == CommentContent::PureNotApplied
+        && function_declaration_start_matcher
+          .matched_statement_starts
+          .contains(&comment.attached_to);
       BuildDiagnostic::invalid_annotation(
         resolved_id.to_string(),
         annotation,
@@ -398,19 +407,22 @@ mod tests {
   use rolldown_ecmascript::EcmaCompiler;
   use rolldown_error::Severity;
 
-  use super::invalid_pure_annotation_warnings;
+  use super::invalid_annotation_warnings;
 
   #[test]
-  fn invalid_pure_annotations_are_warning_severity() {
-    let ast =
-      EcmaCompiler::parse("main.js", "/* #__PURE__ */ globalThis.foo;", SourceType::default())
-        .unwrap();
+  fn invalid_annotations_are_warning_severity() {
+    let ast = EcmaCompiler::parse(
+      "main.js",
+      "/* #__PURE__ */ globalThis.foo; /* #__NO_SIDE_EFFECTS__ */ globalThis.bar;",
+      SourceType::default(),
+    )
+    .unwrap();
     let source = ast.source().clone();
-    let warnings = ast.program.with_dependent(|_owner, dep| {
-      invalid_pure_annotation_warnings(&dep.program, &source, "main.js")
-    });
+    let warnings = ast
+      .program
+      .with_dependent(|_owner, dep| invalid_annotation_warnings(&dep.program, &source, "main.js"));
 
-    assert_eq!(warnings.len(), 1);
-    assert_eq!(warnings[0].severity(), Severity::Warning);
+    assert_eq!(warnings.len(), 2);
+    assert!(warnings.iter().all(|warning| warning.severity() == Severity::Warning));
   }
 }

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -374,8 +374,11 @@ fn invalid_annotation_warnings(
     return Vec::new();
   }
 
-  let target_statement_starts: FxHashSet<u32> =
-    not_applied_comments.iter().map(|comment| comment.attached_to).collect();
+  let target_statement_starts: FxHashSet<u32> = not_applied_comments
+    .iter()
+    .filter(|comment| comment.content == CommentContent::PureNotApplied)
+    .map(|comment| comment.attached_to)
+    .collect();
   let mut function_declaration_start_matcher =
     FunctionDeclarationStartMatcher::new(target_statement_starts);
   function_declaration_start_matcher.visit_program(program);
@@ -395,6 +398,7 @@ fn invalid_annotation_warnings(
         source.clone(),
         span,
         is_before_function_declaration,
+        comment.content == CommentContent::NoSideEffectsNotApplied,
       )
       .with_severity_warning()
     })
@@ -410,7 +414,7 @@ mod tests {
   use super::invalid_annotation_warnings;
 
   #[test]
-  fn invalid_annotations_are_warning_severity() {
+  fn invalid_annotations_have_warning_severity_and_matching_guidance() {
     let ast = EcmaCompiler::parse(
       "main.js",
       "/* #__PURE__ */ globalThis.foo; /* #__NO_SIDE_EFFECTS__ */ globalThis.bar;",
@@ -423,6 +427,12 @@ mod tests {
       .with_dependent(|_owner, dep| invalid_annotation_warnings(&dep.program, &source, "main.js"));
 
     assert_eq!(warnings.len(), 2);
-    assert!(warnings.iter().all(|warning| warning.severity() == Severity::Warning));
+    for (warning, anchor) in warnings.iter().zip(["pure", "no-side-effects"]) {
+      assert_eq!(warning.severity(), Severity::Warning);
+      let rendered = warning.to_diagnostic().convert_to_string(false);
+      assert!(rendered.contains(&format!(
+        "Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#{anchor}"
+      )));
+    }
   }
 }

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
@@ -1,6 +1,144 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:3:1 ]
+   │
+ 3 │ /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:6:1 ]
+   │
+ 6 │ /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:3:1 ]
+   │
+ 3 │ /* #__NO_SIDE_EFFECTS__ */ let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:6:1 ]
+   │
+ 6 │ /* #__NO_SIDE_EFFECTS__ */ let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
 # Assets
 
 ## expr-arrow.js
@@ -238,15 +376,15 @@ export { a, b, c, d };
 ```js
 //#region stmt-export-local.js
 //! Only "c0" and "c2" should have "no side effects" (Rollup only respects "const" and only for the first one)
-var v0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ var v0 = function() {};
 var v1 = function() {};
-let l0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ let l0 = function() {};
 let l1 = function() {};
 const c0 = /* @__NO_SIDE_EFFECTS__ */ function() {};
 const c1 = function() {};
-var v2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ var v2 = () => {};
 var v3 = () => {};
-let l2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ let l2 = () => {};
 let l3 = () => {};
 const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {};
 const c3 = () => {};

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -30,7 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -47,7 +47,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -64,7 +64,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -81,7 +81,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -98,7 +98,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -115,7 +115,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -132,7 +132,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_ignore_annotations/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_ignore_annotations/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -30,7 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -47,7 +47,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -64,7 +64,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -81,7 +81,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -98,7 +98,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -115,7 +115,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -132,7 +132,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -149,7 +149,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -166,7 +166,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -183,7 +183,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -200,7 +200,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_ignore_annotations/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_ignore_annotations/artifacts.snap
@@ -3,6 +3,210 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # warnings
 
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:2:2 ]
+   │
+ 2 │     /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:3:2 ]
+   │
+ 3 │     /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:5:2 ]
+   │
+ 5 │     /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:6:2 ]
+   │
+ 6 │     /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:1:1 ]
+   │
+ 1 │ /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:4:1 ]
+   │
+ 4 │ /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:1:1 ]
+   │
+ 1 │ /* #__NO_SIDE_EFFECTS__ */ var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:4:1 ]
+   │
+ 4 │ /* #__NO_SIDE_EFFECTS__ */ var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
 ## TOLERATED_TRANSFORM
 
 ```text
@@ -386,15 +590,15 @@ export { a, b, c, d };
 
 ```js
 //#region stmt-export-local.js
-var v0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ var v0 = function() {};
 var v1 = function() {};
-let l0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ let l0 = function() {};
 let l1 = function() {};
 const c0 = /* @__NO_SIDE_EFFECTS__ */ function() {};
 const c1 = function() {};
-var v2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ var v2 = () => {};
 var v3 = () => {};
-let l2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ let l2 = () => {};
 let l3 = () => {};
 const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {};
 const c3 = () => {};

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_minify_whitespace/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_minify_whitespace/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -30,7 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -47,7 +47,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -64,7 +64,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     ─────────────┬────────────  
    │                  ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -81,7 +81,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -98,7 +98,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -115,7 +115,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -132,7 +132,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -149,7 +149,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -166,7 +166,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -183,7 +183,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯
@@ -200,7 +200,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_minify_whitespace/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment_minify_whitespace/artifacts.snap
@@ -3,6 +3,210 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # warnings
 
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:2:2 ]
+   │
+ 2 │     /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:3:2 ]
+   │
+ 3 │     /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:5:2 ]
+   │
+ 5 │     /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "ns-export-local.ts" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ ns-export-local.ts:6:2 ]
+   │
+ 6 │     /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {}
+   │     ─────────────┬────────────  
+   │                  ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:1:1 ]
+   │
+ 1 │ /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:4:1 ]
+   │
+ 4 │ /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-export-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-export-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:1:1 ]
+   │
+ 1 │ /* #__NO_SIDE_EFFECTS__ */ var v0 = function() {}, v1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ let l0 = function() {}, l1 = function() {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:4:1 ]
+   │
+ 4 │ /* #__NO_SIDE_EFFECTS__ */ var v2 = () => {}, v3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "stmt-local.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ stmt-local.js:5:1 ]
+   │
+ 5 │ /* #__NO_SIDE_EFFECTS__ */ let l2 = () => {}, l3 = () => {}
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
 ## TOLERATED_TRANSFORM
 
 ```text
@@ -386,15 +590,15 @@ export { a, b, c, d };
 
 ```js
 //#region stmt-export-local.js
-var v0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ var v0 = function() {};
 var v1 = function() {};
-let l0 = function() {};
+/* #__NO_SIDE_EFFECTS__ */ let l0 = function() {};
 let l1 = function() {};
 const c0 = /* @__NO_SIDE_EFFECTS__ */ function() {};
 const c1 = function() {};
-var v2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ var v2 = () => {};
 var v3 = () => {};
-let l2 = () => {};
+/* #__NO_SIDE_EFFECTS__ */ let l2 = () => {};
 let l3 = () => {};
 const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {};
 const c3 = () => {};

--- a/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectWarning": true
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INVALID_ANNOTATION
+
+```text
+[INVALID_ANNOTATION] A comment "/* #__NO_SIDE_EFFECTS__ */" in "main.js" contains an annotation that Rolldown cannot interpret due to the position of the comment.
+   ╭─[ main.js:2:1 ]
+   │
+ 2 │ /* #__NO_SIDE_EFFECTS__ */ globalThis.foo;
+   │ ─────────────┬────────────  
+   │              ╰────────────── comment ignored due to position
+   │ 
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ 
+   │ Help 2: Disable with `checks.invalidAnnotation: false`.
+───╯
+
+```
+
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+/* #__NO_SIDE_EFFECTS__ */ globalThis.foo;
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │ ─────────────┬────────────  
    │              ╰────────────── comment ignored due to position
    │ 
-   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure
+   │ Help 1: Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#no-side-effects
    │ 
    │ Help 2: Disable with `checks.invalidAnnotation: false`.
 ───╯

--- a/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_no_side_effects_annotation/main.js
@@ -1,0 +1,2 @@
+// NO_SIDE_EFFECTS only applies to functions, so this annotation is misplaced.
+/* #__NO_SIDE_EFFECTS__ */ globalThis.foo;

--- a/crates/rolldown_common/src/utils/enhanced_transform.rs
+++ b/crates/rolldown_common/src/utils/enhanced_transform.rs
@@ -355,7 +355,7 @@ pub fn enhanced_transform(
       ..Default::default()
     })
     .parse();
-  if parse_ret.panicked || !parse_ret.diagnostics.is_empty() {
+  if parse_ret.fatal_error || !parse_ret.diagnostics.is_empty() {
     append_oxc_diagnostics(parse_ret.diagnostics, &source, filename, &mut warnings, &mut errors);
     return EnhancedTransformResult::new_for_error(errors, warnings, tsconfig_file_paths);
   }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -33,7 +33,7 @@ impl EcmaCompiler {
           ..ParseOptions::default()
         });
         let ret = parser.parse();
-        if ret.panicked || !ret.diagnostics.is_empty() {
+        if ret.fatal_error || !ret.diagnostics.is_empty() {
           Err(BuildDiagnostic::from_oxc_diagnostics(
             ret.diagnostics,
             &source.clone(),

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -126,6 +126,7 @@ impl BuildDiagnostic {
     source: ArcStr,
     span: oxc::span::Span,
     is_before_function_declaration: bool,
+    is_no_side_effects: bool,
   ) -> Self {
     Self::new_inner(InvalidAnnotation {
       module_id,
@@ -133,6 +134,7 @@ impl BuildDiagnostic {
       source,
       span,
       is_before_function_declaration,
+      is_no_side_effects,
     })
   }
 

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_annotation.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_annotation.rs
@@ -18,6 +18,7 @@ pub struct InvalidAnnotation {
   /// Whether the annotation appears immediately before a function declaration.
   /// When true, an additional hint suggests using `@__NO_SIDE_EFFECTS__`.
   pub is_before_function_declaration: bool,
+  pub is_no_side_effects: bool,
 }
 
 impl BuildEvent for InvalidAnnotation {
@@ -53,8 +54,9 @@ impl BuildEvent for InvalidAnnotation {
       ));
     }
 
-    diagnostic.add_help(String::from(
-      "Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#pure",
+    let anchor = if self.is_no_side_effects { "no-side-effects" } else { "pure" };
+    diagnostic.add_help(format!(
+      "Correct annotation placement: https://rolldown.rs/in-depth/dead-code-elimination#{anchor}",
     ));
     diagnostic.add_help(String::from("Disable with `checks.invalidAnnotation: false`."));
   }
@@ -74,6 +76,7 @@ mod tests {
       "/* #__PURE__ */".to_string(),
       ArcStr::from("/* #__PURE__ */ foo;"),
       Span::new(0, 15),
+      false,
       false,
     )
     .with_severity_warning()

--- a/crates/rolldown_plugin_oxc_runtime/src/generated/embedded_helpers.rs
+++ b/crates/rolldown_plugin_oxc_runtime/src/generated/embedded_helpers.rs
@@ -2,12 +2,12 @@
 // To edit this generated file you have to edit `tasks/generator/src/generators/oxc_runtime_helper.rs`
 
 // This file contains embedded @oxc-project/runtime helpers (both ESM and CJS variants).
-// @oxc-project/runtime version: 0.148.0
+// @oxc-project/runtime version: 0.149.0
 
 use arcstr::ArcStr;
 use phf::{Map, phf_map};
 
-pub const RUNTIME_HELPER_PREFIX: &str = "@oxc-project+runtime@0.148.0/helpers/";
+pub const RUNTIME_HELPER_PREFIX: &str = "@oxc-project+runtime@0.149.0/helpers/";
 pub const RUNTIME_HELPER_UNVERSIONED_PREFIX: &str = "@oxc-project/runtime/helpers/";
 
 /// Map of all helpers from `@oxc-project/runtime/src/helpers/esm/`.

--- a/crates/rolldown_plugin_utils/src/parse_program.rs
+++ b/crates/rolldown_plugin_utils/src/parse_program.rs
@@ -26,7 +26,7 @@ pub fn parse_program<'a>(
     .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
     .parse();
 
-  if parser_ret.panicked
+  if parser_ret.fatal_error
     && let Some(err) =
       parser_ret.diagnostics.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
   {

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -67,7 +67,7 @@ impl Plugin for ViteTransformPlugin {
     let ret = Parser::new(&allocator, args.code, source_type)
       .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
       .parse();
-    if ret.panicked || !ret.diagnostics.is_empty() {
+    if ret.fatal_error || !ret.diagnostics.is_empty() {
       Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.diagnostics,
         args.code,

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -132,7 +132,7 @@ impl IntegrationTest {
           .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
           .parse();
 
-        if ret.panicked || !ret.diagnostics.is_empty() {
+        if ret.fatal_error || !ret.diagnostics.is_empty() {
           let errors_str = ret
             .diagnostics
             .iter()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ catalogs:
       specifier: ^0.1.0
       version: 0.1.0
     '@oxc-project/runtime':
-      specifier: '=0.148.0'
-      version: 0.148.0
+      specifier: '=0.149.0'
+      version: 0.149.0
     '@oxc-project/types':
-      specifier: '=0.148.0'
-      version: 0.148.0
+      specifier: '=0.149.0'
+      version: 0.149.0
     '@pnpm/find-workspace-packages':
       specifier: ^6.0.9
       version: 6.0.9
@@ -139,11 +139,11 @@ catalogs:
       specifier: ^4.0.8
       version: 4.0.8
     oxc-parser:
-      specifier: '=0.148.0'
-      version: 0.148.0
+      specifier: '=0.149.0'
+      version: 0.149.0
     oxc-transform:
-      specifier: '=0.148.0'
-      version: 0.148.0
+      specifier: '=0.149.0'
+      version: 0.149.0
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
@@ -275,7 +275,7 @@ importers:
         version: 0.1.0
       '@oxc-project/runtime':
         specifier: 'catalog:'
-        version: 0.148.0
+        version: 0.149.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.3
@@ -413,7 +413,7 @@ importers:
         version: link:../../packages/rolldown
       unplugin-isolated-decl:
         specifier: ^0.8.1
-        version: 0.8.3(oxc-transform@0.148.0)(rollup@4.63.0)(supports-color@10.2.2)(typescript@6.0.3)
+        version: 0.8.3(oxc-transform@0.149.0)(rollup@4.63.0)(supports-color@10.2.2)(typescript@6.0.3)
 
   examples/lazy-compilation:
     devDependencies:
@@ -428,7 +428,7 @@ importers:
     devDependencies:
       oxc-walker:
         specifier: ^0.5.2
-        version: 0.5.2(oxc-parser@0.148.0)
+        version: 0.5.2(oxc-parser@0.149.0)
       rolldown:
         specifier: workspace:*
         version: link:../../packages/rolldown
@@ -575,7 +575,7 @@ importers:
     dependencies:
       '@oxc-project/types':
         specifier: 'catalog:'
-        version: 0.148.0
+        version: 0.149.0
       '@rolldown/pluginutils':
         specifier: 'catalog:'
         version: 1.0.1
@@ -615,7 +615,7 @@ importers:
         version: 13.0.6
       oxc-parser:
         specifier: 'catalog:'
-        version: 0.148.0
+        version: 0.149.0
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -745,7 +745,7 @@ importers:
         version: 11.8.0
       oxc-transform:
         specifier: 'catalog:'
-        version: 0.148.0
+        version: 0.149.0
       source-map-support:
         specifier: catalog:rollup-tests
         version: 0.5.21
@@ -1770,14 +1770,14 @@ packages:
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@cloudflare/containers@0.3.7':
-    resolution: {integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==, tarball: https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz}
+    resolution: {integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz}
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
   '@cloudflare/sandbox@0.12.7':
-    resolution: {integrity: sha512-7nDEiqrxZfBuUc2y1RxWJMTPe+5q5+QZlZ5k+KXaQRv/Tgimdu4XyFGzMQuQYuI9IFXiPJVfMMPLKUmPg0VWpA==, tarball: https://registry.npmjs.org/@cloudflare/sandbox/-/sandbox-0.12.7.tgz}
+    resolution: {integrity: sha512-7nDEiqrxZfBuUc2y1RxWJMTPe+5q5+QZlZ5k+KXaQRv/Tgimdu4XyFGzMQuQYuI9IFXiPJVfMMPLKUmPg0VWpA==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -1791,7 +1791,7 @@ packages:
         optional: true
 
   '@cloudflare/unenv-preset@2.16.1':
-    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz}
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: '>1.20260305.0 <2.0.0-0'
@@ -1800,74 +1800,74 @@ packages:
         optional: true
 
   '@cloudflare/vite-plugin@1.52.1':
-    resolution: {integrity: sha512-O2IkD8E03qsUxNBdDRfDI9JPl25XIPt+76WJf8tgm206c34jYk8nn12ylBiOI/6NA8XUFhLjRTF1BGY+kVylXw==, tarball: https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.52.1.tgz}
+    resolution: {integrity: sha512-O2IkD8E03qsUxNBdDRfDI9JPl25XIPt+76WJf8tgm206c34jYk8nn12ylBiOI/6NA8XUFhLjRTF1BGY+kVylXw==}
     hasBin: true
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.123.0
 
   '@cloudflare/workerd-darwin-64@1.20260811.1':
-    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz}
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-64@1.20260831.1':
-    resolution: {integrity: sha512-oyZ8xhu+gYTvoxV/sn6NRmTHK95RhEO1Dk54/6oPb0Uu70w7ZeRoCjkJ5aNmfS8Vrkdu6+oL0HNg6EcC61uQ2Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260831.1.tgz}
+    resolution: {integrity: sha512-oyZ8xhu+gYTvoxV/sn6NRmTHK95RhEO1Dk54/6oPb0Uu70w7ZeRoCjkJ5aNmfS8Vrkdu6+oL0HNg6EcC61uQ2Q==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260811.1':
-    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz}
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260831.1':
-    resolution: {integrity: sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260831.1.tgz}
+    resolution: {integrity: sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260811.1':
-    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz}
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-64@1.20260831.1':
-    resolution: {integrity: sha512-WxNKBgjKgeYTolW3yl1Lt3Lu67UlxdeyzWYi9MIqrKBdyQcz+UNG36RevSBf8rv1sTWapRW234VX2keZ+wXapA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260831.1.tgz}
+    resolution: {integrity: sha512-WxNKBgjKgeYTolW3yl1Lt3Lu67UlxdeyzWYi9MIqrKBdyQcz+UNG36RevSBf8rv1sTWapRW234VX2keZ+wXapA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260811.1':
-    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz}
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260831.1':
-    resolution: {integrity: sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260831.1.tgz}
+    resolution: {integrity: sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20260811.1':
-    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz}
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20260831.1':
-    resolution: {integrity: sha512-do+KDYw0PABwsrKUQIccWBZB70kqKcADoSnvzJ8pvMaWUVB4qaCspEZYfm97WNdtY1wt8mlKYqIJyYUNOkTvQg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260831.1.tgz}
+    resolution: {integrity: sha512-do+KDYw0PABwsrKUQIccWBZB70kqKcADoSnvzJ8pvMaWUVB4qaCspEZYfm97WNdtY1wt8mlKYqIJyYUNOkTvQg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workers-types@4.20260702.1':
-    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==, tarball: https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz}
+    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3853,8 +3853,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.148.0':
-    resolution: {integrity: sha512-pHASv9g5pASxb7akHERZNSkrEqPhFaUix98o7d9hbTpolnnFWl7UiRrcMhCsV1+iVO4/cJwKsbKRJTFNs2tdBQ==}
+  '@oxc-parser/binding-android-arm-eabi@0.149.0':
+    resolution: {integrity: sha512-OQmN5XYQ/GNRkbU0Ksb2QSaHOgKWhFw7Bz6lJvANBdwVkLzTlcHXDLj62XrNPtUf3pDxRBr7OoHJrKhHYOb9iA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -3865,8 +3865,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.148.0':
-    resolution: {integrity: sha512-sg/6Ez0KdAygsu0POELux9wN1Po2CP93WY8eNl4DBKIGprsd4QSHBXOb471Pu9i2OCD5sLkISSb2agZEhVn2Zw==}
+  '@oxc-parser/binding-android-arm64@0.149.0':
+    resolution: {integrity: sha512-M7nHwfHY2Xv5Rm1iygvyOTPXrD4d5WRVw+C8eItLwoipzQBnkUMmwh3jvuGLBio2BGetfIH0F7J3Afb1Qn9dJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3877,8 +3877,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.148.0':
-    resolution: {integrity: sha512-yiSJmzGUvCUaJT8X3j40gVcX+ckuHQMuiOtF8DvzTs5+JtB/7XuHFPp4M+vv5u+HlBtDUd4Ks5pyHpWz8mfnkg==}
+  '@oxc-parser/binding-darwin-arm64@0.149.0':
+    resolution: {integrity: sha512-h6NrhqRAVKbgzfShjHoBgjeJ1vQR2o6iNM6/t8JCSej1XRKJyraV08Zz7ey6SsjPzof4ecp48Upg2vidqoDgtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -3894,8 +3894,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.148.0':
-    resolution: {integrity: sha512-6ZeklaamrMy4H2JmhvcJg6iip59tYILtuLaILxyAHT3l5FDxnI5ihVievAft5ZmAbqtlWHErOi1OpJK8gy1wcA==}
+  '@oxc-parser/binding-darwin-x64@0.149.0':
+    resolution: {integrity: sha512-+WRRZeFYqVznJEEttiWNcI43Ij2iD0yphmMFkAuKNOQTyXQ+lLCAVW6aVLOD6nPO6FOymW7HtDh5KmnxZPi/2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3911,8 +3911,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.148.0':
-    resolution: {integrity: sha512-vFsPx+a/qFECPnz/H8nC6x6MDvnWscLTCo/5muojEF54ERUq1kdgbvnWo95YnkhjF9sTIcG/uDxQBh1gffaufQ==}
+  '@oxc-parser/binding-freebsd-x64@0.149.0':
+    resolution: {integrity: sha512-kG0YUZj/4hdHBQDtIr2UZ7Nyxy3M5Et+w3A0V0eefRgtQWE4wJrNflBJMJfwFPiwMLPlPL6qJR+5JdeIqhzW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -3923,8 +3923,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.148.0':
-    resolution: {integrity: sha512-eOr3M+6iGbbxNL4PSS0VtsyQ2eOUxSBh00BqO22SbolDimPSYsBuLr/LCrZBkiqW2BoabhR6V4R8jrRAay7hjg==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.149.0':
+    resolution: {integrity: sha512-gOD5NhD8DG7aJ8CLZ+ve5xoDq0y0J0zKZSfkfMGfk96XLhu21IzSFvjpEvVUGodD7Yyy3Tr9rNdiPEdZjkuRqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3935,8 +3935,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.148.0':
-    resolution: {integrity: sha512-58ZKDw0mQRbCNfrd2IDyV4o8T7enzGERJn41BH2tjrZVGyiKiFzcfDicuB7Zcpb/1xIOrObovr8Dja6lZi8dLw==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.149.0':
+    resolution: {integrity: sha512-UtPYQkciY1NzYRtfKBopYfOjSxPFFVyprs0iH+Z5KZKNv9at/71pGd2KNrlmALhRcNocnxEsc+KuhY3nUlhIxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3948,8 +3948,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.148.0':
-    resolution: {integrity: sha512-Fnu95O4eZ5i++GPvIzBEZ8y4ddTLR+D9paYa8JRaRk6ZK7nHQiWP5xtrhcPQsXqgat1d7sU/d5rbbI0p1FTHSQ==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.149.0':
+    resolution: {integrity: sha512-3jWkwykjJJegMD+5dU9n30mzwvTLi99fkUqHU9Pqdzw3fIVfyn6ZnjOl8l053jogr0BGQPxagTjIKBksp288eQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3968,8 +3968,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.148.0':
-    resolution: {integrity: sha512-3CQy/BMdx7N7H3qrcPxUL+a2CwUZodUcf6oq8iJuNZ9C6Ol1aq3mcWzsgySJ7CHFLvpX21ZDPp1r1X0QLbu/AQ==}
+  '@oxc-parser/binding-linux-arm64-musl@0.149.0':
+    resolution: {integrity: sha512-H7n8zPxnLVI0pkutAxyXJNE/IaCuCJS6ghgv2cl8IDIgXCDZWjG/Bs8rF8BHKQ9gsOpA4m+T4lFaFAdnGuk/cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3988,8 +3988,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.148.0':
-    resolution: {integrity: sha512-9LkaYvfiF8hMOw900csAvkf1oxE8XlmMeGowu5BcastSSwV8mKvKRMNU7HsV+ycyj1dQD8pX5qgOw8ja6SJacg==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.149.0':
+    resolution: {integrity: sha512-aByOTCdLYp8FjwAUUmN7YYjAmPJ/9t0I1ACuhAkYun87fajIHbwuZ/opaBk0Pnfxzp2vYyD8hdG8OQWEglP5oA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -4002,8 +4002,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.148.0':
-    resolution: {integrity: sha512-2GBiM9h26dR4WJfhoMvnFMnFLf7m/kYs4UMqjvrOfQG4BV1nuTJDH22Zc2MQr3INZF7nSKYQ6xlhD3hQ7A6gug==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.149.0':
+    resolution: {integrity: sha512-SAdNs+uxMRBLPM6QuLlOxzE4duWia4EMhqGknsJS2EGnWni7i53gSZhaW3VYPxaP8nk/UsMQxMODIFwBHbRWcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -4016,8 +4016,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.148.0':
-    resolution: {integrity: sha512-uPqZexvKJmEgq4mAu36qe2xTfXZE7oyik1R7KtZ5tl8qKlq1U1fIqTFRUEBZqRGvforoTrGIpatRzcoPKO66RA==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.149.0':
+    resolution: {integrity: sha512-RhmzD62QNtMjuBAeKJ15gzyNRv06Yz1ZFi6lgTiA5S3ixkrSMPJWIPGyqdlC4XiWxwAW9W4jeQNV4/Om9V27gA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -4030,8 +4030,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.148.0':
-    resolution: {integrity: sha512-9oUHvnTbp7ZraFsTC8PN6XhdhPSSxZumYvixWl7Smi353gEULvK6yV0sXNVrdFMHQeaDKFCi8TgDhNK7/A+Y+Q==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.149.0':
+    resolution: {integrity: sha512-HqEExoeKhlfUacdhj7KEe1m93B1SzCUkF88c1qLQR5Km6GPSoMHMIjK7qmRXLzjsO+ipSTWVsnYMVG0j2/mxNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -4044,8 +4044,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.148.0':
-    resolution: {integrity: sha512-2qhDSJwKzbSZzF7lDqqk8sr/yXsmwr3PeUa4/nazIF+zFAYz1gVPEfC34GQtGxzJUUmklaYAL63368LEfrMeyw==}
+  '@oxc-parser/binding-linux-x64-gnu@0.149.0':
+    resolution: {integrity: sha512-FuAv1J7GoSkmxg5glvzlHA88Ld7dOIg23VdAsVLngPZN/ZjZPtCaBZDby1GPn63Yj+7h47/wbcd7i1p2UJTeNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4064,8 +4064,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.148.0':
-    resolution: {integrity: sha512-qQoPDZUFV0bh9xA09XydmkjMBpgc1ukJuhMvzQ9QeVmFaHTS9W5TE5CoLmSl3QQyUP9OuHO3x/WPZTIIZPWR3Q==}
+  '@oxc-parser/binding-linux-x64-musl@0.149.0':
+    resolution: {integrity: sha512-KDFOVgjMIOiMiRUw+jZlAIEZZFG0WgGk+adcldjc+/qz0/kvobnYJqDqNX0+REJbSpSsM1Knj0zrEGTQ6WTIng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4083,8 +4083,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.148.0':
-    resolution: {integrity: sha512-1UGbaQWEXUCLqAmaR5kwRDjx/R4S5LQKZkM9CHmaHkuKhriOF32aRLfS0jCRNE2yGQJLMEA1z9UucbBVqjXnDw==}
+  '@oxc-parser/binding-openharmony-arm64@0.149.0':
+    resolution: {integrity: sha512-O3O+ZBhGEUhtbDXFWRMTuOCBg+fC2hf1wrtZBrd3VJUtV/MDd1LCwZXIHY2nMCnh9Akgjay965pBok2h5AXN0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -4095,8 +4095,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.148.0':
-    resolution: {integrity: sha512-pWKdzRDNG2+NK4h/V6U/CYERcfYD6u28h5IB/VJVsrZaD3muvE58tUj22lieL5vLZ+XFi1GPv9YXckZbJZ9BLA==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.149.0':
+    resolution: {integrity: sha512-9hMvs3GZESAcbUGU3mqXFWRLgBd8TLeosNYfHusHp/hrBnk5lIP2nJtark3hZ6qT+lqSdS79sH8NoWHj1x9iUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -4112,8 +4112,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.148.0':
-    resolution: {integrity: sha512-i3p4x+mvwtjcE1J5HM6V7ggsbXiznExN/4MkNyOy3dfXrVV3bnkSfmZxvo6/84qCVX4ShkpNE1SKt9biIF31GQ==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.149.0':
+    resolution: {integrity: sha512-8hQaS1Urc1NnlutDfhQ+DwijRALGLY+AmqJSBHV4OmyPZDoqgtkmjTHl2tsTLK6PETe6PbIJLKmXcpJuqkf8Lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
@@ -4124,8 +4124,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.148.0':
-    resolution: {integrity: sha512-Ye6vB7VQulghWYkYkECOBYFRVEizz4XyRTUAv+t8BuyurhKU7uD0P9eowL+mKG5Mf8MSYx+DI3Cm8SKZvYG7bQ==}
+  '@oxc-parser/binding-win32-x64-msvc@0.149.0':
+    resolution: {integrity: sha512-xFqDgKSKdY0m2EtHQL7uMuknuEGnvbtxkWllGle5hmhVe5xn5XZ0Zb9iViAsItFAf0CjSiZ5er3XqqAlr5oARA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4143,8 +4143,8 @@ packages:
     resolution: {integrity: sha512-lbXHIpZ1MmK6zuw5txlMdIZ2waLVUIU5Gnm3sEuwJOiqDfQfbtjeHscatmeBoxbv8+If9LFM6PGh/3DcDWYIYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/runtime@0.148.0':
-    resolution: {integrity: sha512-0ExYgJZv8+nFuoV0T/xzX5ZyXFXwkHJFJg9LWTwhqgRLpe+IzBLirvyYKSdS8mPofTBKAjDYIA2o84xh5BHXew==}
+  '@oxc-project/runtime@0.149.0':
+    resolution: {integrity: sha512-XNtswoJPeaVa+Ry8A1FdEaJTAu6xZ8zg4ZijGPOAWWMRCUuDekEDwxmtIgP5DG67Sh1CVmq+bnTbqhnGHhn/Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.101.0':
@@ -4156,8 +4156,8 @@ packages:
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
-  '@oxc-project/types@0.148.0':
-    resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
+  '@oxc-project/types@0.149.0':
+    resolution: {integrity: sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==}
 
   '@oxc-project/types@0.37.0':
     resolution: {integrity: sha512-9shvIr/cpoNo5cX8nWdZmviHLJSidjZy4M0MyfR6ucREZBtABTNBIa1a4emWUJ3qAMwJW6G1v0zm8K2rj9Pf4A==}
@@ -4265,124 +4265,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-transform/binding-android-arm-eabi@0.148.0':
-    resolution: {integrity: sha512-WyGMrKwtZh9i1KXW3/aCADdCqaRrBSF0jScIYAfR8b5yc2K9cxNvsUiyO7AsWH8TEZbc8xZ/I9VDxYhPYrAB2g==}
+  '@oxc-transform/binding-android-arm-eabi@0.149.0':
+    resolution: {integrity: sha512-7JBJ2jwt5uQMfPW+3DUPUUndy94IRsaCYdDw+cuVPn54LF8D8mOgi8y6wp6BKLjglyFSTGRBjFtMhCxLoeOmxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-transform/binding-android-arm64@0.148.0':
-    resolution: {integrity: sha512-FMC9mRboEH7WXYvdScKWEhOxviiORpjN3bMOBFIXX8L+2wWb5vvvql1KDvhW75J3PEJskv/RNnqSn8rEocHVaA==}
+  '@oxc-transform/binding-android-arm64@0.149.0':
+    resolution: {integrity: sha512-Y9sHr0uJrz+U8+6PUYcrmPGAG64BKztzhEGfESQ0oTO5xUEGIi88KaltwnPDmT3ZXGq4jss1BdDXl0VSx2Q4Rw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-transform/binding-darwin-arm64@0.148.0':
-    resolution: {integrity: sha512-DsW3fk6LA4rmdRwZqaiO4+l/Vmsa99O7pf86MeDNP6EQDEaNiPBJvH7EhD7WICFNMTJxCehM9Y5wCUNs403QNA==}
+  '@oxc-transform/binding-darwin-arm64@0.149.0':
+    resolution: {integrity: sha512-+G+n22CYzfXK9ggjosvPBdxa3BqXFWR5d27Od5zZOot6zgK16uMibjzE94GlEY1/h44PRAgjcIsFc815CNGuNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-transform/binding-darwin-x64@0.148.0':
-    resolution: {integrity: sha512-4MFN7jcMovxtxzrsX3gc/IJ0Sbkp5jVx7SZDCh7WCzbwhMyWqLSqmmQvMM84+pKb+G2GUynZCcRCjvNIWM+Q3A==}
+  '@oxc-transform/binding-darwin-x64@0.149.0':
+    resolution: {integrity: sha512-gTmyCY6+Tw9HeND/v0qmFfYmrDxuBJspJ9O7VGLIiiWrFzer7nVSIR/QxPd630KfaEw//WVNF1WLH4lLiyQp1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-transform/binding-freebsd-x64@0.148.0':
-    resolution: {integrity: sha512-wdH9xg/zT+fmsgAsq77O0apQFenuC/iZfRRsdnwcFt0z4Gj6F2yaHxLz9kIN4Wk0V/Fw6b1u+DK5EzAv1fFkNg==}
+  '@oxc-transform/binding-freebsd-x64@0.149.0':
+    resolution: {integrity: sha512-zmj8W+M/WXzaHiDhD6ZlPQRhkhjtNGCJlQ9vgDY5K6PvWcBs30SrMaqgPLpVFNcHCHRDiBqYFWZgiX8BB1ACTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.148.0':
-    resolution: {integrity: sha512-+N5751edKy1AvBCQOlbvbT2MhmtfEyJ57/pX/9Ea6lFwokFUvdq9Fiw1Y/OSA+S9Y+8NQ4Huw58yrjr9mqI9Xw==}
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.149.0':
+    resolution: {integrity: sha512-qK+eNtGWJ27SBsYs6oSsHh7rIJgBBGlf49gZ7cJCqu5nwUJXshNWdah/JBEqf/P2plP9XKSrSH9vLMXqUoqBUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.148.0':
-    resolution: {integrity: sha512-lACDVf+gRhWF67wrpy5OCWr/TSA1r1RQR4szEJlC7+qorI2t4AaoMo4Uj6lSXkbcPCqvsHzTKRdel4G7W3UVpA==}
+  '@oxc-transform/binding-linux-arm-musleabihf@0.149.0':
+    resolution: {integrity: sha512-5ESgQoJfqtiqQjGWVH+ShWZzVQkrm5OnNh1TEdlqn3xFlnHS4WVZMaoyN1eMtbfsA2hPvLZjodXUgjg8C4GVqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.148.0':
-    resolution: {integrity: sha512-RxUCic2Mm635icF+YQ0aVJ4DDHW/Q2/urT+xLreXH94hAv9UZYORXkiOYWuIFntGVhbgWG/MtD8Ergn05VinOw==}
+  '@oxc-transform/binding-linux-arm64-gnu@0.149.0':
+    resolution: {integrity: sha512-vwm2LpyFZ6MGhXgNv3uT4lS36NCRHVHA3SbseUsKcSJdvv+6hsH7XcmmMtCFYAKMJ5BNWhKLwiWkiMz4ypEkhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-arm64-musl@0.148.0':
-    resolution: {integrity: sha512-obdrX7b6fIoGp3+y7oTBrkmiQpxuIRn0qK9n7WvQZA7wLWIdXi7VdtFJZXTyZyCdPhrvA7zxeJIx65ih0nFvig==}
+  '@oxc-transform/binding-linux-arm64-musl@0.149.0':
+    resolution: {integrity: sha512-7xh+zA5ElAJCv6tw/dMql6Yxsko+67tQuPrnNysN4aHPUa5pZjjE3Ny2GCtZH3mjJeiIqoMLqMVffhIkTnK9aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-linux-ppc64-gnu@0.148.0':
-    resolution: {integrity: sha512-FVo6Uvud1ZWZgJb08qtIBEWkIvyUgdUVLNOfx8UAharOfiBbwMk3FEOS7zb9UtJ34e7mJJIJ0i8Ax5Q4kB4+dg==}
+  '@oxc-transform/binding-linux-ppc64-gnu@0.149.0':
+    resolution: {integrity: sha512-rEkRzp3/ETc3mv1dN2l8XG5+XTjebtRYxPw4fOIObKS/H4v1Li/ImtNtO4TbQftMd1b2eAN0XncS11ATbspCXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.148.0':
-    resolution: {integrity: sha512-kAZky+KY2sel4Le0hJAT0LGRdmwC0xTcTup1vwMP58jOy+uPADuCWV/vzO8T8kkajiQuFsOHVMYRKJjXoGmz/Q==}
+  '@oxc-transform/binding-linux-riscv64-gnu@0.149.0':
+    resolution: {integrity: sha512-Jb7zv4TXaotSgZj3UuNeDv8eMaPMPxO1UHK+Dk8vsPxHPitdVoWa52FETzeDa+G/ezu0XhQd1lWbK4UE4eZ5CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-riscv64-musl@0.148.0':
-    resolution: {integrity: sha512-FefTYlbFUtG+Y0HsSYzX97qHFbUQr7+XByrY+KNNasiRYxnUfJCc7ZPa9uN5dfjxnctuVQgRw7k32xXb/9F3JQ==}
+  '@oxc-transform/binding-linux-riscv64-musl@0.149.0':
+    resolution: {integrity: sha512-lP6vGzzuz2GprAcOCuAC5KGBUYNKkT5DekKSyr9ZY5jtCgeNbujyBi6mscRNoFciXTYH2cM5+AhK1bo+KaLgjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.148.0':
-    resolution: {integrity: sha512-wAzfTAcwysr3t/1VujtSWpoJ/1TS5HvWZoE7J2F/yjSY7KiTr1ZHEywzR3Gokru6mfdAXQqcuJtOayjVH+qGRg==}
+  '@oxc-transform/binding-linux-s390x-gnu@0.149.0':
+    resolution: {integrity: sha512-ImqIXvIC+2VFFlOR1GINVii1pGhtWPljUpWHwBfgmIatpnQUuGaguSpkgKHe9DlHm6CCyG2HO6DQzkngCr/naQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-x64-gnu@0.148.0':
-    resolution: {integrity: sha512-UE+ENpz/tXx5DQvG0JY0GqbHaGnk9WXAqfT4+2RYn61TtTZGxCvj4531cbNDavaz+Z3DdAhvn36fwDUTVXyA8Q==}
+  '@oxc-transform/binding-linux-x64-gnu@0.149.0':
+    resolution: {integrity: sha512-7PQJny02cpGl0BOSPEALa34kjmnZIu0Lj3NwAGrhl1ADRsncMxRjiNyfMVA3B1Y/d23rCtcbJ3nF5ZPNBO0sXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-transform/binding-linux-x64-musl@0.148.0':
-    resolution: {integrity: sha512-bD6mTB86bMHdiY42d3r7NjvHXYUwyxP5snjjxH7SKoxwX/7g0xAZHKu5pqivczLllEiVhKiRye9zKgJA0dhsiA==}
+  '@oxc-transform/binding-linux-x64-musl@0.149.0':
+    resolution: {integrity: sha512-wk1R43nOd2Paexew4HtYaK/hQLJNnBBDYs4+P1rEboPwmITAU/hT9jSEntgxb8Aj4HGXenhiKs1tg+HGqJQx/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-transform/binding-openharmony-arm64@0.148.0':
-    resolution: {integrity: sha512-bRKJFm/WSX63laJtTUnlbuAPJACeWlf1SW5KcpFPUyV6XkR4pQYkP1qpM2Uf5pD7IQ51KUS0ktYUzN/Xbusc6g==}
+  '@oxc-transform/binding-openharmony-arm64@0.149.0':
+    resolution: {integrity: sha512-5ODuIVzBcUAz2qItNi95ON/vfIImIuWVhK8EdYTffgk39PZ/6/2wOu614DUxMTHlBFVAFuZ4Y/Yn5aaha3HOYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.148.0':
-    resolution: {integrity: sha512-++mRlVxTsMWqtO0Exqdg7FXZAT8RvMT2iRr34OI/CLEwwwk57eN1L90/BNuxeBOHFb9fLP3PcAGveoZ3nu2P2w==}
+  '@oxc-transform/binding-win32-arm64-msvc@0.149.0':
+    resolution: {integrity: sha512-BDKHl+rkoT6zuKTWbLiniwAd6fClVUAXasUOsAcw6C2Oi+zpDOojX8/P3ztvedmUI677Q5Nz8wsp9q/k0btB1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-transform/binding-win32-ia32-msvc@0.148.0':
-    resolution: {integrity: sha512-URk/3SOr8vQccirhjysHKXdnCLeh3OusZxmSduK9B8NKleyh5YG3sTGsxMy2nAmNVt2aa8+qIQroEwy8Qbk4rw==}
+  '@oxc-transform/binding-win32-ia32-msvc@0.149.0':
+    resolution: {integrity: sha512-HYvXbEZucTU7GHd4k4youQQ+PkVlO6XAASuOStnRlI2M9L11k/k35asPOaLQlrpbi5HghJdSzfx4kkzw8OAr0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-transform/binding-win32-x64-msvc@0.148.0':
-    resolution: {integrity: sha512-TUH3hu8SfaXvK632IE1tCMKfo2nN+Q4BCOTxVRbGPENc+KXc4I1pnj76Kbaj75m87erbsQEgb+726ypC8k6cJg==}
+  '@oxc-transform/binding-win32-x64-msvc@0.149.0':
+    resolution: {integrity: sha512-9rBTE4BFRgxttFQLWFIdr88YeYOU0f5ue2gvq0DoHxxpDvJZnP7uovhTUcNpln2+QmBto1ImbQBmXcOskJjBDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -7760,8 +7760,8 @@ packages:
     resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-parser@0.148.0:
-    resolution: {integrity: sha512-syxUKHeUll89RIABQADcI7sikYrwyssvA6gj4phSSIPezKVM8yMaLAiLLSc7fmzVvrwybfFGFbW5zme9sX87rg==}
+  oxc-parser@0.149.0:
+    resolution: {integrity: sha512-iuirONeHJBp6dFuuZKvkCfFvBiF0uFmojIQooGtazR9+GvcwoayGMtal1+cvDUnEw2k435GBish01HOn5iyVqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-parser@0.37.0:
@@ -7770,8 +7770,8 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxc-transform@0.148.0:
-    resolution: {integrity: sha512-tabVCCHkYFzB94KZDWh2eQK0S1Fj9OAkYtr2spMFmkEy4pZp93MaYGw9O9y+NA3fk7YiDJWKvviywuzR3XTi0g==}
+  oxc-transform@0.149.0:
+    resolution: {integrity: sha512-TDe/I0RlVe0CuZGhRGfBLQGq/W1SaXKABxjaWgKrU0CFcLTQxJTgg1KrUO+2l2stZEVxGIs0DH8EF95z4ppnlw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-walker@0.5.2:
@@ -11459,19 +11459,19 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.148.0':
+  '@oxc-parser/binding-android-arm-eabi@0.149.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.148.0':
+  '@oxc-parser/binding-android-arm64@0.149.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.148.0':
+  '@oxc-parser/binding-darwin-arm64@0.149.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.37.0':
@@ -11480,7 +11480,7 @@ snapshots:
   '@oxc-parser/binding-darwin-x64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.148.0':
+  '@oxc-parser/binding-darwin-x64@0.149.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.37.0':
@@ -11489,25 +11489,25 @@ snapshots:
   '@oxc-parser/binding-freebsd-x64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.148.0':
+  '@oxc-parser/binding-freebsd-x64@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.148.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.148.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.148.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.37.0':
@@ -11516,7 +11516,7 @@ snapshots:
   '@oxc-parser/binding-linux-arm64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.148.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.37.0':
@@ -11525,31 +11525,31 @@ snapshots:
   '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.148.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.148.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.148.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.148.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.148.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.37.0':
@@ -11558,7 +11558,7 @@ snapshots:
   '@oxc-parser/binding-linux-x64-musl@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.148.0':
+  '@oxc-parser/binding-linux-x64-musl@0.149.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.37.0':
@@ -11567,13 +11567,13 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-openharmony-arm64@0.148.0':
+  '@oxc-parser/binding-openharmony-arm64@0.149.0':
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.148.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.149.0':
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.37.0':
@@ -11582,13 +11582,13 @@ snapshots:
   '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.148.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.149.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.143.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.148.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.149.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.37.0':
@@ -11598,7 +11598,7 @@ snapshots:
 
   '@oxc-project/runtime@0.146.0': {}
 
-  '@oxc-project/runtime@0.148.0': {}
+  '@oxc-project/runtime@0.149.0': {}
 
   '@oxc-project/types@0.101.0': {}
 
@@ -11606,7 +11606,7 @@ snapshots:
 
   '@oxc-project/types@0.146.0': {}
 
-  '@oxc-project/types@0.148.0': {}
+  '@oxc-project/types@0.149.0': {}
 
   '@oxc-project/types@0.37.0': {}
 
@@ -11671,61 +11671,61 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
-  '@oxc-transform/binding-android-arm-eabi@0.148.0':
+  '@oxc-transform/binding-android-arm-eabi@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-android-arm64@0.148.0':
+  '@oxc-transform/binding-android-arm64@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-arm64@0.148.0':
+  '@oxc-transform/binding-darwin-arm64@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-x64@0.148.0':
+  '@oxc-transform/binding-darwin-x64@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-freebsd-x64@0.148.0':
+  '@oxc-transform/binding-freebsd-x64@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.148.0':
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.148.0':
+  '@oxc-transform/binding-linux-arm-musleabihf@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.148.0':
+  '@oxc-transform/binding-linux-arm64-gnu@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-musl@0.148.0':
+  '@oxc-transform/binding-linux-arm64-musl@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-ppc64-gnu@0.148.0':
+  '@oxc-transform/binding-linux-ppc64-gnu@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.148.0':
+  '@oxc-transform/binding-linux-riscv64-gnu@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-riscv64-musl@0.148.0':
+  '@oxc-transform/binding-linux-riscv64-musl@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.148.0':
+  '@oxc-transform/binding-linux-s390x-gnu@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-gnu@0.148.0':
+  '@oxc-transform/binding-linux-x64-gnu@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-musl@0.148.0':
+  '@oxc-transform/binding-linux-x64-musl@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-openharmony-arm64@0.148.0':
+  '@oxc-transform/binding-openharmony-arm64@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.148.0':
+  '@oxc-transform/binding-win32-arm64-msvc@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-win32-ia32-msvc@0.148.0':
+  '@oxc-transform/binding-win32-ia32-msvc@0.149.0':
     optional: true
 
-  '@oxc-transform/binding-win32-x64-msvc@0.148.0':
+  '@oxc-transform/binding-win32-x64-msvc@0.149.0':
     optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.64.0':
@@ -14835,29 +14835,29 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
       '@oxc-parser/binding-win32-x64-msvc': 0.143.0
 
-  oxc-parser@0.148.0:
+  oxc-parser@0.149.0:
     dependencies:
-      '@oxc-project/types': 0.148.0
+      '@oxc-project/types': 0.149.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.148.0
-      '@oxc-parser/binding-android-arm64': 0.148.0
-      '@oxc-parser/binding-darwin-arm64': 0.148.0
-      '@oxc-parser/binding-darwin-x64': 0.148.0
-      '@oxc-parser/binding-freebsd-x64': 0.148.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.148.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.148.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.148.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.148.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.148.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.148.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.148.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.148.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.148.0
-      '@oxc-parser/binding-linux-x64-musl': 0.148.0
-      '@oxc-parser/binding-openharmony-arm64': 0.148.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.148.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.148.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.148.0
+      '@oxc-parser/binding-android-arm-eabi': 0.149.0
+      '@oxc-parser/binding-android-arm64': 0.149.0
+      '@oxc-parser/binding-darwin-arm64': 0.149.0
+      '@oxc-parser/binding-darwin-x64': 0.149.0
+      '@oxc-parser/binding-freebsd-x64': 0.149.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.149.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.149.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.149.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.149.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.149.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.149.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.149.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.149.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.149.0
+      '@oxc-parser/binding-linux-x64-musl': 0.149.0
+      '@oxc-parser/binding-openharmony-arm64': 0.149.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.149.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.149.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.149.0
 
   oxc-parser@0.37.0:
     dependencies:
@@ -14894,32 +14894,32 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxc-transform@0.148.0:
+  oxc-transform@0.149.0:
     optionalDependencies:
-      '@oxc-transform/binding-android-arm-eabi': 0.148.0
-      '@oxc-transform/binding-android-arm64': 0.148.0
-      '@oxc-transform/binding-darwin-arm64': 0.148.0
-      '@oxc-transform/binding-darwin-x64': 0.148.0
-      '@oxc-transform/binding-freebsd-x64': 0.148.0
-      '@oxc-transform/binding-linux-arm-gnueabihf': 0.148.0
-      '@oxc-transform/binding-linux-arm-musleabihf': 0.148.0
-      '@oxc-transform/binding-linux-arm64-gnu': 0.148.0
-      '@oxc-transform/binding-linux-arm64-musl': 0.148.0
-      '@oxc-transform/binding-linux-ppc64-gnu': 0.148.0
-      '@oxc-transform/binding-linux-riscv64-gnu': 0.148.0
-      '@oxc-transform/binding-linux-riscv64-musl': 0.148.0
-      '@oxc-transform/binding-linux-s390x-gnu': 0.148.0
-      '@oxc-transform/binding-linux-x64-gnu': 0.148.0
-      '@oxc-transform/binding-linux-x64-musl': 0.148.0
-      '@oxc-transform/binding-openharmony-arm64': 0.148.0
-      '@oxc-transform/binding-win32-arm64-msvc': 0.148.0
-      '@oxc-transform/binding-win32-ia32-msvc': 0.148.0
-      '@oxc-transform/binding-win32-x64-msvc': 0.148.0
+      '@oxc-transform/binding-android-arm-eabi': 0.149.0
+      '@oxc-transform/binding-android-arm64': 0.149.0
+      '@oxc-transform/binding-darwin-arm64': 0.149.0
+      '@oxc-transform/binding-darwin-x64': 0.149.0
+      '@oxc-transform/binding-freebsd-x64': 0.149.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.149.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.149.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.149.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.149.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.149.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.149.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.149.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.149.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.149.0
+      '@oxc-transform/binding-linux-x64-musl': 0.149.0
+      '@oxc-transform/binding-openharmony-arm64': 0.149.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.149.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.149.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.149.0
 
-  oxc-walker@0.5.2(oxc-parser@0.148.0):
+  oxc-walker@0.5.2(oxc-parser@0.149.0):
     dependencies:
       magic-regexp: 0.10.0
-      oxc-parser: 0.148.0
+      oxc-parser: 0.149.0
 
   oxfmt@0.64.0(vite-plus@0.3.0(@types/node@24.10.3)(@vitest/browser-playwright@4.1.11(playwright@1.62.1)(vite@8.2.2(@types/node@24.10.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11))(esbuild@0.28.2)(jiti@2.7.0)(publint@0.3.24)(terser@5.51.2)(tsx@4.23.12)(typescript@6.0.3)(vite@8.2.2(@types/node@24.10.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
@@ -16000,7 +16000,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-isolated-decl@0.8.3(oxc-transform@0.148.0)(rollup@4.63.0)(supports-color@10.2.2)(typescript@6.0.3):
+  unplugin-isolated-decl@0.8.3(oxc-transform@0.149.0)(rollup@4.63.0)(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.63.0)
       debug: 4.4.3(supports-color@10.2.2)
@@ -16008,7 +16008,7 @@ snapshots:
       oxc-parser: 0.37.0
       unplugin: 1.16.1
     optionalDependencies:
-      oxc-transform: 0.148.0
+      oxc-transform: 0.149.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - rollup

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,8 +45,8 @@ catalog:
   '@napi-rs/wasm-runtime': ~1.2.2
   '@oxc-node/cli': ^0.1.0
   '@oxc-node/core': ^0.1.0
-  '@oxc-project/runtime': '=0.148.0'
-  '@oxc-project/types': '=0.148.0'
+  '@oxc-project/runtime': '=0.149.0'
+  '@oxc-project/types': '=0.149.0'
   '@pnpm/find-workspace-packages': ^6.0.9
   '@rolldown/pluginutils': ^1.0.0
   '@rollup/plugin-commonjs': ^29.0.0
@@ -79,8 +79,8 @@ catalog:
   glob: ^13.0.0
   lodash-es: ^4.17.21
   micromatch: ^4.0.8
-  oxc-parser: '=0.148.0'
-  oxc-transform: '=0.148.0'
+  oxc-parser: '=0.149.0'
+  oxc-transform: '=0.149.0'
   pathe: ^2.0.3
   react: ^19.0.0
   react-dom: ^19.0.0


### PR DESCRIPTION
## Summary

- Upgrade Oxc Rust dependencies to 0.149.0.
- Upgrade `@oxc-project/runtime`, `@oxc-project/types`, `oxc-parser`, and `oxc-transform` JavaScript packages to 0.149.0.
- Regenerate the embedded Oxc runtime helpers for `@oxc-project/runtime` 0.149.0.

## Root causes

### oxc-project/oxc#26120

https://github.com/oxc-project/oxc/pull/26120

Oxc now distinguishes misplaced `NO_SIDE_EFFECTS` comments with `CommentContent::NoSideEffectsNotApplied`. Rolldown surfaces that state through its existing `INVALID_ANNOTATION` path, following the `PureNotApplied` handling established in rolldown/rolldown#9505.

A focused fixture records the new warning. The three esbuild snapshots now contain 8, 12, and 12 `INVALID_ANNOTATION` diagnostics because the previously indistinguishable misplaced comments are exposed to Rolldown. They also preserve four comments before `var`/`let` declarations per fixture; Oxc no longer marks those unsupported placements as applied, so retaining them for downstream diagnostics is expected.

Commit: bfb4c57a5d5abbbaf7b99605f78d7ebc999662b7

### oxc-project/oxc#26308

https://github.com/oxc-project/oxc/pull/26308

Oxc now keeps private methods lowered from a class expression inside the scope that also holds the class's private field storage. Previously, for a class expression in a concise arrow body, the lowered `_read` helper was hoisted next to the arrow's outer statement while the `_field` WeakMap stayed inside the arrow, so the helper threw `ReferenceError: _field is not defined` at runtime (regressed in Oxc 0.143.0 / Rolldown 1.2.3).

No Rolldown code changes are needed; the fix ships with the dependency bump. Verified locally with the reproduction from #10818 (`transform.target: 'es2019'`): `rolldown@1.2.7` throws the `ReferenceError`, this branch outputs `42`.

Commit: 116c8b830345ac5c3740439446eb556d31bc7cf7

### oxc-project/oxc#26382

https://github.com/oxc-project/oxc/pull/26382

Oxc renamed `ParserReturn.panicked` to `ParserReturn.fatal_error` to clarify that the parser encountered an unrecoverable syntax error rather than a Rust panic. The field semantics are unchanged.

Every Rolldown `ParserReturn` consumer now uses the new field name. No generated output or snapshots changed.

Commit: 66744f0eb942c375c298689a0c19d11efab2a2e2

fixes #10818
