### PR TITLE
feat: support OpenBSD in the native binding

### DIFF
--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -73,15 +73,17 @@ sugar_path = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
-[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_family = "wasm")))'.dependencies]
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit", "v3"] }
 rolldown_tracking_allocator = { workspace = true, optional = true }
 
-[target.'cfg(all(any(target_os = "linux", target_os = "freebsd"), not(target_arch = "aarch64"), not(target_env = "ohos")))'.dependencies]
+# OpenBSD x64 needs `local_dynamic_tls` for thread-local storage, the same way
+# Linux and FreeBSD do.
+[target.'cfg(all(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"), not(target_arch = "aarch64"), not(target_env = "ohos")))'.dependencies]
 mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit", "local_dynamic_tls", "v3"] }
 rolldown_tracking_allocator = { workspace = true, optional = true }
 
-[target.'cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "android", target_os = "freebsd")))'.dependencies]
+[target.'cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "openbsd")))'.dependencies]
 mimalloc-safe = { workspace = true, features = [
   "skip_collect_on_exit",
   "no_opt_arch",


### PR DESCRIPTION
The FreeBSD rung is the model here.

## What

`crates/rolldown_binding/Cargo.toml` puts OpenBSD on the `local_dynamic_tls`
mimalloc branch, exactly as Linux and FreeBSD are. Without it the x64 build
links a mimalloc TLS path OpenBSD cannot satisfy.

## Verified on OpenBSD 8.0/amd64

```
cargo build --release -p rolldown_binding      # 4m47s -> target/release/librolldown_binding.so
```

The built addon loads in Node with 78 exports. More importantly the async
plugin hooks work. The WASM binding, which OpenBSD otherwise falls back to,
panics with `Access tokio runtime failed in spawn` (napi 3.9,
`tokio_runtime.rs:113`) on any asynchronous hook, which makes `tsdown` — and
therefore most Vite/Rolldown consumers — unusable. With the native binding, a
bundle using async `resolveId`/`load`/`transform`/`buildEnd` hooks completes.

## Why this PR is small

The packaging half — the napi target, the generated loader's `openbsd` branch,
and the release job — cannot live in this repo yet, and I would rather explain
that than hand you a red CI.

`packages/rolldown/src/binding.cjs` is generated by `napi build`, and
`just build-rolldown` is followed by `git diff --exit-code`. The `openbsd`
branch can therefore only come from the `@napi-rs/cli` template, which
currently knows darwin, freebsd, linux, win32, android and openharmony. That
is napi-rs#1183, and I have opened **napi-rs/napi-rs#3504** to add the target
and the template branch. My first revision of this PR carried the generated
hunk by hand and CI correctly rejected it — the invariant works.

Adding `x86_64-unknown-openbsd` to `napi.targets` before that lands would be
worse than doing nothing: `napi create-npm-dirs` and `napi artifacts` would
publish a `@rolldown/binding-openbsd-x64` package that the loader has no
branch to load.

So the order is: napi-rs#3504, a bump of `@napi-rs/cli` here, and then a
follow-up PR adding the napi target, the release job, and the OpenBSD job in
CI. I am happy to send that follow-up the moment #3504 is in — or to fold this
into it and close this one, whichever you prefer.
