### PR TITLE
feat(dev): ship imported bindings for HMR partial accept

### DIFF
--- a/crates/rolldown/src/ast_scanner/hmr.rs
+++ b/crates/rolldown/src/ast_scanner/hmr.rs
@@ -1,8 +1,9 @@
 use super::AstScanner;
 use oxc::ast::ast;
+use oxc_str::CompactStr;
 use rolldown_common::{EcmaModuleAstUsage, ImportKind, ImportRecordMeta};
 use rolldown_ecmascript_utils::ExpressionExt;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub(crate) fn try_extract_hmr_info_from_hot_accept_call(
@@ -18,6 +19,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     // - `import.meta.hot.accept('./dep.js', ...)`
     // - `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
 
+    if call_expr.callee.is_import_meta_hot_accept_exports() {
+      self.extract_hmr_accept_exports(call_expr);
+      return;
+    }
     // Check whether the callee is `import.meta.hot.accept`.
     if !call_expr.callee.is_import_meta_hot_accept() {
       return;
@@ -83,5 +88,35 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       .hmr_info
       .module_request_to_import_record_idx
       .extend(module_request_to_import_record_idx);
+  }
+
+  /// `import.meta.hot.acceptExports('a' | ['a', 'b'], cb?)`. The names are only a hint for
+  /// the server-side prediction and for shipping import bindings; the client records the
+  /// real call at runtime.
+  fn extract_hmr_accept_exports(&mut self, call_expr: &ast::CallExpression<'ast>) {
+    let seen_before = self.result.ast_usage.contains(EcmaModuleAstUsage::HmrAcceptExports);
+    self.result.ast_usage.insert(EcmaModuleAstUsage::HmrAcceptExports);
+    if seen_before && self.result.hmr_info.accepted_exports.is_none() {
+      // an earlier call was unreadable, so the set stays unknown
+      return;
+    }
+    let names: Option<FxHashSet<CompactStr>> = match call_expr.arguments.first() {
+      Some(ast::Argument::StringLiteral(lit)) => {
+        Some(std::iter::once(lit.value.as_str().into()).collect())
+      }
+      Some(ast::Argument::ArrayExpression(array)) => array
+        .elements
+        .iter()
+        .map(|element| match element {
+          ast::ArrayExpressionElement::StringLiteral(lit) => Some(lit.value.as_str().into()),
+          _ => None,
+        })
+        .collect(),
+      _ => None,
+    };
+    match (&mut self.result.hmr_info.accepted_exports, names) {
+      (Some(existing), Some(names)) => existing.extend(names),
+      (existing, names) => *existing = names,
+    }
   }
 }

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -487,6 +487,13 @@ impl<'a, Fs: FileSystem + Clone + 'static> HmrStage<'a, Fs> {
           // Edge boundary: the accepting importer is not re-run, so it joins no set.
           continue;
         }
+        if let Some(accepted) = &module.hmr_info.accepted_exports
+          && crate::hmr::module_graph_delta::imports_only_accepted_exports(
+            importer, module_idx, accepted,
+          )
+        {
+          continue;
+        }
         stack.push(importer_idx);
       }
     }

--- a/crates/rolldown/src/hmr/module_graph_delta.rs
+++ b/crates/rolldown/src/hmr/module_graph_delta.rs
@@ -1,15 +1,70 @@
 use json_escape_simd::escape;
-use rolldown_common::{Module, ModuleIdx, ModuleTable, RUNTIME_MODULE_KEY};
+use oxc_str::CompactStr;
+use rolldown_common::{
+  ImportKind, ImportRecordIdx, ImportRecordMeta, Module, ModuleIdx, ModuleTable, NormalModule,
+  RUNTIME_MODULE_KEY, Specifier,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// Stands for every export: `import * as ns`, `export * from`, `require()`, non-JS records.
+const ANY_BINDING: &str = "*";
+
+/// The export names `module` reads through each static import record, keyed by the record.
+/// `"*"` for a whole-namespace read, an empty list for a side-effect-only import.
+pub fn static_import_bindings(module: &NormalModule) -> FxHashMap<ImportRecordIdx, Vec<&str>> {
+  let mut names_by_record: FxHashMap<ImportRecordIdx, Vec<&str>> = FxHashMap::default();
+  for (record_idx, record) in module.import_records.iter_enumerated() {
+    if !record.kind.is_static() {
+      continue;
+    }
+    let names = names_by_record.entry(record_idx).or_default();
+    if record.kind != ImportKind::Import || record.meta.contains(ImportRecordMeta::IsExportStar) {
+      names.push(ANY_BINDING);
+    }
+  }
+  for named_import in module.named_imports.values() {
+    let Some(names) = names_by_record.get_mut(&named_import.record_idx) else { continue };
+    let name = match &named_import.imported {
+      Specifier::Star => ANY_BINDING,
+      Specifier::Literal(name) => name.as_str(),
+    };
+    if !names.contains(&name) {
+      names.push(name);
+    }
+  }
+  names_by_record
+}
+
+/// Whether every export name `importer` reads from `module` is in `accepted`.
+pub fn imports_only_accepted_exports(
+  importer: &NormalModule,
+  module_idx: ModuleIdx,
+  accepted: &FxHashSet<CompactStr>,
+) -> bool {
+  let bindings = static_import_bindings(importer);
+  importer.import_records.iter_enumerated().all(|(record_idx, record)| {
+    // a dynamic `import()` reads the whole namespace
+    record.resolved_module != Some(module_idx)
+      || bindings
+        .get(&record_idx)
+        .is_some_and(|names| names.iter().all(|name| accepted.contains(*name)))
+  })
+}
+
 /// Renders the compiler-emitted `__rolldown_runtime__.registerGraph(...)` prelude for a
-/// payload carrying `carried_modules` — pure module-graph topology (static + dynamic edges).
+/// payload carrying `carried_modules` — module-graph topology (static + dynamic edges).
 ///
 /// The edge sets mirror the split `EcmaView::rebuild_importer_sets` maintains server-side:
 /// `ImportKind::is_static()` records go to `edges`, `ImportKind::is_dynamic()` (`import()`)
 /// records go to `dynamicEdges` — both resolving to normal modules. `HotAccept` and other
 /// non-static/non-dynamic records contribute no edge, and the runtime module appears
 /// nowhere (parity with its skipped HMR registration header).
+///
+/// `bindings[i][j]` lists the export names `ids[i]` imports through static edge `edges[i][j]`
+/// (re-exports included), `"*"` for anything that reads the whole namespace, and an empty
+/// list for a side-effect-only import. It is only filled for edges into a module that calls
+/// `import.meta.hot.acceptExports`; other entries are `null`, and the key is left out when
+/// no edge qualifies. The runtime reads a missing entry as `"*"`.
 ///
 /// `ids[0, local_count)` are the carried modules in input order; `ids[local_count, ..)` are
 /// foreign edge targets interned on first use. Returns `None` when the payload carries no rows.
@@ -36,23 +91,27 @@ pub fn render_register_graph_source(
   }
 
   let mut edges: Vec<Vec<usize>> = Vec::with_capacity(local_count);
+  let mut bindings: Vec<Vec<Option<Vec<&str>>>> = Vec::with_capacity(local_count);
+  let mut any_bindings = false;
   let mut dynamic_edges: Vec<Vec<usize>> = Vec::with_capacity(local_count);
   // Reused across modules: dedup import records targeting the same module without a
   // linear rescan of the edge list per record (quadratic for high-fan-out modules).
-  let mut seen_static = FxHashSet::default();
+  let mut static_edge_pos: FxHashMap<usize, usize> = FxHashMap::default();
   let mut seen_dynamic = FxHashSet::default();
   for i in 0..local_count {
     let Module::Normal(module) = &module_table.modules[ids[i]] else {
       unreachable!("carried rows are filtered to normal modules above");
     };
-    seen_static.clear();
+    static_edge_pos.clear();
     seen_dynamic.clear();
+    let names_by_record = static_import_bindings(module);
     let mut out_edges = Vec::new();
+    let mut out_bindings: Vec<Option<Vec<&str>>> = Vec::new();
     let mut dyn_out_edges = Vec::new();
-    for record in &module.import_records {
+    for (record_idx, record) in module.import_records.iter_enumerated() {
       // Static edges and dynamic `import()` edges both ship; the runtime keeps them in
-      // separate reverse indexes but unions them in `getImporters`. Other non-static
-      // records (HotAccept, new URL, css url) are not import edges and are skipped.
+      // separate reverse indexes but unions them in `getImporters`. `HotAccept` records
+      // are not import edges and are skipped.
       if !record.kind.is_static() && !record.kind.is_dynamic() {
         continue;
       }
@@ -66,14 +125,26 @@ pub fn render_register_graph_source(
         ids.len() - 1
       });
       if record.kind.is_static() {
-        if seen_static.insert(target_pos) {
+        let edge_pos = *static_edge_pos.entry(target_pos).or_insert_with(|| {
           out_edges.push(target_pos);
+          out_bindings.push(None);
+          out_edges.len() - 1
+        });
+        if target.is_hmr_partially_accepting_module() {
+          let names = out_bindings[edge_pos].get_or_insert_with(Vec::new);
+          for name in names_by_record.get(&record_idx).into_iter().flatten() {
+            if !names.contains(name) {
+              names.push(name);
+            }
+          }
+          any_bindings = true;
         }
       } else if seen_dynamic.insert(target_pos) {
         dyn_out_edges.push(target_pos);
       }
     }
     edges.push(out_edges);
+    bindings.push(out_bindings);
     dynamic_edges.push(dyn_out_edges);
   }
 
@@ -100,6 +171,36 @@ pub fn render_register_graph_source(
       source.push_str(itoa::Buffer::new().format(*target_pos));
     }
     source.push(']');
+  }
+  if any_bindings {
+    source.push_str("],bindings:[");
+    for (i, out_bindings) in bindings.iter().enumerate() {
+      if i > 0 {
+        source.push(',');
+      }
+      source.push('[');
+      // trailing `null`s are dropped: a missing entry reads the same as `null`
+      let len = out_bindings.iter().rposition(Option::is_some).map_or(0, |pos| pos + 1);
+      for (j, names) in out_bindings[..len].iter().enumerate() {
+        if j > 0 {
+          source.push(',');
+        }
+        match names {
+          None => source.push_str("null"),
+          Some(names) => {
+            source.push('[');
+            for (k, name) in names.iter().enumerate() {
+              if k > 0 {
+                source.push(',');
+              }
+              source.push_str(&escape(name));
+            }
+            source.push(']');
+          }
+        }
+      }
+      source.push(']');
+    }
   }
   source.push_str("],dynamicEdges:[");
   for (i, out_edges) in dynamic_edges.iter().enumerate() {

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/artifacts.snap
@@ -1,0 +1,546 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+__rolldown_runtime__.registerGraph({
+	ids: [
+		"named/target.js",
+		"named/importer.js",
+		"non_accepted/target.js",
+		"non_accepted/importer.js",
+		"promoted/target.js",
+		"promoted/importer.js",
+		"side_effect/target.js",
+		"side_effect/importer.js",
+		"default_import/target.js",
+		"default_import/importer.js",
+		"dynamic_import/importer.js",
+		"main.js",
+		"dynamic_import/target.js"
+	],
+	localCount: 12,
+	edges: [
+		[],
+		[0],
+		[],
+		[2],
+		[],
+		[4],
+		[],
+		[6],
+		[],
+		[8],
+		[],
+		[
+			1,
+			3,
+			5,
+			7,
+			9,
+			10
+		]
+	],
+	bindings: [
+		[],
+		[["a"]],
+		[],
+		[["b"]],
+		[],
+		[["*"]],
+		[],
+		[[]],
+		[],
+		[["default"]],
+		[],
+		[]
+	],
+	dynamicEdges: [
+		[],
+		[],
+		[],
+		[],
+		[],
+		[],
+		[],
+		[],
+		[],
+		[],
+		[12],
+		[]
+	]
+});
+//#region named/target.js
+var target_exports$4 = /* @__PURE__ */ __exportAll({
+	a: () => 0,
+	b: () => "b"
+});
+const target_hot$4 = __rolldown_runtime__.createModuleHotContext("named/target.js");
+__rolldown_runtime__.registerModule("named/target.js", { exports: target_exports$4 });
+globalThis.namedAcceptCount ??= 0;
+target_hot$4.acceptExports(["a"], (mod) => {
+	globalThis.namedAcceptCount++;
+	assert.strictEqual(mod.a, 1);
+});
+//#endregion
+//#region named/importer.js
+var importer_exports$5 = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("named/importer.js");
+__rolldown_runtime__.registerModule("named/importer.js", { exports: importer_exports$5 });
+globalThis.namedImporterRuns ??= 0;
+globalThis.namedImporterRuns++;
+globalThis.namedImporterSawA = 0;
+//#endregion
+//#region non_accepted/target.js
+var target_exports$3 = /* @__PURE__ */ __exportAll({
+	a: () => 0,
+	b: () => "b"
+});
+const target_hot$3 = __rolldown_runtime__.createModuleHotContext("non_accepted/target.js");
+__rolldown_runtime__.registerModule("non_accepted/target.js", { exports: target_exports$3 });
+globalThis.nonAcceptedAcceptCount ??= 0;
+target_hot$3.acceptExports(["a"], (mod) => {
+	globalThis.nonAcceptedAcceptCount++;
+	assert.strictEqual(mod.a, 1);
+});
+//#endregion
+//#region non_accepted/importer.js
+var importer_exports$4 = /* @__PURE__ */ __exportAll({});
+const importer_hot$4 = __rolldown_runtime__.createModuleHotContext("non_accepted/importer.js");
+__rolldown_runtime__.registerModule("non_accepted/importer.js", { exports: importer_exports$4 });
+globalThis.nonAcceptedImporterRuns ??= 0;
+globalThis.nonAcceptedImporterRuns++;
+globalThis.nonAcceptedImporterSawB = "b";
+globalThis.nonAcceptedImporterAcceptCount ??= 0;
+importer_hot$4.accept(() => {
+	globalThis.nonAcceptedImporterAcceptCount++;
+});
+//#endregion
+//#region promoted/target.js
+var target_exports$2 = /* @__PURE__ */ __exportAll({
+	a: () => 0,
+	b: () => "b"
+});
+const target_hot$2 = __rolldown_runtime__.createModuleHotContext("promoted/target.js");
+__rolldown_runtime__.registerModule("promoted/target.js", { exports: target_exports$2 });
+globalThis.promotedAcceptCount ??= 0;
+target_hot$2.acceptExports(["a", "b"], (mod) => {
+	globalThis.promotedAcceptCount++;
+	assert.strictEqual(mod.a, 1);
+});
+//#endregion
+//#region promoted/importer.js
+var importer_exports$3 = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("promoted/importer.js");
+__rolldown_runtime__.registerModule("promoted/importer.js", { exports: importer_exports$3 });
+globalThis.promotedImporterRuns ??= 0;
+globalThis.promotedImporterRuns++;
+//#endregion
+//#region side_effect/target.js
+var target_exports$1 = /* @__PURE__ */ __exportAll({ a: () => 0 });
+const target_hot$1 = __rolldown_runtime__.createModuleHotContext("side_effect/target.js");
+__rolldown_runtime__.registerModule("side_effect/target.js", { exports: target_exports$1 });
+globalThis.sideEffectAcceptCount ??= 0;
+target_hot$1.acceptExports([], (mod) => {
+	globalThis.sideEffectAcceptCount++;
+	assert.strictEqual(mod.a, 1);
+});
+//#endregion
+//#region side_effect/importer.js
+var importer_exports$2 = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("side_effect/importer.js");
+__rolldown_runtime__.registerModule("side_effect/importer.js", { exports: importer_exports$2 });
+globalThis.sideEffectImporterRuns ??= 0;
+globalThis.sideEffectImporterRuns++;
+//#endregion
+//#region default_import/target.js
+var target_exports = /* @__PURE__ */ __exportAll({
+	a: () => "a",
+	default: () => 0
+});
+const target_hot = __rolldown_runtime__.createModuleHotContext("default_import/target.js");
+__rolldown_runtime__.registerModule("default_import/target.js", { exports: target_exports });
+globalThis.defaultImportAcceptCount ??= 0;
+target_hot.acceptExports(["default"], (mod) => {
+	globalThis.defaultImportAcceptCount++;
+	assert.strictEqual(mod.default, 1);
+});
+//#endregion
+//#region default_import/importer.js
+var importer_exports$1 = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("default_import/importer.js");
+__rolldown_runtime__.registerModule("default_import/importer.js", { exports: importer_exports$1 });
+globalThis.defaultImportImporterRuns ??= 0;
+globalThis.defaultImportImporterRuns++;
+globalThis.defaultImportImporterSaw = 0;
+//#endregion
+//#region dynamic_import/importer.js
+var importer_exports = /* @__PURE__ */ __exportAll({});
+const importer_hot = __rolldown_runtime__.createModuleHotContext("dynamic_import/importer.js");
+__rolldown_runtime__.registerModule("dynamic_import/importer.js", { exports: importer_exports });
+globalThis.dynamicImportImporterRuns ??= 0;
+globalThis.dynamicImportImporterRuns++;
+import("./target.js").then((mod) => {
+	globalThis.dynamicImportImporterSawA = mod.a;
+});
+importer_hot.accept();
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+process.on("beforeExit", (code) => {
+	if (code !== 0) return;
+	assert.strictEqual(globalThis.namedAcceptCount, 1);
+	assert.strictEqual(globalThis.nonAcceptedAcceptCount, 1);
+	assert.strictEqual(globalThis.promotedAcceptCount, 1);
+	assert.strictEqual(globalThis.sideEffectAcceptCount, 1);
+	assert.strictEqual(globalThis.defaultImportAcceptCount, 1);
+	assert.strictEqual(globalThis.dynamicImportAcceptCount, 1);
+	assert.strictEqual(globalThis.namedImporterRuns, 1);
+	assert.strictEqual(globalThis.promotedImporterRuns, 1);
+	assert.strictEqual(globalThis.sideEffectImporterRuns, 1);
+	assert.strictEqual(globalThis.defaultImportImporterRuns, 1);
+	assert.strictEqual(globalThis.namedImporterSawA, 0);
+	assert.strictEqual(globalThis.defaultImportImporterSaw, 0);
+	assert.strictEqual(globalThis.nonAcceptedImporterRuns, 2);
+	assert.strictEqual(globalThis.nonAcceptedImporterSawB, "b2");
+	assert.strictEqual(globalThis.nonAcceptedImporterAcceptCount, 1);
+	assert.strictEqual(globalThis.dynamicImportImporterRuns, 2);
+	assert.strictEqual(globalThis.dynamicImportImporterSawA, 1);
+});
+//#endregion
+export { __exportAll as t };
+
+```
+
+## target.js
+
+```js
+import { t as __exportAll } from "./main.js";
+import assert from "node:assert";
+__rolldown_runtime__.registerGraph({
+	ids: ["dynamic_import/target.js"],
+	localCount: 1,
+	edges: [[]],
+	dynamicEdges: [[]]
+});
+//#region dynamic_import/target.js
+var target_exports = /* @__PURE__ */ __exportAll({
+	a: () => 0,
+	b: () => "b"
+});
+const target_hot = __rolldown_runtime__.createModuleHotContext("dynamic_import/target.js");
+__rolldown_runtime__.registerModule("dynamic_import/target.js", { exports: target_exports });
+const a = 0;
+globalThis.dynamicImportAcceptCount ??= 0;
+target_hot.acceptExports(["a"], (mod) => {
+	globalThis.dynamicImportAcceptCount++;
+	assert.strictEqual(mod.a, 1);
+});
+//#endregion
+export { a };
+
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["named/target.js"],localCount:1,edges:[[]],dynamicEdges:[[]]});
+//#region named/target.js
+import * as import_node_assert_00 from "node:assert";
+__rolldown_runtime__.registerFactory("named/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			a: () => a,
+			b: () => b
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = 1;
+		const b = "b";
+		hot_target.acceptExports(["a"], () => {
+			import_node_assert_00.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- named/target.js
+
+# HMR Step 1
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["non_accepted/importer.js","non_accepted/target.js"],localCount:2,edges:[[1],[]],bindings:[[["b"]],[]],dynamicEdges:[[],[]]});
+//#region non_accepted/importer.js
+__rolldown_runtime__.registerFactory("non_accepted/importer.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("non_accepted/target.js");
+		var import_target_00 = __rolldown_runtime__.loadExports("non_accepted/target.js");
+		const hot_importer = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		globalThis.nonAcceptedImporterRuns ??= 0;
+		globalThis.nonAcceptedImporterRuns++;
+		globalThis.nonAcceptedImporterSawB = import_target_00.b;
+		globalThis.nonAcceptedImporterAcceptCount ??= 0;
+		hot_importer.accept(() => {
+			globalThis.nonAcceptedImporterAcceptCount++;
+		});
+	} finally {}
+}));
+
+//#endregion
+//#region non_accepted/target.js
+import * as import_node_assert_10 from "node:assert";
+__rolldown_runtime__.registerFactory("non_accepted/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			a: () => a,
+			b: () => b
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = 1;
+		const b = "b2";
+		hot_target.acceptExports(["a"], () => {
+			import_node_assert_10.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- non_accepted/target.js
+
+# HMR Step 2
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["main.js","promoted/importer.js","promoted/target.js","named/importer.js","non_accepted/importer.js","side_effect/importer.js","default_import/importer.js","dynamic_import/importer.js"],localCount:3,edges:[[3,4,1,5,6,7],[2],[]],bindings:[[],[["*"]],[]],dynamicEdges:[[],[],[]]});
+//#region main.js
+import * as import_node_assert_00 from "node:assert";
+__rolldown_runtime__.registerFactory("main.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("named/importer.js");
+		var import_importer_01 = __rolldown_runtime__.loadExports("named/importer.js");
+		__rolldown_runtime__.initModule("non_accepted/importer.js");
+		var import_importer_02 = __rolldown_runtime__.loadExports("non_accepted/importer.js");
+		__rolldown_runtime__.initModule("promoted/importer.js");
+		var import_importer_03 = __rolldown_runtime__.loadExports("promoted/importer.js");
+		__rolldown_runtime__.initModule("side_effect/importer.js");
+		var import_importer_04 = __rolldown_runtime__.loadExports("side_effect/importer.js");
+		__rolldown_runtime__.initModule("default_import/importer.js");
+		var import_importer_05 = __rolldown_runtime__.loadExports("default_import/importer.js");
+		__rolldown_runtime__.initModule("dynamic_import/importer.js");
+		var import_importer_06 = __rolldown_runtime__.loadExports("dynamic_import/importer.js");
+		const hot_main = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		process.on("beforeExit", (code) => {
+			if (code !== 0) return;
+			import_node_assert_00.default.strictEqual(globalThis.namedAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.nonAcceptedAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.promotedAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.sideEffectAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.defaultImportAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.dynamicImportAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.namedImporterRuns, 1);
+			import_node_assert_00.default.strictEqual(globalThis.promotedImporterRuns, 1);
+			import_node_assert_00.default.strictEqual(globalThis.sideEffectImporterRuns, 1);
+			import_node_assert_00.default.strictEqual(globalThis.defaultImportImporterRuns, 1);
+			import_node_assert_00.default.strictEqual(globalThis.namedImporterSawA, 0);
+			import_node_assert_00.default.strictEqual(globalThis.defaultImportImporterSaw, 0);
+			import_node_assert_00.default.strictEqual(globalThis.nonAcceptedImporterRuns, 2);
+			import_node_assert_00.default.strictEqual(globalThis.nonAcceptedImporterSawB, "b2");
+			import_node_assert_00.default.strictEqual(globalThis.nonAcceptedImporterAcceptCount, 1);
+			import_node_assert_00.default.strictEqual(globalThis.dynamicImportImporterRuns, 2);
+			import_node_assert_00.default.strictEqual(globalThis.dynamicImportImporterSawA, 1);
+		});
+	} finally {}
+}));
+
+//#endregion
+//#region promoted/importer.js
+__rolldown_runtime__.registerFactory("promoted/importer.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		__rolldown_runtime__.initModule("promoted/target.js");
+		var import_target_10 = __rolldown_runtime__.loadExports("promoted/target.js");
+		const hot_importer = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		globalThis.promotedImporterRuns ??= 0;
+		globalThis.promotedImporterRuns++;
+	} finally {}
+}));
+
+//#endregion
+//#region promoted/target.js
+import * as import_node_assert_20 from "node:assert";
+__rolldown_runtime__.registerFactory("promoted/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			a: () => a,
+			b: () => b
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = 1;
+		const b = "b";
+		hot_target.acceptExports(["a", "b"], () => {
+			import_node_assert_20.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- promoted/target.js
+
+# HMR Step 3
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["side_effect/target.js"],localCount:1,edges:[[]],dynamicEdges:[[]]});
+//#region side_effect/target.js
+import * as import_node_assert_00 from "node:assert";
+__rolldown_runtime__.registerFactory("side_effect/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ a: () => a });
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = 1;
+		hot_target.acceptExports([], () => {
+			import_node_assert_00.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- side_effect/target.js
+
+# HMR Step 4
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["default_import/target.js"],localCount:1,edges:[[]],dynamicEdges:[[]]});
+//#region default_import/target.js
+import * as import_node_assert_00 from "node:assert";
+__rolldown_runtime__.registerFactory("default_import/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			default: () => __rolldown_default__,
+			a: () => a
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		var __rolldown_default__ = 1;
+		const a = "a";
+		hot_target.acceptExports(["default"], () => {
+			import_node_assert_00.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- default_import/target.js
+
+# HMR Step 5
+
+## Code
+
+```js
+__rolldown_runtime__.registerGraph({ids:["dynamic_import/importer.js","dynamic_import/target.js"],localCount:2,edges:[[],[]],dynamicEdges:[[1],[]]});
+//#region dynamic_import/importer.js
+__rolldown_runtime__.registerFactory("dynamic_import/importer.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		__rolldown_runtime__.registerModule(__rolldown_module_id__);
+		const hot_importer = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		globalThis.dynamicImportImporterRuns ??= 0;
+		globalThis.dynamicImportImporterRuns++;
+		(__rolldown_runtime__.initModule("dynamic_import/target.js"), Promise.resolve().then(() => __rolldown_runtime__.loadExports("dynamic_import/target.js"))).then((mod) => {
+			globalThis.dynamicImportImporterSawA = mod.a;
+		});
+		hot_importer.accept();
+	} finally {}
+}));
+
+//#endregion
+//#region dynamic_import/target.js
+import * as import_node_assert_10 from "node:assert";
+__rolldown_runtime__.registerFactory("dynamic_import/target.js", "esm", (function(__rolldown_module_id__) {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
+			a: () => a,
+			b: () => b
+		});
+		__rolldown_runtime__.registerModule(__rolldown_module_id__, { exports: __rolldown_exports__ });
+		const hot_target = __rolldown_runtime__.createModuleHotContext(__rolldown_module_id__);
+		const a = 1;
+		const b = "b";
+		hot_target.acceptExports(["a"], () => {
+			import_node_assert_10.default.fail("the last generation has no further edit to accept");
+		});
+	} finally {}
+}));
+
+//#endregion
+```
+
+## Meta
+
+- update type: patch
+
+### Changed Ids
+
+- dynamic_import/target.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/importer.js
@@ -1,0 +1,5 @@
+import value from './target.js';
+
+globalThis.defaultImportImporterRuns ??= 0;
+globalThis.defaultImportImporterRuns++;
+globalThis.defaultImportImporterSaw = value;

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/target.hmr-4.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/target.hmr-4.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export default 1;
+export const a = 'a';
+
+import.meta.hot.acceptExports(['default'], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/default_import/target.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+
+export default 0;
+export const a = 'a';
+
+globalThis.defaultImportAcceptCount ??= 0;
+import.meta.hot.acceptExports(['default'], (mod) => {
+  globalThis.defaultImportAcceptCount++;
+  assert.strictEqual(mod.default, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/importer.js
@@ -1,0 +1,8 @@
+globalThis.dynamicImportImporterRuns ??= 0;
+globalThis.dynamicImportImporterRuns++;
+
+import('./target.js').then((mod) => {
+  globalThis.dynamicImportImporterSawA = mod.a;
+});
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/target.hmr-5.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/target.hmr-5.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export const a = 1;
+export const b = 'b';
+
+import.meta.hot.acceptExports(['a'], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/dynamic_import/target.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+
+export const a = 0;
+export const b = 'b';
+
+globalThis.dynamicImportAcceptCount ??= 0;
+import.meta.hot.acceptExports(['a'], (mod) => {
+  globalThis.dynamicImportAcceptCount++;
+  assert.strictEqual(mod.a, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/main.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import './named/importer';
+import './non_accepted/importer';
+import './promoted/importer';
+import './side_effect/importer';
+import './default_import/importer';
+import './dynamic_import/importer';
+
+process.on('beforeExit', (code) => {
+  if (code !== 0) return;
+  assert.strictEqual(globalThis.namedAcceptCount, 1);
+  assert.strictEqual(globalThis.nonAcceptedAcceptCount, 1);
+  assert.strictEqual(globalThis.promotedAcceptCount, 1);
+  assert.strictEqual(globalThis.sideEffectAcceptCount, 1);
+  assert.strictEqual(globalThis.defaultImportAcceptCount, 1);
+  assert.strictEqual(globalThis.dynamicImportAcceptCount, 1);
+
+  assert.strictEqual(globalThis.namedImporterRuns, 1);
+  assert.strictEqual(globalThis.promotedImporterRuns, 1);
+  assert.strictEqual(globalThis.sideEffectImporterRuns, 1);
+  assert.strictEqual(globalThis.defaultImportImporterRuns, 1);
+  assert.strictEqual(globalThis.namedImporterSawA, 0);
+  assert.strictEqual(globalThis.defaultImportImporterSaw, 0);
+
+  assert.strictEqual(globalThis.nonAcceptedImporterRuns, 2);
+  assert.strictEqual(globalThis.nonAcceptedImporterSawB, 'b2');
+  assert.strictEqual(globalThis.nonAcceptedImporterAcceptCount, 1);
+  assert.strictEqual(globalThis.dynamicImportImporterRuns, 2);
+  assert.strictEqual(globalThis.dynamicImportImporterSawA, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/importer.js
@@ -1,0 +1,5 @@
+import { a } from './target.js';
+
+globalThis.namedImporterRuns ??= 0;
+globalThis.namedImporterRuns++;
+globalThis.namedImporterSawA = a;

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/target.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/target.hmr-0.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export const a = 1;
+export const b = 'b';
+
+import.meta.hot.acceptExports(['a'], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/named/target.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+
+export const a = 0;
+export const b = 'b';
+
+globalThis.namedAcceptCount ??= 0;
+import.meta.hot.acceptExports(['a'], (mod) => {
+  globalThis.namedAcceptCount++;
+  assert.strictEqual(mod.a, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/importer.js
@@ -1,0 +1,10 @@
+import { b } from './target.js';
+
+globalThis.nonAcceptedImporterRuns ??= 0;
+globalThis.nonAcceptedImporterRuns++;
+globalThis.nonAcceptedImporterSawB = b;
+
+globalThis.nonAcceptedImporterAcceptCount ??= 0;
+import.meta.hot.accept(() => {
+  globalThis.nonAcceptedImporterAcceptCount++;
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/target.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/target.hmr-1.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export const a = 1;
+export const b = 'b2';
+
+import.meta.hot.acceptExports(['a'], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/non_accepted/target.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+
+export const a = 0;
+export const b = 'b';
+
+globalThis.nonAcceptedAcceptCount ??= 0;
+import.meta.hot.acceptExports(['a'], (mod) => {
+  globalThis.nonAcceptedAcceptCount++;
+  assert.strictEqual(mod.a, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/importer.js
@@ -1,0 +1,4 @@
+import * as ns from './target.js';
+
+globalThis.promotedImporterRuns ??= 0;
+globalThis.promotedImporterRuns++;

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/target.hmr-2.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/target.hmr-2.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+export const a = 1;
+export const b = 'b';
+
+import.meta.hot.acceptExports(['a', 'b'], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/promoted/target.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+
+export const a = 0;
+export const b = 'b';
+
+globalThis.promotedAcceptCount ??= 0;
+import.meta.hot.acceptExports(['a', 'b'], (mod) => {
+  globalThis.promotedAcceptCount++;
+  assert.strictEqual(mod.a, 1);
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/importer.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/importer.js
@@ -1,0 +1,4 @@
+import './target.js';
+
+globalThis.sideEffectImporterRuns ??= 0;
+globalThis.sideEffectImporterRuns++;

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/target.hmr-3.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/target.hmr-3.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+
+export const a = 1;
+
+import.meta.hot.acceptExports([], () => {
+  assert.fail('the last generation has no further edit to accept');
+});

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/target.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept_exports/side_effect/target.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+
+export const a = 0;
+
+globalThis.sideEffectAcceptCount ??= 0;
+import.meta.hot.acceptExports([], (mod) => {
+  globalThis.sideEffectAcceptCount++;
+  assert.strictEqual(mod.a, 1);
+});

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -214,6 +214,8 @@ bitflags! {
         const UnknownExportsRead = 1 << 7;
         /// Top-level return statement (only valid in CommonJS)
         const TopLevelReturn = 1 << 8;
+        /// `import.meta.hot.acceptExports(...)` is called somewhere in the module
+        const HmrAcceptExports = 1 << 9;
         const ModuleOrExports = Self::ModuleRef.bits() | Self::ExportsRef.bits();
     }
 }

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -263,6 +263,10 @@ impl NormalModule {
   pub fn can_accept_hmr_dependency_for(&self, module_id: &ModuleId) -> bool {
     self.hmr_info.deps.contains(module_id)
   }
+
+  pub fn is_hmr_partially_accepting_module(&self) -> bool {
+    self.ast_usage.contains(EcmaModuleAstUsage::HmrAcceptExports)
+  }
 }
 
 #[derive(Debug)]

--- a/crates/rolldown_common/src/types/hmr_info.rs
+++ b/crates/rolldown_common/src/types/hmr_info.rs
@@ -1,4 +1,5 @@
 use arcstr::ArcStr;
+use oxc_str::CompactStr;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{ImportRecordIdx, ModuleId};
@@ -7,4 +8,7 @@ use crate::{ImportRecordIdx, ModuleId};
 pub struct HmrInfo {
   pub deps: FxHashSet<ModuleId>,
   pub module_request_to_import_record_idx: FxHashMap<ArcStr, ImportRecordIdx>,
+  /// Export names passed to `import.meta.hot.acceptExports` as string literals. `None` when
+  /// the module does not call it, or passes a value the scanner cannot read.
+  pub accepted_exports: Option<FxHashSet<CompactStr>>,
 }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/expression_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/expression_ext.rs
@@ -13,6 +13,7 @@ pub trait ExpressionExt<'ast> {
   fn is_import_meta_url(&self) -> bool;
   fn is_import_meta_hot(&self) -> bool;
   fn is_import_meta_hot_accept(&self) -> bool;
+  fn is_import_meta_hot_accept_exports(&self) -> bool;
 }
 
 impl<'ast> ExpressionExt<'ast> for ast::Expression<'ast> {
@@ -64,5 +65,11 @@ impl<'ast> ExpressionExt<'ast> for ast::Expression<'ast> {
   fn is_import_meta_hot_accept(&self) -> bool {
     matches!(self, ast::Expression::StaticMemberExpression(member_expr)
     if member_expr.property.name == "accept" && member_expr.object.is_import_meta_hot())
+  }
+
+  /// Check if the expression is `import.meta.hot.acceptExports`
+  fn is_import_meta_hot_accept_exports(&self) -> bool {
+    matches!(self, ast::Expression::StaticMemberExpression(member_expr)
+    if member_expr.property.name == "acceptExports" && member_expr.object.is_import_meta_hot())
   }
 }

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -23,10 +23,12 @@ class Module {
 }
 
 /**
- * Compiler-emitted module-graph delta — pure topology (static + dynamic edges).
+ * Compiler-emitted module-graph delta — topology (static + dynamic edges).
  * `ids[0, localCount)` are the modules this payload carries; `ids[localCount, …)` are foreign edge targets.
  * `edges[i]` / `dynamicEdges[i]` are the static / dynamic-`import()` out-edges of `ids[i]`.
- * @typedef {{ ids: string[], localCount: number, edges: number[][], dynamicEdges?: number[][] }} ModuleGraphDelta
+ * `bindings[i][j]` are the export names `ids[i]` imports through `edges[i][j]`; a missing or
+ * `null` entry means the whole namespace.
+ * @typedef {{ ids: string[], localCount: number, edges: number[][], bindings?: (string[] | null)[][], dynamicEdges?: number[][] }} ModuleGraphDelta
  * @typedef {{ createModuleHotContext(moduleId: string): any, onModuleCacheRemoval(moduleId: string): void }} DevRuntimeHooks
  */
 
@@ -57,7 +59,7 @@ export class DevRuntime {
   /**
    * Static import edges from `registerGraph` — entries persist across `removeModuleCache`
    * and change only by replacement from a newer payload (last write wins).
-   * @type {Map<string, { edges: string[] }>}
+   * @type {Map<string, { edges: string[], bindings: string[][] }>}
    */
   staticImports = new Map();
   /**
@@ -116,7 +118,8 @@ export class DevRuntime {
         }
         importerSet.add(id);
       }
-      this.staticImports.set(id, { edges });
+      const bindings = edges.map((_, j) => delta.bindings?.[i]?.[j] ?? ['*']);
+      this.staticImports.set(id, { edges, bindings });
 
       // Dynamic `import()` edges are maintained in a parallel reverse index with the same
       // last-write-wins bookkeeping; `getImporters` unions the two.
@@ -168,6 +171,23 @@ export class DevRuntime {
       return [...(this.importers.get(id) ?? [])];
     }
     return [...new Set([...(this.importers.get(id) ?? []), ...dynamic])];
+  }
+
+  /**
+   * `"*"` means the whole namespace, an empty list a side-effect-only import, `undefined` no edge.
+   * @param {string} importer
+   * @param {string} id
+   * @returns {string[] | undefined}
+   */
+  getImportedBindings(importer, id) {
+    const record = this.staticImports.get(importer);
+    const j = record ? record.edges.indexOf(id) : -1;
+    const names = j === -1 ? undefined : record?.bindings[j];
+    if (!this.dynamicImports.get(importer)?.edges.includes(id)) {
+      return names;
+    }
+    if (!names) return ['*'];
+    return names.includes('*') ? names : [...names, '*'];
   }
 
   /**

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -10,6 +10,10 @@ class TestHotContext {
   moduleId;
   /** @type {{ deps: string, cb: Function }[]} */
   callbacks = [];
+  /** @type {Set<string> | null} */
+  acceptedExports = null;
+  /** @type {WeakSet<Function>} */
+  partialCallbacks = new WeakSet();
 
   /**
    * @param {string} moduleId
@@ -30,6 +34,20 @@ class TestHotContext {
       return;
     }
     this.callbacks.push({ deps: args[0], cb: args[1] ?? (() => {}) });
+  }
+
+  /**
+   * @param {string | readonly string[]} exportNames
+   * @param {Function} [cb]
+   */
+  acceptExports(exportNames, cb) {
+    this.acceptedExports ??= new Set();
+    for (const name of typeof exportNames === 'string' ? [exportNames] : exportNames) {
+      this.acceptedExports.add(name);
+    }
+    const callback = cb ?? (() => {});
+    this.partialCallbacks.add(callback);
+    this.callbacks.push({ deps: this.moduleId, cb: callback });
   }
 }
 
@@ -65,6 +83,28 @@ class TestDevRuntime extends BaseDevRuntime {
     return ctx.callbacks.some(({ deps }) =>
       Array.isArray(deps) ? deps.includes(dep) : deps === dep,
     );
+  }
+
+  /**
+   * @param {string} id
+   */
+  isSelfAccepting(id) {
+    const ctx = this.contexts.get(id);
+    if (!ctx) return false;
+    const plainSelfAccept = ctx.callbacks.some(
+      ({ deps, cb }) => deps === id && !ctx.partialCallbacks.has(cb),
+    );
+    if (plainSelfAccept || !ctx.acceptedExports) return plainSelfAccept;
+    const accepted = ctx.acceptedExports;
+    return Object.keys(this.loadExports(id)).every((name) => accepted.has(name));
+  }
+
+  /**
+   * @param {string} id
+   * @returns {Set<string> | null}
+   */
+  acceptedExportsOf(id) {
+    return this.contexts.get(id)?.acceptedExports ?? null;
   }
 
   /**
@@ -127,18 +167,29 @@ class TestDevRuntime extends BaseDevRuntime {
     if (traversedModules.has(id)) return;
     traversedModules.add(id);
     updateSet.add(id);
-    if (this.acceptsDepOf(id, id)) {
+    if (this.isSelfAccepting(id)) {
       boundaries.push([id, id]);
       return;
     }
+    const acceptedExports = this.acceptedExportsOf(id);
+    if (acceptedExports) {
+      boundaries.push([id, id]);
+    }
     const parents = this.getImporters(id).filter((p) => this.isExecuted(p));
     if (!parents.length) {
-      return `no hmr boundary found for module \`${id}\``;
+      return acceptedExports ? undefined : `no hmr boundary found for module \`${id}\``;
     }
     for (const parent of parents) {
+      if (acceptedExports && parent === id) continue;
       if (this.acceptsDepOf(parent, id)) {
         boundaries.push([parent, id]);
         continue;
+      }
+      if (acceptedExports) {
+        const bindings = this.getImportedBindings(parent, id);
+        if (bindings && bindings.every((name) => acceptedExports.has(name))) {
+          continue;
+        }
       }
       if (stack.includes(parent)) {
         return `circular import chain between \`${id}\` and \`${parent}\``;

--- a/packages/rolldown/tests/dev/dev-runtime.test.ts
+++ b/packages/rolldown/tests/dev/dev-runtime.test.ts
@@ -72,6 +72,70 @@ test('registerGraph maintains static + dynamic reverse indexes; getImporters uni
   expect(runtime.getImporters('both.js')).toEqual(['app.js']);
 });
 
+test('registerGraph keeps the export names each static edge imports', async () => {
+  const { runtime } = await createRuntime();
+
+  // app → named (imports `a`, `default`), app → effect (side-effect only), app ⇢ lazy
+  runtime.registerGraph({
+    ids: ['app.js', 'named.js', 'effect.js', 'lazy.js'],
+    localCount: 4,
+    edges: [[1, 2], [], [], []],
+    bindings: [[['a', 'default'], []], [], [], []],
+    dynamicEdges: [[3], [], [], []],
+  });
+  expect(runtime.getImportedBindings('app.js', 'named.js')).toEqual(['a', 'default']);
+  expect(runtime.getImportedBindings('app.js', 'effect.js')).toEqual([]);
+  // a dynamic import() reads the whole namespace
+  expect(runtime.getImportedBindings('app.js', 'lazy.js')).toEqual(['*']);
+  expect(runtime.getImportedBindings('app.js', 'missing.js')).toBeUndefined();
+
+  // a static edge and a dynamic import() to the same module: the import() reads everything
+  runtime.registerGraph({
+    ids: ['both.js', 'dep.js'],
+    localCount: 2,
+    edges: [[1], []],
+    bindings: [[['a']], []],
+    dynamicEdges: [[1], []],
+  });
+  expect(runtime.getImportedBindings('both.js', 'dep.js')).toEqual(['a', '*']);
+  runtime.registerGraph({
+    ids: ['both.js', 'dep.js'],
+    localCount: 2,
+    edges: [[1], []],
+    bindings: [[['*', 'a']], []],
+    dynamicEdges: [[1], []],
+  });
+  expect(runtime.getImportedBindings('both.js', 'dep.js')).toEqual(['*', 'a']);
+
+  // re-carrying a module replaces its names (last write wins)
+  runtime.registerGraph({
+    ids: ['app.js', 'named.js'],
+    localCount: 2,
+    edges: [[1], []],
+    bindings: [[['b']], []],
+  });
+  expect(runtime.getImportedBindings('app.js', 'named.js')).toEqual(['b']);
+
+  // `null` and missing trailing entries mean "imports everything"
+  runtime.registerGraph({
+    ids: ['sparse.js', 'x.js', 'y.js', 'z.js'],
+    localCount: 4,
+    edges: [[1, 2, 3], [], [], []],
+    bindings: [[null, ['a']], [], [], []],
+  });
+  expect(runtime.getImportedBindings('sparse.js', 'x.js')).toEqual(['*']);
+  expect(runtime.getImportedBindings('sparse.js', 'y.js')).toEqual(['a']);
+  expect(runtime.getImportedBindings('sparse.js', 'z.js')).toEqual(['*']);
+
+  // a payload without `bindings` (an older compiler) is read as "imports everything"
+  runtime.registerGraph({
+    ids: ['old.js', 'dep.js'],
+    localCount: 2,
+    edges: [[1], []],
+  });
+  expect(runtime.getImportedBindings('old.js', 'dep.js')).toEqual(['*']);
+});
+
 test('initModule is registry-gated and returns the live exports', async () => {
   const { runtime } = await createRuntime();
   const factory = vi.fn((id: string) => {

--- a/packages/test-dev-server/src/vite-server.ts
+++ b/packages/test-dev-server/src/vite-server.ts
@@ -346,6 +346,7 @@ function toViteConfig(
     },
     experimental: {
       bundledDev: true,
+      hmrPartialAccept: true,
     },
     // Vite 8 runs rolldown natively, so the fixtures' rolldown-style plugins
     // (transform/generateBundle hooks, rolldown builtin plugins) pass through

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/__tests__/hmr-accept-exports.spec.ts
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/__tests__/hmr-accept-exports.spec.ts
@@ -7,23 +7,14 @@ import {
   waitForBuildStable,
 } from '~utils';
 
-// Ports Vite's `hmr` acceptExports behavior. On the client `acceptExports(names, cb)` is a
-// self-accept (export-name filtering is a server-side concern), so editing the module should
-// run the callback with the fresh module rather than full-reloading.
-
 describe('hmr-accept-exports', () => {
   test('renders the initial value', async () => {
     await waitForBuildStable();
     await expect.poll(() => page.textContent('.value')).toBe('exports-v1');
+    await expect.poll(() => page.textContent('.main-runs')).toBe('1');
   });
 
-  // KNOWN GAP: rolldown's scanner recognizes `import.meta.hot.accept(...)` as self-accepting
-  // but not `acceptExports(...)`, so the module's compile-side `HmrSelfAccept` flag is unset.
-  // The server-side propagation walk (`crates/rolldown/src/hmr/hmr_stage.rs` —
-  // `is_hmr_self_accepting_module`) then treats the edit as having no boundary and sends a
-  // full reload, even though the client already registered the self-accept at runtime.
-  // Verified: this currently full-reloads. Unskip once the compiler recognizes acceptExports.
-  test.skip('acceptExports hot-updates via its callback', async () => {
+  test('an importer that reads only accepted exports is not re-run', async () => {
     await waitForBuildStable();
     await plantReloadMarker();
 
@@ -31,6 +22,30 @@ describe('hmr-accept-exports', () => {
     await expect.poll(() => page.textContent('.value')).toBe('exports-v2');
 
     expect(await readReloadMarker()).toBe('alive');
+    expect(await page.textContent('.main-runs')).toBe('1');
+    expect(await page.textContent('.main-saw')).toBe('exports-v1');
+    await waitForBuildStable();
+  });
+
+  // needs the Vite client half of rolldown#10061 (`acceptExports` in `bundledDevHmrClient.ts`)
+  test.skip('an importer that reads a non-accepted export reloads the page', async () => {
+    await waitForBuildStable();
+    await plantReloadMarker();
+    editFile('main.js', (code) =>
+      code
+        .replace("import { value } from './app.js';", "import { value, other } from './app.js';")
+        .replace('String(globalThis.__mainRuns);', 'String(globalThis.__mainRuns) + other;'),
+    );
+    await expect.poll(() => readReloadMarker()).toBe(null);
+    await expect.poll(() => page.textContent('.main-runs')).toBe('1other');
+    await waitForBuildStable();
+
+    await plantReloadMarker();
+    editFile('app.js', (code) => code.replace("'exports-v2'", "'exports-v3'"));
+    await expect.poll(() => page.textContent('.value')).toBe('exports-v3');
+    await expect.poll(() => readReloadMarker()).toBe(null);
+    await expect.poll(() => page.textContent('.main-runs')).toBe('1other');
+    await expect.poll(() => page.textContent('.main-saw')).toBe('exports-v3');
     await waitForBuildStable();
   });
 });

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/app.js
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/app.js
@@ -1,7 +1,5 @@
-// `acceptExports(names, cb)` — on the client this behaves as a self-accept (the export
-// names are a server-side concern). Editing this module runs the callback with the fresh
-// module instead of full-reloading.
 export const value = 'exports-v1';
+export const other = 'other';
 document.querySelector('.value').textContent = value;
 
 import.meta.hot?.acceptExports(['value'], (mod) => {

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/index.html
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/index.html
@@ -1,3 +1,5 @@
 <h1>HMR acceptExports</h1>
 <div class="value"></div>
+<div class="main-runs"></div>
+<div class="main-saw"></div>
 <script type="module" src="./main.js"></script>

--- a/packages/test-dev-server/tests/playground/hmr-accept-exports/main.js
+++ b/packages/test-dev-server/tests/playground/hmr-accept-exports/main.js
@@ -1,1 +1,5 @@
-import './app.js';
+import { value } from './app.js';
+
+globalThis.__mainRuns = (globalThis.__mainRuns ?? 0) + 1;
+document.querySelector('.main-runs').textContent = String(globalThis.__mainRuns);
+document.querySelector('.main-saw').textContent = value;


### PR DESCRIPTION
`import.meta.hot.acceptExports(names, cb)` lets a module accept its own change only for the listed exports. An importer that reads only those exports is left alone. An importer that reads any other export still gets the update.

Rolldown ships the export names each importer reads, so the browser can make the same decision. For each static import edge, the export names the importer reads. `"*"` means the whole namespace (`import * as ns`, `export * from`, `require()`, non-JS records). An empty list means a side-effect-only import.

```js
// header.js:  import { count } from './counter.js'
// title.js:   import { label } from './counter.js'
// main.js:    import './header.js'; import './title.js'
__rolldown_runtime__.registerGraph({
  ids: ["main.js", "header.js", "title.js", "counter.js"],
  localCount: 4,
  edges:    [[1, 2], [3], [3], []],
  bindings: [[], [["count"]], [["label"]], []],
  dynamicEdges: [[], [], [], []],
})
```

Vite: https://github.com/vitejs/vite/pull/23463

closes https://github.com/rolldown/rolldown/issues/10061