### PR TITLE
perf: cache `getModuleInfo` during code splitting

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -582,7 +582,7 @@ impl GenerateStage<'_> {
     if let Some(invalidate_module_info_cache) =
       &chunking_options.internal_invalidate_module_info_cache
     {
-      invalidate_module_info_cache.call().await?;
+      return result.and(invalidate_module_info_cache.call().await.map_err(Into::into));
     }
     result
   }

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -576,7 +576,13 @@ impl GenerateStage<'_> {
       module_to_assigned,
       flattened_entries,
     };
-    splitter.split().await
+    let result = splitter.split().await;
+    // Release the JS module-info cache on both success and failure.
+    // See internal-docs/manual-code-splitting/implementation.md.
+    if let Some(invalidate_js_side_cache) = &chunking_options.invalidate_js_side_cache {
+      invalidate_js_side_cache.call().await?;
+    }
+    result
   }
 }
 

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -579,8 +579,10 @@ impl GenerateStage<'_> {
     let result = splitter.split().await;
     // Release the JS module-info cache on both success and failure.
     // See internal-docs/manual-code-splitting/implementation.md.
-    if let Some(invalidate_js_side_cache) = &chunking_options.invalidate_js_side_cache {
-      invalidate_js_side_cache.call().await?;
+    if let Some(invalidate_module_info_cache) =
+      &chunking_options.internal_invalidate_module_info_cache
+    {
+      invalidate_module_info_cache.call().await?;
     }
     result
   }

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -21,6 +21,7 @@ pub struct BindingManualCodeSplittingOptions {
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
   #[debug("InternalInvalidateModuleInfoCache(...)")]
+  #[napi(ts_type = "() => void")]
   pub internal_invalidate_module_info_cache: Option<JsCallback>,
 }
 

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -20,8 +20,8 @@ pub struct BindingManualCodeSplittingOptions {
   pub max_size: Option<f64>,
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
-  #[debug("InvalidateJsSideCache(...)")]
-  pub invalidate_js_side_cache: Option<JsCallback>,
+  #[debug("InternalInvalidateModuleInfoCache(...)")]
+  pub internal_invalidate_module_info_cache: Option<JsCallback>,
 }
 
 /// The JS side wraps the user's per-id function in one shim per group. The result holds one byte

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -20,6 +20,8 @@ pub struct BindingManualCodeSplittingOptions {
   pub max_size: Option<f64>,
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
+  #[debug("InvalidateJsSideCache(...)")]
+  pub invalidate_js_side_cache: Option<JsCallback>,
 }
 
 /// The JS side wraps the user's per-id function in one shim per group. The result holds one byte

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -326,16 +326,13 @@ fn normalize_sourcemap_path_transform_option(
 
 fn normalize_invalidate_js_side_cache_option(
   invalidate_js_side_cache: Option<JsCallback>,
+  error_context: &'static str,
 ) -> Option<rolldown::InvalidateJsSideCache> {
   invalidate_js_side_cache.map(|ts_fn| {
     rolldown::InvalidateJsSideCache::new(Arc::new(move || {
       let ts_fn = Arc::clone(&ts_fn);
       Box::pin(async move {
-        ts_fn
-          .invoke_async(())
-          .await
-          .context("invalidateJsSideCache option")
-          .map_err(anyhow::Error::from)
+        ts_fn.invoke_async(()).await.context(error_context).map_err(anyhow::Error::from)
       })
     }))
   })
@@ -367,8 +364,9 @@ fn normalize_code_splitting(
   let manual_code_splitting = manual_code_splitting
     .map(|inner| -> napi::Result<ManualCodeSplittingOptions> {
       Ok(ManualCodeSplittingOptions {
-        invalidate_js_side_cache: normalize_invalidate_js_side_cache_option(
-          inner.invalidate_js_side_cache,
+        internal_invalidate_module_info_cache: normalize_invalidate_js_side_cache_option(
+          inner.internal_invalidate_module_info_cache,
+          "internalInvalidateModuleInfoCache callback",
         ),
         min_size: inner.min_size,
         min_share_count: inner.min_share_count,
@@ -477,8 +475,10 @@ pub fn normalize_binding_options(
     normalize_sourcemap_ignore_list_option(output_options.sourcemap_ignore_list);
   let sourcemap_path_transform =
     normalize_sourcemap_path_transform_option(output_options.sourcemap_path_transform);
-  let invalidate_js_side_cache =
-    normalize_invalidate_js_side_cache_option(input_options.invalidate_js_side_cache);
+  let invalidate_js_side_cache = normalize_invalidate_js_side_cache_option(
+    input_options.invalidate_js_side_cache,
+    "invalidateJsSideCache option",
+  );
   let on_log = normalize_on_log_option(input_options.on_log);
 
   let mut module_types = None;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -367,6 +367,9 @@ fn normalize_code_splitting(
   let manual_code_splitting = manual_code_splitting
     .map(|inner| -> napi::Result<ManualCodeSplittingOptions> {
       Ok(ManualCodeSplittingOptions {
+        invalidate_js_side_cache: normalize_invalidate_js_side_cache_option(
+          inner.invalidate_js_side_cache,
+        ),
         min_size: inner.min_size,
         min_share_count: inner.min_share_count,
         min_module_size: inner.min_module_size,

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
-use crate::{ModuleInfo, ModuleTag, SharedModuleInfoDashMap};
+use crate::{InvalidateJsSideCache, ModuleInfo, ModuleTag, SharedModuleInfoDashMap};
 
 /// Schema-only enum for built-in module tags. Used by `schemars` to generate
 /// a restricted JSON Schema for the `tags` field. Not used at runtime.
@@ -36,6 +36,8 @@ pub struct ManualCodeSplittingOptions {
   pub max_module_size: Option<f64>,
   pub include_dependencies_recursively: Option<bool>,
   pub groups: Option<Vec<MatchGroup>>,
+  #[cfg_attr(feature = "deserialize_bundler_options", serde(skip), schemars(skip))]
+  pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -37,7 +37,7 @@ pub struct ManualCodeSplittingOptions {
   pub include_dependencies_recursively: Option<bool>,
   pub groups: Option<Vec<MatchGroup>>,
   #[cfg_attr(feature = "deserialize_bundler_options", serde(skip), schemars(skip))]
-  pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
+  pub internal_invalidate_module_info_cache: Option<InvalidateJsSideCache>,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/internal-docs/manual-code-splitting/implementation.md
+++ b/internal-docs/manual-code-splitting/implementation.md
@@ -10,7 +10,7 @@ Manual code splitting lets users define chunk boundaries via `manualCodeSplittin
 
 All dynamic group-name callbacks in one manual splitting pass share a `ChunkingContextImpl`. It caches complete JavaScript `ModuleInfo` objects by module ID after their first native lookup. Scanning has completed before this pass, so dependency arrays and entry flags are stable. `meta` retains its shared JavaScript reference, `moduleSideEffects` reads and writes the existing module-option store, and `code` remains a lazy getter.
 
-The binding supplies a private `internalInvalidateModuleInfoCache` callback on the manual splitting options. `apply_manual_code_splitting` invokes it after `split` returns, including errors. The callback drops the cache and disables caching on retained contexts; the next splitting pass creates a fresh context. The plugin-context API and graph construction do not use this cache.
+The binding supplies a private `internalInvalidateModuleInfoCache` callback on the manual splitting options. `apply_manual_code_splitting` invokes it after `split` returns, including errors. If both splitting and invalidation fail, the splitting error takes precedence. The callback drops the cache and disables caching on retained contexts; `moduleSideEffects` continues to read and write the shared module-option store. The next splitting pass creates a fresh context. The plugin-context API and graph construction do not use this cache.
 
 ### `entriesAware`
 

--- a/internal-docs/manual-code-splitting/implementation.md
+++ b/internal-docs/manual-code-splitting/implementation.md
@@ -6,6 +6,12 @@ Manual code splitting lets users define chunk boundaries via `manualCodeSplittin
 
 ## Important features
 
+### JavaScript module information cache
+
+All dynamic group-name callbacks in one manual splitting pass share a `ChunkingContextImpl`. It caches complete JavaScript `ModuleInfo` objects by module ID after their first native lookup. Scanning has completed before this pass, so dependency arrays and entry flags are stable. `meta` retains its shared JavaScript reference, `moduleSideEffects` reads and writes the existing module-option store, and `code` remains a lazy getter.
+
+The binding supplies a private `invalidateJsSideCache` callback on the manual splitting options. `apply_manual_code_splitting` invokes it after `split` returns, including errors. The callback drops the cache and disables caching on retained contexts; the next splitting pass creates a fresh context. The plugin-context API and graph construction do not use this cache.
+
 ### `entriesAware`
 
 When `entriesAware: true`, a group's modules are further split by **which entry points can reach them**. This produces per-entry-set chunks instead of one monolithic group chunk.

--- a/internal-docs/manual-code-splitting/implementation.md
+++ b/internal-docs/manual-code-splitting/implementation.md
@@ -10,7 +10,7 @@ Manual code splitting lets users define chunk boundaries via `manualCodeSplittin
 
 All dynamic group-name callbacks in one manual splitting pass share a `ChunkingContextImpl`. It caches complete JavaScript `ModuleInfo` objects by module ID after their first native lookup. Scanning has completed before this pass, so dependency arrays and entry flags are stable. `meta` retains its shared JavaScript reference, `moduleSideEffects` reads and writes the existing module-option store, and `code` remains a lazy getter.
 
-The binding supplies a private `invalidateJsSideCache` callback on the manual splitting options. `apply_manual_code_splitting` invokes it after `split` returns, including errors. The callback drops the cache and disables caching on retained contexts; the next splitting pass creates a fresh context. The plugin-context API and graph construction do not use this cache.
+The binding supplies a private `internalInvalidateModuleInfoCache` callback on the manual splitting options. `apply_manual_code_splitting` invokes it after `split` returns, including errors. The callback drops the cache and disables caching on retained contexts; the next splitting pass creates a fresh context. The plugin-context API and graph construction do not use this cache.
 
 ### `entriesAware`
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2588,6 +2588,7 @@ export interface BindingManualCodeSplittingOptions {
   maxSize?: number
   minModuleSize?: number
   maxModuleSize?: number
+  invalidateJsSideCache?: JsCallback
 }
 
 export interface BindingMatchGroup {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2588,7 +2588,7 @@ export interface BindingManualCodeSplittingOptions {
   maxSize?: number
   minModuleSize?: number
   maxModuleSize?: number
-  invalidateJsSideCache?: JsCallback
+  internalInvalidateModuleInfoCache?: JsCallback
 }
 
 export interface BindingMatchGroup {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2588,7 +2588,7 @@ export interface BindingManualCodeSplittingOptions {
   maxSize?: number
   minModuleSize?: number
   maxModuleSize?: number
-  internalInvalidateModuleInfoCache?: JsCallback
+  internalInvalidateModuleInfoCache?: () => void
 }
 
 export interface BindingMatchGroup {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -142,6 +142,10 @@ export interface CommentsOptions {
 
 /** @inline @category Code Splitting */
 export interface ChunkingContext {
+  /**
+   * The returned object and its dependency arrays are reused within the current chunking pass.
+   * Treat graph fields as read-only. `meta` properties and the `moduleSideEffects` field remain mutable.
+   */
   getModuleInfo(moduleId: string): ModuleInfo | null;
 }
 

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2588,7 +2588,7 @@ export interface BindingManualCodeSplittingOptions {
   maxSize?: number
   minModuleSize?: number
   maxModuleSize?: number
-  internalInvalidateModuleInfoCache?: JsCallback
+  internalInvalidateModuleInfoCache?: () => void
 }
 
 export interface BindingMatchGroup {

--- a/packages/rolldown/src/rolldown-binding.wasi.d.cts
+++ b/packages/rolldown/src/rolldown-binding.wasi.d.cts
@@ -2588,6 +2588,7 @@ export interface BindingManualCodeSplittingOptions {
   maxSize?: number
   minModuleSize?: number
   maxModuleSize?: number
+  internalInvalidateModuleInfoCache?: JsCallback
 }
 
 export interface BindingMatchGroup {

--- a/packages/rolldown/src/types/chunking-context.ts
+++ b/packages/rolldown/src/types/chunking-context.ts
@@ -24,16 +24,14 @@ export class ChunkingContextImpl {
     if (bindingInfo) {
       const option = this.pluginContextData.getModuleOption(moduleId);
       const info = transformModuleInfo(bindingInfo, option);
-      if (this.moduleInfoCache) {
-        Object.defineProperty(info, 'moduleSideEffects', {
-          get: () => option.moduleSideEffects,
-          set: (moduleSideEffects: ModuleInfo['moduleSideEffects']) => {
-            option.moduleSideEffects = moduleSideEffects;
-            option.invalidate = true;
-          },
-        });
-        this.moduleInfoCache.set(moduleId, info);
-      }
+      Object.defineProperty(info, 'moduleSideEffects', {
+        get: () => option.moduleSideEffects,
+        set: (moduleSideEffects: ModuleInfo['moduleSideEffects']) => {
+          option.moduleSideEffects = moduleSideEffects;
+          option.invalidate = true;
+        },
+      });
+      this.moduleInfoCache?.set(moduleId, info);
       return info;
     }
     return null;

--- a/packages/rolldown/src/types/chunking-context.ts
+++ b/packages/rolldown/src/types/chunking-context.ts
@@ -4,17 +4,36 @@ import { transformModuleInfo } from '../utils/transform-module-info';
 import type { ModuleInfo } from './module-info';
 
 export class ChunkingContextImpl {
+  private moduleInfoCache: Map<string, ModuleInfo> | undefined = new Map();
+
   constructor(
     private context: BindingChunkingContext,
     private pluginContextData: PluginContextData,
   ) {}
+
+  clearModuleInfoCache(): void {
+    this.moduleInfoCache = undefined;
+  }
+
   getModuleInfo(moduleId: string): ModuleInfo | null {
+    const cached = this.moduleInfoCache?.get(moduleId);
+    if (cached) {
+      return cached;
+    }
     const bindingInfo = this.context.getModuleInfo(moduleId);
     if (bindingInfo) {
-      const info = transformModuleInfo(
-        bindingInfo,
-        this.pluginContextData.getModuleOption(moduleId),
-      );
+      const option = this.pluginContextData.getModuleOption(moduleId);
+      const info = transformModuleInfo(bindingInfo, option);
+      if (this.moduleInfoCache) {
+        Object.defineProperty(info, 'moduleSideEffects', {
+          get: () => option.moduleSideEffects,
+          set: (moduleSideEffects: ModuleInfo['moduleSideEffects']) => {
+            option.moduleSideEffects = moduleSideEffects;
+            option.invalidate = true;
+          },
+        });
+        this.moduleInfoCache.set(moduleId, info);
+      }
       return info;
     }
     return null;

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -357,8 +357,15 @@ function bindingifyCodeSplitting(
   let advancedChunksResult: BindingOutputOptions['manualCodeSplitting'];
   if (effectiveChunksOption != null) {
     const { groups, ...restOptions } = effectiveChunksOption;
+    let chunkingContext: ChunkingContextImpl | undefined;
+    const getChunkingContext = (bindingContext: BindingChunkingContext) =>
+      (chunkingContext ??= new ChunkingContextImpl(bindingContext, pluginContextData));
     advancedChunksResult = {
       ...restOptions,
+      invalidateJsSideCache: () => {
+        chunkingContext?.clearModuleInfoCache();
+        chunkingContext = undefined;
+      },
       groups: groups?.map((group) => {
         const { name, test, ...restGroup } = group;
         return {
@@ -386,7 +393,7 @@ function bindingifyCodeSplitting(
                     'codeSplitting groups[].name',
                     name,
                   ),
-                  pluginContextData,
+                  getChunkingContext,
                 )
               : name,
         };
@@ -427,18 +434,18 @@ function batchTest(test: CodeSplittingTestFunction): (ids: string[]) => Uint8Arr
 }
 
 /**
- * This is the `name` equivalent of {@linkcode batchTest}. The context wrapper holds no per-call
- * state, so one instance serves the whole batch.
+ * This is the `name` equivalent of {@linkcode batchTest}. All groups in a chunking pass share
+ * a context so repeated module queries reuse their JavaScript values.
  */
 function batchName(
   name: CodeSplittingNameFunction,
-  pluginContextData: PluginContextData,
+  getChunkingContext: (bindingContext: BindingChunkingContext) => ChunkingContextImpl,
 ): (
   ids: string[],
   bindingContext: BindingChunkingContext,
 ) => ReturnType<CodeSplittingNameFunction>[] {
   return (ids, bindingContext) => {
-    const context = new ChunkingContextImpl(bindingContext, pluginContextData);
+    const context = getChunkingContext(bindingContext);
     const results: ReturnType<CodeSplittingNameFunction>[] = [];
     for (let index = 0; index < ids.length; index++) {
       const result = name(ids[index], context);

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -362,7 +362,7 @@ function bindingifyCodeSplitting(
       (chunkingContext ??= new ChunkingContextImpl(bindingContext, pluginContextData));
     advancedChunksResult = {
       ...restOptions,
-      invalidateJsSideCache: () => {
+      internalInvalidateModuleInfoCache: () => {
         chunkingContext?.clearModuleInfoCache();
         chunkingContext = undefined;
       },

--- a/packages/rolldown/tests/behaviors/chunking-module-info-cache.test.ts
+++ b/packages/rolldown/tests/behaviors/chunking-module-info-cache.test.ts
@@ -26,9 +26,13 @@ test('shares module info across groups and releases it before rendering', async 
         },
         renderChunk() {
           renderCalls++;
-          const info = chunkingContext.getModuleInfo('dep');
+          const info = chunkingContext.getModuleInfo('dep')!;
           expect(info === firstInfo).toBe(false);
           expect(chunkingContext.getModuleInfo('dep') === info).toBe(false);
+          info.moduleSideEffects = false;
+          expect(this.getModuleInfo('dep')!.moduleSideEffects).toBe(false);
+          this.getModuleInfo('dep')!.moduleSideEffects = true;
+          expect(info.moduleSideEffects).toBe(true);
         },
       },
     ],
@@ -87,9 +91,13 @@ test.each(['name throws', 'name returns invalid type', 'later test throws'])(
           load: (id) => modules[id],
           renderError() {
             checkedError = true;
-            const info = context.getModuleInfo('dep');
+            const info = context.getModuleInfo('dep')!;
             expect(info === cached).toBe(false);
             expect(context.getModuleInfo('dep') === info).toBe(false);
+            info.moduleSideEffects = null;
+            expect(this.getModuleInfo('dep')!.moduleSideEffects).toBeNull();
+            this.getModuleInfo('dep')!.moduleSideEffects = false;
+            expect(info.moduleSideEffects).toBe(false);
           },
         },
       ],

--- a/packages/rolldown/tests/behaviors/chunking-module-info-cache.test.ts
+++ b/packages/rolldown/tests/behaviors/chunking-module-info-cache.test.ts
@@ -1,0 +1,166 @@
+import type { ChunkingContext, ModuleInfo, OutputOptions, PluginContext } from 'rolldown';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
+
+const modules: Record<string, string> = {
+  entry: 'import "dep"; import "external"; console.log("entry");',
+  dep: 'console.log("dep"); export const value = 1;',
+};
+
+test('shares module info across groups and releases it before rendering', async () => {
+  let getPluginModuleInfo: PluginContext['getModuleInfo'];
+  let chunkingContext: ChunkingContext;
+  let firstInfo: ModuleInfo | undefined;
+  let groupCalls = 0;
+  let renderCalls = 0;
+  const build = await rolldown({
+    input: 'entry',
+    external: ['external'],
+    plugins: [
+      {
+        name: 'virtual-modules',
+        resolveId: (id) => id,
+        load: (id) => modules[id],
+        buildEnd() {
+          getPluginModuleInfo = this.getModuleInfo;
+        },
+        renderChunk() {
+          renderCalls++;
+          const info = chunkingContext.getModuleInfo('dep');
+          expect(info === firstInfo).toBe(false);
+          expect(chunkingContext.getModuleInfo('dep') === info).toBe(false);
+        },
+      },
+    ],
+  });
+  try {
+    await build.generate({
+      codeSplitting: {
+        groups: [0, 1].map(() => ({
+          name(_id, context) {
+            groupCalls++;
+            chunkingContext = context;
+            const info = context.getModuleInfo('dep')!;
+            firstInfo ??= info;
+            expect(info).toBe(firstInfo);
+            expect(info.importers).toEqual(['entry']);
+            expect(context.getModuleInfo('external')).toBe(context.getModuleInfo('external'));
+            expect(context.getModuleInfo('missing')).toBeNull();
+            getPluginModuleInfo('dep')!.moduleSideEffects = true;
+            expect(info.moduleSideEffects).toBe(true);
+            getPluginModuleInfo('dep')!.moduleSideEffects = false;
+            expect(info.moduleSideEffects).toBe(false);
+            info.moduleSideEffects = true;
+            expect(getPluginModuleInfo('dep')!.moduleSideEffects).toBe(true);
+            info.moduleSideEffects = null;
+            expect(info.moduleSideEffects).toBeNull();
+            expect(getPluginModuleInfo('dep')!.moduleSideEffects).toBeNull();
+            expect(info.meta).toBe(getPluginModuleInfo('dep')!.meta);
+            info.meta.group = 'shared';
+            expect(getPluginModuleInfo('dep')!.meta.group).toBe('shared');
+            return null;
+          },
+        })),
+      },
+    });
+    expect(groupCalls).toBeGreaterThanOrEqual(4);
+    expect(renderCalls).toBeGreaterThan(0);
+  } finally {
+    await build.close();
+  }
+});
+
+test.each(['name throws', 'name returns invalid type', 'later test throws'])(
+  'releases cached module info when %s',
+  async (failure) => {
+    let context: ChunkingContext;
+    let cached: ModuleInfo;
+    let fail = true;
+    let checkedError = false;
+    const build = await rolldown({
+      input: 'entry',
+      external: ['external'],
+      plugins: [
+        {
+          name: 'virtual-modules',
+          resolveId: (id) => id,
+          load: (id) => modules[id],
+          renderError() {
+            checkedError = true;
+            const info = context.getModuleInfo('dep');
+            expect(info === cached).toBe(false);
+            expect(context.getModuleInfo('dep') === info).toBe(false);
+          },
+        },
+      ],
+    });
+    const output: OutputOptions = {
+      codeSplitting: {
+        groups: [
+          {
+            name(_id, ctx) {
+              context = ctx;
+              cached = ctx.getModuleInfo('dep')!;
+              expect(ctx.getModuleInfo('dep')).toBe(cached);
+              if (fail && failure === 'name throws') throw new Error('classifier failure');
+              if (fail && failure === 'name returns invalid type') return 1 as unknown as string;
+              return null;
+            },
+          },
+          {
+            name: 'second',
+            test() {
+              if (fail) throw new Error('classifier failure');
+              return false;
+            },
+          },
+        ],
+      },
+    };
+    try {
+      await expect(build.generate(output)).rejects.toThrow(
+        failure === 'name returns invalid type' ? 'expected a string' : 'classifier failure',
+      );
+      expect(checkedError).toBe(true);
+      const previousInfo = cached!;
+      fail = false;
+      await build.generate(output);
+      expect(cached! === previousInfo).toBe(false);
+    } finally {
+      await build.close();
+    }
+  },
+);
+
+test('manualChunks reuses module info within each output', async () => {
+  let previous: ModuleInfo | undefined;
+  const build = await rolldown({
+    input: 'entry',
+    external: ['external'],
+    plugins: [
+      {
+        name: 'virtual-modules',
+        resolveId: (id) => id,
+        load: (id) => modules[id],
+      },
+    ],
+  });
+  try {
+    for (let pass = 0; pass < 2; pass++) {
+      let current: ModuleInfo | undefined;
+      await build.generate({
+        manualChunks(_id, context) {
+          const info = context.getModuleInfo('dep')!;
+          current ??= info;
+          expect(info).toBe(current);
+          expect(info === previous).toBe(false);
+          return null;
+        },
+      });
+      expect(current).toBeDefined();
+      previous = current;
+    }
+  } finally {
+    await build.close();
+  }
+});

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { RolldownWatcher, WatchOptions } from 'rolldown';
+import type { ModuleInfo, RolldownWatcher, WatchOptions } from 'rolldown';
 import { rolldown, watch as _watch } from 'rolldown';
 import { sleep } from 'rolldown-tests/utils';
 import { test, vi } from 'vitest';
@@ -610,6 +610,59 @@ console.log(a + 1000)
 
     await waitBuildFinished(watcher);
     expect(fs.readdirSync(path.join(cwd, 'dist'))).toHaveLength(1);
+  },
+);
+
+test.concurrent(
+  'chunking module-info cache refreshes incoming edges in incremental builds',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const { dir: cwd } = createTestWithMultiFiles(
+      'chunking-module-info-cache',
+      task.result?.retryCount ?? 0,
+      {
+        'main.js': `import './dep.js'; console.log('main')`,
+        'dep.js': `console.log('dep')`,
+      },
+    );
+    const main = path.join(cwd, 'main.js');
+    const dep = path.join(cwd, 'dep.js');
+    let latestInfo: ModuleInfo | undefined;
+    const watcher = watch({
+      cwd,
+      input: 'main.js',
+      experimental: { incrementalBuild: true },
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name(_id, context) {
+                latestInfo = context.getModuleInfo(dep)!;
+                expect(context.getModuleInfo(dep)).toBe(latestInfo);
+                return null;
+              },
+            },
+          ],
+        },
+      },
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+    await waitBuildFinished(watcher);
+    const firstInfo = latestInfo!;
+    expect(firstInfo.importers).toEqual([main]);
+    expect(firstInfo.dynamicImporters).toEqual([]);
+
+    watcher.clear('event');
+    await editFile(main, `import('./dep.js'); console.log('main')`);
+    await waitBuildFinished(watcher);
+    expect(latestInfo === firstInfo).toBe(false);
+    expect(latestInfo!.importers).toEqual([]);
+    expect(latestInfo!.dynamicImporters).toEqual([main]);
   },
 );
 


### PR DESCRIPTION
Repeated module-graph queries during custom chunking incur redundant native-to-JavaScript conversions. This PR reuses module information for the duration of each chunking pass to reduce that overhead.

## Implementation

Repeated queries for the same module share a complete object across all groups within one pass. The cache applies to `codeSplitting.groups[].name` and `manualChunks`; plugin-context `getModuleInfo()` remains unchanged.

- Release the cache when the pass completes, including when a user callback throws, before rendering or reporting the error.
- Keep `meta` shared and read/write `moduleSideEffects` through the existing module-option store.
- Preserve lazy access to `code`. Callers must treat cached graph fields and dependency arrays as read-only.

## Performance

Local synthetic benchmark on an Apple M3 Pro with 36 GiB RAM, macOS 26.6.2 and Node.js v24.12.0. Both variants use the same release build with caching enabled or disabled. Results are medians of five fresh-process runs per variant, alternating execution order.

The graph contains an entry importing 5,000 leaf modules, all importing one shared dependency. Two chunking groups query each visited module 20 times, for 200,040 queries in total.

| Metric | Cache disabled | Cache enabled | Improvement |
| --- | ---: | ---: | ---: |
| Build time | 687 ms | 140 ms | 4.9× faster |
| Peak RSS | 596 MiB | 392 MiB | 34% less |

Build time includes bundle creation, generation and closing, excluding package import. Peak RSS covers the entire process, including native memory. Generated code hashes and query checksums match between variants.

With one query per visited module, build time is approximately unchanged: 131 ms versus 133 ms. These synthetic results illustrate repeated-query workloads, not general application speedups.

## Validation

Public-API regression tests cover object reuse across groups, mutable metadata, cleanup after callback errors, repeated outputs and cache invalidation during incremental watch builds. Local validation passed 968 runtime tests and four type tests.