### PR TITLE
fix: include external wildcard re-exports in `OutputChunk.imports`

### DIFF
--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -204,10 +204,10 @@ pub async fn finalize_assets(
         .iter()
         .flat_map(|importee_idx| &index_chunk_to_instances[*importee_idx])
         .map(|importee_asset_idx| index_ins_chunk_to_filename[*importee_asset_idx].clone())
-        .chain(chunk.direct_imports_from_external_modules.iter().map(|(idx, _)| {
-          link_output.module_table[*idx]
+        .chain(super::static_external_imports(chunk, &link_output.module_table).map(|idx| {
+          link_output.module_table[idx]
             .as_external()
-            .expect("direct_imports_from_external_modules should only contain external modules")
+            .expect("static external imports should only contain external modules")
             .get_file_name(resolved_paths)
         }))
         .collect();

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -1,8 +1,9 @@
 use self::render_chunk_exports::get_chunk_export_names;
 use arcstr::ArcStr;
+use itertools::{EitherOrBoth, Itertools};
 use rolldown_common::{
-  Chunk, ChunkKind, ChunkMeta, ModuleId, ModuleIdx, PreserveEntrySignatures, RenderedModule,
-  RollupPreRenderedChunk, RollupRenderedChunk, SharedNormalizedBundlerOptions,
+  Chunk, ChunkKind, ChunkMeta, ModuleId, ModuleIdx, ModuleTable, PreserveEntrySignatures,
+  RenderedModule, RollupPreRenderedChunk, RollupRenderedChunk, SharedNormalizedBundlerOptions,
 };
 use rustc_hash::FxHashMap;
 
@@ -15,6 +16,22 @@ pub mod finalize_chunks;
 pub mod namespace_marker;
 pub mod render_chunk_exports;
 pub mod validate_options_for_multi_chunk_output;
+
+fn static_external_imports<'a>(
+  chunk: &'a Chunk,
+  module_table: &'a ModuleTable,
+) -> impl Iterator<Item = ModuleIdx> + 'a {
+  chunk
+    .direct_imports_from_external_modules
+    .iter()
+    .map(|(idx, _)| *idx)
+    .merge_join_by(chunk.entry_level_external_module_idx.iter().copied(), |a, b| {
+      module_table[*a].exec_order().cmp(&module_table[*b].exec_order()).then_with(|| a.cmp(b))
+    })
+    .map(|item| match item {
+      EitherOrBoth::Left(idx) | EitherOrBoth::Right(idx) | EitherOrBoth::Both(idx, _) => idx,
+    })
+}
 
 pub fn generate_pre_rendered_chunk(
   chunk: &Chunk,
@@ -73,10 +90,10 @@ pub fn generate_rendered_chunk(
           .expect("should have preliminary_filename")
           .clone()
       })
-      .chain(chunk.direct_imports_from_external_modules.iter().map(|(idx, _)| {
-        link_output.module_table[*idx]
+      .chain(static_external_imports(chunk, &link_output.module_table).map(|idx| {
+        link_output.module_table[idx]
           .as_external()
-          .expect("direct_imports_from_external_modules should only contain external modules")
+          .expect("static external imports should only contain external modules")
           .get_file_name(*resolved_paths)
       }))
       .collect(),

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -1,6 +1,6 @@
 use self::render_chunk_exports::get_chunk_export_names;
 use arcstr::ArcStr;
-use itertools::{EitherOrBoth, Itertools};
+use itertools::Itertools;
 use rolldown_common::{
   Chunk, ChunkKind, ChunkMeta, ModuleId, ModuleIdx, ModuleTable, PreserveEntrySignatures,
   RenderedModule, RollupPreRenderedChunk, RollupRenderedChunk, SharedNormalizedBundlerOptions,
@@ -25,12 +25,10 @@ fn static_external_imports<'a>(
     .direct_imports_from_external_modules
     .iter()
     .map(|(idx, _)| *idx)
-    .merge_join_by(chunk.entry_level_external_module_idx.iter().copied(), |a, b| {
-      module_table[*a].exec_order().cmp(&module_table[*b].exec_order()).then_with(|| a.cmp(b))
+    .merge_by(chunk.entry_level_external_module_idx.iter().copied(), |a, b| {
+      module_table[*a].exec_order() <= module_table[*b].exec_order()
     })
-    .map(|item| match item {
-      EitherOrBoth::Left(idx) | EitherOrBoth::Right(idx) | EitherOrBoth::Both(idx, _) => idx,
-    })
+    .dedup()
 }
 
 pub fn generate_pre_rendered_chunk(

--- a/packages/rolldown/tests/fixtures/output/static-imports-metadata/external-star/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/static-imports-metadata/external-star/_config.ts
@@ -1,0 +1,37 @@
+import type { OutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+const expectedImports = ['mapped/star-first.js', 'mapped/named-second.js', 'mapped/both.js'];
+
+export default defineTest({
+  config: {
+    external: ['star-first', 'named-second', 'both'],
+    output: {
+      paths: {
+        'star-first': 'mapped/star-first.js',
+        'named-second': 'mapped/named-second.js',
+        both: 'mapped/both.js',
+      },
+    },
+    plugins: [
+      {
+        name: 'test-plugin',
+        renderChunk: (_code, chunk) => {
+          expect(chunk.imports).toStrictEqual(expectedImports);
+        },
+        generateBundle: (_options, bundle) => {
+          const chunk = bundle['main.js'] as OutputChunk;
+          expect(chunk.imports).toStrictEqual(expectedImports);
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const chunk = output.output[0] as OutputChunk;
+    expect(chunk.code).toContain('export * from "mapped/star-first.js"');
+    expect(chunk.code).toContain('import { named } from "mapped/named-second.js"');
+    expect(chunk.code).toContain('export * from "mapped/both.js"');
+    expect(chunk.code).toContain('import { named as alsoNamed } from "mapped/both.js"');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/static-imports-metadata/external-star/main.js
+++ b/packages/rolldown/tests/fixtures/output/static-imports-metadata/external-star/main.js
@@ -1,0 +1,4 @@
+export * from 'star-first';
+export { named } from 'named-second';
+export * from 'both';
+export { named as alsoNamed } from 'both';


### PR DESCRIPTION
Ensure that `OutputChunk.imports` includes external re-exports, from both `export { named } from 'external';` (this already worked, I believe because such exports are rewritten into an import/export pair) and `export * from 'external';` , to match rollup's behavior. We do this by including `EntryLevelExternal` imports in addition to those in `direct_imports_from_external_modules`.

This changes only the value of `imports`, not any other chunk data or metadata.

Fixes #10833.

AI disclosure: all the code in this PR was written using Amp, pointed at my completely hand-written "real world" bug report in #10833. You may see the full thread [here](https://ampcode.com/threads/T-01a083ed-6925-75f9-a80a-fda4a3705396).

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->
