### PR TITLE
fix(rolldown): order dynamic entries by reachability, not by path

### DIFF
--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc::span::Span;
@@ -155,8 +157,45 @@ impl<'a> LinkStage<'a> {
       .extract_if(0.., |item| !matches!(item.kind, EntryPointKind::UserDefined))
       .collect_vec();
 
+    // The order the graph first reaches each module, walking from the user-defined
+    // entries. `sort_modules` walks entries in this order, and for modules in an
+    // import cycle the entry the walk starts from is what decides which side of the
+    // cycle is executed first.
+    //
+    // A dynamic entry reached only through another one can never be evaluated before
+    // it at runtime, so ordering the two by path can pick an execution order that
+    // cannot happen, leaving a cyclic module to read a binding whose declaration has
+    // not run yet. Reach order models what the runtime does: the first dynamic import
+    // to fire is the first one the graph arrives at.
+    let reach_order = {
+      let modules = &scan_stage_output.module_table.modules;
+      let mut order = FxHashMap::default();
+      let mut queue = VecDeque::new();
+      for entry in &scan_stage_output.entry_points {
+        let next = order.len();
+        if order.insert(entry.idx, next).is_none() {
+          queue.push_back(entry.idx);
+        }
+      }
+      while let Some(idx) = queue.pop_front() {
+        for rec in modules[idx].import_records() {
+          let Some(dep) = rec.resolved_module else { continue };
+          if !order.contains_key(&dep) {
+            order.insert(dep, order.len());
+            queue.push_back(dep);
+          }
+        }
+      }
+      order
+    };
+
     rest.sort_by_cached_key(|item| {
-      (item.kind, scan_stage_output.module_table.modules[item.idx].id().as_str())
+      (
+        item.kind,
+        // Entries the walk never reaches keep their path-ordered position.
+        reach_order.get(&item.idx).copied().unwrap_or(usize::MAX),
+        scan_stage_output.module_table.modules[item.idx].id().as_str(),
+      )
     });
 
     scan_stage_output.entry_points.extend(rest);

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/_config.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "`routes.js` and `server.js` are both dynamic entries, and `routes.js` sorts first by path, but it can only be reached by first evaluating `server.js`, which is what dynamically imports it. `server.js` and `router.js` form an import cycle in which `server.js` calls `router.js`'s `toNamespace` while its own module body runs, so the cycle only works when `router.js` is executed first. Starting the walk at `routes.js` reverses that and leaves `toNamespace` hoisted-but-unassigned at the call site.",
+  "config": {
+    "format": "esm"
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/artifacts.snap
@@ -1,0 +1,64 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+const { serverExports } = await import("./server2.js");
+if (serverExports.name !== "server") throw new Error(`expected the namespace to be built, got ${serverExports.name}`);
+console.log("ok");
+//#endregion
+
+```
+
+## routes.js
+
+```js
+import { r as getRouter } from "./server.js";
+//#region routes.js
+const route = () => `route(${getRouter()})`;
+//#endregion
+export { route };
+
+```
+
+## server.js
+
+```js
+//#region router.js
+var toNamespace = (all) => {
+	const target = {};
+	for (const key in all) Object.defineProperty(target, key, {
+		value: all[key],
+		enumerable: true
+	});
+	return target;
+};
+const getRouter = () => `router(${getContext()})`;
+//#endregion
+//#region server.js
+function getContext() {
+	return "context";
+}
+async function loadRoutes() {
+	return [(await import("./routes.js")).route(), getRouter()];
+}
+const serverExports = toNamespace({
+	name: "server",
+	loadRoutes
+});
+//#endregion
+export { serverExports as n, getRouter as r, getContext as t };
+
+```
+
+## server2.js
+
+```js
+import { n as serverExports } from "./server.js";
+export { serverExports };
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/main.js
@@ -1,0 +1,8 @@
+const { serverExports } = await import('./server.js');
+
+// Throws `toNamespace is not a function` if the cycle is executed in the order
+// no runtime can produce.
+if (serverExports.name !== 'server') {
+  throw new Error(`expected the namespace to be built, got ${serverExports.name}`);
+}
+console.log('ok');

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/router.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/router.js
@@ -1,0 +1,16 @@
+import { getContext } from './server.js';
+
+// `var`, so an execution order that runs this module too late leaves the call
+// site with `undefined` rather than a TDZ error.
+var toNamespace = (all) => {
+  const target = {};
+  for (const key in all) {
+    Object.defineProperty(target, key, { value: all[key], enumerable: true });
+  }
+  return target;
+};
+
+// Deferred: the other half of the cycle is only read when this is called.
+export const getRouter = () => `router(${getContext()})`;
+
+export { toNamespace };

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/routes.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/routes.js
@@ -1,0 +1,3 @@
+import { getRouter } from './router.js';
+
+export const route = () => `route(${getRouter()})`;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/server.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle/server.js
@@ -1,0 +1,17 @@
+import { toNamespace, getRouter } from './router.js';
+
+export function getContext() {
+  return 'context';
+}
+
+async function loadRoutes() {
+  const routes = await import('./routes.js');
+  return [routes.route(), getRouter()];
+}
+
+// Runs while this module's body is evaluated, so `toNamespace` must already be
+// assigned by the time the cycle reaches here.
+export const serverExports = toNamespace({
+  name: 'server',
+  loadRoutes,
+});

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/namespace_dead_star_reexports/artifacts.snap
@@ -24,27 +24,27 @@ await init_main();
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
-//#region default-only.js
-function mark$1() {
-	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
-	return 42;
-}
-var default_only_default;
-function init_default_only() {
-	return (init_default_only = __esmMin((() => {
-		default_only_default = /* @__PURE__ */ mark$1();
-	})))();
-}
-//#endregion
 //#region shadowed.js
-function mark() {
+function mark$1() {
 	globalThis.shadowedValue = typeof globalThis.shadowedValue === "number" ? globalThis.shadowedValue + 1 : 0;
 	return 2;
 }
 var x;
 function init_shadowed() {
 	return (init_shadowed = __esmMin((() => {
-		x = /* @__PURE__ */ mark();
+		x = /* @__PURE__ */ mark$1();
+	})))();
+}
+//#endregion
+//#region default-only.js
+function mark() {
+	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
+	return 42;
+}
+var default_only_default;
+function init_default_only() {
+	return (init_default_only = __esmMin((() => {
+		default_only_default = /* @__PURE__ */ mark();
 	})))();
 }
 //#endregion
@@ -119,27 +119,27 @@ await import("./page-a.js");
 ```js
 import { t as __esmMin } from "./rolldown-runtime.js";
 import assert from "node:assert";
-//#region default-only.js
-function mark$1() {
-	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
-	return 42;
-}
-var default_only_default;
-function init_default_only() {
-	return (init_default_only = __esmMin((() => {
-		default_only_default = /* @__PURE__ */ mark$1();
-	})))();
-}
-//#endregion
 //#region shadowed.js
-function mark() {
+function mark$1() {
 	globalThis.shadowedValue = typeof globalThis.shadowedValue === "number" ? globalThis.shadowedValue + 1 : 0;
 	return 2;
 }
 var x;
 function init_shadowed() {
 	return (init_shadowed = __esmMin((() => {
-		x = /* @__PURE__ */ mark();
+		x = /* @__PURE__ */ mark$1();
+	})))();
+}
+//#endregion
+//#region default-only.js
+function mark() {
+	globalThis.defaultValue = typeof globalThis.defaultValue === "number" ? globalThis.defaultValue + 1 : 0;
+	return 42;
+}
+var default_only_default;
+function init_default_only() {
+	return (init_default_only = __esmMin((() => {
+		default_only_default = /* @__PURE__ */ mark();
 	})))();
 }
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/10734/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/10734/artifacts.snap
@@ -1,15 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
-
-## INEFFECTIVE_DYNAMIC_IMPORT
-
-```text
-[INEFFECTIVE_DYNAMIC_IMPORT] shared.js is dynamically imported by service.js but also statically imported by service.js, dynamic import will not move module into another chunk.
-
-```
-
 # Assets
 
 ## chain-a.js
@@ -27,7 +18,7 @@ export { chain_a_exports as n, __exportAll as r, chainA as t };
 ## cyclic.js
 
 ```js
-import { entryValue, r as chainB } from "./service.js";
+import { entryValue, n as chainB } from "./service.js";
 //#region cyclic.js
 const cyclic = "cyclic" + chainB + entryValue;
 //#endregion
@@ -48,12 +39,10 @@ export { done };
 ## service.js
 
 ```js
-import { r as __exportAll, t as chainA } from "./chain-a.js";
+import { r as __exportAll } from "./chain-a.js";
+import { t as shared } from "./shared.js";
 //#region chain-b.js
 const chainB = "chainB";
-//#endregion
-//#region shared.js
-const shared = "shared" + chainA;
 //#endregion
 //#region service.js
 var service_exports = /* @__PURE__ */ __exportAll({
@@ -64,17 +53,21 @@ var service_exports = /* @__PURE__ */ __exportAll({
 });
 const entryValue = "entry" + shared + chainB;
 const loadCyclic = () => import("./cyclic.js");
-const loadShared = () => import("./shared.js");
+const loadShared = () => import("./shared.js").then((n) => n.n);
 const loadChainA = () => import("./chain-a.js").then((n) => n.n);
 //#endregion
-export { entryValue, loadChainA, loadCyclic, loadShared, shared as n, chainB as r, service_exports as t };
+export { entryValue, loadChainA, loadCyclic, loadShared, chainB as n, service_exports as t };
 
 ```
 
 ## shared.js
 
 ```js
-import { n as shared } from "./service.js";
-export { shared };
+import { r as __exportAll, t as chainA } from "./chain-a.js";
+//#region shared.js
+var shared_exports = /* @__PURE__ */ __exportAll({ shared: () => shared });
+const shared = "shared" + chainA;
+//#endregion
+export { shared_exports as n, shared as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/9320/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9320/artifacts.snap
@@ -3,22 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## action.js
+## form.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-//#region form.js
-var form_exports = /* @__PURE__ */ __exportAll({
-	callActionFromForm: () => callActionFromForm,
-	formImpl: () => formImpl
-});
-function formImpl() {
-	return "form-result";
-}
-function callActionFromForm() {
-	return actionImpl();
-}
-//#endregion
 //#region action.js
 var action_exports = /* @__PURE__ */ __exportAll({
 	actionImpl: () => actionImpl,
@@ -31,7 +19,19 @@ function callFormFromAction() {
 	return formImpl();
 }
 //#endregion
-export { form_exports as n, action_exports as t };
+//#region form.js
+var form_exports = /* @__PURE__ */ __exportAll({
+	callActionFromForm: () => callActionFromForm,
+	formImpl: () => formImpl
+});
+function formImpl() {
+	return "form-result";
+}
+function callActionFromForm() {
+	return actionImpl();
+}
+//#endregion
+export { action_exports as n, form_exports as t };
 
 ```
 
@@ -40,8 +40,8 @@ export { form_exports as n, action_exports as t };
 ```js
 //#region main.js
 async function main() {
-	const formNs = await import("./action.js").then((n) => n.n);
-	const actionNs = await import("./action.js").then((n) => n.t);
+	const formNs = await import("./form.js").then((n) => n.t);
+	const actionNs = await import("./form.js").then((n) => n.n);
 	globalThis.__9320_formNs = formNs;
 	globalThis.__9320_actionNs = actionNs;
 }

--- a/crates/rolldown/tests/rolldown/issues/9320_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9320_star/artifacts.snap
@@ -3,18 +3,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## action.js
+## form.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-//#region form-exports.js
-function formImpl() {
-	return "form-result";
-}
-//#endregion
-//#region form.js
-var form_exports = /* @__PURE__ */ __exportAll({ formImpl: () => formImpl });
-//#endregion
 //#region action-exports.js
 function actionImpl() {
 	return "action-result";
@@ -23,7 +15,15 @@ function actionImpl() {
 //#region action.js
 var action_exports = /* @__PURE__ */ __exportAll({ actionImpl: () => actionImpl });
 //#endregion
-export { form_exports as n, action_exports as t };
+//#region form-exports.js
+function formImpl() {
+	return "form-result";
+}
+//#endregion
+//#region form.js
+var form_exports = /* @__PURE__ */ __exportAll({ formImpl: () => formImpl });
+//#endregion
+export { action_exports as n, form_exports as t };
 
 ```
 
@@ -32,8 +32,8 @@ export { form_exports as n, action_exports as t };
 ```js
 //#region main.js
 async function main() {
-	const formNs = await import("./action.js").then((n) => n.n);
-	const actionNs = await import("./action.js").then((n) => n.t);
+	const formNs = await import("./form.js").then((n) => n.t);
+	const actionNs = await import("./form.js").then((n) => n.n);
 	globalThis.__9320_star_formNs = formNs;
 	globalThis.__9320_star_actionNs = actionNs;
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -98,20 +98,20 @@ const rawImportModule = /* #__PURE__ */ Object.assign({
 	"./modules/b.ts": () => Promise.resolve().then(() => b_exports)
 });
 const excludeSelf = /* #__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling.js") });
-const excludeSelfRaw = /* #__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling3.js") });
-const customQueryString = /* #__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling2.js") });
+const excludeSelfRaw = /* #__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling2.js") });
+const customQueryString = /* #__PURE__ */ Object.assign({ "./sibling.ts": () => import("./sibling3.js") });
 const parent = /* #__PURE__ */ Object.assign({});
 const rootMixedRelative = /* #__PURE__ */ Object.assign({
-	"/b/a.ts": () => import("./a3.js").then((m) => m["default"]),
-	"/b/b.ts": () => import("./b3.js").then((m) => m["default"]),
-	"/b/index.ts": () => import("./b5.js").then((m) => m["default"])
+	"/b/a.ts": () => import("./a2.js").then((m) => m["default"]),
+	"/b/b.ts": () => import("./b2.js").then((m) => m["default"]),
+	"/b/index.ts": () => import("./b3.js").then((m) => m["default"])
 });
 const cleverCwd1 = /* #__PURE__ */ Object.assign({ "./node_modules/framework/pages/hello.page.js": () => import("./hello.page.js") });
 const cleverCwd2 = /* #__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"../b/a.ts": () => import("./a2.js"),
-	"../b/b.ts": () => import("./b2.js")
+	"../b/a.ts": () => import("./a3.js"),
+	"../b/b.ts": () => import("./b4.js")
 });
 const customBase = /* #__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
@@ -120,14 +120,14 @@ const customBase = /* #__PURE__ */ Object.assign({
 	"./sibling.ts": () => import("./sibling.js")
 });
 const customRootBase = /* #__PURE__ */ Object.assign({
-	"./a.ts": () => import("./a2.js"),
-	"./b.ts": () => import("./b2.js"),
-	"./index.ts": () => import("./b4.js")
+	"./a.ts": () => import("./a3.js"),
+	"./b.ts": () => import("./b4.js"),
+	"./index.ts": () => import("./b5.js")
 });
 const customBaseParent = /* #__PURE__ */ Object.assign({
-	"../b/a.ts": () => import("./a2.js"),
-	"../b/b.ts": () => import("./b2.js"),
-	"../b/index.ts": () => import("./b4.js")
+	"../b/a.ts": () => import("./a3.js"),
+	"../b/b.ts": () => import("./b4.js"),
+	"../b/index.ts": () => import("./b5.js")
 });
 //#endregion
 export { basic, basicEager, basicEagerWithObjectKeys, basicEagerWithObjectValues, basicWithObjectKeys, basicWithObjectValues, cleverCwd1, cleverCwd2, customBase, customBaseParent, customQueryString, customRootBase, eagerAs, excludeSelf, excludeSelfRaw, ignore, ignoreWithObjectKeys, ignoreWithObjectValues, namedDefault, namedDefaultWithObjectKeys, namedDefaultWithObjectValues, namedEager, namedEagerWithObjectKeys, namedEagerWithObjectValues, parent, rawImportModule, rootMixedRelative };


### PR DESCRIPTION
Fixes #10863.

## The bug

Two modules in an import cycle can be given an execution order that cannot occur at runtime. When one of them reads a binding from the other while its own body is evaluating, the bundled output throws.

Minimal reproduction (no plugins, `input` + `format: esm` only):

```
entry.js   --dynamic-->  server.js
server.js  --static--->  router.js     (calls __exportAll while its body runs)
router.js  --static--->  server.js     (calls getStartContext, deferred)
server.js  --dynamic-->  routeA.js
routeA.js  --static--->  router.js
```

```
native ESM  : OK [ 'default' ]
rolldown    : FAIL __exportAll is not a function
```

Output:

```js
//#region src/server.js
const server_exports = __exportAll({ default: () => loadRoutes });   // call
//#endregion
//#region src/router.js
var __exportAll = (all) => { /* ... */ };                            // declaration
```

Reproduces identically on 1.1.5 through 1.2.8, so this is not a recent regression.

## Cause

`LinkStage::new` sorts non-user-defined entries by `(kind, module id)`, and the module id is the path:

```rust
rest.sort_by_cached_key(|item| {
  (item.kind, scan_stage_output.module_table.modules[item.idx].id().as_str())
});
```

`sort_modules` then walks the entries in that order. For modules in a cycle, the entry the walk starts from is what decides which side is executed first.

`routeA.js` sorts before `server.js` by path, so the walk starts at `routeA.js`:

```
routeA -> router -> server (cycle, already on the stack) -> emit server -> emit router
```

`server.js` gets the lower exec order and is concatenated first, so the `var` it calls is hoisted but unassigned.

That order is not one legal option among several. `routeA.js` is dynamically imported from inside `server.js`, so it can never be evaluated first. Forcing that order by hand fails under plain Node too:

```
node -e "import('./src/routeA.js').then(() => import('./src/server.js'))"
TypeError: __exportAll is not a function
```

## The change

Order entries within a kind by when the module graph first reaches them, breadth-first from the entry points, instead of by path. This models what the runtime does: the first dynamic import to fire is the first one the graph arrives at. Entries the walk never reaches keep their previous path-ordered position, and `kind` stays the primary key, so nothing moves between kinds.

**An alternative I tried and rejected**, in case it saves a reviewer the same detour: counting how many dynamic imports deep each module is (a 0-1 BFS, static edges free) and using that only as a tie-break ahead of the path. It is more conservative — it leaves fan-out cases such as an import glob completely untouched — but it does not fix the bug. In the real-world case the two cycle members are `server.js` and `router.js`, and `server.js` imports `router.js` *both* statically and dynamically. The static edge puts them at the same depth, the path tie-break then picks `router.js`, and the cycle still flips. Depth cannot separate a cycle whose members are also statically bound.

## Tests

New fixture: `crates/rolldown/tests/rolldown/code_splitting/dynamic_entry_order_with_cycle`. It executes, and throws `toNamespace is not a function` without the change.

| suite | before | after |
|---|---|---|
| `cargo test -p rolldown` | 2001 passed, 2 failed | 2002 passed, 1 failed |
| `packages/rolldown/tests` (fixtures) | 426 passed, 1 failed | 426 passed, 1 failed |

The remaining failures are the same with and without the change on my machine: `test262_module_code` in the Rust suite, and `function/advanced-chunks/relative-path-name` in the fixture suite. `cargo fmt --check` and `cargo clippy -p rolldown --all-targets` are clean.

Five existing snapshots move:

- **`issues/9320`, `issues/9320_star`** — two mutually reachable dynamic entries. The emitted order now follows `main.js`'s own import order (`form.js` then `action.js`) rather than the alphabetical one.
- **`strict_execution_order/namespace_dead_star_reexports`** — region order and one deconflicted suffix swap. Both modules are lazily initialised, so evaluation order is unchanged.
- **`builtin-plugin/import-glob/vite/transform`** — chunk names only. That fixture sets `chunkFileNames: '[name].js'` over colliding basenames, so the numeric dedupe suffixes shift (`a3` ↔ `a2`, `sibling3` ↔ `sibling2`); every glob key still resolves to the chunk holding its module. Worth a maintainer's opinion on whether shifting dedupe suffixes is acceptable for a correctness fix, since it is the one user-visible output change beyond the cycle ordering itself.
- **`issues/10734`** — the substantive one. `shared.js` now gets its own chunk, so the `INEFFECTIVE_DYNAMIC_IMPORT` warning no longer fires. `service.js` still imports it statically, so it is still evaluated before `service.js`, but this changes what that fixture exercises.

## Verified against a real application

The case this came from is a TanStack Start app built through Nitro, which re-bundles Vite's already-chunked SSR output. Running that build with the patched bundler:

```
without the fix:  first use at line 1644, declaration at line 1725  -> TypeError
with the fix:     declaration at line 94,  first use at line 2254   -> chunk evaluates
```

Downstream reports: nitrojs/nitro#4605, nitrojs/nitro#4113.

## Not addressed

The change makes the order match the only order the runtime can produce for *this* shape. It does not make cycles safe in general: where two dynamic entries are genuinely mutually reachable, either order is legal and one side can still observe an unassigned binding. #10673 is an instance of that, and I do not think this fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
