### PR TITLE
test(dev): cover stale dynamic entry references after partial scans

### DIFF
--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/__tests__/hmr-dynamic-entry-cache.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/__tests__/hmr-dynamic-entry-cache.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { editFile, page, waitForBuildStable } from '~utils';
+
+const plantMarker = () =>
+  page.evaluate(() => ((window as unknown as { __marker?: string }).__marker = 'alive'));
+const readMarker = () =>
+  page.evaluate(() => (window as unknown as { __marker?: string }).__marker ?? null);
+
+describe('hmr-dynamic-entry-cache', () => {
+  test('keeps dynamic entry references synchronized across reload rebuilds', async () => {
+    await waitForBuildStable();
+    await expect.poll(() => page.textContent('.value')).toBe('bundle ok');
+
+    await plantMarker();
+    editFile('main.ts', (code) => code.replace("document.body.dataset.loaded = 'true';", ''));
+    await expect.poll(readMarker).toBe(null);
+    await expect.poll(() => page.textContent('.value')).toBe('bundle ok');
+    await waitForBuildStable();
+
+    await plantMarker();
+    editFile('main.ts', (code) =>
+      code.replace(
+        /\(async \(\) => \{[\s\S]*\}\)\(\);/,
+        "document.querySelector('.value')!.textContent = 'dynamic import removed';",
+      ),
+    );
+    await expect.poll(readMarker).toBe(null);
+    await expect.poll(() => page.textContent('.value')).toBe('dynamic import removed');
+    await waitForBuildStable();
+  });
+});

--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/dev.config.mjs
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/dev.config.mjs
@@ -1,0 +1,14 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'browser',
+  build: {
+    input: {
+      main: 'main.ts',
+    },
+    platform: 'browser',
+    experimental: {
+      devMode: {},
+    },
+  },
+});

--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/index.html
@@ -1,0 +1,3 @@
+<div class="value"></div>
+
+<script type="module" src="./main.ts"></script>

--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/main.ts
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/main.ts
@@ -1,0 +1,7 @@
+document.body.dataset.loaded = 'true';
+
+(async () => {
+  const pages = import.meta.glob('./page.ts');
+  const page = (await pages['./page.ts']()) as { boot: () => void };
+  page.boot();
+})();

--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/package.json
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rolldown/test-hmr-dynamic-entry-cache",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/page.ts
+++ b/packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache/page.ts
@@ -1,0 +1,3 @@
+export function boot() {
+  document.querySelector('.value')!.textContent = 'bundle ok';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,6 +885,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/playground/hmr-dynamic-entry-cache:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/playground/hmr-dynamic-import-accept-dep:
     devDependencies:
       '@rolldown/test-dev-server':


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://rolldown.rs/contribution-guide/.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Rolldown!
-->