### PR TITLE
ci: wait for npm bindings before publishing rolldown

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -64,8 +64,16 @@ jobs:
     name: Publish npm Packages
     runs-on: ubuntu-latest
     environment: release
+    timeout-minutes: 300
     permissions:
       id-token: write # for `npm publish --provenance`
+    env:
+      # npm publish-time scanning makes a successful upload temporarily
+      # unavailable to installs. After each dependency tier becomes visible on
+      # this runner's registry edge, allow time for other CDN edges to settle.
+      # Native bindings can stay hidden for ~90 minutes (#10721).
+      PUBLISH_PROPAGATION_MIN_SECONDS: '60'
+      PUBLISH_PROPAGATION_TIMEOUT_SECONDS: '7200'
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -119,6 +127,10 @@ jobs:
           find ./packages/ -type d -maxdepth 1 -exec cp LICENSE {} \;
           find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
 
+      - name: Install npm
+        # Needed before any `npm publish` so OIDC provenance uses a current npm.
+        run: npm install -g npm
+
       - name: Publish(Dry Run)
         # `NAPI_DRY_RUN` makes rolldown's `prepublishOnly` hook pass `--dry-run`
         # through to `napi pre-publish`. Without it, the hook publishes the
@@ -128,10 +140,28 @@ jobs:
         run: |
           vp pm publish -r --tag latest --dry-run --no-git-checks
 
-      - name: Publish
-        run: |
-          npm install -g npm
-          vp pm publish -r --tag latest --no-git-checks
+      # `npm publish` can succeed before npm's malware scan makes the tarball
+      # installable. Publish bindings first, wait until they resolve, then
+      # publish packages that pin them in optionalDependencies (#10721, #10723).
+      - name: Publish binding packages
+        run: vp run --filter rolldown prepublishOnly
+
+      - name: Wait for binding packages
+        run: node scripts/misc/wait-for-npm-packages.mjs --from-binding-dirs packages/rolldown/npm
+
+      - name: Publish npm packages
+        # Bindings are already on npm. Skip napi's optional publish so this
+        # step only uploads rolldown / @rolldown/browser / @rolldown/debug.
+        env:
+          NAPI_SKIP_OPTIONAL_PUBLISH: '1'
+        run: vp pm publish -r --tag latest --no-git-checks
+
+      - name: Wait for published packages
+        run: >-
+          node scripts/misc/wait-for-npm-packages.mjs
+          --from-package-json packages/rolldown/package.json
+          --from-package-json packages/browser/package.json
+          --from-package-json packages/debug/package.json
 
   release:
     needs: [check, publish]

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -127,7 +127,7 @@
     "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi|node)$/'",
     "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi:release|node)$/'",
     "# Scrips for docs #": "_",
-    "prepublishOnly": "napi pre-publish -t npm --no-gh-release ${NAPI_DRY_RUN:+--dry-run}",
+    "prepublishOnly": "napi pre-publish -t npm --no-gh-release ${NAPI_DRY_RUN:+--dry-run} ${NAPI_SKIP_OPTIONAL_PUBLISH:+--skip-optional-publish}",
     "publint": "publint ."
   },
   "dependencies": {

--- a/scripts/misc/wait-for-npm-packages.mjs
+++ b/scripts/misc/wait-for-npm-packages.mjs
@@ -1,0 +1,282 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+/** The registry used by the release workflow. */
+const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org';
+
+/**
+ * npm installs resolve versions from the abbreviated packument, which is
+ * cached separately from the full package document.
+ */
+const ABBREVIATED_PACKUMENT_ACCEPT = 'application/vnd.npm.install-v1+json';
+
+/**
+ * npm publish-time scanning can hold native binding tarballs for a long time
+ * (about 90 minutes in https://github.com/rolldown/rolldown/issues/10721).
+ * Fail the release rather than publish `rolldown` against missing optionals.
+ */
+const DEFAULT_TIMEOUT_SECONDS = 7200;
+const DEFAULT_MIN_SECONDS = 60;
+const DEFAULT_POLL_SECONDS = 15;
+
+async function fetchNpmPackument(name, options) {
+  const registry = options.registry.replace(/\/+$/, '');
+  const response = await options.fetchImpl(`${registry}/${name.replace('/', '%2f')}`, {
+    headers: { accept: ABBREVIATED_PACKUMENT_ACCEPT },
+    signal: options.signal,
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`registry returned HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+/**
+ * Checks the same metadata document an npm install uses, then verifies that
+ * the tarball referenced by that document can also be fetched.
+ */
+async function isNpmPackageAvailable(pkg, options) {
+  const packument = await fetchNpmPackument(pkg.name, options);
+  const tarball = packument?.versions?.[pkg.version]?.dist?.tarball;
+  if (!tarball) {
+    return false;
+  }
+
+  const tarballResponse = await options.fetchImpl(tarball, {
+    method: 'HEAD',
+    signal: options.signal,
+  });
+  return tarballResponse.ok;
+}
+
+function propagationTimeoutError(pending, timeoutSeconds) {
+  const packageList = [...pending].map(([name, version]) => `${name}@${version}`).join(', ');
+  return new Error(
+    `Timed out after ${timeoutSeconds}s waiting for npm propagation: ${packageList}`,
+  );
+}
+
+/**
+ * Waits until every package version is installable before the release moves
+ * on to a package that pins it as a dependency.
+ */
+async function waitForNpmPackages(packages, options) {
+  if (packages.length === 0) {
+    return;
+  }
+
+  const start = options.now();
+  const deadline = start + options.timeoutSeconds * 1000;
+  const pending = new Map(packages.map((pkg) => [pkg.name, pkg.version]));
+
+  options.log(`Waiting for ${pending.size} npm package version(s) to become installable...`);
+
+  while (pending.size > 0) {
+    const remainingMilliseconds = deadline - options.now();
+    if (remainingMilliseconds <= 0) {
+      throw propagationTimeoutError(pending, options.timeoutSeconds);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), remainingMilliseconds);
+    try {
+      const results = await Promise.all(
+        [...pending].map(async ([name, version]) => {
+          try {
+            const available = await isNpmPackageAvailable(
+              { name, version },
+              { ...options, signal: controller.signal },
+            );
+            return { name, version, available, error: null };
+          } catch (error) {
+            return { name, version, available: false, error };
+          }
+        }),
+      );
+
+      if (controller.signal.aborted || options.now() >= deadline) {
+        throw propagationTimeoutError(pending, options.timeoutSeconds);
+      }
+
+      for (const result of results) {
+        if (result.available) {
+          options.log(`  ${result.name}@${result.version}: available`);
+          pending.delete(result.name);
+        } else if (result.error) {
+          options.log(
+            `  ${result.name}@${result.version}: check failed, retrying (${String(result.error)})`,
+          );
+        }
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (pending.size === 0) {
+      break;
+    }
+    const remainingAfterRound = deadline - options.now();
+    if (remainingAfterRound <= 0) {
+      throw propagationTimeoutError(pending, options.timeoutSeconds);
+    }
+    await options.sleep(Math.min(options.pollSeconds * 1000, remainingAfterRound));
+  }
+
+  if (options.minSeconds > 0) {
+    const elapsedSeconds = Math.round((options.now() - start) / 1000);
+    options.log(
+      `All versions are installable after ${elapsedSeconds}s; settling for a further ${options.minSeconds}s.`,
+    );
+    await options.sleep(options.minSeconds * 1000);
+  }
+}
+
+function parseNpmPackageSpec(spec) {
+  const separator = spec.lastIndexOf('@');
+  if (separator <= 0 || separator === spec.length - 1) {
+    throw new Error(`Expected a package argument in the form name@version, received ${spec}`);
+  }
+  return { name: spec.slice(0, separator), version: spec.slice(separator + 1) };
+}
+
+function readPackageJsonNameVersion(packageJsonPath) {
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  if (typeof pkg.name !== 'string' || typeof pkg.version !== 'string') {
+    throw new Error(`Expected name and version in ${packageJsonPath}`);
+  }
+  return { name: pkg.name, version: pkg.version };
+}
+
+/**
+ * Binding packages that napi actually uploaded. napi skips targets whose
+ * `.node` / `.wasm` file is missing, but still lists every target in
+ * `optionalDependencies`, so we must not wait on those missing packages.
+ */
+async function collectPublishedBindingPackages(npmDir) {
+  const packages = [];
+  if (!existsSync(npmDir)) {
+    throw new Error(`Binding npm directory does not exist: ${npmDir}`);
+  }
+
+  const entries = await readdir(npmDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const dir = join(npmDir, entry.name);
+    const packageJsonPath = join(dir, 'package.json');
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+    const files = await readdir(dir);
+    const hasBinary = files.some((file) => file.endsWith('.node') || file.endsWith('.wasm'));
+    if (!hasBinary) {
+      continue;
+    }
+    packages.push(readPackageJsonNameVersion(packageJsonPath));
+  }
+
+  packages.sort((a, b) => a.name.localeCompare(b.name));
+  return packages;
+}
+
+function readNonNegativeInteger(name, fallback) {
+  const value = process.env[name];
+  if (value === undefined || value.trim() === '') {
+    return fallback;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Expected ${name} to be a non-negative integer, received ${value}`);
+  }
+  return Number(value);
+}
+
+/** Uses the release workflow's propagation settings. */
+async function waitForNpmPackagesFromEnv(packages) {
+  if (packages.length === 0) {
+    throw new Error(
+      'No npm packages to wait for. Pass name@version, --from-package-json, or --from-binding-dirs.',
+    );
+  }
+
+  if (process.env.PUBLISH_SKIP_PROPAGATION_WAIT === 'true') {
+    console.log('Skipping npm propagation wait.');
+    return;
+  }
+
+  await waitForNpmPackages(packages, {
+    registry: process.env.PUBLISH_REGISTRY ?? DEFAULT_NPM_REGISTRY,
+    fetchImpl: fetch,
+    minSeconds: readNonNegativeInteger('PUBLISH_PROPAGATION_MIN_SECONDS', DEFAULT_MIN_SECONDS),
+    timeoutSeconds: readNonNegativeInteger(
+      'PUBLISH_PROPAGATION_TIMEOUT_SECONDS',
+      DEFAULT_TIMEOUT_SECONDS,
+    ),
+    pollSeconds: readNonNegativeInteger('PUBLISH_PROPAGATION_POLL_SECONDS', DEFAULT_POLL_SECONDS),
+    sleep,
+    now: Date.now,
+    log: console.log,
+  });
+}
+
+function parseArgs(argv) {
+  const specs = [];
+  const packageJsonFiles = [];
+  const bindingDirs = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--from-binding-dirs') {
+      const dir = argv[++i];
+      if (!dir) {
+        throw new Error('Expected a directory after --from-binding-dirs');
+      }
+      bindingDirs.push(dir);
+    } else if (arg === '--from-package-json') {
+      const file = argv[++i];
+      if (!file) {
+        throw new Error('Expected a path after --from-package-json');
+      }
+      packageJsonFiles.push(file);
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      specs.push(arg);
+    }
+  }
+
+  return { specs, packageJsonFiles, bindingDirs };
+}
+
+async function collectPackagesFromArgs(argv, cwd = process.cwd()) {
+  const { specs, packageJsonFiles, bindingDirs } = parseArgs(argv);
+  const packages = specs.map((spec) => parseNpmPackageSpec(spec));
+
+  for (const file of packageJsonFiles) {
+    packages.push(readPackageJsonNameVersion(resolve(cwd, file)));
+  }
+  for (const dir of bindingDirs) {
+    packages.push(...(await collectPublishedBindingPackages(resolve(cwd, dir))));
+  }
+
+  return packages;
+}
+
+async function main() {
+  const packages = await collectPackagesFromArgs(process.argv.slice(2));
+  await waitForNpmPackagesFromEnv(packages);
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && pathToFileURL(resolve(invokedPath)).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts", "src/**/*.ts"],
+  "include": [
+    "ci/**/*.js",
+    "meta/**/*.js",
+    "misc/**/*.js",
+    "misc/**/*.mjs",
+    "misc/**/*.d.ts",
+    "src/**/*.ts"
+  ],
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "module": "ESNext",


### PR DESCRIPTION
`npm publish` can succeed before npm's malware scan makes the package installable.

After `rolldown@1.2.5` was published, some `@rolldown/binding-*` packages 404'd for about 90 minutes (#10721). The main package listed them in `optionalDependencies`, so installs failed.

This change gates the release CI, same idea as [vite-plus#2601](https://github.com/voidzero-dev/vite-plus/pull/2601):

1. Publish `@rolldown/binding-*` first (`napi pre-publish`)
2. Wait until npm can install those versions (packument + tarball)
3. Publish `rolldown`, `@rolldown/browser`, `@rolldown/debug`
4. Wait again before the GitHub Release / Discord announce

If the binding wait times out (default 2 hours), `rolldown` is not published.

Fixes #10723